### PR TITLE
Making pipe operators primitive

### DIFF
--- a/examples/tactics/Poly1.fst
+++ b/examples/tactics/Poly1.fst
@@ -21,7 +21,7 @@ open FStar.Mul
 assume val modulo_addition_lemma (a:int) (n:pos) (b:int) : Lemma ((a + b * n) % n = a % n)
 assume val lemma_div_mod (a:int) (n:pos) : Lemma (a == (a / n) * n + a % n)
 
-#set-options "--z3rlimit 100 --max_fuel 0 --max_ifuel 0 --using_facts_from '* -FStar.Tactics'"
+#set-options "--z3rlimit 150 --max_fuel 0 --max_ifuel 0 --using_facts_from '* -FStar.Tactics'"
 
 // To print timing
 #set-options "--query_stats"

--- a/ocaml/fstar-lib/FStar_Parser_LexFStar.ml
+++ b/ocaml/fstar-lib/FStar_Parser_LexFStar.ml
@@ -579,6 +579,10 @@ match%sedlex lexbuf with
  | '`', '`', (Plus (Compl ('`' | 10 | 13 | 0x2028 | 0x2029) | '`', Compl ('`' | 10 | 13 | 0x2028 | 0x2029))), '`', '`' ->
    IDENT (trim_both lexbuf 2 2)
 
+ (* Pipe operators have special treatment in the parser. *)
+ | "<|" -> PIPE_LEFT
+ | "|>" -> PIPE_RIGHT
+
  | op_token_1
  | op_token_2
  | op_token_3

--- a/ocaml/fstar-lib/FStar_Parser_Parse.mly
+++ b/ocaml/fstar-lib/FStar_Parser_Parse.mly
@@ -118,7 +118,8 @@ let parse_extension_blob (extension_name:string)
 %token DOT_LENS_PAREN_LEFT DOT_LPAREN DOT_LBRACK_BAR LBRACK LBRACK_BAR LBRACE_BAR LBRACE BANG_LBRACE
 %token BAR_RBRACK BAR_RBRACE UNDERSCORE LENS_PAREN_LEFT LENS_PAREN_RIGHT
 %token BAR RBRACK RBRACE DOLLAR
-%token PRIVATE REIFIABLE REFLECTABLE REIFY RANGE_OF SET_RANGE_OF LBRACE_COLON_PATTERN PIPE_RIGHT
+%token PRIVATE REIFIABLE REFLECTABLE REIFY RANGE_OF SET_RANGE_OF LBRACE_COLON_PATTERN
+%token PIPE_LEFT PIPE_RIGHT
 %token NEW_EFFECT SUB_EFFECT LAYERED_EFFECT POLYMONADIC_BIND POLYMONADIC_SUBCOMP SPLICE SPLICET SQUIGGLY_RARROW TOTAL
 %token REQUIRES ENSURES DECREASES LBRACE_COLON_WELL_FOUNDED
 %token MINUS COLON_EQUALS QUOTE BACKTICK_AT BACKTICK_HASH
@@ -144,6 +145,7 @@ let parse_extension_blob (extension_name:string)
 %left     OPINFIX0c EQUALS
 %left     OPINFIX0d
 %left     PIPE_RIGHT
+%right    PIPE_LEFT
 %right    OPINFIX1
 %left     OPINFIX2 MINUS QUOTE
 %left     OPINFIX3
@@ -1199,8 +1201,14 @@ tmEqWith(X):
   (* see https:/ /github.com/fsprojects/FsLexYacc/issues/39 *)
   | e1=tmEqWith(X) tok=COLON_EQUALS e2=tmEqWith(X)
       { mk_term (Op(mk_ident(":=", rr $loc(tok)), [e1; e2])) (rr $loc) Un}
-  | e1=tmEqWith(X) tok=PIPE_RIGHT e2=tmEqWith(X)
-      { mk_term (Op(mk_ident("|>", rr $loc(tok)), [e1; e2])) (rr $loc) Un}
+
+ | e1=tmEqWith(X) op=PIPE_LEFT e2=tmEqWith(X)
+      { mk_term (Op(mk_ident("<|", rr $loc(op)), [e1; e2])) (rr $loc) Un}
+
+ | e1=tmEqWith(X) op=PIPE_RIGHT e2=tmEqWith(X)
+      { mk_term (Op(mk_ident("|>", rr $loc(op)), [e1; e2])) (rr $loc) Un}
+
+
   | e1=tmEqWith(X) op=operatorInfix0ad12 e2=tmEqWith(X)
       { mk_term (Op(op, [e1; e2])) (rr2 $loc(e1) $loc(e2)) Un}
   | e1=tmEqWith(X) tok=MINUS e2=tmEqWith(X)
@@ -1267,7 +1275,6 @@ binop_name:
   | o=CONJUNCTION            { mk_ident ("/\\", rr $loc) }
   | o=DISJUNCTION            { mk_ident ("\\/", rr $loc) }
   | o=IFF                    { mk_ident ("<==>", rr $loc) }
-  | o=PIPE_RIGHT             { mk_ident ("|>", rr $loc) }
   | o=COLON_EQUALS           { mk_ident (":=", rr $loc) }
   | o=COLON_COLON            { mk_ident ("::", rr $loc) }
   | o=OP_MIXFIX_ASSIGNMENT   { mk_ident (o, rr $loc) }

--- a/ocaml/fstar-lib/generated/FStar_CheckedFiles.ml
+++ b/ocaml/fstar-lib/generated/FStar_CheckedFiles.ml
@@ -129,26 +129,20 @@ let (hash_dependences :
         then
           let uu___1 =
             let uu___2 =
-              let uu___3 =
-                FStar_Compiler_Effect.op_Bar_Greater module_name
-                  (FStar_Parser_Dep.interface_of deps) in
-              FStar_Compiler_Effect.op_Bar_Greater uu___3
-                FStar_Compiler_Util.must in
-            FStar_Compiler_Effect.op_Bar_Greater uu___2
-              FStar_Parser_Dep.cache_file_name in
-          FStar_Compiler_Effect.op_Bar_Greater uu___1
-            (fun uu___2 -> FStar_Pervasives_Native.Some uu___2)
+              let uu___3 = FStar_Parser_Dep.interface_of deps module_name in
+              FStar_Compiler_Util.must uu___3 in
+            FStar_Parser_Dep.cache_file_name uu___2 in
+          FStar_Pervasives_Native.Some uu___1
         else FStar_Pervasives_Native.None in
       let binary_deps =
         let uu___ = FStar_Parser_Dep.deps_of deps fn1 in
-        FStar_Compiler_Effect.op_Bar_Greater uu___
-          (FStar_Compiler_List.filter
-             (fun fn2 ->
-                let uu___1 =
-                  (FStar_Parser_Dep.is_interface fn2) &&
-                    (let uu___2 = FStar_Parser_Dep.lowercase_module_name fn2 in
-                     uu___2 = module_name) in
-                Prims.op_Negation uu___1)) in
+        FStar_Compiler_List.filter
+          (fun fn2 ->
+             let uu___1 =
+               (FStar_Parser_Dep.is_interface fn2) &&
+                 (let uu___2 = FStar_Parser_Dep.lowercase_module_name fn2 in
+                  uu___2 = module_name) in
+             Prims.op_Negation uu___1) uu___ in
       let binary_deps1 =
         FStar_Compiler_List.sortWith
           (fun fn11 ->
@@ -237,13 +231,9 @@ let (load_checked_file : Prims.string -> Prims.string -> cache_t) =
          FStar_Compiler_Util.print1 "Trying to load checked file result %s\n"
            checked_fn
        else ());
-      (let elt =
-         FStar_Compiler_Effect.op_Bar_Greater checked_fn
-           (FStar_Compiler_Util.smap_try_find mcache) in
-       let uu___1 =
-         FStar_Compiler_Effect.op_Bar_Greater elt FStar_Compiler_Util.is_some in
-       if uu___1
-       then FStar_Compiler_Effect.op_Bar_Greater elt FStar_Compiler_Util.must
+      (let elt = FStar_Compiler_Util.smap_try_find mcache checked_fn in
+       if FStar_Compiler_Util.is_some elt
+       then FStar_Compiler_Util.must elt
        else
          (let add_and_return elt1 =
             FStar_Compiler_Util.smap_add mcache checked_fn elt1; elt1 in
@@ -273,10 +263,10 @@ let (load_checked_file : Prims.string -> Prims.string -> cache_t) =
                       FStar_Compiler_Util.digest_of_file fn in
                     if x.digest <> current_digest
                     then
-                      ((let uu___6 =
+                      ((let uu___5 =
                           FStar_Options.debug_at_level_no_module
                             (FStar_Options.Other "CheckedFiles") in
-                        if uu___6
+                        if uu___5
                         then
                           FStar_Compiler_Util.print4
                             "Checked file %s is stale since incorrect digest of %s, expected: %s, found: %s\n"
@@ -320,13 +310,9 @@ let (load_checked_file_with_tc_result :
          | (Invalid msg, uu___1) -> FStar_Pervasives.Inl msg
          | (Valid uu___1, uu___2) ->
              let uu___3 =
-               let uu___4 =
-                 FStar_Compiler_Effect.op_Bar_Greater checked_fn
-                   load_tc_result in
-               FStar_Compiler_Effect.op_Bar_Greater uu___4
-                 FStar_Pervasives_Native.snd in
-             FStar_Compiler_Effect.op_Bar_Greater uu___3
-               (fun uu___4 -> FStar_Pervasives.Inr uu___4)
+               let uu___4 = load_tc_result checked_fn in
+               FStar_Pervasives_Native.snd uu___4 in
+             FStar_Pervasives.Inr uu___3
          | (Unknown, parsing_data) ->
              let uu___1 = hash_dependences deps fn in
              (match uu___1 with
@@ -335,9 +321,7 @@ let (load_checked_file_with_tc_result :
                   (FStar_Compiler_Util.smap_add mcache checked_fn elt1;
                    FStar_Pervasives.Inl msg)
               | FStar_Pervasives.Inr deps_dig' ->
-                  let uu___2 =
-                    FStar_Compiler_Effect.op_Bar_Greater checked_fn
-                      load_tc_result in
+                  let uu___2 = load_tc_result checked_fn in
                   (match uu___2 with
                    | (deps_dig, tc_result1) ->
                        if deps_dig = deps_dig'
@@ -352,10 +336,8 @@ let (load_checked_file_with_tc_result :
                           (let validate_iface_cache uu___4 =
                              let iface =
                                let uu___5 =
-                                 FStar_Compiler_Effect.op_Bar_Greater fn
-                                   FStar_Parser_Dep.lowercase_module_name in
-                               FStar_Compiler_Effect.op_Bar_Greater uu___5
-                                 (FStar_Parser_Dep.interface_of deps) in
+                                 FStar_Parser_Dep.lowercase_module_name fn in
+                               FStar_Parser_Dep.interface_of deps uu___5 in
                              match iface with
                              | FStar_Pervasives_Native.None -> ()
                              | FStar_Pervasives_Native.Some iface1 ->
@@ -364,9 +346,8 @@ let (load_checked_file_with_tc_result :
                                        match () with
                                        | () ->
                                            let iface_checked_fn =
-                                             FStar_Compiler_Effect.op_Bar_Greater
-                                               iface1
-                                               FStar_Parser_Dep.cache_file_name in
+                                             FStar_Parser_Dep.cache_file_name
+                                               iface1 in
                                            let uu___6 =
                                              FStar_Compiler_Util.smap_try_find
                                                mcache iface_checked_fn in
@@ -452,8 +433,7 @@ let (load_parsing_data_from_cache :
                 match () with
                 | () ->
                     let uu___2 = FStar_Parser_Dep.cache_file_name file_name in
-                    FStar_Compiler_Effect.op_Bar_Greater uu___2
-                      (fun uu___3 -> FStar_Pervasives_Native.Some uu___3)) ()
+                    FStar_Pervasives_Native.Some uu___2) ()
            with | uu___1 -> FStar_Pervasives_Native.None in
          match cache_file with
          | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
@@ -529,13 +509,10 @@ let (load_module_from_cache :
              FStar_Parser_Dep.interface_of uu___1 uu___2 in
            let uu___1 =
              (FStar_Parser_Dep.is_implementation fn) &&
-               (FStar_Compiler_Effect.op_Bar_Greater i_fn_opt
-                  FStar_Compiler_Util.is_some) in
+               (FStar_Compiler_Util.is_some i_fn_opt) in
            if uu___1
            then
-             let i_fn =
-               FStar_Compiler_Effect.op_Bar_Greater i_fn_opt
-                 FStar_Compiler_Util.must in
+             let i_fn = FStar_Compiler_Util.must i_fn_opt in
              let i_tc = load_with_profiling i_fn in
              match i_tc with
              | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None

--- a/ocaml/fstar-lib/generated/FStar_Common.ml
+++ b/ocaml/fstar-lib/generated/FStar_Common.ml
@@ -23,8 +23,7 @@ let (try_convert_file_name_to_mixed : Prims.string -> Prims.string) =
             let uu___1 =
               FStar_Compiler_Util.run_process label "cygpath" ["-m"; s]
                 FStar_Pervasives_Native.None in
-            FStar_Compiler_Effect.op_Bar_Greater uu___1
-              FStar_Compiler_Util.trim_string in
+            FStar_Compiler_Util.trim_string uu___1 in
           (FStar_Compiler_Util.smap_add cache s out; out)
     else s
 let snapshot :
@@ -148,14 +147,8 @@ let max_suffix :
         | [] -> (acc, [])
         | x::xs2 when f x -> aux (x :: acc) xs2
         | x::xs2 -> (acc, (x :: xs2)) in
-      let uu___ =
-        let uu___1 =
-          FStar_Compiler_Effect.op_Bar_Greater xs FStar_Compiler_List.rev in
-        FStar_Compiler_Effect.op_Bar_Greater uu___1 (aux []) in
-      FStar_Compiler_Effect.op_Bar_Greater uu___
-        (fun uu___1 ->
-           match uu___1 with
-           | (xs1, ys) -> ((FStar_Compiler_List.rev ys), xs1))
+      let uu___ = aux [] (FStar_Compiler_List.rev xs) in
+      match uu___ with | (xs1, ys) -> ((FStar_Compiler_List.rev ys), xs1)
 let rec eq_list :
   'a .
     ('a -> 'a -> Prims.bool) -> 'a Prims.list -> 'a Prims.list -> Prims.bool

--- a/ocaml/fstar-lib/generated/FStar_Compiler_Misc.ml
+++ b/ocaml/fstar-lib/generated/FStar_Compiler_Misc.ml
@@ -3,13 +3,11 @@ let (compare_version : Prims.string -> Prims.string -> FStar_Order.order) =
   fun v1 ->
     fun v2 ->
       let cs1 =
-        FStar_Compiler_Effect.op_Bar_Greater
-          (FStar_Compiler_String.split [46] v1)
-          (FStar_Compiler_List.map FStar_Compiler_Util.int_of_string) in
+        FStar_Compiler_List.map FStar_Compiler_Util.int_of_string
+          (FStar_Compiler_String.split [46] v1) in
       let cs2 =
-        FStar_Compiler_Effect.op_Bar_Greater
-          (FStar_Compiler_String.split [46] v2)
-          (FStar_Compiler_List.map FStar_Compiler_Util.int_of_string) in
+        FStar_Compiler_List.map FStar_Compiler_Util.int_of_string
+          (FStar_Compiler_String.split [46] v2) in
       FStar_Order.compare_list cs1 cs2 FStar_Order.compare_int
 let (version_gt : Prims.string -> Prims.string -> Prims.bool) =
   fun v1 ->

--- a/ocaml/fstar-lib/generated/FStar_Compiler_Set.ml
+++ b/ocaml/fstar-lib/generated/FStar_Compiler_Set.ml
@@ -55,17 +55,13 @@ let for_all :
   fun uu___ ->
     fun p ->
       fun s ->
-        let uu___1 = elems uu___ s in
-        FStar_Compiler_Effect.op_Bar_Greater uu___1
-          (FStar_Compiler_List.for_all p)
+        let uu___1 = elems uu___ s in FStar_Compiler_List.for_all p uu___1
 let for_any :
   'a . 'a FStar_Class_Ord.ord -> ('a -> Prims.bool) -> 'a set -> Prims.bool =
   fun uu___ ->
     fun p ->
       fun s ->
-        let uu___1 = elems uu___ s in
-        FStar_Compiler_Effect.op_Bar_Greater uu___1
-          (FStar_Compiler_List.existsb p)
+        let uu___1 = elems uu___ s in FStar_Compiler_List.existsb p uu___1
 let collect :
   'a 'b . 'b FStar_Class_Ord.ord -> ('a -> 'b set) -> 'a Prims.list -> 'b set
   =

--- a/ocaml/fstar-lib/generated/FStar_Defensive.ml
+++ b/ocaml/fstar-lib/generated/FStar_Defensive.ml
@@ -27,8 +27,7 @@ let pp_set :
                  FStar_Pprint.rbracket ds in
              let uu___2 =
                let uu___3 = FStar_Compiler_Set.elems uu___ s in
-               FStar_Compiler_Effect.op_Bar_Greater uu___3
-                 (FStar_Compiler_List.map (FStar_Class_PP.pp uu___1)) in
+               FStar_Compiler_List.map (FStar_Class_PP.pp uu___1) uu___3 in
              doclist uu___2)
       }
 let __def_check_scoped :

--- a/ocaml/fstar-lib/generated/FStar_Errors.ml
+++ b/ocaml/fstar-lib/generated/FStar_Errors.ml
@@ -258,15 +258,14 @@ let (ctx_doc : Prims.string Prims.list -> FStar_Pprint.document) =
     if uu___
     then
       let uu___1 =
-        FStar_Compiler_Effect.op_Bar_Greater ctx
-          (FStar_Compiler_List.map
-             (fun s ->
-                let uu___2 =
-                  let uu___3 = FStar_Pprint.doc_of_string "> " in
-                  let uu___4 = FStar_Pprint.doc_of_string s in
-                  FStar_Pprint.op_Hat_Hat uu___3 uu___4 in
-                FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline uu___2)) in
-      FStar_Compiler_Effect.op_Bar_Greater uu___1 FStar_Pprint.concat
+        FStar_Compiler_List.map
+          (fun s ->
+             let uu___2 =
+               let uu___3 = FStar_Pprint.doc_of_string "> " in
+               let uu___4 = FStar_Pprint.doc_of_string s in
+               FStar_Pprint.op_Hat_Hat uu___3 uu___4 in
+             FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline uu___2) ctx in
+      FStar_Pprint.concat uu___1
     else FStar_Pprint.empty
 let (issue_message : issue -> FStar_Errors_Msg.error_message) =
   fun i ->

--- a/ocaml/fstar-lib/generated/FStar_Errors_Msg.ml
+++ b/ocaml/fstar-lib/generated/FStar_Errors_Msg.ml
@@ -24,10 +24,9 @@ let (sublist :
         let uu___1 =
           let uu___2 =
             let uu___3 =
-              FStar_Compiler_Effect.op_Bar_Greater ds
-                (FStar_Compiler_List.map
-                   (fun d -> FStar_Pprint.op_Hat_Hat h d)) in
-            FStar_Compiler_Effect.op_Bar_Greater uu___3 vconcat in
+              FStar_Compiler_List.map (fun d -> FStar_Pprint.op_Hat_Hat h d)
+                ds in
+            vconcat uu___3 in
           FStar_Pprint.align uu___2 in
         FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline uu___1 in
       FStar_Pprint.nest (Prims.of_int (2)) uu___

--- a/ocaml/fstar-lib/generated/FStar_Extraction_Krml.ml
+++ b/ocaml/fstar-lib/generated/FStar_Extraction_Krml.ml
@@ -2669,10 +2669,9 @@ and (translate_constant : FStar_Extraction_ML_Syntax.mlconstant -> expr) =
     | FStar_Extraction_ML_Syntax.MLC_Bool b -> EBool b
     | FStar_Extraction_ML_Syntax.MLC_String s ->
         ((let uu___1 =
-            FStar_Compiler_Effect.op_Bar_Greater
-              (FStar_String.list_of_string s)
-              (FStar_Compiler_Util.for_some
-                 (fun c1 -> c1 = (FStar_Char.char_of_int Prims.int_zero))) in
+            FStar_Compiler_Util.for_some
+              (fun c1 -> c1 = (FStar_Char.char_of_int Prims.int_zero))
+              (FStar_String.list_of_string s) in
           if uu___1
           then
             let uu___2 =

--- a/ocaml/fstar-lib/generated/FStar_Extraction_ML_Code.ml
+++ b/ocaml/fstar-lib/generated/FStar_Extraction_ML_Code.ml
@@ -1063,15 +1063,13 @@ and (doc_of_lets :
                                   (min_op_prec, NonAssoc) ty in
                               let vars =
                                 let uu___7 =
-                                  FStar_Compiler_Effect.op_Bar_Greater vs
-                                    (FStar_Compiler_List.map
-                                       (fun x ->
-                                          doc_of_mltype currentModule
-                                            (min_op_prec, NonAssoc)
-                                            (FStar_Extraction_ML_Syntax.MLTY_Var
-                                               x))) in
-                                FStar_Compiler_Effect.op_Bar_Greater uu___7
-                                  reduce1 in
+                                  FStar_Compiler_List.map
+                                    (fun x ->
+                                       doc_of_mltype currentModule
+                                         (min_op_prec, NonAssoc)
+                                         (FStar_Extraction_ML_Syntax.MLTY_Var
+                                            x)) vs in
+                                reduce1 uu___7 in
                               reduce1 [text ":"; vars; text "."; ty1])
                        else text "") in
                 let uu___4 =
@@ -1382,7 +1380,7 @@ let (doc_of_mllib_r :
                   FStar_Compiler_List.op_At
                     [head; hardline; text "open Prims"] uu___4 in
                 FStar_Compiler_List.op_At prefix uu___3 in
-              FStar_Compiler_Effect.op_Less_Bar reduce uu___2 in
+              reduce uu___2 in
         let docs =
           FStar_Compiler_List.map
             (fun uu___1 ->

--- a/ocaml/fstar-lib/generated/FStar_Extraction_ML_Modul.ml
+++ b/ocaml/fstar-lib/generated/FStar_Extraction_ML_Modul.ml
@@ -113,8 +113,7 @@ let (fail_exp :
                     FStar_Syntax_Syntax.Tm_constant uu___9 in
                   FStar_Syntax_Syntax.mk uu___8
                     FStar_Compiler_Range_Type.dummyRange in
-                FStar_Compiler_Effect.op_Less_Bar FStar_Syntax_Syntax.as_arg
-                  uu___7 in
+                FStar_Syntax_Syntax.as_arg uu___7 in
               [uu___6] in
             uu___4 :: uu___5 in
           {
@@ -138,8 +137,7 @@ let (always_fail :
               let uu___1 =
                 FStar_Syntax_Syntax.gen_bv "_" FStar_Pervasives_Native.None
                   t1 in
-              FStar_Compiler_Effect.op_Less_Bar FStar_Syntax_Syntax.mk_binder
-                uu___1 in
+              FStar_Syntax_Syntax.mk_binder uu___1 in
             let uu___1 = fail_exp lid t1 in
             FStar_Syntax_Util.abs [b] uu___1 FStar_Pervasives_Native.None
         | (bs, t1) ->
@@ -409,16 +407,14 @@ let (print_ifamily : inductive_family -> unit) =
     let uu___2 = FStar_Syntax_Print.term_to_string i.ityp in
     let uu___3 =
       let uu___4 =
-        FStar_Compiler_Effect.op_Bar_Greater i.idatas
-          (FStar_Compiler_List.map
-             (fun d ->
-                let uu___5 = FStar_Syntax_Print.lid_to_string d.dname in
-                let uu___6 =
-                  let uu___7 = FStar_Syntax_Print.term_to_string d.dtyp in
-                  Prims.strcat " : " uu___7 in
-                Prims.strcat uu___5 uu___6)) in
-      FStar_Compiler_Effect.op_Bar_Greater uu___4
-        (FStar_Compiler_String.concat "\n\t\t") in
+        FStar_Compiler_List.map
+          (fun d ->
+             let uu___5 = FStar_Syntax_Print.lid_to_string d.dname in
+             let uu___6 =
+               let uu___7 = FStar_Syntax_Print.term_to_string d.dtyp in
+               Prims.strcat " : " uu___7 in
+             Prims.strcat uu___5 uu___6) i.idatas in
+      FStar_Compiler_String.concat "\n\t\t" uu___4 in
     FStar_Compiler_Util.print4 "\n\t%s %s : %s { %s }\n" uu___ uu___1 uu___2
       uu___3
 let (bundle_as_inductive_families :
@@ -451,53 +447,46 @@ let (bundle_as_inductive_families :
                           (match uu___4 with
                            | (bs1, t2) ->
                                let datas1 =
-                                 FStar_Compiler_Effect.op_Bar_Greater ses
-                                   (FStar_Compiler_List.collect
-                                      (fun se1 ->
-                                         match se1.FStar_Syntax_Syntax.sigel
-                                         with
-                                         | FStar_Syntax_Syntax.Sig_datacon
-                                             { FStar_Syntax_Syntax.lid1 = d;
-                                               FStar_Syntax_Syntax.us1 = us1;
-                                               FStar_Syntax_Syntax.t1 = t3;
-                                               FStar_Syntax_Syntax.ty_lid =
-                                                 l';
-                                               FStar_Syntax_Syntax.num_ty_params
-                                                 = nparams;
-                                               FStar_Syntax_Syntax.mutuals1 =
-                                                 uu___5;_}
-                                             when FStar_Ident.lid_equals l l'
-                                             ->
-                                             let uu___6 =
-                                               FStar_Syntax_Subst.open_univ_vars
-                                                 us1 t3 in
-                                             (match uu___6 with
-                                              | (_us1, t4) ->
-                                                  let uu___7 =
-                                                    FStar_Syntax_Util.arrow_formals
-                                                      t4 in
-                                                  (match uu___7 with
-                                                   | (bs', body) ->
-                                                       let uu___8 =
-                                                         FStar_Compiler_Util.first_N
-                                                           (FStar_Compiler_List.length
-                                                              bs1) bs' in
-                                                       (match uu___8 with
-                                                        | (bs_params, rest)
-                                                            ->
-                                                            let subst =
-                                                              FStar_Compiler_List.map2
-                                                                (fun uu___9
-                                                                   ->
-                                                                   fun
-                                                                    uu___10
-                                                                    ->
-                                                                    match 
+                                 FStar_Compiler_List.collect
+                                   (fun se1 ->
+                                      match se1.FStar_Syntax_Syntax.sigel
+                                      with
+                                      | FStar_Syntax_Syntax.Sig_datacon
+                                          { FStar_Syntax_Syntax.lid1 = d;
+                                            FStar_Syntax_Syntax.us1 = us1;
+                                            FStar_Syntax_Syntax.t1 = t3;
+                                            FStar_Syntax_Syntax.ty_lid = l';
+                                            FStar_Syntax_Syntax.num_ty_params
+                                              = nparams;
+                                            FStar_Syntax_Syntax.mutuals1 =
+                                              uu___5;_}
+                                          when FStar_Ident.lid_equals l l' ->
+                                          let uu___6 =
+                                            FStar_Syntax_Subst.open_univ_vars
+                                              us1 t3 in
+                                          (match uu___6 with
+                                           | (_us1, t4) ->
+                                               let uu___7 =
+                                                 FStar_Syntax_Util.arrow_formals
+                                                   t4 in
+                                               (match uu___7 with
+                                                | (bs', body) ->
+                                                    let uu___8 =
+                                                      FStar_Compiler_Util.first_N
+                                                        (FStar_Compiler_List.length
+                                                           bs1) bs' in
+                                                    (match uu___8 with
+                                                     | (bs_params, rest) ->
+                                                         let subst =
+                                                           FStar_Compiler_List.map2
+                                                             (fun uu___9 ->
+                                                                fun uu___10
+                                                                  ->
+                                                                  match 
                                                                     (uu___9,
                                                                     uu___10)
-                                                                    with
-                                                                    | 
-                                                                    ({
+                                                                  with
+                                                                  | ({
                                                                     FStar_Syntax_Syntax.binder_bv
                                                                     = b';
                                                                     FStar_Syntax_Syntax.binder_qual
@@ -526,24 +515,21 @@ let (bundle_as_inductive_families :
                                                                     uu___18) in
                                                                     FStar_Syntax_Syntax.NT
                                                                     uu___17)
-                                                                bs_params bs1 in
-                                                            let t5 =
-                                                              let uu___9 =
-                                                                let uu___10 =
-                                                                  FStar_Syntax_Syntax.mk_Total
-                                                                    body in
-                                                                FStar_Syntax_Util.arrow
-                                                                  rest
-                                                                  uu___10 in
-                                                              FStar_Compiler_Effect.op_Bar_Greater
-                                                                uu___9
-                                                                (FStar_Syntax_Subst.subst
-                                                                   subst) in
-                                                            [{
-                                                               dname = d;
-                                                               dtyp = t5
-                                                             }])))
-                                         | uu___5 -> [])) in
+                                                             bs_params bs1 in
+                                                         let t5 =
+                                                           let uu___9 =
+                                                             let uu___10 =
+                                                               FStar_Syntax_Syntax.mk_Total
+                                                                 body in
+                                                             FStar_Syntax_Util.arrow
+                                                               rest uu___10 in
+                                                           FStar_Syntax_Subst.subst
+                                                             subst uu___9 in
+                                                         [{
+                                                            dname = d;
+                                                            dtyp = t5
+                                                          }])))
+                                      | uu___5 -> []) ses in
                                let metadata =
                                  let uu___5 =
                                    extract_metadata
@@ -704,18 +690,15 @@ let (iface_to_string : iface -> Prims.string) =
     let uu___ =
       let uu___1 =
         FStar_Compiler_List.map (print_binding cm) iface1.iface_bindings in
-      FStar_Compiler_Effect.op_Bar_Greater uu___1
-        (FStar_Compiler_String.concat "\n") in
+      FStar_Compiler_String.concat "\n" uu___1 in
     let uu___1 =
       let uu___2 =
         FStar_Compiler_List.map (print_tydef cm) iface1.iface_tydefs in
-      FStar_Compiler_Effect.op_Bar_Greater uu___2
-        (FStar_Compiler_String.concat "\n") in
+      FStar_Compiler_String.concat "\n" uu___2 in
     let uu___2 =
       let uu___3 =
         FStar_Compiler_List.map print_type_name iface1.iface_type_names in
-      FStar_Compiler_Effect.op_Bar_Greater uu___3
-        (FStar_Compiler_String.concat "\n") in
+      FStar_Compiler_String.concat "\n" uu___3 in
     FStar_Compiler_Util.format4
       "Interface %s = {\niface_bindings=\n%s;\n\niface_tydefs=\n%s;\n\niface_type_names=%s;\n}"
       (mlpath_to_string iface1.iface_module_name) uu___ uu___1 uu___2
@@ -731,8 +714,7 @@ let (gamma_to_string : FStar_Extraction_ML_UEnv.uenv -> Prims.string) =
            | uu___2 -> []) uu___ in
     let uu___ =
       let uu___1 = FStar_Compiler_List.map (print_binding cm) gamma in
-      FStar_Compiler_Effect.op_Bar_Greater uu___1
-        (FStar_Compiler_String.concat "\n") in
+      FStar_Compiler_String.concat "\n" uu___1 in
     FStar_Compiler_Util.format1 "Gamma = {\n %s }" uu___
 let (extract_typ_abbrev :
   FStar_Extraction_ML_UEnv.uenv ->
@@ -772,10 +754,8 @@ let (extract_typ_abbrev :
               let def =
                 let uu___1 =
                   let uu___2 = FStar_Syntax_Subst.compress lbdef1 in
-                  FStar_Compiler_Effect.op_Bar_Greater uu___2
-                    FStar_Syntax_Util.unmeta in
-                FStar_Compiler_Effect.op_Bar_Greater uu___1
-                  FStar_Syntax_Util.un_uinst in
+                  FStar_Syntax_Util.unmeta uu___2 in
+                FStar_Syntax_Util.un_uinst uu___1 in
               let def1 =
                 match def.FStar_Syntax_Syntax.n with
                 | FStar_Syntax_Syntax.Tm_abs uu___1 ->
@@ -803,9 +783,9 @@ let (extract_typ_abbrev :
                         let body1 =
                           let uu___3 =
                             FStar_Extraction_ML_Term.term_as_mlty env1 body in
-                          FStar_Compiler_Effect.op_Bar_Greater uu___3
-                            (FStar_Extraction_ML_Util.eraseTypeDeep
-                               (FStar_Extraction_ML_Util.udelta_unfold env1)) in
+                          FStar_Extraction_ML_Util.eraseTypeDeep
+                            (FStar_Extraction_ML_Util.udelta_unfold env1)
+                            uu___3 in
                         let metadata =
                           let has_val_decl =
                             FStar_Extraction_ML_UEnv.has_tydef_declaration
@@ -825,13 +805,12 @@ let (extract_typ_abbrev :
                         let tyscheme = (ml_bs, body1) in
                         let uu___3 =
                           let uu___4 =
-                            FStar_Compiler_Effect.op_Bar_Greater quals
-                              (FStar_Compiler_Util.for_some
-                                 (fun uu___5 ->
-                                    match uu___5 with
-                                    | FStar_Syntax_Syntax.Assumption -> true
-                                    | FStar_Syntax_Syntax.New -> true
-                                    | uu___6 -> false)) in
+                            FStar_Compiler_Util.for_some
+                              (fun uu___5 ->
+                                 match uu___5 with
+                                 | FStar_Syntax_Syntax.Assumption -> true
+                                 | FStar_Syntax_Syntax.New -> true
+                                 | uu___6 -> false) quals in
                           if uu___4
                           then
                             let uu___5 =
@@ -969,9 +948,8 @@ let (extract_bundle_iface :
         match uu___ with
         | (env_iparams, vars) ->
             let uu___1 =
-              FStar_Compiler_Effect.op_Bar_Greater ind.idatas
-                (FStar_Compiler_Util.fold_map (extract_ctor env_iparams vars)
-                   env1) in
+              FStar_Compiler_Util.fold_map (extract_ctor env_iparams vars)
+                env1 ind.idatas in
             (match uu___1 with
              | (env2, ctors) ->
                  let env3 =
@@ -1072,12 +1050,11 @@ let (extract_type_declaration :
               fun t ->
                 let uu___ =
                   let uu___1 =
-                    FStar_Compiler_Effect.op_Bar_Greater quals
-                      (FStar_Compiler_Util.for_some
-                         (fun uu___2 ->
-                            match uu___2 with
-                            | FStar_Syntax_Syntax.Assumption -> true
-                            | uu___3 -> false)) in
+                    FStar_Compiler_Util.for_some
+                      (fun uu___2 ->
+                         match uu___2 with
+                         | FStar_Syntax_Syntax.Assumption -> true
+                         | uu___3 -> false) quals in
                   Prims.op_Negation uu___1 in
                 if uu___
                 then
@@ -1161,10 +1138,8 @@ let (extract_reifiable_effect :
              (FStar_Extraction_ML_Syntax.NonRec, [lb]))) in
       let rec extract_fv tm =
         (let uu___1 =
-           let uu___2 =
-             let uu___3 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
-             FStar_TypeChecker_Env.debug uu___3 in
-           FStar_Compiler_Effect.op_Less_Bar uu___2
+           let uu___2 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
+           FStar_TypeChecker_Env.debug uu___2
              (FStar_Options.Other "ExtractionReify") in
          if uu___1
          then
@@ -1187,12 +1162,9 @@ let (extract_reifiable_effect :
               | { FStar_Extraction_ML_UEnv.exp_b_name = uu___3;
                   FStar_Extraction_ML_UEnv.exp_b_expr = uu___4;
                   FStar_Extraction_ML_UEnv.exp_b_tscheme = tysc;_} ->
-                  let uu___5 =
-                    FStar_Compiler_Effect.op_Less_Bar
-                      (FStar_Extraction_ML_Syntax.with_ty
-                         FStar_Extraction_ML_Syntax.MLTY_Top)
-                      (FStar_Extraction_ML_Syntax.MLE_Name mlp) in
-                  (uu___5, tysc))
+                  ((FStar_Extraction_ML_Syntax.with_ty
+                      FStar_Extraction_ML_Syntax.MLTY_Top
+                      (FStar_Extraction_ML_Syntax.MLE_Name mlp)), tysc))
          | uu___2 ->
              let uu___3 =
                let uu___4 =
@@ -1203,10 +1175,8 @@ let (extract_reifiable_effect :
              FStar_Compiler_Effect.failwith uu___3) in
       let extract_action g1 a =
         (let uu___1 =
-           let uu___2 =
-             let uu___3 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g1 in
-             FStar_TypeChecker_Env.debug uu___3 in
-           FStar_Compiler_Effect.op_Less_Bar uu___2
+           let uu___2 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g1 in
+           FStar_TypeChecker_Env.debug uu___2
              (FStar_Options.Other "ExtractionReify") in
          if uu___1
          then
@@ -1265,10 +1235,8 @@ let (extract_reifiable_effect :
                    | (a_nm, a_lid, exp_b, g2) ->
                        ((let uu___6 =
                            let uu___7 =
-                             let uu___8 =
-                               FStar_Extraction_ML_UEnv.tcenv_of_uenv g2 in
-                             FStar_TypeChecker_Env.debug uu___8 in
-                           FStar_Compiler_Effect.op_Less_Bar uu___7
+                             FStar_Extraction_ML_UEnv.tcenv_of_uenv g2 in
+                           FStar_TypeChecker_Env.debug uu___7
                              (FStar_Options.Other "ExtractionReify") in
                          if uu___6
                          then
@@ -1280,10 +1248,8 @@ let (extract_reifiable_effect :
                          else ());
                         (let uu___7 =
                            let uu___8 =
-                             let uu___9 =
-                               FStar_Extraction_ML_UEnv.tcenv_of_uenv g2 in
-                             FStar_TypeChecker_Env.debug uu___9 in
-                           FStar_Compiler_Effect.op_Less_Bar uu___8
+                             FStar_Extraction_ML_UEnv.tcenv_of_uenv g2 in
+                           FStar_TypeChecker_Env.debug uu___8
                              (FStar_Options.Other "ExtractionReify") in
                          if uu___7
                          then
@@ -1305,13 +1271,9 @@ let (extract_reifiable_effect :
         let uu___1 =
           let uu___2 =
             let uu___3 =
-              let uu___4 =
-                FStar_Compiler_Effect.op_Bar_Greater ed
-                  FStar_Syntax_Util.get_return_repr in
-              FStar_Compiler_Effect.op_Bar_Greater uu___4
-                FStar_Compiler_Util.must in
-            FStar_Compiler_Effect.op_Bar_Greater uu___3
-              FStar_Pervasives_Native.snd in
+              let uu___4 = FStar_Syntax_Util.get_return_repr ed in
+              FStar_Compiler_Util.must uu___4 in
+            FStar_Pervasives_Native.snd uu___3 in
           extract_fv uu___2 in
         match uu___1 with
         | (return_tm, ty_sc) ->
@@ -1329,13 +1291,9 @@ let (extract_reifiable_effect :
             let uu___2 =
               let uu___3 =
                 let uu___4 =
-                  let uu___5 =
-                    FStar_Compiler_Effect.op_Bar_Greater ed
-                      FStar_Syntax_Util.get_bind_repr in
-                  FStar_Compiler_Effect.op_Bar_Greater uu___5
-                    FStar_Compiler_Util.must in
-                FStar_Compiler_Effect.op_Bar_Greater uu___4
-                  FStar_Pervasives_Native.snd in
+                  let uu___5 = FStar_Syntax_Util.get_bind_repr ed in
+                  FStar_Compiler_Util.must uu___5 in
+                FStar_Pervasives_Native.snd uu___4 in
               extract_fv uu___3 in
             match uu___2 with
             | (bind_tm, ty_sc) ->
@@ -1469,11 +1427,9 @@ let (split_let_rec_types_and_terms :
                     FStar_Compiler_List.map
                       (fun lb1 ->
                          let uu___4 =
-                           FStar_Compiler_Effect.op_Bar_Greater
-                             lb1.FStar_Syntax_Syntax.lbname
-                             FStar_Compiler_Util.right in
-                         FStar_Compiler_Effect.op_Bar_Greater uu___4
-                           FStar_Syntax_Syntax.lid_of_fv) lbs1 in
+                           FStar_Compiler_Util.right
+                             lb1.FStar_Syntax_Syntax.lbname in
+                         FStar_Syntax_Syntax.lid_of_fv uu___4) lbs1 in
                   {
                     FStar_Syntax_Syntax.lbs1 = (true, lbs1);
                     FStar_Syntax_Syntax.lids1 = uu___3
@@ -1540,11 +1496,8 @@ let (extract_let_rec_types :
            match uu___2 with
            | (env1, iface_opt, impls) ->
                let uu___3 = FStar_Compiler_Option.get iface_opt in
-               let uu___4 =
-                 FStar_Compiler_Effect.op_Bar_Greater
-                   (FStar_Compiler_List.rev impls)
-                   FStar_Compiler_List.flatten in
-               (env1, uu___3, uu___4))
+               (env1, uu___3,
+                 (FStar_Compiler_List.flatten (FStar_Compiler_List.rev impls))))
 let (get_noextract_to :
   FStar_Syntax_Syntax.sigelt ->
     FStar_Options.codegen_t FStar_Pervasives_Native.option -> Prims.bool)
@@ -1666,13 +1619,11 @@ let rec (extract_sigelt_iface :
              FStar_Extraction_ML_Term.is_arity g lb.FStar_Syntax_Syntax.lbtyp
              ->
              let uu___3 =
-               FStar_Compiler_Effect.op_Bar_Greater
-                 se1.FStar_Syntax_Syntax.sigquals
-                 (FStar_Compiler_Util.for_some
-                    (fun uu___4 ->
-                       match uu___4 with
-                       | FStar_Syntax_Syntax.Projector uu___5 -> true
-                       | uu___5 -> false)) in
+               FStar_Compiler_Util.for_some
+                 (fun uu___4 ->
+                    match uu___4 with
+                    | FStar_Syntax_Syntax.Projector uu___5 -> true
+                    | uu___5 -> false) se1.FStar_Syntax_Syntax.sigquals in
              if uu___3
              then (g, empty_iface)
              else
@@ -1721,9 +1672,8 @@ let rec (extract_sigelt_iface :
              ->
              let quals = se1.FStar_Syntax_Syntax.sigquals in
              let uu___3 =
-               (FStar_Compiler_Effect.op_Bar_Greater quals
-                  (FStar_Compiler_List.contains
-                     FStar_Syntax_Syntax.Assumption))
+               (FStar_Compiler_List.contains FStar_Syntax_Syntax.Assumption
+                  quals)
                  &&
                  (let uu___4 =
                     let uu___5 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
@@ -1847,8 +1797,7 @@ let (extract_iface' :
                        | (g2, iface') ->
                            let uu___5 = iface_union iface2 iface' in
                            (g2, uu___5))) (g, iface1) decls in
-         (let uu___4 = FStar_Options.restore_cmd_line_options true in
-          FStar_Compiler_Effect.op_Less_Bar (fun uu___5 -> ()) uu___4);
+         (let uu___4 = FStar_Options.restore_cmd_line_options true in ());
          res)
 let (extract_iface :
   FStar_Extraction_ML_UEnv.uenv ->
@@ -1974,9 +1923,8 @@ let (extract_bundle :
         match uu___ with
         | (env_iparams, vars) ->
             let uu___1 =
-              FStar_Compiler_Effect.op_Bar_Greater ind.idatas
-                (FStar_Compiler_Util.fold_map (extract_ctor env_iparams vars)
-                   env1) in
+              FStar_Compiler_Util.fold_map (extract_ctor env_iparams vars)
+                env1 ind.idatas in
             (match uu___1 with
              | (env2, ctors) ->
                  let uu___2 = FStar_Syntax_Util.arrow_formals ind.ityp in
@@ -1984,13 +1932,12 @@ let (extract_bundle :
                   | (indices, uu___3) ->
                       let ml_params =
                         let uu___4 =
-                          FStar_Compiler_Effect.op_Bar_Greater indices
-                            (FStar_Compiler_List.mapi
-                               (fun i ->
-                                  fun uu___5 ->
-                                    let uu___6 =
-                                      FStar_Compiler_Util.string_of_int i in
-                                    Prims.strcat "'dummyV" uu___6)) in
+                          FStar_Compiler_List.mapi
+                            (fun i ->
+                               fun uu___5 ->
+                                 let uu___6 =
+                                   FStar_Compiler_Util.string_of_int i in
+                                 Prims.strcat "'dummyV" uu___6) indices in
                         FStar_Compiler_List.append vars uu___4 in
                       let uu___4 =
                         let uu___5 =
@@ -2204,13 +2151,11 @@ let rec (extract_sig :
                      lb.FStar_Syntax_Syntax.lbtyp
                    ->
                    let uu___6 =
-                     FStar_Compiler_Effect.op_Bar_Greater
-                       se1.FStar_Syntax_Syntax.sigquals
-                       (FStar_Compiler_Util.for_some
-                          (fun uu___7 ->
-                             match uu___7 with
-                             | FStar_Syntax_Syntax.Projector uu___8 -> true
-                             | uu___8 -> false)) in
+                     FStar_Compiler_Util.for_some
+                       (fun uu___7 ->
+                          match uu___7 with
+                          | FStar_Syntax_Syntax.Projector uu___8 -> true
+                          | uu___8 -> false) se1.FStar_Syntax_Syntax.sigquals in
                    if uu___6
                    then (g, [])
                    else
@@ -2346,9 +2291,8 @@ let rec (extract_sig :
                    ->
                    let quals = se1.FStar_Syntax_Syntax.sigquals in
                    let uu___6 =
-                     (FStar_Compiler_Effect.op_Bar_Greater quals
-                        (FStar_Compiler_List.contains
-                           FStar_Syntax_Syntax.Assumption))
+                     (FStar_Compiler_List.contains
+                        FStar_Syntax_Syntax.Assumption quals)
                        &&
                        (let uu___7 =
                           let uu___8 =
@@ -2730,60 +2674,58 @@ and (extract_sig_let :
                                        FStar_Syntax_Syntax.lbattrs = uu___13;
                                        FStar_Syntax_Syntax.lbpos = uu___14;_})
                                       ->
-                                      let uu___15 =
-                                        FStar_Compiler_Effect.op_Bar_Greater
+                                      if
+                                        FStar_Compiler_List.contains
+                                          FStar_Extraction_ML_Syntax.Erased
                                           ml_lb.FStar_Extraction_ML_Syntax.mllb_meta
-                                          (FStar_Compiler_List.contains
-                                             FStar_Extraction_ML_Syntax.Erased) in
-                                      if uu___15
                                       then (env, ml_lbs)
                                       else
                                         (let lb_lid =
-                                           let uu___17 =
-                                             let uu___18 =
+                                           let uu___16 =
+                                             let uu___17 =
                                                FStar_Compiler_Util.right
                                                  lbname in
-                                             uu___18.FStar_Syntax_Syntax.fv_name in
-                                           uu___17.FStar_Syntax_Syntax.v in
+                                             uu___17.FStar_Syntax_Syntax.fv_name in
+                                           uu___16.FStar_Syntax_Syntax.v in
                                          let flags'' =
-                                           let uu___17 =
-                                             let uu___18 =
+                                           let uu___16 =
+                                             let uu___17 =
                                                FStar_Syntax_Subst.compress t in
-                                             uu___18.FStar_Syntax_Syntax.n in
-                                           match uu___17 with
+                                             uu___17.FStar_Syntax_Syntax.n in
+                                           match uu___16 with
                                            | FStar_Syntax_Syntax.Tm_arrow
                                                {
                                                  FStar_Syntax_Syntax.bs1 =
-                                                   uu___18;
+                                                   uu___17;
                                                  FStar_Syntax_Syntax.comp =
                                                    {
                                                      FStar_Syntax_Syntax.n =
                                                        FStar_Syntax_Syntax.Comp
                                                        {
                                                          FStar_Syntax_Syntax.comp_univs
-                                                           = uu___19;
+                                                           = uu___18;
                                                          FStar_Syntax_Syntax.effect_name
                                                            = e;
                                                          FStar_Syntax_Syntax.result_typ
-                                                           = uu___20;
+                                                           = uu___19;
                                                          FStar_Syntax_Syntax.effect_args
-                                                           = uu___21;
+                                                           = uu___20;
                                                          FStar_Syntax_Syntax.flags
-                                                           = uu___22;_};
+                                                           = uu___21;_};
                                                      FStar_Syntax_Syntax.pos
-                                                       = uu___23;
+                                                       = uu___22;
                                                      FStar_Syntax_Syntax.vars
-                                                       = uu___24;
+                                                       = uu___23;
                                                      FStar_Syntax_Syntax.hash_code
-                                                       = uu___25;_};_}
+                                                       = uu___24;_};_}
                                                when
-                                               let uu___26 =
+                                               let uu___25 =
                                                  FStar_Ident.string_of_lid e in
-                                               uu___26 =
+                                               uu___25 =
                                                  "FStar.HyperStack.ST.StackInline"
                                                ->
                                                [FStar_Extraction_ML_Syntax.StackInline]
-                                           | uu___18 -> [] in
+                                           | uu___17 -> [] in
                                          let meta =
                                            FStar_Compiler_List.op_At flags
                                              (FStar_Compiler_List.op_At
@@ -2808,30 +2750,28 @@ and (extract_sig_let :
                                                =
                                                (ml_lb.FStar_Extraction_ML_Syntax.print_typ)
                                            } in
-                                         let uu___17 =
-                                           let uu___18 =
-                                             FStar_Compiler_Effect.op_Bar_Greater
-                                               quals
-                                               (FStar_Compiler_Util.for_some
-                                                  (fun uu___19 ->
-                                                     match uu___19 with
-                                                     | FStar_Syntax_Syntax.Projector
-                                                         uu___20 -> true
-                                                     | uu___20 -> false)) in
-                                           if uu___18
+                                         let uu___16 =
+                                           let uu___17 =
+                                             FStar_Compiler_Util.for_some
+                                               (fun uu___18 ->
+                                                  match uu___18 with
+                                                  | FStar_Syntax_Syntax.Projector
+                                                      uu___19 -> true
+                                                  | uu___19 -> false) quals in
+                                           if uu___17
                                            then
-                                             let uu___19 =
-                                               let uu___20 =
+                                             let uu___18 =
+                                               let uu___19 =
                                                  FStar_Compiler_Util.right
                                                    lbname in
-                                               let uu___21 =
+                                               let uu___20 =
                                                  FStar_Compiler_Util.must
                                                    ml_lb1.FStar_Extraction_ML_Syntax.mllb_tysc in
                                                FStar_Extraction_ML_UEnv.extend_fv
-                                                 env uu___20 uu___21
+                                                 env uu___19 uu___20
                                                  ml_lb1.FStar_Extraction_ML_Syntax.mllb_add_unit in
-                                             match uu___19 with
-                                             | (env1, mls, uu___20) ->
+                                             match uu___18 with
+                                             | (env1, mls, uu___19) ->
                                                  (env1,
                                                    {
                                                      FStar_Extraction_ML_Syntax.mllb_name
@@ -2853,17 +2793,17 @@ and (extract_sig_let :
                                                        (ml_lb1.FStar_Extraction_ML_Syntax.print_typ)
                                                    })
                                            else
-                                             (let uu___20 =
-                                                let uu___21 =
+                                             (let uu___19 =
+                                                let uu___20 =
                                                   FStar_Compiler_Util.must
                                                     ml_lb1.FStar_Extraction_ML_Syntax.mllb_tysc in
                                                 FStar_Extraction_ML_UEnv.extend_lb
-                                                  env lbname t uu___21
+                                                  env lbname t uu___20
                                                   ml_lb1.FStar_Extraction_ML_Syntax.mllb_add_unit in
-                                              match uu___20 with
-                                              | (env1, uu___21, uu___22) ->
+                                              match uu___19 with
+                                              | (env1, uu___20, uu___21) ->
                                                   (env1, ml_lb1)) in
-                                         match uu___17 with
+                                         match uu___16 with
                                          | (g1, ml_lb2) ->
                                              (g1, (ml_lb2 :: ml_lbs))))
                            (g, []) bindings (FStar_Pervasives_Native.snd lbs) in
@@ -2929,11 +2869,9 @@ let (extract' :
                    then
                      let nm =
                        let uu___4 =
-                         FStar_Compiler_Effect.op_Bar_Greater
-                           (FStar_Syntax_Util.lids_of_sigelt se)
-                           (FStar_Compiler_List.map FStar_Ident.string_of_lid) in
-                       FStar_Compiler_Effect.op_Bar_Greater uu___4
-                         (FStar_Compiler_String.concat ", ") in
+                         FStar_Compiler_List.map FStar_Ident.string_of_lid
+                           (FStar_Syntax_Util.lids_of_sigelt se) in
+                       FStar_Compiler_String.concat ", " uu___4 in
                      (FStar_Compiler_Util.print1 "+++About to extract {%s}\n"
                         nm;
                       (let uu___5 =
@@ -2980,8 +2918,7 @@ let (extract :
   =
   fun g ->
     fun m ->
-      (let uu___1 = FStar_Options.restore_cmd_line_options true in
-       FStar_Compiler_Effect.op_Less_Bar (fun uu___2 -> ()) uu___1);
+      (let uu___1 = FStar_Options.restore_cmd_line_options true in ());
       (let tgt =
          let uu___1 = FStar_Options.codegen () in
          match uu___1 with
@@ -3035,7 +2972,6 @@ let (extract :
                 | (g2, mllib1) ->
                     ((let uu___7 =
                         FStar_Options.restore_cmd_line_options true in
-                      FStar_Compiler_Effect.op_Less_Bar (fun uu___8 -> ())
-                        uu___7);
+                      ());
                      (let uu___7 = FStar_Extraction_ML_UEnv.exit_module g2 in
                       (uu___7, mllib1)))))))

--- a/ocaml/fstar-lib/generated/FStar_Extraction_ML_RegEmb.ml
+++ b/ocaml/fstar-lib/generated/FStar_Extraction_ML_RegEmb.ml
@@ -53,7 +53,7 @@ let (ml_lam :
   =
   fun nm ->
     fun e ->
-      FStar_Compiler_Effect.op_Less_Bar mk
+      mk
         (FStar_Extraction_ML_Syntax.MLE_Fun
            ([(nm, FStar_Extraction_ML_Syntax.MLTY_Top)], e))
 let (ml_none : FStar_Extraction_ML_Syntax.mlexpr) =
@@ -99,23 +99,16 @@ let (ml_magic : FStar_Extraction_ML_Syntax.mlexpr) =
 let (as_name :
   FStar_Extraction_ML_Syntax.mlpath -> FStar_Extraction_ML_Syntax.mlexpr) =
   fun mlp ->
-    FStar_Compiler_Effect.op_Less_Bar
-      (FStar_Extraction_ML_Syntax.with_ty FStar_Extraction_ML_Syntax.MLTY_Top)
+    FStar_Extraction_ML_Syntax.with_ty FStar_Extraction_ML_Syntax.MLTY_Top
       (FStar_Extraction_ML_Syntax.MLE_Name mlp)
 let (ml_failwith : Prims.string -> FStar_Extraction_ML_Syntax.mlexpr) =
   fun s ->
-    let uu___ =
-      let uu___1 =
-        let uu___2 = as_name ([], "failwith") in
-        let uu___3 =
-          let uu___4 =
-            FStar_Compiler_Effect.op_Less_Bar mk
+    mk
+      (FStar_Extraction_ML_Syntax.MLE_App
+         ((as_name ([], "failwith")),
+           [mk
               (FStar_Extraction_ML_Syntax.MLE_Const
-                 (FStar_Extraction_ML_Syntax.MLC_String s)) in
-          [uu___4] in
-        (uu___2, uu___3) in
-      FStar_Extraction_ML_Syntax.MLE_App uu___1 in
-    FStar_Compiler_Effect.op_Less_Bar mk uu___
+                 (FStar_Extraction_ML_Syntax.MLC_String s))]))
 let rec (as_ml_list :
   FStar_Extraction_ML_Syntax.mlexpr Prims.list ->
     FStar_Extraction_ML_Syntax.mlexpr)
@@ -160,7 +153,7 @@ let (not_implemented_warning :
                   FStar_Errors.lookup
                     FStar_Errors_Codes.Warning_PluginNotImplemented in
                 FStar_Errors.error_number uu___4 in
-              FStar_Compiler_Effect.op_Less_Bar Prims.string_of_int uu___3 in
+              Prims.string_of_int uu___3 in
             FStar_Compiler_Util.format3
               "Plugin `%s' can not run natively because %s (use --warn_error -%s to carry on)."
               t msg uu___2 in
@@ -1123,12 +1116,8 @@ let rec (embedding_for :
                       FStar_Compiler_Util.find_opt (find_env_entry bv) env in
                     FStar_Compiler_Util.must uu___1 in
                   FStar_Pervasives_Native.snd uu___ in
-                let uu___ =
-                  let uu___1 =
-                    let uu___2 = let uu___3 = str_to_name s in [uu___3] in
-                    (comb, uu___2) in
-                  FStar_Extraction_ML_Syntax.MLE_App uu___1 in
-                FStar_Compiler_Effect.op_Less_Bar mk uu___
+                mk
+                  (FStar_Extraction_ML_Syntax.MLE_App (comb, [str_to_name s]))
             | FStar_Syntax_Syntax.Tm_refine
                 { FStar_Syntax_Syntax.b = x;
                   FStar_Syntax_Syntax.phi = uu___;_}
@@ -1185,8 +1174,7 @@ let rec (embedding_for :
                             match uu___2 with
                             | (t4, uu___3) ->
                                 embedding_for tcenv mutuals k env t4) args in
-                     FStar_Compiler_Effect.op_Less_Bar mk
-                       (FStar_Extraction_ML_Syntax.MLE_App (e_head, e_args)))
+                     mk (FStar_Extraction_ML_Syntax.MLE_App (e_head, e_args)))
             | FStar_Syntax_Syntax.Tm_fvar fv when
                 FStar_Compiler_List.existsb
                   (FStar_Ident.lid_equals
@@ -1203,7 +1191,7 @@ let rec (embedding_for :
                         FStar_Ident.string_of_id uu___3 in
                       Prims.strcat "__knot_e_" uu___2 in
                     FStar_Extraction_ML_Syntax.MLE_Var uu___1 in
-                  FStar_Compiler_Effect.op_Less_Bar mk uu___ in
+                  mk uu___ in
                 mk
                   (FStar_Extraction_ML_Syntax.MLE_App
                      (head, [FStar_Extraction_ML_Syntax.ml_unit]))
@@ -1288,38 +1276,33 @@ let (interpret_plugin_as_term_fun :
                   FStar_Syntax_Syntax.delta_constant;
                 FStar_TypeChecker_Env.ForExtraction] tcenv t in
             let as_name1 mlp =
-              FStar_Compiler_Effect.op_Less_Bar
-                (FStar_Extraction_ML_Syntax.with_ty
-                   FStar_Extraction_ML_Syntax.MLTY_Top)
+              FStar_Extraction_ML_Syntax.with_ty
+                FStar_Extraction_ML_Syntax.MLTY_Top
                 (FStar_Extraction_ML_Syntax.MLE_Name mlp) in
             let lid_to_name l =
               let uu___ =
                 let uu___1 = FStar_Extraction_ML_UEnv.mlpath_of_lident env l in
                 FStar_Extraction_ML_Syntax.MLE_Name uu___1 in
-              FStar_Compiler_Effect.op_Less_Bar
-                (FStar_Extraction_ML_Syntax.with_ty
-                   FStar_Extraction_ML_Syntax.MLTY_Top) uu___ in
+              FStar_Extraction_ML_Syntax.with_ty
+                FStar_Extraction_ML_Syntax.MLTY_Top uu___ in
             let str_to_name s = as_name1 ([], s) in
             let fv_lid_embedded =
               let uu___ =
                 let uu___1 =
-                  let uu___2 = as_name1 (["FStar_Ident"], "lid_of_str") in
-                  let uu___3 =
-                    let uu___4 =
-                      let uu___5 =
-                        let uu___6 =
-                          let uu___7 = FStar_Ident.string_of_lid fv_lid in
-                          FStar_Extraction_ML_Syntax.MLC_String uu___7 in
-                        FStar_Extraction_ML_Syntax.MLE_Const uu___6 in
-                      FStar_Compiler_Effect.op_Less_Bar
-                        (FStar_Extraction_ML_Syntax.with_ty
-                           FStar_Extraction_ML_Syntax.MLTY_Top) uu___5 in
-                    [uu___4] in
-                  (uu___2, uu___3) in
+                  let uu___2 =
+                    let uu___3 =
+                      let uu___4 =
+                        let uu___5 =
+                          let uu___6 = FStar_Ident.string_of_lid fv_lid in
+                          FStar_Extraction_ML_Syntax.MLC_String uu___6 in
+                        FStar_Extraction_ML_Syntax.MLE_Const uu___5 in
+                      FStar_Extraction_ML_Syntax.with_ty
+                        FStar_Extraction_ML_Syntax.MLTY_Top uu___4 in
+                    [uu___3] in
+                  ((as_name1 (["FStar_Ident"], "lid_of_str")), uu___2) in
                 FStar_Extraction_ML_Syntax.MLE_App uu___1 in
-              FStar_Compiler_Effect.op_Less_Bar
-                (FStar_Extraction_ML_Syntax.with_ty
-                   FStar_Extraction_ML_Syntax.MLTY_Top) uu___ in
+              FStar_Extraction_ML_Syntax.with_ty
+                FStar_Extraction_ML_Syntax.MLTY_Top uu___ in
             let mk_tactic_interpretation l arity =
               if arity > FStar_Tactics_V2_InterpFuns.max_tac_arity
               then
@@ -1358,35 +1341,24 @@ let (interpret_plugin_as_term_fun :
                     let uu___ =
                       let uu___1 =
                         let uu___2 =
-                          as_name1
-                            (["FStar_Syntax_Embeddings"], "debug_wrap") in
-                        let uu___3 =
-                          let uu___4 =
-                            let uu___5 =
-                              let uu___6 =
-                                let uu___7 = FStar_Ident.string_of_lid fv_lid in
-                                FStar_Extraction_ML_Syntax.MLC_String uu___7 in
-                              FStar_Extraction_ML_Syntax.MLE_Const uu___6 in
-                            FStar_Compiler_Effect.op_Less_Bar
-                              (FStar_Extraction_ML_Syntax.with_ty
-                                 FStar_Extraction_ML_Syntax.MLTY_Top) uu___5 in
-                          let uu___5 =
-                            let uu___6 =
-                              let uu___7 =
-                                let uu___8 =
-                                  let uu___9 =
-                                    let uu___10 =
-                                      let uu___11 = str_to_name "args" in
-                                      [uu___11] in
-                                    (body, uu___10) in
-                                  FStar_Extraction_ML_Syntax.MLE_App uu___9 in
-                                FStar_Compiler_Effect.op_Less_Bar mk uu___8 in
-                              ml_lam "_" uu___7 in
-                            [uu___6] in
-                          uu___4 :: uu___5 in
-                        (uu___2, uu___3) in
+                          let uu___3 =
+                            let uu___4 =
+                              let uu___5 =
+                                let uu___6 = FStar_Ident.string_of_lid fv_lid in
+                                FStar_Extraction_ML_Syntax.MLC_String uu___6 in
+                              FStar_Extraction_ML_Syntax.MLE_Const uu___5 in
+                            FStar_Extraction_ML_Syntax.with_ty
+                              FStar_Extraction_ML_Syntax.MLTY_Top uu___4 in
+                          [uu___3;
+                          ml_lam "_"
+                            (mk
+                               (FStar_Extraction_ML_Syntax.MLE_App
+                                  (body, [str_to_name "args"])))] in
+                        ((as_name1
+                            (["FStar_Syntax_Embeddings"], "debug_wrap")),
+                          uu___2) in
                       FStar_Extraction_ML_Syntax.MLE_App uu___1 in
-                    FStar_Compiler_Effect.op_Less_Bar mk uu___ in
+                    mk uu___ in
                   ml_lam "args" body1
               | uu___ ->
                   let args_tail =
@@ -1403,61 +1375,42 @@ let (interpret_plugin_as_term_fun :
                       (fun hd_var -> mk_cons (fst_pat hd_var)) tvar_names
                       args_tail in
                   let branch =
-                    let uu___1 =
-                      let uu___2 =
-                        let uu___3 =
-                          let uu___4 =
-                            let uu___5 = as_name1 ([], "args") in [uu___5] in
-                          (body, uu___4) in
-                        FStar_Extraction_ML_Syntax.MLE_App uu___3 in
-                      FStar_Compiler_Effect.op_Less_Bar mk uu___2 in
-                    (pattern, FStar_Pervasives_Native.None, uu___1) in
+                    (pattern, FStar_Pervasives_Native.None,
+                      (mk
+                         (FStar_Extraction_ML_Syntax.MLE_App
+                            (body, [as_name1 ([], "args")])))) in
                   let default_branch =
-                    let uu___1 =
-                      let uu___2 =
-                        let uu___3 =
-                          let uu___4 = str_to_name "failwith" in
-                          let uu___5 =
-                            let uu___6 =
-                              FStar_Compiler_Effect.op_Less_Bar mk
-                                (FStar_Extraction_ML_Syntax.MLE_Const
-                                   (FStar_Extraction_ML_Syntax.MLC_String
-                                      "arity mismatch")) in
-                            [uu___6] in
-                          (uu___4, uu___5) in
-                        FStar_Extraction_ML_Syntax.MLE_App uu___3 in
-                      FStar_Compiler_Effect.op_Less_Bar mk uu___2 in
                     (FStar_Extraction_ML_Syntax.MLP_Wild,
-                      FStar_Pervasives_Native.None, uu___1) in
+                      FStar_Pervasives_Native.None,
+                      (mk
+                         (FStar_Extraction_ML_Syntax.MLE_App
+                            ((str_to_name "failwith"),
+                              [mk
+                                 (FStar_Extraction_ML_Syntax.MLE_Const
+                                    (FStar_Extraction_ML_Syntax.MLC_String
+                                       "arity mismatch"))])))) in
                   let body1 =
-                    let uu___1 =
-                      let uu___2 =
-                        let uu___3 = as_name1 ([], "args") in
-                        (uu___3, [branch; default_branch]) in
-                      FStar_Extraction_ML_Syntax.MLE_Match uu___2 in
-                    FStar_Compiler_Effect.op_Less_Bar mk uu___1 in
+                    mk
+                      (FStar_Extraction_ML_Syntax.MLE_Match
+                         ((as_name1 ([], "args")), [branch; default_branch])) in
                   let body2 =
                     let uu___1 =
                       let uu___2 =
                         let uu___3 =
-                          as_name1
-                            (["FStar_Syntax_Embeddings"], "debug_wrap") in
-                        let uu___4 =
-                          let uu___5 =
-                            let uu___6 =
-                              let uu___7 =
-                                let uu___8 = FStar_Ident.string_of_lid fv_lid in
-                                FStar_Extraction_ML_Syntax.MLC_String uu___8 in
-                              FStar_Extraction_ML_Syntax.MLE_Const uu___7 in
-                            FStar_Compiler_Effect.op_Less_Bar
-                              (FStar_Extraction_ML_Syntax.with_ty
-                                 FStar_Extraction_ML_Syntax.MLTY_Top) uu___6 in
-                          let uu___6 =
-                            let uu___7 = ml_lam "_" body1 in [uu___7] in
-                          uu___5 :: uu___6 in
-                        (uu___3, uu___4) in
+                          let uu___4 =
+                            let uu___5 =
+                              let uu___6 =
+                                let uu___7 = FStar_Ident.string_of_lid fv_lid in
+                                FStar_Extraction_ML_Syntax.MLC_String uu___7 in
+                              FStar_Extraction_ML_Syntax.MLE_Const uu___6 in
+                            FStar_Extraction_ML_Syntax.with_ty
+                              FStar_Extraction_ML_Syntax.MLTY_Top uu___5 in
+                          [uu___4; ml_lam "_" body1] in
+                        ((as_name1
+                            (["FStar_Syntax_Embeddings"], "debug_wrap")),
+                          uu___3) in
                       FStar_Extraction_ML_Syntax.MLE_App uu___2 in
-                    FStar_Compiler_Effect.op_Less_Bar mk uu___1 in
+                    mk uu___1 in
                   ml_lam "args" body2 in
             let uu___ = FStar_Syntax_Util.arrow_formals_comp t1 in
             match uu___ with
@@ -1477,8 +1430,7 @@ let (interpret_plugin_as_term_fun :
                            | (bs1, rest) ->
                                let c1 =
                                  let uu___4 = FStar_Syntax_Util.arrow rest c in
-                                 FStar_Compiler_Effect.op_Less_Bar
-                                   FStar_Syntax_Syntax.mk_Total uu___4 in
+                                 FStar_Syntax_Syntax.mk_Total uu___4 in
                                (bs1, c1))
                         else
                           (let msg =
@@ -1556,33 +1508,30 @@ let (interpret_plugin_as_term_fun :
                                     let uu___4 =
                                       let uu___5 =
                                         let uu___6 = lid_to_name fv_lid1 in
-                                        let uu___7 =
-                                          let uu___8 =
-                                            FStar_Compiler_Effect.op_Less_Bar
-                                              (FStar_Extraction_ML_Syntax.with_ty
-                                                 FStar_Extraction_ML_Syntax.MLTY_Top)
-                                              (FStar_Extraction_ML_Syntax.MLE_Const
-                                                 (FStar_Extraction_ML_Syntax.MLC_Int
-                                                    ((Prims.string_of_int
-                                                        tvar_arity),
-                                                      FStar_Pervasives_Native.None))) in
-                                          [uu___8; fv_lid_embedded; cb] in
-                                        uu___6 :: uu___7 in
+                                        [uu___6;
+                                        FStar_Extraction_ML_Syntax.with_ty
+                                          FStar_Extraction_ML_Syntax.MLTY_Top
+                                          (FStar_Extraction_ML_Syntax.MLE_Const
+                                             (FStar_Extraction_ML_Syntax.MLC_Int
+                                                ((Prims.string_of_int
+                                                    tvar_arity),
+                                                  FStar_Pervasives_Native.None)));
+                                        fv_lid_embedded;
+                                        cb] in
                                       res_embedding :: uu___5 in
                                     FStar_Compiler_List.op_At
                                       arg_unembeddings uu___4 in
                                   let fun_embedding =
-                                    FStar_Compiler_Effect.op_Less_Bar mk
+                                    mk
                                       (FStar_Extraction_ML_Syntax.MLE_App
                                          (embed_fun_N, args)) in
                                   let tabs =
                                     abstract_tvars tvar_names fun_embedding in
                                   let cb_tabs = ml_lam "cb" tabs in
-                                  let uu___4 =
-                                    if loc = NBETerm
-                                    then cb_tabs
-                                    else ml_lam "_psc" cb_tabs in
-                                  (uu___4, arity, true)
+                                  (((if loc = NBETerm
+                                     then cb_tabs
+                                     else ml_lam "_psc" cb_tabs)), arity,
+                                    true)
                                 else
                                   (let uu___5 =
                                      let uu___6 =
@@ -1601,17 +1550,13 @@ let (interpret_plugin_as_term_fun :
                                        let uu___6 =
                                          let uu___7 =
                                            let uu___8 =
-                                             mk_from_tactic loc
-                                               non_tvar_arity in
-                                           let uu___9 =
-                                             let uu___10 =
-                                               lid_to_name fv_lid1 in
-                                             [uu___10] in
-                                           (uu___8, uu___9) in
+                                             let uu___9 = lid_to_name fv_lid1 in
+                                             [uu___9] in
+                                           ((mk_from_tactic loc
+                                               non_tvar_arity), uu___8) in
                                          FStar_Extraction_ML_Syntax.MLE_App
                                            uu___7 in
-                                       FStar_Compiler_Effect.op_Less_Bar mk
-                                         uu___6 in
+                                       mk uu___6 in
                                      let psc = str_to_name "psc" in
                                      let ncb = str_to_name "ncb" in
                                      let all_args = str_to_name "args" in
@@ -1630,8 +1575,7 @@ let (interpret_plugin_as_term_fun :
                                                  uu___10 in
                                              FStar_Extraction_ML_Syntax.MLE_Const
                                                uu___9 in
-                                           FStar_Compiler_Effect.op_Less_Bar
-                                             mk uu___8 in
+                                           mk uu___8 in
                                          [uu___7] in
                                        FStar_Compiler_List.op_At uu___6
                                          (FStar_Compiler_List.op_At [tac_fun]
@@ -1641,25 +1585,19 @@ let (interpret_plugin_as_term_fun :
                                      let tabs =
                                        match tvar_names with
                                        | [] ->
-                                           let uu___6 =
-                                             FStar_Compiler_Effect.op_Less_Bar
-                                               mk
-                                               (FStar_Extraction_ML_Syntax.MLE_App
-                                                  (h,
-                                                    (FStar_Compiler_List.op_At
-                                                       args [all_args]))) in
-                                           ml_lam "args" uu___6
+                                           ml_lam "args"
+                                             (mk
+                                                (FStar_Extraction_ML_Syntax.MLE_App
+                                                   (h,
+                                                     (FStar_Compiler_List.op_At
+                                                        args [all_args]))))
                                        | uu___6 ->
-                                           let uu___7 =
-                                             FStar_Compiler_Effect.op_Less_Bar
-                                               mk
-                                               (FStar_Extraction_ML_Syntax.MLE_App
-                                                  (h, args)) in
-                                           abstract_tvars tvar_names uu___7 in
-                                     let uu___6 =
-                                       let uu___7 = ml_lam "ncb" tabs in
-                                       ml_lam "psc" uu___7 in
-                                     (uu___6, (arity + Prims.int_one), false)
+                                           abstract_tvars tvar_names
+                                             (mk
+                                                (FStar_Extraction_ML_Syntax.MLE_App
+                                                   (h, args))) in
+                                     ((ml_lam "psc" (ml_lam "ncb" tabs)),
+                                       (arity + Prims.int_one), false)
                                    else
                                      (let uu___7 =
                                         let uu___8 =
@@ -1718,131 +1656,126 @@ let (mk_unembed :
         fun ctors ->
           let e_branches = FStar_Compiler_Util.mk_ref [] in
           let arg_v = fresh "tm" in
-          FStar_Compiler_Effect.op_Bar_Greater ctors
-            (FStar_Compiler_List.iter
-               (fun ctor ->
-                  match ctor.FStar_Syntax_Syntax.sigel with
-                  | FStar_Syntax_Syntax.Sig_datacon
-                      { FStar_Syntax_Syntax.lid1 = lid;
-                        FStar_Syntax_Syntax.us1 = us;
-                        FStar_Syntax_Syntax.t1 = t;
-                        FStar_Syntax_Syntax.ty_lid = ty_lid;
-                        FStar_Syntax_Syntax.num_ty_params = num_ty_params;
-                        FStar_Syntax_Syntax.mutuals1 = uu___1;_}
-                      ->
-                      let fv = fresh "fv" in
-                      let uu___2 = FStar_Syntax_Util.arrow_formals t in
-                      (match uu___2 with
-                       | (bs, c) ->
-                           let vs =
-                             FStar_Compiler_List.map
-                               (fun b ->
-                                  let uu___3 =
-                                    let uu___4 =
-                                      FStar_Ident.string_of_id
-                                        (b.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.ppname in
-                                    fresh uu___4 in
-                                  (uu___3,
-                                    ((b.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort)))
-                               bs in
-                           let pat_s =
-                             let uu___3 =
-                               let uu___4 = FStar_Ident.string_of_lid lid in
-                               FStar_Extraction_ML_Syntax.MLC_String uu___4 in
-                             FStar_Extraction_ML_Syntax.MLP_Const uu___3 in
-                           let pat_args =
-                             let uu___3 =
-                               FStar_Compiler_Effect.op_Bar_Greater vs
-                                 (FStar_Compiler_List.map
-                                    (fun uu___4 ->
+          FStar_Compiler_List.iter
+            (fun ctor ->
+               match ctor.FStar_Syntax_Syntax.sigel with
+               | FStar_Syntax_Syntax.Sig_datacon
+                   { FStar_Syntax_Syntax.lid1 = lid;
+                     FStar_Syntax_Syntax.us1 = us;
+                     FStar_Syntax_Syntax.t1 = t;
+                     FStar_Syntax_Syntax.ty_lid = ty_lid;
+                     FStar_Syntax_Syntax.num_ty_params = num_ty_params;
+                     FStar_Syntax_Syntax.mutuals1 = uu___1;_}
+                   ->
+                   let fv = fresh "fv" in
+                   let uu___2 = FStar_Syntax_Util.arrow_formals t in
+                   (match uu___2 with
+                    | (bs, c) ->
+                        let vs =
+                          FStar_Compiler_List.map
+                            (fun b ->
+                               let uu___3 =
+                                 let uu___4 =
+                                   FStar_Ident.string_of_id
+                                     (b.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.ppname in
+                                 fresh uu___4 in
+                               (uu___3,
+                                 ((b.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort)))
+                            bs in
+                        let pat_s =
+                          let uu___3 =
+                            let uu___4 = FStar_Ident.string_of_lid lid in
+                            FStar_Extraction_ML_Syntax.MLC_String uu___4 in
+                          FStar_Extraction_ML_Syntax.MLP_Const uu___3 in
+                        let pat_args =
+                          let uu___3 =
+                            FStar_Compiler_List.map
+                              (fun uu___4 ->
+                                 match uu___4 with
+                                 | (v, uu___5) ->
+                                     FStar_Extraction_ML_Syntax.MLP_Var v) vs in
+                          pats_to_list_pat uu___3 in
+                        let pat_both =
+                          FStar_Extraction_ML_Syntax.MLP_Tuple
+                            [pat_s; pat_args] in
+                        let ret =
+                          match record_fields with
+                          | FStar_Pervasives_Native.Some fields ->
+                              let uu___3 =
+                                FStar_Compiler_List.map2
+                                  (fun uu___4 ->
+                                     fun fld ->
                                        match uu___4 with
                                        | (v, uu___5) ->
-                                           FStar_Extraction_ML_Syntax.MLP_Var
-                                             v)) in
-                             FStar_Compiler_Effect.op_Bar_Greater uu___3
-                               pats_to_list_pat in
-                           let pat_both =
-                             FStar_Extraction_ML_Syntax.MLP_Tuple
-                               [pat_s; pat_args] in
-                           let ret =
-                             match record_fields with
-                             | FStar_Pervasives_Native.Some fields ->
-                                 let uu___3 =
-                                   FStar_Compiler_List.map2
-                                     (fun uu___4 ->
-                                        fun fld ->
-                                          match uu___4 with
-                                          | (v, uu___5) ->
-                                              ((FStar_Pervasives_Native.snd
-                                                  fld),
-                                                (mk
-                                                   (FStar_Extraction_ML_Syntax.MLE_Var
-                                                      v)))) vs fields in
-                                 ml_record lid uu___3
-                             | FStar_Pervasives_Native.None ->
-                                 let uu___3 =
-                                   FStar_Compiler_List.map
-                                     (fun uu___4 ->
-                                        match uu___4 with
-                                        | (v, uu___5) ->
-                                            mk
-                                              (FStar_Extraction_ML_Syntax.MLE_Var
-                                                 v)) vs in
-                                 ml_ctor lid uu___3 in
-                           let ret1 =
-                             mk
-                               (FStar_Extraction_ML_Syntax.MLE_App
-                                  (ml_some, [ret])) in
-                           let body =
-                             FStar_Compiler_List.fold_right
-                               (fun uu___3 ->
-                                  fun body1 ->
-                                    match uu___3 with
-                                    | (v, ty) ->
-                                        let body2 =
-                                          mk
-                                            (FStar_Extraction_ML_Syntax.MLE_Fun
-                                               ([(v,
-                                                   FStar_Extraction_ML_Syntax.MLTY_Top)],
-                                                 body1)) in
-                                        let uu___4 =
-                                          let uu___5 =
-                                            let uu___6 = ml_name bind_opt_lid in
-                                            let uu___7 =
-                                              let uu___8 =
-                                                let uu___9 =
-                                                  let uu___10 =
-                                                    let uu___11 =
-                                                      ml_name unembed_lid in
-                                                    let uu___12 =
-                                                      let uu___13 =
-                                                        embedding_for tcenv
-                                                          mutuals SyntaxTerm
-                                                          [] ty in
-                                                      [uu___13;
-                                                      mk
-                                                        (FStar_Extraction_ML_Syntax.MLE_Var
-                                                           v)] in
-                                                    (uu___11, uu___12) in
-                                                  FStar_Extraction_ML_Syntax.MLE_App
-                                                    uu___10 in
-                                                mk uu___9 in
-                                              [uu___8; body2] in
-                                            (uu___6, uu___7) in
-                                          FStar_Extraction_ML_Syntax.MLE_App
-                                            uu___5 in
-                                        mk uu___4) vs ret1 in
-                           let br =
-                             (pat_both, FStar_Pervasives_Native.None, body) in
-                           let uu___3 =
-                             let uu___4 =
-                               FStar_Compiler_Effect.op_Bang e_branches in
-                             br :: uu___4 in
-                           FStar_Compiler_Effect.op_Colon_Equals e_branches
-                             uu___3)
-                  | uu___1 ->
-                      FStar_Compiler_Effect.failwith
-                        "impossible, filter above"));
+                                           ((FStar_Pervasives_Native.snd fld),
+                                             (mk
+                                                (FStar_Extraction_ML_Syntax.MLE_Var
+                                                   v)))) vs fields in
+                              ml_record lid uu___3
+                          | FStar_Pervasives_Native.None ->
+                              let uu___3 =
+                                FStar_Compiler_List.map
+                                  (fun uu___4 ->
+                                     match uu___4 with
+                                     | (v, uu___5) ->
+                                         mk
+                                           (FStar_Extraction_ML_Syntax.MLE_Var
+                                              v)) vs in
+                              ml_ctor lid uu___3 in
+                        let ret1 =
+                          mk
+                            (FStar_Extraction_ML_Syntax.MLE_App
+                               (ml_some, [ret])) in
+                        let body =
+                          FStar_Compiler_List.fold_right
+                            (fun uu___3 ->
+                               fun body1 ->
+                                 match uu___3 with
+                                 | (v, ty) ->
+                                     let body2 =
+                                       mk
+                                         (FStar_Extraction_ML_Syntax.MLE_Fun
+                                            ([(v,
+                                                FStar_Extraction_ML_Syntax.MLTY_Top)],
+                                              body1)) in
+                                     let uu___4 =
+                                       let uu___5 =
+                                         let uu___6 = ml_name bind_opt_lid in
+                                         let uu___7 =
+                                           let uu___8 =
+                                             let uu___9 =
+                                               let uu___10 =
+                                                 let uu___11 =
+                                                   ml_name unembed_lid in
+                                                 let uu___12 =
+                                                   let uu___13 =
+                                                     embedding_for tcenv
+                                                       mutuals SyntaxTerm []
+                                                       ty in
+                                                   [uu___13;
+                                                   mk
+                                                     (FStar_Extraction_ML_Syntax.MLE_Var
+                                                        v)] in
+                                                 (uu___11, uu___12) in
+                                               FStar_Extraction_ML_Syntax.MLE_App
+                                                 uu___10 in
+                                             mk uu___9 in
+                                           [uu___8; body2] in
+                                         (uu___6, uu___7) in
+                                       FStar_Extraction_ML_Syntax.MLE_App
+                                         uu___5 in
+                                     mk uu___4) vs ret1 in
+                        let br =
+                          (pat_both, FStar_Pervasives_Native.None, body) in
+                        let uu___3 =
+                          let uu___4 =
+                            FStar_Compiler_Effect.op_Bang e_branches in
+                          br :: uu___4 in
+                        FStar_Compiler_Effect.op_Colon_Equals e_branches
+                          uu___3)
+               | uu___1 ->
+                   FStar_Compiler_Effect.failwith "impossible, filter above")
+            ctors;
           (let nomatch =
              (FStar_Extraction_ML_Syntax.MLP_Wild,
                FStar_Pervasives_Native.None, ml_none) in
@@ -1872,140 +1805,134 @@ let (mk_embed :
         fun ctors ->
           let e_branches = FStar_Compiler_Util.mk_ref [] in
           let arg_v = fresh "tm" in
-          FStar_Compiler_Effect.op_Bar_Greater ctors
-            (FStar_Compiler_List.iter
-               (fun ctor ->
-                  match ctor.FStar_Syntax_Syntax.sigel with
-                  | FStar_Syntax_Syntax.Sig_datacon
-                      { FStar_Syntax_Syntax.lid1 = lid;
-                        FStar_Syntax_Syntax.us1 = us;
-                        FStar_Syntax_Syntax.t1 = t;
-                        FStar_Syntax_Syntax.ty_lid = ty_lid;
-                        FStar_Syntax_Syntax.num_ty_params = num_ty_params;
-                        FStar_Syntax_Syntax.mutuals1 = uu___1;_}
-                      ->
-                      let fv = fresh "fv" in
-                      let uu___2 = FStar_Syntax_Util.arrow_formals t in
-                      (match uu___2 with
-                       | (bs, c) ->
-                           let vs =
-                             FStar_Compiler_List.map
-                               (fun b ->
-                                  let uu___3 =
-                                    let uu___4 =
-                                      FStar_Ident.string_of_id
-                                        (b.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.ppname in
-                                    fresh uu___4 in
-                                  (uu___3,
-                                    ((b.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort)))
-                               bs in
-                           let pat =
-                             match record_fields with
-                             | FStar_Pervasives_Native.Some fields ->
-                                 let uu___3 =
+          FStar_Compiler_List.iter
+            (fun ctor ->
+               match ctor.FStar_Syntax_Syntax.sigel with
+               | FStar_Syntax_Syntax.Sig_datacon
+                   { FStar_Syntax_Syntax.lid1 = lid;
+                     FStar_Syntax_Syntax.us1 = us;
+                     FStar_Syntax_Syntax.t1 = t;
+                     FStar_Syntax_Syntax.ty_lid = ty_lid;
+                     FStar_Syntax_Syntax.num_ty_params = num_ty_params;
+                     FStar_Syntax_Syntax.mutuals1 = uu___1;_}
+                   ->
+                   let fv = fresh "fv" in
+                   let uu___2 = FStar_Syntax_Util.arrow_formals t in
+                   (match uu___2 with
+                    | (bs, c) ->
+                        let vs =
+                          FStar_Compiler_List.map
+                            (fun b ->
+                               let uu___3 =
+                                 let uu___4 =
+                                   FStar_Ident.string_of_id
+                                     (b.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.ppname in
+                                 fresh uu___4 in
+                               (uu___3,
+                                 ((b.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort)))
+                            bs in
+                        let pat =
+                          match record_fields with
+                          | FStar_Pervasives_Native.Some fields ->
+                              let uu___3 =
+                                let uu___4 =
+                                  FStar_Compiler_List.map2
+                                    (fun v ->
+                                       fun fld ->
+                                         ((FStar_Pervasives_Native.snd fld),
+                                           (FStar_Extraction_ML_Syntax.MLP_Var
+                                              (FStar_Pervasives_Native.fst v))))
+                                    vs fields in
+                                ([], uu___4) in
+                              FStar_Extraction_ML_Syntax.MLP_Record uu___3
+                          | FStar_Pervasives_Native.None ->
+                              let uu___3 =
+                                let uu___4 =
+                                  let uu___5 = FStar_Ident.path_of_lid lid in
+                                  splitlast uu___5 in
+                                let uu___5 =
+                                  FStar_Compiler_List.map
+                                    (fun v ->
+                                       FStar_Extraction_ML_Syntax.MLP_Var
+                                         (FStar_Pervasives_Native.fst v)) vs in
+                                (uu___4, uu___5) in
+                              FStar_Extraction_ML_Syntax.MLP_CTor uu___3 in
+                        let fvar = ml_name s_tdataconstr_lid in
+                        let lid_of_str = ml_name lid_of_str_lid in
+                        let head =
+                          let uu___3 =
+                            let uu___4 =
+                              let uu___5 =
+                                let uu___6 =
+                                  let uu___7 =
+                                    let uu___8 =
+                                      let uu___9 =
+                                        let uu___10 =
+                                          let uu___11 =
+                                            let uu___12 =
+                                              let uu___13 =
+                                                FStar_Ident.string_of_lid lid in
+                                              FStar_Extraction_ML_Syntax.MLC_String
+                                                uu___13 in
+                                            FStar_Extraction_ML_Syntax.MLE_Const
+                                              uu___12 in
+                                          mk uu___11 in
+                                        [uu___10] in
+                                      (lid_of_str, uu___9) in
+                                    FStar_Extraction_ML_Syntax.MLE_App uu___8 in
+                                  mk uu___7 in
+                                [uu___6] in
+                              (fvar, uu___5) in
+                            FStar_Extraction_ML_Syntax.MLE_App uu___4 in
+                          mk uu___3 in
+                        let mk_mk_app t1 ts =
+                          let ts1 =
+                            FStar_Compiler_List.map
+                              (fun t2 ->
+                                 mk
+                                   (FStar_Extraction_ML_Syntax.MLE_Tuple
+                                      [t2; ml_none])) ts in
+                          let uu___3 =
+                            let uu___4 =
+                              let uu___5 = ml_name mk_app_lid in
+                              let uu___6 =
+                                let uu___7 =
+                                  let uu___8 = as_ml_list ts1 in [uu___8] in
+                                t1 :: uu___7 in
+                              (uu___5, uu___6) in
+                            FStar_Extraction_ML_Syntax.MLE_App uu___4 in
+                          mk uu___3 in
+                        let args =
+                          FStar_Compiler_List.map
+                            (fun uu___3 ->
+                               match uu___3 with
+                               | (v, ty) ->
+                                   let vt =
+                                     mk
+                                       (FStar_Extraction_ML_Syntax.MLE_Var v) in
                                    let uu___4 =
-                                     FStar_Compiler_List.map2
-                                       (fun v ->
-                                          fun fld ->
-                                            ((FStar_Pervasives_Native.snd fld),
-                                              (FStar_Extraction_ML_Syntax.MLP_Var
-                                                 (FStar_Pervasives_Native.fst
-                                                    v)))) vs fields in
-                                   ([], uu___4) in
-                                 FStar_Extraction_ML_Syntax.MLP_Record uu___3
-                             | FStar_Pervasives_Native.None ->
-                                 let uu___3 =
-                                   let uu___4 =
-                                     let uu___5 = FStar_Ident.path_of_lid lid in
-                                     splitlast uu___5 in
-                                   let uu___5 =
-                                     FStar_Compiler_List.map
-                                       (fun v ->
-                                          FStar_Extraction_ML_Syntax.MLP_Var
-                                            (FStar_Pervasives_Native.fst v))
-                                       vs in
-                                   (uu___4, uu___5) in
-                                 FStar_Extraction_ML_Syntax.MLP_CTor uu___3 in
-                           let fvar = ml_name s_tdataconstr_lid in
-                           let lid_of_str = ml_name lid_of_str_lid in
-                           let head =
-                             let uu___3 =
-                               let uu___4 =
-                                 let uu___5 =
-                                   let uu___6 =
-                                     let uu___7 =
-                                       let uu___8 =
-                                         let uu___9 =
-                                           let uu___10 =
-                                             let uu___11 =
-                                               let uu___12 =
-                                                 let uu___13 =
-                                                   FStar_Ident.string_of_lid
-                                                     lid in
-                                                 FStar_Extraction_ML_Syntax.MLC_String
-                                                   uu___13 in
-                                               FStar_Extraction_ML_Syntax.MLE_Const
-                                                 uu___12 in
-                                             mk uu___11 in
-                                           [uu___10] in
-                                         (lid_of_str, uu___9) in
-                                       FStar_Extraction_ML_Syntax.MLE_App
-                                         uu___8 in
-                                     mk uu___7 in
-                                   [uu___6] in
-                                 (fvar, uu___5) in
-                               FStar_Extraction_ML_Syntax.MLE_App uu___4 in
-                             mk uu___3 in
-                           let mk_mk_app t1 ts =
-                             let ts1 =
-                               FStar_Compiler_List.map
-                                 (fun t2 ->
-                                    mk
-                                      (FStar_Extraction_ML_Syntax.MLE_Tuple
-                                         [t2; ml_none])) ts in
-                             let uu___3 =
-                               let uu___4 =
-                                 let uu___5 = ml_name mk_app_lid in
-                                 let uu___6 =
-                                   let uu___7 =
-                                     let uu___8 = as_ml_list ts1 in [uu___8] in
-                                   t1 :: uu___7 in
-                                 (uu___5, uu___6) in
-                               FStar_Extraction_ML_Syntax.MLE_App uu___4 in
-                             mk uu___3 in
-                           let args =
-                             FStar_Compiler_Effect.op_Bar_Greater vs
-                               (FStar_Compiler_List.map
-                                  (fun uu___3 ->
-                                     match uu___3 with
-                                     | (v, ty) ->
-                                         let vt =
-                                           mk
-                                             (FStar_Extraction_ML_Syntax.MLE_Var
-                                                v) in
-                                         let uu___4 =
-                                           let uu___5 =
-                                             let uu___6 = ml_name embed_lid in
-                                             let uu___7 =
-                                               let uu___8 =
-                                                 embedding_for tcenv mutuals
-                                                   SyntaxTerm [] ty in
-                                               [uu___8; vt] in
-                                             (uu___6, uu___7) in
-                                           FStar_Extraction_ML_Syntax.MLE_App
-                                             uu___5 in
-                                         mk uu___4)) in
-                           let ret = mk_mk_app head args in
-                           let br = (pat, FStar_Pervasives_Native.None, ret) in
-                           let uu___3 =
-                             let uu___4 =
-                               FStar_Compiler_Effect.op_Bang e_branches in
-                             br :: uu___4 in
-                           FStar_Compiler_Effect.op_Colon_Equals e_branches
-                             uu___3)
-                  | uu___1 ->
-                      FStar_Compiler_Effect.failwith
-                        "impossible, filter above"));
+                                     let uu___5 =
+                                       let uu___6 = ml_name embed_lid in
+                                       let uu___7 =
+                                         let uu___8 =
+                                           embedding_for tcenv mutuals
+                                             SyntaxTerm [] ty in
+                                         [uu___8; vt] in
+                                       (uu___6, uu___7) in
+                                     FStar_Extraction_ML_Syntax.MLE_App
+                                       uu___5 in
+                                   mk uu___4) vs in
+                        let ret = mk_mk_app head args in
+                        let br = (pat, FStar_Pervasives_Native.None, ret) in
+                        let uu___3 =
+                          let uu___4 =
+                            FStar_Compiler_Effect.op_Bang e_branches in
+                          br :: uu___4 in
+                        FStar_Compiler_Effect.op_Colon_Equals e_branches
+                          uu___3)
+               | uu___1 ->
+                   FStar_Compiler_Effect.failwith "impossible, filter above")
+            ctors;
           (let branches =
              let uu___1 = FStar_Compiler_Effect.op_Bang e_branches in
              FStar_Compiler_List.rev uu___1 in
@@ -2058,9 +1985,8 @@ let (__do_handle_plugin :
                   (match uu___2 with
                    | (register, args) ->
                        let h =
-                         FStar_Compiler_Effect.op_Less_Bar
-                           (FStar_Extraction_ML_Syntax.with_ty
-                              FStar_Extraction_ML_Syntax.MLTY_Top)
+                         FStar_Extraction_ML_Syntax.with_ty
+                           FStar_Extraction_ML_Syntax.MLTY_Top
                            (FStar_Extraction_ML_Syntax.MLE_Name register) in
                        let arity1 =
                          FStar_Extraction_ML_Syntax.MLE_Const
@@ -2068,9 +1994,8 @@ let (__do_handle_plugin :
                               ((Prims.string_of_int arity),
                                 FStar_Pervasives_Native.None)) in
                        let app =
-                         FStar_Compiler_Effect.op_Less_Bar
-                           (FStar_Extraction_ML_Syntax.with_ty
-                              FStar_Extraction_ML_Syntax.MLTY_Top)
+                         FStar_Extraction_ML_Syntax.with_ty
+                           FStar_Extraction_ML_Syntax.MLTY_Top
                            (FStar_Extraction_ML_Syntax.MLE_App
                               (h,
                                 (FStar_Compiler_List.op_At
@@ -2208,46 +2133,46 @@ let (__do_handle_plugin :
                     [lb])) in
             let lbs = FStar_Compiler_List.concatMap proc_one mutual_sigelts in
             let unthunking =
-              FStar_Compiler_Effect.op_Bar_Greater mutual_sigelts
-                (FStar_Compiler_List.concatMap
-                   (fun se1 ->
-                      let tlid =
-                        match se1.FStar_Syntax_Syntax.sigel with
-                        | FStar_Syntax_Syntax.Sig_inductive_typ
-                            { FStar_Syntax_Syntax.lid = tlid1;
-                              FStar_Syntax_Syntax.us = uu___1;
-                              FStar_Syntax_Syntax.params = uu___2;
-                              FStar_Syntax_Syntax.num_uniform_params = uu___3;
-                              FStar_Syntax_Syntax.t = uu___4;
-                              FStar_Syntax_Syntax.mutuals = uu___5;
-                              FStar_Syntax_Syntax.ds = uu___6;_}
-                            -> tlid1 in
-                      let name =
-                        let uu___1 =
-                          let uu___2 = FStar_Ident.ids_of_lid tlid in
-                          FStar_Compiler_List.last uu___2 in
-                        FStar_Ident.string_of_id uu___1 in
-                      let app =
-                        let head =
-                          FStar_Compiler_Effect.op_Less_Bar mk
-                            (FStar_Extraction_ML_Syntax.MLE_Var
-                               (Prims.strcat "__knot_e_" name)) in
-                        mk
-                          (FStar_Extraction_ML_Syntax.MLE_App
-                             (head, [FStar_Extraction_ML_Syntax.ml_unit])) in
-                      let lb =
-                        {
-                          FStar_Extraction_ML_Syntax.mllb_name =
-                            (Prims.strcat "e_" name);
-                          FStar_Extraction_ML_Syntax.mllb_tysc =
-                            FStar_Pervasives_Native.None;
-                          FStar_Extraction_ML_Syntax.mllb_add_unit = false;
-                          FStar_Extraction_ML_Syntax.mllb_def = app;
-                          FStar_Extraction_ML_Syntax.mllb_meta = [];
-                          FStar_Extraction_ML_Syntax.print_typ = false
-                        } in
-                      [FStar_Extraction_ML_Syntax.MLM_Let
-                         (FStar_Extraction_ML_Syntax.NonRec, [lb])])) in
+              FStar_Compiler_List.concatMap
+                (fun se1 ->
+                   let tlid =
+                     match se1.FStar_Syntax_Syntax.sigel with
+                     | FStar_Syntax_Syntax.Sig_inductive_typ
+                         { FStar_Syntax_Syntax.lid = tlid1;
+                           FStar_Syntax_Syntax.us = uu___1;
+                           FStar_Syntax_Syntax.params = uu___2;
+                           FStar_Syntax_Syntax.num_uniform_params = uu___3;
+                           FStar_Syntax_Syntax.t = uu___4;
+                           FStar_Syntax_Syntax.mutuals = uu___5;
+                           FStar_Syntax_Syntax.ds = uu___6;_}
+                         -> tlid1 in
+                   let name =
+                     let uu___1 =
+                       let uu___2 = FStar_Ident.ids_of_lid tlid in
+                       FStar_Compiler_List.last uu___2 in
+                     FStar_Ident.string_of_id uu___1 in
+                   let app =
+                     let head =
+                       mk
+                         (FStar_Extraction_ML_Syntax.MLE_Var
+                            (Prims.strcat "__knot_e_" name)) in
+                     mk
+                       (FStar_Extraction_ML_Syntax.MLE_App
+                          (head, [FStar_Extraction_ML_Syntax.ml_unit])) in
+                   let lb =
+                     {
+                       FStar_Extraction_ML_Syntax.mllb_name =
+                         (Prims.strcat "e_" name);
+                       FStar_Extraction_ML_Syntax.mllb_tysc =
+                         FStar_Pervasives_Native.None;
+                       FStar_Extraction_ML_Syntax.mllb_add_unit = false;
+                       FStar_Extraction_ML_Syntax.mllb_def = app;
+                       FStar_Extraction_ML_Syntax.mllb_meta = [];
+                       FStar_Extraction_ML_Syntax.print_typ = false
+                     } in
+                   [FStar_Extraction_ML_Syntax.MLM_Let
+                      (FStar_Extraction_ML_Syntax.NonRec, [lb])])
+                mutual_sigelts in
             FStar_Compiler_List.op_At
               [FStar_Extraction_ML_Syntax.MLM_Let
                  (FStar_Extraction_ML_Syntax.Rec, lbs)] unthunking

--- a/ocaml/fstar-lib/generated/FStar_Extraction_ML_Syntax.ml
+++ b/ocaml/fstar-lib/generated/FStar_Extraction_ML_Syntax.ml
@@ -1025,8 +1025,7 @@ let (mlmodule1_to_string : mlmodule1 -> Prims.string) =
     | MLM_Ty d ->
         let uu___ =
           let uu___1 = FStar_Compiler_List.map one_mltydecl_to_string d in
-          FStar_Compiler_Effect.op_Bar_Greater uu___1
-            (FStar_Compiler_String.concat "; ") in
+          FStar_Compiler_String.concat "; " uu___1 in
         FStar_Compiler_Util.format1 "MLM_Ty [%s]" uu___
     | MLM_Let l ->
         let uu___ = mlletbinding_to_string l in
@@ -1050,6 +1049,5 @@ let (mlmodule_to_string : mlmodule -> Prims.string) =
   fun m ->
     let uu___ =
       let uu___1 = FStar_Compiler_List.map mlmodule1_to_string m in
-      FStar_Compiler_Effect.op_Bar_Greater uu___1
-        (FStar_Compiler_String.concat ";\n") in
+      FStar_Compiler_String.concat ";\n" uu___1 in
     FStar_Compiler_Util.format1 "[ %s ]" uu___

--- a/ocaml/fstar-lib/generated/FStar_Extraction_ML_Term.ml
+++ b/ocaml/fstar-lib/generated/FStar_Extraction_ML_Term.ml
@@ -65,14 +65,12 @@ let err_ill_typed_application :
                   FStar_Extraction_ML_Code.string_of_mlty uu___5 ty in
                 let uu___5 =
                   let uu___6 =
-                    FStar_Compiler_Effect.op_Bar_Greater args
-                      (FStar_Compiler_List.map
-                         (fun uu___7 ->
-                            match uu___7 with
-                            | (x, uu___8) ->
-                                FStar_Syntax_Print.term_to_string x)) in
-                  FStar_Compiler_Effect.op_Bar_Greater uu___6
-                    (FStar_Compiler_String.concat " ") in
+                    FStar_Compiler_List.map
+                      (fun uu___7 ->
+                         match uu___7 with
+                         | (x, uu___8) -> FStar_Syntax_Print.term_to_string x)
+                      args in
+                  FStar_Compiler_String.concat " " uu___6 in
                 FStar_Compiler_Util.format4
                   "Ill-typed application: source application is %s \n translated prefix to %s at type %s\n remaining args are %s\n"
                   uu___2 uu___3 uu___4 uu___5 in
@@ -182,8 +180,7 @@ let err_cannot_extract_effect :
                   FStar_Compiler_Util.format3
                     "Cannot extract effect %s because %s (when extracting %s)"
                     uu___4 reason ctxt in
-                FStar_Compiler_Effect.op_Less_Bar FStar_Errors_Msg.text
-                  uu___3 in
+                FStar_Errors_Msg.text uu___3 in
               [uu___2] in
             (FStar_Errors_Codes.Fatal_UnexpectedEffect, uu___1) in
           FStar_Errors.raise_error_doc uu___ r
@@ -579,10 +576,9 @@ let rec (is_fstar_value : FStar_Syntax_Syntax.term -> Prims.bool) =
         let uu___1 = is_constructor head in
         if uu___1
         then
-          FStar_Compiler_Effect.op_Bar_Greater args
-            (FStar_Compiler_List.for_all
-               (fun uu___2 ->
-                  match uu___2 with | (te, uu___3) -> is_fstar_value te))
+          FStar_Compiler_List.for_all
+            (fun uu___2 ->
+               match uu___2 with | (te, uu___3) -> is_fstar_value te) args
         else false
     | FStar_Syntax_Syntax.Tm_meta
         { FStar_Syntax_Syntax.tm2 = t1; FStar_Syntax_Syntax.meta = uu___1;_}
@@ -628,7 +624,7 @@ let (unit_binder : unit -> FStar_Syntax_Syntax.binder) =
     let uu___1 =
       FStar_Syntax_Syntax.new_bv FStar_Pervasives_Native.None
         FStar_Syntax_Syntax.t_unit in
-    FStar_Compiler_Effect.op_Less_Bar FStar_Syntax_Syntax.mk_binder uu___1
+    FStar_Syntax_Syntax.mk_binder uu___1
 let (check_pats_for_ite :
   (FStar_Syntax_Syntax.pat * FStar_Syntax_Syntax.term
     FStar_Pervasives_Native.option * FStar_Syntax_Syntax.term) Prims.list ->
@@ -730,10 +726,10 @@ let (instantiate_maybe_partial :
                      let uu___2 = FStar_Compiler_Util.first_N n_args vars in
                      match uu___2 with
                      | (uu___3, rest_vars) ->
-                         FStar_Compiler_Effect.op_Bar_Greater rest_vars
-                           (FStar_Compiler_List.map
-                              (fun uu___4 ->
-                                 FStar_Extraction_ML_Syntax.MLTY_Erased)) in
+                         FStar_Compiler_List.map
+                           (fun uu___4 ->
+                              FStar_Extraction_ML_Syntax.MLTY_Erased)
+                           rest_vars in
                    let tyargs1 =
                      FStar_Compiler_List.op_At tyargs extra_tyargs in
                    let ts = instantiate_tyscheme (vars, t) tyargs1 in
@@ -756,8 +752,7 @@ let (instantiate_maybe_partial :
                    match uu___2 with
                    | (vs_ts, g1) ->
                        let f =
-                         FStar_Compiler_Effect.op_Less_Bar
-                           (FStar_Extraction_ML_Syntax.with_ty t1)
+                         FStar_Extraction_ML_Syntax.with_ty t1
                            (FStar_Extraction_ML_Syntax.MLE_Fun (vs_ts, tapp)) in
                        (f, FStar_Extraction_ML_Syntax.E_PURE, t1))
                 else
@@ -788,11 +783,9 @@ let (eta_expand :
                               FStar_Extraction_ML_Syntax.with_ty t1
                                 (FStar_Extraction_ML_Syntax.MLE_Var v)) vs_ts in
                    let body =
-                     FStar_Compiler_Effect.op_Less_Bar
-                       (FStar_Extraction_ML_Syntax.with_ty r)
+                     FStar_Extraction_ML_Syntax.with_ty r
                        (FStar_Extraction_ML_Syntax.MLE_App (e, vs_es)) in
-                   FStar_Compiler_Effect.op_Less_Bar
-                     (FStar_Extraction_ML_Syntax.with_ty t)
+                   FStar_Extraction_ML_Syntax.with_ty t
                      (FStar_Extraction_ML_Syntax.MLE_Fun (vs_ts, body)))
 let (default_value_for_ty :
   FStar_Extraction_ML_UEnv.uenv ->
@@ -817,8 +810,7 @@ let (default_value_for_ty :
                   FStar_Extraction_ML_Syntax.ml_unit
                   FStar_Extraction_ML_Syntax.MLTY_Erased
             | uu___1 ->
-                FStar_Compiler_Effect.op_Less_Bar
-                  (FStar_Extraction_ML_Syntax.with_ty r2)
+                FStar_Extraction_ML_Syntax.with_ty r2
                   (FStar_Extraction_ML_Syntax.MLE_Coerce
                      (FStar_Extraction_ML_Syntax.ml_unit,
                        FStar_Extraction_ML_Syntax.MLTY_Erased, r2)) in
@@ -831,8 +823,7 @@ let (default_value_for_ty :
                  let uu___3 =
                    let uu___4 = let uu___5 = body r in (vs_ts, uu___5) in
                    FStar_Extraction_ML_Syntax.MLE_Fun uu___4 in
-                 FStar_Compiler_Effect.op_Less_Bar
-                   (FStar_Extraction_ML_Syntax.with_ty t) uu___3)
+                 FStar_Extraction_ML_Syntax.with_ty t uu___3)
 let (maybe_eta_expand_coercion :
   FStar_Extraction_ML_UEnv.uenv ->
     FStar_Extraction_ML_Syntax.mlty ->
@@ -915,30 +906,24 @@ let (apply_coercion :
                        (mk_fun arg body2)
                    else
                      (let lb =
-                        let uu___6 =
-                          let uu___7 =
-                            let uu___8 =
-                              let uu___9 =
-                                FStar_Compiler_Effect.op_Less_Bar
-                                  (FStar_Extraction_ML_Syntax.with_ty s0)
-                                  (FStar_Extraction_ML_Syntax.MLE_Var
-                                     (FStar_Pervasives_Native.fst arg)) in
-                              (uu___9, s0, t0) in
-                            FStar_Extraction_ML_Syntax.MLE_Coerce uu___8 in
-                          FStar_Extraction_ML_Syntax.with_ty t0 uu___7 in
                         {
                           FStar_Extraction_ML_Syntax.mllb_name =
                             (FStar_Pervasives_Native.fst arg);
                           FStar_Extraction_ML_Syntax.mllb_tysc =
                             (FStar_Pervasives_Native.Some ([], t0));
                           FStar_Extraction_ML_Syntax.mllb_add_unit = false;
-                          FStar_Extraction_ML_Syntax.mllb_def = uu___6;
+                          FStar_Extraction_ML_Syntax.mllb_def =
+                            (FStar_Extraction_ML_Syntax.with_ty t0
+                               (FStar_Extraction_ML_Syntax.MLE_Coerce
+                                  ((FStar_Extraction_ML_Syntax.with_ty s0
+                                      (FStar_Extraction_ML_Syntax.MLE_Var
+                                         (FStar_Pervasives_Native.fst arg))),
+                                    s0, t0)));
                           FStar_Extraction_ML_Syntax.mllb_meta = [];
                           FStar_Extraction_ML_Syntax.print_typ = false
                         } in
                       let body3 =
-                        FStar_Compiler_Effect.op_Less_Bar
-                          (FStar_Extraction_ML_Syntax.with_ty s1)
+                        FStar_Extraction_ML_Syntax.with_ty s1
                           (FStar_Extraction_ML_Syntax.MLE_Let
                              ((FStar_Extraction_ML_Syntax.NonRec, [lb]),
                                body2)) in
@@ -950,8 +935,7 @@ let (apply_coercion :
                      let uu___5 =
                        let uu___6 = aux body ty1 expect1 in (lbs, uu___6) in
                      FStar_Extraction_ML_Syntax.MLE_Let uu___5 in
-                   FStar_Compiler_Effect.op_Less_Bar
-                     (FStar_Extraction_ML_Syntax.with_ty expect1) uu___4
+                   FStar_Extraction_ML_Syntax.with_ty expect1 uu___4
                | (FStar_Extraction_ML_Syntax.MLE_Match (s, branches), uu___2,
                   uu___3) ->
                    let uu___4 =
@@ -960,8 +944,7 @@ let (apply_coercion :
                          FStar_Compiler_List.map coerce_branch branches in
                        (s, uu___6) in
                      FStar_Extraction_ML_Syntax.MLE_Match uu___5 in
-                   FStar_Compiler_Effect.op_Less_Bar
-                     (FStar_Extraction_ML_Syntax.with_ty expect1) uu___4
+                   FStar_Extraction_ML_Syntax.with_ty expect1 uu___4
                | (FStar_Extraction_ML_Syntax.MLE_If (s, b1, b2_opt), uu___2,
                   uu___3) ->
                    let uu___4 =
@@ -972,8 +955,7 @@ let (apply_coercion :
                            (fun b2 -> aux b2 ty1 expect1) in
                        (s, uu___6, uu___7) in
                      FStar_Extraction_ML_Syntax.MLE_If uu___5 in
-                   FStar_Compiler_Effect.op_Less_Bar
-                     (FStar_Extraction_ML_Syntax.with_ty expect1) uu___4
+                   FStar_Extraction_ML_Syntax.with_ty expect1 uu___4
                | (FStar_Extraction_ML_Syntax.MLE_Seq es, uu___2, uu___3) ->
                    let uu___4 = FStar_Compiler_Util.prefix es in
                    (match uu___4 with
@@ -984,8 +966,7 @@ let (apply_coercion :
                               let uu___8 = aux last ty1 expect1 in [uu___8] in
                             FStar_Compiler_List.op_At prefix uu___7 in
                           FStar_Extraction_ML_Syntax.MLE_Seq uu___6 in
-                        FStar_Compiler_Effect.op_Less_Bar
-                          (FStar_Extraction_ML_Syntax.with_ty expect1) uu___5)
+                        FStar_Extraction_ML_Syntax.with_ty expect1 uu___5)
                | (FStar_Extraction_ML_Syntax.MLE_Try (s, branches), uu___2,
                   uu___3) ->
                    let uu___4 =
@@ -994,8 +975,7 @@ let (apply_coercion :
                          FStar_Compiler_List.map coerce_branch branches in
                        (s, uu___6) in
                      FStar_Extraction_ML_Syntax.MLE_Try uu___5 in
-                   FStar_Compiler_Effect.op_Less_Bar
-                     (FStar_Extraction_ML_Syntax.with_ty expect1) uu___4
+                   FStar_Extraction_ML_Syntax.with_ty expect1 uu___4
                | uu___2 ->
                    FStar_Extraction_ML_Syntax.with_ty expect1
                      (FStar_Extraction_ML_Syntax.MLE_Coerce
@@ -1120,28 +1100,21 @@ let maybe_reify_comp :
     fun env ->
       fun c ->
         let uu___ =
-          let uu___1 =
-            FStar_Compiler_Effect.op_Bar_Greater c
-              FStar_Syntax_Util.comp_effect_name in
-          FStar_Compiler_Effect.op_Bar_Greater uu___1
-            (FStar_TypeChecker_Util.effect_extraction_mode env) in
+          FStar_TypeChecker_Util.effect_extraction_mode env
+            (FStar_Syntax_Util.comp_effect_name c) in
         match uu___ with
         | FStar_Syntax_Syntax.Extract_reify ->
             let uu___1 =
               FStar_TypeChecker_Env.reify_comp env c
                 FStar_Syntax_Syntax.U_unknown in
-            FStar_Compiler_Effect.op_Bar_Greater uu___1
-              (FStar_TypeChecker_Normalize.normalize extraction_norm_steps
-                 env)
+            FStar_TypeChecker_Normalize.normalize extraction_norm_steps env
+              uu___1
         | FStar_Syntax_Syntax.Extract_primitive ->
             FStar_Syntax_Util.comp_result c
         | FStar_Syntax_Syntax.Extract_none s ->
-            let uu___1 =
-              FStar_Compiler_Effect.op_Bar_Greater c
-                FStar_Syntax_Util.comp_effect_name in
-            let uu___2 = FStar_Syntax_Print.comp_to_string c in
-            err_cannot_extract_effect uu___1 c.FStar_Syntax_Syntax.pos s
-              uu___2
+            let uu___1 = FStar_Syntax_Print.comp_to_string c in
+            err_cannot_extract_effect (FStar_Syntax_Util.comp_effect_name c)
+              c.FStar_Syntax_Syntax.pos s uu___1
 let (maybe_reify_term :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
@@ -1397,37 +1370,36 @@ and (binders_as_ml_binders :
   fun g ->
     fun bs ->
       let uu___ =
-        FStar_Compiler_Effect.op_Bar_Greater bs
-          (FStar_Compiler_List.fold_left
-             (fun uu___1 ->
-                fun b ->
-                  match uu___1 with
-                  | (ml_bs, env) ->
-                      let uu___2 = is_type_binder g b in
-                      if uu___2
-                      then
-                        let b1 = b.FStar_Syntax_Syntax.binder_bv in
-                        let env1 =
-                          FStar_Extraction_ML_UEnv.extend_ty env b1 true in
-                        let ml_b =
-                          let uu___3 =
-                            FStar_Extraction_ML_UEnv.lookup_ty env1 b1 in
-                          uu___3.FStar_Extraction_ML_UEnv.ty_b_name in
-                        let ml_b1 =
-                          (ml_b, FStar_Extraction_ML_Syntax.ml_unit_ty) in
-                        ((ml_b1 :: ml_bs), env1)
-                      else
-                        (let b1 = b.FStar_Syntax_Syntax.binder_bv in
-                         let t =
-                           translate_term_to_mlty env
-                             b1.FStar_Syntax_Syntax.sort in
-                         let uu___4 =
-                           FStar_Extraction_ML_UEnv.extend_bv env b1 
-                             ([], t) false false in
-                         match uu___4 with
-                         | (env1, b2, uu___5) ->
-                             let ml_b = (b2, t) in ((ml_b :: ml_bs), env1)))
-             ([], g)) in
+        FStar_Compiler_List.fold_left
+          (fun uu___1 ->
+             fun b ->
+               match uu___1 with
+               | (ml_bs, env) ->
+                   let uu___2 = is_type_binder g b in
+                   if uu___2
+                   then
+                     let b1 = b.FStar_Syntax_Syntax.binder_bv in
+                     let env1 =
+                       FStar_Extraction_ML_UEnv.extend_ty env b1 true in
+                     let ml_b =
+                       let uu___3 =
+                         FStar_Extraction_ML_UEnv.lookup_ty env1 b1 in
+                       uu___3.FStar_Extraction_ML_UEnv.ty_b_name in
+                     let ml_b1 =
+                       (ml_b, FStar_Extraction_ML_Syntax.ml_unit_ty) in
+                     ((ml_b1 :: ml_bs), env1)
+                   else
+                     (let b1 = b.FStar_Syntax_Syntax.binder_bv in
+                      let t =
+                        translate_term_to_mlty env
+                          b1.FStar_Syntax_Syntax.sort in
+                      let uu___4 =
+                        FStar_Extraction_ML_UEnv.extend_bv env b1 ([], t)
+                          false false in
+                      match uu___4 with
+                      | (env1, b2, uu___5) ->
+                          let ml_b = (b2, t) in ((ml_b :: ml_bs), env1)))
+          ([], g) bs in
       match uu___ with
       | (ml_bs, env) -> ((FStar_Compiler_List.rev ml_bs), env)
 let (term_as_mlty :
@@ -1604,9 +1576,8 @@ let rec (extract_one_pat :
                               (FStar_Const.Const_int
                                  (c, FStar_Pervasives_Native.None)) in
                           FStar_Extraction_ML_Syntax.MLE_Const uu___3 in
-                        FStar_Compiler_Effect.op_Less_Bar
-                          (FStar_Extraction_ML_Syntax.with_ty
-                             FStar_Extraction_ML_Syntax.ml_int_ty) uu___2 in
+                        FStar_Extraction_ML_Syntax.with_ty
+                          FStar_Extraction_ML_Syntax.ml_int_ty uu___2 in
                       (uu___1, FStar_Extraction_ML_Syntax.ml_int_ty)
                   | FStar_Pervasives_Native.Some sw ->
                       let source_term =
@@ -1626,13 +1597,10 @@ let rec (extract_one_pat :
                       | (g1, x) ->
                           let x_exp =
                             let x_exp1 =
-                              FStar_Compiler_Effect.op_Less_Bar
-                                (FStar_Extraction_ML_Syntax.with_ty
-                                   expected_ty)
+                              FStar_Extraction_ML_Syntax.with_ty expected_ty
                                 (FStar_Extraction_ML_Syntax.MLE_Var x) in
                             let coerce x1 =
-                              FStar_Compiler_Effect.op_Less_Bar
-                                (FStar_Extraction_ML_Syntax.with_ty ml_ty)
+                              FStar_Extraction_ML_Syntax.with_ty ml_ty
                                 (FStar_Extraction_ML_Syntax.MLE_Coerce
                                    (x1, ml_ty, expected_ty)) in
                             match expected_ty with
@@ -1642,9 +1610,8 @@ let rec (extract_one_pat :
                                 let uu___3 = ok ml_ty in
                                 if uu___3 then x_exp1 else coerce x_exp1 in
                           let when_clause =
-                            FStar_Compiler_Effect.op_Less_Bar
-                              (FStar_Extraction_ML_Syntax.with_ty
-                                 FStar_Extraction_ML_Syntax.ml_bool_ty)
+                            FStar_Extraction_ML_Syntax.with_ty
+                              FStar_Extraction_ML_Syntax.ml_bool_ty
                               (FStar_Extraction_ML_Syntax.MLE_App
                                  (FStar_Extraction_ML_Util.prims_op_equality,
                                    [x_exp; mlc])) in
@@ -1722,23 +1689,23 @@ let rec (extract_one_pat :
                       | (tysVarPats, restPats) ->
                           let f_ty =
                             let mlty_args =
-                              FStar_Compiler_Effect.op_Bar_Greater tysVarPats
-                                (FStar_Compiler_List.map
-                                   (fun uu___3 ->
-                                      match uu___3 with
-                                      | (p1, uu___4) ->
-                                          (match expected_ty with
-                                           | FStar_Extraction_ML_Syntax.MLTY_Top
-                                               ->
-                                               FStar_Extraction_ML_Syntax.MLTY_Top
-                                           | uu___5 ->
-                                               (match p1.FStar_Syntax_Syntax.v
-                                                with
-                                                | FStar_Syntax_Syntax.Pat_dot_term
-                                                    (FStar_Pervasives_Native.Some
-                                                    t) -> term_as_mlty g t
-                                                | uu___6 ->
-                                                    FStar_Extraction_ML_Syntax.MLTY_Top)))) in
+                              FStar_Compiler_List.map
+                                (fun uu___3 ->
+                                   match uu___3 with
+                                   | (p1, uu___4) ->
+                                       (match expected_ty with
+                                        | FStar_Extraction_ML_Syntax.MLTY_Top
+                                            ->
+                                            FStar_Extraction_ML_Syntax.MLTY_Top
+                                        | uu___5 ->
+                                            (match p1.FStar_Syntax_Syntax.v
+                                             with
+                                             | FStar_Syntax_Syntax.Pat_dot_term
+                                                 (FStar_Pervasives_Native.Some
+                                                 t) -> term_as_mlty g t
+                                             | uu___6 ->
+                                                 FStar_Extraction_ML_Syntax.MLTY_Top)))
+                                tysVarPats in
                             let f_ty1 =
                               FStar_Extraction_ML_Util.subst tys mlty_args in
                             FStar_Extraction_ML_Util.uncurry_mlty_fun f_ty1 in
@@ -1759,10 +1726,8 @@ let rec (extract_one_pat :
                                             FStar_Extraction_ML_Code.string_of_mlty
                                               uu___10 in
                                           FStar_Compiler_List.map uu___9 args in
-                                        FStar_Compiler_Effect.op_Bar_Greater
-                                          uu___8
-                                          (FStar_Compiler_String.concat
-                                             " -> ") in
+                                        FStar_Compiler_String.concat " -> "
+                                          uu___8 in
                                       let res =
                                         let uu___8 =
                                           FStar_Extraction_ML_UEnv.current_module_of_uenv
@@ -1818,17 +1783,15 @@ let rec (extract_one_pat :
                                  | ((g2, f_ty1, sub_pats_ok), restMLPats) ->
                                      let uu___6 =
                                        let uu___7 =
-                                         FStar_Compiler_Effect.op_Bar_Greater
+                                         FStar_Compiler_List.collect
+                                           (fun uu___8 ->
+                                              match uu___8 with
+                                              | FStar_Pervasives_Native.Some
+                                                  x -> [x]
+                                              | uu___9 -> [])
                                            (FStar_Compiler_List.append
-                                              tyMLPats restMLPats)
-                                           (FStar_Compiler_List.collect
-                                              (fun uu___8 ->
-                                                 match uu___8 with
-                                                 | FStar_Pervasives_Native.Some
-                                                     x -> [x]
-                                                 | uu___9 -> [])) in
-                                       FStar_Compiler_Effect.op_Bar_Greater
-                                         uu___7 FStar_Compiler_List.split in
+                                              tyMLPats restMLPats) in
+                                       FStar_Compiler_List.split uu___7 in
                                      (match uu___6 with
                                       | (mlPats, when_clauses) ->
                                           let pat_ty_compat =
@@ -1842,11 +1805,9 @@ let rec (extract_one_pat :
                                                   f.FStar_Syntax_Syntax.fv_qual
                                                   (FStar_Extraction_ML_Syntax.MLP_CTor
                                                      (d, mlPats)) in
-                                              let uu___10 =
-                                                FStar_Compiler_Effect.op_Bar_Greater
-                                                  when_clauses
-                                                  FStar_Compiler_List.flatten in
-                                              (uu___9, uu___10) in
+                                              (uu___9,
+                                                (FStar_Compiler_List.flatten
+                                                   when_clauses)) in
                                             FStar_Pervasives_Native.Some
                                               uu___8 in
                                           (g2, uu___7,
@@ -1908,15 +1869,11 @@ let (maybe_eta_data_and_project_record :
                 let uu___1 = FStar_Extraction_ML_UEnv.new_mlident g1 in
                 (match uu___1 with
                  | (g2, x) ->
-                     let uu___2 =
-                       let uu___3 =
-                         let uu___4 =
-                           FStar_Compiler_Effect.op_Less_Bar
-                             (FStar_Extraction_ML_Syntax.with_ty t0)
-                             (FStar_Extraction_ML_Syntax.MLE_Var x) in
-                         ((x, t0), uu___4) in
-                       uu___3 :: more_args in
-                     eta_args g2 uu___2 t1)
+                     eta_args g2
+                       (((x, t0),
+                          (FStar_Extraction_ML_Syntax.with_ty t0
+                             (FStar_Extraction_ML_Syntax.MLE_Var x))) ::
+                       more_args) t1)
             | FStar_Extraction_ML_Syntax.MLTY_Named (uu___, uu___1) ->
                 ((FStar_Compiler_List.rev more_args), t)
             | uu___ ->
@@ -1944,9 +1901,8 @@ let (maybe_eta_data_and_project_record :
                   FStar_Compiler_List.map FStar_Ident.string_of_id uu___1 in
                 let fields1 = record_fields g tyname fields args in
                 let path1 = FStar_Extraction_ML_UEnv.no_fstar_stubs_ns path in
-                FStar_Compiler_Effect.op_Less_Bar
-                  (FStar_Extraction_ML_Syntax.with_ty
-                     e.FStar_Extraction_ML_Syntax.mlty)
+                FStar_Extraction_ML_Syntax.with_ty
+                  e.FStar_Extraction_ML_Syntax.mlty
                   (FStar_Extraction_ML_Syntax.MLE_Record (path1, fields1))
             | uu___ -> e in
           let resugar_and_maybe_eta qual1 e =
@@ -1966,22 +1922,15 @@ let (maybe_eta_data_and_project_record :
                                ->
                                let body =
                                  let uu___3 =
-                                   let uu___4 =
-                                     FStar_Compiler_Effect.op_Less_Bar
-                                       (FStar_Extraction_ML_Syntax.with_ty
-                                          tres)
-                                       (FStar_Extraction_ML_Syntax.MLE_CTor
-                                          (head,
-                                            (FStar_Compiler_List.op_At args
-                                               eargs1))) in
-                                   FStar_Compiler_Effect.op_Less_Bar
-                                     (as_record qual1) uu___4 in
-                                 FStar_Compiler_Effect.op_Less_Bar
-                                   FStar_Extraction_ML_Util.resugar_exp
-                                   uu___3 in
-                               FStar_Compiler_Effect.op_Less_Bar
-                                 (FStar_Extraction_ML_Syntax.with_ty
-                                    e.FStar_Extraction_ML_Syntax.mlty)
+                                   as_record qual1
+                                     (FStar_Extraction_ML_Syntax.with_ty tres
+                                        (FStar_Extraction_ML_Syntax.MLE_CTor
+                                           (head,
+                                             (FStar_Compiler_List.op_At args
+                                                eargs1)))) in
+                                 FStar_Extraction_ML_Util.resugar_exp uu___3 in
+                               FStar_Extraction_ML_Syntax.with_ty
+                                 e.FStar_Extraction_ML_Syntax.mlty
                                  (FStar_Extraction_ML_Syntax.MLE_Fun
                                     (binders, body))
                            | uu___3 ->
@@ -2010,13 +1959,9 @@ let (maybe_eta_data_and_project_record :
                 match args with
                 | [] -> proj
                 | uu___2 ->
-                    let uu___3 =
-                      let uu___4 =
-                        FStar_Compiler_Effect.op_Less_Bar
-                          (FStar_Extraction_ML_Syntax.with_ty
-                             FStar_Extraction_ML_Syntax.MLTY_Top) proj in
-                      (uu___4, args) in
-                    FStar_Extraction_ML_Syntax.MLE_App uu___3 in
+                    FStar_Extraction_ML_Syntax.MLE_App
+                      ((FStar_Extraction_ML_Syntax.with_ty
+                          FStar_Extraction_ML_Syntax.MLTY_Top proj), args) in
               FStar_Extraction_ML_Syntax.with_ty
                 mlAppExpr.FStar_Extraction_ML_Syntax.mlty e
           | (FStar_Extraction_ML_Syntax.MLE_App
@@ -2046,13 +1991,9 @@ let (maybe_eta_data_and_project_record :
                 match args with
                 | [] -> proj
                 | uu___5 ->
-                    let uu___6 =
-                      let uu___7 =
-                        FStar_Compiler_Effect.op_Less_Bar
-                          (FStar_Extraction_ML_Syntax.with_ty
-                             FStar_Extraction_ML_Syntax.MLTY_Top) proj in
-                      (uu___7, args) in
-                    FStar_Extraction_ML_Syntax.MLE_App uu___6 in
+                    FStar_Extraction_ML_Syntax.MLE_App
+                      ((FStar_Extraction_ML_Syntax.with_ty
+                          FStar_Extraction_ML_Syntax.MLTY_Top proj), args) in
               FStar_Extraction_ML_Syntax.with_ty
                 mlAppExpr.FStar_Extraction_ML_Syntax.mlty e
           | (FStar_Extraction_ML_Syntax.MLE_App
@@ -2063,13 +2004,10 @@ let (maybe_eta_data_and_project_record :
                 FStar_Extraction_ML_Syntax.loc = uu___1;_},
               mlargs),
              FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Data_ctor)) ->
-              let uu___2 =
-                FStar_Compiler_Effect.op_Less_Bar
-                  (FStar_Extraction_ML_Syntax.with_ty
-                     mlAppExpr.FStar_Extraction_ML_Syntax.mlty)
-                  (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, mlargs)) in
-              FStar_Compiler_Effect.op_Less_Bar (resugar_and_maybe_eta qual)
-                uu___2
+              resugar_and_maybe_eta qual
+                (FStar_Extraction_ML_Syntax.with_ty
+                   mlAppExpr.FStar_Extraction_ML_Syntax.mlty
+                   (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, mlargs)))
           | (FStar_Extraction_ML_Syntax.MLE_App
              ({
                 FStar_Extraction_ML_Syntax.expr =
@@ -2079,13 +2017,10 @@ let (maybe_eta_data_and_project_record :
               mlargs),
              FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Record_ctor
              uu___2)) ->
-              let uu___3 =
-                FStar_Compiler_Effect.op_Less_Bar
-                  (FStar_Extraction_ML_Syntax.with_ty
-                     mlAppExpr.FStar_Extraction_ML_Syntax.mlty)
-                  (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, mlargs)) in
-              FStar_Compiler_Effect.op_Less_Bar (resugar_and_maybe_eta qual)
-                uu___3
+              resugar_and_maybe_eta qual
+                (FStar_Extraction_ML_Syntax.with_ty
+                   mlAppExpr.FStar_Extraction_ML_Syntax.mlty
+                   (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, mlargs)))
           | (FStar_Extraction_ML_Syntax.MLE_App
              ({
                 FStar_Extraction_ML_Syntax.expr =
@@ -2100,13 +2035,10 @@ let (maybe_eta_data_and_project_record :
                 FStar_Extraction_ML_Syntax.loc = uu___4;_},
               mlargs),
              FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Data_ctor)) ->
-              let uu___5 =
-                FStar_Compiler_Effect.op_Less_Bar
-                  (FStar_Extraction_ML_Syntax.with_ty
-                     mlAppExpr.FStar_Extraction_ML_Syntax.mlty)
-                  (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, mlargs)) in
-              FStar_Compiler_Effect.op_Less_Bar (resugar_and_maybe_eta qual)
-                uu___5
+              resugar_and_maybe_eta qual
+                (FStar_Extraction_ML_Syntax.with_ty
+                   mlAppExpr.FStar_Extraction_ML_Syntax.mlty
+                   (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, mlargs)))
           | (FStar_Extraction_ML_Syntax.MLE_App
              ({
                 FStar_Extraction_ML_Syntax.expr =
@@ -2122,32 +2054,23 @@ let (maybe_eta_data_and_project_record :
               mlargs),
              FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Record_ctor
              uu___5)) ->
-              let uu___6 =
-                FStar_Compiler_Effect.op_Less_Bar
-                  (FStar_Extraction_ML_Syntax.with_ty
-                     mlAppExpr.FStar_Extraction_ML_Syntax.mlty)
-                  (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, mlargs)) in
-              FStar_Compiler_Effect.op_Less_Bar (resugar_and_maybe_eta qual)
-                uu___6
+              resugar_and_maybe_eta qual
+                (FStar_Extraction_ML_Syntax.with_ty
+                   mlAppExpr.FStar_Extraction_ML_Syntax.mlty
+                   (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, mlargs)))
           | (FStar_Extraction_ML_Syntax.MLE_Name mlp,
              FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Data_ctor)) ->
-              let uu___ =
-                FStar_Compiler_Effect.op_Less_Bar
-                  (FStar_Extraction_ML_Syntax.with_ty
-                     mlAppExpr.FStar_Extraction_ML_Syntax.mlty)
-                  (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, [])) in
-              FStar_Compiler_Effect.op_Less_Bar (resugar_and_maybe_eta qual)
-                uu___
+              resugar_and_maybe_eta qual
+                (FStar_Extraction_ML_Syntax.with_ty
+                   mlAppExpr.FStar_Extraction_ML_Syntax.mlty
+                   (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, [])))
           | (FStar_Extraction_ML_Syntax.MLE_Name mlp,
              FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Record_ctor
              uu___)) ->
-              let uu___1 =
-                FStar_Compiler_Effect.op_Less_Bar
-                  (FStar_Extraction_ML_Syntax.with_ty
-                     mlAppExpr.FStar_Extraction_ML_Syntax.mlty)
-                  (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, [])) in
-              FStar_Compiler_Effect.op_Less_Bar (resugar_and_maybe_eta qual)
-                uu___1
+              resugar_and_maybe_eta qual
+                (FStar_Extraction_ML_Syntax.with_ty
+                   mlAppExpr.FStar_Extraction_ML_Syntax.mlty
+                   (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, [])))
           | (FStar_Extraction_ML_Syntax.MLE_TApp
              ({
                 FStar_Extraction_ML_Syntax.expr =
@@ -2156,13 +2079,10 @@ let (maybe_eta_data_and_project_record :
                 FStar_Extraction_ML_Syntax.loc = uu___1;_},
               uu___2),
              FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Data_ctor)) ->
-              let uu___3 =
-                FStar_Compiler_Effect.op_Less_Bar
-                  (FStar_Extraction_ML_Syntax.with_ty
-                     mlAppExpr.FStar_Extraction_ML_Syntax.mlty)
-                  (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, [])) in
-              FStar_Compiler_Effect.op_Less_Bar (resugar_and_maybe_eta qual)
-                uu___3
+              resugar_and_maybe_eta qual
+                (FStar_Extraction_ML_Syntax.with_ty
+                   mlAppExpr.FStar_Extraction_ML_Syntax.mlty
+                   (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, [])))
           | (FStar_Extraction_ML_Syntax.MLE_TApp
              ({
                 FStar_Extraction_ML_Syntax.expr =
@@ -2172,13 +2092,10 @@ let (maybe_eta_data_and_project_record :
               uu___2),
              FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Record_ctor
              uu___3)) ->
-              let uu___4 =
-                FStar_Compiler_Effect.op_Less_Bar
-                  (FStar_Extraction_ML_Syntax.with_ty
-                     mlAppExpr.FStar_Extraction_ML_Syntax.mlty)
-                  (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, [])) in
-              FStar_Compiler_Effect.op_Less_Bar (resugar_and_maybe_eta qual)
-                uu___4
+              resugar_and_maybe_eta qual
+                (FStar_Extraction_ML_Syntax.with_ty
+                   mlAppExpr.FStar_Extraction_ML_Syntax.mlty
+                   (FStar_Extraction_ML_Syntax.MLE_CTor (mlp, [])))
           | uu___ -> mlAppExpr
 let (maybe_promote_effect :
   FStar_Extraction_ML_Syntax.mlexpr ->
@@ -2239,9 +2156,7 @@ let (extract_lb_sig :
                      FStar_Syntax_Syntax.comp = c;_}
                    when
                    let uu___5 = FStar_Compiler_List.hd bs in
-                   FStar_Compiler_Effect.op_Bar_Greater uu___5
-                     (is_type_binder g)
-                   ->
+                   is_type_binder g uu___5 ->
                    let uu___5 = FStar_Syntax_Subst.open_comp bs c in
                    (match uu___5 with
                     | (bs1, c1) ->
@@ -2264,8 +2179,7 @@ let (extract_lb_sig :
                                FStar_Compiler_List.length tbinders in
                              let lbdef1 =
                                let uu___7 = normalize_abs lbdef in
-                               FStar_Compiler_Effect.op_Bar_Greater uu___7
-                                 FStar_Syntax_Util.unmeta in
+                               FStar_Syntax_Util.unmeta uu___7 in
                              (match lbdef1.FStar_Syntax_Syntax.n with
                               | FStar_Syntax_Syntax.Tm_abs
                                   { FStar_Syntax_Syntax.bs = bs2;
@@ -2345,25 +2259,24 @@ let (extract_lb_sig :
                                                   expected_source_ty in
                                               let polytype =
                                                 let uu___9 =
-                                                  FStar_Compiler_Effect.op_Bar_Greater
-                                                    targs
-                                                    (FStar_Compiler_List.map
-                                                       (fun uu___10 ->
-                                                          match uu___10 with
-                                                          | {
-                                                              FStar_Syntax_Syntax.binder_bv
-                                                                = x;
-                                                              FStar_Syntax_Syntax.binder_qual
-                                                                = uu___11;
-                                                              FStar_Syntax_Syntax.binder_positivity
-                                                                = uu___12;
-                                                              FStar_Syntax_Syntax.binder_attrs
-                                                                = uu___13;_}
-                                                              ->
-                                                              let uu___14 =
-                                                                FStar_Extraction_ML_UEnv.lookup_ty
-                                                                  env x in
-                                                              uu___14.FStar_Extraction_ML_UEnv.ty_b_name)) in
+                                                  FStar_Compiler_List.map
+                                                    (fun uu___10 ->
+                                                       match uu___10 with
+                                                       | {
+                                                           FStar_Syntax_Syntax.binder_bv
+                                                             = x;
+                                                           FStar_Syntax_Syntax.binder_qual
+                                                             = uu___11;
+                                                           FStar_Syntax_Syntax.binder_positivity
+                                                             = uu___12;
+                                                           FStar_Syntax_Syntax.binder_attrs
+                                                             = uu___13;_}
+                                                           ->
+                                                           let uu___14 =
+                                                             FStar_Extraction_ML_UEnv.lookup_ty
+                                                               env x in
+                                                           uu___14.FStar_Extraction_ML_UEnv.ty_b_name)
+                                                    targs in
                                                 (uu___9, expected_t) in
                                               let add_unit =
                                                 match rest_args with
@@ -2420,48 +2333,44 @@ let (extract_lb_sig :
                                   let expected_t = term_as_mlty env tbody in
                                   let polytype =
                                     let uu___8 =
-                                      FStar_Compiler_Effect.op_Bar_Greater
-                                        tbinders
-                                        (FStar_Compiler_List.map
-                                           (fun uu___9 ->
-                                              match uu___9 with
-                                              | {
-                                                  FStar_Syntax_Syntax.binder_bv
-                                                    = x;
-                                                  FStar_Syntax_Syntax.binder_qual
-                                                    = uu___10;
-                                                  FStar_Syntax_Syntax.binder_positivity
-                                                    = uu___11;
-                                                  FStar_Syntax_Syntax.binder_attrs
-                                                    = uu___12;_}
-                                                  ->
-                                                  let uu___13 =
-                                                    FStar_Extraction_ML_UEnv.lookup_ty
-                                                      env x in
-                                                  uu___13.FStar_Extraction_ML_UEnv.ty_b_name)) in
+                                      FStar_Compiler_List.map
+                                        (fun uu___9 ->
+                                           match uu___9 with
+                                           | {
+                                               FStar_Syntax_Syntax.binder_bv
+                                                 = x;
+                                               FStar_Syntax_Syntax.binder_qual
+                                                 = uu___10;
+                                               FStar_Syntax_Syntax.binder_positivity
+                                                 = uu___11;
+                                               FStar_Syntax_Syntax.binder_attrs
+                                                 = uu___12;_}
+                                               ->
+                                               let uu___13 =
+                                                 FStar_Extraction_ML_UEnv.lookup_ty
+                                                   env x in
+                                               uu___13.FStar_Extraction_ML_UEnv.ty_b_name)
+                                        tbinders in
                                     (uu___8, expected_t) in
                                   let args =
-                                    FStar_Compiler_Effect.op_Bar_Greater
-                                      tbinders
-                                      (FStar_Compiler_List.map
-                                         (fun uu___8 ->
-                                            match uu___8 with
-                                            | {
-                                                FStar_Syntax_Syntax.binder_bv
-                                                  = bv;
-                                                FStar_Syntax_Syntax.binder_qual
-                                                  = uu___9;
-                                                FStar_Syntax_Syntax.binder_positivity
-                                                  = uu___10;
-                                                FStar_Syntax_Syntax.binder_attrs
-                                                  = uu___11;_}
-                                                ->
-                                                let uu___12 =
-                                                  FStar_Syntax_Syntax.bv_to_name
-                                                    bv in
-                                                FStar_Compiler_Effect.op_Bar_Greater
-                                                  uu___12
-                                                  FStar_Syntax_Syntax.as_arg)) in
+                                    FStar_Compiler_List.map
+                                      (fun uu___8 ->
+                                         match uu___8 with
+                                         | {
+                                             FStar_Syntax_Syntax.binder_bv =
+                                               bv;
+                                             FStar_Syntax_Syntax.binder_qual
+                                               = uu___9;
+                                             FStar_Syntax_Syntax.binder_positivity
+                                               = uu___10;
+                                             FStar_Syntax_Syntax.binder_attrs
+                                               = uu___11;_}
+                                             ->
+                                             let uu___12 =
+                                               FStar_Syntax_Syntax.bv_to_name
+                                                 bv in
+                                             FStar_Syntax_Syntax.as_arg
+                                               uu___12) tbinders in
                                   let e =
                                     FStar_Syntax_Syntax.mk
                                       (FStar_Syntax_Syntax.Tm_app
@@ -2492,48 +2401,44 @@ let (extract_lb_sig :
                                   let expected_t = term_as_mlty env tbody in
                                   let polytype =
                                     let uu___8 =
-                                      FStar_Compiler_Effect.op_Bar_Greater
-                                        tbinders
-                                        (FStar_Compiler_List.map
-                                           (fun uu___9 ->
-                                              match uu___9 with
-                                              | {
-                                                  FStar_Syntax_Syntax.binder_bv
-                                                    = x;
-                                                  FStar_Syntax_Syntax.binder_qual
-                                                    = uu___10;
-                                                  FStar_Syntax_Syntax.binder_positivity
-                                                    = uu___11;
-                                                  FStar_Syntax_Syntax.binder_attrs
-                                                    = uu___12;_}
-                                                  ->
-                                                  let uu___13 =
-                                                    FStar_Extraction_ML_UEnv.lookup_ty
-                                                      env x in
-                                                  uu___13.FStar_Extraction_ML_UEnv.ty_b_name)) in
+                                      FStar_Compiler_List.map
+                                        (fun uu___9 ->
+                                           match uu___9 with
+                                           | {
+                                               FStar_Syntax_Syntax.binder_bv
+                                                 = x;
+                                               FStar_Syntax_Syntax.binder_qual
+                                                 = uu___10;
+                                               FStar_Syntax_Syntax.binder_positivity
+                                                 = uu___11;
+                                               FStar_Syntax_Syntax.binder_attrs
+                                                 = uu___12;_}
+                                               ->
+                                               let uu___13 =
+                                                 FStar_Extraction_ML_UEnv.lookup_ty
+                                                   env x in
+                                               uu___13.FStar_Extraction_ML_UEnv.ty_b_name)
+                                        tbinders in
                                     (uu___8, expected_t) in
                                   let args =
-                                    FStar_Compiler_Effect.op_Bar_Greater
-                                      tbinders
-                                      (FStar_Compiler_List.map
-                                         (fun uu___8 ->
-                                            match uu___8 with
-                                            | {
-                                                FStar_Syntax_Syntax.binder_bv
-                                                  = bv;
-                                                FStar_Syntax_Syntax.binder_qual
-                                                  = uu___9;
-                                                FStar_Syntax_Syntax.binder_positivity
-                                                  = uu___10;
-                                                FStar_Syntax_Syntax.binder_attrs
-                                                  = uu___11;_}
-                                                ->
-                                                let uu___12 =
-                                                  FStar_Syntax_Syntax.bv_to_name
-                                                    bv in
-                                                FStar_Compiler_Effect.op_Bar_Greater
-                                                  uu___12
-                                                  FStar_Syntax_Syntax.as_arg)) in
+                                    FStar_Compiler_List.map
+                                      (fun uu___8 ->
+                                         match uu___8 with
+                                         | {
+                                             FStar_Syntax_Syntax.binder_bv =
+                                               bv;
+                                             FStar_Syntax_Syntax.binder_qual
+                                               = uu___9;
+                                             FStar_Syntax_Syntax.binder_positivity
+                                               = uu___10;
+                                             FStar_Syntax_Syntax.binder_attrs
+                                               = uu___11;_}
+                                             ->
+                                             let uu___12 =
+                                               FStar_Syntax_Syntax.bv_to_name
+                                                 bv in
+                                             FStar_Syntax_Syntax.as_arg
+                                               uu___12) tbinders in
                                   let e =
                                     FStar_Syntax_Syntax.mk
                                       (FStar_Syntax_Syntax.Tm_app
@@ -2564,48 +2469,44 @@ let (extract_lb_sig :
                                   let expected_t = term_as_mlty env tbody in
                                   let polytype =
                                     let uu___8 =
-                                      FStar_Compiler_Effect.op_Bar_Greater
-                                        tbinders
-                                        (FStar_Compiler_List.map
-                                           (fun uu___9 ->
-                                              match uu___9 with
-                                              | {
-                                                  FStar_Syntax_Syntax.binder_bv
-                                                    = x;
-                                                  FStar_Syntax_Syntax.binder_qual
-                                                    = uu___10;
-                                                  FStar_Syntax_Syntax.binder_positivity
-                                                    = uu___11;
-                                                  FStar_Syntax_Syntax.binder_attrs
-                                                    = uu___12;_}
-                                                  ->
-                                                  let uu___13 =
-                                                    FStar_Extraction_ML_UEnv.lookup_ty
-                                                      env x in
-                                                  uu___13.FStar_Extraction_ML_UEnv.ty_b_name)) in
+                                      FStar_Compiler_List.map
+                                        (fun uu___9 ->
+                                           match uu___9 with
+                                           | {
+                                               FStar_Syntax_Syntax.binder_bv
+                                                 = x;
+                                               FStar_Syntax_Syntax.binder_qual
+                                                 = uu___10;
+                                               FStar_Syntax_Syntax.binder_positivity
+                                                 = uu___11;
+                                               FStar_Syntax_Syntax.binder_attrs
+                                                 = uu___12;_}
+                                               ->
+                                               let uu___13 =
+                                                 FStar_Extraction_ML_UEnv.lookup_ty
+                                                   env x in
+                                               uu___13.FStar_Extraction_ML_UEnv.ty_b_name)
+                                        tbinders in
                                     (uu___8, expected_t) in
                                   let args =
-                                    FStar_Compiler_Effect.op_Bar_Greater
-                                      tbinders
-                                      (FStar_Compiler_List.map
-                                         (fun uu___8 ->
-                                            match uu___8 with
-                                            | {
-                                                FStar_Syntax_Syntax.binder_bv
-                                                  = bv;
-                                                FStar_Syntax_Syntax.binder_qual
-                                                  = uu___9;
-                                                FStar_Syntax_Syntax.binder_positivity
-                                                  = uu___10;
-                                                FStar_Syntax_Syntax.binder_attrs
-                                                  = uu___11;_}
-                                                ->
-                                                let uu___12 =
-                                                  FStar_Syntax_Syntax.bv_to_name
-                                                    bv in
-                                                FStar_Compiler_Effect.op_Bar_Greater
-                                                  uu___12
-                                                  FStar_Syntax_Syntax.as_arg)) in
+                                    FStar_Compiler_List.map
+                                      (fun uu___8 ->
+                                         match uu___8 with
+                                         | {
+                                             FStar_Syntax_Syntax.binder_bv =
+                                               bv;
+                                             FStar_Syntax_Syntax.binder_qual
+                                               = uu___9;
+                                             FStar_Syntax_Syntax.binder_positivity
+                                               = uu___10;
+                                             FStar_Syntax_Syntax.binder_attrs
+                                               = uu___11;_}
+                                             ->
+                                             let uu___12 =
+                                               FStar_Syntax_Syntax.bv_to_name
+                                                 bv in
+                                             FStar_Syntax_Syntax.as_arg
+                                               uu___12) tbinders in
                                   let e =
                                     FStar_Syntax_Syntax.mk
                                       (FStar_Syntax_Syntax.Tm_app
@@ -2617,8 +2518,8 @@ let (extract_lb_sig :
                                     (lbtyp1, (tbinders, polytype)), false, e)
                               | uu___7 -> err_value_restriction lbdef1)))
                | uu___5 -> no_gen ()) in
-      FStar_Compiler_Effect.op_Bar_Greater (FStar_Pervasives_Native.snd lbs)
-        (FStar_Compiler_List.map maybe_generalize)
+      FStar_Compiler_List.map maybe_generalize
+        (FStar_Pervasives_Native.snd lbs)
 let (extract_lb_iface :
   FStar_Extraction_ML_UEnv.uenv ->
     FStar_Syntax_Syntax.letbindings ->
@@ -2738,11 +2639,8 @@ and (term_as_mlexpr' :
       (let is_match t =
          let uu___1 =
            let uu___2 =
-             let uu___3 =
-               FStar_Compiler_Effect.op_Bar_Greater t
-                 FStar_Syntax_Subst.compress in
-             FStar_Compiler_Effect.op_Bar_Greater uu___3
-               FStar_Syntax_Util.unascribe in
+             let uu___3 = FStar_Syntax_Subst.compress t in
+             FStar_Syntax_Util.unascribe uu___3 in
            uu___2.FStar_Syntax_Syntax.n in
          match uu___1 with
          | FStar_Syntax_Syntax.Tm_match uu___2 -> true
@@ -2753,9 +2651,7 @@ and (term_as_mlexpr' :
               match uu___1 with
               | (t, uu___2) ->
                   let uu___3 =
-                    let uu___4 =
-                      FStar_Compiler_Effect.op_Bar_Greater t
-                        FStar_Syntax_Subst.compress in
+                    let uu___4 = FStar_Syntax_Subst.compress t in
                     uu___4.FStar_Syntax_Syntax.n in
                   (match uu___3 with
                    | FStar_Syntax_Syntax.Tm_name uu___4 -> true
@@ -2765,11 +2661,8 @@ and (term_as_mlexpr' :
        let apply_to_match_branches head args =
          let uu___1 =
            let uu___2 =
-             let uu___3 =
-               FStar_Compiler_Effect.op_Bar_Greater head
-                 FStar_Syntax_Subst.compress in
-             FStar_Compiler_Effect.op_Bar_Greater uu___3
-               FStar_Syntax_Util.unascribe in
+             let uu___3 = FStar_Syntax_Subst.compress head in
+             FStar_Syntax_Util.unascribe uu___3 in
            uu___2.FStar_Syntax_Syntax.n in
          match uu___1 with
          | FStar_Syntax_Syntax.Tm_match
@@ -2779,26 +2672,25 @@ and (term_as_mlexpr' :
                FStar_Syntax_Syntax.rc_opt1 = uu___3;_}
              ->
              let branches1 =
-               FStar_Compiler_Effect.op_Bar_Greater branches
-                 (FStar_Compiler_List.map
-                    (fun uu___4 ->
-                       match uu___4 with
-                       | (pat, when_opt, body) ->
-                           (pat, when_opt,
-                             {
-                               FStar_Syntax_Syntax.n =
-                                 (FStar_Syntax_Syntax.Tm_app
-                                    {
-                                      FStar_Syntax_Syntax.hd = body;
-                                      FStar_Syntax_Syntax.args = args
-                                    });
-                               FStar_Syntax_Syntax.pos =
-                                 (body.FStar_Syntax_Syntax.pos);
-                               FStar_Syntax_Syntax.vars =
-                                 (body.FStar_Syntax_Syntax.vars);
-                               FStar_Syntax_Syntax.hash_code =
-                                 (body.FStar_Syntax_Syntax.hash_code)
-                             }))) in
+               FStar_Compiler_List.map
+                 (fun uu___4 ->
+                    match uu___4 with
+                    | (pat, when_opt, body) ->
+                        (pat, when_opt,
+                          {
+                            FStar_Syntax_Syntax.n =
+                              (FStar_Syntax_Syntax.Tm_app
+                                 {
+                                   FStar_Syntax_Syntax.hd = body;
+                                   FStar_Syntax_Syntax.args = args
+                                 });
+                            FStar_Syntax_Syntax.pos =
+                              (body.FStar_Syntax_Syntax.pos);
+                            FStar_Syntax_Syntax.vars =
+                              (body.FStar_Syntax_Syntax.vars);
+                            FStar_Syntax_Syntax.hash_code =
+                              (body.FStar_Syntax_Syntax.hash_code)
+                          })) branches in
              {
                FStar_Syntax_Syntax.n =
                  (FStar_Syntax_Syntax.Tm_match
@@ -2875,24 +2767,16 @@ and (term_as_mlexpr' :
             | { FStar_Extraction_ML_UEnv.exp_b_name = uu___3;
                 FStar_Extraction_ML_UEnv.exp_b_expr = fw;
                 FStar_Extraction_ML_UEnv.exp_b_tscheme = uu___4;_} ->
-                let uu___5 =
-                  let uu___6 =
-                    let uu___7 =
-                      let uu___8 =
-                        let uu___9 =
-                          FStar_Compiler_Effect.op_Less_Bar
-                            (FStar_Extraction_ML_Syntax.with_ty
-                               FStar_Extraction_ML_Syntax.ml_string_ty)
+                ((FStar_Extraction_ML_Syntax.with_ty
+                    FStar_Extraction_ML_Syntax.ml_int_ty
+                    (FStar_Extraction_ML_Syntax.MLE_App
+                       (fw,
+                         [FStar_Extraction_ML_Syntax.with_ty
+                            FStar_Extraction_ML_Syntax.ml_string_ty
                             (FStar_Extraction_ML_Syntax.MLE_Const
                                (FStar_Extraction_ML_Syntax.MLC_String
-                                  "Cannot evaluate open quotation at runtime")) in
-                        [uu___9] in
-                      (fw, uu___8) in
-                    FStar_Extraction_ML_Syntax.MLE_App uu___7 in
-                  FStar_Compiler_Effect.op_Less_Bar
-                    (FStar_Extraction_ML_Syntax.with_ty
-                       FStar_Extraction_ML_Syntax.ml_int_ty) uu___6 in
-                (uu___5, FStar_Extraction_ML_Syntax.E_PURE,
+                                  "Cannot evaluate open quotation at runtime"))]))),
+                  FStar_Extraction_ML_Syntax.E_PURE,
                   FStar_Extraction_ML_Syntax.ml_int_ty))
        | FStar_Syntax_Syntax.Tm_quoted
            (qt,
@@ -3156,12 +3040,9 @@ and (term_as_mlexpr' :
                                             (targ, f1, t2)))) ml_bs (f, t1) in
                           (match uu___4 with
                            | (f1, tfun) ->
-                               let uu___5 =
-                                 FStar_Compiler_Effect.op_Less_Bar
-                                   (FStar_Extraction_ML_Syntax.with_ty tfun)
+                               ((FStar_Extraction_ML_Syntax.with_ty tfun
                                    (FStar_Extraction_ML_Syntax.MLE_Fun
-                                      (ml_bs, ml_body)) in
-                               (uu___5, f1, tfun)))))
+                                      (ml_bs, ml_body))), f1, tfun)))))
        | FStar_Syntax_Syntax.Tm_app
            {
              FStar_Syntax_Syntax.hd =
@@ -3181,8 +3062,7 @@ and (term_as_mlexpr' :
              let uu___6 =
                FStar_Extraction_ML_Util.mlexpr_of_range
                  a1.FStar_Syntax_Syntax.pos in
-             FStar_Compiler_Effect.op_Less_Bar
-               (FStar_Extraction_ML_Syntax.with_ty ty) uu___6 in
+             FStar_Extraction_ML_Syntax.with_ty ty uu___6 in
            (uu___5, FStar_Extraction_ML_Syntax.E_PURE, ty)
        | FStar_Syntax_Syntax.Tm_app
            {
@@ -3217,24 +3097,16 @@ and (term_as_mlexpr' :
             | { FStar_Extraction_ML_UEnv.exp_b_name = uu___7;
                 FStar_Extraction_ML_UEnv.exp_b_expr = fw;
                 FStar_Extraction_ML_UEnv.exp_b_tscheme = uu___8;_} ->
-                let uu___9 =
-                  let uu___10 =
-                    let uu___11 =
-                      let uu___12 =
-                        let uu___13 =
-                          FStar_Compiler_Effect.op_Less_Bar
-                            (FStar_Extraction_ML_Syntax.with_ty
-                               FStar_Extraction_ML_Syntax.ml_string_ty)
+                ((FStar_Extraction_ML_Syntax.with_ty
+                    FStar_Extraction_ML_Syntax.ml_int_ty
+                    (FStar_Extraction_ML_Syntax.MLE_App
+                       (fw,
+                         [FStar_Extraction_ML_Syntax.with_ty
+                            FStar_Extraction_ML_Syntax.ml_string_ty
                             (FStar_Extraction_ML_Syntax.MLE_Const
                                (FStar_Extraction_ML_Syntax.MLC_String
-                                  "Extraction of reflect is not supported")) in
-                        [uu___13] in
-                      (fw, uu___12) in
-                    FStar_Extraction_ML_Syntax.MLE_App uu___11 in
-                  FStar_Compiler_Effect.op_Less_Bar
-                    (FStar_Extraction_ML_Syntax.with_ty
-                       FStar_Extraction_ML_Syntax.ml_int_ty) uu___10 in
-                (uu___9, FStar_Extraction_ML_Syntax.E_PURE,
+                                  "Extraction of reflect is not supported"))]))),
+                  FStar_Extraction_ML_Syntax.E_PURE,
                   FStar_Extraction_ML_Syntax.ml_int_ty))
        | FStar_Syntax_Syntax.Tm_app uu___1 when is_steel_with_invariant_g t
            ->
@@ -3262,15 +3134,9 @@ and (term_as_mlexpr' :
        | FStar_Syntax_Syntax.Tm_app
            { FStar_Syntax_Syntax.hd = head;
              FStar_Syntax_Syntax.args = args;_}
-           when
-           (is_match head) &&
-             (FStar_Compiler_Effect.op_Bar_Greater args
-                should_apply_to_match_branches)
-           ->
-           let uu___1 =
-             FStar_Compiler_Effect.op_Bar_Greater args
-               (apply_to_match_branches head) in
-           FStar_Compiler_Effect.op_Bar_Greater uu___1 (term_as_mlexpr g)
+           when (is_match head) && (should_apply_to_match_branches args) ->
+           let uu___1 = apply_to_match_branches head args in
+           term_as_mlexpr g uu___1
        | FStar_Syntax_Syntax.Tm_app
            { FStar_Syntax_Syntax.hd = head;
              FStar_Syntax_Syntax.args = args;_}
@@ -3279,20 +3145,15 @@ and (term_as_mlexpr' :
              (FStar_Ident.lid_equals rc.FStar_Syntax_Syntax.residual_effect
                 FStar_Parser_Const.effect_Tot_lid)
                ||
-               (FStar_Compiler_Effect.op_Bar_Greater
-                  rc.FStar_Syntax_Syntax.residual_flags
-                  (FStar_Compiler_List.existsb
-                     (fun uu___1 ->
-                        match uu___1 with
-                        | FStar_Syntax_Syntax.TOTAL -> true
-                        | uu___2 -> false))) in
+               (FStar_Compiler_List.existsb
+                  (fun uu___1 ->
+                     match uu___1 with
+                     | FStar_Syntax_Syntax.TOTAL -> true
+                     | uu___2 -> false) rc.FStar_Syntax_Syntax.residual_flags) in
            let uu___1 =
              let uu___2 =
-               let uu___3 =
-                 FStar_Compiler_Effect.op_Bar_Greater head
-                   FStar_Syntax_Subst.compress in
-               FStar_Compiler_Effect.op_Bar_Greater uu___3
-                 FStar_Syntax_Util.unascribe in
+               let uu___3 = FStar_Syntax_Subst.compress head in
+               FStar_Syntax_Util.unascribe uu___3 in
              uu___2.FStar_Syntax_Syntax.n in
            (match uu___1 with
             | FStar_Syntax_Syntax.Tm_abs
@@ -3301,18 +3162,15 @@ and (term_as_mlexpr' :
                   FStar_Syntax_Syntax.rc_opt = rc;_}
                 ->
                 let uu___3 =
-                  let uu___4 =
-                    let uu___5 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
-                    FStar_TypeChecker_Normalize.normalize
-                      [FStar_TypeChecker_Env.Beta;
-                      FStar_TypeChecker_Env.Iota;
-                      FStar_TypeChecker_Env.Zeta;
-                      FStar_TypeChecker_Env.EraseUniverses;
-                      FStar_TypeChecker_Env.AllowUnboundUniverses;
-                      FStar_TypeChecker_Env.ForExtraction] uu___5 in
-                  FStar_Compiler_Effect.op_Bar_Greater t uu___4 in
-                FStar_Compiler_Effect.op_Bar_Greater uu___3
-                  (term_as_mlexpr g)
+                  let uu___4 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
+                  FStar_TypeChecker_Normalize.normalize
+                    [FStar_TypeChecker_Env.Beta;
+                    FStar_TypeChecker_Env.Iota;
+                    FStar_TypeChecker_Env.Zeta;
+                    FStar_TypeChecker_Env.EraseUniverses;
+                    FStar_TypeChecker_Env.AllowUnboundUniverses;
+                    FStar_TypeChecker_Env.ForExtraction] uu___4 t in
+                term_as_mlexpr g uu___3
             | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reify lopt)
                 ->
                 (match lopt with
@@ -3320,11 +3178,8 @@ and (term_as_mlexpr' :
                      let e =
                        let uu___2 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
                        let uu___3 =
-                         let uu___4 =
-                           FStar_Compiler_Effect.op_Bar_Greater args
-                             FStar_Compiler_List.hd in
-                         FStar_Compiler_Effect.op_Bar_Greater uu___4
-                           FStar_Pervasives_Native.fst in
+                         let uu___4 = FStar_Compiler_List.hd args in
+                         FStar_Pervasives_Native.fst uu___4 in
                        maybe_reify_term uu___2 uu___3 l in
                      let tm =
                        let uu___2 = FStar_TypeChecker_Util.remove_reify e in
@@ -3349,12 +3204,9 @@ and (term_as_mlexpr' :
                   | ((mlhead, mlargs_f), (f, t1)) ->
                       let mk_head uu___5 =
                         let mlargs =
-                          FStar_Compiler_Effect.op_Bar_Greater
-                            (FStar_Compiler_List.rev mlargs_f)
-                            (FStar_Compiler_List.map
-                               FStar_Pervasives_Native.fst) in
-                        FStar_Compiler_Effect.op_Less_Bar
-                          (FStar_Extraction_ML_Syntax.with_ty t1)
+                          FStar_Compiler_List.map FStar_Pervasives_Native.fst
+                            (FStar_Compiler_List.rev mlargs_f) in
+                        FStar_Extraction_ML_Syntax.with_ty t1
                           (FStar_Extraction_ML_Syntax.MLE_App
                              (mlhead, mlargs)) in
                       (FStar_Extraction_ML_UEnv.debug g
@@ -3454,14 +3306,12 @@ and (term_as_mlexpr' :
                                           FStar_Extraction_ML_Syntax.MLTY_Top in
                                       let mlhead1 =
                                         let mlargs =
-                                          FStar_Compiler_Effect.op_Bar_Greater
-                                            (FStar_Compiler_List.rev mlargs_f)
-                                            (FStar_Compiler_List.map
-                                               FStar_Pervasives_Native.fst) in
+                                          FStar_Compiler_List.map
+                                            FStar_Pervasives_Native.fst
+                                            (FStar_Compiler_List.rev mlargs_f) in
                                         let head1 =
-                                          FStar_Compiler_Effect.op_Less_Bar
-                                            (FStar_Extraction_ML_Syntax.with_ty
-                                               FStar_Extraction_ML_Syntax.MLTY_Top)
+                                          FStar_Extraction_ML_Syntax.with_ty
+                                            FStar_Extraction_ML_Syntax.MLTY_Top
                                             (FStar_Extraction_ML_Syntax.MLE_App
                                                (mlhead, mlargs)) in
                                         maybe_coerce
@@ -3474,14 +3324,12 @@ and (term_as_mlexpr' :
                                   | uu___8 ->
                                       let mlhead1 =
                                         let mlargs =
-                                          FStar_Compiler_Effect.op_Bar_Greater
-                                            (FStar_Compiler_List.rev mlargs_f)
-                                            (FStar_Compiler_List.map
-                                               FStar_Pervasives_Native.fst) in
+                                          FStar_Compiler_List.map
+                                            FStar_Pervasives_Native.fst
+                                            (FStar_Compiler_List.rev mlargs_f) in
                                         let head1 =
-                                          FStar_Compiler_Effect.op_Less_Bar
-                                            (FStar_Extraction_ML_Syntax.with_ty
-                                               FStar_Extraction_ML_Syntax.MLTY_Top)
+                                          FStar_Extraction_ML_Syntax.with_ty
+                                            FStar_Extraction_ML_Syntax.MLTY_Top
                                             (FStar_Extraction_ML_Syntax.MLE_App
                                                (mlhead, mlargs)) in
                                         maybe_coerce
@@ -3617,14 +3465,12 @@ and (term_as_mlexpr' :
                                            (vars, t1) provided_type_args in
                                        (match uu___11 with
                                         | (head3, uu___12, t2) ->
-                                            let uu___13 =
-                                              FStar_Compiler_Effect.op_Bar_Greater
+                                            ((FStar_Extraction_ML_Syntax.with_ty
+                                                t2
                                                 (FStar_Extraction_ML_Syntax.MLE_App
                                                    (head3,
-                                                     [FStar_Extraction_ML_Syntax.ml_unit]))
-                                                (FStar_Extraction_ML_Syntax.with_ty
-                                                   t2) in
-                                            (uu___13, t2))
+                                                     [FStar_Extraction_ML_Syntax.ml_unit]))),
+                                              t2))
                                    | uu___9 ->
                                        FStar_Compiler_Effect.failwith
                                          "Impossible: Unexpected head term" in
@@ -3742,14 +3588,12 @@ and (term_as_mlexpr' :
                                            (vars, t1) provided_type_args in
                                        (match uu___11 with
                                         | (head3, uu___12, t2) ->
-                                            let uu___13 =
-                                              FStar_Compiler_Effect.op_Bar_Greater
+                                            ((FStar_Extraction_ML_Syntax.with_ty
+                                                t2
                                                 (FStar_Extraction_ML_Syntax.MLE_App
                                                    (head3,
-                                                     [FStar_Extraction_ML_Syntax.ml_unit]))
-                                                (FStar_Extraction_ML_Syntax.with_ty
-                                                   t2) in
-                                            (uu___13, t2))
+                                                     [FStar_Extraction_ML_Syntax.ml_unit]))),
+                                              t2))
                                    | uu___9 ->
                                        FStar_Compiler_Effect.failwith
                                          "Impossible: Unexpected head term" in
@@ -4029,67 +3873,63 @@ and (term_as_mlexpr' :
                         FStar_Ident.lid_of_path uu___4
                           FStar_Compiler_Range_Type.dummyRange in
                       FStar_TypeChecker_Env.set_current_module uu___2 uu___3 in
-                    FStar_Compiler_Effect.op_Bar_Greater lbs1
-                      (FStar_Compiler_List.map
-                         (fun lb ->
-                            let lbdef =
-                              let norm_call uu___2 =
-                                let uu___3 =
-                                  let uu___4 =
-                                    let uu___5 =
-                                      FStar_TypeChecker_Env.current_module
-                                        tcenv in
-                                    FStar_Ident.string_of_lid uu___5 in
-                                  FStar_Pervasives_Native.Some uu___4 in
-                                FStar_Profiling.profile
-                                  (fun uu___4 ->
-                                     FStar_TypeChecker_Normalize.normalize
-                                       (FStar_TypeChecker_Env.PureSubtermsWithinComputations
-                                       :: FStar_TypeChecker_Env.Reify ::
-                                       extraction_norm_steps) tcenv
-                                       lb.FStar_Syntax_Syntax.lbdef) uu___3
-                                  "FStar.Extraction.ML.Term.normalize_lb_def" in
-                              let uu___2 =
-                                (FStar_Compiler_Effect.op_Less_Bar
-                                   (FStar_TypeChecker_Env.debug tcenv)
-                                   (FStar_Options.Other "Extraction"))
-                                  ||
-                                  (FStar_Compiler_Effect.op_Less_Bar
-                                     (FStar_TypeChecker_Env.debug tcenv)
-                                     (FStar_Options.Other "ExtractNorm")) in
-                              if uu___2
-                              then
-                                ((let uu___4 =
-                                    FStar_Syntax_Print.lbname_to_string
-                                      lb.FStar_Syntax_Syntax.lbname in
-                                  let uu___5 =
-                                    FStar_Syntax_Print.term_to_string
-                                      lb.FStar_Syntax_Syntax.lbdef in
-                                  FStar_Compiler_Util.print2
-                                    "Starting to normalize top-level let %s = %s\n"
-                                    uu___4 uu___5);
-                                 (let a = norm_call () in
-                                  (let uu___5 =
-                                     FStar_Syntax_Print.term_to_string a in
-                                   FStar_Compiler_Util.print1
-                                     "Normalized to %s\n" uu___5);
-                                  a))
-                              else norm_call () in
-                            {
-                              FStar_Syntax_Syntax.lbname =
-                                (lb.FStar_Syntax_Syntax.lbname);
-                              FStar_Syntax_Syntax.lbunivs =
-                                (lb.FStar_Syntax_Syntax.lbunivs);
-                              FStar_Syntax_Syntax.lbtyp =
-                                (lb.FStar_Syntax_Syntax.lbtyp);
-                              FStar_Syntax_Syntax.lbeff =
-                                (lb.FStar_Syntax_Syntax.lbeff);
-                              FStar_Syntax_Syntax.lbdef = lbdef;
-                              FStar_Syntax_Syntax.lbattrs =
-                                (lb.FStar_Syntax_Syntax.lbattrs);
-                              FStar_Syntax_Syntax.lbpos =
-                                (lb.FStar_Syntax_Syntax.lbpos)
-                            }))
+                    FStar_Compiler_List.map
+                      (fun lb ->
+                         let lbdef =
+                           let norm_call uu___2 =
+                             let uu___3 =
+                               let uu___4 =
+                                 let uu___5 =
+                                   FStar_TypeChecker_Env.current_module tcenv in
+                                 FStar_Ident.string_of_lid uu___5 in
+                               FStar_Pervasives_Native.Some uu___4 in
+                             FStar_Profiling.profile
+                               (fun uu___4 ->
+                                  FStar_TypeChecker_Normalize.normalize
+                                    (FStar_TypeChecker_Env.PureSubtermsWithinComputations
+                                    :: FStar_TypeChecker_Env.Reify ::
+                                    extraction_norm_steps) tcenv
+                                    lb.FStar_Syntax_Syntax.lbdef) uu___3
+                               "FStar.Extraction.ML.Term.normalize_lb_def" in
+                           let uu___2 =
+                             (FStar_TypeChecker_Env.debug tcenv
+                                (FStar_Options.Other "Extraction"))
+                               ||
+                               (FStar_TypeChecker_Env.debug tcenv
+                                  (FStar_Options.Other "ExtractNorm")) in
+                           if uu___2
+                           then
+                             ((let uu___4 =
+                                 FStar_Syntax_Print.lbname_to_string
+                                   lb.FStar_Syntax_Syntax.lbname in
+                               let uu___5 =
+                                 FStar_Syntax_Print.term_to_string
+                                   lb.FStar_Syntax_Syntax.lbdef in
+                               FStar_Compiler_Util.print2
+                                 "Starting to normalize top-level let %s = %s\n"
+                                 uu___4 uu___5);
+                              (let a = norm_call () in
+                               (let uu___5 =
+                                  FStar_Syntax_Print.term_to_string a in
+                                FStar_Compiler_Util.print1
+                                  "Normalized to %s\n" uu___5);
+                               a))
+                           else norm_call () in
+                         {
+                           FStar_Syntax_Syntax.lbname =
+                             (lb.FStar_Syntax_Syntax.lbname);
+                           FStar_Syntax_Syntax.lbunivs =
+                             (lb.FStar_Syntax_Syntax.lbunivs);
+                           FStar_Syntax_Syntax.lbtyp =
+                             (lb.FStar_Syntax_Syntax.lbtyp);
+                           FStar_Syntax_Syntax.lbeff =
+                             (lb.FStar_Syntax_Syntax.lbeff);
+                           FStar_Syntax_Syntax.lbdef = lbdef;
+                           FStar_Syntax_Syntax.lbattrs =
+                             (lb.FStar_Syntax_Syntax.lbattrs);
+                           FStar_Syntax_Syntax.lbpos =
+                             (lb.FStar_Syntax_Syntax.lbpos)
+                         }) lbs1
                   else lbs1 in
                 let check_lb env uu___2 =
                   match uu___2 with
@@ -4171,8 +4011,7 @@ and (term_as_mlexpr' :
                  | (env_body, lbs4, env_burn) ->
                      let env_def = if is_rec then env_body else env_burn in
                      let lbs5 =
-                       FStar_Compiler_Effect.op_Bar_Greater lbs4
-                         (FStar_Compiler_List.map (check_lb env_def)) in
+                       FStar_Compiler_List.map (check_lb env_def) lbs4 in
                      let e'_rng = e'1.FStar_Syntax_Syntax.pos in
                      let uu___3 = term_as_mlexpr env_body e'1 in
                      (match uu___3 with
@@ -4254,9 +4093,8 @@ and (term_as_mlexpr' :
                                                  (e, uu___11, uu___12) in
                                                FStar_Extraction_ML_Syntax.MLE_If
                                                  uu___10 in
-                                             FStar_Compiler_Effect.op_Less_Bar
-                                               (FStar_Extraction_ML_Syntax.with_ty
-                                                  t_branch) uu___9 in
+                                             FStar_Extraction_ML_Syntax.with_ty
+                                               t_branch uu___9 in
                                            let uu___9 =
                                              FStar_Extraction_ML_Util.join
                                                then_e1.FStar_Syntax_Syntax.pos
@@ -4267,69 +4105,62 @@ and (term_as_mlexpr' :
                               "ITE pats matched but then and else expressions not found?")
                      else
                        (let uu___6 =
-                          FStar_Compiler_Effect.op_Bar_Greater pats
-                            (FStar_Compiler_Util.fold_map
-                               (fun compat ->
-                                  fun br ->
-                                    let uu___7 =
-                                      FStar_Syntax_Subst.open_branch br in
-                                    match uu___7 with
-                                    | (pat, when_opt, branch) ->
-                                        let uu___8 =
-                                          extract_pat g pat t_e
-                                            term_as_mlexpr in
-                                        (match uu___8 with
-                                         | (env, p, pat_t_compat) ->
-                                             let uu___9 =
-                                               match when_opt with
-                                               | FStar_Pervasives_Native.None
-                                                   ->
-                                                   (FStar_Pervasives_Native.None,
-                                                     FStar_Extraction_ML_Syntax.E_PURE)
-                                               | FStar_Pervasives_Native.Some
-                                                   w ->
-                                                   let w_pos =
-                                                     w.FStar_Syntax_Syntax.pos in
-                                                   let uu___10 =
-                                                     term_as_mlexpr env w in
-                                                   (match uu___10 with
-                                                    | (w1, f_w, t_w) ->
-                                                        let w2 =
-                                                          maybe_coerce w_pos
-                                                            env w1 t_w
-                                                            FStar_Extraction_ML_Syntax.ml_bool_ty in
-                                                        ((FStar_Pervasives_Native.Some
-                                                            w2), f_w)) in
-                                             (match uu___9 with
-                                              | (when_opt1, f_when) ->
-                                                  let uu___10 =
-                                                    term_as_mlexpr env branch in
-                                                  (match uu___10 with
-                                                   | (mlbranch, f_branch,
-                                                      t_branch) ->
-                                                       let uu___11 =
-                                                         FStar_Compiler_Effect.op_Bar_Greater
-                                                           p
-                                                           (FStar_Compiler_List.map
-                                                              (fun uu___12 ->
-                                                                 match uu___12
-                                                                 with
-                                                                 | (p1, wopt)
-                                                                    ->
-                                                                    let when_clause
-                                                                    =
-                                                                    FStar_Extraction_ML_Util.conjoin_opt
-                                                                    wopt
-                                                                    when_opt1 in
-                                                                    (p1,
-                                                                    (when_clause,
-                                                                    f_when),
-                                                                    (mlbranch,
-                                                                    f_branch,
-                                                                    t_branch)))) in
-                                                       ((compat &&
-                                                           pat_t_compat),
-                                                         uu___11))))) true) in
+                          FStar_Compiler_Util.fold_map
+                            (fun compat ->
+                               fun br ->
+                                 let uu___7 =
+                                   FStar_Syntax_Subst.open_branch br in
+                                 match uu___7 with
+                                 | (pat, when_opt, branch) ->
+                                     let uu___8 =
+                                       extract_pat g pat t_e term_as_mlexpr in
+                                     (match uu___8 with
+                                      | (env, p, pat_t_compat) ->
+                                          let uu___9 =
+                                            match when_opt with
+                                            | FStar_Pervasives_Native.None ->
+                                                (FStar_Pervasives_Native.None,
+                                                  FStar_Extraction_ML_Syntax.E_PURE)
+                                            | FStar_Pervasives_Native.Some w
+                                                ->
+                                                let w_pos =
+                                                  w.FStar_Syntax_Syntax.pos in
+                                                let uu___10 =
+                                                  term_as_mlexpr env w in
+                                                (match uu___10 with
+                                                 | (w1, f_w, t_w) ->
+                                                     let w2 =
+                                                       maybe_coerce w_pos env
+                                                         w1 t_w
+                                                         FStar_Extraction_ML_Syntax.ml_bool_ty in
+                                                     ((FStar_Pervasives_Native.Some
+                                                         w2), f_w)) in
+                                          (match uu___9 with
+                                           | (when_opt1, f_when) ->
+                                               let uu___10 =
+                                                 term_as_mlexpr env branch in
+                                               (match uu___10 with
+                                                | (mlbranch, f_branch,
+                                                   t_branch) ->
+                                                    let uu___11 =
+                                                      FStar_Compiler_List.map
+                                                        (fun uu___12 ->
+                                                           match uu___12 with
+                                                           | (p1, wopt) ->
+                                                               let when_clause
+                                                                 =
+                                                                 FStar_Extraction_ML_Util.conjoin_opt
+                                                                   wopt
+                                                                   when_opt1 in
+                                                               (p1,
+                                                                 (when_clause,
+                                                                   f_when),
+                                                                 (mlbranch,
+                                                                   f_branch,
+                                                                   t_branch)))
+                                                        p in
+                                                    ((compat && pat_t_compat),
+                                                      uu___11))))) true pats in
                         match uu___6 with
                         | (pat_t_compat, mlbranches) ->
                             let mlbranches1 =
@@ -4355,8 +4186,7 @@ and (term_as_mlexpr' :
                                       FStar_Compiler_Util.print2
                                         "Coercing scrutinee %s from type %s because pattern type is incompatible\n"
                                         uu___10 uu___11);
-                                 FStar_Compiler_Effect.op_Less_Bar
-                                   (FStar_Extraction_ML_Syntax.with_ty t_e)
+                                 FStar_Extraction_ML_Syntax.with_ty t_e
                                    (FStar_Extraction_ML_Syntax.MLE_Coerce
                                       (e, t_e,
                                         FStar_Extraction_ML_Syntax.MLTY_Top))) in
@@ -4379,26 +4209,15 @@ and (term_as_mlexpr' :
                                       FStar_Extraction_ML_UEnv.exp_b_tscheme
                                         = uu___9;_}
                                       ->
-                                      let uu___10 =
-                                        let uu___11 =
-                                          let uu___12 =
-                                            let uu___13 =
-                                              let uu___14 =
-                                                FStar_Compiler_Effect.op_Less_Bar
-                                                  (FStar_Extraction_ML_Syntax.with_ty
-                                                     FStar_Extraction_ML_Syntax.ml_string_ty)
+                                      ((FStar_Extraction_ML_Syntax.with_ty
+                                          FStar_Extraction_ML_Syntax.ml_int_ty
+                                          (FStar_Extraction_ML_Syntax.MLE_App
+                                             (fw,
+                                               [FStar_Extraction_ML_Syntax.with_ty
+                                                  FStar_Extraction_ML_Syntax.ml_string_ty
                                                   (FStar_Extraction_ML_Syntax.MLE_Const
                                                      (FStar_Extraction_ML_Syntax.MLC_String
-                                                        "unreachable")) in
-                                              [uu___14] in
-                                            (fw, uu___13) in
-                                          FStar_Extraction_ML_Syntax.MLE_App
-                                            uu___12 in
-                                        FStar_Compiler_Effect.op_Less_Bar
-                                          (FStar_Extraction_ML_Syntax.with_ty
-                                             FStar_Extraction_ML_Syntax.ml_int_ty)
-                                          uu___11 in
-                                      (uu___10,
+                                                        "unreachable"))]))),
                                         FStar_Extraction_ML_Syntax.E_PURE,
                                         FStar_Extraction_ML_Syntax.ml_int_ty))
                              | (uu___7, uu___8, (uu___9, f_first, t_first))::rest
@@ -4445,35 +4264,31 @@ and (term_as_mlexpr' :
                                  (match uu___10 with
                                   | (topt, f_match) ->
                                       let mlbranches2 =
-                                        FStar_Compiler_Effect.op_Bar_Greater
-                                          mlbranches1
-                                          (FStar_Compiler_List.map
-                                             (fun uu___11 ->
-                                                match uu___11 with
-                                                | (p, (wopt, uu___12),
-                                                   (b1, uu___13, t1)) ->
-                                                    let b2 =
-                                                      match topt with
-                                                      | FStar_Pervasives_Native.None
-                                                          ->
-                                                          FStar_Extraction_ML_Syntax.apply_obj_repr
-                                                            b1 t1
-                                                      | FStar_Pervasives_Native.Some
-                                                          uu___14 -> b1 in
-                                                    (p, wopt, b2))) in
+                                        FStar_Compiler_List.map
+                                          (fun uu___11 ->
+                                             match uu___11 with
+                                             | (p, (wopt, uu___12),
+                                                (b1, uu___13, t1)) ->
+                                                 let b2 =
+                                                   match topt with
+                                                   | FStar_Pervasives_Native.None
+                                                       ->
+                                                       FStar_Extraction_ML_Syntax.apply_obj_repr
+                                                         b1 t1
+                                                   | FStar_Pervasives_Native.Some
+                                                       uu___14 -> b1 in
+                                                 (p, wopt, b2)) mlbranches1 in
                                       let t_match =
                                         match topt with
                                         | FStar_Pervasives_Native.None ->
                                             FStar_Extraction_ML_Syntax.MLTY_Top
                                         | FStar_Pervasives_Native.Some t1 ->
                                             t1 in
-                                      let uu___11 =
-                                        FStar_Compiler_Effect.op_Less_Bar
-                                          (FStar_Extraction_ML_Syntax.with_ty
-                                             t_match)
+                                      ((FStar_Extraction_ML_Syntax.with_ty
+                                          t_match
                                           (FStar_Extraction_ML_Syntax.MLE_Match
-                                             (e1, mlbranches2)) in
-                                      (uu___11, f_match, t_match)))))))
+                                             (e1, mlbranches2))), f_match,
+                                        t_match)))))))
 let (ind_discriminator_body :
   FStar_Extraction_ML_UEnv.uenv ->
     FStar_Ident.lident ->
@@ -4486,8 +4301,7 @@ let (ind_discriminator_body :
           let uu___1 =
             let uu___2 = FStar_Extraction_ML_UEnv.tcenv_of_uenv env in
             FStar_TypeChecker_Env.lookup_lid uu___2 discName in
-          FStar_Compiler_Effect.op_Less_Bar FStar_Pervasives_Native.fst
-            uu___1 in
+          FStar_Pervasives_Native.fst uu___1 in
         match uu___ with
         | (uu___1, fstar_disc_type) ->
             let uu___2 =
@@ -4500,19 +4314,17 @@ let (ind_discriminator_body :
                     FStar_Syntax_Syntax.comp = uu___4;_}
                   ->
                   let binders1 =
-                    FStar_Compiler_Effect.op_Bar_Greater binders
-                      (FStar_Compiler_List.filter
-                         (fun uu___5 ->
-                            match uu___5 with
-                            | { FStar_Syntax_Syntax.binder_bv = uu___6;
-                                FStar_Syntax_Syntax.binder_qual =
-                                  FStar_Pervasives_Native.Some
-                                  (FStar_Syntax_Syntax.Implicit uu___7);
-                                FStar_Syntax_Syntax.binder_positivity =
-                                  uu___8;
-                                FStar_Syntax_Syntax.binder_attrs = uu___9;_}
-                                -> true
-                            | uu___6 -> false)) in
+                    FStar_Compiler_List.filter
+                      (fun uu___5 ->
+                         match uu___5 with
+                         | { FStar_Syntax_Syntax.binder_bv = uu___6;
+                             FStar_Syntax_Syntax.binder_qual =
+                               FStar_Pervasives_Native.Some
+                               (FStar_Syntax_Syntax.Implicit uu___7);
+                             FStar_Syntax_Syntax.binder_positivity = uu___8;
+                             FStar_Syntax_Syntax.binder_attrs = uu___9;_} ->
+                             true
+                         | uu___6 -> false) binders in
                   FStar_Compiler_List.fold_right
                     (fun uu___5 ->
                        fun uu___6 ->
@@ -4542,56 +4354,40 @@ let (ind_discriminator_body :
                               let uu___7 =
                                 let uu___8 =
                                   let uu___9 =
-                                    FStar_Compiler_Effect.op_Less_Bar
-                                      (FStar_Extraction_ML_Syntax.with_ty
-                                         targ)
-                                      (FStar_Extraction_ML_Syntax.MLE_Name
-                                         ([], mlid)) in
-                                  let uu___10 =
-                                    let uu___11 =
-                                      let uu___12 =
-                                        let uu___13 =
-                                          let uu___14 =
+                                    let uu___10 =
+                                      let uu___11 =
+                                        let uu___12 =
+                                          let uu___13 =
                                             FStar_Extraction_ML_UEnv.mlpath_of_lident
                                               g1 constrName in
-                                          (uu___14,
+                                          (uu___13,
                                             [FStar_Extraction_ML_Syntax.MLP_Wild]) in
                                         FStar_Extraction_ML_Syntax.MLP_CTor
-                                          uu___13 in
-                                      let uu___13 =
-                                        FStar_Compiler_Effect.op_Less_Bar
-                                          (FStar_Extraction_ML_Syntax.with_ty
-                                             FStar_Extraction_ML_Syntax.ml_bool_ty)
-                                          (FStar_Extraction_ML_Syntax.MLE_Const
-                                             (FStar_Extraction_ML_Syntax.MLC_Bool
-                                                true)) in
-                                      (uu___12, FStar_Pervasives_Native.None,
-                                        uu___13) in
-                                    let uu___12 =
-                                      let uu___13 =
-                                        let uu___14 =
-                                          FStar_Compiler_Effect.op_Less_Bar
-                                            (FStar_Extraction_ML_Syntax.with_ty
-                                               FStar_Extraction_ML_Syntax.ml_bool_ty)
-                                            (FStar_Extraction_ML_Syntax.MLE_Const
-                                               (FStar_Extraction_ML_Syntax.MLC_Bool
-                                                  false)) in
-                                        (FStar_Extraction_ML_Syntax.MLP_Wild,
-                                          FStar_Pervasives_Native.None,
-                                          uu___14) in
-                                      [uu___13] in
-                                    uu___11 :: uu___12 in
-                                  (uu___9, uu___10) in
+                                          uu___12 in
+                                      (uu___11, FStar_Pervasives_Native.None,
+                                        (FStar_Extraction_ML_Syntax.with_ty
+                                           FStar_Extraction_ML_Syntax.ml_bool_ty
+                                           (FStar_Extraction_ML_Syntax.MLE_Const
+                                              (FStar_Extraction_ML_Syntax.MLC_Bool
+                                                 true)))) in
+                                    [uu___10;
+                                    (FStar_Extraction_ML_Syntax.MLP_Wild,
+                                      FStar_Pervasives_Native.None,
+                                      (FStar_Extraction_ML_Syntax.with_ty
+                                         FStar_Extraction_ML_Syntax.ml_bool_ty
+                                         (FStar_Extraction_ML_Syntax.MLE_Const
+                                            (FStar_Extraction_ML_Syntax.MLC_Bool
+                                               false))))] in
+                                  ((FStar_Extraction_ML_Syntax.with_ty targ
+                                      (FStar_Extraction_ML_Syntax.MLE_Name
+                                         ([], mlid))), uu___9) in
                                 FStar_Extraction_ML_Syntax.MLE_Match uu___8 in
-                              FStar_Compiler_Effect.op_Less_Bar
-                                (FStar_Extraction_ML_Syntax.with_ty
-                                   FStar_Extraction_ML_Syntax.ml_bool_ty)
-                                uu___7 in
+                              FStar_Extraction_ML_Syntax.with_ty
+                                FStar_Extraction_ML_Syntax.ml_bool_ty uu___7 in
                             ((FStar_Compiler_List.op_At wildcards
                                 [(mlid, targ)]), uu___6) in
                           FStar_Extraction_ML_Syntax.MLE_Fun uu___5 in
-                        FStar_Compiler_Effect.op_Less_Bar
-                          (FStar_Extraction_ML_Syntax.with_ty disc_ty) uu___4 in
+                        FStar_Extraction_ML_Syntax.with_ty disc_ty uu___4 in
                       let uu___4 =
                         FStar_Extraction_ML_UEnv.mlpath_of_lident env
                           discName in

--- a/ocaml/fstar-lib/generated/FStar_Extraction_ML_UEnv.ml
+++ b/ocaml/fstar-lib/generated/FStar_Extraction_ML_UEnv.ml
@@ -437,18 +437,17 @@ let (mlpath_of_lident :
 let (is_type_name : uenv -> FStar_Syntax_Syntax.fv -> Prims.bool) =
   fun g ->
     fun fv ->
-      FStar_Compiler_Effect.op_Bar_Greater g.type_names
-        (FStar_Compiler_Util.for_some
-           (fun uu___ ->
-              match uu___ with
-              | (x, uu___1) -> FStar_Syntax_Syntax.fv_eq fv x))
+      FStar_Compiler_Util.for_some
+        (fun uu___ ->
+           match uu___ with | (x, uu___1) -> FStar_Syntax_Syntax.fv_eq fv x)
+        g.type_names
 let (is_fv_type : uenv -> FStar_Syntax_Syntax.fv -> Prims.bool) =
   fun g ->
     fun fv ->
       (is_type_name g fv) ||
-        (FStar_Compiler_Effect.op_Bar_Greater g.tydefs
-           (FStar_Compiler_Util.for_some
-              (fun tydef1 -> FStar_Syntax_Syntax.fv_eq fv tydef1.tydef_fv)))
+        (FStar_Compiler_Util.for_some
+           (fun tydef1 -> FStar_Syntax_Syntax.fv_eq fv tydef1.tydef_fv)
+           g.tydefs)
 let (no_fstar_stubs_ns :
   FStar_Extraction_ML_Syntax.mlsymbol Prims.list ->
     FStar_Extraction_ML_Syntax.mlsymbol Prims.list)
@@ -603,7 +602,7 @@ let (mlns_of_lid :
     let uu___ =
       let uu___1 = FStar_Ident.ns_of_lid x in
       FStar_Compiler_List.map FStar_Ident.string_of_id uu___1 in
-    FStar_Compiler_Effect.op_Bar_Greater uu___ no_fstar_stubs_ns
+    no_fstar_stubs_ns uu___
 let (new_mlpath_of_lident :
   uenv -> FStar_Ident.lident -> (FStar_Extraction_ML_Syntax.mlpath * uenv)) =
   fun g ->
@@ -727,9 +726,8 @@ let (extend_bv :
                   else
                     if add_unit
                     then
-                      FStar_Compiler_Effect.op_Less_Bar
-                        (FStar_Extraction_ML_Syntax.with_ty
-                           FStar_Extraction_ML_Syntax.MLTY_Top)
+                      FStar_Extraction_ML_Syntax.with_ty
+                        FStar_Extraction_ML_Syntax.MLTY_Top
                         (FStar_Extraction_ML_Syntax.MLE_App
                            ((FStar_Extraction_ML_Syntax.with_ty
                                FStar_Extraction_ML_Syntax.MLTY_Top mlx),
@@ -839,9 +837,8 @@ let (extend_fv :
                 let mly1 =
                   if add_unit
                   then
-                    FStar_Compiler_Effect.op_Less_Bar
-                      (FStar_Extraction_ML_Syntax.with_ty
-                         FStar_Extraction_ML_Syntax.MLTY_Top)
+                    FStar_Extraction_ML_Syntax.with_ty
+                      FStar_Extraction_ML_Syntax.MLTY_Top
                       (FStar_Extraction_ML_Syntax.MLE_App
                          ((FStar_Extraction_ML_Syntax.with_ty
                              FStar_Extraction_ML_Syntax.MLTY_Top mly),

--- a/ocaml/fstar-lib/generated/FStar_Extraction_ML_Util.ml
+++ b/ocaml/fstar-lib/generated/FStar_Extraction_ML_Util.ml
@@ -13,16 +13,13 @@ let pruneNones :
            | FStar_Pervasives_Native.Some xs -> xs :: ll
            | FStar_Pervasives_Native.None -> ll) l []
 let (mk_range_mle : FStar_Extraction_ML_Syntax.mlexpr) =
-  FStar_Compiler_Effect.op_Less_Bar
-    (FStar_Extraction_ML_Syntax.with_ty FStar_Extraction_ML_Syntax.MLTY_Top)
+  FStar_Extraction_ML_Syntax.with_ty FStar_Extraction_ML_Syntax.MLTY_Top
     (FStar_Extraction_ML_Syntax.MLE_Name (["FStar"; "Range"], "mk_range"))
 let (dummy_range_mle : FStar_Extraction_ML_Syntax.mlexpr) =
-  FStar_Compiler_Effect.op_Less_Bar
-    (FStar_Extraction_ML_Syntax.with_ty FStar_Extraction_ML_Syntax.MLTY_Top)
+  FStar_Extraction_ML_Syntax.with_ty FStar_Extraction_ML_Syntax.MLTY_Top
     (FStar_Extraction_ML_Syntax.MLE_Name (["FStar"; "Range"], "dummyRange"))
 let (fstar_real_of_string : FStar_Extraction_ML_Syntax.mlexpr) =
-  FStar_Compiler_Effect.op_Less_Bar
-    (FStar_Extraction_ML_Syntax.with_ty FStar_Extraction_ML_Syntax.MLTY_Top)
+  FStar_Extraction_ML_Syntax.with_ty FStar_Extraction_ML_Syntax.MLTY_Top
     (FStar_Extraction_ML_Syntax.MLE_Name (["FStar"; "Real"], "of_string"))
 let (mlconst_of_const' :
   FStar_Const.sconst -> FStar_Extraction_ML_Syntax.mlconstant) =
@@ -78,55 +75,46 @@ let (mlexpr_of_range :
             let uu___3 = FStar_Compiler_Util.string_of_int i in
             (uu___3, FStar_Pervasives_Native.None) in
           FStar_Extraction_ML_Syntax.MLC_Int uu___2 in
-        FStar_Compiler_Effect.op_Bar_Greater uu___1
-          (fun uu___2 -> FStar_Extraction_ML_Syntax.MLE_Const uu___2) in
-      FStar_Compiler_Effect.op_Bar_Greater uu___
-        (FStar_Extraction_ML_Syntax.with_ty
-           FStar_Extraction_ML_Syntax.ml_int_ty) in
+        FStar_Extraction_ML_Syntax.MLE_Const uu___1 in
+      FStar_Extraction_ML_Syntax.with_ty FStar_Extraction_ML_Syntax.ml_int_ty
+        uu___ in
     let cstr s =
-      let uu___ =
-        FStar_Compiler_Effect.op_Bar_Greater
-          (FStar_Extraction_ML_Syntax.MLC_String s)
-          (fun uu___1 -> FStar_Extraction_ML_Syntax.MLE_Const uu___1) in
-      FStar_Compiler_Effect.op_Bar_Greater uu___
-        (FStar_Extraction_ML_Syntax.with_ty
-           FStar_Extraction_ML_Syntax.ml_string_ty) in
+      FStar_Extraction_ML_Syntax.with_ty
+        FStar_Extraction_ML_Syntax.ml_string_ty
+        (FStar_Extraction_ML_Syntax.MLE_Const
+           (FStar_Extraction_ML_Syntax.MLC_String s)) in
     let drop_path = FStar_Compiler_Util.basename in
     let uu___ =
       let uu___1 =
         let uu___2 =
           let uu___3 =
             let uu___4 = FStar_Compiler_Range_Ops.file_of_range r in
-            FStar_Compiler_Effect.op_Bar_Greater uu___4 drop_path in
-          FStar_Compiler_Effect.op_Bar_Greater uu___3 cstr in
+            drop_path uu___4 in
+          cstr uu___3 in
         let uu___3 =
           let uu___4 =
             let uu___5 =
               let uu___6 = FStar_Compiler_Range_Ops.start_of_range r in
-              FStar_Compiler_Effect.op_Bar_Greater uu___6
-                FStar_Compiler_Range_Ops.line_of_pos in
-            FStar_Compiler_Effect.op_Bar_Greater uu___5 cint in
+              FStar_Compiler_Range_Ops.line_of_pos uu___6 in
+            cint uu___5 in
           let uu___5 =
             let uu___6 =
               let uu___7 =
                 let uu___8 = FStar_Compiler_Range_Ops.start_of_range r in
-                FStar_Compiler_Effect.op_Bar_Greater uu___8
-                  FStar_Compiler_Range_Ops.col_of_pos in
-              FStar_Compiler_Effect.op_Bar_Greater uu___7 cint in
+                FStar_Compiler_Range_Ops.col_of_pos uu___8 in
+              cint uu___7 in
             let uu___7 =
               let uu___8 =
                 let uu___9 =
                   let uu___10 = FStar_Compiler_Range_Ops.end_of_range r in
-                  FStar_Compiler_Effect.op_Bar_Greater uu___10
-                    FStar_Compiler_Range_Ops.line_of_pos in
-                FStar_Compiler_Effect.op_Bar_Greater uu___9 cint in
+                  FStar_Compiler_Range_Ops.line_of_pos uu___10 in
+                cint uu___9 in
               let uu___9 =
                 let uu___10 =
                   let uu___11 =
                     let uu___12 = FStar_Compiler_Range_Ops.end_of_range r in
-                    FStar_Compiler_Effect.op_Bar_Greater uu___12
-                      FStar_Compiler_Range_Ops.col_of_pos in
-                  FStar_Compiler_Effect.op_Bar_Greater uu___11 cint in
+                    FStar_Compiler_Range_Ops.col_of_pos uu___12 in
+                  cint uu___11 in
                 [uu___10] in
               uu___8 :: uu___9 in
             uu___6 :: uu___7 in
@@ -144,16 +132,11 @@ let (mlexpr_of_const :
       | FStar_Const.Const_range r -> mlexpr_of_range r
       | FStar_Const.Const_real s ->
           let str = mlconst_of_const p (FStar_Const.Const_string (s, p)) in
-          let uu___ =
-            let uu___1 =
-              let uu___2 =
-                FStar_Compiler_Effect.op_Less_Bar
-                  (FStar_Extraction_ML_Syntax.with_ty
-                     FStar_Extraction_ML_Syntax.ml_string_ty)
-                  (FStar_Extraction_ML_Syntax.MLE_Const str) in
-              [uu___2] in
-            (fstar_real_of_string, uu___1) in
-          FStar_Extraction_ML_Syntax.MLE_App uu___
+          FStar_Extraction_ML_Syntax.MLE_App
+            (fstar_real_of_string,
+              [FStar_Extraction_ML_Syntax.with_ty
+                 FStar_Extraction_ML_Syntax.ml_string_ty
+                 (FStar_Extraction_ML_Syntax.MLE_Const str)])
       | uu___ ->
           let uu___1 = mlconst_of_const p c in
           FStar_Extraction_ML_Syntax.MLE_Const uu___1
@@ -393,8 +376,7 @@ let rec (type_leq_c :
                              if uu___4
                              then FStar_Extraction_ML_Syntax.ml_unit
                              else
-                               FStar_Compiler_Effect.op_Less_Bar
-                                 (FStar_Extraction_ML_Syntax.with_ty t2')
+                               FStar_Extraction_ML_Syntax.with_ty t2'
                                  (FStar_Extraction_ML_Syntax.MLE_Coerce
                                     (FStar_Extraction_ML_Syntax.ml_unit,
                                       FStar_Extraction_ML_Syntax.ml_unit_ty,
@@ -402,11 +384,9 @@ let rec (type_leq_c :
                            let uu___4 =
                              let uu___5 =
                                let uu___6 =
-                                 let uu___7 =
-                                   mk_ty_fun [x]
-                                     body1.FStar_Extraction_ML_Syntax.mlty in
-                                 FStar_Extraction_ML_Syntax.with_ty uu___7 in
-                               FStar_Compiler_Effect.op_Less_Bar uu___6
+                                 mk_ty_fun [x]
+                                   body1.FStar_Extraction_ML_Syntax.mlty in
+                               FStar_Extraction_ML_Syntax.with_ty uu___6
                                  (FStar_Extraction_ML_Syntax.MLE_Fun
                                     ([x], body1)) in
                              FStar_Pervasives_Native.Some uu___5 in
@@ -416,9 +396,7 @@ let rec (type_leq_c :
                         (let uu___4 =
                            let uu___5 =
                              let uu___6 = mk_fun xs body in
-                             FStar_Compiler_Effect.op_Less_Bar
-                               (fun uu___7 ->
-                                  FStar_Pervasives_Native.Some uu___7) uu___6 in
+                             FStar_Pervasives_Native.Some uu___6 in
                            type_leq_c unfold_ty uu___5 t2 t2' in
                          match uu___4 with
                          | (ok, body1) ->
@@ -491,8 +469,7 @@ and (type_leq :
     fun t1 ->
       fun t2 ->
         let uu___ = type_leq_c g FStar_Pervasives_Native.None t1 t2 in
-        FStar_Compiler_Effect.op_Bar_Greater uu___
-          FStar_Pervasives_Native.fst
+        FStar_Pervasives_Native.fst uu___
 let rec (erase_effect_annotations :
   FStar_Extraction_ML_Syntax.mlty -> FStar_Extraction_ML_Syntax.mlty) =
   fun t ->
@@ -538,9 +515,8 @@ let (resugar_exp :
         let uu___ = is_xtuple mlp in
         (match uu___ with
          | FStar_Pervasives_Native.Some n ->
-             FStar_Compiler_Effect.op_Less_Bar
-               (FStar_Extraction_ML_Syntax.with_ty
-                  e.FStar_Extraction_ML_Syntax.mlty)
+             FStar_Extraction_ML_Syntax.with_ty
+               e.FStar_Extraction_ML_Syntax.mlty
                (FStar_Extraction_ML_Syntax.MLE_Tuple args)
          | uu___1 -> e)
     | uu___ -> e
@@ -554,9 +530,8 @@ let (record_field_path :
           FStar_Compiler_Util.prefix uu___3 in
         (match uu___2 with
          | (ns, uu___3) ->
-             FStar_Compiler_Effect.op_Bar_Greater ns
-               (FStar_Compiler_List.map
-                  (fun id -> FStar_Ident.string_of_id id)))
+             FStar_Compiler_List.map (fun id -> FStar_Ident.string_of_id id)
+               ns)
     | uu___1 -> FStar_Compiler_Effect.failwith "impos"
 let record_fields :
   'a .
@@ -614,10 +589,8 @@ let (ml_module_name_of_lid : FStar_Ident.lident -> Prims.string) =
   fun l ->
     let mlp =
       let uu___ =
-        let uu___1 =
-          FStar_Compiler_Effect.op_Bar_Greater l FStar_Ident.ns_of_lid in
-        FStar_Compiler_Effect.op_Bar_Greater uu___1
-          (FStar_Compiler_List.map FStar_Ident.string_of_id) in
+        let uu___1 = FStar_Ident.ns_of_lid l in
+        FStar_Compiler_List.map FStar_Ident.string_of_id uu___1 in
       let uu___1 =
         let uu___2 = FStar_Ident.ident_of_lid l in
         FStar_Ident.string_of_id uu___2 in
@@ -678,18 +651,15 @@ let rec (eraseTypeDeep :
           FStar_Extraction_ML_Syntax.MLTY_Tuple uu___
       | uu___ -> t
 let (prims_op_equality : FStar_Extraction_ML_Syntax.mlexpr) =
-  FStar_Compiler_Effect.op_Less_Bar
-    (FStar_Extraction_ML_Syntax.with_ty FStar_Extraction_ML_Syntax.MLTY_Top)
+  FStar_Extraction_ML_Syntax.with_ty FStar_Extraction_ML_Syntax.MLTY_Top
     (FStar_Extraction_ML_Syntax.MLE_Name (["Prims"], "op_Equality"))
 let (prims_op_amp_amp : FStar_Extraction_ML_Syntax.mlexpr) =
   let uu___ =
-    let uu___1 =
-      mk_ty_fun
-        [("x", FStar_Extraction_ML_Syntax.ml_bool_ty);
-        ("y", FStar_Extraction_ML_Syntax.ml_bool_ty)]
-        FStar_Extraction_ML_Syntax.ml_bool_ty in
-    FStar_Extraction_ML_Syntax.with_ty uu___1 in
-  FStar_Compiler_Effect.op_Less_Bar uu___
+    mk_ty_fun
+      [("x", FStar_Extraction_ML_Syntax.ml_bool_ty);
+      ("y", FStar_Extraction_ML_Syntax.ml_bool_ty)]
+      FStar_Extraction_ML_Syntax.ml_bool_ty in
+  FStar_Extraction_ML_Syntax.with_ty uu___
     (FStar_Extraction_ML_Syntax.MLE_Name (["Prims"], "op_AmpAmp"))
 let (conjoin :
   FStar_Extraction_ML_Syntax.mlexpr ->
@@ -697,9 +667,8 @@ let (conjoin :
   =
   fun e1 ->
     fun e2 ->
-      FStar_Compiler_Effect.op_Less_Bar
-        (FStar_Extraction_ML_Syntax.with_ty
-           FStar_Extraction_ML_Syntax.ml_bool_ty)
+      FStar_Extraction_ML_Syntax.with_ty
+        FStar_Extraction_ML_Syntax.ml_bool_ty
         (FStar_Extraction_ML_Syntax.MLE_App (prims_op_amp_amp, [e1; e2]))
 let (conjoin_opt :
   FStar_Extraction_ML_Syntax.mlexpr FStar_Pervasives_Native.option ->

--- a/ocaml/fstar-lib/generated/FStar_Ident.ml
+++ b/ocaml/fstar-lib/generated/FStar_Ident.ml
@@ -65,7 +65,7 @@ let (lid_of_ns_and_id : ipath -> ident -> lident) =
     fun id ->
       let nsstr =
         let uu___ = FStar_Compiler_List.map string_of_id ns in
-        FStar_Compiler_Effect.op_Bar_Greater uu___ text_of_path in
+        text_of_path uu___ in
       {
         ns;
         ident = id;
@@ -119,7 +119,7 @@ let (ml_path_of_lid : lident -> Prims.string) =
       let uu___1 = path_of_ns lid1.ns in
       let uu___2 = let uu___3 = string_of_id lid1.ident in [uu___3] in
       FStar_Compiler_List.op_At uu___1 uu___2 in
-    FStar_Compiler_Effect.op_Less_Bar (FStar_String.concat "_") uu___
+    FStar_String.concat "_" uu___
 let (string_of_lid : lident -> Prims.string) = fun lid1 -> lid1.str
 let (qual_id : lident -> ident -> lident) =
   fun lid1 ->

--- a/ocaml/fstar-lib/generated/FStar_Interactive_CompletionTable.ml
+++ b/ocaml/fstar-lib/generated/FStar_Interactive_CompletionTable.ml
@@ -888,7 +888,5 @@ let (autocomplete_mod_or_ns :
       fun filter ->
         let uu___ =
           let uu___1 = trie_find_prefix tbl.tbl_mods query1 in
-          FStar_Compiler_Effect.op_Bar_Greater uu___1
-            (FStar_Compiler_List.filter_map filter) in
-        FStar_Compiler_Effect.op_Bar_Greater uu___
-          (FStar_Compiler_List.map completion_result_of_ns_or_mod)
+          FStar_Compiler_List.filter_map filter uu___1 in
+        FStar_Compiler_List.map completion_result_of_ns_or_mod uu___

--- a/ocaml/fstar-lib/generated/FStar_Interactive_Ide.ml
+++ b/ocaml/fstar-lib/generated/FStar_Interactive_Ide.ml
@@ -97,9 +97,7 @@ let (run_repl_transaction :
                          FStar_Interactive_PushHelper.run_repl_task
                            st1.FStar_Interactive_Ide_Types.repl_curmod env1
                            task in
-                       FStar_Compiler_Effect.op_Less_Bar
-                         (fun uu___4 -> FStar_Pervasives_Native.Some uu___4)
-                         uu___3) in
+                       FStar_Pervasives_Native.Some uu___3) in
                 match uu___2 with
                 | FStar_Pervasives_Native.Some (curmod, env1) when
                     check_success () -> (curmod, env1, true)
@@ -202,8 +200,7 @@ let (run_repl_ld_transactions :
               (debug "Loading" task;
                progress_callback task;
                (let uu___3 = FStar_Options.restore_cmd_line_options false in
-                FStar_Compiler_Effect.op_Bar_Greater uu___3
-                  (fun uu___4 -> ()));
+                ());
                (let timestamped_task =
                   FStar_Interactive_PushHelper.update_task_timestamps task in
                 let push_kind =
@@ -288,25 +285,20 @@ let (unpack_interactive_query :
                 errloc in
             FStar_Interactive_JsonHelper.InvalidQuery uu___2 in
           FStar_Compiler_Effect.raise uu___1 in
-    let request =
-      FStar_Compiler_Effect.op_Bar_Greater json
-        FStar_Interactive_JsonHelper.js_assoc in
+    let request = FStar_Interactive_JsonHelper.js_assoc json in
     let qid =
       let uu___ = assoc "query" "query-id" request in
-      FStar_Compiler_Effect.op_Bar_Greater uu___
-        FStar_Interactive_JsonHelper.js_str in
+      FStar_Interactive_JsonHelper.js_str uu___ in
     try
       (fun uu___ ->
          match () with
          | () ->
              let query =
                let uu___1 = assoc "query" "query" request in
-               FStar_Compiler_Effect.op_Bar_Greater uu___1
-                 FStar_Interactive_JsonHelper.js_str in
+               FStar_Interactive_JsonHelper.js_str uu___1 in
              let args =
                let uu___1 = assoc "query" "args" request in
-               FStar_Compiler_Effect.op_Bar_Greater uu___1
-                 FStar_Interactive_JsonHelper.js_assoc in
+               FStar_Interactive_JsonHelper.js_assoc uu___1 in
              let arg k = assoc "[args]" k args in
              let try_arg k =
                let uu___1 = FStar_Interactive_JsonHelper.try_assoc k args in
@@ -317,30 +309,24 @@ let (unpack_interactive_query :
              let read_position err loc =
                let uu___1 =
                  let uu___2 = assoc err "filename" loc in
-                 FStar_Compiler_Effect.op_Bar_Greater uu___2
-                   FStar_Interactive_JsonHelper.js_str in
+                 FStar_Interactive_JsonHelper.js_str uu___2 in
                let uu___2 =
                  let uu___3 = assoc err "line" loc in
-                 FStar_Compiler_Effect.op_Bar_Greater uu___3
-                   FStar_Interactive_JsonHelper.js_int in
+                 FStar_Interactive_JsonHelper.js_int uu___3 in
                let uu___3 =
                  let uu___4 = assoc err "column" loc in
-                 FStar_Compiler_Effect.op_Bar_Greater uu___4
-                   FStar_Interactive_JsonHelper.js_int in
+                 FStar_Interactive_JsonHelper.js_int uu___4 in
                (uu___1, uu___2, uu___3) in
              let read_to_position uu___1 =
                let to_pos =
                  let uu___2 = arg "to-position" in
-                 FStar_Compiler_Effect.op_Bar_Greater uu___2
-                   FStar_Interactive_JsonHelper.js_assoc in
+                 FStar_Interactive_JsonHelper.js_assoc uu___2 in
                let uu___2 =
                  let uu___3 = assoc "to-position.line" "line" to_pos in
-                 FStar_Compiler_Effect.op_Bar_Greater uu___3
-                   FStar_Interactive_JsonHelper.js_int in
+                 FStar_Interactive_JsonHelper.js_int uu___3 in
                let uu___3 =
                  let uu___4 = assoc "to-position.column" "column" to_pos in
-                 FStar_Compiler_Effect.op_Bar_Greater uu___4
-                   FStar_Interactive_JsonHelper.js_int in
+                 FStar_Interactive_JsonHelper.js_int uu___4 in
                ("<input>", uu___2, uu___3) in
              let parse_full_buffer_kind kind =
                match kind with
@@ -368,28 +354,23 @@ let (unpack_interactive_query :
                | "segment" ->
                    let uu___2 =
                      let uu___3 = arg "code" in
-                     FStar_Compiler_Effect.op_Bar_Greater uu___3
-                       FStar_Interactive_JsonHelper.js_str in
+                     FStar_Interactive_JsonHelper.js_str uu___3 in
                    FStar_Interactive_Ide_Types.Segment uu___2
                | "peek" ->
                    let uu___2 =
                      let uu___3 =
                        let uu___4 = arg "kind" in
-                       FStar_Compiler_Effect.op_Bar_Greater uu___4
-                         FStar_Interactive_Ide_Types.js_pushkind in
+                       FStar_Interactive_Ide_Types.js_pushkind uu___4 in
                      let uu___4 =
                        let uu___5 = arg "line" in
-                       FStar_Compiler_Effect.op_Bar_Greater uu___5
-                         FStar_Interactive_JsonHelper.js_int in
+                       FStar_Interactive_JsonHelper.js_int uu___5 in
                      let uu___5 =
                        let uu___6 = arg "column" in
-                       FStar_Compiler_Effect.op_Bar_Greater uu___6
-                         FStar_Interactive_JsonHelper.js_int in
+                       FStar_Interactive_JsonHelper.js_int uu___6 in
                      let uu___6 =
                        let uu___7 =
                          let uu___8 = arg "code" in
-                         FStar_Compiler_Effect.op_Bar_Greater uu___8
-                           FStar_Interactive_JsonHelper.js_str in
+                         FStar_Interactive_JsonHelper.js_str uu___8 in
                        FStar_Pervasives.Inl uu___7 in
                      {
                        FStar_Interactive_Ide_Types.push_kind = uu___3;
@@ -404,21 +385,17 @@ let (unpack_interactive_query :
                    let uu___2 =
                      let uu___3 =
                        let uu___4 = arg "kind" in
-                       FStar_Compiler_Effect.op_Bar_Greater uu___4
-                         FStar_Interactive_Ide_Types.js_pushkind in
+                       FStar_Interactive_Ide_Types.js_pushkind uu___4 in
                      let uu___4 =
                        let uu___5 = arg "line" in
-                       FStar_Compiler_Effect.op_Bar_Greater uu___5
-                         FStar_Interactive_JsonHelper.js_int in
+                       FStar_Interactive_JsonHelper.js_int uu___5 in
                      let uu___5 =
                        let uu___6 = arg "column" in
-                       FStar_Compiler_Effect.op_Bar_Greater uu___6
-                         FStar_Interactive_JsonHelper.js_int in
+                       FStar_Interactive_JsonHelper.js_int uu___6 in
                      let uu___6 =
                        let uu___7 =
                          let uu___8 = arg "code" in
-                         FStar_Compiler_Effect.op_Bar_Greater uu___8
-                           FStar_Interactive_JsonHelper.js_str in
+                         FStar_Interactive_JsonHelper.js_str uu___8 in
                        FStar_Pervasives.Inl uu___7 in
                      {
                        FStar_Interactive_Ide_Types.push_kind = uu___3;
@@ -432,63 +409,54 @@ let (unpack_interactive_query :
                | "push-partial-checked-file" ->
                    let uu___2 =
                      let uu___3 = arg "until-lid" in
-                     FStar_Compiler_Effect.op_Bar_Greater uu___3
-                       FStar_Interactive_JsonHelper.js_str in
+                     FStar_Interactive_JsonHelper.js_str uu___3 in
                    FStar_Interactive_Ide_Types.PushPartialCheckedFile uu___2
                | "full-buffer" ->
                    let uu___2 =
                      let uu___3 =
                        let uu___4 = arg "code" in
-                       FStar_Compiler_Effect.op_Bar_Greater uu___4
-                         FStar_Interactive_JsonHelper.js_str in
+                       FStar_Interactive_JsonHelper.js_str uu___4 in
                      let uu___4 =
                        let uu___5 =
                          let uu___6 = arg "kind" in
-                         FStar_Compiler_Effect.op_Bar_Greater uu___6
-                           FStar_Interactive_JsonHelper.js_str in
+                         FStar_Interactive_JsonHelper.js_str uu___6 in
                        parse_full_buffer_kind uu___5 in
                      let uu___5 =
                        let uu___6 = arg "with-symbols" in
-                       FStar_Compiler_Effect.op_Bar_Greater uu___6
-                         FStar_Interactive_JsonHelper.js_bool in
+                       FStar_Interactive_JsonHelper.js_bool uu___6 in
                      (uu___3, uu___4, uu___5) in
                    FStar_Interactive_Ide_Types.FullBuffer uu___2
                | "autocomplete" ->
                    let uu___2 =
                      let uu___3 =
                        let uu___4 = arg "partial-symbol" in
-                       FStar_Compiler_Effect.op_Bar_Greater uu___4
-                         FStar_Interactive_JsonHelper.js_str in
+                       FStar_Interactive_JsonHelper.js_str uu___4 in
                      let uu___4 =
                        let uu___5 = try_arg "context" in
-                       FStar_Compiler_Effect.op_Bar_Greater uu___5
-                         FStar_Interactive_Ide_Types.js_optional_completion_context in
+                       FStar_Interactive_Ide_Types.js_optional_completion_context
+                         uu___5 in
                      (uu___3, uu___4) in
                    FStar_Interactive_Ide_Types.AutoComplete uu___2
                | "lookup" ->
                    let uu___2 =
                      let uu___3 =
                        let uu___4 = arg "symbol" in
-                       FStar_Compiler_Effect.op_Bar_Greater uu___4
-                         FStar_Interactive_JsonHelper.js_str in
+                       FStar_Interactive_JsonHelper.js_str uu___4 in
                      let uu___4 =
                        let uu___5 = try_arg "context" in
-                       FStar_Compiler_Effect.op_Bar_Greater uu___5
-                         FStar_Interactive_Ide_Types.js_optional_lookup_context in
+                       FStar_Interactive_Ide_Types.js_optional_lookup_context
+                         uu___5 in
                      let uu___5 =
                        let uu___6 =
                          let uu___7 = try_arg "location" in
-                         FStar_Compiler_Effect.op_Bar_Greater uu___7
-                           (FStar_Compiler_Util.map_option
-                              FStar_Interactive_JsonHelper.js_assoc) in
-                       FStar_Compiler_Effect.op_Bar_Greater uu___6
-                         (FStar_Compiler_Util.map_option
-                            (read_position "[location]")) in
+                         FStar_Compiler_Util.map_option
+                           FStar_Interactive_JsonHelper.js_assoc uu___7 in
+                       FStar_Compiler_Util.map_option
+                         (read_position "[location]") uu___6 in
                      let uu___6 =
                        let uu___7 = arg "requested-info" in
-                       FStar_Compiler_Effect.op_Bar_Greater uu___7
-                         (FStar_Interactive_JsonHelper.js_list
-                            FStar_Interactive_JsonHelper.js_str) in
+                       FStar_Interactive_JsonHelper.js_list
+                         FStar_Interactive_JsonHelper.js_str uu___7 in
                      let uu___7 = try_arg "symbol-range" in
                      (uu___3, uu___4, uu___5, uu___6, uu___7) in
                    FStar_Interactive_Ide_Types.Lookup uu___2
@@ -496,40 +464,35 @@ let (unpack_interactive_query :
                    let uu___2 =
                      let uu___3 =
                        let uu___4 = arg "term" in
-                       FStar_Compiler_Effect.op_Bar_Greater uu___4
-                         FStar_Interactive_JsonHelper.js_str in
+                       FStar_Interactive_JsonHelper.js_str uu___4 in
                      let uu___4 =
                        let uu___5 = try_arg "rules" in
-                       FStar_Compiler_Effect.op_Bar_Greater uu___5
-                         (FStar_Compiler_Util.map_option
-                            (FStar_Interactive_JsonHelper.js_list
-                               FStar_Interactive_Ide_Types.js_reductionrule)) in
+                       FStar_Compiler_Util.map_option
+                         (FStar_Interactive_JsonHelper.js_list
+                            FStar_Interactive_Ide_Types.js_reductionrule)
+                         uu___5 in
                      (uu___3, uu___4) in
                    FStar_Interactive_Ide_Types.Compute uu___2
                | "search" ->
                    let uu___2 =
                      let uu___3 = arg "terms" in
-                     FStar_Compiler_Effect.op_Bar_Greater uu___3
-                       FStar_Interactive_JsonHelper.js_str in
+                     FStar_Interactive_JsonHelper.js_str uu___3 in
                    FStar_Interactive_Ide_Types.Search uu___2
                | "vfs-add" ->
                    let uu___2 =
                      let uu___3 =
                        let uu___4 = try_arg "filename" in
-                       FStar_Compiler_Effect.op_Bar_Greater uu___4
-                         (FStar_Compiler_Util.map_option
-                            FStar_Interactive_JsonHelper.js_str) in
+                       FStar_Compiler_Util.map_option
+                         FStar_Interactive_JsonHelper.js_str uu___4 in
                      let uu___4 =
                        let uu___5 = arg "contents" in
-                       FStar_Compiler_Effect.op_Bar_Greater uu___5
-                         FStar_Interactive_JsonHelper.js_str in
+                       FStar_Interactive_JsonHelper.js_str uu___5 in
                      (uu___3, uu___4) in
                    FStar_Interactive_Ide_Types.VfsAdd uu___2
                | "format" ->
                    let uu___2 =
                      let uu___3 = arg "code" in
-                     FStar_Compiler_Effect.op_Bar_Greater uu___3
-                       FStar_Interactive_JsonHelper.js_str in
+                     FStar_Interactive_JsonHelper.js_str uu___3 in
                    FStar_Interactive_Ide_Types.Format uu___2
                | "restart-solver" ->
                    FStar_Interactive_Ide_Types.RestartSolver
@@ -538,12 +501,10 @@ let (unpack_interactive_query :
                      let uu___3 =
                        let uu___4 =
                          let uu___5 = arg "cancel-line" in
-                         FStar_Compiler_Effect.op_Bar_Greater uu___5
-                           FStar_Interactive_JsonHelper.js_int in
+                         FStar_Interactive_JsonHelper.js_int uu___5 in
                        let uu___5 =
                          let uu___6 = arg "cancel-column" in
-                         FStar_Compiler_Effect.op_Bar_Greater uu___6
-                           FStar_Interactive_JsonHelper.js_int in
+                         FStar_Interactive_JsonHelper.js_int uu___6 in
                        ("<input>", uu___4, uu___5) in
                      FStar_Pervasives_Native.Some uu___3 in
                    FStar_Interactive_Ide_Types.Cancel uu___2
@@ -765,8 +726,7 @@ let (alist_of_protocol_info : (Prims.string * FStar_Json.json) Prims.list) =
     let uu___ =
       FStar_Compiler_List.map (fun uu___1 -> FStar_Json.JsonStr uu___1)
         FStar_Interactive_Ide_Types.interactive_protocol_features in
-    FStar_Compiler_Effect.op_Less_Bar
-      (fun uu___1 -> FStar_Json.JsonList uu___1) uu___ in
+    FStar_Json.JsonList uu___ in
   [("version", js_version); ("features", js_features)]
 type fstar_option_permission_level =
   | OptSet 
@@ -1011,43 +971,40 @@ let (sig_of_fstar_option :
 let (fstar_options_list_cache : fstar_option Prims.list) =
   let defaults = FStar_Compiler_Util.smap_of_list FStar_Options.defaults in
   let uu___ =
-    FStar_Compiler_Effect.op_Bar_Greater FStar_Options.all_specs_with_types
-      (FStar_Compiler_List.filter_map
-         (fun uu___1 ->
-            match uu___1 with
-            | (_shortname, name, typ, doc) ->
-                let uu___2 = FStar_Compiler_Util.smap_try_find defaults name in
-                FStar_Compiler_Effect.op_Bar_Greater uu___2
-                  (FStar_Compiler_Util.map_option
-                     (fun default_value ->
-                        let uu___3 = sig_of_fstar_option name typ in
-                        let uu___4 = snippets_of_fstar_option name typ in
-                        let uu___5 =
-                          if doc = FStar_Pprint.empty
-                          then FStar_Pervasives_Native.None
-                          else
-                            (let uu___7 = FStar_Errors_Msg.renderdoc doc in
-                             FStar_Pervasives_Native.Some uu___7) in
-                        let uu___6 =
-                          let uu___7 = FStar_Options.settable name in
-                          if uu___7 then OptSet else OptReadOnly in
-                        {
-                          opt_name = name;
-                          opt_sig = uu___3;
-                          opt_value = FStar_Options.Unset;
-                          opt_default = default_value;
-                          opt_type = typ;
-                          opt_snippets = uu___4;
-                          opt_documentation = uu___5;
-                          opt_permission_level = uu___6
-                        })))) in
-  FStar_Compiler_Effect.op_Bar_Greater uu___
-    (FStar_Compiler_List.sortWith
-       (fun o1 ->
-          fun o2 ->
-            FStar_Compiler_String.compare
-              (FStar_Compiler_String.lowercase o1.opt_name)
-              (FStar_Compiler_String.lowercase o2.opt_name)))
+    FStar_Compiler_List.filter_map
+      (fun uu___1 ->
+         match uu___1 with
+         | (_shortname, name, typ, doc) ->
+             let uu___2 = FStar_Compiler_Util.smap_try_find defaults name in
+             FStar_Compiler_Util.map_option
+               (fun default_value ->
+                  let uu___3 = sig_of_fstar_option name typ in
+                  let uu___4 = snippets_of_fstar_option name typ in
+                  let uu___5 =
+                    if doc = FStar_Pprint.empty
+                    then FStar_Pervasives_Native.None
+                    else
+                      (let uu___7 = FStar_Errors_Msg.renderdoc doc in
+                       FStar_Pervasives_Native.Some uu___7) in
+                  let uu___6 =
+                    let uu___7 = FStar_Options.settable name in
+                    if uu___7 then OptSet else OptReadOnly in
+                  {
+                    opt_name = name;
+                    opt_sig = uu___3;
+                    opt_value = FStar_Options.Unset;
+                    opt_default = default_value;
+                    opt_type = typ;
+                    opt_snippets = uu___4;
+                    opt_documentation = uu___5;
+                    opt_permission_level = uu___6
+                  }) uu___2) FStar_Options.all_specs_with_types in
+  FStar_Compiler_List.sortWith
+    (fun o1 ->
+       fun o2 ->
+         FStar_Compiler_String.compare
+           (FStar_Compiler_String.lowercase o1.opt_name)
+           (FStar_Compiler_String.lowercase o2.opt_name)) uu___
 let (fstar_options_map_cache : fstar_option FStar_Compiler_Util.smap) =
   let cache = FStar_Compiler_Util.smap_create (Prims.of_int (50)) in
   FStar_Compiler_List.iter
@@ -1206,15 +1163,13 @@ let run_segment :
           FStar_Compiler_Util.sigint_ignore
           (fun uu___1 ->
              let uu___2 = collect_decls () in
-             FStar_Compiler_Effect.op_Less_Bar
-               (fun uu___3 -> FStar_Pervasives_Native.Some uu___3) uu___2) in
+             FStar_Pervasives_Native.Some uu___2) in
       match uu___ with
       | FStar_Pervasives_Native.None ->
           let errors =
             let uu___1 = collect_errors () in
-            FStar_Compiler_Effect.op_Bar_Greater uu___1
-              (FStar_Compiler_List.map
-                 FStar_Interactive_Ide_Types.json_of_issue) in
+            FStar_Compiler_List.map FStar_Interactive_Ide_Types.json_of_issue
+              uu___1 in
           ((FStar_Interactive_Ide_Types.QueryNOK,
              (FStar_Json.JsonList errors)), (FStar_Pervasives.Inl st))
       | FStar_Pervasives_Native.Some decls ->
@@ -1229,8 +1184,7 @@ let run_segment :
             FStar_Json.JsonAssoc uu___1 in
           let js_decls =
             let uu___1 = FStar_Compiler_List.map json_of_decl decls in
-            FStar_Compiler_Effect.op_Less_Bar
-              (fun uu___2 -> FStar_Json.JsonList uu___2) uu___1 in
+            FStar_Json.JsonList uu___1 in
           ((FStar_Interactive_Ide_Types.QueryOK,
              (FStar_Json.JsonAssoc [("decls", js_decls)])),
             (FStar_Pervasives.Inl st))
@@ -1323,8 +1277,7 @@ let (load_deps :
            let uu___1 =
              FStar_Interactive_PushHelper.deps_and_repl_ld_tasks_of_our_file
                st.FStar_Interactive_Ide_Types.repl_fname in
-           FStar_Compiler_Effect.op_Less_Bar
-             (fun uu___2 -> FStar_Pervasives_Native.Some uu___2) uu___1) in
+           FStar_Pervasives_Native.Some uu___1) in
     match uu___ with
     | FStar_Pervasives_Native.None -> FStar_Pervasives.Inr st
     | FStar_Pervasives_Native.Some (deps, tasks, dep_graph) ->
@@ -1553,8 +1506,7 @@ let (load_partial_checked_file :
                                     m tc_result.FStar_CheckedFiles.mii
                                     (FStar_TypeChecker_Normalize.erase_universes
                                        env2) in
-                                FStar_Compiler_Effect.op_Less_Bar
-                                  (FStar_Universal.with_dsenv_of_tcenv env2)
+                                FStar_Universal.with_dsenv_of_tcenv env2
                                   uu___8 in
                               match uu___7 with
                               | (uu___8, env3) ->
@@ -1594,9 +1546,8 @@ let (run_load_partial_file :
             let uu___1 = collect_errors () in
             FStar_Compiler_List.map rephrase_dependency_error uu___1 in
           let js_errors =
-            FStar_Compiler_Effect.op_Bar_Greater errors
-              (FStar_Compiler_List.map
-                 FStar_Interactive_Ide_Types.json_of_issue) in
+            FStar_Compiler_List.map FStar_Interactive_Ide_Types.json_of_issue
+              errors in
           ((FStar_Interactive_Ide_Types.QueryNOK,
              (FStar_Json.JsonList js_errors)), (FStar_Pervasives.Inl st1))
       | FStar_Pervasives.Inl (st1, deps) ->
@@ -1612,8 +1563,7 @@ let (run_load_partial_file :
                  let uu___2 =
                    load_partial_checked_file env1
                      st2.FStar_Interactive_Ide_Types.repl_fname decl_name in
-                 FStar_Compiler_Effect.op_Less_Bar
-                   (fun uu___3 -> FStar_Pervasives_Native.Some uu___3) uu___2) in
+                 FStar_Pervasives_Native.Some uu___2) in
           (match uu___1 with
            | FStar_Pervasives_Native.Some (env1, curmod) when
                let uu___2 = FStar_Errors.get_err_count () in
@@ -1643,9 +1593,8 @@ let (run_load_partial_file :
            | uu___2 ->
                let json_error_list =
                  let uu___3 = collect_errors () in
-                 FStar_Compiler_Effect.op_Bar_Greater uu___3
-                   (FStar_Compiler_List.map
-                      FStar_Interactive_Ide_Types.json_of_issue) in
+                 FStar_Compiler_List.map
+                   FStar_Interactive_Ide_Types.json_of_issue uu___3 in
                let json_errors = FStar_Json.JsonList json_error_list in
                let st3 =
                  FStar_Interactive_PushHelper.pop_repl "load partial file"
@@ -1846,9 +1795,8 @@ let (run_push_without_deps :
                   | uu___4 -> ());
                  (let json_errors =
                     let uu___4 =
-                      FStar_Compiler_Effect.op_Bar_Greater errs
-                        (FStar_Compiler_List.map
-                           FStar_Interactive_Ide_Types.json_of_issue) in
+                      FStar_Compiler_List.map
+                        FStar_Interactive_Ide_Types.json_of_issue errs in
                     FStar_Json.JsonList uu___4 in
                   (match (errs, status) with
                    | (uu___5::uu___6, FStar_Interactive_Ide_Types.QueryOK) ->
@@ -1902,14 +1850,12 @@ let (run_push_with_deps :
              let uu___3 = collect_errors () in
              FStar_Compiler_List.map rephrase_dependency_error uu___3 in
            let js_errors =
-             FStar_Compiler_Effect.op_Bar_Greater errors
-               (FStar_Compiler_List.map
-                  FStar_Interactive_Ide_Types.json_of_issue) in
+             FStar_Compiler_List.map
+               FStar_Interactive_Ide_Types.json_of_issue errors in
            ((FStar_Interactive_Ide_Types.QueryNOK,
               (FStar_Json.JsonList js_errors)), (FStar_Pervasives.Inl st1))
        | FStar_Pervasives.Inl (st1, deps) ->
-           ((let uu___4 = FStar_Options.restore_cmd_line_options false in
-             FStar_Compiler_Effect.op_Bar_Greater uu___4 (fun uu___5 -> ()));
+           ((let uu___4 = FStar_Options.restore_cmd_line_options false in ());
             (let names =
                FStar_Interactive_PushHelper.add_module_completions
                  st1.FStar_Interactive_Ide_Types.repl_fname deps
@@ -2211,17 +2157,16 @@ let candidates_of_fstar_option :
                 Prims.strcat "("
                   (Prims.strcat explanation
                      (Prims.strcat " " (Prims.strcat opt_type ")"))) in
-            FStar_Compiler_Effect.op_Bar_Greater opt.opt_snippets
-              (FStar_Compiler_List.map
-                 (fun snippet ->
-                    {
-                      FStar_Interactive_CompletionTable.completion_match_length
-                        = match_len;
-                      FStar_Interactive_CompletionTable.completion_candidate
-                        = snippet;
-                      FStar_Interactive_CompletionTable.completion_annotation
-                        = annot
-                    }))
+            FStar_Compiler_List.map
+              (fun snippet ->
+                 {
+                   FStar_Interactive_CompletionTable.completion_match_length
+                     = match_len;
+                   FStar_Interactive_CompletionTable.completion_candidate =
+                     snippet;
+                   FStar_Interactive_CompletionTable.completion_annotation =
+                     annot
+                 }) opt.opt_snippets
 let run_option_autocomplete :
   'uuuuu 'uuuuu1 'uuuuu2 .
     'uuuuu ->
@@ -2298,9 +2243,7 @@ let run_and_rewind :
                    FStar_Compiler_Util.with_sigint_handler
                      FStar_Compiler_Util.sigint_raise
                      (fun uu___1 ->
-                        let uu___2 = task st1 in
-                        FStar_Compiler_Effect.op_Less_Bar
-                          (fun uu___3 -> FStar_Pervasives.Inl uu___3) uu___2))
+                        let uu___2 = task st1 in FStar_Pervasives.Inl uu___2))
               ()
           with
           | FStar_Compiler_Util.SigInt -> FStar_Pervasives.Inl sigint_default

--- a/ocaml/fstar-lib/generated/FStar_Interactive_Ide_Types.ml
+++ b/ocaml/fstar-lib/generated/FStar_Interactive_Ide_Types.ml
@@ -618,8 +618,7 @@ let (json_of_issue : FStar_Errors.issue -> FStar_Json.json) =
       FStar_Compiler_List.op_At
         [("level", (json_of_issue_level issue.FStar_Errors.issue_level))]
         uu___1 in
-    FStar_Compiler_Effect.op_Less_Bar
-      (fun uu___1 -> FStar_Json.JsonAssoc uu___1) uu___
+    FStar_Json.JsonAssoc uu___
 let (js_pushkind : FStar_Json.json -> push_kind) =
   fun s ->
     let uu___ = FStar_Interactive_JsonHelper.js_str s in

--- a/ocaml/fstar-lib/generated/FStar_Interactive_Incremental.ml
+++ b/ocaml/fstar-lib/generated/FStar_Interactive_Incremental.ml
@@ -549,11 +549,8 @@ let (format_code :
           (match uu___ with
            | (formatted_code_rev, leftover_comments) ->
                let code1 =
-                 let uu___1 =
-                   FStar_Compiler_Effect.op_Bar_Greater formatted_code_rev
-                     FStar_Compiler_List.rev in
-                 FStar_Compiler_Effect.op_Bar_Greater uu___1
-                   (FStar_Compiler_String.concat "\n\n") in
+                 FStar_Compiler_String.concat "\n\n"
+                   (FStar_Compiler_List.rev formatted_code_rev) in
                let formatted_code =
                  match leftover_comments with
                  | [] -> code1

--- a/ocaml/fstar-lib/generated/FStar_Interactive_JsonHelper.ml
+++ b/ocaml/fstar-lib/generated/FStar_Interactive_JsonHelper.ml
@@ -99,9 +99,7 @@ let (js_str_int : FStar_Json.json -> Prims.int) =
 let (arg : Prims.string -> assoct -> FStar_Json.json) =
   fun k ->
     fun r ->
-      let uu___ =
-        let uu___1 = assoc "params" r in
-        FStar_Compiler_Effect.op_Bar_Greater uu___1 js_assoc in
+      let uu___ = let uu___1 = assoc "params" r in js_assoc uu___1 in
       assoc k uu___
 let (uri_to_path : Prims.string -> Prims.string) =
   fun u ->
@@ -145,13 +143,10 @@ let (js_compl_context : FStar_Json.json -> completion_context) =
   fun uu___ ->
     match uu___ with
     | FStar_Json.JsonAssoc a ->
-        let uu___1 =
-          let uu___2 = assoc "triggerKind" a in
-          FStar_Compiler_Effect.op_Bar_Greater uu___2 js_int in
+        let uu___1 = let uu___2 = assoc "triggerKind" a in js_int uu___2 in
         let uu___2 =
           let uu___3 = try_assoc "triggerChar" a in
-          FStar_Compiler_Effect.op_Bar_Greater uu___3
-            (FStar_Compiler_Util.map_option js_str) in
+          FStar_Compiler_Util.map_option js_str uu___3 in
         { trigger_kind = uu___1; trigger_char = uu___2 }
     | other -> js_fail "dictionary" other
 type txdoc_item =
@@ -178,19 +173,11 @@ let (js_txdoc_item : FStar_Json.json -> txdoc_item) =
     | FStar_Json.JsonAssoc a ->
         let arg1 k = assoc k a in
         let uu___1 =
-          let uu___2 =
-            let uu___3 = arg1 "uri" in
-            FStar_Compiler_Effect.op_Bar_Greater uu___3 js_str in
+          let uu___2 = let uu___3 = arg1 "uri" in js_str uu___3 in
           uri_to_path uu___2 in
-        let uu___2 =
-          let uu___3 = arg1 "languageId" in
-          FStar_Compiler_Effect.op_Bar_Greater uu___3 js_str in
-        let uu___3 =
-          let uu___4 = arg1 "version" in
-          FStar_Compiler_Effect.op_Bar_Greater uu___4 js_int in
-        let uu___4 =
-          let uu___5 = arg1 "text" in
-          FStar_Compiler_Effect.op_Bar_Greater uu___5 js_str in
+        let uu___2 = let uu___3 = arg1 "languageId" in js_str uu___3 in
+        let uu___3 = let uu___4 = arg1 "version" in js_int uu___4 in
+        let uu___4 = let uu___5 = arg1 "text" in js_str uu___5 in
         { fname = uu___1; langId = uu___2; version = uu___3; text = uu___4 }
     | other -> js_fail "dictionary" other
 type txdoc_pos = {
@@ -207,24 +194,16 @@ let (js_txdoc_id : assoct -> Prims.string) =
   fun r ->
     let uu___ =
       let uu___1 =
-        let uu___2 =
-          let uu___3 = arg "textDocument" r in
-          FStar_Compiler_Effect.op_Bar_Greater uu___3 js_assoc in
+        let uu___2 = let uu___3 = arg "textDocument" r in js_assoc uu___3 in
         assoc "uri" uu___2 in
-      FStar_Compiler_Effect.op_Bar_Greater uu___1 js_str in
+      js_str uu___1 in
     uri_to_path uu___
 let (js_txdoc_pos : assoct -> txdoc_pos) =
   fun r ->
-    let pos =
-      let uu___ = arg "position" r in
-      FStar_Compiler_Effect.op_Bar_Greater uu___ js_assoc in
+    let pos = let uu___ = arg "position" r in js_assoc uu___ in
     let uu___ = js_txdoc_id r in
-    let uu___1 =
-      let uu___2 = assoc "line" pos in
-      FStar_Compiler_Effect.op_Bar_Greater uu___2 js_int in
-    let uu___2 =
-      let uu___3 = assoc "character" pos in
-      FStar_Compiler_Effect.op_Bar_Greater uu___3 js_int in
+    let uu___1 = let uu___2 = assoc "line" pos in js_int uu___2 in
+    let uu___2 = let uu___3 = assoc "character" pos in js_int uu___3 in
     { path = uu___; line = uu___1; col = uu___2 }
 type workspace_folder = {
   wk_uri: Prims.string ;
@@ -246,27 +225,15 @@ let (js_wsch_event : FStar_Json.json -> wsch_event) =
   fun uu___ ->
     match uu___ with
     | FStar_Json.JsonAssoc a ->
-        let added' =
-          let uu___1 = assoc "added" a in
-          FStar_Compiler_Effect.op_Bar_Greater uu___1 js_assoc in
-        let removed' =
-          let uu___1 = assoc "removed" a in
-          FStar_Compiler_Effect.op_Bar_Greater uu___1 js_assoc in
+        let added' = let uu___1 = assoc "added" a in js_assoc uu___1 in
+        let removed' = let uu___1 = assoc "removed" a in js_assoc uu___1 in
         let uu___1 =
-          let uu___2 =
-            let uu___3 = assoc "uri" added' in
-            FStar_Compiler_Effect.op_Bar_Greater uu___3 js_str in
-          let uu___3 =
-            let uu___4 = assoc "name" added' in
-            FStar_Compiler_Effect.op_Bar_Greater uu___4 js_str in
+          let uu___2 = let uu___3 = assoc "uri" added' in js_str uu___3 in
+          let uu___3 = let uu___4 = assoc "name" added' in js_str uu___4 in
           { wk_uri = uu___2; wk_name = uu___3 } in
         let uu___2 =
-          let uu___3 =
-            let uu___4 = assoc "uri" removed' in
-            FStar_Compiler_Effect.op_Bar_Greater uu___4 js_str in
-          let uu___4 =
-            let uu___5 = assoc "name" removed' in
-            FStar_Compiler_Effect.op_Bar_Greater uu___5 js_str in
+          let uu___3 = let uu___4 = assoc "uri" removed' in js_str uu___4 in
+          let uu___4 = let uu___5 = assoc "name" removed' in js_str uu___5 in
           { wk_uri = uu___3; wk_name = uu___4 } in
         { added = uu___1; removed = uu___2 }
     | other -> js_fail "dictionary" other
@@ -279,8 +246,7 @@ let (js_contentch : FStar_Json.json -> Prims.string) =
             (fun uu___2 ->
                match uu___2 with
                | FStar_Json.JsonAssoc a ->
-                   let uu___3 = assoc "text" a in
-                   FStar_Compiler_Effect.op_Bar_Greater uu___3 js_str) l in
+                   let uu___3 = assoc "text" a in js_str uu___3) l in
         FStar_Compiler_List.hd uu___1
     | other -> js_fail "dictionary" other
 type lquery =
@@ -550,27 +516,19 @@ let (js_rng : FStar_Json.json -> rng) =
         let c = assoc "character" in
         let uu___1 =
           let uu___2 =
-            let uu___3 =
-              let uu___4 = FStar_Compiler_Effect.op_Bar_Greater st js_assoc in
-              l uu___4 in
-            FStar_Compiler_Effect.op_Bar_Greater uu___3 js_int in
+            let uu___3 = let uu___4 = js_assoc st in l uu___4 in
+            js_int uu___3 in
           let uu___3 =
-            let uu___4 =
-              let uu___5 = FStar_Compiler_Effect.op_Bar_Greater st js_assoc in
-              c uu___5 in
-            FStar_Compiler_Effect.op_Bar_Greater uu___4 js_int in
+            let uu___4 = let uu___5 = js_assoc st in c uu___5 in
+            js_int uu___4 in
           (uu___2, uu___3) in
         let uu___2 =
           let uu___3 =
-            let uu___4 =
-              let uu___5 = FStar_Compiler_Effect.op_Bar_Greater fin js_assoc in
-              l uu___5 in
-            FStar_Compiler_Effect.op_Bar_Greater uu___4 js_int in
+            let uu___4 = let uu___5 = js_assoc fin in l uu___5 in
+            js_int uu___4 in
           let uu___4 =
-            let uu___5 =
-              let uu___6 = FStar_Compiler_Effect.op_Bar_Greater st js_assoc in
-              c uu___6 in
-            FStar_Compiler_Effect.op_Bar_Greater uu___5 js_int in
+            let uu___5 = let uu___6 = js_assoc st in c uu___6 in
+            js_int uu___5 in
           (uu___3, uu___4) in
         { rng_start = uu___1; rng_end = uu___2 }
     | other -> js_fail "dictionary" other

--- a/ocaml/fstar-lib/generated/FStar_Interactive_Legacy.ml
+++ b/ocaml/fstar-lib/generated/FStar_Interactive_Legacy.ml
@@ -152,8 +152,7 @@ let (push_with_kind :
           FStar_Options.push ();
           if restore_cmd_line_options
           then
-            (let uu___2 = FStar_Options.restore_cmd_line_options false in
-             FStar_Compiler_Effect.op_Bar_Greater uu___2 (fun uu___3 -> ()))
+            (let uu___2 = FStar_Options.restore_cmd_line_options false in ())
           else ();
           res
 let (check_frag :
@@ -198,9 +197,7 @@ let (check_frag :
              FStar_Pervasives_Native.None)
 let (report_fail : unit -> unit) =
   fun uu___ ->
-    (let uu___2 = FStar_Errors.report_all () in
-     FStar_Compiler_Effect.op_Bar_Greater uu___2 (fun uu___3 -> ()));
-    FStar_Errors.clear ()
+    (let uu___2 = FStar_Errors.report_all () in ()); FStar_Errors.clear ()
 type input_chunks =
   | Push of (Prims.bool * Prims.int * Prims.int) 
   | Pop of Prims.string 
@@ -662,12 +659,12 @@ let rec (go :
                                 | FStar_Pervasives_Native.Some lid2 -> lid2) in
                            let uu___2 =
                              FStar_TypeChecker_Env.try_lookup_lid env lid1 in
-                           FStar_Compiler_Effect.op_Bar_Greater uu___2
-                             (FStar_Compiler_Util.map_option
-                                (fun uu___3 ->
-                                   match uu___3 with
-                                   | ((uu___4, typ), r) ->
-                                       ((FStar_Pervasives.Inr lid1), typ, r)))) in
+                           FStar_Compiler_Util.map_option
+                             (fun uu___3 ->
+                                match uu___3 with
+                                | ((uu___4, typ), r) ->
+                                    ((FStar_Pervasives.Inr lid1), typ, r))
+                             uu___2) in
                   ((match info_opt with
                     | FStar_Pervasives_Native.None ->
                         FStar_Compiler_Util.print_string "\n#done-nok\n"
@@ -702,16 +699,15 @@ let rec (go :
                                    (FStar_Compiler_String.length hs))
                            | uu___1 ->
                                let uu___2 = measure_anchored_match ts1 tc in
-                               FStar_Compiler_Effect.op_Bar_Greater uu___2
-                                 (FStar_Compiler_Util.map_option
-                                    (fun uu___3 ->
-                                       match uu___3 with
-                                       | (matched, len) ->
-                                           ((hc :: matched),
-                                             (((FStar_Compiler_String.length
-                                                  hc_text)
-                                                 + Prims.int_one)
-                                                + len)))))
+                               FStar_Compiler_Util.map_option
+                                 (fun uu___3 ->
+                                    match uu___3 with
+                                    | (matched, len) ->
+                                        ((hc :: matched),
+                                          (((FStar_Compiler_String.length
+                                               hc_text)
+                                              + Prims.int_one)
+                                             + len))) uu___2)
                         else FStar_Pervasives_Native.None in
                   let rec locate_match needle candidate =
                     let uu___1 = measure_anchored_match needle candidate in
@@ -723,12 +719,11 @@ let rec (go :
                          | [] -> FStar_Pervasives_Native.None
                          | hc::tc ->
                              let uu___2 = locate_match needle tc in
-                             FStar_Compiler_Effect.op_Bar_Greater uu___2
-                               (FStar_Compiler_Util.map_option
-                                  (fun uu___3 ->
-                                     match uu___3 with
-                                     | (prefix, matched, len) ->
-                                         ((hc :: prefix), matched, len)))) in
+                             FStar_Compiler_Util.map_option
+                               (fun uu___3 ->
+                                  match uu___3 with
+                                  | (prefix, matched, len) ->
+                                      ((hc :: prefix), matched, len)) uu___2) in
                   let str_of_ids ids =
                     let uu___1 =
                       FStar_Compiler_List.map FStar_Ident.string_of_id ids in
@@ -783,52 +778,50 @@ let rec (go :
                                ((FStar_Compiler_String.length s) + out) +
                                  Prims.int_one)
                           (FStar_Compiler_String.length id) orig_ns in
-                      FStar_Compiler_Effect.op_Bar_Greater exported_names
-                        (FStar_Compiler_List.filter_map
-                           (fun n ->
-                              if FStar_Compiler_Util.starts_with n id
-                              then
-                                let lid =
-                                  let uu___1 = FStar_Ident.ids_of_lid m in
-                                  let uu___2 = FStar_Ident.id_of_text n in
-                                  FStar_Ident.lid_of_ns_and_id uu___1 uu___2 in
-                                let uu___1 =
-                                  FStar_Syntax_DsEnv.resolve_to_fully_qualified_name
-                                    env.FStar_TypeChecker_Env.dsenv lid in
-                                FStar_Compiler_Option.map
-                                  (fun fqn ->
-                                     let uu___2 =
-                                       let uu___3 =
-                                         FStar_Compiler_List.map
-                                           FStar_Ident.id_of_text orig_ns in
-                                       let uu___4 =
-                                         let uu___5 =
-                                           FStar_Ident.ident_of_lid fqn in
-                                         [uu___5] in
-                                       FStar_Compiler_List.op_At uu___3
-                                         uu___4 in
-                                     ([], uu___2, matched_length)) uu___1
-                              else FStar_Pervasives_Native.None)) in
+                      FStar_Compiler_List.filter_map
+                        (fun n ->
+                           if FStar_Compiler_Util.starts_with n id
+                           then
+                             let lid =
+                               let uu___1 = FStar_Ident.ids_of_lid m in
+                               let uu___2 = FStar_Ident.id_of_text n in
+                               FStar_Ident.lid_of_ns_and_id uu___1 uu___2 in
+                             let uu___1 =
+                               FStar_Syntax_DsEnv.resolve_to_fully_qualified_name
+                                 env.FStar_TypeChecker_Env.dsenv lid in
+                             FStar_Compiler_Option.map
+                               (fun fqn ->
+                                  let uu___2 =
+                                    let uu___3 =
+                                      FStar_Compiler_List.map
+                                        FStar_Ident.id_of_text orig_ns in
+                                    let uu___4 =
+                                      let uu___5 =
+                                        FStar_Ident.ident_of_lid fqn in
+                                      [uu___5] in
+                                    FStar_Compiler_List.op_At uu___3 uu___4 in
+                                  ([], uu___2, matched_length)) uu___1
+                           else FStar_Pervasives_Native.None) exported_names in
                     let case_b_find_matches_in_env uu___1 =
                       let matches1 =
                         FStar_Compiler_List.filter_map
                           (match_lident_against needle) all_lidents_in_env in
-                      FStar_Compiler_Effect.op_Bar_Greater matches1
-                        (FStar_Compiler_List.filter
-                           (fun uu___2 ->
-                              match uu___2 with
-                              | (ns, id, uu___3) ->
-                                  let uu___4 =
-                                    let uu___5 = FStar_Ident.lid_of_ids id in
-                                    FStar_Syntax_DsEnv.resolve_to_fully_qualified_name
-                                      env.FStar_TypeChecker_Env.dsenv uu___5 in
-                                  (match uu___4 with
-                                   | FStar_Pervasives_Native.None -> false
-                                   | FStar_Pervasives_Native.Some l ->
-                                       let uu___5 =
-                                         FStar_Ident.lid_of_ids
-                                           (FStar_Compiler_List.op_At ns id) in
-                                       FStar_Ident.lid_equals l uu___5))) in
+                      FStar_Compiler_List.filter
+                        (fun uu___2 ->
+                           match uu___2 with
+                           | (ns, id, uu___3) ->
+                               let uu___4 =
+                                 let uu___5 = FStar_Ident.lid_of_ids id in
+                                 FStar_Syntax_DsEnv.resolve_to_fully_qualified_name
+                                   env.FStar_TypeChecker_Env.dsenv uu___5 in
+                               (match uu___4 with
+                                | FStar_Pervasives_Native.None -> false
+                                | FStar_Pervasives_Native.Some l ->
+                                    let uu___5 =
+                                      FStar_Ident.lid_of_ids
+                                        (FStar_Compiler_List.op_At ns id) in
+                                    FStar_Ident.lid_equals l uu___5))
+                        matches1 in
                     let uu___1 = FStar_Compiler_Util.prefix needle in
                     match uu___1 with
                     | (ns, id) ->
@@ -847,11 +840,10 @@ let rec (go :
                                    case_b_find_matches_in_env ()
                                | FStar_Pervasives_Native.Some m ->
                                    case_a_find_transitive_includes ns m id) in
-                        FStar_Compiler_Effect.op_Bar_Greater matched_ids
-                          (FStar_Compiler_List.map
-                             (fun x ->
-                                let uu___2 = shorten_namespace x in
-                                prepare_candidate uu___2)) in
+                        FStar_Compiler_List.map
+                          (fun x ->
+                             let uu___2 = shorten_namespace x in
+                             prepare_candidate uu___2) matched_ids in
                   ((let uu___2 =
                       FStar_Compiler_Util.sort_with
                         (fun uu___3 ->

--- a/ocaml/fstar-lib/generated/FStar_Interactive_Lsp.ml
+++ b/ocaml/fstar-lib/generated/FStar_Interactive_Lsp.ml
@@ -6,17 +6,15 @@ let (unpack_lsp_query :
   fun r ->
     let qid =
       let uu___ = FStar_Interactive_JsonHelper.try_assoc "id" r in
-      FStar_Compiler_Effect.op_Bar_Greater uu___
-        (FStar_Compiler_Util.map_option
-           FStar_Interactive_JsonHelper.js_str_int) in
+      FStar_Compiler_Util.map_option FStar_Interactive_JsonHelper.js_str_int
+        uu___ in
     try
       (fun uu___ ->
          match () with
          | () ->
              let method1 =
                let uu___1 = FStar_Interactive_JsonHelper.assoc "method" r in
-               FStar_Compiler_Effect.op_Bar_Greater uu___1
-                 FStar_Interactive_JsonHelper.js_str in
+               FStar_Interactive_JsonHelper.js_str uu___1 in
              let uu___1 =
                match method1 with
                | "initialize" ->
@@ -24,13 +22,11 @@ let (unpack_lsp_query :
                      let uu___3 =
                        let uu___4 =
                          FStar_Interactive_JsonHelper.arg "processId" r in
-                       FStar_Compiler_Effect.op_Bar_Greater uu___4
-                         FStar_Interactive_JsonHelper.js_int in
+                       FStar_Interactive_JsonHelper.js_int uu___4 in
                      let uu___4 =
                        let uu___5 =
                          FStar_Interactive_JsonHelper.arg "rootUri" r in
-                       FStar_Compiler_Effect.op_Bar_Greater uu___5
-                         FStar_Interactive_JsonHelper.js_str in
+                       FStar_Interactive_JsonHelper.js_str uu___5 in
                      (uu___3, uu___4) in
                    FStar_Interactive_JsonHelper.Initialize uu___2
                | "initialized" -> FStar_Interactive_JsonHelper.Initialized
@@ -39,14 +35,12 @@ let (unpack_lsp_query :
                | "$/cancelRequest" ->
                    let uu___2 =
                      let uu___3 = FStar_Interactive_JsonHelper.arg "id" r in
-                     FStar_Compiler_Effect.op_Bar_Greater uu___3
-                       FStar_Interactive_JsonHelper.js_str_int in
+                     FStar_Interactive_JsonHelper.js_str_int uu___3 in
                    FStar_Interactive_JsonHelper.Cancel uu___2
                | "workspace/didChangeWorkspaceFolders" ->
                    let uu___2 =
                      let uu___3 = FStar_Interactive_JsonHelper.arg "event" r in
-                     FStar_Compiler_Effect.op_Bar_Greater uu___3
-                       FStar_Interactive_JsonHelper.js_wsch_event in
+                     FStar_Interactive_JsonHelper.js_wsch_event uu___3 in
                    FStar_Interactive_JsonHelper.FolderChange uu___2
                | "workspace/didChangeConfiguration" ->
                    FStar_Interactive_JsonHelper.ChangeConfig
@@ -55,22 +49,19 @@ let (unpack_lsp_query :
                | "workspace/symbol" ->
                    let uu___2 =
                      let uu___3 = FStar_Interactive_JsonHelper.arg "query" r in
-                     FStar_Compiler_Effect.op_Bar_Greater uu___3
-                       FStar_Interactive_JsonHelper.js_str in
+                     FStar_Interactive_JsonHelper.js_str uu___3 in
                    FStar_Interactive_JsonHelper.Symbol uu___2
                | "workspace/executeCommand" ->
                    let uu___2 =
                      let uu___3 =
                        FStar_Interactive_JsonHelper.arg "command" r in
-                     FStar_Compiler_Effect.op_Bar_Greater uu___3
-                       FStar_Interactive_JsonHelper.js_str in
+                     FStar_Interactive_JsonHelper.js_str uu___3 in
                    FStar_Interactive_JsonHelper.ExecCommand uu___2
                | "textDocument/didOpen" ->
                    let uu___2 =
                      let uu___3 =
                        FStar_Interactive_JsonHelper.arg "textDocument" r in
-                     FStar_Compiler_Effect.op_Bar_Greater uu___3
-                       FStar_Interactive_JsonHelper.js_txdoc_item in
+                     FStar_Interactive_JsonHelper.js_txdoc_item uu___3 in
                    FStar_Interactive_JsonHelper.DidOpen uu___2
                | "textDocument/didChange" ->
                    let uu___2 =
@@ -78,8 +69,7 @@ let (unpack_lsp_query :
                      let uu___4 =
                        let uu___5 =
                          FStar_Interactive_JsonHelper.arg "contentChanges" r in
-                       FStar_Compiler_Effect.op_Bar_Greater uu___5
-                         FStar_Interactive_JsonHelper.js_contentch in
+                       FStar_Interactive_JsonHelper.js_contentch uu___5 in
                      (uu___3, uu___4) in
                    FStar_Interactive_JsonHelper.DidChange uu___2
                | "textDocument/willSave" ->
@@ -93,8 +83,7 @@ let (unpack_lsp_query :
                      let uu___3 = FStar_Interactive_JsonHelper.js_txdoc_id r in
                      let uu___4 =
                        let uu___5 = FStar_Interactive_JsonHelper.arg "text" r in
-                       FStar_Compiler_Effect.op_Bar_Greater uu___5
-                         FStar_Interactive_JsonHelper.js_str in
+                       FStar_Interactive_JsonHelper.js_str uu___5 in
                      (uu___3, uu___4) in
                    FStar_Interactive_JsonHelper.DidSave uu___2
                | "textDocument/didClose" ->
@@ -106,8 +95,7 @@ let (unpack_lsp_query :
                      let uu___4 =
                        let uu___5 =
                          FStar_Interactive_JsonHelper.arg "context" r in
-                       FStar_Compiler_Effect.op_Bar_Greater uu___5
-                         FStar_Interactive_JsonHelper.js_compl_context in
+                       FStar_Interactive_JsonHelper.js_compl_context uu___5 in
                      (uu___3, uu___4) in
                    FStar_Interactive_JsonHelper.Completion uu___2
                | "completionItem/resolve" ->
@@ -187,9 +175,7 @@ let (deserialize_lsp_query :
       (fun uu___ ->
          match () with
          | () ->
-             let uu___1 =
-               FStar_Compiler_Effect.op_Bar_Greater js_query
-                 FStar_Interactive_JsonHelper.js_assoc in
+             let uu___1 = FStar_Interactive_JsonHelper.js_assoc js_query in
              unpack_lsp_query uu___1) ()
     with
     | FStar_Interactive_JsonHelper.UnexpectedJsonType (expected, got) ->

--- a/ocaml/fstar-lib/generated/FStar_Interactive_PushHelper.ml
+++ b/ocaml/fstar-lib/generated/FStar_Interactive_PushHelper.ml
@@ -354,10 +354,8 @@ let (tc_one :
     fun intf_opt ->
       fun modf ->
         let parse_data =
-          let uu___ =
-            let uu___1 = FStar_TypeChecker_Env.dep_graph env in
-            FStar_Parser_Dep.parsing_data_of uu___1 in
-          FStar_Compiler_Effect.op_Bar_Greater modf uu___ in
+          let uu___ = FStar_TypeChecker_Env.dep_graph env in
+          FStar_Parser_Dep.parsing_data_of uu___ modf in
         let uu___ =
           FStar_Universal.tc_one_file_for_ide env intf_opt modf parse_data in
         match uu___ with | (uu___1, env1) -> env1

--- a/ocaml/fstar-lib/generated/FStar_Interactive_QueryHelper.ml
+++ b/ocaml/fstar-lib/generated/FStar_Interactive_QueryHelper.ml
@@ -79,15 +79,13 @@ let (symlookup :
               let uu___ =
                 FStar_Syntax_DsEnv.resolve_to_fully_qualified_name
                   tcenv.FStar_TypeChecker_Env.dsenv lid in
-              FStar_Compiler_Effect.op_Less_Bar
-                (FStar_Compiler_Util.dflt lid) uu___ in
+              FStar_Compiler_Util.dflt lid uu___ in
             let uu___ = FStar_TypeChecker_Env.try_lookup_lid tcenv lid1 in
-            FStar_Compiler_Effect.op_Bar_Greater uu___
-              (FStar_Compiler_Util.map_option
-                 (fun uu___1 ->
-                    match uu___1 with
-                    | ((uu___2, typ), r) ->
-                        ((FStar_Pervasives.Inr lid1), typ, r))) in
+            FStar_Compiler_Util.map_option
+              (fun uu___1 ->
+                 match uu___1 with
+                 | ((uu___2, typ), r) ->
+                     ((FStar_Pervasives.Inr lid1), typ, r)) uu___ in
           let docs_of_lid lid = FStar_Pervasives_Native.None in
           let def_of_lid lid =
             let uu___ = FStar_TypeChecker_Env.lookup_qname tcenv lid in

--- a/ocaml/fstar-lib/generated/FStar_Main.ml
+++ b/ocaml/fstar-lib/generated/FStar_Main.ml
@@ -16,24 +16,23 @@ let (finished_message :
         let uu___1 = FStar_Options.silent () in Prims.op_Negation uu___1 in
       if uu___
       then
-        (FStar_Compiler_Effect.op_Bar_Greater fmods
-           (FStar_Compiler_List.iter
-              (fun uu___2 ->
-                 match uu___2 with
-                 | (iface, name) ->
-                     let tag =
-                       if iface then "i'face (or impl+i'face)" else "module" in
-                     let uu___3 =
-                       let uu___4 = FStar_Ident.string_of_lid name in
-                       FStar_Options.should_print_message uu___4 in
-                     if uu___3
-                     then
-                       let uu___4 =
-                         let uu___5 = FStar_Ident.string_of_lid name in
-                         FStar_Compiler_Util.format2 "Verified %s: %s\n" tag
-                           uu___5 in
-                       print_to uu___4
-                     else ()));
+        (FStar_Compiler_List.iter
+           (fun uu___2 ->
+              match uu___2 with
+              | (iface, name) ->
+                  let tag =
+                    if iface then "i'face (or impl+i'face)" else "module" in
+                  let uu___3 =
+                    let uu___4 = FStar_Ident.string_of_lid name in
+                    FStar_Options.should_print_message uu___4 in
+                  if uu___3
+                  then
+                    let uu___4 =
+                      let uu___5 = FStar_Ident.string_of_lid name in
+                      FStar_Compiler_Util.format2 "Verified %s: %s\n" tag
+                        uu___5 in
+                    print_to uu___4
+                  else ()) fmods;
          if errs > Prims.int_zero
          then
            (if errs = Prims.int_one
@@ -52,8 +51,7 @@ let (finished_message :
       else ()
 let (report_errors : (Prims.bool * FStar_Ident.lident) Prims.list -> unit) =
   fun fmods ->
-    (let uu___1 = FStar_Errors.report_all () in
-     FStar_Compiler_Effect.op_Bar_Greater uu___1 (fun uu___2 -> ()));
+    (let uu___1 = FStar_Errors.report_all () in ());
     (let nerrs = FStar_Errors.get_err_count () in
      if nerrs > Prims.int_zero
      then
@@ -64,12 +62,10 @@ let (load_native_tactics : unit -> unit) =
   fun uu___ ->
     let modules_to_load =
       let uu___1 = FStar_Options.load () in
-      FStar_Compiler_Effect.op_Bar_Greater uu___1
-        (FStar_Compiler_List.map FStar_Ident.lid_of_str) in
+      FStar_Compiler_List.map FStar_Ident.lid_of_str uu___1 in
     let cmxs_to_load =
       let uu___1 = FStar_Options.load_cmxs () in
-      FStar_Compiler_Effect.op_Bar_Greater uu___1
-        (FStar_Compiler_List.map FStar_Ident.lid_of_str) in
+      FStar_Compiler_List.map FStar_Ident.lid_of_str uu___1 in
     let ml_module_name m = FStar_Extraction_ML_Util.ml_module_name_of_lid m in
     let ml_file m =
       let uu___1 = ml_module_name m in Prims.strcat uu___1 ".ml" in
@@ -117,9 +113,8 @@ let (load_native_tactics : unit -> unit) =
                        FStar_Errors.raise_err uu___6
                    | FStar_Pervasives_Native.Some f -> f))) in
     let cmxs_files =
-      FStar_Compiler_Effect.op_Bar_Greater
-        (FStar_Compiler_List.op_At modules_to_load cmxs_to_load)
-        (FStar_Compiler_List.map cmxs_file) in
+      FStar_Compiler_List.map cmxs_file
+        (FStar_Compiler_List.op_At modules_to_load cmxs_to_load) in
     (let uu___2 = FStar_Options.debug_any () in
      if uu___2
      then
@@ -238,12 +233,11 @@ let go : 'uuuuu . 'uuuuu -> unit =
                                    | (tcrs, env, cleanup1) ->
                                        ((let uu___16 = cleanup1 env in ());
                                         (let module_names =
-                                           FStar_Compiler_Effect.op_Bar_Greater
-                                             tcrs
-                                             (FStar_Compiler_List.map
-                                                (fun tcr ->
-                                                   FStar_Universal.module_or_interface_name
-                                                     tcr.FStar_CheckedFiles.checked_module)) in
+                                           FStar_Compiler_List.map
+                                             (fun tcr ->
+                                                FStar_Universal.module_or_interface_name
+                                                  tcr.FStar_CheckedFiles.checked_module)
+                                             tcrs in
                                          report_errors module_names;
                                          finished_message module_names
                                            Prims.int_zero))))

--- a/ocaml/fstar-lib/generated/FStar_Options.ml
+++ b/ocaml/fstar-lib/generated/FStar_Options.ml
@@ -156,10 +156,7 @@ let (as_list' : option_val -> option_val Prims.list) =
 let as_list :
   'uuuuu . (option_val -> 'uuuuu) -> option_val -> 'uuuuu Prims.list =
   fun as_t ->
-    fun x ->
-      let uu___ = as_list' x in
-      FStar_Compiler_Effect.op_Bar_Greater uu___
-        (FStar_Compiler_List.map as_t)
+    fun x -> let uu___ = as_list' x in FStar_Compiler_List.map as_t uu___
 let as_option :
   'uuuuu .
     (option_val -> 'uuuuu) ->
@@ -179,7 +176,7 @@ let (as_comma_string_list : option_val -> Prims.string Prims.list) =
             (fun l ->
                let uu___2 = as_string l in
                FStar_Compiler_Util.split uu___2 ",") ls in
-        FStar_Compiler_Effect.op_Less_Bar FStar_Compiler_List.flatten uu___1
+        FStar_Compiler_List.flatten uu___1
     | uu___1 ->
         FStar_Compiler_Effect.failwith "Impos: expected String (comma list)"
 let copy_optionstate :
@@ -410,8 +407,7 @@ let (init : unit -> unit) =
   fun uu___ ->
     let o = internal_peek () in
     FStar_Compiler_Util.smap_clear o;
-    FStar_Compiler_Effect.op_Bar_Greater defaults
-      (FStar_Compiler_List.iter set_option')
+    FStar_Compiler_List.iter set_option' defaults
 let (clear : unit -> unit) =
   fun uu___ ->
     let o = FStar_Compiler_Util.smap_create (Prims.of_int (50)) in
@@ -461,8 +457,7 @@ let (set_verification_options : optionstate -> unit) =
       (fun k ->
          let uu___ =
            let uu___1 = FStar_Compiler_Util.smap_try_find o k in
-           FStar_Compiler_Effect.op_Bar_Greater uu___1
-             FStar_Compiler_Util.must in
+           FStar_Compiler_Util.must uu___1 in
          set_option k uu___) verifopts
 let lookup_opt : 'uuuuu . Prims.string -> (option_val -> 'uuuuu) -> 'uuuuu =
   fun s -> fun c -> let uu___ = get_option s in c uu___
@@ -736,21 +731,18 @@ let (one_debug_level_geq : debug_level_t -> debug_level_t -> Prims.bool) =
 let (debug_level_geq : debug_level_t -> Prims.bool) =
   fun l2 ->
     let uu___ = get_debug_level () in
-    FStar_Compiler_Effect.op_Bar_Greater uu___
-      (FStar_Compiler_Util.for_some
-         (fun l1 -> one_debug_level_geq (dlevel l1) l2))
+    FStar_Compiler_Util.for_some
+      (fun l1 -> one_debug_level_geq (dlevel l1) l2) uu___
 let (universe_include_path_base_dirs : Prims.string Prims.list) =
   let sub_dirs = ["legacy"; "experimental"; ".cache"] in
-  FStar_Compiler_Effect.op_Bar_Greater ["/ulib"; "/lib/fstar"]
-    (FStar_Compiler_List.collect
-       (fun d ->
-          let uu___ =
-            FStar_Compiler_Effect.op_Bar_Greater sub_dirs
-              (FStar_Compiler_List.map
-                 (fun s ->
-                    let uu___1 = FStar_Compiler_String.op_Hat "/" s in
-                    FStar_Compiler_String.op_Hat d uu___1)) in
-          d :: uu___))
+  FStar_Compiler_List.collect
+    (fun d ->
+       let uu___ =
+         FStar_Compiler_List.map
+           (fun s ->
+              let uu___1 = FStar_Compiler_String.op_Hat "/" s in
+              FStar_Compiler_String.op_Hat d uu___1) sub_dirs in
+       d :: uu___) ["/ulib"; "/lib/fstar"]
 let (_version : Prims.string FStar_Compiler_Effect.ref) =
   FStar_Compiler_Util.mk_ref ""
 let (_platform : Prims.string FStar_Compiler_Effect.ref) =
@@ -3560,10 +3552,10 @@ let (settable_specs :
   ((FStar_BaseTypes.char * Prims.string * unit FStar_Getopt.opt_variant) *
     FStar_Pprint.document) Prims.list)
   =
-  FStar_Compiler_Effect.op_Bar_Greater all_specs
-    (FStar_Compiler_List.filter
-       (fun uu___ ->
-          match uu___ with | ((uu___1, x, uu___2), uu___3) -> settable x))
+  FStar_Compiler_List.filter
+    (fun uu___ ->
+       match uu___ with | ((uu___1, x, uu___2), uu___3) -> settable x)
+    all_specs
 let (uu___656 :
   (((unit -> FStar_Getopt.parse_cmdline_res) -> unit) *
     (unit -> FStar_Getopt.parse_cmdline_res)))
@@ -3638,8 +3630,7 @@ let (restore_cmd_line_options : Prims.bool -> FStar_Getopt.parse_cmdline_res)
     if should_clear then clear () else init ();
     (let specs1 =
        let uu___1 = specs false in
-       FStar_Compiler_Effect.op_Less_Bar
-         (FStar_Compiler_List.map FStar_Pervasives_Native.fst) uu___1 in
+       FStar_Compiler_List.map FStar_Pervasives_Native.fst uu___1 in
      let r =
        FStar_Getopt.parse_cmdline specs1 (parse_filename_arg specs1 false) in
      (let uu___2 =
@@ -3705,11 +3696,10 @@ let (include_path : unit -> Prims.string Prims.list) =
                FStar_Compiler_String.op_Hat fstar_bin_directory "/.." in
              let defs = universe_include_path_base_dirs in
              let uu___4 =
-               FStar_Compiler_Effect.op_Bar_Greater defs
-                 (FStar_Compiler_List.map
-                    (fun x -> FStar_Compiler_String.op_Hat fstar_home x)) in
-             FStar_Compiler_Effect.op_Bar_Greater uu___4
-               (FStar_Compiler_List.filter FStar_Compiler_Util.file_exists)
+               FStar_Compiler_List.map
+                 (fun x -> FStar_Compiler_String.op_Hat fstar_home x) defs in
+             FStar_Compiler_List.filter FStar_Compiler_Util.file_exists
+               uu___4
          | FStar_Pervasives_Native.Some s -> [s] in
        let uu___3 =
          let uu___4 =
@@ -3850,27 +3840,23 @@ let (parse_settings :
                else s in
              ((path_of_text s1), true)) in
     let uu___ =
-      FStar_Compiler_Effect.op_Bar_Greater ns
-        (FStar_Compiler_List.collect
-           (fun s ->
-              let s1 = FStar_Compiler_Util.trim_string s in
-              if s1 = ""
-              then []
-              else
-                with_cache
-                  (fun s2 ->
-                     let s3 = FStar_Compiler_Util.replace_char s2 32 44 in
-                     let uu___2 =
-                       let uu___3 =
-                         FStar_Compiler_Effect.op_Bar_Greater
-                           (FStar_Compiler_Util.splitlines s3)
-                           (FStar_Compiler_List.concatMap
-                              (fun s4 -> FStar_Compiler_Util.split s4 ",")) in
-                       FStar_Compiler_Effect.op_Bar_Greater uu___3
-                         (FStar_Compiler_List.filter (fun s4 -> s4 <> "")) in
-                     FStar_Compiler_Effect.op_Bar_Greater uu___2
-                       (FStar_Compiler_List.map parse_one_setting)) s1)) in
-    FStar_Compiler_Effect.op_Bar_Greater uu___ FStar_Compiler_List.rev
+      FStar_Compiler_List.collect
+        (fun s ->
+           let s1 = FStar_Compiler_Util.trim_string s in
+           if s1 = ""
+           then []
+           else
+             with_cache
+               (fun s2 ->
+                  let s3 = FStar_Compiler_Util.replace_char s2 32 44 in
+                  let uu___2 =
+                    let uu___3 =
+                      FStar_Compiler_List.concatMap
+                        (fun s4 -> FStar_Compiler_Util.split s4 ",")
+                        (FStar_Compiler_Util.splitlines s3) in
+                    FStar_Compiler_List.filter (fun s4 -> s4 <> "") uu___3 in
+                  FStar_Compiler_List.map parse_one_setting uu___2) s1) ns in
+    FStar_Compiler_List.rev uu___
 let (admit_smt_queries : unit -> Prims.bool) =
   fun uu___ -> get_admit_smt_queries ()
 let (admit_except : unit -> Prims.string FStar_Pervasives_Native.option) =
@@ -3946,20 +3932,17 @@ let (codegen : unit -> codegen_t FStar_Pervasives_Native.option) =
     let uu___1 = get_codegen () in
     FStar_Compiler_Util.map_opt uu___1
       (fun s ->
-         let uu___2 = parse_codegen s in
-         FStar_Compiler_Effect.op_Bar_Greater uu___2 FStar_Compiler_Util.must)
+         let uu___2 = parse_codegen s in FStar_Compiler_Util.must uu___2)
 let (codegen_libs : unit -> Prims.string Prims.list Prims.list) =
   fun uu___ ->
     let uu___1 = get_codegen_lib () in
-    FStar_Compiler_Effect.op_Bar_Greater uu___1
-      (FStar_Compiler_List.map (fun x -> FStar_Compiler_Util.split x "."))
+    FStar_Compiler_List.map (fun x -> FStar_Compiler_Util.split x ".") uu___1
 let (debug_any : unit -> Prims.bool) =
   fun uu___ -> let uu___1 = get_debug () in uu___1 <> []
 let (debug_module : Prims.string -> Prims.bool) =
   fun modul ->
     let uu___ = get_debug () in
-    FStar_Compiler_Effect.op_Bar_Greater uu___
-      (FStar_Compiler_List.existsb (module_name_eq modul))
+    FStar_Compiler_List.existsb (module_name_eq modul) uu___
 let (debug_at_level_no_module : debug_level_t -> Prims.bool) =
   fun level -> debug_level_geq level
 let (debug_at_level : Prims.string -> debug_level_t -> Prims.bool) =
@@ -3981,8 +3964,7 @@ let (detail_hint_replay : unit -> Prims.bool) =
 let (dump_module : Prims.string -> Prims.bool) =
   fun s ->
     let uu___ = get_dump_module () in
-    FStar_Compiler_Effect.op_Bar_Greater uu___
-      (FStar_Compiler_List.existsb (module_name_eq s))
+    FStar_Compiler_List.existsb (module_name_eq s) uu___
 let (eager_subtyping : unit -> Prims.bool) =
   fun uu___ -> get_eager_subtyping ()
 let (error_contexts : unit -> Prims.bool) =
@@ -4050,8 +4032,7 @@ let (no_default_includes : unit -> Prims.bool) =
 let (no_extract : Prims.string -> Prims.bool) =
   fun s ->
     let uu___ = get_no_extract () in
-    FStar_Compiler_Effect.op_Bar_Greater uu___
-      (FStar_Compiler_List.existsb (module_name_eq s))
+    FStar_Compiler_List.existsb (module_name_eq s) uu___
 let (normalize_pure_terms_for_extraction : unit -> Prims.bool) =
   fun uu___ -> get_normalize_pure_terms_for_extraction ()
 let (no_location_info : unit -> Prims.bool) =
@@ -4126,9 +4107,8 @@ let (parse_split_queries :
 let (split_queries : unit -> split_queries_t) =
   fun uu___ ->
     let uu___1 =
-      let uu___2 = get_split_queries () in
-      FStar_Compiler_Effect.op_Bar_Greater uu___2 parse_split_queries in
-    FStar_Compiler_Effect.op_Bar_Greater uu___1 FStar_Compiler_Util.must
+      let uu___2 = get_split_queries () in parse_split_queries uu___2 in
+    FStar_Compiler_Util.must uu___1
 let (tactic_raw_binders : unit -> Prims.bool) =
   fun uu___ -> get_tactic_raw_binders ()
 let (tactics_failhard : unit -> Prims.bool) =
@@ -4214,11 +4194,10 @@ let (module_matches_namespace_filter :
               (matches_path ms ps)
         | uu___ -> false in
       let uu___ =
-        FStar_Compiler_Effect.op_Bar_Greater setting
-          (FStar_Compiler_Util.try_find
-             (fun uu___1 ->
-                match uu___1 with
-                | (path, uu___2) -> matches_path m_components path)) in
+        FStar_Compiler_Util.try_find
+          (fun uu___1 ->
+             match uu___1 with
+             | (path, uu___2) -> matches_path m_components path) setting in
       match uu___ with
       | FStar_Pervasives_Native.None -> false
       | FStar_Pervasives_Native.Some (uu___1, flag) -> flag
@@ -4257,8 +4236,7 @@ let (print_pes : parsed_extract_setting -> Prims.string) =
              | (tgt, s) ->
                  FStar_Compiler_Util.format2 "(%s, %s)" (print_codegen tgt) s)
           pes.target_specific_settings in
-      FStar_Compiler_Effect.op_Bar_Greater uu___1
-        (FStar_Compiler_String.concat "; ") in
+      FStar_Compiler_String.concat "; " uu___1 in
     FStar_Compiler_Util.format2
       "{ target_specific_settings = %s;\n\t\n               default_settings = %s }"
       uu___
@@ -4444,19 +4422,17 @@ let (should_extract : Prims.string -> codegen_t -> Prims.bool) =
             match uu___1 with
             | [] -> false
             | ns ->
-                FStar_Compiler_Effect.op_Bar_Greater ns
-                  (FStar_Compiler_Util.for_some
-                     (fun n ->
-                        FStar_Compiler_Util.starts_with m2
-                          (FStar_Compiler_String.lowercase n))) in
+                FStar_Compiler_Util.for_some
+                  (fun n ->
+                     FStar_Compiler_Util.starts_with m2
+                       (FStar_Compiler_String.lowercase n)) ns in
           let should_extract_module m2 =
             let uu___1 = get_extract_module () in
             match uu___1 with
             | [] -> false
             | l ->
-                FStar_Compiler_Effect.op_Bar_Greater l
-                  (FStar_Compiler_Util.for_some
-                     (fun n -> (FStar_Compiler_String.lowercase n) = m2)) in
+                FStar_Compiler_Util.for_some
+                  (fun n -> (FStar_Compiler_String.lowercase n) = m2) l in
           (let uu___1 = no_extract m1 in Prims.op_Negation uu___1) &&
             (let uu___1 =
                let uu___2 = get_extract_namespace () in
@@ -4664,10 +4640,8 @@ let (all_ext_options : unit -> (Prims.string * Prims.string) Prims.list) =
     match ext with
     | FStar_Pervasives_Native.None -> []
     | FStar_Pervasives_Native.Some strs ->
-        let uu___1 =
-          FStar_Compiler_Effect.op_Bar_Greater strs
-            (FStar_Compiler_List.collect parse_ext) in
-        FStar_Compiler_Effect.op_Bar_Greater uu___1 ext_dedup
+        let uu___1 = FStar_Compiler_List.collect parse_ext strs in
+        ext_dedup uu___1
 let (ext_getv : Prims.string -> Prims.string) =
   fun k ->
     let ext = all_ext_options () in
@@ -4689,15 +4663,14 @@ let (ext_getns : Prims.string -> (Prims.string * Prims.string) Prims.list) =
         (let uu___ = FStar_Compiler_Util.substring s2 Prims.int_zero l1 in
          uu___ = s1) in
     let exts = all_ext_options () in
-    FStar_Compiler_Effect.op_Bar_Greater exts
-      (FStar_Compiler_List.filter_map
-         (fun uu___ ->
-            match uu___ with
-            | (k', v) ->
-                let uu___1 =
-                  (k' = ns) ||
-                    (let uu___2 = FStar_Compiler_String.op_Hat ns ":" in
-                     is_prefix uu___2 k') in
-                if uu___1
-                then FStar_Pervasives_Native.Some (k', v)
-                else FStar_Pervasives_Native.None))
+    FStar_Compiler_List.filter_map
+      (fun uu___ ->
+         match uu___ with
+         | (k', v) ->
+             let uu___1 =
+               (k' = ns) ||
+                 (let uu___2 = FStar_Compiler_String.op_Hat ns ":" in
+                  is_prefix uu___2 k') in
+             if uu___1
+             then FStar_Pervasives_Native.Some (k', v)
+             else FStar_Pervasives_Native.None) exts

--- a/ocaml/fstar-lib/generated/FStar_Parser_AST.ml
+++ b/ocaml/fstar-lib/generated/FStar_Parser_AST.ml
@@ -1271,13 +1271,10 @@ let focusBranches :
          (let focussed =
             let uu___1 =
               FStar_Compiler_List.filter FStar_Pervasives_Native.fst branches in
-            FStar_Compiler_Effect.op_Bar_Greater uu___1
-              (FStar_Compiler_List.map FStar_Pervasives_Native.snd) in
+            FStar_Compiler_List.map FStar_Pervasives_Native.snd uu___1 in
           let uu___1 = let uu___2 = mkWildAdmitMagic r in [uu___2] in
           FStar_Compiler_List.op_At focussed uu___1))
-      else
-        FStar_Compiler_Effect.op_Bar_Greater branches
-          (FStar_Compiler_List.map FStar_Pervasives_Native.snd)
+      else FStar_Compiler_List.map FStar_Pervasives_Native.snd branches
 let (focusLetBindings :
   (Prims.bool * (pattern * term)) Prims.list ->
     FStar_Compiler_Range_Type.range -> (pattern * term) Prims.list)
@@ -1300,9 +1297,7 @@ let (focusLetBindings :
                   else
                     (let uu___3 = mkAdmitMagic r in
                      ((FStar_Pervasives_Native.fst lb), uu___3))) lbs)
-      else
-        FStar_Compiler_Effect.op_Bar_Greater lbs
-          (FStar_Compiler_List.map FStar_Pervasives_Native.snd)
+      else FStar_Compiler_List.map FStar_Pervasives_Native.snd lbs
 let (focusAttrLetBindings :
   (attributes_ FStar_Pervasives_Native.option * (Prims.bool * (pattern *
     term))) Prims.list ->
@@ -1333,10 +1328,9 @@ let (focusAttrLetBindings :
                        ((FStar_Pervasives_Native.fst lb), uu___4) in
                      (attr, uu___3))) lbs)
       else
-        FStar_Compiler_Effect.op_Bar_Greater lbs
-          (FStar_Compiler_List.map
-             (fun uu___1 ->
-                match uu___1 with | (attr, (uu___2, lb)) -> (attr, lb)))
+        FStar_Compiler_List.map
+          (fun uu___1 ->
+             match uu___1 with | (attr, (uu___2, lb)) -> (attr, lb)) lbs
 let (mkFsTypApp :
   term -> term Prims.list -> FStar_Compiler_Range_Type.range -> term) =
   fun t ->
@@ -1798,16 +1792,14 @@ let rec (term_to_string : term -> Prims.string) =
           match l with
           | [] -> " "
           | hd::tl ->
-              let uu___1 =
-                let uu___2 = term_to_string hd in
-                FStar_Compiler_List.fold_left
-                  (fun s ->
-                     fun t ->
-                       let uu___3 =
-                         let uu___4 = term_to_string t in
-                         Prims.strcat "; " uu___4 in
-                       Prims.strcat s uu___3) uu___2 in
-              FStar_Compiler_Effect.op_Bar_Greater tl uu___1 in
+              let uu___1 = term_to_string hd in
+              FStar_Compiler_List.fold_left
+                (fun s ->
+                   fun t ->
+                     let uu___2 =
+                       let uu___3 = term_to_string t in
+                       Prims.strcat "; " uu___3 in
+                     Prims.strcat s uu___2) uu___1 tl in
         FStar_Compiler_Util.format1 "%[%s]" uu___
     | Decreases (t, uu___) ->
         let uu___1 = term_to_string t in
@@ -1826,9 +1818,7 @@ let rec (term_to_string : term -> Prims.string) =
         let uu___ = FStar_Ident.string_of_id s in
         let uu___1 =
           let uu___2 =
-            FStar_Compiler_List.map
-              (fun x1 ->
-                 FStar_Compiler_Effect.op_Bar_Greater x1 term_to_string) xs in
+            FStar_Compiler_List.map (fun x1 -> term_to_string x1) xs in
           FStar_Compiler_String.concat ", " uu___2 in
         FStar_Compiler_Util.format2 "%s(%s)" uu___ uu___1
     | Tvar id -> FStar_Ident.string_of_id id
@@ -1852,18 +1842,18 @@ let rec (term_to_string : term -> Prims.string) =
         FStar_Compiler_Util.format2 "(%s %s)" uu___ uu___1
     | Abs (pats, t) ->
         let uu___ = to_string_l " " pat_to_string pats in
-        let uu___1 = FStar_Compiler_Effect.op_Bar_Greater t term_to_string in
+        let uu___1 = term_to_string t in
         FStar_Compiler_Util.format2 "(fun %s -> %s)" uu___ uu___1
     | App (t1, t2, imp1) ->
-        let uu___ = FStar_Compiler_Effect.op_Bar_Greater t1 term_to_string in
-        let uu___1 = FStar_Compiler_Effect.op_Bar_Greater t2 term_to_string in
+        let uu___ = term_to_string t1 in
+        let uu___1 = term_to_string t2 in
         FStar_Compiler_Util.format3 "%s %s%s" uu___ (imp_to_string imp1)
           uu___1
     | Let (Rec, (a, (p, b))::lbs, body) ->
         let uu___ = attrs_opt_to_string a in
         let uu___1 =
-          let uu___2 = FStar_Compiler_Effect.op_Bar_Greater p pat_to_string in
-          let uu___3 = FStar_Compiler_Effect.op_Bar_Greater b term_to_string in
+          let uu___2 = pat_to_string p in
+          let uu___3 = term_to_string b in
           FStar_Compiler_Util.format2 "%s=%s" uu___2 uu___3 in
         let uu___2 =
           to_string_l " "
@@ -1871,21 +1861,19 @@ let rec (term_to_string : term -> Prims.string) =
                match uu___3 with
                | (a1, (p1, b1)) ->
                    let uu___4 = attrs_opt_to_string a1 in
-                   let uu___5 =
-                     FStar_Compiler_Effect.op_Bar_Greater p1 pat_to_string in
-                   let uu___6 =
-                     FStar_Compiler_Effect.op_Bar_Greater b1 term_to_string in
+                   let uu___5 = pat_to_string p1 in
+                   let uu___6 = term_to_string b1 in
                    FStar_Compiler_Util.format3 "%sand %s=%s" uu___4 uu___5
                      uu___6) lbs in
-        let uu___3 = FStar_Compiler_Effect.op_Bar_Greater body term_to_string in
+        let uu___3 = term_to_string body in
         FStar_Compiler_Util.format4 "%slet rec %s%s in %s" uu___ uu___1
           uu___2 uu___3
     | Let (q, (attrs, (pat, tm))::[], body) ->
         let uu___ = attrs_opt_to_string attrs in
         let uu___1 = string_of_let_qualifier q in
-        let uu___2 = FStar_Compiler_Effect.op_Bar_Greater pat pat_to_string in
-        let uu___3 = FStar_Compiler_Effect.op_Bar_Greater tm term_to_string in
-        let uu___4 = FStar_Compiler_Effect.op_Bar_Greater body term_to_string in
+        let uu___2 = pat_to_string pat in
+        let uu___3 = term_to_string tm in
+        let uu___4 = term_to_string body in
         FStar_Compiler_Util.format5 "%slet %s %s = %s in %s" uu___ uu___1
           uu___2 uu___3 uu___4
     | Let (uu___, uu___1, uu___2) ->
@@ -1897,8 +1885,8 @@ let rec (term_to_string : term -> Prims.string) =
         let uu___1 = term_to_string t in
         FStar_Compiler_Util.format2 "let open %s in %s" uu___ uu___1
     | Seq (t1, t2) ->
-        let uu___ = FStar_Compiler_Effect.op_Bar_Greater t1 term_to_string in
-        let uu___1 = FStar_Compiler_Effect.op_Bar_Greater t2 term_to_string in
+        let uu___ = term_to_string t1 in
+        let uu___1 = term_to_string t2 in
         FStar_Compiler_Util.format2 "%s; %s" uu___ uu___1
     | Bind (id, t1, t2) ->
         let uu___ = FStar_Ident.string_of_id id in
@@ -1910,7 +1898,7 @@ let rec (term_to_string : term -> Prims.string) =
           match op_opt with
           | FStar_Pervasives_Native.Some op -> FStar_Ident.string_of_id op
           | FStar_Pervasives_Native.None -> "" in
-        let uu___1 = FStar_Compiler_Effect.op_Bar_Greater t1 term_to_string in
+        let uu___1 = term_to_string t1 in
         let uu___2 =
           match ret_opt with
           | FStar_Pervasives_Native.None -> ""
@@ -1924,8 +1912,8 @@ let rec (term_to_string : term -> Prims.string) =
                     FStar_Compiler_Util.format1 " as %s " uu___4 in
               let uu___4 = term_to_string ret in
               FStar_Compiler_Util.format3 "%s%s %s " uu___3 s uu___4 in
-        let uu___3 = FStar_Compiler_Effect.op_Bar_Greater t2 term_to_string in
-        let uu___4 = FStar_Compiler_Effect.op_Bar_Greater t3 term_to_string in
+        let uu___3 = term_to_string t2 in
+        let uu___4 = term_to_string t3 in
         FStar_Compiler_Util.format5 "if%s %s %sthen %s else %s" uu___ uu___1
           uu___2 uu___3 uu___4
     | Match (t, op_opt, ret_opt, branches) ->
@@ -1935,25 +1923,24 @@ let rec (term_to_string : term -> Prims.string) =
           FStar_Pervasives_Native.None
     | Ascribed (t1, t2, FStar_Pervasives_Native.None, flag) ->
         let s = if flag then "$:" else "<:" in
-        let uu___ = FStar_Compiler_Effect.op_Bar_Greater t1 term_to_string in
-        let uu___1 = FStar_Compiler_Effect.op_Bar_Greater t2 term_to_string in
+        let uu___ = term_to_string t1 in
+        let uu___1 = term_to_string t2 in
         FStar_Compiler_Util.format3 "(%s %s %s)" uu___ s uu___1
     | Ascribed (t1, t2, FStar_Pervasives_Native.Some tac, flag) ->
         let s = if flag then "$:" else "<:" in
-        let uu___ = FStar_Compiler_Effect.op_Bar_Greater t1 term_to_string in
-        let uu___1 = FStar_Compiler_Effect.op_Bar_Greater t2 term_to_string in
-        let uu___2 = FStar_Compiler_Effect.op_Bar_Greater tac term_to_string in
+        let uu___ = term_to_string t1 in
+        let uu___1 = term_to_string t2 in
+        let uu___2 = term_to_string tac in
         FStar_Compiler_Util.format4 "(%s %s %s by %s)" uu___ s uu___1 uu___2
     | Record (FStar_Pervasives_Native.Some e, fields) ->
-        let uu___ = FStar_Compiler_Effect.op_Bar_Greater e term_to_string in
+        let uu___ = term_to_string e in
         let uu___1 =
           to_string_l " "
             (fun uu___2 ->
                match uu___2 with
                | (l, e1) ->
                    let uu___3 = FStar_Ident.string_of_lid l in
-                   let uu___4 =
-                     FStar_Compiler_Effect.op_Bar_Greater e1 term_to_string in
+                   let uu___4 = term_to_string e1 in
                    FStar_Compiler_Util.format2 "%s=%s" uu___3 uu___4) fields in
         FStar_Compiler_Util.format2 "{%s with %s}" uu___ uu___1
     | Record (FStar_Pervasives_Native.None, fields) ->
@@ -1963,12 +1950,11 @@ let rec (term_to_string : term -> Prims.string) =
                match uu___1 with
                | (l, e) ->
                    let uu___2 = FStar_Ident.string_of_lid l in
-                   let uu___3 =
-                     FStar_Compiler_Effect.op_Bar_Greater e term_to_string in
+                   let uu___3 = term_to_string e in
                    FStar_Compiler_Util.format2 "%s=%s" uu___2 uu___3) fields in
         FStar_Compiler_Util.format1 "{%s}" uu___
     | Project (e, l) ->
-        let uu___ = FStar_Compiler_Effect.op_Bar_Greater e term_to_string in
+        let uu___ = term_to_string e in
         let uu___1 = FStar_Ident.string_of_lid l in
         FStar_Compiler_Util.format2 "%s.%s" uu___ uu___1
     | Product ([], t) -> term_to_string t
@@ -1982,70 +1968,65 @@ let rec (term_to_string : term -> Prims.string) =
           mk_term uu___1 x.range x.level in
         term_to_string uu___
     | Product (b::[], t) when x.level = Type_level ->
-        let uu___ = FStar_Compiler_Effect.op_Bar_Greater b binder_to_string in
-        let uu___1 = FStar_Compiler_Effect.op_Bar_Greater t term_to_string in
+        let uu___ = binder_to_string b in
+        let uu___1 = term_to_string t in
         FStar_Compiler_Util.format2 "%s -> %s" uu___ uu___1
     | Product (b::[], t) when x.level = Kind ->
-        let uu___ = FStar_Compiler_Effect.op_Bar_Greater b binder_to_string in
-        let uu___1 = FStar_Compiler_Effect.op_Bar_Greater t term_to_string in
+        let uu___ = binder_to_string b in
+        let uu___1 = term_to_string t in
         FStar_Compiler_Util.format2 "%s => %s" uu___ uu___1
     | Sum (binders, t) ->
         let uu___ =
-          FStar_Compiler_Effect.op_Bar_Greater
-            (FStar_Compiler_List.op_At binders [FStar_Pervasives.Inr t])
-            (FStar_Compiler_List.map
-               (fun uu___1 ->
-                  match uu___1 with
-                  | FStar_Pervasives.Inl b -> binder_to_string b
-                  | FStar_Pervasives.Inr t1 -> term_to_string t1)) in
-        FStar_Compiler_Effect.op_Bar_Greater uu___
-          (FStar_Compiler_String.concat " & ")
+          FStar_Compiler_List.map
+            (fun uu___1 ->
+               match uu___1 with
+               | FStar_Pervasives.Inl b -> binder_to_string b
+               | FStar_Pervasives.Inr t1 -> term_to_string t1)
+            (FStar_Compiler_List.op_At binders [FStar_Pervasives.Inr t]) in
+        FStar_Compiler_String.concat " & " uu___
     | QForall (bs, (uu___, pats), t) ->
         let uu___1 = to_string_l " " binder_to_string bs in
         let uu___2 =
           to_string_l " \\/ " (to_string_l "; " term_to_string) pats in
-        let uu___3 = FStar_Compiler_Effect.op_Bar_Greater t term_to_string in
+        let uu___3 = term_to_string t in
         FStar_Compiler_Util.format3 "forall %s.{:pattern %s} %s" uu___1
           uu___2 uu___3
     | QExists (bs, (uu___, pats), t) ->
         let uu___1 = to_string_l " " binder_to_string bs in
         let uu___2 =
           to_string_l " \\/ " (to_string_l "; " term_to_string) pats in
-        let uu___3 = FStar_Compiler_Effect.op_Bar_Greater t term_to_string in
+        let uu___3 = term_to_string t in
         FStar_Compiler_Util.format3 "exists %s.{:pattern %s} %s" uu___1
           uu___2 uu___3
     | QuantOp (i, bs, (uu___, []), t) ->
         let uu___1 = FStar_Ident.string_of_id i in
         let uu___2 = to_string_l " " binder_to_string bs in
-        let uu___3 = FStar_Compiler_Effect.op_Bar_Greater t term_to_string in
+        let uu___3 = term_to_string t in
         FStar_Compiler_Util.format3 "%s %s. %s" uu___1 uu___2 uu___3
     | QuantOp (i, bs, (uu___, pats), t) ->
         let uu___1 = FStar_Ident.string_of_id i in
         let uu___2 = to_string_l " " binder_to_string bs in
         let uu___3 =
           to_string_l " \\/ " (to_string_l "; " term_to_string) pats in
-        let uu___4 = FStar_Compiler_Effect.op_Bar_Greater t term_to_string in
+        let uu___4 = term_to_string t in
         FStar_Compiler_Util.format4 "%s %s.{:pattern %s} %s" uu___1 uu___2
           uu___3 uu___4
     | Refine (b, t) ->
-        let uu___ = FStar_Compiler_Effect.op_Bar_Greater b binder_to_string in
-        let uu___1 = FStar_Compiler_Effect.op_Bar_Greater t term_to_string in
+        let uu___ = binder_to_string b in
+        let uu___1 = term_to_string t in
         FStar_Compiler_Util.format2 "%s:{%s}" uu___ uu___1
     | NamedTyp (x1, t) ->
         let uu___ = FStar_Ident.string_of_id x1 in
-        let uu___1 = FStar_Compiler_Effect.op_Bar_Greater t term_to_string in
+        let uu___1 = term_to_string t in
         FStar_Compiler_Util.format2 "%s:%s" uu___ uu___1
     | Paren t ->
-        let uu___ = FStar_Compiler_Effect.op_Bar_Greater t term_to_string in
+        let uu___ = term_to_string t in
         FStar_Compiler_Util.format1 "(%s)" uu___
     | Product (bs, t) ->
         let uu___ =
-          let uu___1 =
-            FStar_Compiler_Effect.op_Bar_Greater bs
-              (FStar_Compiler_List.map binder_to_string) in
-          FStar_Compiler_Effect.op_Bar_Greater uu___1
-            (FStar_Compiler_String.concat ",") in
-        let uu___1 = FStar_Compiler_Effect.op_Bar_Greater t term_to_string in
+          let uu___1 = FStar_Compiler_List.map binder_to_string bs in
+          FStar_Compiler_String.concat "," uu___1 in
+        let uu___1 = term_to_string t in
         FStar_Compiler_Util.format2 "Unidentified product: [%s] %s" uu___
           uu___1
     | Discrim lid ->
@@ -2054,8 +2035,7 @@ let rec (term_to_string : term -> Prims.string) =
     | Attributes ts ->
         let uu___ =
           let uu___1 = FStar_Compiler_List.map term_to_string ts in
-          FStar_Compiler_Effect.op_Less_Bar
-            (FStar_Compiler_String.concat " ") uu___1 in
+          FStar_Compiler_String.concat " " uu___1 in
         FStar_Compiler_Util.format1 "(attributes %s)" uu___
     | Antiquote t ->
         let uu___ = term_to_string t in
@@ -2074,8 +2054,7 @@ let rec (term_to_string : term -> Prims.string) =
         let uu___1 = term_to_string init in
         let uu___2 =
           let uu___3 = FStar_Compiler_List.map calc_step_to_string steps in
-          FStar_Compiler_Effect.op_Less_Bar
-            (FStar_Compiler_String.concat " ") uu___3 in
+          FStar_Compiler_String.concat " " uu___3 in
         FStar_Compiler_Util.format3 "calc (%s) { %s %s }" uu___ uu___1 uu___2
     | ElimForall (bs, t, vs) ->
         let uu___ = binders_to_string " " bs in
@@ -2181,8 +2160,7 @@ and (binders_to_string : Prims.string -> binder Prims.list -> Prims.string) =
   fun sep ->
     fun bs ->
       let uu___ = FStar_Compiler_List.map binder_to_string bs in
-      FStar_Compiler_Effect.op_Bar_Greater uu___
-        (FStar_Compiler_String.concat sep)
+      FStar_Compiler_String.concat sep uu___
 and (try_or_match_to_string :
   term ->
     term ->
@@ -2206,8 +2184,7 @@ and (try_or_match_to_string :
               | FStar_Pervasives_Native.Some op ->
                   FStar_Ident.string_of_id op
               | FStar_Pervasives_Native.None -> "" in
-            let uu___1 =
-              FStar_Compiler_Effect.op_Bar_Greater scrutinee term_to_string in
+            let uu___1 = term_to_string scrutinee in
             let uu___2 =
               match ret_opt with
               | FStar_Pervasives_Native.None -> ""
@@ -2226,17 +2203,14 @@ and (try_or_match_to_string :
                 (fun uu___4 ->
                    match uu___4 with
                    | (p, w, e) ->
-                       let uu___5 =
-                         FStar_Compiler_Effect.op_Bar_Greater p pat_to_string in
+                       let uu___5 = pat_to_string p in
                        let uu___6 =
                          match w with
                          | FStar_Pervasives_Native.None -> ""
                          | FStar_Pervasives_Native.Some e1 ->
                              let uu___7 = term_to_string e1 in
                              FStar_Compiler_Util.format1 "when %s" uu___7 in
-                       let uu___7 =
-                         FStar_Compiler_Effect.op_Bar_Greater e
-                           term_to_string in
+                       let uu___7 = term_to_string e in
                        FStar_Compiler_Util.format3 "%s %s -> %s" uu___5
                          uu___6 uu___7) branches in
             FStar_Compiler_Util.format5 "%s%s %s %swith %s" s uu___ uu___1
@@ -2260,15 +2234,13 @@ and (binder_to_string : binder -> Prims.string) =
             FStar_Compiler_Util.format1 "%s:_" uu___
         | TAnnotated (i, t) ->
             let uu___ = FStar_Ident.string_of_id i in
-            let uu___1 =
-              FStar_Compiler_Effect.op_Bar_Greater t term_to_string in
+            let uu___1 = term_to_string t in
             FStar_Compiler_Util.format2 "%s:%s" uu___ uu___1
         | Annotated (i, t) ->
             let uu___ = FStar_Ident.string_of_id i in
-            let uu___1 =
-              FStar_Compiler_Effect.op_Bar_Greater t term_to_string in
+            let uu___1 = term_to_string t in
             FStar_Compiler_Util.format2 "%s:%s" uu___ uu___1
-        | NoName t -> FStar_Compiler_Effect.op_Bar_Greater t term_to_string in
+        | NoName t -> term_to_string t in
       let uu___ = aqual_to_string x1.aqual in
       let uu___1 = attr_list_to_string x1.battributes in
       FStar_Compiler_Util.format3 "%s%s%s" uu___ uu___1 s in
@@ -2309,7 +2281,7 @@ and (pat_to_string : pattern -> Prims.string) =
         let uu___ = term_to_string t in
         FStar_Compiler_Util.format1 "`%%%s" uu___
     | PatApp (p, ps) ->
-        let uu___ = FStar_Compiler_Effect.op_Bar_Greater p pat_to_string in
+        let uu___ = pat_to_string p in
         let uu___1 = to_string_l " " pat_to_string ps in
         FStar_Compiler_Util.format2 "(%s %s)" uu___ uu___1
     | PatTvar (i, aq, attrs) ->
@@ -2339,8 +2311,7 @@ and (pat_to_string : pattern -> Prims.string) =
                match uu___1 with
                | (f, e) ->
                    let uu___2 = FStar_Ident.string_of_lid f in
-                   let uu___3 =
-                     FStar_Compiler_Effect.op_Bar_Greater e pat_to_string in
+                   let uu___3 = pat_to_string e in
                    FStar_Compiler_Util.format2 "%s=%s" uu___2 uu___3) l in
         FStar_Compiler_Util.format1 "{%s}" uu___
     | PatOr l -> to_string_l "|\n " pat_to_string l
@@ -2348,13 +2319,13 @@ and (pat_to_string : pattern -> Prims.string) =
         let uu___ = FStar_Ident.string_of_id op in
         FStar_Compiler_Util.format1 "(%s)" uu___
     | PatAscribed (p, (t, FStar_Pervasives_Native.None)) ->
-        let uu___ = FStar_Compiler_Effect.op_Bar_Greater p pat_to_string in
-        let uu___1 = FStar_Compiler_Effect.op_Bar_Greater t term_to_string in
+        let uu___ = pat_to_string p in
+        let uu___1 = term_to_string t in
         FStar_Compiler_Util.format2 "(%s:%s)" uu___ uu___1
     | PatAscribed (p, (t, FStar_Pervasives_Native.Some tac)) ->
-        let uu___ = FStar_Compiler_Effect.op_Bar_Greater p pat_to_string in
-        let uu___1 = FStar_Compiler_Effect.op_Bar_Greater t term_to_string in
-        let uu___2 = FStar_Compiler_Effect.op_Bar_Greater tac term_to_string in
+        let uu___ = pat_to_string p in
+        let uu___1 = term_to_string t in
+        let uu___2 = term_to_string tac in
         FStar_Compiler_Util.format3 "(%s:%s by %s)" uu___ uu___1 uu___2
 and (attrs_opt_to_string :
   term Prims.list FStar_Pervasives_Native.option -> Prims.string) =
@@ -2364,8 +2335,7 @@ and (attrs_opt_to_string :
     | FStar_Pervasives_Native.Some attrs ->
         let uu___1 =
           let uu___2 = FStar_Compiler_List.map term_to_string attrs in
-          FStar_Compiler_Effect.op_Bar_Greater uu___2
-            (FStar_Compiler_String.concat "; ") in
+          FStar_Compiler_String.concat "; " uu___2 in
         FStar_Compiler_Util.format1 "[@ %s]" uu___1
 let rec (head_id_of_pat : pattern -> FStar_Ident.lident Prims.list) =
   fun p ->
@@ -2379,9 +2349,8 @@ let rec (head_id_of_pat : pattern -> FStar_Ident.lident Prims.list) =
 let (lids_of_let :
   (pattern * term) Prims.list -> FStar_Ident.lident Prims.list) =
   fun defs ->
-    FStar_Compiler_Effect.op_Bar_Greater defs
-      (FStar_Compiler_List.collect
-         (fun uu___ -> match uu___ with | (p, uu___1) -> head_id_of_pat p))
+    FStar_Compiler_List.collect
+      (fun uu___ -> match uu___ with | (p, uu___1) -> head_id_of_pat p) defs
 let (id_of_tycon : tycon -> Prims.string) =
   fun uu___ ->
     match uu___ with
@@ -2425,21 +2394,17 @@ let (decl_to_string : decl -> Prims.string) =
         let uu___1 =
           let uu___2 =
             let uu___3 = lids_of_let pats in
-            FStar_Compiler_Effect.op_Bar_Greater uu___3
-              (FStar_Compiler_List.map (fun l -> FStar_Ident.string_of_lid l)) in
-          FStar_Compiler_Effect.op_Bar_Greater uu___2
-            (FStar_Compiler_String.concat ", ") in
+            FStar_Compiler_List.map (fun l -> FStar_Ident.string_of_lid l)
+              uu___3 in
+          FStar_Compiler_String.concat ", " uu___2 in
         Prims.strcat "let " uu___1
     | Assume (i, uu___) ->
         let uu___1 = FStar_Ident.string_of_id i in
         Prims.strcat "assume " uu___1
     | Tycon (uu___, uu___1, tys) ->
         let uu___2 =
-          let uu___3 =
-            FStar_Compiler_Effect.op_Bar_Greater tys
-              (FStar_Compiler_List.map id_of_tycon) in
-          FStar_Compiler_Effect.op_Bar_Greater uu___3
-            (FStar_Compiler_String.concat ", ") in
+          let uu___3 = FStar_Compiler_List.map id_of_tycon tys in
+          FStar_Compiler_String.concat ", " uu___3 in
         Prims.strcat "type " uu___2
     | Val (i, uu___) ->
         let uu___1 = FStar_Ident.string_of_id i in Prims.strcat "val " uu___1
@@ -2477,8 +2442,7 @@ let (decl_to_string : decl -> Prims.string) =
                 let uu___4 =
                   FStar_Compiler_List.map
                     (fun i -> FStar_Ident.string_of_id i) ids in
-                FStar_Compiler_Effect.op_Less_Bar
-                  (FStar_Compiler_String.concat ";") uu___4 in
+                FStar_Compiler_String.concat ";" uu___4 in
               let uu___4 =
                 let uu___5 =
                   let uu___6 = term_to_string t in Prims.strcat uu___6 ")" in
@@ -2497,17 +2461,11 @@ let (modul_to_string : modul -> Prims.string) =
   fun m ->
     match m with
     | Module (uu___, decls) ->
-        let uu___1 =
-          FStar_Compiler_Effect.op_Bar_Greater decls
-            (FStar_Compiler_List.map decl_to_string) in
-        FStar_Compiler_Effect.op_Bar_Greater uu___1
-          (FStar_Compiler_String.concat "\n")
+        let uu___1 = FStar_Compiler_List.map decl_to_string decls in
+        FStar_Compiler_String.concat "\n" uu___1
     | Interface (uu___, decls, uu___1) ->
-        let uu___2 =
-          FStar_Compiler_Effect.op_Bar_Greater decls
-            (FStar_Compiler_List.map decl_to_string) in
-        FStar_Compiler_Effect.op_Bar_Greater uu___2
-          (FStar_Compiler_String.concat "\n")
+        let uu___2 = FStar_Compiler_List.map decl_to_string decls in
+        FStar_Compiler_String.concat "\n" uu___2
 let (decl_is_val : FStar_Ident.ident -> decl -> Prims.bool) =
   fun id ->
     fun decl1 ->
@@ -2535,8 +2493,4 @@ let (ident_of_binder :
 let (idents_of_binders :
   binder Prims.list ->
     FStar_Compiler_Range_Type.range -> FStar_Ident.ident Prims.list)
-  =
-  fun bs ->
-    fun r ->
-      FStar_Compiler_Effect.op_Bar_Greater bs
-        (FStar_Compiler_List.map (ident_of_binder r))
+  = fun bs -> fun r -> FStar_Compiler_List.map (ident_of_binder r) bs

--- a/ocaml/fstar-lib/generated/FStar_Parser_Dep.ml
+++ b/ocaml/fstar-lib/generated/FStar_Parser_Dep.ml
@@ -321,16 +321,13 @@ let (str_of_parsing_data : parsing_data -> Prims.string) =
   fun uu___ ->
     match uu___ with
     | Mk_pd l ->
-        FStar_Compiler_Effect.op_Bar_Greater l
-          (FStar_Compiler_List.fold_left
-             (fun s ->
-                fun elt ->
-                  let uu___1 =
-                    let uu___2 =
-                      FStar_Compiler_Effect.op_Bar_Greater elt
-                        str_of_parsing_data_elt in
-                    Prims.strcat "; " uu___2 in
-                  Prims.strcat s uu___1) "")
+        FStar_Compiler_List.fold_left
+          (fun s ->
+             fun elt ->
+               let uu___1 =
+                 let uu___2 = str_of_parsing_data_elt elt in
+                 Prims.strcat "; " uu___2 in
+               Prims.strcat s uu___1) "" l
 let (friends : parsing_data -> FStar_Ident.lident Prims.list) =
   fun p ->
     let uu___ = p in
@@ -519,11 +516,9 @@ let (cache_file_name : Prims.string -> Prims.string) =
       if lax
       then Prims.strcat fn ".checked.lax"
       else Prims.strcat fn ".checked" in
-    let mname = FStar_Compiler_Effect.op_Bar_Greater fn module_name_of_file in
+    let mname = module_name_of_file fn in
     let uu___ =
-      let uu___1 =
-        FStar_Compiler_Effect.op_Bar_Greater cache_fn
-          FStar_Compiler_Util.basename in
+      let uu___1 = FStar_Compiler_Util.basename cache_fn in
       FStar_Options.find_file uu___1 in
     match uu___ with
     | FStar_Pervasives_Native.Some path ->
@@ -551,8 +546,7 @@ let (cache_file_name : Prims.string -> Prims.string) =
                     FStar_Compiler_Util.format3
                       "Did not expect %s to be already checked, but found it in an unexpected location %s instead of %s"
                       mname path uu___7 in
-                  FStar_Compiler_Effect.op_Less_Bar FStar_Errors_Msg.text
-                    uu___6 in
+                  FStar_Errors_Msg.text uu___6 in
                 [uu___5] in
               (FStar_Errors_Codes.Warning_UnexpectedCheckedFile, uu___4) in
             FStar_Errors.log_issue_doc FStar_Compiler_Range_Type.dummyRange
@@ -564,9 +558,7 @@ let (cache_file_name : Prims.string -> Prims.string) =
                  expected_cache_file) in
           if uu___2 then expected_cache_file else path))
     | FStar_Pervasives_Native.None ->
-        let uu___1 =
-          FStar_Compiler_Effect.op_Bar_Greater mname
-            FStar_Options.should_be_already_cached in
+        let uu___1 = FStar_Options.should_be_already_cached mname in
         if uu___1
         then
           let uu___2 =
@@ -589,7 +581,7 @@ let (parsing_data_of : deps -> Prims.string -> parsing_data) =
   fun deps1 ->
     fun fn ->
       let uu___ = FStar_Compiler_Util.smap_try_find deps1.parse_results fn in
-      FStar_Compiler_Effect.op_Bar_Greater uu___ FStar_Compiler_Util.must
+      FStar_Compiler_Util.must uu___
 let (file_of_dep_aux :
   Prims.bool ->
     files_for_module_name -> file_name Prims.list -> dependence -> file_name)
@@ -599,11 +591,11 @@ let (file_of_dep_aux :
       fun all_cmd_line_files ->
         fun d ->
           let cmd_line_has_impl key =
-            FStar_Compiler_Effect.op_Bar_Greater all_cmd_line_files
-              (FStar_Compiler_Util.for_some
-                 (fun fn ->
-                    (is_implementation fn) &&
-                      (let uu___ = lowercase_module_name fn in key = uu___))) in
+            FStar_Compiler_Util.for_some
+              (fun fn ->
+                 (is_implementation fn) &&
+                   (let uu___ = lowercase_module_name fn in key = uu___))
+              all_cmd_line_files in
           let maybe_use_cache_of f =
             if use_checked_file then cache_file_name f else f in
           match d with
@@ -712,8 +704,7 @@ let (dependences_of :
               let uu___2 =
                 FStar_Compiler_List.map
                   (file_of_dep file_system_map all_cmd_line_files) deps2 in
-              FStar_Compiler_Effect.op_Bar_Greater uu___2
-                (FStar_Compiler_List.filter (fun k -> k <> fn))
+              FStar_Compiler_List.filter (fun k -> k <> fn) uu___2
 let (print_graph :
   FStar_Compiler_Util.out_channel -> Prims.string -> dependence_graph -> unit)
   =
@@ -778,14 +769,13 @@ let (build_inclusion_candidates_list :
              (fun f ->
                 let f1 = FStar_Compiler_Util.basename f in
                 let uu___1 = check_and_strip_suffix f1 in
-                FStar_Compiler_Effect.op_Bar_Greater uu___1
-                  (FStar_Compiler_Util.map_option
-                     (fun longname ->
-                        let full_path =
-                          if d = cwd
-                          then f1
-                          else FStar_Compiler_Util.join_paths d f1 in
-                        (longname, full_path)))) files
+                FStar_Compiler_Util.map_option
+                  (fun longname ->
+                     let full_path =
+                       if d = cwd
+                       then f1
+                       else FStar_Compiler_Util.join_paths d f1 in
+                     (longname, full_path)) uu___1) files
          else
            (let uu___2 =
               let uu___3 =
@@ -904,8 +894,7 @@ let (core_modules : unit -> Prims.string Prims.list) =
           [uu___6] in
         uu___4 :: uu___5 in
       uu___2 :: uu___3 in
-    FStar_Compiler_Effect.op_Bar_Greater uu___1
-      (FStar_Compiler_List.map module_name_of_file)
+    FStar_Compiler_List.map module_name_of_file uu___1
 let (implicit_ns_deps : FStar_Ident.lident Prims.list) =
   [FStar_Parser_Const.fstar_ns_lid]
 let (implicit_module_deps : FStar_Ident.lident Prims.list) =
@@ -973,10 +962,8 @@ let (enter_namespace :
                      then
                        let str =
                          let uu___3 =
-                           FStar_Compiler_Effect.op_Bar_Greater
-                             suffix_filename FStar_Compiler_Util.must in
-                         FStar_Compiler_Effect.op_Bar_Greater uu___3
-                           intf_and_impl_to_string in
+                           FStar_Compiler_Util.must suffix_filename in
+                         intf_and_impl_to_string uu___3 in
                        let uu___3 =
                          let uu___4 =
                            let uu___5 =
@@ -984,8 +971,7 @@ let (enter_namespace :
                                FStar_Compiler_Util.format4
                                  "Implicitly opening %s namespace shadows (%s -> %s), rename %s to avoid conflicts"
                                  prefix1 suffix str str in
-                             FStar_Compiler_Effect.op_Less_Bar
-                               FStar_Errors_Msg.text uu___6 in
+                             FStar_Errors_Msg.text uu___6 in
                            [uu___5] in
                          (FStar_Errors_Codes.Warning_UnexpectedFile, uu___4) in
                        FStar_Errors.log_issue_doc
@@ -1020,12 +1006,11 @@ let (collect_one :
             if uu___ then [UseImplementation mname] else [] in
           let auto_open =
             let uu___ = hard_coded_dependencies filename1 in
-            FStar_Compiler_Effect.op_Bar_Greater uu___
-              (FStar_Compiler_List.map
-                 (fun uu___1 ->
-                    match uu___1 with
-                    | (lid, k) ->
-                        P_implicit_open_module_or_namespace (k, lid))) in
+            FStar_Compiler_List.map
+              (fun uu___1 ->
+                 match uu___1 with
+                 | (lid, k) -> P_implicit_open_module_or_namespace (k, lid))
+              uu___ in
           let working_map = FStar_Compiler_Util.smap_copy original_map1 in
           let set_interface_inlining uu___ =
             let uu___1 = is_interface filename1 in
@@ -1179,80 +1164,70 @@ let (collect_one :
             else () in
           (match pd with
            | Mk_pd l ->
-               FStar_Compiler_Effect.op_Bar_Greater
-                 (FStar_Compiler_List.op_At auto_open l)
-                 (FStar_Compiler_List.iter
-                    (fun elt ->
-                       match elt with
-                       | P_begin_module lid -> begin_module lid
-                       | P_open (b, lid) -> record_open b lid
-                       | P_implicit_open_module_or_namespace (k, lid) ->
-                           record_implicit_open_module_or_namespace (lid, k)
-                       | P_dep (b, lid) -> add_dep_on_module lid b
-                       | P_alias (id, lid) ->
-                           let uu___1 = record_module_alias id lid in ()
-                       | P_lid lid -> record_lid lid
-                       | P_inline_for_extraction -> set_interface_inlining ())));
+               FStar_Compiler_List.iter
+                 (fun elt ->
+                    match elt with
+                    | P_begin_module lid -> begin_module lid
+                    | P_open (b, lid) -> record_open b lid
+                    | P_implicit_open_module_or_namespace (k, lid) ->
+                        record_implicit_open_module_or_namespace (lid, k)
+                    | P_dep (b, lid) -> add_dep_on_module lid b
+                    | P_alias (id, lid) ->
+                        let uu___1 = record_module_alias id lid in ()
+                    | P_lid lid -> record_lid lid
+                    | P_inline_for_extraction -> set_interface_inlining ())
+                 (FStar_Compiler_List.op_At auto_open l));
           (let uu___1 = FStar_Compiler_Effect.op_Bang deps1 in
            let uu___2 =
              FStar_Compiler_Effect.op_Bang has_inline_for_extraction in
            (uu___1, uu___2, mo_roots)) in
-        let data_from_cache =
-          FStar_Compiler_Effect.op_Bar_Greater filename
-            get_parsing_data_from_cache in
-        let uu___ =
-          FStar_Compiler_Effect.op_Bar_Greater data_from_cache
-            FStar_Compiler_Util.is_some in
-        if uu___
+        let data_from_cache = get_parsing_data_from_cache filename in
+        if FStar_Compiler_Util.is_some data_from_cache
         then
-          let uu___1 =
-            let uu___2 =
-              FStar_Compiler_Effect.op_Bar_Greater data_from_cache
-                FStar_Compiler_Util.must in
-            from_parsing_data uu___2 original_map filename in
-          match uu___1 with
+          let uu___ =
+            let uu___1 = FStar_Compiler_Util.must data_from_cache in
+            from_parsing_data uu___1 original_map filename in
+          match uu___ with
           | (deps1, has_inline_for_extraction, mo_roots) ->
-              ((let uu___3 =
+              ((let uu___2 =
                   FStar_Options.debug_at_level_no_module
                     (FStar_Options.Other "Dep") in
-                if uu___3
+                if uu___2
                 then
-                  let uu___4 =
+                  let uu___3 =
                     FStar_Class_Show.show
                       (FStar_Class_Show.show_list showable_dependence) deps1 in
                   FStar_Compiler_Util.print2
                     "Reading the parsing data for %s from its checked file .. found [%s]\n"
-                    filename uu___4
+                    filename uu___3
                 else ());
-               (let uu___3 =
-                  FStar_Compiler_Effect.op_Bar_Greater data_from_cache
-                    FStar_Compiler_Util.must in
-                (uu___3, deps1, has_inline_for_extraction, mo_roots)))
+               (let uu___2 = FStar_Compiler_Util.must data_from_cache in
+                (uu___2, deps1, has_inline_for_extraction, mo_roots)))
         else
           (let num_of_toplevelmods =
              FStar_Compiler_Util.mk_ref Prims.int_zero in
            let pd = FStar_Compiler_Util.mk_ref [] in
            let add_to_parsing_data elt =
-             let uu___2 =
-               let uu___3 =
-                 let uu___4 = FStar_Compiler_Effect.op_Bang pd in
+             let uu___1 =
+               let uu___2 =
+                 let uu___3 = FStar_Compiler_Effect.op_Bang pd in
                  FStar_Compiler_List.existsML
-                   (fun e -> parsing_data_elt_eq e elt) uu___4 in
-               Prims.op_Negation uu___3 in
-             if uu___2
+                   (fun e -> parsing_data_elt_eq e elt) uu___3 in
+               Prims.op_Negation uu___2 in
+             if uu___1
              then
-               let uu___3 =
-                 let uu___4 = FStar_Compiler_Effect.op_Bang pd in elt ::
-                   uu___4 in
-               FStar_Compiler_Effect.op_Colon_Equals pd uu___3
+               let uu___2 =
+                 let uu___3 = FStar_Compiler_Effect.op_Bang pd in elt ::
+                   uu___3 in
+               FStar_Compiler_Effect.op_Colon_Equals pd uu___2
              else () in
-           let rec collect_module uu___2 =
-             match uu___2 with
+           let rec collect_module uu___1 =
+             match uu___1 with
              | FStar_Parser_AST.Module (lid, decls) ->
                  (check_module_declaration_against_filename lid filename;
                   add_to_parsing_data (P_begin_module lid);
                   collect_decls decls)
-             | FStar_Parser_AST.Interface (lid, decls, uu___3) ->
+             | FStar_Parser_AST.Interface (lid, decls, uu___2) ->
                  (check_module_declaration_against_filename lid filename;
                   add_to_parsing_data (P_begin_module lid);
                   collect_decls decls)
@@ -1263,12 +1238,12 @@ let (collect_one :
                   FStar_Compiler_List.iter collect_term
                     x.FStar_Parser_AST.attrs;
                   (match x.FStar_Parser_AST.d with
-                   | FStar_Parser_AST.Val uu___4 when
+                   | FStar_Parser_AST.Val uu___3 when
                        FStar_Compiler_List.contains
                          FStar_Parser_AST.Inline_for_extraction
                          x.FStar_Parser_AST.quals
                        -> add_to_parsing_data P_inline_for_extraction
-                   | uu___4 -> ())) decls
+                   | uu___3 -> ())) decls
            and collect_decl d =
              match d with
              | FStar_Parser_AST.Include lid ->
@@ -1276,181 +1251,176 @@ let (collect_one :
              | FStar_Parser_AST.Open lid ->
                  add_to_parsing_data (P_open (false, lid))
              | FStar_Parser_AST.Friend lid ->
-                 let uu___2 =
-                   let uu___3 =
-                     let uu___4 =
-                       let uu___5 = lowercase_join_longident lid true in
-                       FStar_Compiler_Effect.op_Bar_Greater uu___5
-                         FStar_Ident.lid_of_str in
-                     (true, uu___4) in
-                   P_dep uu___3 in
-                 add_to_parsing_data uu___2
+                 let uu___1 =
+                   let uu___2 =
+                     let uu___3 =
+                       let uu___4 = lowercase_join_longident lid true in
+                       FStar_Ident.lid_of_str uu___4 in
+                     (true, uu___3) in
+                   P_dep uu___2 in
+                 add_to_parsing_data uu___1
              | FStar_Parser_AST.ModuleAbbrev (ident, lid) ->
                  add_to_parsing_data (P_alias (ident, lid))
-             | FStar_Parser_AST.TopLevelLet (uu___2, patterms) ->
+             | FStar_Parser_AST.TopLevelLet (uu___1, patterms) ->
                  FStar_Compiler_List.iter
-                   (fun uu___3 ->
-                      match uu___3 with
+                   (fun uu___2 ->
+                      match uu___2 with
                       | (pat, t) -> (collect_pattern pat; collect_term t))
                    patterms
-             | FStar_Parser_AST.Splice (uu___2, uu___3, t) -> collect_term t
-             | FStar_Parser_AST.Assume (uu___2, t) -> collect_term t
+             | FStar_Parser_AST.Splice (uu___1, uu___2, t) -> collect_term t
+             | FStar_Parser_AST.Assume (uu___1, t) -> collect_term t
              | FStar_Parser_AST.SubEffect
-                 { FStar_Parser_AST.msource = uu___2;
-                   FStar_Parser_AST.mdest = uu___3;
+                 { FStar_Parser_AST.msource = uu___1;
+                   FStar_Parser_AST.mdest = uu___2;
                    FStar_Parser_AST.lift_op =
                      FStar_Parser_AST.NonReifiableLift t;
-                   FStar_Parser_AST.braced = uu___4;_}
+                   FStar_Parser_AST.braced = uu___3;_}
                  -> collect_term t
              | FStar_Parser_AST.SubEffect
-                 { FStar_Parser_AST.msource = uu___2;
-                   FStar_Parser_AST.mdest = uu___3;
+                 { FStar_Parser_AST.msource = uu___1;
+                   FStar_Parser_AST.mdest = uu___2;
                    FStar_Parser_AST.lift_op = FStar_Parser_AST.LiftForFree t;
-                   FStar_Parser_AST.braced = uu___4;_}
+                   FStar_Parser_AST.braced = uu___3;_}
                  -> collect_term t
-             | FStar_Parser_AST.Val (uu___2, t) -> collect_term t
+             | FStar_Parser_AST.Val (uu___1, t) -> collect_term t
              | FStar_Parser_AST.SubEffect
-                 { FStar_Parser_AST.msource = uu___2;
-                   FStar_Parser_AST.mdest = uu___3;
+                 { FStar_Parser_AST.msource = uu___1;
+                   FStar_Parser_AST.mdest = uu___2;
                    FStar_Parser_AST.lift_op = FStar_Parser_AST.ReifiableLift
                      (t0, t1);
-                   FStar_Parser_AST.braced = uu___4;_}
+                   FStar_Parser_AST.braced = uu___3;_}
                  -> (collect_term t0; collect_term t1)
-             | FStar_Parser_AST.Tycon (uu___2, tc, ts) ->
+             | FStar_Parser_AST.Tycon (uu___1, tc, ts) ->
                  (if tc
                   then
                     add_to_parsing_data
                       (P_lid FStar_Parser_Const.mk_class_lid)
                   else ();
                   FStar_Compiler_List.iter collect_tycon ts)
-             | FStar_Parser_AST.Exception (uu___2, t) ->
+             | FStar_Parser_AST.Exception (uu___1, t) ->
                  FStar_Compiler_Util.iter_opt t collect_term
              | FStar_Parser_AST.NewEffect ed -> collect_effect_decl ed
              | FStar_Parser_AST.LayeredEffect ed -> collect_effect_decl ed
-             | FStar_Parser_AST.Polymonadic_bind (uu___2, uu___3, uu___4, t)
+             | FStar_Parser_AST.Polymonadic_bind (uu___1, uu___2, uu___3, t)
                  -> collect_term t
-             | FStar_Parser_AST.Polymonadic_subcomp (uu___2, uu___3, t) ->
+             | FStar_Parser_AST.Polymonadic_subcomp (uu___1, uu___2, t) ->
                  collect_term t
-             | FStar_Parser_AST.Pragma uu___2 -> ()
-             | FStar_Parser_AST.DeclSyntaxExtension uu___2 -> ()
+             | FStar_Parser_AST.Pragma uu___1 -> ()
+             | FStar_Parser_AST.DeclSyntaxExtension uu___1 -> ()
              | FStar_Parser_AST.TopLevelModule lid ->
                  (FStar_Compiler_Util.incr num_of_toplevelmods;
-                  (let uu___3 =
-                     let uu___4 =
+                  (let uu___2 =
+                     let uu___3 =
                        FStar_Compiler_Effect.op_Bang num_of_toplevelmods in
-                     uu___4 > Prims.int_one in
-                   if uu___3
+                     uu___3 > Prims.int_one in
+                   if uu___2
                    then
-                     let uu___4 =
-                       let uu___5 =
-                         let uu___6 = string_of_lid lid true in
+                     let uu___3 =
+                       let uu___4 =
+                         let uu___5 = string_of_lid lid true in
                          FStar_Compiler_Util.format1
                            "Automatic dependency analysis demands one module per file (module %s not supported)"
-                           uu___6 in
-                       (FStar_Errors_Codes.Fatal_OneModulePerFile, uu___5) in
-                     let uu___5 = FStar_Ident.range_of_lid lid in
-                     FStar_Errors.raise_error uu___4 uu___5
+                           uu___5 in
+                       (FStar_Errors_Codes.Fatal_OneModulePerFile, uu___4) in
+                     let uu___4 = FStar_Ident.range_of_lid lid in
+                     FStar_Errors.raise_error uu___3 uu___4
                    else ()))
-           and collect_tycon uu___2 =
-             match uu___2 with
-             | FStar_Parser_AST.TyconAbstract (uu___3, binders, k) ->
+           and collect_tycon uu___1 =
+             match uu___1 with
+             | FStar_Parser_AST.TyconAbstract (uu___2, binders, k) ->
                  (collect_binders binders;
                   FStar_Compiler_Util.iter_opt k collect_term)
-             | FStar_Parser_AST.TyconAbbrev (uu___3, binders, k, t) ->
+             | FStar_Parser_AST.TyconAbbrev (uu___2, binders, k, t) ->
                  (collect_binders binders;
                   FStar_Compiler_Util.iter_opt k collect_term;
                   collect_term t)
              | FStar_Parser_AST.TyconRecord
-                 (uu___3, binders, k, uu___4, identterms) ->
+                 (uu___2, binders, k, uu___3, identterms) ->
                  (collect_binders binders;
                   FStar_Compiler_Util.iter_opt k collect_term;
                   collect_tycon_record identterms)
-             | FStar_Parser_AST.TyconVariant (uu___3, binders, k, identterms)
+             | FStar_Parser_AST.TyconVariant (uu___2, binders, k, identterms)
                  ->
                  (collect_binders binders;
                   FStar_Compiler_Util.iter_opt k collect_term;
-                  (let uu___6 =
+                  (let uu___5 =
                      FStar_Compiler_List.filter_map
                        FStar_Pervasives_Native.__proj__Mktuple3__item___2
                        identterms in
                    FStar_Compiler_List.iter
-                     (fun uu___7 ->
-                        match uu___7 with
+                     (fun uu___6 ->
+                        match uu___6 with
                         | FStar_Parser_AST.VpOfNotation t -> collect_term t
                         | FStar_Parser_AST.VpArbitrary t -> collect_term t
                         | FStar_Parser_AST.VpRecord (record, t) ->
                             (collect_tycon_record record;
                              FStar_Compiler_Util.iter_opt t collect_term))
-                     uu___6))
+                     uu___5))
            and collect_tycon_record r =
              FStar_Compiler_List.iter
-               (fun uu___2 ->
-                  match uu___2 with
-                  | (uu___3, aq, attrs, t) ->
+               (fun uu___1 ->
+                  match uu___1 with
+                  | (uu___2, aq, attrs, t) ->
                       (collect_aqual aq;
-                       FStar_Compiler_Effect.op_Bar_Greater attrs
-                         (FStar_Compiler_List.iter collect_term);
+                       FStar_Compiler_List.iter collect_term attrs;
                        collect_term t)) r
-           and collect_effect_decl uu___2 =
-             match uu___2 with
-             | FStar_Parser_AST.DefineEffect (uu___3, binders, t, decls) ->
+           and collect_effect_decl uu___1 =
+             match uu___1 with
+             | FStar_Parser_AST.DefineEffect (uu___2, binders, t, decls) ->
                  (collect_binders binders;
                   collect_term t;
                   collect_decls decls)
-             | FStar_Parser_AST.RedefineEffect (uu___3, binders, t) ->
+             | FStar_Parser_AST.RedefineEffect (uu___2, binders, t) ->
                  (collect_binders binders; collect_term t)
            and collect_binders binders =
              FStar_Compiler_List.iter collect_binder binders
            and collect_binder b =
              collect_aqual b.FStar_Parser_AST.aqual;
-             FStar_Compiler_Effect.op_Bar_Greater
-               b.FStar_Parser_AST.battributes
-               (FStar_Compiler_List.iter collect_term);
+             FStar_Compiler_List.iter collect_term
+               b.FStar_Parser_AST.battributes;
              (match b with
               | {
-                  FStar_Parser_AST.b = FStar_Parser_AST.Annotated (uu___4, t);
-                  FStar_Parser_AST.brange = uu___5;
-                  FStar_Parser_AST.blevel = uu___6;
-                  FStar_Parser_AST.aqual = uu___7;
-                  FStar_Parser_AST.battributes = uu___8;_} -> collect_term t
-              | {
-                  FStar_Parser_AST.b = FStar_Parser_AST.TAnnotated
-                    (uu___4, t);
-                  FStar_Parser_AST.brange = uu___5;
-                  FStar_Parser_AST.blevel = uu___6;
-                  FStar_Parser_AST.aqual = uu___7;
-                  FStar_Parser_AST.battributes = uu___8;_} -> collect_term t
-              | { FStar_Parser_AST.b = FStar_Parser_AST.NoName t;
+                  FStar_Parser_AST.b = FStar_Parser_AST.Annotated (uu___3, t);
                   FStar_Parser_AST.brange = uu___4;
                   FStar_Parser_AST.blevel = uu___5;
                   FStar_Parser_AST.aqual = uu___6;
                   FStar_Parser_AST.battributes = uu___7;_} -> collect_term t
-              | uu___4 -> ())
-           and collect_aqual uu___2 =
-             match uu___2 with
+              | {
+                  FStar_Parser_AST.b = FStar_Parser_AST.TAnnotated
+                    (uu___3, t);
+                  FStar_Parser_AST.brange = uu___4;
+                  FStar_Parser_AST.blevel = uu___5;
+                  FStar_Parser_AST.aqual = uu___6;
+                  FStar_Parser_AST.battributes = uu___7;_} -> collect_term t
+              | { FStar_Parser_AST.b = FStar_Parser_AST.NoName t;
+                  FStar_Parser_AST.brange = uu___3;
+                  FStar_Parser_AST.blevel = uu___4;
+                  FStar_Parser_AST.aqual = uu___5;
+                  FStar_Parser_AST.battributes = uu___6;_} -> collect_term t
+              | uu___3 -> ())
+           and collect_aqual uu___1 =
+             match uu___1 with
              | FStar_Pervasives_Native.Some (FStar_Parser_AST.Meta t) ->
                  collect_term t
              | FStar_Pervasives_Native.Some (FStar_Parser_AST.TypeClassArg)
                  ->
                  add_to_parsing_data (P_lid FStar_Parser_Const.tcresolve_lid)
-             | uu___3 -> ()
+             | uu___2 -> ()
            and collect_term t = collect_term' t.FStar_Parser_AST.tm
-           and collect_constant uu___2 =
-             match uu___2 with
+           and collect_constant uu___1 =
+             match uu___1 with
              | FStar_Const.Const_int
-                 (uu___3, FStar_Pervasives_Native.Some
+                 (uu___2, FStar_Pervasives_Native.Some
                   (FStar_Const.Unsigned, FStar_Const.Sizet))
                  ->
-                 let uu___4 =
-                   let uu___5 =
-                     let uu___6 =
-                       FStar_Compiler_Effect.op_Bar_Greater "fstar.sizeT"
-                         FStar_Ident.lid_of_str in
-                     (false, uu___6) in
-                   P_dep uu___5 in
-                 add_to_parsing_data uu___4
+                 let uu___3 =
+                   let uu___4 =
+                     let uu___5 = FStar_Ident.lid_of_str "fstar.sizeT" in
+                     (false, uu___5) in
+                   P_dep uu___4 in
+                 add_to_parsing_data uu___3
              | FStar_Const.Const_int
-                 (uu___3, FStar_Pervasives_Native.Some (signedness, width))
+                 (uu___2, FStar_Pervasives_Native.Some (signedness, width))
                  ->
                  let u =
                    match signedness with
@@ -1462,54 +1432,47 @@ let (collect_one :
                    | FStar_Const.Int16 -> "16"
                    | FStar_Const.Int32 -> "32"
                    | FStar_Const.Int64 -> "64" in
-                 let uu___4 =
-                   let uu___5 =
-                     let uu___6 =
-                       let uu___7 =
+                 let uu___3 =
+                   let uu___4 =
+                     let uu___5 =
+                       let uu___6 =
                          FStar_Compiler_Util.format2 "fstar.%sint%s" u w in
-                       FStar_Compiler_Effect.op_Bar_Greater uu___7
-                         FStar_Ident.lid_of_str in
-                     (false, uu___6) in
-                   P_dep uu___5 in
-                 add_to_parsing_data uu___4
-             | FStar_Const.Const_char uu___3 ->
-                 let uu___4 =
-                   let uu___5 =
-                     let uu___6 =
-                       FStar_Compiler_Effect.op_Bar_Greater "fstar.char"
-                         FStar_Ident.lid_of_str in
-                     (false, uu___6) in
-                   P_dep uu___5 in
-                 add_to_parsing_data uu___4
+                       FStar_Ident.lid_of_str uu___6 in
+                     (false, uu___5) in
+                   P_dep uu___4 in
+                 add_to_parsing_data uu___3
+             | FStar_Const.Const_char uu___2 ->
+                 let uu___3 =
+                   let uu___4 =
+                     let uu___5 = FStar_Ident.lid_of_str "fstar.char" in
+                     (false, uu___5) in
+                   P_dep uu___4 in
+                 add_to_parsing_data uu___3
              | FStar_Const.Const_range_of ->
-                 let uu___3 =
-                   let uu___4 =
-                     let uu___5 =
-                       FStar_Compiler_Effect.op_Bar_Greater "fstar.range"
-                         FStar_Ident.lid_of_str in
-                     (false, uu___5) in
-                   P_dep uu___4 in
-                 add_to_parsing_data uu___3
+                 let uu___2 =
+                   let uu___3 =
+                     let uu___4 = FStar_Ident.lid_of_str "fstar.range" in
+                     (false, uu___4) in
+                   P_dep uu___3 in
+                 add_to_parsing_data uu___2
              | FStar_Const.Const_set_range_of ->
-                 let uu___3 =
-                   let uu___4 =
-                     let uu___5 =
-                       FStar_Compiler_Effect.op_Bar_Greater "fstar.range"
-                         FStar_Ident.lid_of_str in
-                     (false, uu___5) in
-                   P_dep uu___4 in
-                 add_to_parsing_data uu___3
-             | uu___3 -> ()
-           and collect_term' uu___2 =
-             match uu___2 with
+                 let uu___2 =
+                   let uu___3 =
+                     let uu___4 = FStar_Ident.lid_of_str "fstar.range" in
+                     (false, uu___4) in
+                   P_dep uu___3 in
+                 add_to_parsing_data uu___2
+             | uu___2 -> ()
+           and collect_term' uu___1 =
+             match uu___1 with
              | FStar_Parser_AST.Wild -> ()
              | FStar_Parser_AST.Const c -> collect_constant c
-             | FStar_Parser_AST.Op (uu___3, ts) ->
+             | FStar_Parser_AST.Op (uu___2, ts) ->
                  FStar_Compiler_List.iter collect_term ts
-             | FStar_Parser_AST.Tvar uu___3 -> ()
-             | FStar_Parser_AST.Uvar uu___3 -> ()
+             | FStar_Parser_AST.Tvar uu___2 -> ()
+             | FStar_Parser_AST.Uvar uu___2 -> ()
              | FStar_Parser_AST.Var lid -> add_to_parsing_data (P_lid lid)
-             | FStar_Parser_AST.Projector (lid, uu___3) ->
+             | FStar_Parser_AST.Projector (lid, uu___2) ->
                  add_to_parsing_data (P_lid lid)
              | FStar_Parser_AST.Discrim lid ->
                  add_to_parsing_data (P_lid lid)
@@ -1517,19 +1480,19 @@ let (collect_one :
              | FStar_Parser_AST.Construct (lid, termimps) ->
                  (add_to_parsing_data (P_lid lid);
                   FStar_Compiler_List.iter
-                    (fun uu___4 ->
-                       match uu___4 with | (t, uu___5) -> collect_term t)
+                    (fun uu___3 ->
+                       match uu___3 with | (t, uu___4) -> collect_term t)
                     termimps)
              | FStar_Parser_AST.Abs (pats, t) ->
                  (collect_patterns pats; collect_term t)
-             | FStar_Parser_AST.App (t1, t2, uu___3) ->
+             | FStar_Parser_AST.App (t1, t2, uu___2) ->
                  (collect_term t1; collect_term t2)
-             | FStar_Parser_AST.Let (uu___3, patterms, t) ->
+             | FStar_Parser_AST.Let (uu___2, patterms, t) ->
                  (FStar_Compiler_List.iter
-                    (fun uu___5 ->
-                       match uu___5 with
+                    (fun uu___4 ->
+                       match uu___4 with
                        | (attrs_opt, (pat, t1)) ->
-                           ((let uu___7 =
+                           ((let uu___6 =
                                FStar_Compiler_Util.map_opt attrs_opt
                                  (FStar_Compiler_List.iter collect_term) in
                              ());
@@ -1538,8 +1501,8 @@ let (collect_one :
                   collect_term t)
              | FStar_Parser_AST.LetOperator (lets, body) ->
                  (FStar_Compiler_List.iter
-                    (fun uu___4 ->
-                       match uu___4 with
+                    (fun uu___3 ->
+                       match uu___3 with
                        | (ident, pat, def) ->
                            (collect_pattern pat; collect_term def)) lets;
                   collect_term body)
@@ -1547,38 +1510,38 @@ let (collect_one :
                  (add_to_parsing_data (P_open (true, lid)); collect_term t)
              | FStar_Parser_AST.LetOpenRecord (r, rty, e) ->
                  (collect_term r; collect_term rty; collect_term e)
-             | FStar_Parser_AST.Bind (uu___3, t1, t2) ->
+             | FStar_Parser_AST.Bind (uu___2, t1, t2) ->
                  (collect_term t1; collect_term t2)
              | FStar_Parser_AST.Seq (t1, t2) ->
                  (collect_term t1; collect_term t2)
-             | FStar_Parser_AST.If (t1, uu___3, ret_opt, t2, t3) ->
+             | FStar_Parser_AST.If (t1, uu___2, ret_opt, t2, t3) ->
                  (collect_term t1;
                   (match ret_opt with
                    | FStar_Pervasives_Native.None -> ()
-                   | FStar_Pervasives_Native.Some (uu___6, ret, uu___7) ->
+                   | FStar_Pervasives_Native.Some (uu___5, ret, uu___6) ->
                        collect_term ret);
                   collect_term t2;
                   collect_term t3)
-             | FStar_Parser_AST.Match (t, uu___3, ret_opt, bs) ->
+             | FStar_Parser_AST.Match (t, uu___2, ret_opt, bs) ->
                  (collect_term t;
                   (match ret_opt with
                    | FStar_Pervasives_Native.None -> ()
-                   | FStar_Pervasives_Native.Some (uu___6, ret, uu___7) ->
+                   | FStar_Pervasives_Native.Some (uu___5, ret, uu___6) ->
                        collect_term ret);
                   collect_branches bs)
              | FStar_Parser_AST.TryWith (t, bs) ->
                  (collect_term t; collect_branches bs)
              | FStar_Parser_AST.Ascribed
-                 (t1, t2, FStar_Pervasives_Native.None, uu___3) ->
+                 (t1, t2, FStar_Pervasives_Native.None, uu___2) ->
                  (collect_term t1; collect_term t2)
              | FStar_Parser_AST.Ascribed
-                 (t1, t2, FStar_Pervasives_Native.Some tac, uu___3) ->
+                 (t1, t2, FStar_Pervasives_Native.Some tac, uu___2) ->
                  (collect_term t1; collect_term t2; collect_term tac)
              | FStar_Parser_AST.Record (t, idterms) ->
                  (FStar_Compiler_Util.iter_opt t collect_term;
                   FStar_Compiler_List.iter
-                    (fun uu___4 ->
-                       match uu___4 with
+                    (fun uu___3 ->
+                       match uu___3 with
                        | (fn, t1) -> (collect_fieldname fn; collect_term t1))
                     idterms)
              | FStar_Parser_AST.Project (t, f) ->
@@ -1587,168 +1550,168 @@ let (collect_one :
                  (collect_binders binders; collect_term t)
              | FStar_Parser_AST.Sum (binders, t) ->
                  (FStar_Compiler_List.iter
-                    (fun uu___4 ->
-                       match uu___4 with
+                    (fun uu___3 ->
+                       match uu___3 with
                        | FStar_Pervasives.Inl b -> collect_binder b
                        | FStar_Pervasives.Inr t1 -> collect_term t1) binders;
                   collect_term t)
-             | FStar_Parser_AST.QForall (binders, (uu___3, ts), t) ->
+             | FStar_Parser_AST.QForall (binders, (uu___2, ts), t) ->
                  (collect_binders binders;
                   FStar_Compiler_List.iter
                     (FStar_Compiler_List.iter collect_term) ts;
                   collect_term t)
-             | FStar_Parser_AST.QExists (binders, (uu___3, ts), t) ->
+             | FStar_Parser_AST.QExists (binders, (uu___2, ts), t) ->
                  (collect_binders binders;
                   FStar_Compiler_List.iter
                     (FStar_Compiler_List.iter collect_term) ts;
                   collect_term t)
-             | FStar_Parser_AST.QuantOp (uu___3, binders, (uu___4, ts), t) ->
+             | FStar_Parser_AST.QuantOp (uu___2, binders, (uu___3, ts), t) ->
                  (collect_binders binders;
                   FStar_Compiler_List.iter
                     (FStar_Compiler_List.iter collect_term) ts;
                   collect_term t)
              | FStar_Parser_AST.Refine (binder, t) ->
                  (collect_binder binder; collect_term t)
-             | FStar_Parser_AST.NamedTyp (uu___3, t) -> collect_term t
+             | FStar_Parser_AST.NamedTyp (uu___2, t) -> collect_term t
              | FStar_Parser_AST.Paren t -> collect_term t
-             | FStar_Parser_AST.Requires (t, uu___3) -> collect_term t
-             | FStar_Parser_AST.Ensures (t, uu___3) -> collect_term t
-             | FStar_Parser_AST.Labeled (t, uu___3, uu___4) -> collect_term t
+             | FStar_Parser_AST.Requires (t, uu___2) -> collect_term t
+             | FStar_Parser_AST.Ensures (t, uu___2) -> collect_term t
+             | FStar_Parser_AST.Labeled (t, uu___2, uu___3) -> collect_term t
              | FStar_Parser_AST.LexList l ->
                  FStar_Compiler_List.iter collect_term l
              | FStar_Parser_AST.WFOrder (t1, t2) ->
-                 ((let uu___4 =
-                     let uu___5 =
-                       let uu___6 =
+                 ((let uu___3 =
+                     let uu___4 =
+                       let uu___5 =
                          FStar_Ident.lid_of_str "FStar.WellFounded" in
-                       (false, uu___6) in
-                     P_dep uu___5 in
-                   add_to_parsing_data uu___4);
+                       (false, uu___5) in
+                     P_dep uu___4 in
+                   add_to_parsing_data uu___3);
                   collect_term t1;
                   collect_term t2)
-             | FStar_Parser_AST.Decreases (t, uu___3) -> collect_term t
-             | FStar_Parser_AST.Quote (t, uu___3) -> collect_term t
+             | FStar_Parser_AST.Decreases (t, uu___2) -> collect_term t
+             | FStar_Parser_AST.Quote (t, uu___2) -> collect_term t
              | FStar_Parser_AST.Antiquote t -> collect_term t
              | FStar_Parser_AST.VQuote t -> collect_term t
              | FStar_Parser_AST.Attributes cattributes ->
                  FStar_Compiler_List.iter collect_term cattributes
              | FStar_Parser_AST.CalcProof (rel, init, steps) ->
-                 ((let uu___4 =
-                     let uu___5 =
-                       let uu___6 = FStar_Ident.lid_of_str "FStar.Calc" in
-                       (false, uu___6) in
-                     P_dep uu___5 in
-                   add_to_parsing_data uu___4);
+                 ((let uu___3 =
+                     let uu___4 =
+                       let uu___5 = FStar_Ident.lid_of_str "FStar.Calc" in
+                       (false, uu___5) in
+                     P_dep uu___4 in
+                   add_to_parsing_data uu___3);
                   collect_term rel;
                   collect_term init;
                   FStar_Compiler_List.iter
-                    (fun uu___6 ->
-                       match uu___6 with
+                    (fun uu___5 ->
+                       match uu___5 with
                        | FStar_Parser_AST.CalcStep (rel1, just, next) ->
                            (collect_term rel1;
                             collect_term just;
                             collect_term next)) steps)
              | FStar_Parser_AST.IntroForall (bs, p, e) ->
-                 ((let uu___4 =
-                     let uu___5 =
-                       let uu___6 =
+                 ((let uu___3 =
+                     let uu___4 =
+                       let uu___5 =
                          FStar_Ident.lid_of_str "FStar.Classical.Sugar" in
-                       (false, uu___6) in
-                     P_dep uu___5 in
-                   add_to_parsing_data uu___4);
+                       (false, uu___5) in
+                     P_dep uu___4 in
+                   add_to_parsing_data uu___3);
                   collect_binders bs;
                   collect_term p;
                   collect_term e)
              | FStar_Parser_AST.IntroExists (bs, t, vs, e) ->
-                 ((let uu___4 =
-                     let uu___5 =
-                       let uu___6 =
+                 ((let uu___3 =
+                     let uu___4 =
+                       let uu___5 =
                          FStar_Ident.lid_of_str "FStar.Classical.Sugar" in
-                       (false, uu___6) in
-                     P_dep uu___5 in
-                   add_to_parsing_data uu___4);
+                       (false, uu___5) in
+                     P_dep uu___4 in
+                   add_to_parsing_data uu___3);
                   collect_binders bs;
                   collect_term t;
                   FStar_Compiler_List.iter collect_term vs;
                   collect_term e)
              | FStar_Parser_AST.IntroImplies (p, q, x, e) ->
-                 ((let uu___4 =
-                     let uu___5 =
-                       let uu___6 =
+                 ((let uu___3 =
+                     let uu___4 =
+                       let uu___5 =
                          FStar_Ident.lid_of_str "FStar.Classical.Sugar" in
-                       (false, uu___6) in
-                     P_dep uu___5 in
-                   add_to_parsing_data uu___4);
+                       (false, uu___5) in
+                     P_dep uu___4 in
+                   add_to_parsing_data uu___3);
                   collect_term p;
                   collect_term q;
                   collect_binder x;
                   collect_term e)
              | FStar_Parser_AST.IntroOr (b, p, q, r) ->
-                 ((let uu___4 =
-                     let uu___5 =
-                       let uu___6 =
+                 ((let uu___3 =
+                     let uu___4 =
+                       let uu___5 =
                          FStar_Ident.lid_of_str "FStar.Classical.Sugar" in
-                       (false, uu___6) in
-                     P_dep uu___5 in
-                   add_to_parsing_data uu___4);
+                       (false, uu___5) in
+                     P_dep uu___4 in
+                   add_to_parsing_data uu___3);
                   collect_term p;
                   collect_term q;
                   collect_term r)
              | FStar_Parser_AST.IntroAnd (p, q, r, e) ->
-                 ((let uu___4 =
-                     let uu___5 =
-                       let uu___6 =
+                 ((let uu___3 =
+                     let uu___4 =
+                       let uu___5 =
                          FStar_Ident.lid_of_str "FStar.Classical.Sugar" in
-                       (false, uu___6) in
-                     P_dep uu___5 in
-                   add_to_parsing_data uu___4);
+                       (false, uu___5) in
+                     P_dep uu___4 in
+                   add_to_parsing_data uu___3);
                   collect_term p;
                   collect_term q;
                   collect_term r;
                   collect_term e)
              | FStar_Parser_AST.ElimForall (bs, p, vs) ->
-                 ((let uu___4 =
-                     let uu___5 =
-                       let uu___6 =
+                 ((let uu___3 =
+                     let uu___4 =
+                       let uu___5 =
                          FStar_Ident.lid_of_str "FStar.Classical.Sugar" in
-                       (false, uu___6) in
-                     P_dep uu___5 in
-                   add_to_parsing_data uu___4);
+                       (false, uu___5) in
+                     P_dep uu___4 in
+                   add_to_parsing_data uu___3);
                   collect_binders bs;
                   collect_term p;
                   FStar_Compiler_List.iter collect_term vs)
              | FStar_Parser_AST.ElimExists (bs, p, q, b, e) ->
-                 ((let uu___4 =
-                     let uu___5 =
-                       let uu___6 =
+                 ((let uu___3 =
+                     let uu___4 =
+                       let uu___5 =
                          FStar_Ident.lid_of_str "FStar.Classical.Sugar" in
-                       (false, uu___6) in
-                     P_dep uu___5 in
-                   add_to_parsing_data uu___4);
+                       (false, uu___5) in
+                     P_dep uu___4 in
+                   add_to_parsing_data uu___3);
                   collect_binders bs;
                   collect_term p;
                   collect_term q;
                   collect_binder b;
                   collect_term e)
              | FStar_Parser_AST.ElimImplies (p, q, e) ->
-                 ((let uu___4 =
-                     let uu___5 =
-                       let uu___6 =
+                 ((let uu___3 =
+                     let uu___4 =
+                       let uu___5 =
                          FStar_Ident.lid_of_str "FStar.Classical.Sugar" in
-                       (false, uu___6) in
-                     P_dep uu___5 in
-                   add_to_parsing_data uu___4);
+                       (false, uu___5) in
+                     P_dep uu___4 in
+                   add_to_parsing_data uu___3);
                   collect_term p;
                   collect_term q;
                   collect_term e)
              | FStar_Parser_AST.ElimAnd (p, q, r, x, y, e) ->
-                 ((let uu___4 =
-                     let uu___5 =
-                       let uu___6 =
+                 ((let uu___3 =
+                     let uu___4 =
+                       let uu___5 =
                          FStar_Ident.lid_of_str "FStar.Classical.Sugar" in
-                       (false, uu___6) in
-                     P_dep uu___5 in
-                   add_to_parsing_data uu___4);
+                       (false, uu___5) in
+                     P_dep uu___4 in
+                   add_to_parsing_data uu___3);
                   collect_term p;
                   collect_term q;
                   collect_term r;
@@ -1756,13 +1719,13 @@ let (collect_one :
                   collect_binder y;
                   collect_term e)
              | FStar_Parser_AST.ElimOr (p, q, r, x, e, y, e') ->
-                 ((let uu___4 =
-                     let uu___5 =
-                       let uu___6 =
+                 ((let uu___3 =
+                     let uu___4 =
+                       let uu___5 =
                          FStar_Ident.lid_of_str "FStar.Classical.Sugar" in
-                       (false, uu___6) in
-                     P_dep uu___5 in
-                   add_to_parsing_data uu___4);
+                       (false, uu___5) in
+                     P_dep uu___4 in
+                   add_to_parsing_data uu___3);
                   collect_term p;
                   collect_term q;
                   collect_term r;
@@ -1773,33 +1736,30 @@ let (collect_one :
            and collect_patterns ps =
              FStar_Compiler_List.iter collect_pattern ps
            and collect_pattern p = collect_pattern' p.FStar_Parser_AST.pat
-           and collect_pattern' uu___2 =
-             match uu___2 with
-             | FStar_Parser_AST.PatVar (uu___3, aqual, attrs) ->
+           and collect_pattern' uu___1 =
+             match uu___1 with
+             | FStar_Parser_AST.PatVar (uu___2, aqual, attrs) ->
                  (collect_aqual aqual;
-                  FStar_Compiler_Effect.op_Bar_Greater attrs
-                    (FStar_Compiler_List.iter collect_term))
-             | FStar_Parser_AST.PatTvar (uu___3, aqual, attrs) ->
+                  FStar_Compiler_List.iter collect_term attrs)
+             | FStar_Parser_AST.PatTvar (uu___2, aqual, attrs) ->
                  (collect_aqual aqual;
-                  FStar_Compiler_Effect.op_Bar_Greater attrs
-                    (FStar_Compiler_List.iter collect_term))
+                  FStar_Compiler_List.iter collect_term attrs)
              | FStar_Parser_AST.PatWild (aqual, attrs) ->
                  (collect_aqual aqual;
-                  FStar_Compiler_Effect.op_Bar_Greater attrs
-                    (FStar_Compiler_List.iter collect_term))
-             | FStar_Parser_AST.PatOp uu___3 -> ()
-             | FStar_Parser_AST.PatConst uu___3 -> ()
+                  FStar_Compiler_List.iter collect_term attrs)
+             | FStar_Parser_AST.PatOp uu___2 -> ()
+             | FStar_Parser_AST.PatConst uu___2 -> ()
              | FStar_Parser_AST.PatVQuote t -> collect_term t
              | FStar_Parser_AST.PatApp (p, ps) ->
                  (collect_pattern p; collect_patterns ps)
-             | FStar_Parser_AST.PatName uu___3 -> ()
+             | FStar_Parser_AST.PatName uu___2 -> ()
              | FStar_Parser_AST.PatList ps -> collect_patterns ps
              | FStar_Parser_AST.PatOr ps -> collect_patterns ps
-             | FStar_Parser_AST.PatTuple (ps, uu___3) -> collect_patterns ps
+             | FStar_Parser_AST.PatTuple (ps, uu___2) -> collect_patterns ps
              | FStar_Parser_AST.PatRecord lidpats ->
                  FStar_Compiler_List.iter
-                   (fun uu___3 ->
-                      match uu___3 with | (uu___4, p) -> collect_pattern p)
+                   (fun uu___2 ->
+                      match uu___2 with | (uu___3, p) -> collect_pattern p)
                    lidpats
              | FStar_Parser_AST.PatAscribed
                  (p, (t, FStar_Pervasives_Native.None)) ->
@@ -1809,36 +1769,36 @@ let (collect_one :
                  (collect_pattern p; collect_term t; collect_term tac)
            and collect_branches bs =
              FStar_Compiler_List.iter collect_branch bs
-           and collect_branch uu___2 =
-             match uu___2 with
+           and collect_branch uu___1 =
+             match uu___1 with
              | (pat, t1, t2) ->
                  (collect_pattern pat;
                   FStar_Compiler_Util.iter_opt t1 collect_term;
                   collect_term t2)
            and collect_fieldname fn =
-             let uu___2 = let uu___3 = FStar_Ident.nsstr fn in uu___3 <> "" in
-             if uu___2
+             let uu___1 = let uu___2 = FStar_Ident.nsstr fn in uu___2 <> "" in
+             if uu___1
              then
-               let uu___3 =
-                 let uu___4 =
-                   let uu___5 =
-                     let uu___6 = FStar_Ident.ns_of_lid fn in
-                     FStar_Ident.lid_of_ids uu___6 in
-                   (false, uu___5) in
-                 P_dep uu___4 in
-               add_to_parsing_data uu___3
+               let uu___2 =
+                 let uu___3 =
+                   let uu___4 =
+                     let uu___5 = FStar_Ident.ns_of_lid fn in
+                     FStar_Ident.lid_of_ids uu___5 in
+                   (false, uu___4) in
+                 P_dep uu___3 in
+               add_to_parsing_data uu___2
              else () in
-           let uu___2 = FStar_Parser_Driver.parse_file filename in
-           match uu___2 with
-           | (ast, uu___3) ->
+           let uu___1 = FStar_Parser_Driver.parse_file filename in
+           match uu___1 with
+           | (ast, uu___2) ->
                (collect_module ast;
                 (let pd1 =
-                   let uu___5 =
-                     let uu___6 = FStar_Compiler_Effect.op_Bang pd in
-                     FStar_Compiler_List.rev uu___6 in
-                   Mk_pd uu___5 in
-                 let uu___5 = from_parsing_data pd1 original_map filename in
-                 match uu___5 with
+                   let uu___4 =
+                     let uu___5 = FStar_Compiler_Effect.op_Bang pd in
+                     FStar_Compiler_List.rev uu___5 in
+                   Mk_pd uu___4 in
+                 let uu___4 = from_parsing_data pd1 original_map filename in
+                 match uu___4 with
                  | (deps1, has_inline_for_extraction, mo_roots) ->
                      (pd1, deps1, has_inline_for_extraction, mo_roots))))
 let (collect_one_cache :
@@ -1874,18 +1834,17 @@ let (widen_deps :
               (match uu___1 with
                | Deps dg' ->
                    let widen_one deps1 =
-                     FStar_Compiler_Effect.op_Bar_Greater deps1
-                       (FStar_Compiler_List.map
-                          (fun d ->
-                             match d with
-                             | PreferInterface m when
-                                 (FStar_Compiler_List.contains m friends1) &&
-                                   (has_implementation file_system_map m)
-                                 ->
-                                 (FStar_Compiler_Effect.op_Colon_Equals
-                                    widened1 true;
-                                  FriendImplementation m)
-                             | uu___2 -> d)) in
+                     FStar_Compiler_List.map
+                       (fun d ->
+                          match d with
+                          | PreferInterface m when
+                              (FStar_Compiler_List.contains m friends1) &&
+                                (has_implementation file_system_map m)
+                              ->
+                              (FStar_Compiler_Effect.op_Colon_Equals widened1
+                                 true;
+                               FriendImplementation m)
+                          | uu___2 -> d) deps1 in
                    (FStar_Compiler_Util.smap_fold dg
                       (fun filename ->
                          fun dep_node1 ->
@@ -2084,19 +2043,18 @@ let (collect :
         | [] -> all_files_in_include_paths ()
         | uu___ -> all_cmd_line_files in
       let all_cmd_line_files2 =
-        FStar_Compiler_Effect.op_Bar_Greater all_cmd_line_files1
-          (FStar_Compiler_List.map
-             (fun fn ->
-                let uu___ = FStar_Options.find_file fn in
-                match uu___ with
-                | FStar_Pervasives_Native.None ->
-                    let uu___1 =
-                      let uu___2 =
-                        FStar_Compiler_Util.format1
-                          "File %s could not be found" fn in
-                      (FStar_Errors_Codes.Fatal_ModuleOrFileNotFound, uu___2) in
-                    FStar_Errors.raise_err uu___1
-                | FStar_Pervasives_Native.Some fn1 -> fn1)) in
+        FStar_Compiler_List.map
+          (fun fn ->
+             let uu___ = FStar_Options.find_file fn in
+             match uu___ with
+             | FStar_Pervasives_Native.None ->
+                 let uu___1 =
+                   let uu___2 =
+                     FStar_Compiler_Util.format1 "File %s could not be found"
+                       fn in
+                   (FStar_Errors_Codes.Fatal_ModuleOrFileNotFound, uu___2) in
+                 FStar_Errors.raise_err uu___1
+             | FStar_Pervasives_Native.Some fn1 -> fn1) all_cmd_line_files1 in
       let dep_graph = deps_empty () in
       let file_system_map = build_map all_cmd_line_files2 in
       let interfaces_needing_inlining = FStar_Compiler_Util.mk_ref [] in
@@ -2189,27 +2147,26 @@ let (collect :
                      "Impossible: Failed to find dependencies of %s" filename in
                  FStar_Compiler_Effect.failwith uu___2 in
            let direct_deps =
-             FStar_Compiler_Effect.op_Bar_Greater node.edges
-               (FStar_Compiler_List.collect
-                  (fun x ->
-                     match x with
-                     | UseInterface f ->
-                         let uu___1 =
-                           implementation_of_internal file_system_map1 f in
-                         (match uu___1 with
-                          | FStar_Pervasives_Native.None -> [x]
-                          | FStar_Pervasives_Native.Some fn when
-                              fn = filename -> [x]
-                          | uu___2 -> [x; UseImplementation f])
-                     | PreferInterface f ->
-                         let uu___1 =
-                           implementation_of_internal file_system_map1 f in
-                         (match uu___1 with
-                          | FStar_Pervasives_Native.None -> [x]
-                          | FStar_Pervasives_Native.Some fn when
-                              fn = filename -> [x]
-                          | uu___2 -> [x; UseImplementation f])
-                     | uu___1 -> [x])) in
+             FStar_Compiler_List.collect
+               (fun x ->
+                  match x with
+                  | UseInterface f ->
+                      let uu___1 =
+                        implementation_of_internal file_system_map1 f in
+                      (match uu___1 with
+                       | FStar_Pervasives_Native.None -> [x]
+                       | FStar_Pervasives_Native.Some fn when fn = filename
+                           -> [x]
+                       | uu___2 -> [x; UseImplementation f])
+                  | PreferInterface f ->
+                      let uu___1 =
+                        implementation_of_internal file_system_map1 f in
+                      (match uu___1 with
+                       | FStar_Pervasives_Native.None -> [x]
+                       | FStar_Pervasives_Native.Some fn when fn = filename
+                           -> [x]
+                       | uu___2 -> [x; UseImplementation f])
+                  | uu___1 -> [x]) node.edges in
            match node.color with
            | Gray -> cycle_detected dep_graph1 cycle filename
            | Black -> ()
@@ -2248,11 +2205,10 @@ let (collect :
          (let uu___2 = FStar_Compiler_Effect.op_Bang mo_files in
           FStar_Compiler_List.iter (aux []) uu___2) in
        full_cycle_detection all_cmd_line_files2 file_system_map;
-       FStar_Compiler_Effect.op_Bar_Greater all_cmd_line_files2
-         (FStar_Compiler_List.iter
-            (fun f ->
-               let m = lowercase_module_name f in
-               FStar_Options.add_verify_module m));
+       FStar_Compiler_List.iter
+         (fun f ->
+            let m = lowercase_module_name f in
+            FStar_Options.add_verify_module m) all_cmd_line_files2;
        (let inlining_ifaces =
           FStar_Compiler_Effect.op_Bang interfaces_needing_inlining in
         let uu___3 =
@@ -2287,15 +2243,13 @@ let (print_digest : (Prims.string * Prims.string) Prims.list -> Prims.string)
   =
   fun dig ->
     let uu___ =
-      FStar_Compiler_Effect.op_Bar_Greater dig
-        (FStar_Compiler_List.map
-           (fun uu___1 ->
-              match uu___1 with
-              | (m, d) ->
-                  let uu___2 = FStar_Compiler_Util.base64_encode d in
-                  FStar_Compiler_Util.format2 "%s:%s" m uu___2)) in
-    FStar_Compiler_Effect.op_Bar_Greater uu___
-      (FStar_Compiler_String.concat "\n")
+      FStar_Compiler_List.map
+        (fun uu___1 ->
+           match uu___1 with
+           | (m, d) ->
+               let uu___2 = FStar_Compiler_Util.base64_encode d in
+               FStar_Compiler_Util.format2 "%s:%s" m uu___2) dig in
+    FStar_Compiler_String.concat "\n" uu___
 let (print_make : FStar_Compiler_Util.out_channel -> deps -> unit) =
   fun outc ->
     fun deps1 ->
@@ -2303,23 +2257,20 @@ let (print_make : FStar_Compiler_Util.out_channel -> deps -> unit) =
       let all_cmd_line_files = deps1.cmd_line_files in
       let deps2 = deps1.dep_graph in
       let keys = deps_keys deps2 in
-      FStar_Compiler_Effect.op_Bar_Greater keys
-        (FStar_Compiler_List.iter
-           (fun f ->
-              let dep_node1 =
-                let uu___ = deps_try_find deps2 f in
-                FStar_Compiler_Effect.op_Bar_Greater uu___
-                  FStar_Compiler_Option.get in
-              let files =
-                FStar_Compiler_List.map
-                  (file_of_dep file_system_map all_cmd_line_files)
-                  dep_node1.edges in
-              let files1 =
-                FStar_Compiler_List.map
-                  (fun s -> FStar_Compiler_Util.replace_chars s 32 "\\ ")
-                  files in
-              FStar_Compiler_Util.print2 "%s: %s\n\n" f
-                (FStar_Compiler_String.concat " " files1)))
+      FStar_Compiler_List.iter
+        (fun f ->
+           let dep_node1 =
+             let uu___ = deps_try_find deps2 f in
+             FStar_Compiler_Option.get uu___ in
+           let files =
+             FStar_Compiler_List.map
+               (file_of_dep file_system_map all_cmd_line_files)
+               dep_node1.edges in
+           let files1 =
+             FStar_Compiler_List.map
+               (fun s -> FStar_Compiler_Util.replace_chars s 32 "\\ ") files in
+           FStar_Compiler_Util.print2 "%s: %s\n\n" f
+             (FStar_Compiler_String.concat " " files1)) keys
 let (print_raw : FStar_Compiler_Util.out_channel -> deps -> unit) =
   fun outc ->
     fun deps1 ->
@@ -2337,15 +2288,12 @@ let (print_raw : FStar_Compiler_Util.out_channel -> deps -> unit) =
                            let uu___5 =
                              FStar_Compiler_List.map dep_to_string
                                dep_node1.edges in
-                           FStar_Compiler_Effect.op_Bar_Greater uu___5
-                             (FStar_Compiler_String.concat ";\n\t") in
+                           FStar_Compiler_String.concat ";\n\t" uu___5 in
                          FStar_Compiler_Util.format2 "%s -> [\n\t%s\n] " k
                            uu___4 in
                        uu___3 :: out) [] in
-            FStar_Compiler_Effect.op_Bar_Greater uu___2
-              (FStar_Compiler_String.concat ";;\n") in
-          FStar_Compiler_Effect.op_Bar_Greater uu___1
-            (fun s -> FStar_Compiler_Util.fprint outc "%s\n" [s])
+            FStar_Compiler_String.concat ";;\n" uu___2 in
+          FStar_Compiler_Util.fprint outc "%s\n" [uu___1]
 let (print_full : FStar_Compiler_Util.out_channel -> deps -> unit) =
   fun outc ->
     fun deps1 ->
@@ -2424,9 +2372,7 @@ let (print_full : FStar_Compiler_Util.out_channel -> deps -> unit) =
       let sb =
         let uu___ = FStar_BigInt.of_int_fs (Prims.of_int (10000)) in
         FStar_StringBuffer.create uu___ in
-      let pr str =
-        let uu___ = FStar_StringBuffer.add str sb in
-        FStar_Compiler_Effect.op_Less_Bar (fun uu___1 -> ()) uu___ in
+      let pr str = let uu___ = FStar_StringBuffer.add str sb in () in
       let print_entry target first_dep all_deps =
         pr target; pr ": "; pr first_dep; pr "\\\n\t"; pr all_deps; pr "\n\n" in
       let keys = deps_keys deps1.dep_graph in
@@ -2472,324 +2418,292 @@ let (print_full : FStar_Compiler_Util.out_channel -> deps -> unit) =
       match uu___ with
       | (widened, dep_graph) ->
           let all_checked_files =
-            FStar_Compiler_Effect.op_Bar_Greater keys
-              (FStar_Compiler_List.fold_left
-                 (fun all_checked_files1 ->
-                    fun file_name1 ->
-                      let process_one_key uu___1 =
-                        let dep_node1 =
-                          let uu___2 =
-                            deps_try_find deps1.dep_graph file_name1 in
-                          FStar_Compiler_Effect.op_Bar_Greater uu___2
-                            FStar_Compiler_Option.get in
-                        let uu___2 =
-                          let uu___3 = is_interface file_name1 in
-                          if uu___3
-                          then
-                            (FStar_Pervasives_Native.None,
-                              FStar_Pervasives_Native.None)
-                          else
-                            (let uu___5 =
-                               let uu___6 = lowercase_module_name file_name1 in
-                               interface_of deps1 uu___6 in
-                             match uu___5 with
-                             | FStar_Pervasives_Native.None ->
-                                 (FStar_Pervasives_Native.None,
-                                   FStar_Pervasives_Native.None)
-                             | FStar_Pervasives_Native.Some iface ->
-                                 let uu___6 =
-                                   let uu___7 =
-                                     let uu___8 =
-                                       let uu___9 =
-                                         deps_try_find deps1.dep_graph iface in
-                                       FStar_Compiler_Option.get uu___9 in
-                                     uu___8.edges in
-                                   FStar_Pervasives_Native.Some uu___7 in
-                                 ((FStar_Pervasives_Native.Some iface),
-                                   uu___6)) in
-                        match uu___2 with
-                        | (iface_fn, iface_deps) ->
-                            let iface_deps1 =
-                              FStar_Compiler_Util.map_opt iface_deps
-                                (FStar_Compiler_List.filter
-                                   (fun iface_dep ->
-                                      let uu___3 =
-                                        FStar_Compiler_Util.for_some
-                                          (dep_subsumed_by iface_dep)
-                                          dep_node1.edges in
-                                      Prims.op_Negation uu___3)) in
-                            let norm_f = norm_path file_name1 in
-                            let files =
-                              FStar_Compiler_List.map
-                                (file_of_dep_aux true deps1.file_system_map
-                                   deps1.cmd_line_files) dep_node1.edges in
-                            let files1 =
-                              match iface_deps1 with
-                              | FStar_Pervasives_Native.None -> files
-                              | FStar_Pervasives_Native.Some iface_deps2 ->
-                                  let iface_files =
-                                    FStar_Compiler_List.map
-                                      (file_of_dep_aux true
-                                         deps1.file_system_map
-                                         deps1.cmd_line_files) iface_deps2 in
-                                  FStar_Compiler_Util.remove_dups
-                                    (fun x -> fun y -> x = y)
-                                    (FStar_Compiler_List.op_At files
-                                       iface_files) in
-                            let files2 =
-                              let uu___3 =
-                                FStar_Compiler_Effect.op_Bar_Greater iface_fn
-                                  FStar_Compiler_Util.is_some in
-                              if uu___3
-                              then
-                                let iface_fn1 =
-                                  FStar_Compiler_Effect.op_Bar_Greater
-                                    iface_fn FStar_Compiler_Util.must in
-                                let uu___4 =
-                                  FStar_Compiler_Effect.op_Bar_Greater files1
-                                    (FStar_Compiler_List.filter
-                                       (fun f -> f <> iface_fn1)) in
-                                FStar_Compiler_Effect.op_Bar_Greater uu___4
-                                  (fun files3 ->
-                                     let uu___5 = cache_file_name iface_fn1 in
-                                     uu___5 :: files3)
-                              else files1 in
-                            let files3 =
-                              FStar_Compiler_List.map norm_path files2 in
-                            let files4 =
-                              FStar_Compiler_String.concat "\\\n\t" files3 in
-                            let cache_file_name1 = cache_file file_name1 in
-                            let all_checked_files2 =
-                              let uu___3 =
-                                let uu___4 =
-                                  let uu___5 = module_name_of_file file_name1 in
-                                  FStar_Options.should_be_already_cached
-                                    uu___5 in
-                                Prims.op_Negation uu___4 in
-                              if uu___3
-                              then
-                                (print_entry cache_file_name1 norm_f files4;
-                                 cache_file_name1
-                                 ::
-                                 all_checked_files1)
-                              else all_checked_files1 in
-                            let uu___3 =
-                              let uu___4 = FStar_Options.cmi () in
-                              if uu___4
-                              then
-                                profile
-                                  (fun uu___5 ->
-                                     let uu___6 = dep_graph_copy dep_graph in
-                                     topological_dependences_of'
-                                       deps1.file_system_map uu___6
-                                       deps1.interfaces_with_inlining
-                                       [file_name1] widened)
-                                  "FStar.Parser.Dep.topological_dependences_of_2"
-                              else
-                                (let maybe_widen_deps f_deps =
-                                   FStar_Compiler_List.map
-                                     (fun dep ->
-                                        file_of_dep_aux false
-                                          deps1.file_system_map
-                                          deps1.cmd_line_files dep) f_deps in
-                                 let fst_files =
-                                   maybe_widen_deps dep_node1.edges in
-                                 let fst_files_from_iface =
-                                   match iface_deps1 with
-                                   | FStar_Pervasives_Native.None -> []
-                                   | FStar_Pervasives_Native.Some iface_deps2
-                                       -> maybe_widen_deps iface_deps2 in
-                                 let uu___6 =
-                                   FStar_Compiler_Util.remove_dups
-                                     (fun x -> fun y -> x = y)
-                                     (FStar_Compiler_List.op_At fst_files
-                                        fst_files_from_iface) in
-                                 (uu___6, false)) in
-                            (match uu___3 with
-                             | (all_fst_files_dep, widened1) ->
-                                 let all_checked_fst_dep_files =
-                                   FStar_Compiler_Effect.op_Bar_Greater
-                                     all_fst_files_dep
-                                     (FStar_Compiler_List.map cache_file) in
-                                 let all_checked_fst_dep_files_string =
-                                   FStar_Compiler_String.concat " \\\n\t"
-                                     all_checked_fst_dep_files in
-                                 ((let uu___5 = is_implementation file_name1 in
-                                   if uu___5
+            FStar_Compiler_List.fold_left
+              (fun all_checked_files1 ->
+                 fun file_name1 ->
+                   let process_one_key uu___1 =
+                     let dep_node1 =
+                       let uu___2 = deps_try_find deps1.dep_graph file_name1 in
+                       FStar_Compiler_Option.get uu___2 in
+                     let uu___2 =
+                       let uu___3 = is_interface file_name1 in
+                       if uu___3
+                       then
+                         (FStar_Pervasives_Native.None,
+                           FStar_Pervasives_Native.None)
+                       else
+                         (let uu___5 =
+                            let uu___6 = lowercase_module_name file_name1 in
+                            interface_of deps1 uu___6 in
+                          match uu___5 with
+                          | FStar_Pervasives_Native.None ->
+                              (FStar_Pervasives_Native.None,
+                                FStar_Pervasives_Native.None)
+                          | FStar_Pervasives_Native.Some iface ->
+                              let uu___6 =
+                                let uu___7 =
+                                  let uu___8 =
+                                    let uu___9 =
+                                      deps_try_find deps1.dep_graph iface in
+                                    FStar_Compiler_Option.get uu___9 in
+                                  uu___8.edges in
+                                FStar_Pervasives_Native.Some uu___7 in
+                              ((FStar_Pervasives_Native.Some iface), uu___6)) in
+                     match uu___2 with
+                     | (iface_fn, iface_deps) ->
+                         let iface_deps1 =
+                           FStar_Compiler_Util.map_opt iface_deps
+                             (FStar_Compiler_List.filter
+                                (fun iface_dep ->
+                                   let uu___3 =
+                                     FStar_Compiler_Util.for_some
+                                       (dep_subsumed_by iface_dep)
+                                       dep_node1.edges in
+                                   Prims.op_Negation uu___3)) in
+                         let norm_f = norm_path file_name1 in
+                         let files =
+                           FStar_Compiler_List.map
+                             (file_of_dep_aux true deps1.file_system_map
+                                deps1.cmd_line_files) dep_node1.edges in
+                         let files1 =
+                           match iface_deps1 with
+                           | FStar_Pervasives_Native.None -> files
+                           | FStar_Pervasives_Native.Some iface_deps2 ->
+                               let iface_files =
+                                 FStar_Compiler_List.map
+                                   (file_of_dep_aux true
+                                      deps1.file_system_map
+                                      deps1.cmd_line_files) iface_deps2 in
+                               FStar_Compiler_Util.remove_dups
+                                 (fun x -> fun y -> x = y)
+                                 (FStar_Compiler_List.op_At files iface_files) in
+                         let files2 =
+                           if FStar_Compiler_Util.is_some iface_fn
+                           then
+                             let iface_fn1 =
+                               FStar_Compiler_Util.must iface_fn in
+                             let uu___3 =
+                               FStar_Compiler_List.filter
+                                 (fun f -> f <> iface_fn1) files1 in
+                             let uu___4 = cache_file_name iface_fn1 in uu___4
+                               :: uu___3
+                           else files1 in
+                         let files3 =
+                           FStar_Compiler_List.map norm_path files2 in
+                         let files4 =
+                           FStar_Compiler_String.concat "\\\n\t" files3 in
+                         let cache_file_name1 = cache_file file_name1 in
+                         let all_checked_files2 =
+                           let uu___3 =
+                             let uu___4 =
+                               let uu___5 = module_name_of_file file_name1 in
+                               FStar_Options.should_be_already_cached uu___5 in
+                             Prims.op_Negation uu___4 in
+                           if uu___3
+                           then
+                             (print_entry cache_file_name1 norm_f files4;
+                              cache_file_name1
+                              ::
+                              all_checked_files1)
+                           else all_checked_files1 in
+                         let uu___3 =
+                           let uu___4 = FStar_Options.cmi () in
+                           if uu___4
+                           then
+                             profile
+                               (fun uu___5 ->
+                                  let uu___6 = dep_graph_copy dep_graph in
+                                  topological_dependences_of'
+                                    deps1.file_system_map uu___6
+                                    deps1.interfaces_with_inlining
+                                    [file_name1] widened)
+                               "FStar.Parser.Dep.topological_dependences_of_2"
+                           else
+                             (let maybe_widen_deps f_deps =
+                                FStar_Compiler_List.map
+                                  (fun dep ->
+                                     file_of_dep_aux false
+                                       deps1.file_system_map
+                                       deps1.cmd_line_files dep) f_deps in
+                              let fst_files =
+                                maybe_widen_deps dep_node1.edges in
+                              let fst_files_from_iface =
+                                match iface_deps1 with
+                                | FStar_Pervasives_Native.None -> []
+                                | FStar_Pervasives_Native.Some iface_deps2 ->
+                                    maybe_widen_deps iface_deps2 in
+                              let uu___6 =
+                                FStar_Compiler_Util.remove_dups
+                                  (fun x -> fun y -> x = y)
+                                  (FStar_Compiler_List.op_At fst_files
+                                     fst_files_from_iface) in
+                              (uu___6, false)) in
+                         (match uu___3 with
+                          | (all_fst_files_dep, widened1) ->
+                              let all_checked_fst_dep_files =
+                                FStar_Compiler_List.map cache_file
+                                  all_fst_files_dep in
+                              let all_checked_fst_dep_files_string =
+                                FStar_Compiler_String.concat " \\\n\t"
+                                  all_checked_fst_dep_files in
+                              ((let uu___5 = is_implementation file_name1 in
+                                if uu___5
+                                then
+                                  ((let uu___7 =
+                                      (FStar_Options.cmi ()) && widened1 in
+                                    if uu___7
+                                    then
+                                      let mname =
+                                        lowercase_module_name file_name1 in
+                                      ((let uu___9 =
+                                          output_ml_file file_name1 in
+                                        print_entry uu___9 cache_file_name1
+                                          all_checked_fst_dep_files_string);
+                                       (let uu___10 =
+                                          FStar_Options.should_extract mname
+                                            FStar_Options.FSharp in
+                                        if uu___10
+                                        then
+                                          let uu___11 =
+                                            output_fs_file file_name1 in
+                                          print_entry uu___11
+                                            cache_file_name1
+                                            all_checked_fst_dep_files_string
+                                        else ());
+                                       (let uu___10 =
+                                          output_krml_file file_name1 in
+                                        print_entry uu___10 cache_file_name1
+                                          all_checked_fst_dep_files_string))
+                                    else
+                                      (let mname =
+                                         lowercase_module_name file_name1 in
+                                       (let uu___10 =
+                                          output_ml_file file_name1 in
+                                        print_entry uu___10 cache_file_name1
+                                          "");
+                                       (let uu___11 =
+                                          FStar_Options.should_extract mname
+                                            FStar_Options.FSharp in
+                                        if uu___11
+                                        then
+                                          let uu___12 =
+                                            output_fs_file file_name1 in
+                                          print_entry uu___12
+                                            cache_file_name1 ""
+                                        else ());
+                                       (let uu___11 =
+                                          output_krml_file file_name1 in
+                                        print_entry uu___11 cache_file_name1
+                                          "")));
+                                   (let cmx_files =
+                                      let extracted_fst_files =
+                                        FStar_Compiler_List.filter
+                                          (fun df ->
+                                             (let uu___7 =
+                                                lowercase_module_name df in
+                                              let uu___8 =
+                                                lowercase_module_name
+                                                  file_name1 in
+                                              uu___7 <> uu___8) &&
+                                               (let uu___7 =
+                                                  lowercase_module_name df in
+                                                FStar_Options.should_extract
+                                                  uu___7 FStar_Options.OCaml))
+                                          all_fst_files_dep in
+                                      FStar_Compiler_List.map output_cmx_file
+                                        extracted_fst_files in
+                                    let uu___7 =
+                                      let uu___8 =
+                                        lowercase_module_name file_name1 in
+                                      FStar_Options.should_extract uu___8
+                                        FStar_Options.OCaml in
+                                    if uu___7
+                                    then
+                                      let cmx_files1 =
+                                        FStar_Compiler_String.concat "\\\n\t"
+                                          cmx_files in
+                                      let uu___8 = output_cmx_file file_name1 in
+                                      let uu___9 = output_ml_file file_name1 in
+                                      print_entry uu___8 uu___9 cmx_files1
+                                    else ()))
+                                else
+                                  (let uu___7 =
+                                     (let uu___8 =
+                                        let uu___9 =
+                                          lowercase_module_name file_name1 in
+                                        has_implementation
+                                          deps1.file_system_map uu___9 in
+                                      Prims.op_Negation uu___8) &&
+                                       (is_interface file_name1) in
+                                   if uu___7
                                    then
-                                     ((let uu___7 =
-                                         (FStar_Options.cmi ()) && widened1 in
-                                       if uu___7
-                                       then
-                                         let mname =
-                                           lowercase_module_name file_name1 in
-                                         ((let uu___9 =
-                                             output_ml_file file_name1 in
-                                           print_entry uu___9
-                                             cache_file_name1
-                                             all_checked_fst_dep_files_string);
-                                          (let uu___10 =
-                                             FStar_Options.should_extract
-                                               mname FStar_Options.FSharp in
-                                           if uu___10
-                                           then
-                                             let uu___11 =
-                                               output_fs_file file_name1 in
-                                             print_entry uu___11
-                                               cache_file_name1
-                                               all_checked_fst_dep_files_string
-                                           else ());
-                                          (let uu___10 =
-                                             output_krml_file file_name1 in
-                                           print_entry uu___10
-                                             cache_file_name1
-                                             all_checked_fst_dep_files_string))
-                                       else
-                                         (let mname =
-                                            lowercase_module_name file_name1 in
-                                          (let uu___10 =
-                                             output_ml_file file_name1 in
-                                           print_entry uu___10
-                                             cache_file_name1 "");
-                                          (let uu___11 =
-                                             FStar_Options.should_extract
-                                               mname FStar_Options.FSharp in
-                                           if uu___11
-                                           then
-                                             let uu___12 =
-                                               output_fs_file file_name1 in
-                                             print_entry uu___12
-                                               cache_file_name1 ""
-                                           else ());
-                                          (let uu___11 =
-                                             output_krml_file file_name1 in
-                                           print_entry uu___11
-                                             cache_file_name1 "")));
-                                      (let cmx_files =
-                                         let extracted_fst_files =
-                                           FStar_Compiler_Effect.op_Bar_Greater
-                                             all_fst_files_dep
-                                             (FStar_Compiler_List.filter
-                                                (fun df ->
-                                                   (let uu___7 =
-                                                      lowercase_module_name
-                                                        df in
-                                                    let uu___8 =
-                                                      lowercase_module_name
-                                                        file_name1 in
-                                                    uu___7 <> uu___8) &&
-                                                     (let uu___7 =
-                                                        lowercase_module_name
-                                                          df in
-                                                      FStar_Options.should_extract
-                                                        uu___7
-                                                        FStar_Options.OCaml))) in
-                                         FStar_Compiler_Effect.op_Bar_Greater
-                                           extracted_fst_files
-                                           (FStar_Compiler_List.map
-                                              output_cmx_file) in
-                                       let uu___7 =
-                                         let uu___8 =
-                                           lowercase_module_name file_name1 in
-                                         FStar_Options.should_extract uu___8
-                                           FStar_Options.OCaml in
-                                       if uu___7
-                                       then
-                                         let cmx_files1 =
-                                           FStar_Compiler_String.concat
-                                             "\\\n\t" cmx_files in
-                                         let uu___8 =
-                                           output_cmx_file file_name1 in
-                                         let uu___9 =
-                                           output_ml_file file_name1 in
-                                         print_entry uu___8 uu___9 cmx_files1
-                                       else ()))
-                                   else
-                                     (let uu___7 =
-                                        (let uu___8 =
-                                           let uu___9 =
-                                             lowercase_module_name file_name1 in
-                                           has_implementation
-                                             deps1.file_system_map uu___9 in
-                                         Prims.op_Negation uu___8) &&
-                                          (is_interface file_name1) in
-                                      if uu___7
+                                     let uu___8 =
+                                       (FStar_Options.cmi ()) &&
+                                         (widened1 || true) in
+                                     (if uu___8
                                       then
-                                        let uu___8 =
-                                          (FStar_Options.cmi ()) &&
-                                            (widened1 || true) in
-                                        (if uu___8
-                                         then
-                                           let uu___9 =
-                                             output_krml_file file_name1 in
-                                           print_entry uu___9
-                                             cache_file_name1
-                                             all_checked_fst_dep_files_string
-                                         else
-                                           (let uu___10 =
-                                              output_krml_file file_name1 in
-                                            print_entry uu___10
-                                              cache_file_name1 ""))
-                                      else ()));
-                                  all_checked_files2)) in
-                      profile process_one_key
-                        "FStar.Parser.Dep.process_one_key") []) in
+                                        let uu___9 =
+                                          output_krml_file file_name1 in
+                                        print_entry uu___9 cache_file_name1
+                                          all_checked_fst_dep_files_string
+                                      else
+                                        (let uu___10 =
+                                           output_krml_file file_name1 in
+                                         print_entry uu___10 cache_file_name1
+                                           ""))
+                                   else ()));
+                               all_checked_files2)) in
+                   profile process_one_key "FStar.Parser.Dep.process_one_key")
+              [] keys in
           let all_fst_files =
-            let uu___1 =
-              FStar_Compiler_Effect.op_Bar_Greater keys
-                (FStar_Compiler_List.filter is_implementation) in
-            FStar_Compiler_Effect.op_Bar_Greater uu___1
-              (FStar_Compiler_Util.sort_with FStar_Compiler_String.compare) in
+            let uu___1 = FStar_Compiler_List.filter is_implementation keys in
+            FStar_Compiler_Util.sort_with FStar_Compiler_String.compare
+              uu___1 in
           let all_fsti_files =
-            let uu___1 =
-              FStar_Compiler_Effect.op_Bar_Greater keys
-                (FStar_Compiler_List.filter is_interface) in
-            FStar_Compiler_Effect.op_Bar_Greater uu___1
-              (FStar_Compiler_Util.sort_with FStar_Compiler_String.compare) in
+            let uu___1 = FStar_Compiler_List.filter is_interface keys in
+            FStar_Compiler_Util.sort_with FStar_Compiler_String.compare
+              uu___1 in
           let all_ml_files =
             let ml_file_map =
               FStar_Compiler_Util.smap_create (Prims.of_int (41)) in
-            FStar_Compiler_Effect.op_Bar_Greater all_fst_files
-              (FStar_Compiler_List.iter
-                 (fun fst_file ->
-                    let mname = lowercase_module_name fst_file in
-                    let uu___2 =
-                      FStar_Options.should_extract mname FStar_Options.OCaml in
-                    if uu___2
-                    then
-                      let uu___3 = output_ml_file fst_file in
-                      FStar_Compiler_Util.smap_add ml_file_map mname uu___3
-                    else ()));
+            FStar_Compiler_List.iter
+              (fun fst_file ->
+                 let mname = lowercase_module_name fst_file in
+                 let uu___2 =
+                   FStar_Options.should_extract mname FStar_Options.OCaml in
+                 if uu___2
+                 then
+                   let uu___3 = output_ml_file fst_file in
+                   FStar_Compiler_Util.smap_add ml_file_map mname uu___3
+                 else ()) all_fst_files;
             sort_output_files ml_file_map in
           let all_fs_files =
             let fs_file_map =
               FStar_Compiler_Util.smap_create (Prims.of_int (41)) in
-            FStar_Compiler_Effect.op_Bar_Greater all_fst_files
-              (FStar_Compiler_List.iter
-                 (fun fst_file ->
-                    let mname = lowercase_module_name fst_file in
-                    let uu___2 =
-                      FStar_Options.should_extract mname FStar_Options.FSharp in
-                    if uu___2
-                    then
-                      let uu___3 = output_fs_file fst_file in
-                      FStar_Compiler_Util.smap_add fs_file_map mname uu___3
-                    else ()));
+            FStar_Compiler_List.iter
+              (fun fst_file ->
+                 let mname = lowercase_module_name fst_file in
+                 let uu___2 =
+                   FStar_Options.should_extract mname FStar_Options.FSharp in
+                 if uu___2
+                 then
+                   let uu___3 = output_fs_file fst_file in
+                   FStar_Compiler_Util.smap_add fs_file_map mname uu___3
+                 else ()) all_fst_files;
             sort_output_files fs_file_map in
           let all_krml_files =
             let krml_file_map =
               FStar_Compiler_Util.smap_create (Prims.of_int (41)) in
-            FStar_Compiler_Effect.op_Bar_Greater keys
-              (FStar_Compiler_List.iter
-                 (fun fst_file ->
-                    let mname = lowercase_module_name fst_file in
-                    let uu___2 =
-                      FStar_Options.should_extract mname FStar_Options.Krml in
-                    if uu___2
-                    then
-                      let uu___3 = output_krml_file fst_file in
-                      FStar_Compiler_Util.smap_add krml_file_map mname uu___3
-                    else ()));
+            FStar_Compiler_List.iter
+              (fun fst_file ->
+                 let mname = lowercase_module_name fst_file in
+                 let uu___2 =
+                   FStar_Options.should_extract mname FStar_Options.Krml in
+                 if uu___2
+                 then
+                   let uu___3 = output_krml_file fst_file in
+                   FStar_Compiler_Util.smap_add krml_file_map mname uu___3
+                 else ()) keys;
             sort_output_files krml_file_map in
           let print_all tag files =
             pr tag;
@@ -2797,31 +2711,30 @@ let (print_full : FStar_Compiler_Util.out_channel -> deps -> unit) =
             FStar_Compiler_List.iter
               (fun f -> pr (norm_path f); pr " \\\n\t") files;
             pr "\n" in
-          (FStar_Compiler_Effect.op_Bar_Greater all_fsti_files
-             (FStar_Compiler_List.iter
-                (fun fsti ->
-                   let mn = lowercase_module_name fsti in
-                   let range_of_file fsti1 =
-                     let r =
-                       FStar_Compiler_Range_Ops.set_file_of_range
-                         FStar_Compiler_Range_Type.dummyRange fsti1 in
-                     let uu___2 = FStar_Compiler_Range_Type.def_range r in
-                     FStar_Compiler_Range_Type.set_use_range r uu___2 in
-                   let uu___2 =
-                     let uu___3 = has_implementation deps1.file_system_map mn in
-                     Prims.op_Negation uu___3 in
-                   if uu___2
-                   then
-                     let uu___3 = range_of_file fsti in
-                     let uu___4 =
-                       let uu___5 =
-                         let uu___6 = module_name_of_file fsti in
-                         FStar_Compiler_Util.format1
-                           "Interface %s is admitted without an implementation"
-                           uu___6 in
-                       (FStar_Errors_Codes.Warning_WarnOnUse, uu___5) in
-                     FStar_Errors.log_issue uu___3 uu___4
-                   else ()));
+          (FStar_Compiler_List.iter
+             (fun fsti ->
+                let mn = lowercase_module_name fsti in
+                let range_of_file fsti1 =
+                  let r =
+                    FStar_Compiler_Range_Ops.set_file_of_range
+                      FStar_Compiler_Range_Type.dummyRange fsti1 in
+                  let uu___2 = FStar_Compiler_Range_Type.def_range r in
+                  FStar_Compiler_Range_Type.set_use_range r uu___2 in
+                let uu___2 =
+                  let uu___3 = has_implementation deps1.file_system_map mn in
+                  Prims.op_Negation uu___3 in
+                if uu___2
+                then
+                  let uu___3 = range_of_file fsti in
+                  let uu___4 =
+                    let uu___5 =
+                      let uu___6 = module_name_of_file fsti in
+                      FStar_Compiler_Util.format1
+                        "Interface %s is admitted without an implementation"
+                        uu___6 in
+                    (FStar_Errors_Codes.Warning_WarnOnUse, uu___5) in
+                  FStar_Errors.log_issue uu___3 uu___4
+                else ()) all_fsti_files;
            print_all "ALL_FST_FILES" all_fst_files;
            print_all "ALL_FSTI_FILES" all_fsti_files;
            print_all "ALL_CHECKED_FILES" all_checked_files;
@@ -2877,11 +2790,10 @@ let (deps_has_implementation : deps -> FStar_Ident.lident -> Prims.bool) =
       let m =
         let uu___ = FStar_Ident.string_of_lid module_name1 in
         FStar_Compiler_String.lowercase uu___ in
-      FStar_Compiler_Effect.op_Bar_Greater deps1.all_files
-        (FStar_Compiler_Util.for_some
-           (fun f ->
-              (is_implementation f) &&
-                (let uu___ =
-                   let uu___1 = module_name_of_file f in
-                   FStar_Compiler_String.lowercase uu___1 in
-                 uu___ = m)))
+      FStar_Compiler_Util.for_some
+        (fun f ->
+           (is_implementation f) &&
+             (let uu___ =
+                let uu___1 = module_name_of_file f in
+                FStar_Compiler_String.lowercase uu___1 in
+              uu___ = m)) deps1.all_files

--- a/ocaml/fstar-lib/generated/FStar_Parser_ToDocument.ml
+++ b/ocaml/fstar-lib/generated/FStar_Parser_ToDocument.ml
@@ -118,9 +118,7 @@ let precede_break_separate_map :
         fun l ->
           let uu___ =
             let uu___1 = FStar_Pprint.op_Hat_Hat prec FStar_Pprint.space in
-            let uu___2 =
-              let uu___3 = FStar_Compiler_List.hd l in
-              FStar_Compiler_Effect.op_Bar_Greater uu___3 f in
+            let uu___2 = let uu___3 = FStar_Compiler_List.hd l in f uu___3 in
             FStar_Pprint.precede uu___1 uu___2 in
           let uu___1 =
             let uu___2 = FStar_Compiler_List.tl l in
@@ -664,8 +662,7 @@ let (is_operatorInfix0ad12 : FStar_Ident.ident -> Prims.bool) =
   fun op ->
     let uu___ =
       let uu___1 =
-        let uu___2 = FStar_Ident.string_of_id op in
-        FStar_Compiler_Effect.op_Less_Bar matches_level uu___2 in
+        let uu___2 = FStar_Ident.string_of_id op in matches_level uu___2 in
       FStar_Compiler_List.tryFind uu___1 operatorInfix0ad12 in
     uu___ <> FStar_Pervasives_Native.None
 let (is_operatorInfix34 : FStar_Ident.ident -> Prims.bool) =
@@ -673,8 +670,7 @@ let (is_operatorInfix34 : FStar_Ident.ident -> Prims.bool) =
   fun op ->
     let uu___ =
       let uu___1 =
-        let uu___2 = FStar_Ident.string_of_id op in
-        FStar_Compiler_Effect.op_Less_Bar matches_level uu___2 in
+        let uu___2 = FStar_Ident.string_of_id op in matches_level uu___2 in
       FStar_Compiler_List.tryFind uu___1 opinfix34 in
     uu___ <> FStar_Pervasives_Native.None
 let (handleable_args_length : FStar_Ident.ident -> Prims.int) =
@@ -1128,8 +1124,7 @@ let rec (p_decl : FStar_Parser_AST.decl -> FStar_Pprint.document) =
             let uu___2 =
               let uu___3 = FStar_Ident.string_of_id id in
               FStar_Compiler_Util.char_at uu___3 Prims.int_zero in
-            FStar_Compiler_Effect.op_Bar_Greater uu___2
-              FStar_Compiler_Util.is_upper in
+            FStar_Compiler_Util.is_upper uu___2 in
           if uu___1
           then
             let uu___2 = p_qualifier FStar_Parser_AST.Assumption in
@@ -1275,12 +1270,11 @@ and (p_rawDecl : FStar_Parser_AST.decl -> FStar_Pprint.document) =
           p_typeDeclWithKw s uu___1 in
         let uu___1 =
           let uu___2 = FStar_Compiler_List.tl tcdefs in
-          FStar_Compiler_Effect.op_Less_Bar
-            (FStar_Pprint.concat_map
-               (fun x ->
-                  let uu___3 =
-                    let uu___4 = str "and" in p_typeDeclWithKw uu___4 x in
-                  FStar_Pprint.op_Hat_Hat break1 uu___3)) uu___2 in
+          FStar_Pprint.concat_map
+            (fun x ->
+               let uu___3 =
+                 let uu___4 = str "and" in p_typeDeclWithKw uu___4 x in
+               FStar_Pprint.op_Hat_Hat break1 uu___3) uu___2 in
         FStar_Pprint.op_Hat_Hat uu___ uu___1
     | FStar_Parser_AST.TopLevelLet (q, lbs) ->
         let let_doc =
@@ -1306,15 +1300,14 @@ and (p_rawDecl : FStar_Parser_AST.decl -> FStar_Pprint.document) =
               FStar_Pprint.op_Hat_Hat uu___4 uu___5 in
             FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu___3 in
           FStar_Pprint.op_Hat_Hat uu___1 uu___2 in
-        FStar_Compiler_Effect.op_Less_Bar FStar_Pprint.group uu___
+        FStar_Pprint.group uu___
     | FStar_Parser_AST.Assume (id, t) ->
         let decl_keyword =
           let uu___ =
             let uu___1 =
               let uu___2 = FStar_Ident.string_of_id id in
               FStar_Compiler_Util.char_at uu___2 Prims.int_zero in
-            FStar_Compiler_Effect.op_Bar_Greater uu___1
-              FStar_Compiler_Util.is_upper in
+            FStar_Compiler_Util.is_upper uu___1 in
           if uu___
           then FStar_Pprint.empty
           else
@@ -1464,7 +1457,7 @@ and (p_typeDeclWithKw :
                    FStar_Pprint.nest (Prims.of_int (2)) uu___6 in
                  FStar_Pprint.op_Hat_Hat decl uu___5 in
                FStar_Pprint.ifflat uu___3 uu___4 in
-             FStar_Compiler_Effect.op_Less_Bar FStar_Pprint.group uu___2)
+             FStar_Pprint.group uu___2)
 and (p_typeDecl :
   FStar_Pprint.document ->
     FStar_Parser_AST.tycon ->
@@ -1541,7 +1534,7 @@ and (p_typeDeclRecord :
                let sep = if ps then FStar_Pprint.semi else FStar_Pprint.empty in
                inline_comment_or_above comm field sep) in
     let uu___ = separate_map_last FStar_Pprint.hardline p_recordField fields in
-    FStar_Compiler_Effect.op_Bar_Greater uu___ braces_with_nesting
+    braces_with_nesting uu___
 and (p_typeDeclPrefix :
   FStar_Pprint.document ->
     Prims.bool ->
@@ -1717,8 +1710,7 @@ and (p_letlhs :
                                FStar_Pprint.op_Hat_Hat FStar_Pprint.space
                                  uu___9 in
                              FStar_Pprint.op_Hat_Hat kw uu___8 in
-                           FStar_Compiler_Effect.op_Less_Bar
-                             FStar_Pprint.group uu___7)
+                           FStar_Pprint.group uu___7)
                   | uu___3 ->
                       let ascr_doc =
                         match ascr with
@@ -2406,7 +2398,7 @@ and (inline_comment_or_above :
                  FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline uu___5 in
                FStar_Pprint.op_Hat_Hat comm uu___4 in
              FStar_Pprint.ifflat uu___2 uu___3 in
-           FStar_Compiler_Effect.op_Less_Bar FStar_Pprint.group uu___1)
+           FStar_Pprint.group uu___1)
 and (p_term :
   Prims.bool -> Prims.bool -> FStar_Parser_AST.term -> FStar_Pprint.document)
   =
@@ -3073,8 +3065,7 @@ and (p_noSeqTerm' :
                     FStar_Pprint.op_Hat_Hat uu___6 uu___7 in
                   FStar_Pprint.op_Hat_Hat uu___4 uu___5 in
                 FStar_Pprint.op_Hat_Hat FStar_Pprint.hardline uu___3 in
-              FStar_Compiler_Effect.op_Less_Bar
-                (FStar_Pprint.nest (Prims.of_int (2))) uu___2 in
+              FStar_Pprint.nest (Prims.of_int (2)) uu___2 in
             FStar_Pprint.enclose head uu___ uu___1
         | FStar_Parser_AST.IntroForall (xs, p, e1) ->
             let p1 = p_noSeqTermAndComment false false p in
@@ -4203,7 +4194,7 @@ and (collapse_binders :
                                        FStar_Pprint.space y in
                                    FStar_Pprint.op_Hat_Hat x uu___4) hd tl in
                           f uu___3 typ in
-                        FStar_Compiler_Effect.op_Less_Bar (wrap is_tc) uu___2)) in
+                        wrap is_tc uu___2)) in
         let uu___ = accumulate_binders p_Tm e in
         match uu___ with
         | (bs_ds, ret_d) ->
@@ -4301,7 +4292,7 @@ and (p_tmEqWith' :
             (match uu___ with
              | (left, mine, right) ->
                  let uu___1 =
-                   let uu___2 = FStar_Compiler_Effect.op_Less_Bar str op1 in
+                   let uu___2 = str op1 in
                    let uu___3 = p_tmEqWith' p_X left e1 in
                    let uu___4 = p_tmEqWith' p_X right e2 in
                    infix0 uu___2 uu___3 uu___4 in
@@ -5042,17 +5033,11 @@ let (modul_to_document : FStar_Parser_AST.modul -> FStar_Pprint.document) =
   fun m ->
     match m with
     | FStar_Parser_AST.Module (uu___, decls) ->
-        let uu___1 =
-          FStar_Compiler_Effect.op_Bar_Greater decls
-            (FStar_Compiler_List.map decl_to_document) in
-        FStar_Compiler_Effect.op_Bar_Greater uu___1
-          (FStar_Pprint.separate FStar_Pprint.hardline)
+        let uu___1 = FStar_Compiler_List.map decl_to_document decls in
+        FStar_Pprint.separate FStar_Pprint.hardline uu___1
     | FStar_Parser_AST.Interface (uu___, decls, uu___1) ->
-        let uu___2 =
-          FStar_Compiler_Effect.op_Bar_Greater decls
-            (FStar_Compiler_List.map decl_to_document) in
-        FStar_Compiler_Effect.op_Bar_Greater uu___2
-          (FStar_Pprint.separate FStar_Pprint.hardline)
+        let uu___2 = FStar_Compiler_List.map decl_to_document decls in
+        FStar_Pprint.separate FStar_Pprint.hardline uu___2
 let (comments_to_document :
   (Prims.string * FStar_Compiler_Range_Type.range) Prims.list ->
     FStar_Pprint.document)

--- a/ocaml/fstar-lib/generated/FStar_Prettyprint.ml
+++ b/ocaml/fstar-lib/generated/FStar_Prettyprint.ml
@@ -45,8 +45,7 @@ let (generate : printing_mode -> Prims.string Prims.list -> unit) =
                           FStar_Pprint.pretty_string
                             (FStar_Compiler_Util.float_of_string "1.0")
                             (Prims.of_int (100)) doc in
-                        FStar_Compiler_Effect.op_Less_Bar
-                          (FStar_Compiler_Util.append_to_file f) uu___3
+                        FStar_Compiler_Util.append_to_file f uu___3
                     | FStar_Pervasives_Native.None ->
                         FStar_Pprint.pretty_out_channel
                           (FStar_Compiler_Util.float_of_string "1.0")
@@ -84,7 +83,6 @@ let (generate : printing_mode -> Prims.string Prims.list -> unit) =
                      FStar_Pprint.pretty_string
                        (FStar_Compiler_Util.float_of_string "1.0")
                        (Prims.of_int (100)) left_over_doc in
-                   FStar_Compiler_Effect.op_Less_Bar
-                     (FStar_Compiler_Util.append_to_file outf1) uu___2);
+                   FStar_Compiler_Util.append_to_file outf1 uu___2);
                   FStar_Compiler_Util.close_out_channel outf1)) in
       FStar_Compiler_List.iter (parse_and_prettyprint m) filenames

--- a/ocaml/fstar-lib/generated/FStar_Profiling.ml
+++ b/ocaml/fstar-lib/generated/FStar_Profiling.ml
@@ -91,21 +91,20 @@ let (report_and_clear : Prims.string -> unit) =
               let uu___1 = FStar_Compiler_Effect.op_Bang c2.total_time in
               let uu___2 = FStar_Compiler_Effect.op_Bang c1.total_time in
               uu___1 - uu___2) ctrs in
-     FStar_Compiler_Effect.op_Bar_Greater ctrs1
-       (FStar_Compiler_List.iter
-          (fun c ->
-             let warn =
-               let uu___1 = FStar_Compiler_Effect.op_Bang c.running in
-               if uu___1
-               then " (Warning, this counter is still running)"
-               else
-                 (let uu___3 = FStar_Compiler_Effect.op_Bang c.undercount in
-                  if uu___3
-                  then
-                    " (Warning, some operations raised exceptions and we not accounted for)"
-                  else "") in
-             let uu___1 =
-               let uu___2 = FStar_Compiler_Effect.op_Bang c.total_time in
-               FStar_Compiler_Util.string_of_int uu___2 in
-             FStar_Compiler_Util.print4 "%s, profiled %s:\t %s ms%s\n" tag
-               c.cid uu___1 warn)))
+     FStar_Compiler_List.iter
+       (fun c ->
+          let warn =
+            let uu___1 = FStar_Compiler_Effect.op_Bang c.running in
+            if uu___1
+            then " (Warning, this counter is still running)"
+            else
+              (let uu___3 = FStar_Compiler_Effect.op_Bang c.undercount in
+               if uu___3
+               then
+                 " (Warning, some operations raised exceptions and we not accounted for)"
+               else "") in
+          let uu___1 =
+            let uu___2 = FStar_Compiler_Effect.op_Bang c.total_time in
+            FStar_Compiler_Util.string_of_int uu___2 in
+          FStar_Compiler_Util.print4 "%s, profiled %s:\t %s ms%s\n" tag 
+            c.cid uu___1 warn) ctrs1)

--- a/ocaml/fstar-lib/generated/FStar_Reflection_V1_Builtins.ml
+++ b/ocaml/fstar-lib/generated/FStar_Reflection_V1_Builtins.ml
@@ -158,9 +158,7 @@ let (pack_universe :
 let rec (inspect_ln :
   FStar_Syntax_Syntax.term -> FStar_Reflection_V1_Data.term_view) =
   fun t ->
-    let t1 =
-      FStar_Compiler_Effect.op_Bar_Greater t
-        FStar_Syntax_Subst.compress_subst in
+    let t1 = FStar_Syntax_Subst.compress_subst t in
     match t1.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_meta
         { FStar_Syntax_Syntax.tm2 = t2; FStar_Syntax_Syntax.meta = uu___;_}
@@ -315,10 +313,7 @@ let rec (inspect_ln :
         FStar_Reflection_V1_Data.Tv_Match (t2, ret_opt, brs1)
     | FStar_Syntax_Syntax.Tm_unknown -> FStar_Reflection_V1_Data.Tv_Unknown
     | FStar_Syntax_Syntax.Tm_lazy i ->
-        let uu___ =
-          FStar_Compiler_Effect.op_Bar_Greater i
-            FStar_Syntax_Util.unfold_lazy in
-        FStar_Compiler_Effect.op_Bar_Greater uu___ inspect_ln
+        let uu___ = FStar_Syntax_Util.unfold_lazy i in inspect_ln uu___
     | uu___ ->
         ((let uu___2 =
             let uu___3 =
@@ -365,9 +360,7 @@ let (inspect_comp :
             (FStar_Compiler_List.length ct.FStar_Syntax_Syntax.comp_univs) =
               Prims.int_zero
           then FStar_Syntax_Syntax.U_unknown
-          else
-            FStar_Compiler_Effect.op_Bar_Greater
-              ct.FStar_Syntax_Syntax.comp_univs FStar_Compiler_List.hd in
+          else FStar_Compiler_List.hd ct.FStar_Syntax_Syntax.comp_univs in
         let uu___ =
           FStar_Ident.lid_equals ct.FStar_Syntax_Syntax.effect_name
             FStar_Parser_Const.effect_Lemma_lid in
@@ -561,7 +554,7 @@ let (pack_ln :
               let uu___ =
                 let uu___1 = pack_const c in
                 FStar_Syntax_Syntax.Pat_constant uu___1 in
-              FStar_Compiler_Effect.op_Less_Bar wrap uu___
+              wrap uu___
           | FStar_Reflection_V1_Data.Pat_Cons (fv, us_opt, ps) ->
               let uu___ =
                 let uu___1 =
@@ -573,13 +566,11 @@ let (pack_ln :
                       ps in
                   (fv, us_opt, uu___2) in
                 FStar_Syntax_Syntax.Pat_cons uu___1 in
-              FStar_Compiler_Effect.op_Less_Bar wrap uu___
+              wrap uu___
           | FStar_Reflection_V1_Data.Pat_Var (bv, _sort) ->
-              FStar_Compiler_Effect.op_Less_Bar wrap
-                (FStar_Syntax_Syntax.Pat_var bv)
+              wrap (FStar_Syntax_Syntax.Pat_var bv)
           | FStar_Reflection_V1_Data.Pat_Dot_Term eopt ->
-              FStar_Compiler_Effect.op_Less_Bar wrap
-                (FStar_Syntax_Syntax.Pat_dot_term eopt) in
+              wrap (FStar_Syntax_Syntax.Pat_dot_term eopt) in
         let brs1 =
           FStar_Compiler_List.map
             (fun uu___ ->
@@ -675,10 +666,8 @@ let (defs_in_module :
         (fun l ->
            let ns =
              let uu___1 =
-               let uu___2 = FStar_Ident.ids_of_lid l in
-               FStar_Compiler_Effect.op_Bar_Greater uu___2 init in
-             FStar_Compiler_Effect.op_Bar_Greater uu___1
-               (FStar_Compiler_List.map FStar_Ident.string_of_id) in
+               let uu___2 = FStar_Ident.ids_of_lid l in init uu___2 in
+             FStar_Compiler_List.map FStar_Ident.string_of_id uu___1 in
            if ns = modul
            then
              let uu___1 =
@@ -813,8 +802,7 @@ let (sigelt_quals :
   FStar_Syntax_Syntax.sigelt -> FStar_Reflection_V1_Data.qualifier Prims.list)
   =
   fun se ->
-    FStar_Compiler_Effect.op_Bar_Greater se.FStar_Syntax_Syntax.sigquals
-      (FStar_Compiler_List.map syntax_to_rd_qual)
+    FStar_Compiler_List.map syntax_to_rd_qual se.FStar_Syntax_Syntax.sigquals
 let (set_sigelt_quals :
   FStar_Reflection_V1_Data.qualifier Prims.list ->
     FStar_Syntax_Syntax.sigelt -> FStar_Syntax_Syntax.sigelt)
@@ -1018,7 +1006,7 @@ let (pack_sigelt :
         let packed = FStar_Compiler_List.map pack_letbinding lbs in
         let lbs1 = FStar_Compiler_List.map FStar_Pervasives_Native.snd packed in
         let lids = FStar_Compiler_List.map FStar_Pervasives_Native.fst packed in
-        FStar_Compiler_Effect.op_Less_Bar FStar_Syntax_Syntax.mk_sigelt
+        FStar_Syntax_Syntax.mk_sigelt
           (FStar_Syntax_Syntax.Sig_let
              {
                FStar_Syntax_Syntax.lbs1 = (r, lbs1);
@@ -1043,8 +1031,7 @@ let (pack_sigelt :
                   let uu___2 = FStar_Syntax_Syntax.mk_Total ty1 in
                   FStar_Syntax_Util.arrow param_bs uu___2 in
                 let ty3 = FStar_Syntax_Subst.subst s ty2 in
-                FStar_Compiler_Effect.op_Less_Bar
-                  FStar_Syntax_Syntax.mk_sigelt
+                FStar_Syntax_Syntax.mk_sigelt
                   (FStar_Syntax_Syntax.Sig_datacon
                      {
                        FStar_Syntax_Syntax.lid1 = lid;
@@ -1065,7 +1052,7 @@ let (pack_sigelt :
             let ty1 = FStar_Syntax_Subst.close param_bs1 ty in
             let param_bs2 = FStar_Syntax_Subst.subst_binders s param_bs1 in
             let ty2 = FStar_Syntax_Subst.subst s ty1 in
-            FStar_Compiler_Effect.op_Less_Bar FStar_Syntax_Syntax.mk_sigelt
+            FStar_Syntax_Syntax.mk_sigelt
               (FStar_Syntax_Syntax.Sig_inductive_typ
                  {
                    FStar_Syntax_Syntax.lid = ind_lid;
@@ -1078,7 +1065,7 @@ let (pack_sigelt :
                    FStar_Syntax_Syntax.ds = c_lids
                  }) in
           let se =
-            FStar_Compiler_Effect.op_Less_Bar FStar_Syntax_Syntax.mk_sigelt
+            FStar_Syntax_Syntax.mk_sigelt
               (FStar_Syntax_Syntax.Sig_bundle
                  {
                    FStar_Syntax_Syntax.ses = (ind_se :: ctor_ses);
@@ -1101,7 +1088,7 @@ let (pack_sigelt :
           FStar_Ident.lid_of_path nm FStar_Compiler_Range_Type.dummyRange in
         (check_lid val_lid;
          (let typ = FStar_Syntax_Subst.close_univ_vars us_names1 ty in
-          FStar_Compiler_Effect.op_Less_Bar FStar_Syntax_Syntax.mk_sigelt
+          FStar_Syntax_Syntax.mk_sigelt
             (FStar_Syntax_Syntax.Sig_declare_typ
                {
                  FStar_Syntax_Syntax.lid2 = val_lid;

--- a/ocaml/fstar-lib/generated/FStar_Reflection_V1_Embeddings.ml
+++ b/ocaml/fstar-lib/generated/FStar_Reflection_V1_Embeddings.ml
@@ -206,11 +206,8 @@ let (e_universe_view :
              let uu___3 = unembed e_universe u in
              FStar_Compiler_Util.bind_opt uu___3
                (fun u1 ->
-                  let uu___4 =
-                    FStar_Compiler_Effect.op_Bar_Greater u1
-                      (fun uu___5 -> FStar_Reflection_V1_Data.Uv_Succ uu___5) in
-                  FStar_Compiler_Effect.op_Bar_Greater uu___4
-                    (fun uu___5 -> FStar_Pervasives_Native.Some uu___5))
+                  FStar_Pervasives_Native.Some
+                    (FStar_Reflection_V1_Data.Uv_Succ u1))
          | (FStar_Syntax_Syntax.Tm_fvar fv, (us, uu___2)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_V1_Constants.ref_Uv_Max.FStar_Reflection_V1_Constants.lid
@@ -220,11 +217,8 @@ let (e_universe_view :
                unembed uu___4 us in
              FStar_Compiler_Util.bind_opt uu___3
                (fun us1 ->
-                  let uu___4 =
-                    FStar_Compiler_Effect.op_Bar_Greater us1
-                      (fun uu___5 -> FStar_Reflection_V1_Data.Uv_Max uu___5) in
-                  FStar_Compiler_Effect.op_Bar_Greater uu___4
-                    (fun uu___5 -> FStar_Pervasives_Native.Some uu___5))
+                  FStar_Pervasives_Native.Some
+                    (FStar_Reflection_V1_Data.Uv_Max us1))
          | (FStar_Syntax_Syntax.Tm_fvar fv, (n, uu___2)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_V1_Constants.ref_Uv_BVar.FStar_Reflection_V1_Constants.lid
@@ -232,11 +226,8 @@ let (e_universe_view :
              let uu___3 = unembed FStar_Syntax_Embeddings.e_int n in
              FStar_Compiler_Util.bind_opt uu___3
                (fun n1 ->
-                  let uu___4 =
-                    FStar_Compiler_Effect.op_Bar_Greater n1
-                      (fun uu___5 -> FStar_Reflection_V1_Data.Uv_BVar uu___5) in
-                  FStar_Compiler_Effect.op_Bar_Greater uu___4
-                    (fun uu___5 -> FStar_Pervasives_Native.Some uu___5))
+                  FStar_Pervasives_Native.Some
+                    (FStar_Reflection_V1_Data.Uv_BVar n1))
          | (FStar_Syntax_Syntax.Tm_fvar fv, (i, uu___2)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_V1_Constants.ref_Uv_Name.FStar_Reflection_V1_Constants.lid
@@ -249,11 +240,8 @@ let (e_universe_view :
                unembed uu___4 i in
              FStar_Compiler_Util.bind_opt uu___3
                (fun i1 ->
-                  let uu___4 =
-                    FStar_Compiler_Effect.op_Bar_Greater i1
-                      (fun uu___5 -> FStar_Reflection_V1_Data.Uv_Name uu___5) in
-                  FStar_Compiler_Effect.op_Bar_Greater uu___4
-                    (fun uu___5 -> FStar_Pervasives_Native.Some uu___5))
+                  FStar_Pervasives_Native.Some
+                    (FStar_Reflection_V1_Data.Uv_Name i1))
          | (FStar_Syntax_Syntax.Tm_fvar fv, (u, uu___2)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_V1_Constants.ref_Uv_Unif.FStar_Reflection_V1_Constants.lid
@@ -261,11 +249,8 @@ let (e_universe_view :
              let u1 =
                FStar_Syntax_Util.unlazy_as_t
                  FStar_Syntax_Syntax.Lazy_universe_uvar u in
-             let uu___3 =
-               FStar_Compiler_Effect.op_Bar_Greater u1
-                 (fun uu___4 -> FStar_Reflection_V1_Data.Uv_Unif uu___4) in
-             FStar_Compiler_Effect.op_Bar_Greater uu___3
-               (fun uu___4 -> FStar_Pervasives_Native.Some uu___4)
+             FStar_Pervasives_Native.Some
+               (FStar_Reflection_V1_Data.Uv_Unif u1)
          | (FStar_Syntax_Syntax.Tm_fvar fv, []) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_V1_Constants.ref_Uv_Unk.FStar_Reflection_V1_Constants.lid
@@ -380,8 +365,7 @@ let (e_const :
              let uu___3 = unembed FStar_Syntax_Embeddings.e_int i in
              FStar_Compiler_Util.bind_opt uu___3
                (fun i1 ->
-                  FStar_Compiler_Effect.op_Less_Bar
-                    (fun uu___4 -> FStar_Pervasives_Native.Some uu___4)
+                  FStar_Pervasives_Native.Some
                     (FStar_Reflection_V1_Data.C_Int i1))
          | (FStar_Syntax_Syntax.Tm_fvar fv, (s, uu___2)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
@@ -390,8 +374,7 @@ let (e_const :
              let uu___3 = unembed FStar_Syntax_Embeddings.e_string s in
              FStar_Compiler_Util.bind_opt uu___3
                (fun s1 ->
-                  FStar_Compiler_Effect.op_Less_Bar
-                    (fun uu___4 -> FStar_Pervasives_Native.Some uu___4)
+                  FStar_Pervasives_Native.Some
                     (FStar_Reflection_V1_Data.C_String s1))
          | (FStar_Syntax_Syntax.Tm_fvar fv, (r, uu___2)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
@@ -400,16 +383,12 @@ let (e_const :
              let uu___3 = unembed FStar_Syntax_Embeddings.e_range r in
              FStar_Compiler_Util.bind_opt uu___3
                (fun r1 ->
-                  FStar_Compiler_Effect.op_Less_Bar
-                    (fun uu___4 -> FStar_Pervasives_Native.Some uu___4)
+                  FStar_Pervasives_Native.Some
                     (FStar_Reflection_V1_Data.C_Range r1))
          | (FStar_Syntax_Syntax.Tm_fvar fv, []) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_V1_Constants.ref_C_Reify.FStar_Reflection_V1_Constants.lid
-             ->
-             FStar_Compiler_Effect.op_Less_Bar
-               (fun uu___2 -> FStar_Pervasives_Native.Some uu___2)
-               FStar_Reflection_V1_Data.C_Reify
+             -> FStar_Pervasives_Native.Some FStar_Reflection_V1_Data.C_Reify
          | (FStar_Syntax_Syntax.Tm_fvar fv, (ns, uu___2)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Reflection_V1_Constants.ref_C_Reflect.FStar_Reflection_V1_Constants.lid
@@ -417,8 +396,7 @@ let (e_const :
              let uu___3 = unembed FStar_Syntax_Embeddings.e_string_list ns in
              FStar_Compiler_Util.bind_opt uu___3
                (fun ns1 ->
-                  FStar_Compiler_Effect.op_Less_Bar
-                    (fun uu___4 -> FStar_Pervasives_Native.Some uu___4)
+                  FStar_Pervasives_Native.Some
                     (FStar_Reflection_V1_Data.C_Reflect ns1))
          | uu___2 -> FStar_Pervasives_Native.None) in
   mk_emb embed_const unembed_const
@@ -515,8 +493,7 @@ let rec e_pattern_aq :
                let uu___3 = unembed e_const c in
                FStar_Compiler_Util.bind_opt uu___3
                  (fun c1 ->
-                    FStar_Compiler_Effect.op_Less_Bar
-                      (fun uu___4 -> FStar_Pervasives_Native.Some uu___4)
+                    FStar_Pervasives_Native.Some
                       (FStar_Reflection_V1_Data.Pat_Constant c1))
            | (FStar_Syntax_Syntax.Tm_fvar fv,
               (f, uu___2)::(us_opt, uu___3)::(ps, uu___4)::[]) when
@@ -544,9 +521,7 @@ let rec e_pattern_aq :
                            unembed uu___8 ps in
                          FStar_Compiler_Util.bind_opt uu___7
                            (fun ps1 ->
-                              FStar_Compiler_Effect.op_Less_Bar
-                                (fun uu___8 ->
-                                   FStar_Pervasives_Native.Some uu___8)
+                              FStar_Pervasives_Native.Some
                                 (FStar_Reflection_V1_Data.Pat_Cons
                                    (f1, us_opt1, ps1)))))
            | (FStar_Syntax_Syntax.Tm_fvar fv,
@@ -562,8 +537,7 @@ let rec e_pattern_aq :
                       unembed uu___6 sort in
                     FStar_Compiler_Util.bind_opt uu___5
                       (fun sort1 ->
-                         FStar_Compiler_Effect.op_Less_Bar
-                           (fun uu___6 -> FStar_Pervasives_Native.Some uu___6)
+                         FStar_Pervasives_Native.Some
                            (FStar_Reflection_V1_Data.Pat_Var (bv1, sort1))))
            | (FStar_Syntax_Syntax.Tm_fvar fv, (eopt, uu___2)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
@@ -574,8 +548,7 @@ let rec e_pattern_aq :
                  unembed uu___4 eopt in
                FStar_Compiler_Util.bind_opt uu___3
                  (fun eopt1 ->
-                    FStar_Compiler_Effect.op_Less_Bar
-                      (fun uu___4 -> FStar_Pervasives_Native.Some uu___4)
+                    FStar_Pervasives_Native.Some
                       (FStar_Reflection_V1_Data.Pat_Dot_Term eopt1))
            | uu___2 -> FStar_Pervasives_Native.None) in
     mk_emb embed_pattern unembed_pattern
@@ -933,8 +906,7 @@ let (e_term_view_aq :
                let uu___3 = unembed e_bv b in
                FStar_Compiler_Util.bind_opt uu___3
                  (fun b1 ->
-                    FStar_Compiler_Effect.op_Less_Bar
-                      (fun uu___4 -> FStar_Pervasives_Native.Some uu___4)
+                    FStar_Pervasives_Native.Some
                       (FStar_Reflection_V1_Data.Tv_Var b1))
            | (FStar_Syntax_Syntax.Tm_fvar fv, (b, uu___2)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
@@ -943,8 +915,7 @@ let (e_term_view_aq :
                let uu___3 = unembed e_bv b in
                FStar_Compiler_Util.bind_opt uu___3
                  (fun b1 ->
-                    FStar_Compiler_Effect.op_Less_Bar
-                      (fun uu___4 -> FStar_Pervasives_Native.Some uu___4)
+                    FStar_Pervasives_Native.Some
                       (FStar_Reflection_V1_Data.Tv_BVar b1))
            | (FStar_Syntax_Syntax.Tm_fvar fv, (f, uu___2)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
@@ -953,8 +924,7 @@ let (e_term_view_aq :
                let uu___3 = unembed e_fv f in
                FStar_Compiler_Util.bind_opt uu___3
                  (fun f1 ->
-                    FStar_Compiler_Effect.op_Less_Bar
-                      (fun uu___4 -> FStar_Pervasives_Native.Some uu___4)
+                    FStar_Pervasives_Native.Some
                       (FStar_Reflection_V1_Data.Tv_FVar f1))
            | (FStar_Syntax_Syntax.Tm_fvar fv, (f, uu___2)::(us, uu___3)::[])
                when
@@ -969,8 +939,7 @@ let (e_term_view_aq :
                       unembed uu___6 us in
                     FStar_Compiler_Util.bind_opt uu___5
                       (fun us1 ->
-                         FStar_Compiler_Effect.op_Less_Bar
-                           (fun uu___6 -> FStar_Pervasives_Native.Some uu___6)
+                         FStar_Pervasives_Native.Some
                            (FStar_Reflection_V1_Data.Tv_UInst (f1, us1))))
            | (FStar_Syntax_Syntax.Tm_fvar fv, (l, uu___2)::(r, uu___3)::[])
                when
@@ -983,8 +952,7 @@ let (e_term_view_aq :
                     let uu___5 = unembed e_argv r in
                     FStar_Compiler_Util.bind_opt uu___5
                       (fun r1 ->
-                         FStar_Compiler_Effect.op_Less_Bar
-                           (fun uu___6 -> FStar_Pervasives_Native.Some uu___6)
+                         FStar_Pervasives_Native.Some
                            (FStar_Reflection_V1_Data.Tv_App (l1, r1))))
            | (FStar_Syntax_Syntax.Tm_fvar fv, (b, uu___2)::(t1, uu___3)::[])
                when
@@ -997,8 +965,7 @@ let (e_term_view_aq :
                     let uu___5 = unembed e_term t1 in
                     FStar_Compiler_Util.bind_opt uu___5
                       (fun t2 ->
-                         FStar_Compiler_Effect.op_Less_Bar
-                           (fun uu___6 -> FStar_Pervasives_Native.Some uu___6)
+                         FStar_Pervasives_Native.Some
                            (FStar_Reflection_V1_Data.Tv_Abs (b1, t2))))
            | (FStar_Syntax_Syntax.Tm_fvar fv, (b, uu___2)::(t1, uu___3)::[])
                when
@@ -1011,8 +978,7 @@ let (e_term_view_aq :
                     let uu___5 = unembed e_comp t1 in
                     FStar_Compiler_Util.bind_opt uu___5
                       (fun c ->
-                         FStar_Compiler_Effect.op_Less_Bar
-                           (fun uu___6 -> FStar_Pervasives_Native.Some uu___6)
+                         FStar_Pervasives_Native.Some
                            (FStar_Reflection_V1_Data.Tv_Arrow (b1, c))))
            | (FStar_Syntax_Syntax.Tm_fvar fv, (u, uu___2)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
@@ -1021,8 +987,7 @@ let (e_term_view_aq :
                let uu___3 = unembed e_universe u in
                FStar_Compiler_Util.bind_opt uu___3
                  (fun u1 ->
-                    FStar_Compiler_Effect.op_Less_Bar
-                      (fun uu___4 -> FStar_Pervasives_Native.Some uu___4)
+                    FStar_Pervasives_Native.Some
                       (FStar_Reflection_V1_Data.Tv_Type u1))
            | (FStar_Syntax_Syntax.Tm_fvar fv,
               (b, uu___2)::(sort, uu___3)::(t1, uu___4)::[]) when
@@ -1038,9 +1003,7 @@ let (e_term_view_aq :
                          let uu___7 = unembed e_term t1 in
                          FStar_Compiler_Util.bind_opt uu___7
                            (fun t2 ->
-                              FStar_Compiler_Effect.op_Less_Bar
-                                (fun uu___8 ->
-                                   FStar_Pervasives_Native.Some uu___8)
+                              FStar_Pervasives_Native.Some
                                 (FStar_Reflection_V1_Data.Tv_Refine
                                    (b1, sort1, t2)))))
            | (FStar_Syntax_Syntax.Tm_fvar fv, (c, uu___2)::[]) when
@@ -1050,8 +1013,7 @@ let (e_term_view_aq :
                let uu___3 = unembed e_const c in
                FStar_Compiler_Util.bind_opt uu___3
                  (fun c1 ->
-                    FStar_Compiler_Effect.op_Less_Bar
-                      (fun uu___4 -> FStar_Pervasives_Native.Some uu___4)
+                    FStar_Pervasives_Native.Some
                       (FStar_Reflection_V1_Data.Tv_Const c1))
            | (FStar_Syntax_Syntax.Tm_fvar fv, (u, uu___2)::(l, uu___3)::[])
                when
@@ -1064,8 +1026,7 @@ let (e_term_view_aq :
                     let ctx_u_s =
                       FStar_Syntax_Util.unlazy_as_t
                         FStar_Syntax_Syntax.Lazy_uvar l in
-                    FStar_Compiler_Effect.op_Less_Bar
-                      (fun uu___5 -> FStar_Pervasives_Native.Some uu___5)
+                    FStar_Pervasives_Native.Some
                       (FStar_Reflection_V1_Data.Tv_Uvar (u1, ctx_u_s)))
            | (FStar_Syntax_Syntax.Tm_fvar fv,
               (r, uu___2)::(attrs, uu___3)::(b, uu___4)::(ty, uu___5)::
@@ -1093,10 +1054,7 @@ let (e_term_view_aq :
                                         let uu___13 = unembed e_term t2 in
                                         FStar_Compiler_Util.bind_opt uu___13
                                           (fun t21 ->
-                                             FStar_Compiler_Effect.op_Less_Bar
-                                               (fun uu___14 ->
-                                                  FStar_Pervasives_Native.Some
-                                                    uu___14)
+                                             FStar_Pervasives_Native.Some
                                                (FStar_Reflection_V1_Data.Tv_Let
                                                   (r1, attrs1, b1, ty1, t11,
                                                     t21))))))))
@@ -1117,9 +1075,7 @@ let (e_term_view_aq :
                            unembed e_match_returns_annotation ret_opt in
                          FStar_Compiler_Util.bind_opt uu___7
                            (fun ret_opt1 ->
-                              FStar_Compiler_Effect.op_Less_Bar
-                                (fun uu___8 ->
-                                   FStar_Pervasives_Native.Some uu___8)
+                              FStar_Pervasives_Native.Some
                                 (FStar_Reflection_V1_Data.Tv_Match
                                    (t2, ret_opt1, brs1)))))
            | (FStar_Syntax_Syntax.Tm_fvar fv,
@@ -1144,9 +1100,7 @@ let (e_term_view_aq :
                                 unembed FStar_Syntax_Embeddings.e_bool use_eq in
                               FStar_Compiler_Util.bind_opt uu___9
                                 (fun use_eq1 ->
-                                   FStar_Compiler_Effect.op_Less_Bar
-                                     (fun uu___10 ->
-                                        FStar_Pervasives_Native.Some uu___10)
+                                   FStar_Pervasives_Native.Some
                                      (FStar_Reflection_V1_Data.Tv_AscribedT
                                         (e1, t2, tacopt1, use_eq1))))))
            | (FStar_Syntax_Syntax.Tm_fvar fv,
@@ -1171,24 +1125,20 @@ let (e_term_view_aq :
                                 unembed FStar_Syntax_Embeddings.e_bool use_eq in
                               FStar_Compiler_Util.bind_opt uu___9
                                 (fun use_eq1 ->
-                                   FStar_Compiler_Effect.op_Less_Bar
-                                     (fun uu___10 ->
-                                        FStar_Pervasives_Native.Some uu___10)
+                                   FStar_Pervasives_Native.Some
                                      (FStar_Reflection_V1_Data.Tv_AscribedC
                                         (e1, c1, tacopt1, use_eq1))))))
            | (FStar_Syntax_Syntax.Tm_fvar fv, []) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_V1_Constants.ref_Tv_Unknown.FStar_Reflection_V1_Constants.lid
                ->
-               FStar_Compiler_Effect.op_Less_Bar
-                 (fun uu___2 -> FStar_Pervasives_Native.Some uu___2)
+               FStar_Pervasives_Native.Some
                  FStar_Reflection_V1_Data.Tv_Unknown
            | (FStar_Syntax_Syntax.Tm_fvar fv, []) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_V1_Constants.ref_Tv_Unsupp.FStar_Reflection_V1_Constants.lid
                ->
-               FStar_Compiler_Effect.op_Less_Bar
-                 (fun uu___2 -> FStar_Pervasives_Native.Some uu___2)
+               FStar_Pervasives_Native.Some
                  FStar_Reflection_V1_Data.Tv_Unsupp
            | uu___2 -> FStar_Pervasives_Native.None) in
     mk_emb embed_term_view unembed_term_view
@@ -1256,8 +1206,7 @@ let (e_bv_view :
                   let uu___5 = unembed FStar_Syntax_Embeddings.e_int idx in
                   FStar_Compiler_Util.bind_opt uu___5
                     (fun idx1 ->
-                       FStar_Compiler_Effect.op_Less_Bar
-                         (fun uu___6 -> FStar_Pervasives_Native.Some uu___6)
+                       FStar_Pervasives_Native.Some
                          {
                            FStar_Reflection_V1_Data.bv_ppname = nm1;
                            FStar_Reflection_V1_Data.bv_index = idx1
@@ -1332,9 +1281,7 @@ let (e_binder_view :
                             let uu___9 = unembed e_term sort in
                             FStar_Compiler_Util.bind_opt uu___9
                               (fun sort1 ->
-                                 FStar_Compiler_Effect.op_Less_Bar
-                                   (fun uu___10 ->
-                                      FStar_Pervasives_Native.Some uu___10)
+                                 FStar_Pervasives_Native.Some
                                    {
                                      FStar_Reflection_V1_Data.binder_bv = bv1;
                                      FStar_Reflection_V1_Data.binder_qual =
@@ -1443,8 +1390,7 @@ let (e_comp_view :
              let uu___3 = unembed e_term t2 in
              FStar_Compiler_Util.bind_opt uu___3
                (fun t3 ->
-                  FStar_Compiler_Effect.op_Less_Bar
-                    (fun uu___4 -> FStar_Pervasives_Native.Some uu___4)
+                  FStar_Pervasives_Native.Some
                     (FStar_Reflection_V1_Data.C_Total t3))
          | (FStar_Syntax_Syntax.Tm_fvar fv, (t2, uu___2)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
@@ -1453,8 +1399,7 @@ let (e_comp_view :
              let uu___3 = unembed e_term t2 in
              FStar_Compiler_Util.bind_opt uu___3
                (fun t3 ->
-                  FStar_Compiler_Effect.op_Less_Bar
-                    (fun uu___4 -> FStar_Pervasives_Native.Some uu___4)
+                  FStar_Pervasives_Native.Some
                     (FStar_Reflection_V1_Data.C_GTotal t3))
          | (FStar_Syntax_Syntax.Tm_fvar fv,
             (pre, uu___2)::(post, uu___3)::(pats, uu___4)::[]) when
@@ -1470,9 +1415,7 @@ let (e_comp_view :
                        let uu___7 = unembed e_term pats in
                        FStar_Compiler_Util.bind_opt uu___7
                          (fun pats1 ->
-                            FStar_Compiler_Effect.op_Less_Bar
-                              (fun uu___8 ->
-                                 FStar_Pervasives_Native.Some uu___8)
+                            FStar_Pervasives_Native.Some
                               (FStar_Reflection_V1_Data.C_Lemma
                                  (pre1, post1, pats1)))))
          | (FStar_Syntax_Syntax.Tm_fvar fv,
@@ -1505,10 +1448,7 @@ let (e_comp_view :
                                    unembed uu___12 decrs in
                                  FStar_Compiler_Util.bind_opt uu___11
                                    (fun decrs1 ->
-                                      FStar_Compiler_Effect.op_Less_Bar
-                                        (fun uu___12 ->
-                                           FStar_Pervasives_Native.Some
-                                             uu___12)
+                                      FStar_Pervasives_Native.Some
                                         (FStar_Reflection_V1_Data.C_Eff
                                            (us1, eff1, res1, args2, decrs1)))))))
          | uu___2 -> FStar_Pervasives_Native.None) in
@@ -1646,9 +1586,7 @@ let (e_lb_view :
                             let uu___9 = unembed e_term def in
                             FStar_Compiler_Util.bind_opt uu___9
                               (fun def1 ->
-                                 FStar_Compiler_Effect.op_Less_Bar
-                                   (fun uu___10 ->
-                                      FStar_Pervasives_Native.Some uu___10)
+                                 FStar_Pervasives_Native.Some
                                    {
                                      FStar_Reflection_V1_Data.lb_fv = fv'1;
                                      FStar_Reflection_V1_Data.lb_us = us1;
@@ -1797,10 +1735,7 @@ let (e_sigelt_view :
                                    unembed uu___12 dcs in
                                  FStar_Compiler_Util.bind_opt uu___11
                                    (fun dcs1 ->
-                                      FStar_Compiler_Effect.op_Less_Bar
-                                        (fun uu___12 ->
-                                           FStar_Pervasives_Native.Some
-                                             uu___12)
+                                      FStar_Pervasives_Native.Some
                                         (FStar_Reflection_V1_Data.Sg_Inductive
                                            (nm1, us1, bs1, t3, dcs1)))))))
          | (FStar_Syntax_Syntax.Tm_fvar fv, (r, uu___2)::(lbs, uu___3)::[])
@@ -1816,8 +1751,7 @@ let (e_sigelt_view :
                     unembed uu___6 lbs in
                   FStar_Compiler_Util.bind_opt uu___5
                     (fun lbs1 ->
-                       FStar_Compiler_Effect.op_Less_Bar
-                         (fun uu___6 -> FStar_Pervasives_Native.Some uu___6)
+                       FStar_Pervasives_Native.Some
                          (FStar_Reflection_V1_Data.Sg_Let (r1, lbs1))))
          | (FStar_Syntax_Syntax.Tm_fvar fv,
             (nm, uu___2)::(us, uu___3)::(t2, uu___4)::[]) when
@@ -1833,9 +1767,7 @@ let (e_sigelt_view :
                        let uu___7 = unembed e_term t2 in
                        FStar_Compiler_Util.bind_opt uu___7
                          (fun t3 ->
-                            FStar_Compiler_Effect.op_Less_Bar
-                              (fun uu___8 ->
-                                 FStar_Pervasives_Native.Some uu___8)
+                            FStar_Pervasives_Native.Some
                               (FStar_Reflection_V1_Data.Sg_Val (nm1, us1, t3)))))
          | (FStar_Syntax_Syntax.Tm_fvar fv, []) when
              FStar_Syntax_Syntax.fv_eq_lid fv
@@ -2068,8 +2000,7 @@ let (e_qualifier :
              let uu___3 = unembed e_lid l in
              FStar_Compiler_Util.bind_opt uu___3
                (fun l1 ->
-                  FStar_Compiler_Effect.op_Less_Bar
-                    (fun uu___4 -> FStar_Pervasives_Native.Some uu___4)
+                  FStar_Pervasives_Native.Some
                     (FStar_Reflection_V1_Data.Reflectable l1))
          | (FStar_Syntax_Syntax.Tm_fvar fv, (l, uu___2)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
@@ -2078,8 +2009,7 @@ let (e_qualifier :
              let uu___3 = unembed e_lid l in
              FStar_Compiler_Util.bind_opt uu___3
                (fun l1 ->
-                  FStar_Compiler_Effect.op_Less_Bar
-                    (fun uu___4 -> FStar_Pervasives_Native.Some uu___4)
+                  FStar_Pervasives_Native.Some
                     (FStar_Reflection_V1_Data.Discriminator l1))
          | (FStar_Syntax_Syntax.Tm_fvar fv, (l, uu___2)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
@@ -2088,8 +2018,7 @@ let (e_qualifier :
              let uu___3 = unembed e_lid l in
              FStar_Compiler_Util.bind_opt uu___3
                (fun l1 ->
-                  FStar_Compiler_Effect.op_Less_Bar
-                    (fun uu___4 -> FStar_Pervasives_Native.Some uu___4)
+                  FStar_Pervasives_Native.Some
                     (FStar_Reflection_V1_Data.Action l1))
          | (FStar_Syntax_Syntax.Tm_fvar fv, (payload, uu___2)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
@@ -2102,8 +2031,7 @@ let (e_qualifier :
                (fun uu___4 ->
                   match uu___4 with
                   | (l, i) ->
-                      FStar_Compiler_Effect.op_Less_Bar
-                        (fun uu___5 -> FStar_Pervasives_Native.Some uu___5)
+                      FStar_Pervasives_Native.Some
                         (FStar_Reflection_V1_Data.Projector (l, i)))
          | (FStar_Syntax_Syntax.Tm_fvar fv, (payload, uu___2)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
@@ -2119,8 +2047,7 @@ let (e_qualifier :
                (fun uu___4 ->
                   match uu___4 with
                   | (ids1, ids2) ->
-                      FStar_Compiler_Effect.op_Less_Bar
-                        (fun uu___5 -> FStar_Pervasives_Native.Some uu___5)
+                      FStar_Pervasives_Native.Some
                         (FStar_Reflection_V1_Data.RecordType (ids1, ids2)))
          | (FStar_Syntax_Syntax.Tm_fvar fv, (payload, uu___2)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
@@ -2136,8 +2063,7 @@ let (e_qualifier :
                (fun uu___4 ->
                   match uu___4 with
                   | (ids1, ids2) ->
-                      FStar_Compiler_Effect.op_Less_Bar
-                        (fun uu___5 -> FStar_Pervasives_Native.Some uu___5)
+                      FStar_Pervasives_Native.Some
                         (FStar_Reflection_V1_Data.RecordConstructor
                            (ids1, ids2)))
          | uu___2 -> FStar_Pervasives_Native.None) in

--- a/ocaml/fstar-lib/generated/FStar_Reflection_V1_NBEEmbeddings.ml
+++ b/ocaml/fstar-lib/generated/FStar_Reflection_V1_NBEEmbeddings.ml
@@ -88,8 +88,7 @@ let (e_bv : FStar_Syntax_Syntax.bv FStar_TypeChecker_NBETerm.embedding) =
          uu___2)
         ->
         let uu___3 = FStar_Compiler_Dyn.undyn b in
-        FStar_Compiler_Effect.op_Less_Bar
-          (fun uu___4 -> FStar_Pervasives_Native.Some uu___4) uu___3
+        FStar_Pervasives_Native.Some uu___3
     | uu___ ->
         ((let uu___2 =
             let uu___3 =
@@ -331,8 +330,7 @@ let (e_const :
         let uu___ =
           let uu___1 =
             let uu___2 =
-              FStar_Compiler_Effect.op_Less_Bar
-                FStar_TypeChecker_NBETerm.mk_t
+              FStar_TypeChecker_NBETerm.mk_t
                 (FStar_TypeChecker_NBETerm.Constant
                    (FStar_TypeChecker_NBETerm.Int i)) in
             FStar_TypeChecker_NBETerm.as_arg uu___2 in
@@ -400,9 +398,7 @@ let (e_const :
             cb i in
         FStar_Compiler_Util.bind_opt uu___1
           (fun i1 ->
-             FStar_Compiler_Effect.op_Less_Bar
-               (fun uu___2 -> FStar_Pervasives_Native.Some uu___2)
-               (FStar_Reflection_V1_Data.C_Int i1))
+             FStar_Pervasives_Native.Some (FStar_Reflection_V1_Data.C_Int i1))
     | FStar_TypeChecker_NBETerm.Construct (fv, [], (s, uu___)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_V1_Constants.ref_C_String.FStar_Reflection_V1_Constants.lid
@@ -412,8 +408,7 @@ let (e_const :
             FStar_TypeChecker_NBETerm.e_string cb s in
         FStar_Compiler_Util.bind_opt uu___1
           (fun s1 ->
-             FStar_Compiler_Effect.op_Less_Bar
-               (fun uu___2 -> FStar_Pervasives_Native.Some uu___2)
+             FStar_Pervasives_Native.Some
                (FStar_Reflection_V1_Data.C_String s1))
     | FStar_TypeChecker_NBETerm.Construct (fv, [], (r, uu___)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
@@ -424,8 +419,7 @@ let (e_const :
             cb r in
         FStar_Compiler_Util.bind_opt uu___1
           (fun r1 ->
-             FStar_Compiler_Effect.op_Less_Bar
-               (fun uu___2 -> FStar_Pervasives_Native.Some uu___2)
+             FStar_Pervasives_Native.Some
                (FStar_Reflection_V1_Data.C_Range r1))
     | FStar_TypeChecker_NBETerm.Construct (fv, [], []) when
         FStar_Syntax_Syntax.fv_eq_lid fv
@@ -440,8 +434,7 @@ let (e_const :
             FStar_TypeChecker_NBETerm.e_string_list cb ns in
         FStar_Compiler_Util.bind_opt uu___1
           (fun ns1 ->
-             FStar_Compiler_Effect.op_Less_Bar
-               (fun uu___2 -> FStar_Pervasives_Native.Some uu___2)
+             FStar_Pervasives_Native.Some
                (FStar_Reflection_V1_Data.C_Reflect ns1))
     | uu___ ->
         ((let uu___2 =
@@ -564,8 +557,7 @@ let rec e_pattern_aq :
           let uu___1 = FStar_TypeChecker_NBETerm.unembed e_const cb c in
           FStar_Compiler_Util.bind_opt uu___1
             (fun c1 ->
-               FStar_Compiler_Effect.op_Less_Bar
-                 (fun uu___2 -> FStar_Pervasives_Native.Some uu___2)
+               FStar_Pervasives_Native.Some
                  (FStar_Reflection_V1_Data.Pat_Constant c1))
       | FStar_TypeChecker_NBETerm.Construct
           (fv, [], (ps, uu___)::(us_opt, uu___1)::(f, uu___2)::[]) when
@@ -592,8 +584,7 @@ let rec e_pattern_aq :
                       FStar_TypeChecker_NBETerm.unembed uu___6 cb ps in
                     FStar_Compiler_Util.bind_opt uu___5
                       (fun ps1 ->
-                         FStar_Compiler_Effect.op_Less_Bar
-                           (fun uu___6 -> FStar_Pervasives_Native.Some uu___6)
+                         FStar_Pervasives_Native.Some
                            (FStar_Reflection_V1_Data.Pat_Cons (f1, us, ps1)))))
       | FStar_TypeChecker_NBETerm.Construct
           (fv, [], (sort, uu___)::(bv, uu___1)::[]) when
@@ -608,8 +599,7 @@ let rec e_pattern_aq :
                  FStar_TypeChecker_NBETerm.unembed uu___4 cb sort in
                FStar_Compiler_Util.bind_opt uu___3
                  (fun sort1 ->
-                    FStar_Compiler_Effect.op_Less_Bar
-                      (fun uu___4 -> FStar_Pervasives_Native.Some uu___4)
+                    FStar_Pervasives_Native.Some
                       (FStar_Reflection_V1_Data.Pat_Var (bv1, sort1))))
       | FStar_TypeChecker_NBETerm.Construct (fv, [], (eopt, uu___)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
@@ -620,8 +610,7 @@ let rec e_pattern_aq :
             FStar_TypeChecker_NBETerm.unembed uu___2 cb eopt in
           FStar_Compiler_Util.bind_opt uu___1
             (fun eopt1 ->
-               FStar_Compiler_Effect.op_Less_Bar
-                 (fun uu___2 -> FStar_Pervasives_Native.Some uu___2)
+               FStar_Pervasives_Native.Some
                  (FStar_Reflection_V1_Data.Pat_Dot_Term eopt1))
       | uu___ ->
           ((let uu___2 =
@@ -783,11 +772,8 @@ let (e_universe_view :
         let uu___2 = FStar_TypeChecker_NBETerm.unembed e_universe cb u in
         FStar_Compiler_Util.bind_opt uu___2
           (fun u1 ->
-             let uu___3 =
-               FStar_Compiler_Effect.op_Bar_Greater u1
-                 (fun uu___4 -> FStar_Reflection_V1_Data.Uv_Succ uu___4) in
-             FStar_Compiler_Effect.op_Bar_Greater uu___3
-               (fun uu___4 -> FStar_Pervasives_Native.Some uu___4))
+             FStar_Pervasives_Native.Some
+               (FStar_Reflection_V1_Data.Uv_Succ u1))
     | FStar_TypeChecker_NBETerm.Construct (fv, uu___, (us, uu___1)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_V1_Constants.ref_Uv_Max.FStar_Reflection_V1_Constants.lid
@@ -797,11 +783,8 @@ let (e_universe_view :
           FStar_TypeChecker_NBETerm.unembed uu___3 cb us in
         FStar_Compiler_Util.bind_opt uu___2
           (fun us1 ->
-             let uu___3 =
-               FStar_Compiler_Effect.op_Bar_Greater us1
-                 (fun uu___4 -> FStar_Reflection_V1_Data.Uv_Max uu___4) in
-             FStar_Compiler_Effect.op_Bar_Greater uu___3
-               (fun uu___4 -> FStar_Pervasives_Native.Some uu___4))
+             FStar_Pervasives_Native.Some
+               (FStar_Reflection_V1_Data.Uv_Max us1))
     | FStar_TypeChecker_NBETerm.Construct (fv, uu___, (n, uu___1)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_V1_Constants.ref_Uv_BVar.FStar_Reflection_V1_Constants.lid
@@ -811,11 +794,8 @@ let (e_universe_view :
             cb n in
         FStar_Compiler_Util.bind_opt uu___2
           (fun n1 ->
-             let uu___3 =
-               FStar_Compiler_Effect.op_Bar_Greater n1
-                 (fun uu___4 -> FStar_Reflection_V1_Data.Uv_BVar uu___4) in
-             FStar_Compiler_Effect.op_Bar_Greater uu___3
-               (fun uu___4 -> FStar_Pervasives_Native.Some uu___4))
+             FStar_Pervasives_Native.Some
+               (FStar_Reflection_V1_Data.Uv_BVar n1))
     | FStar_TypeChecker_NBETerm.Construct (fv, uu___, (i, uu___1)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_V1_Constants.ref_Uv_Name.FStar_Reflection_V1_Constants.lid
@@ -828,21 +808,14 @@ let (e_universe_view :
           FStar_TypeChecker_NBETerm.unembed uu___3 cb i in
         FStar_Compiler_Util.bind_opt uu___2
           (fun i1 ->
-             let uu___3 =
-               FStar_Compiler_Effect.op_Bar_Greater i1
-                 (fun uu___4 -> FStar_Reflection_V1_Data.Uv_Name uu___4) in
-             FStar_Compiler_Effect.op_Bar_Greater uu___3
-               (fun uu___4 -> FStar_Pervasives_Native.Some uu___4))
+             FStar_Pervasives_Native.Some
+               (FStar_Reflection_V1_Data.Uv_Name i1))
     | FStar_TypeChecker_NBETerm.Construct (fv, uu___, (u, uu___1)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_V1_Constants.ref_Uv_Unif.FStar_Reflection_V1_Constants.lid
         ->
         let u1 = unlazy_as_t FStar_Syntax_Syntax.Lazy_universe_uvar u in
-        let uu___2 =
-          FStar_Compiler_Effect.op_Bar_Greater u1
-            (fun uu___3 -> FStar_Reflection_V1_Data.Uv_Unif uu___3) in
-        FStar_Compiler_Effect.op_Bar_Greater uu___2
-          (fun uu___3 -> FStar_Pervasives_Native.Some uu___3)
+        FStar_Pervasives_Native.Some (FStar_Reflection_V1_Data.Uv_Unif u1)
     | FStar_TypeChecker_NBETerm.Construct (fv, uu___, []) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_V1_Constants.ref_Uv_Unk.FStar_Reflection_V1_Constants.lid
@@ -1172,8 +1145,7 @@ let (e_term_view_aq :
           let uu___2 = FStar_TypeChecker_NBETerm.unembed e_bv cb b in
           FStar_Compiler_Util.bind_opt uu___2
             (fun b1 ->
-               FStar_Compiler_Effect.op_Less_Bar
-                 (fun uu___3 -> FStar_Pervasives_Native.Some uu___3)
+               FStar_Pervasives_Native.Some
                  (FStar_Reflection_V1_Data.Tv_Var b1))
       | FStar_TypeChecker_NBETerm.Construct (fv, uu___, (b, uu___1)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
@@ -1182,8 +1154,7 @@ let (e_term_view_aq :
           let uu___2 = FStar_TypeChecker_NBETerm.unembed e_bv cb b in
           FStar_Compiler_Util.bind_opt uu___2
             (fun b1 ->
-               FStar_Compiler_Effect.op_Less_Bar
-                 (fun uu___3 -> FStar_Pervasives_Native.Some uu___3)
+               FStar_Pervasives_Native.Some
                  (FStar_Reflection_V1_Data.Tv_BVar b1))
       | FStar_TypeChecker_NBETerm.Construct (fv, uu___, (f, uu___1)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
@@ -1192,8 +1163,7 @@ let (e_term_view_aq :
           let uu___2 = FStar_TypeChecker_NBETerm.unembed e_fv cb f in
           FStar_Compiler_Util.bind_opt uu___2
             (fun f1 ->
-               FStar_Compiler_Effect.op_Less_Bar
-                 (fun uu___3 -> FStar_Pervasives_Native.Some uu___3)
+               FStar_Pervasives_Native.Some
                  (FStar_Reflection_V1_Data.Tv_FVar f1))
       | FStar_TypeChecker_NBETerm.Construct
           (fv, uu___, (f, uu___1)::(us, uu___2)::[]) when
@@ -1208,8 +1178,7 @@ let (e_term_view_aq :
                  FStar_TypeChecker_NBETerm.unembed uu___5 cb us in
                FStar_Compiler_Util.bind_opt uu___4
                  (fun us1 ->
-                    FStar_Compiler_Effect.op_Less_Bar
-                      (fun uu___5 -> FStar_Pervasives_Native.Some uu___5)
+                    FStar_Pervasives_Native.Some
                       (FStar_Reflection_V1_Data.Tv_UInst (f1, us1))))
       | FStar_TypeChecker_NBETerm.Construct
           (fv, uu___, (r, uu___1)::(l, uu___2)::[]) when
@@ -1222,8 +1191,7 @@ let (e_term_view_aq :
                let uu___4 = FStar_TypeChecker_NBETerm.unembed e_argv cb r in
                FStar_Compiler_Util.bind_opt uu___4
                  (fun r1 ->
-                    FStar_Compiler_Effect.op_Less_Bar
-                      (fun uu___5 -> FStar_Pervasives_Native.Some uu___5)
+                    FStar_Pervasives_Native.Some
                       (FStar_Reflection_V1_Data.Tv_App (l1, r1))))
       | FStar_TypeChecker_NBETerm.Construct
           (fv, uu___, (t1, uu___1)::(b, uu___2)::[]) when
@@ -1236,8 +1204,7 @@ let (e_term_view_aq :
                let uu___4 = FStar_TypeChecker_NBETerm.unembed e_term cb t1 in
                FStar_Compiler_Util.bind_opt uu___4
                  (fun t2 ->
-                    FStar_Compiler_Effect.op_Less_Bar
-                      (fun uu___5 -> FStar_Pervasives_Native.Some uu___5)
+                    FStar_Pervasives_Native.Some
                       (FStar_Reflection_V1_Data.Tv_Abs (b1, t2))))
       | FStar_TypeChecker_NBETerm.Construct
           (fv, uu___, (t1, uu___1)::(b, uu___2)::[]) when
@@ -1250,8 +1217,7 @@ let (e_term_view_aq :
                let uu___4 = FStar_TypeChecker_NBETerm.unembed e_comp cb t1 in
                FStar_Compiler_Util.bind_opt uu___4
                  (fun c ->
-                    FStar_Compiler_Effect.op_Less_Bar
-                      (fun uu___5 -> FStar_Pervasives_Native.Some uu___5)
+                    FStar_Pervasives_Native.Some
                       (FStar_Reflection_V1_Data.Tv_Arrow (b1, c))))
       | FStar_TypeChecker_NBETerm.Construct (fv, uu___, (u, uu___1)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
@@ -1260,8 +1226,7 @@ let (e_term_view_aq :
           let uu___2 = FStar_TypeChecker_NBETerm.unembed e_universe cb u in
           FStar_Compiler_Util.bind_opt uu___2
             (fun u1 ->
-               FStar_Compiler_Effect.op_Less_Bar
-                 (fun uu___3 -> FStar_Pervasives_Native.Some uu___3)
+               FStar_Pervasives_Native.Some
                  (FStar_Reflection_V1_Data.Tv_Type u1))
       | FStar_TypeChecker_NBETerm.Construct
           (fv, uu___, (t1, uu___1)::(sort, uu___2)::(b, uu___3)::[]) when
@@ -1278,8 +1243,7 @@ let (e_term_view_aq :
                       FStar_TypeChecker_NBETerm.unembed e_term cb t1 in
                     FStar_Compiler_Util.bind_opt uu___6
                       (fun t2 ->
-                         FStar_Compiler_Effect.op_Less_Bar
-                           (fun uu___7 -> FStar_Pervasives_Native.Some uu___7)
+                         FStar_Pervasives_Native.Some
                            (FStar_Reflection_V1_Data.Tv_Refine
                               (b1, sort1, t2)))))
       | FStar_TypeChecker_NBETerm.Construct (fv, uu___, (c, uu___1)::[]) when
@@ -1289,8 +1253,7 @@ let (e_term_view_aq :
           let uu___2 = FStar_TypeChecker_NBETerm.unembed e_const cb c in
           FStar_Compiler_Util.bind_opt uu___2
             (fun c1 ->
-               FStar_Compiler_Effect.op_Less_Bar
-                 (fun uu___3 -> FStar_Pervasives_Native.Some uu___3)
+               FStar_Pervasives_Native.Some
                  (FStar_Reflection_V1_Data.Tv_Const c1))
       | FStar_TypeChecker_NBETerm.Construct
           (fv, uu___, (l, uu___1)::(u, uu___2)::[]) when
@@ -1303,8 +1266,7 @@ let (e_term_view_aq :
           FStar_Compiler_Util.bind_opt uu___3
             (fun u1 ->
                let ctx_u_s = unlazy_as_t FStar_Syntax_Syntax.Lazy_uvar l in
-               FStar_Compiler_Effect.op_Less_Bar
-                 (fun uu___4 -> FStar_Pervasives_Native.Some uu___4)
+               FStar_Pervasives_Native.Some
                  (FStar_Reflection_V1_Data.Tv_Uvar (u1, ctx_u_s)))
       | FStar_TypeChecker_NBETerm.Construct
           (fv, uu___,
@@ -1342,10 +1304,7 @@ let (e_term_view_aq :
                                        cb t2 in
                                    FStar_Compiler_Util.bind_opt uu___12
                                      (fun t21 ->
-                                        FStar_Compiler_Effect.op_Less_Bar
-                                          (fun uu___13 ->
-                                             FStar_Pervasives_Native.Some
-                                               uu___13)
+                                        FStar_Pervasives_Native.Some
                                           (FStar_Reflection_V1_Data.Tv_Let
                                              (r1, attrs1, b1, ty1, t11, t21))))))))
       | FStar_TypeChecker_NBETerm.Construct
@@ -1367,8 +1326,7 @@ let (e_term_view_aq :
                         e_match_returns_annotation cb ret_opt in
                     FStar_Compiler_Util.bind_opt uu___6
                       (fun ret_opt1 ->
-                         FStar_Compiler_Effect.op_Less_Bar
-                           (fun uu___7 -> FStar_Pervasives_Native.Some uu___7)
+                         FStar_Pervasives_Native.Some
                            (FStar_Reflection_V1_Data.Tv_Match
                               (t2, ret_opt1, brs1)))))
       | FStar_TypeChecker_NBETerm.Construct
@@ -1394,9 +1352,7 @@ let (e_term_view_aq :
                              FStar_TypeChecker_NBETerm.e_bool cb use_eq in
                          FStar_Compiler_Util.bind_opt uu___8
                            (fun use_eq1 ->
-                              FStar_Compiler_Effect.op_Less_Bar
-                                (fun uu___9 ->
-                                   FStar_Pervasives_Native.Some uu___9)
+                              FStar_Pervasives_Native.Some
                                 (FStar_Reflection_V1_Data.Tv_AscribedT
                                    (e1, t2, tacopt1, use_eq1))))))
       | FStar_TypeChecker_NBETerm.Construct
@@ -1422,25 +1378,17 @@ let (e_term_view_aq :
                              FStar_TypeChecker_NBETerm.e_bool cb use_eq in
                          FStar_Compiler_Util.bind_opt uu___8
                            (fun use_eq1 ->
-                              FStar_Compiler_Effect.op_Less_Bar
-                                (fun uu___9 ->
-                                   FStar_Pervasives_Native.Some uu___9)
+                              FStar_Pervasives_Native.Some
                                 (FStar_Reflection_V1_Data.Tv_AscribedC
                                    (e1, c1, tacopt1, use_eq1))))))
       | FStar_TypeChecker_NBETerm.Construct (fv, uu___, []) when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_V1_Constants.ref_Tv_Unknown.FStar_Reflection_V1_Constants.lid
-          ->
-          FStar_Compiler_Effect.op_Less_Bar
-            (fun uu___1 -> FStar_Pervasives_Native.Some uu___1)
-            FStar_Reflection_V1_Data.Tv_Unknown
+          -> FStar_Pervasives_Native.Some FStar_Reflection_V1_Data.Tv_Unknown
       | FStar_TypeChecker_NBETerm.Construct (fv, uu___, []) when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_V1_Constants.ref_Tv_Unsupp.FStar_Reflection_V1_Constants.lid
-          ->
-          FStar_Compiler_Effect.op_Less_Bar
-            (fun uu___1 -> FStar_Pervasives_Native.Some uu___1)
-            FStar_Reflection_V1_Data.Tv_Unsupp
+          -> FStar_Pervasives_Native.Some FStar_Reflection_V1_Data.Tv_Unsupp
       | uu___ ->
           ((let uu___2 =
               let uu___3 =
@@ -1498,8 +1446,7 @@ let (e_bv_view :
                  FStar_TypeChecker_NBETerm.e_int cb idx in
              FStar_Compiler_Util.bind_opt uu___4
                (fun idx1 ->
-                  FStar_Compiler_Effect.op_Less_Bar
-                    (fun uu___5 -> FStar_Pervasives_Native.Some uu___5)
+                  FStar_Pervasives_Native.Some
                     {
                       FStar_Reflection_V1_Data.bv_ppname = nm1;
                       FStar_Reflection_V1_Data.bv_index = idx1
@@ -1578,9 +1525,7 @@ let (e_binder_view :
                          FStar_TypeChecker_NBETerm.unembed e_term cb sort in
                        FStar_Compiler_Util.bind_opt uu___8
                          (fun sort1 ->
-                            FStar_Compiler_Effect.op_Less_Bar
-                              (fun uu___9 ->
-                                 FStar_Pervasives_Native.Some uu___9)
+                            FStar_Pervasives_Native.Some
                               {
                                 FStar_Reflection_V1_Data.binder_bv = bv1;
                                 FStar_Reflection_V1_Data.binder_qual = q1;
@@ -1686,8 +1631,7 @@ let (e_comp_view :
         let uu___2 = FStar_TypeChecker_NBETerm.unembed e_term cb t1 in
         FStar_Compiler_Util.bind_opt uu___2
           (fun t2 ->
-             FStar_Compiler_Effect.op_Less_Bar
-               (fun uu___3 -> FStar_Pervasives_Native.Some uu___3)
+             FStar_Pervasives_Native.Some
                (FStar_Reflection_V1_Data.C_Total t2))
     | FStar_TypeChecker_NBETerm.Construct (fv, uu___, (t1, uu___1)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
@@ -1696,8 +1640,7 @@ let (e_comp_view :
         let uu___2 = FStar_TypeChecker_NBETerm.unembed e_term cb t1 in
         FStar_Compiler_Util.bind_opt uu___2
           (fun t2 ->
-             FStar_Compiler_Effect.op_Less_Bar
-               (fun uu___3 -> FStar_Pervasives_Native.Some uu___3)
+             FStar_Pervasives_Native.Some
                (FStar_Reflection_V1_Data.C_GTotal t2))
     | FStar_TypeChecker_NBETerm.Construct
         (fv, uu___, (post, uu___1)::(pre, uu___2)::(pats, uu___3)::[]) when
@@ -1714,8 +1657,7 @@ let (e_comp_view :
                     FStar_TypeChecker_NBETerm.unembed e_term cb pats in
                   FStar_Compiler_Util.bind_opt uu___6
                     (fun pats1 ->
-                       FStar_Compiler_Effect.op_Less_Bar
-                         (fun uu___7 -> FStar_Pervasives_Native.Some uu___7)
+                       FStar_Pervasives_Native.Some
                          (FStar_Reflection_V1_Data.C_Lemma
                             (pre1, post1, pats1)))))
     | FStar_TypeChecker_NBETerm.Construct
@@ -1753,9 +1695,7 @@ let (e_comp_view :
                                 decrs in
                             FStar_Compiler_Util.bind_opt uu___10
                               (fun decrs1 ->
-                                 FStar_Compiler_Effect.op_Less_Bar
-                                   (fun uu___11 ->
-                                      FStar_Pervasives_Native.Some uu___11)
+                                 FStar_Pervasives_Native.Some
                                    (FStar_Reflection_V1_Data.C_Eff
                                       (us1, eff1, res1, args1, decrs1)))))))
     | uu___ ->
@@ -1903,9 +1843,7 @@ let (e_lb_view :
                          FStar_TypeChecker_NBETerm.unembed e_term cb def in
                        FStar_Compiler_Util.bind_opt uu___8
                          (fun def1 ->
-                            FStar_Compiler_Effect.op_Less_Bar
-                              (fun uu___9 ->
-                                 FStar_Pervasives_Native.Some uu___9)
+                            FStar_Pervasives_Native.Some
                               {
                                 FStar_Reflection_V1_Data.lb_fv = fv'1;
                                 FStar_Reflection_V1_Data.lb_us = us1;
@@ -2075,9 +2013,7 @@ let (e_sigelt_view :
                                 dcs in
                             FStar_Compiler_Util.bind_opt uu___10
                               (fun dcs1 ->
-                                 FStar_Compiler_Effect.op_Less_Bar
-                                   (fun uu___11 ->
-                                      FStar_Pervasives_Native.Some uu___11)
+                                 FStar_Pervasives_Native.Some
                                    (FStar_Reflection_V1_Data.Sg_Inductive
                                       (nm1, us1, bs1, t2, dcs1)))))))
     | FStar_TypeChecker_NBETerm.Construct
@@ -2095,8 +2031,7 @@ let (e_sigelt_view :
                FStar_TypeChecker_NBETerm.unembed uu___5 cb lbs in
              FStar_Compiler_Util.bind_opt uu___4
                (fun lbs1 ->
-                  FStar_Compiler_Effect.op_Less_Bar
-                    (fun uu___5 -> FStar_Pervasives_Native.Some uu___5)
+                  FStar_Pervasives_Native.Some
                     (FStar_Reflection_V1_Data.Sg_Let (r1, lbs1))))
     | FStar_TypeChecker_NBETerm.Construct
         (fv, uu___, (t1, uu___1)::(us, uu___2)::(nm, uu___3)::[]) when
@@ -2113,8 +2048,7 @@ let (e_sigelt_view :
                   let uu___6 = FStar_TypeChecker_NBETerm.unembed e_term cb t1 in
                   FStar_Compiler_Util.bind_opt uu___6
                     (fun t2 ->
-                       FStar_Compiler_Effect.op_Less_Bar
-                         (fun uu___7 -> FStar_Pervasives_Native.Some uu___7)
+                       FStar_Pervasives_Native.Some
                          (FStar_Reflection_V1_Data.Sg_Val (nm1, us1, t2)))))
     | FStar_TypeChecker_NBETerm.Construct (fv, uu___, []) when
         FStar_Syntax_Syntax.fv_eq_lid fv

--- a/ocaml/fstar-lib/generated/FStar_Reflection_V2_Builtins.ml
+++ b/ocaml/fstar-lib/generated/FStar_Reflection_V2_Builtins.ml
@@ -172,9 +172,7 @@ let rec (inspect_pat :
 let rec (inspect_ln :
   FStar_Syntax_Syntax.term -> FStar_Reflection_V2_Data.term_view) =
   fun t ->
-    let t1 =
-      FStar_Compiler_Effect.op_Bar_Greater t
-        FStar_Syntax_Subst.compress_subst in
+    let t1 = FStar_Syntax_Subst.compress_subst t in
     match t1.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_meta
         { FStar_Syntax_Syntax.tm2 = t2; FStar_Syntax_Syntax.meta = uu___;_}
@@ -296,10 +294,7 @@ let rec (inspect_ln :
         FStar_Reflection_V2_Data.Tv_Match (t2, ret_opt, brs1)
     | FStar_Syntax_Syntax.Tm_unknown -> FStar_Reflection_V2_Data.Tv_Unknown
     | FStar_Syntax_Syntax.Tm_lazy i ->
-        let uu___ =
-          FStar_Compiler_Effect.op_Bar_Greater i
-            FStar_Syntax_Util.unfold_lazy in
-        FStar_Compiler_Effect.op_Bar_Greater uu___ inspect_ln
+        let uu___ = FStar_Syntax_Util.unfold_lazy i in inspect_ln uu___
     | uu___ ->
         ((let uu___2 =
             let uu___3 =
@@ -346,9 +341,7 @@ let (inspect_comp :
             (FStar_Compiler_List.length ct.FStar_Syntax_Syntax.comp_univs) =
               Prims.int_zero
           then FStar_Syntax_Syntax.U_unknown
-          else
-            FStar_Compiler_Effect.op_Bar_Greater
-              ct.FStar_Syntax_Syntax.comp_univs FStar_Compiler_List.hd in
+          else FStar_Compiler_List.hd ct.FStar_Syntax_Syntax.comp_univs in
         let uu___ =
           FStar_Ident.lid_equals ct.FStar_Syntax_Syntax.effect_name
             FStar_Parser_Const.effect_Lemma_lid in
@@ -461,7 +454,7 @@ let rec (pack_pat :
         let uu___ =
           let uu___1 = pack_const c in
           FStar_Syntax_Syntax.Pat_constant uu___1 in
-        FStar_Compiler_Effect.op_Less_Bar wrap uu___
+        wrap uu___
     | FStar_Reflection_V2_Data.Pat_Cons (head, univs, subpats) ->
         let uu___ =
           let uu___1 =
@@ -473,15 +466,13 @@ let rec (pack_pat :
                 subpats in
             (head, univs, uu___2) in
           FStar_Syntax_Syntax.Pat_cons uu___1 in
-        FStar_Compiler_Effect.op_Less_Bar wrap uu___
+        wrap uu___
     | FStar_Reflection_V2_Data.Pat_Var (sort, ppname) ->
         let bv =
           FStar_Syntax_Syntax.gen_bv ppname FStar_Pervasives_Native.None sort in
-        FStar_Compiler_Effect.op_Less_Bar wrap
-          (FStar_Syntax_Syntax.Pat_var bv)
+        wrap (FStar_Syntax_Syntax.Pat_var bv)
     | FStar_Reflection_V2_Data.Pat_Dot_Term eopt ->
-        FStar_Compiler_Effect.op_Less_Bar wrap
-          (FStar_Syntax_Syntax.Pat_dot_term eopt)
+        wrap (FStar_Syntax_Syntax.Pat_dot_term eopt)
 let (pack_ln :
   FStar_Reflection_V2_Data.term_view -> FStar_Syntax_Syntax.term) =
   fun tv ->
@@ -653,10 +644,8 @@ let (defs_in_module :
         (fun l ->
            let ns =
              let uu___1 =
-               let uu___2 = FStar_Ident.ids_of_lid l in
-               FStar_Compiler_Effect.op_Bar_Greater uu___2 init in
-             FStar_Compiler_Effect.op_Bar_Greater uu___1
-               (FStar_Compiler_List.map FStar_Ident.string_of_id) in
+               let uu___2 = FStar_Ident.ids_of_lid l in init uu___2 in
+             FStar_Compiler_List.map FStar_Ident.string_of_id uu___1 in
            if ns = modul
            then
              let uu___1 =
@@ -777,8 +766,7 @@ let (sigelt_quals :
   FStar_Syntax_Syntax.sigelt -> FStar_Reflection_V2_Data.qualifier Prims.list)
   =
   fun se ->
-    FStar_Compiler_Effect.op_Bar_Greater se.FStar_Syntax_Syntax.sigquals
-      (FStar_Compiler_List.map syntax_to_rd_qual)
+    FStar_Compiler_List.map syntax_to_rd_qual se.FStar_Syntax_Syntax.sigquals
 let (set_sigelt_quals :
   FStar_Reflection_V2_Data.qualifier Prims.list ->
     FStar_Syntax_Syntax.sigelt -> FStar_Syntax_Syntax.sigelt)
@@ -898,7 +886,7 @@ let (pack_sigelt :
         let packed = FStar_Compiler_List.map pack_letbinding lbs in
         let lbs1 = FStar_Compiler_List.map FStar_Pervasives_Native.snd packed in
         let lids = FStar_Compiler_List.map FStar_Pervasives_Native.fst packed in
-        FStar_Compiler_Effect.op_Less_Bar FStar_Syntax_Syntax.mk_sigelt
+        FStar_Syntax_Syntax.mk_sigelt
           (FStar_Syntax_Syntax.Sig_let
              {
                FStar_Syntax_Syntax.lbs1 = (r, lbs1);
@@ -917,8 +905,7 @@ let (pack_sigelt :
                 let lid =
                   FStar_Ident.lid_of_path nm1
                     FStar_Compiler_Range_Type.dummyRange in
-                FStar_Compiler_Effect.op_Less_Bar
-                  FStar_Syntax_Syntax.mk_sigelt
+                FStar_Syntax_Syntax.mk_sigelt
                   (FStar_Syntax_Syntax.Sig_datacon
                      {
                        FStar_Syntax_Syntax.lid1 = lid;
@@ -935,7 +922,7 @@ let (pack_sigelt :
                  let uu___1 = FStar_Syntax_Util.lid_of_sigelt se in
                  FStar_Compiler_Util.must uu___1) ctor_ses in
           let ind_se =
-            FStar_Compiler_Effect.op_Less_Bar FStar_Syntax_Syntax.mk_sigelt
+            FStar_Syntax_Syntax.mk_sigelt
               (FStar_Syntax_Syntax.Sig_inductive_typ
                  {
                    FStar_Syntax_Syntax.lid = ind_lid;
@@ -948,7 +935,7 @@ let (pack_sigelt :
                    FStar_Syntax_Syntax.ds = c_lids
                  }) in
           let se =
-            FStar_Compiler_Effect.op_Less_Bar FStar_Syntax_Syntax.mk_sigelt
+            FStar_Syntax_Syntax.mk_sigelt
               (FStar_Syntax_Syntax.Sig_bundle
                  {
                    FStar_Syntax_Syntax.ses = (ind_se :: ctor_ses);
@@ -969,7 +956,7 @@ let (pack_sigelt :
         let val_lid =
           FStar_Ident.lid_of_path nm FStar_Compiler_Range_Type.dummyRange in
         (check_lid val_lid;
-         FStar_Compiler_Effect.op_Less_Bar FStar_Syntax_Syntax.mk_sigelt
+         FStar_Syntax_Syntax.mk_sigelt
            (FStar_Syntax_Syntax.Sig_declare_typ
               {
                 FStar_Syntax_Syntax.lid2 = val_lid;
@@ -1187,9 +1174,8 @@ let (vars_of_env :
   FStar_TypeChecker_Env.env -> FStar_Reflection_V2_Data.binding Prims.list) =
   fun e ->
     let uu___ = FStar_TypeChecker_Env.all_binders e in
-    FStar_Compiler_Effect.op_Bar_Greater uu___
-      (FStar_Compiler_List.map
-         (fun b -> bv_to_binding b.FStar_Syntax_Syntax.binder_bv))
+    FStar_Compiler_List.map
+      (fun b -> bv_to_binding b.FStar_Syntax_Syntax.binder_bv) uu___
 let eqopt :
   'uuuuu .
     unit ->

--- a/ocaml/fstar-lib/generated/FStar_Reflection_V2_Embeddings.ml
+++ b/ocaml/fstar-lib/generated/FStar_Reflection_V2_Embeddings.ml
@@ -157,24 +157,21 @@ let (e_term_aq :
               (fun aq_ts ->
                  let uu___2 =
                    let uu___3 =
-                     FStar_Compiler_Effect.op_Bar_Greater aq_ts
-                       (FStar_Compiler_List.mapi
-                          (fun i ->
-                             fun at ->
-                               let x =
-                                 FStar_Syntax_Syntax.new_bv
-                                   FStar_Pervasives_Native.None
-                                   FStar_Syntax_Syntax.t_term in
-                               ((FStar_Syntax_Syntax.DB ((shift + i), x)),
-                                 (FStar_Syntax_Syntax.NT (x, at))))) in
-                   FStar_Compiler_Effect.op_Bar_Greater uu___3
-                     FStar_Compiler_List.unzip in
+                     FStar_Compiler_List.mapi
+                       (fun i ->
+                          fun at ->
+                            let x =
+                              FStar_Syntax_Syntax.new_bv
+                                FStar_Pervasives_Native.None
+                                FStar_Syntax_Syntax.t_term in
+                            ((FStar_Syntax_Syntax.DB ((shift + i), x)),
+                              (FStar_Syntax_Syntax.NT (x, at)))) aq_ts in
+                   FStar_Compiler_List.unzip uu___3 in
                  match uu___2 with
                  | (subst_open, subst) ->
                      let uu___3 =
                        let uu___4 = FStar_Syntax_Subst.subst subst_open t1 in
-                       FStar_Compiler_Effect.op_Less_Bar
-                         (FStar_Syntax_Subst.subst subst) uu___4 in
+                       FStar_Syntax_Subst.subst subst uu___4 in
                      FStar_Pervasives_Native.Some uu___3) in
       let t1 = FStar_Syntax_Util.unmeta t in
       let uu___ =

--- a/ocaml/fstar-lib/generated/FStar_Reflection_V2_NBEEmbeddings.ml
+++ b/ocaml/fstar-lib/generated/FStar_Reflection_V2_NBEEmbeddings.ml
@@ -88,8 +88,7 @@ let (e_bv : FStar_Syntax_Syntax.bv FStar_TypeChecker_NBETerm.embedding) =
          uu___2)
         ->
         let uu___3 = FStar_Compiler_Dyn.undyn b in
-        FStar_Compiler_Effect.op_Less_Bar
-          (fun uu___4 -> FStar_Pervasives_Native.Some uu___4) uu___3
+        FStar_Pervasives_Native.Some uu___3
     | uu___ ->
         ((let uu___2 =
             let uu___3 =
@@ -115,8 +114,7 @@ let (e_namedv :
          uu___2)
         ->
         let uu___3 = FStar_Compiler_Dyn.undyn b in
-        FStar_Compiler_Effect.op_Less_Bar
-          (fun uu___4 -> FStar_Pervasives_Native.Some uu___4) uu___3
+        FStar_Pervasives_Native.Some uu___3
     | uu___ ->
         ((let uu___2 =
             let uu___3 =
@@ -359,8 +357,7 @@ let (e_vconst :
         let uu___ =
           let uu___1 =
             let uu___2 =
-              FStar_Compiler_Effect.op_Less_Bar
-                FStar_TypeChecker_NBETerm.mk_t
+              FStar_TypeChecker_NBETerm.mk_t
                 (FStar_TypeChecker_NBETerm.Constant
                    (FStar_TypeChecker_NBETerm.Int i)) in
             FStar_TypeChecker_NBETerm.as_arg uu___2 in
@@ -428,9 +425,7 @@ let (e_vconst :
             cb i in
         FStar_Compiler_Util.bind_opt uu___1
           (fun i1 ->
-             FStar_Compiler_Effect.op_Less_Bar
-               (fun uu___2 -> FStar_Pervasives_Native.Some uu___2)
-               (FStar_Reflection_V2_Data.C_Int i1))
+             FStar_Pervasives_Native.Some (FStar_Reflection_V2_Data.C_Int i1))
     | FStar_TypeChecker_NBETerm.Construct (fv, [], (s, uu___)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_V2_Constants.ref_C_String.FStar_Reflection_V2_Constants.lid
@@ -440,8 +435,7 @@ let (e_vconst :
             FStar_TypeChecker_NBETerm.e_string cb s in
         FStar_Compiler_Util.bind_opt uu___1
           (fun s1 ->
-             FStar_Compiler_Effect.op_Less_Bar
-               (fun uu___2 -> FStar_Pervasives_Native.Some uu___2)
+             FStar_Pervasives_Native.Some
                (FStar_Reflection_V2_Data.C_String s1))
     | FStar_TypeChecker_NBETerm.Construct (fv, [], (r, uu___)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
@@ -452,8 +446,7 @@ let (e_vconst :
             cb r in
         FStar_Compiler_Util.bind_opt uu___1
           (fun r1 ->
-             FStar_Compiler_Effect.op_Less_Bar
-               (fun uu___2 -> FStar_Pervasives_Native.Some uu___2)
+             FStar_Pervasives_Native.Some
                (FStar_Reflection_V2_Data.C_Range r1))
     | FStar_TypeChecker_NBETerm.Construct (fv, [], []) when
         FStar_Syntax_Syntax.fv_eq_lid fv
@@ -468,8 +461,7 @@ let (e_vconst :
             FStar_TypeChecker_NBETerm.e_string_list cb ns in
         FStar_Compiler_Util.bind_opt uu___1
           (fun ns1 ->
-             FStar_Compiler_Effect.op_Less_Bar
-               (fun uu___2 -> FStar_Pervasives_Native.Some uu___2)
+             FStar_Pervasives_Native.Some
                (FStar_Reflection_V2_Data.C_Reflect ns1))
     | uu___ ->
         ((let uu___2 =
@@ -596,8 +588,7 @@ let rec e_pattern_aq :
           let uu___1 = FStar_TypeChecker_NBETerm.unembed e_vconst cb c in
           FStar_Compiler_Util.bind_opt uu___1
             (fun c1 ->
-               FStar_Compiler_Effect.op_Less_Bar
-                 (fun uu___2 -> FStar_Pervasives_Native.Some uu___2)
+               FStar_Pervasives_Native.Some
                  (FStar_Reflection_V2_Data.Pat_Constant c1))
       | FStar_TypeChecker_NBETerm.Construct
           (fv, [], (ps, uu___)::(us_opt, uu___1)::(f, uu___2)::[]) when
@@ -624,8 +615,7 @@ let rec e_pattern_aq :
                       FStar_TypeChecker_NBETerm.unembed uu___6 cb ps in
                     FStar_Compiler_Util.bind_opt uu___5
                       (fun ps1 ->
-                         FStar_Compiler_Effect.op_Less_Bar
-                           (fun uu___6 -> FStar_Pervasives_Native.Some uu___6)
+                         FStar_Pervasives_Native.Some
                            (FStar_Reflection_V2_Data.Pat_Cons (f1, us, ps1)))))
       | FStar_TypeChecker_NBETerm.Construct
           (fv, [], (ppname, uu___)::(sort, uu___1)::[]) when
@@ -644,8 +634,7 @@ let rec e_pattern_aq :
                  FStar_TypeChecker_NBETerm.unembed uu___4 cb ppname in
                FStar_Compiler_Util.bind_opt uu___3
                  (fun ppname1 ->
-                    FStar_Compiler_Effect.op_Less_Bar
-                      (fun uu___4 -> FStar_Pervasives_Native.Some uu___4)
+                    FStar_Pervasives_Native.Some
                       (FStar_Reflection_V2_Data.Pat_Var (sort1, ppname1))))
       | FStar_TypeChecker_NBETerm.Construct (fv, [], (eopt, uu___)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
@@ -656,8 +645,7 @@ let rec e_pattern_aq :
             FStar_TypeChecker_NBETerm.unembed uu___2 cb eopt in
           FStar_Compiler_Util.bind_opt uu___1
             (fun eopt1 ->
-               FStar_Compiler_Effect.op_Less_Bar
-                 (fun uu___2 -> FStar_Pervasives_Native.Some uu___2)
+               FStar_Pervasives_Native.Some
                  (FStar_Reflection_V2_Data.Pat_Dot_Term eopt1))
       | uu___ ->
           ((let uu___2 =
@@ -843,11 +831,8 @@ let (e_universe_view :
         let uu___2 = FStar_TypeChecker_NBETerm.unembed e_universe cb u in
         FStar_Compiler_Util.bind_opt uu___2
           (fun u1 ->
-             let uu___3 =
-               FStar_Compiler_Effect.op_Bar_Greater u1
-                 (fun uu___4 -> FStar_Reflection_V2_Data.Uv_Succ uu___4) in
-             FStar_Compiler_Effect.op_Bar_Greater uu___3
-               (fun uu___4 -> FStar_Pervasives_Native.Some uu___4))
+             FStar_Pervasives_Native.Some
+               (FStar_Reflection_V2_Data.Uv_Succ u1))
     | FStar_TypeChecker_NBETerm.Construct (fv, uu___, (us, uu___1)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_V2_Constants.ref_Uv_Max.FStar_Reflection_V2_Constants.lid
@@ -857,11 +842,8 @@ let (e_universe_view :
           FStar_TypeChecker_NBETerm.unembed uu___3 cb us in
         FStar_Compiler_Util.bind_opt uu___2
           (fun us1 ->
-             let uu___3 =
-               FStar_Compiler_Effect.op_Bar_Greater us1
-                 (fun uu___4 -> FStar_Reflection_V2_Data.Uv_Max uu___4) in
-             FStar_Compiler_Effect.op_Bar_Greater uu___3
-               (fun uu___4 -> FStar_Pervasives_Native.Some uu___4))
+             FStar_Pervasives_Native.Some
+               (FStar_Reflection_V2_Data.Uv_Max us1))
     | FStar_TypeChecker_NBETerm.Construct (fv, uu___, (n, uu___1)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_V2_Constants.ref_Uv_BVar.FStar_Reflection_V2_Constants.lid
@@ -871,11 +853,8 @@ let (e_universe_view :
             cb n in
         FStar_Compiler_Util.bind_opt uu___2
           (fun n1 ->
-             let uu___3 =
-               FStar_Compiler_Effect.op_Bar_Greater n1
-                 (fun uu___4 -> FStar_Reflection_V2_Data.Uv_BVar uu___4) in
-             FStar_Compiler_Effect.op_Bar_Greater uu___3
-               (fun uu___4 -> FStar_Pervasives_Native.Some uu___4))
+             FStar_Pervasives_Native.Some
+               (FStar_Reflection_V2_Data.Uv_BVar n1))
     | FStar_TypeChecker_NBETerm.Construct (fv, uu___, (i, uu___1)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_V2_Constants.ref_Uv_Name.FStar_Reflection_V2_Constants.lid
@@ -883,21 +862,14 @@ let (e_universe_view :
         let uu___2 = FStar_TypeChecker_NBETerm.unembed e_ident cb i in
         FStar_Compiler_Util.bind_opt uu___2
           (fun i1 ->
-             let uu___3 =
-               FStar_Compiler_Effect.op_Bar_Greater i1
-                 (fun uu___4 -> FStar_Reflection_V2_Data.Uv_Name uu___4) in
-             FStar_Compiler_Effect.op_Bar_Greater uu___3
-               (fun uu___4 -> FStar_Pervasives_Native.Some uu___4))
+             FStar_Pervasives_Native.Some
+               (FStar_Reflection_V2_Data.Uv_Name i1))
     | FStar_TypeChecker_NBETerm.Construct (fv, uu___, (u, uu___1)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_V2_Constants.ref_Uv_Unif.FStar_Reflection_V2_Constants.lid
         ->
         let u1 = unlazy_as_t FStar_Syntax_Syntax.Lazy_universe_uvar u in
-        let uu___2 =
-          FStar_Compiler_Effect.op_Bar_Greater u1
-            (fun uu___3 -> FStar_Reflection_V2_Data.Uv_Unif uu___3) in
-        FStar_Compiler_Effect.op_Bar_Greater uu___2
-          (fun uu___3 -> FStar_Pervasives_Native.Some uu___3)
+        FStar_Pervasives_Native.Some (FStar_Reflection_V2_Data.Uv_Unif u1)
     | FStar_TypeChecker_NBETerm.Construct (fv, uu___, []) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Reflection_V2_Constants.ref_Uv_Unk.FStar_Reflection_V2_Constants.lid
@@ -1018,9 +990,7 @@ let (e_subst_elt :
                     let uu___5 =
                       let uu___6 = FStar_BigInt.to_int_fs i1 in (uu___6, x1) in
                     FStar_Syntax_Syntax.DB uu___5 in
-                  FStar_Compiler_Effect.op_Less_Bar
-                    (fun uu___5 -> FStar_Pervasives_Native.Some uu___5)
-                    uu___4))
+                  FStar_Pervasives_Native.Some uu___4))
     | FStar_TypeChecker_NBETerm.Construct
         (fv, [], (i, uu___)::(x, uu___1)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
@@ -1038,9 +1008,7 @@ let (e_subst_elt :
                     let uu___5 =
                       let uu___6 = FStar_BigInt.to_int_fs i1 in (x1, uu___6) in
                     FStar_Syntax_Syntax.NM uu___5 in
-                  FStar_Compiler_Effect.op_Less_Bar
-                    (fun uu___5 -> FStar_Pervasives_Native.Some uu___5)
-                    uu___4))
+                  FStar_Pervasives_Native.Some uu___4))
     | FStar_TypeChecker_NBETerm.Construct
         (fv, [], (t1, uu___)::(x, uu___1)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
@@ -1052,8 +1020,7 @@ let (e_subst_elt :
              let uu___3 = FStar_TypeChecker_NBETerm.unembed e_term cb t1 in
              FStar_Compiler_Util.bind_opt uu___3
                (fun t2 ->
-                  FStar_Compiler_Effect.op_Less_Bar
-                    (fun uu___4 -> FStar_Pervasives_Native.Some uu___4)
+                  FStar_Pervasives_Native.Some
                     (FStar_Syntax_Syntax.NT (x1, t2))))
     | FStar_TypeChecker_NBETerm.Construct
         (fv, [], (u, uu___)::(i, uu___1)::[]) when
@@ -1072,9 +1039,7 @@ let (e_subst_elt :
                     let uu___5 =
                       let uu___6 = FStar_BigInt.to_int_fs i1 in (uu___6, u1) in
                     FStar_Syntax_Syntax.UN uu___5 in
-                  FStar_Compiler_Effect.op_Less_Bar
-                    (fun uu___5 -> FStar_Pervasives_Native.Some uu___5)
-                    uu___4))
+                  FStar_Pervasives_Native.Some uu___4))
     | FStar_TypeChecker_NBETerm.Construct
         (fv, [], (i, uu___)::(n, uu___1)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
@@ -1092,9 +1057,7 @@ let (e_subst_elt :
                     let uu___5 =
                       let uu___6 = FStar_BigInt.to_int_fs i1 in (n1, uu___6) in
                     FStar_Syntax_Syntax.UD uu___5 in
-                  FStar_Compiler_Effect.op_Less_Bar
-                    (fun uu___5 -> FStar_Pervasives_Native.Some uu___5)
-                    uu___4))
+                  FStar_Pervasives_Native.Some uu___4))
     | uu___ ->
         ((let uu___2 =
             let uu___3 =
@@ -1409,8 +1372,7 @@ let (e_term_view_aq :
           let uu___2 = FStar_TypeChecker_NBETerm.unembed e_bv cb b in
           FStar_Compiler_Util.bind_opt uu___2
             (fun b1 ->
-               FStar_Compiler_Effect.op_Less_Bar
-                 (fun uu___3 -> FStar_Pervasives_Native.Some uu___3)
+               FStar_Pervasives_Native.Some
                  (FStar_Reflection_V2_Data.Tv_Var b1))
       | FStar_TypeChecker_NBETerm.Construct (fv, uu___, (b, uu___1)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
@@ -1419,8 +1381,7 @@ let (e_term_view_aq :
           let uu___2 = FStar_TypeChecker_NBETerm.unembed e_bv cb b in
           FStar_Compiler_Util.bind_opt uu___2
             (fun b1 ->
-               FStar_Compiler_Effect.op_Less_Bar
-                 (fun uu___3 -> FStar_Pervasives_Native.Some uu___3)
+               FStar_Pervasives_Native.Some
                  (FStar_Reflection_V2_Data.Tv_BVar b1))
       | FStar_TypeChecker_NBETerm.Construct (fv, uu___, (f, uu___1)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
@@ -1429,8 +1390,7 @@ let (e_term_view_aq :
           let uu___2 = FStar_TypeChecker_NBETerm.unembed e_fv cb f in
           FStar_Compiler_Util.bind_opt uu___2
             (fun f1 ->
-               FStar_Compiler_Effect.op_Less_Bar
-                 (fun uu___3 -> FStar_Pervasives_Native.Some uu___3)
+               FStar_Pervasives_Native.Some
                  (FStar_Reflection_V2_Data.Tv_FVar f1))
       | FStar_TypeChecker_NBETerm.Construct
           (fv, uu___, (f, uu___1)::(us, uu___2)::[]) when
@@ -1445,8 +1405,7 @@ let (e_term_view_aq :
                  FStar_TypeChecker_NBETerm.unembed uu___5 cb us in
                FStar_Compiler_Util.bind_opt uu___4
                  (fun us1 ->
-                    FStar_Compiler_Effect.op_Less_Bar
-                      (fun uu___5 -> FStar_Pervasives_Native.Some uu___5)
+                    FStar_Pervasives_Native.Some
                       (FStar_Reflection_V2_Data.Tv_UInst (f1, us1))))
       | FStar_TypeChecker_NBETerm.Construct
           (fv, uu___, (r, uu___1)::(l, uu___2)::[]) when
@@ -1459,8 +1418,7 @@ let (e_term_view_aq :
                let uu___4 = FStar_TypeChecker_NBETerm.unembed e_argv cb r in
                FStar_Compiler_Util.bind_opt uu___4
                  (fun r1 ->
-                    FStar_Compiler_Effect.op_Less_Bar
-                      (fun uu___5 -> FStar_Pervasives_Native.Some uu___5)
+                    FStar_Pervasives_Native.Some
                       (FStar_Reflection_V2_Data.Tv_App (l1, r1))))
       | FStar_TypeChecker_NBETerm.Construct
           (fv, uu___, (t1, uu___1)::(b, uu___2)::[]) when
@@ -1473,8 +1431,7 @@ let (e_term_view_aq :
                let uu___4 = FStar_TypeChecker_NBETerm.unembed e_term cb t1 in
                FStar_Compiler_Util.bind_opt uu___4
                  (fun t2 ->
-                    FStar_Compiler_Effect.op_Less_Bar
-                      (fun uu___5 -> FStar_Pervasives_Native.Some uu___5)
+                    FStar_Pervasives_Native.Some
                       (FStar_Reflection_V2_Data.Tv_Abs (b1, t2))))
       | FStar_TypeChecker_NBETerm.Construct
           (fv, uu___, (t1, uu___1)::(b, uu___2)::[]) when
@@ -1487,8 +1444,7 @@ let (e_term_view_aq :
                let uu___4 = FStar_TypeChecker_NBETerm.unembed e_comp cb t1 in
                FStar_Compiler_Util.bind_opt uu___4
                  (fun c ->
-                    FStar_Compiler_Effect.op_Less_Bar
-                      (fun uu___5 -> FStar_Pervasives_Native.Some uu___5)
+                    FStar_Pervasives_Native.Some
                       (FStar_Reflection_V2_Data.Tv_Arrow (b1, c))))
       | FStar_TypeChecker_NBETerm.Construct (fv, uu___, (u, uu___1)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
@@ -1497,8 +1453,7 @@ let (e_term_view_aq :
           let uu___2 = FStar_TypeChecker_NBETerm.unembed e_universe cb u in
           FStar_Compiler_Util.bind_opt uu___2
             (fun u1 ->
-               FStar_Compiler_Effect.op_Less_Bar
-                 (fun uu___3 -> FStar_Pervasives_Native.Some uu___3)
+               FStar_Pervasives_Native.Some
                  (FStar_Reflection_V2_Data.Tv_Type u1))
       | FStar_TypeChecker_NBETerm.Construct
           (fv, uu___, (t1, uu___1)::(b, uu___2)::[]) when
@@ -1511,8 +1466,7 @@ let (e_term_view_aq :
                let uu___4 = FStar_TypeChecker_NBETerm.unembed e_term cb t1 in
                FStar_Compiler_Util.bind_opt uu___4
                  (fun t2 ->
-                    FStar_Compiler_Effect.op_Less_Bar
-                      (fun uu___5 -> FStar_Pervasives_Native.Some uu___5)
+                    FStar_Pervasives_Native.Some
                       (FStar_Reflection_V2_Data.Tv_Refine (b1, t2))))
       | FStar_TypeChecker_NBETerm.Construct (fv, uu___, (c, uu___1)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
@@ -1521,8 +1475,7 @@ let (e_term_view_aq :
           let uu___2 = FStar_TypeChecker_NBETerm.unembed e_vconst cb c in
           FStar_Compiler_Util.bind_opt uu___2
             (fun c1 ->
-               FStar_Compiler_Effect.op_Less_Bar
-                 (fun uu___3 -> FStar_Pervasives_Native.Some uu___3)
+               FStar_Pervasives_Native.Some
                  (FStar_Reflection_V2_Data.Tv_Const c1))
       | FStar_TypeChecker_NBETerm.Construct
           (fv, uu___, (l, uu___1)::(u, uu___2)::[]) when
@@ -1535,8 +1488,7 @@ let (e_term_view_aq :
           FStar_Compiler_Util.bind_opt uu___3
             (fun u1 ->
                let ctx_u_s = unlazy_as_t FStar_Syntax_Syntax.Lazy_uvar l in
-               FStar_Compiler_Effect.op_Less_Bar
-                 (fun uu___4 -> FStar_Pervasives_Native.Some uu___4)
+               FStar_Pervasives_Native.Some
                  (FStar_Reflection_V2_Data.Tv_Uvar (u1, ctx_u_s)))
       | FStar_TypeChecker_NBETerm.Construct
           (fv, uu___,
@@ -1569,9 +1521,7 @@ let (e_term_view_aq :
                                   t2 in
                               FStar_Compiler_Util.bind_opt uu___10
                                 (fun t21 ->
-                                   FStar_Compiler_Effect.op_Less_Bar
-                                     (fun uu___11 ->
-                                        FStar_Pervasives_Native.Some uu___11)
+                                   FStar_Pervasives_Native.Some
                                      (FStar_Reflection_V2_Data.Tv_Let
                                         (r1, attrs1, b1, t11, t21)))))))
       | FStar_TypeChecker_NBETerm.Construct
@@ -1593,8 +1543,7 @@ let (e_term_view_aq :
                         e_match_returns_annotation cb ret_opt in
                     FStar_Compiler_Util.bind_opt uu___6
                       (fun ret_opt1 ->
-                         FStar_Compiler_Effect.op_Less_Bar
-                           (fun uu___7 -> FStar_Pervasives_Native.Some uu___7)
+                         FStar_Pervasives_Native.Some
                            (FStar_Reflection_V2_Data.Tv_Match
                               (t2, ret_opt1, brs1)))))
       | FStar_TypeChecker_NBETerm.Construct
@@ -1620,9 +1569,7 @@ let (e_term_view_aq :
                              FStar_TypeChecker_NBETerm.e_bool cb use_eq in
                          FStar_Compiler_Util.bind_opt uu___8
                            (fun use_eq1 ->
-                              FStar_Compiler_Effect.op_Less_Bar
-                                (fun uu___9 ->
-                                   FStar_Pervasives_Native.Some uu___9)
+                              FStar_Pervasives_Native.Some
                                 (FStar_Reflection_V2_Data.Tv_AscribedT
                                    (e1, t2, tacopt1, use_eq1))))))
       | FStar_TypeChecker_NBETerm.Construct
@@ -1648,25 +1595,17 @@ let (e_term_view_aq :
                              FStar_TypeChecker_NBETerm.e_bool cb use_eq in
                          FStar_Compiler_Util.bind_opt uu___8
                            (fun use_eq1 ->
-                              FStar_Compiler_Effect.op_Less_Bar
-                                (fun uu___9 ->
-                                   FStar_Pervasives_Native.Some uu___9)
+                              FStar_Pervasives_Native.Some
                                 (FStar_Reflection_V2_Data.Tv_AscribedC
                                    (e1, c1, tacopt1, use_eq1))))))
       | FStar_TypeChecker_NBETerm.Construct (fv, uu___, []) when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_V2_Constants.ref_Tv_Unknown.FStar_Reflection_V2_Constants.lid
-          ->
-          FStar_Compiler_Effect.op_Less_Bar
-            (fun uu___1 -> FStar_Pervasives_Native.Some uu___1)
-            FStar_Reflection_V2_Data.Tv_Unknown
+          -> FStar_Pervasives_Native.Some FStar_Reflection_V2_Data.Tv_Unknown
       | FStar_TypeChecker_NBETerm.Construct (fv, uu___, []) when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_V2_Constants.ref_Tv_Unsupp.FStar_Reflection_V2_Constants.lid
-          ->
-          FStar_Compiler_Effect.op_Less_Bar
-            (fun uu___1 -> FStar_Pervasives_Native.Some uu___1)
-            FStar_Reflection_V2_Data.Tv_Unsupp
+          -> FStar_Pervasives_Native.Some FStar_Reflection_V2_Data.Tv_Unsupp
       | uu___ ->
           ((let uu___2 =
               let uu___3 =
@@ -2061,8 +2000,7 @@ let (e_comp_view :
         let uu___2 = FStar_TypeChecker_NBETerm.unembed e_term cb t1 in
         FStar_Compiler_Util.bind_opt uu___2
           (fun t2 ->
-             FStar_Compiler_Effect.op_Less_Bar
-               (fun uu___3 -> FStar_Pervasives_Native.Some uu___3)
+             FStar_Pervasives_Native.Some
                (FStar_Reflection_V2_Data.C_Total t2))
     | FStar_TypeChecker_NBETerm.Construct (fv, uu___, (t1, uu___1)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
@@ -2071,8 +2009,7 @@ let (e_comp_view :
         let uu___2 = FStar_TypeChecker_NBETerm.unembed e_term cb t1 in
         FStar_Compiler_Util.bind_opt uu___2
           (fun t2 ->
-             FStar_Compiler_Effect.op_Less_Bar
-               (fun uu___3 -> FStar_Pervasives_Native.Some uu___3)
+             FStar_Pervasives_Native.Some
                (FStar_Reflection_V2_Data.C_GTotal t2))
     | FStar_TypeChecker_NBETerm.Construct
         (fv, uu___, (post, uu___1)::(pre, uu___2)::(pats, uu___3)::[]) when
@@ -2089,8 +2026,7 @@ let (e_comp_view :
                     FStar_TypeChecker_NBETerm.unembed e_term cb pats in
                   FStar_Compiler_Util.bind_opt uu___6
                     (fun pats1 ->
-                       FStar_Compiler_Effect.op_Less_Bar
-                         (fun uu___7 -> FStar_Pervasives_Native.Some uu___7)
+                       FStar_Pervasives_Native.Some
                          (FStar_Reflection_V2_Data.C_Lemma
                             (pre1, post1, pats1)))))
     | FStar_TypeChecker_NBETerm.Construct
@@ -2128,9 +2064,7 @@ let (e_comp_view :
                                 decrs in
                             FStar_Compiler_Util.bind_opt uu___10
                               (fun decrs1 ->
-                                 FStar_Compiler_Effect.op_Less_Bar
-                                   (fun uu___11 ->
-                                      FStar_Pervasives_Native.Some uu___11)
+                                 FStar_Pervasives_Native.Some
                                    (FStar_Reflection_V2_Data.C_Eff
                                       (us1, eff1, res1, args1, decrs1)))))))
     | uu___ ->
@@ -2271,9 +2205,7 @@ let (e_lb_view :
                          FStar_TypeChecker_NBETerm.unembed e_term cb def in
                        FStar_Compiler_Util.bind_opt uu___8
                          (fun def1 ->
-                            FStar_Compiler_Effect.op_Less_Bar
-                              (fun uu___9 ->
-                                 FStar_Pervasives_Native.Some uu___9)
+                            FStar_Pervasives_Native.Some
                               {
                                 FStar_Reflection_V2_Data.lb_fv = fv'1;
                                 FStar_Reflection_V2_Data.lb_us = us1;
@@ -2443,9 +2375,7 @@ let (e_sigelt_view :
                                 dcs in
                             FStar_Compiler_Util.bind_opt uu___10
                               (fun dcs1 ->
-                                 FStar_Compiler_Effect.op_Less_Bar
-                                   (fun uu___11 ->
-                                      FStar_Pervasives_Native.Some uu___11)
+                                 FStar_Pervasives_Native.Some
                                    (FStar_Reflection_V2_Data.Sg_Inductive
                                       (nm1, us1, bs1, t2, dcs1)))))))
     | FStar_TypeChecker_NBETerm.Construct
@@ -2463,8 +2393,7 @@ let (e_sigelt_view :
                FStar_TypeChecker_NBETerm.unembed uu___5 cb lbs in
              FStar_Compiler_Util.bind_opt uu___4
                (fun lbs1 ->
-                  FStar_Compiler_Effect.op_Less_Bar
-                    (fun uu___5 -> FStar_Pervasives_Native.Some uu___5)
+                  FStar_Pervasives_Native.Some
                     (FStar_Reflection_V2_Data.Sg_Let (r1, lbs1))))
     | FStar_TypeChecker_NBETerm.Construct
         (fv, uu___, (t1, uu___1)::(us, uu___2)::(nm, uu___3)::[]) when
@@ -2481,8 +2410,7 @@ let (e_sigelt_view :
                   let uu___6 = FStar_TypeChecker_NBETerm.unembed e_term cb t1 in
                   FStar_Compiler_Util.bind_opt uu___6
                     (fun t2 ->
-                       FStar_Compiler_Effect.op_Less_Bar
-                         (fun uu___7 -> FStar_Pervasives_Native.Some uu___7)
+                       FStar_Pervasives_Native.Some
                          (FStar_Reflection_V2_Data.Sg_Val (nm1, us1, t2)))))
     | FStar_TypeChecker_NBETerm.Construct (fv, uu___, []) when
         FStar_Syntax_Syntax.fv_eq_lid fv

--- a/ocaml/fstar-lib/generated/FStar_SMTEncoding_Encode.ml
+++ b/ocaml/fstar-lib/generated/FStar_SMTEncoding_Encode.ml
@@ -80,9 +80,8 @@ let (prims : prims_t) =
                   let xname_decl =
                     let uu___3 =
                       let uu___4 =
-                        FStar_Compiler_Effect.op_Bar_Greater vars
-                          (FStar_Compiler_List.map
-                             FStar_SMTEncoding_Term.fv_sort) in
+                        FStar_Compiler_List.map
+                          FStar_SMTEncoding_Term.fv_sort vars in
                       (x1, uu___4, FStar_SMTEncoding_Term.Term_sort,
                         FStar_Pervasives_Native.None) in
                     FStar_SMTEncoding_Term.DeclFun uu___3 in
@@ -103,9 +102,8 @@ let (prims : prims_t) =
                     FStar_SMTEncoding_EncodeTerm.mk_Apply xtok1 vars in
                   let tot_fun_axioms =
                     let all_vars_but_one =
-                      FStar_Compiler_Effect.op_Bar_Greater
-                        (FStar_Compiler_Util.prefix vars)
-                        FStar_Pervasives_Native.fst in
+                      FStar_Pervasives_Native.fst
+                        (FStar_Compiler_Util.prefix vars) in
                     let axiom_name = Prims.strcat "primitive_tot_fun_" x1 in
                     let tot_fun_axiom_for_x =
                       let uu___3 =
@@ -124,14 +122,10 @@ let (prims : prims_t) =
                                  let vars2 =
                                    FStar_Compiler_List.op_At vars1 [var] in
                                  let axiom_name1 =
-                                   let uu___5 =
-                                     let uu___6 =
-                                       let uu___7 =
-                                         FStar_Compiler_Effect.op_Bar_Greater
-                                           vars2 FStar_Compiler_List.length in
-                                       Prims.string_of_int uu___7 in
-                                     Prims.strcat "." uu___6 in
-                                   Prims.strcat axiom_name uu___5 in
+                                   Prims.strcat axiom_name
+                                     (Prims.strcat "."
+                                        (Prims.string_of_int
+                                           (FStar_Compiler_List.length vars2))) in
                                  let uu___5 =
                                    let uu___6 =
                                      let uu___7 =
@@ -208,8 +202,7 @@ let (prims : prims_t) =
                     let uu___4 =
                       let uu___5 =
                         let uu___6 = FStar_SMTEncoding_Util.mkEq (x, y) in
-                        FStar_Compiler_Effect.op_Less_Bar
-                          FStar_SMTEncoding_Term.boxBool uu___6 in
+                        FStar_SMTEncoding_Term.boxBool uu___6 in
                       quant axy uu___5 in
                     (FStar_Parser_Const.op_Eq, uu___4) in
                   let uu___4 =
@@ -219,8 +212,7 @@ let (prims : prims_t) =
                           let uu___8 =
                             let uu___9 = FStar_SMTEncoding_Util.mkEq (x, y) in
                             FStar_SMTEncoding_Util.mkNot uu___9 in
-                          FStar_Compiler_Effect.op_Less_Bar
-                            FStar_SMTEncoding_Term.boxBool uu___8 in
+                          FStar_SMTEncoding_Term.boxBool uu___8 in
                         quant axy uu___7 in
                       (FStar_Parser_Const.op_notEq, uu___6) in
                     let uu___6 =
@@ -235,8 +227,7 @@ let (prims : prims_t) =
                                   FStar_SMTEncoding_Term.unboxBool y in
                                 (uu___12, uu___13) in
                               FStar_SMTEncoding_Util.mkAnd uu___11 in
-                            FStar_Compiler_Effect.op_Less_Bar
-                              FStar_SMTEncoding_Term.boxBool uu___10 in
+                            FStar_SMTEncoding_Term.boxBool uu___10 in
                           quant xy uu___9 in
                         (FStar_Parser_Const.op_And, uu___8) in
                       let uu___8 =
@@ -251,8 +242,7 @@ let (prims : prims_t) =
                                     FStar_SMTEncoding_Term.unboxBool y in
                                   (uu___14, uu___15) in
                                 FStar_SMTEncoding_Util.mkOr uu___13 in
-                              FStar_Compiler_Effect.op_Less_Bar
-                                FStar_SMTEncoding_Term.boxBool uu___12 in
+                              FStar_SMTEncoding_Term.boxBool uu___12 in
                             quant xy uu___11 in
                           (FStar_Parser_Const.op_Or, uu___10) in
                         let uu___10 =
@@ -263,8 +253,7 @@ let (prims : prims_t) =
                                   let uu___15 =
                                     FStar_SMTEncoding_Term.unboxBool x in
                                   FStar_SMTEncoding_Util.mkNot uu___15 in
-                                FStar_Compiler_Effect.op_Less_Bar
-                                  FStar_SMTEncoding_Term.boxBool uu___14 in
+                                FStar_SMTEncoding_Term.boxBool uu___14 in
                               quant qx uu___13 in
                             (FStar_Parser_Const.op_Negation, uu___12) in
                           let uu___12 =
@@ -279,8 +268,7 @@ let (prims : prims_t) =
                                         FStar_SMTEncoding_Term.unboxInt y in
                                       (uu___18, uu___19) in
                                     FStar_SMTEncoding_Util.mkLT uu___17 in
-                                  FStar_Compiler_Effect.op_Less_Bar
-                                    FStar_SMTEncoding_Term.boxBool uu___16 in
+                                  FStar_SMTEncoding_Term.boxBool uu___16 in
                                 quant xy uu___15 in
                               (FStar_Parser_Const.op_LT, uu___14) in
                             let uu___14 =
@@ -295,8 +283,7 @@ let (prims : prims_t) =
                                           FStar_SMTEncoding_Term.unboxInt y in
                                         (uu___20, uu___21) in
                                       FStar_SMTEncoding_Util.mkLTE uu___19 in
-                                    FStar_Compiler_Effect.op_Less_Bar
-                                      FStar_SMTEncoding_Term.boxBool uu___18 in
+                                    FStar_SMTEncoding_Term.boxBool uu___18 in
                                   quant xy uu___17 in
                                 (FStar_Parser_Const.op_LTE, uu___16) in
                               let uu___16 =
@@ -311,9 +298,7 @@ let (prims : prims_t) =
                                             FStar_SMTEncoding_Term.unboxInt y in
                                           (uu___22, uu___23) in
                                         FStar_SMTEncoding_Util.mkGT uu___21 in
-                                      FStar_Compiler_Effect.op_Less_Bar
-                                        FStar_SMTEncoding_Term.boxBool
-                                        uu___20 in
+                                      FStar_SMTEncoding_Term.boxBool uu___20 in
                                     quant xy uu___19 in
                                   (FStar_Parser_Const.op_GT, uu___18) in
                                 let uu___18 =
@@ -331,8 +316,7 @@ let (prims : prims_t) =
                                             (uu___24, uu___25) in
                                           FStar_SMTEncoding_Util.mkGTE
                                             uu___23 in
-                                        FStar_Compiler_Effect.op_Less_Bar
-                                          FStar_SMTEncoding_Term.boxBool
+                                        FStar_SMTEncoding_Term.boxBool
                                           uu___22 in
                                       quant xy uu___21 in
                                     (FStar_Parser_Const.op_GTE, uu___20) in
@@ -351,8 +335,7 @@ let (prims : prims_t) =
                                               (uu___26, uu___27) in
                                             FStar_SMTEncoding_Util.mkSub
                                               uu___25 in
-                                          FStar_Compiler_Effect.op_Less_Bar
-                                            FStar_SMTEncoding_Term.boxInt
+                                          FStar_SMTEncoding_Term.boxInt
                                             uu___24 in
                                         quant xy uu___23 in
                                       (FStar_Parser_Const.op_Subtraction,
@@ -367,8 +350,7 @@ let (prims : prims_t) =
                                                   x in
                                               FStar_SMTEncoding_Util.mkMinus
                                                 uu___27 in
-                                            FStar_Compiler_Effect.op_Less_Bar
-                                              FStar_SMTEncoding_Term.boxInt
+                                            FStar_SMTEncoding_Term.boxInt
                                               uu___26 in
                                           quant qx uu___25 in
                                         (FStar_Parser_Const.op_Minus,
@@ -388,8 +370,7 @@ let (prims : prims_t) =
                                                   (uu___30, uu___31) in
                                                 FStar_SMTEncoding_Util.mkAdd
                                                   uu___29 in
-                                              FStar_Compiler_Effect.op_Less_Bar
-                                                FStar_SMTEncoding_Term.boxInt
+                                              FStar_SMTEncoding_Term.boxInt
                                                 uu___28 in
                                             quant xy uu___27 in
                                           (FStar_Parser_Const.op_Addition,
@@ -409,8 +390,7 @@ let (prims : prims_t) =
                                                     (uu___32, uu___33) in
                                                   FStar_SMTEncoding_Util.mkMul
                                                     uu___31 in
-                                                FStar_Compiler_Effect.op_Less_Bar
-                                                  FStar_SMTEncoding_Term.boxInt
+                                                FStar_SMTEncoding_Term.boxInt
                                                   uu___30 in
                                               quant xy uu___29 in
                                             (FStar_Parser_Const.op_Multiply,
@@ -430,8 +410,7 @@ let (prims : prims_t) =
                                                       (uu___34, uu___35) in
                                                     FStar_SMTEncoding_Util.mkDiv
                                                       uu___33 in
-                                                  FStar_Compiler_Effect.op_Less_Bar
-                                                    FStar_SMTEncoding_Term.boxInt
+                                                  FStar_SMTEncoding_Term.boxInt
                                                     uu___32 in
                                                 quant xy uu___31 in
                                               (FStar_Parser_Const.op_Division,
@@ -451,8 +430,7 @@ let (prims : prims_t) =
                                                         (uu___36, uu___37) in
                                                       FStar_SMTEncoding_Util.mkMod
                                                         uu___35 in
-                                                    FStar_Compiler_Effect.op_Less_Bar
-                                                      FStar_SMTEncoding_Term.boxInt
+                                                    FStar_SMTEncoding_Term.boxInt
                                                       uu___34 in
                                                   quant xy uu___33 in
                                                 (FStar_Parser_Const.op_Modulus,
@@ -472,8 +450,7 @@ let (prims : prims_t) =
                                                           (uu___38, uu___39) in
                                                         FStar_SMTEncoding_Util.mkLT
                                                           uu___37 in
-                                                      FStar_Compiler_Effect.op_Less_Bar
-                                                        FStar_SMTEncoding_Term.boxBool
+                                                      FStar_SMTEncoding_Term.boxBool
                                                         uu___36 in
                                                     quant xy uu___35 in
                                                   (FStar_Parser_Const.real_op_LT,
@@ -494,8 +471,7 @@ let (prims : prims_t) =
                                                               uu___41) in
                                                           FStar_SMTEncoding_Util.mkLTE
                                                             uu___39 in
-                                                        FStar_Compiler_Effect.op_Less_Bar
-                                                          FStar_SMTEncoding_Term.boxBool
+                                                        FStar_SMTEncoding_Term.boxBool
                                                           uu___38 in
                                                       quant xy uu___37 in
                                                     (FStar_Parser_Const.real_op_LTE,
@@ -516,8 +492,7 @@ let (prims : prims_t) =
                                                                 uu___43) in
                                                             FStar_SMTEncoding_Util.mkGT
                                                               uu___41 in
-                                                          FStar_Compiler_Effect.op_Less_Bar
-                                                            FStar_SMTEncoding_Term.boxBool
+                                                          FStar_SMTEncoding_Term.boxBool
                                                             uu___40 in
                                                         quant xy uu___39 in
                                                       (FStar_Parser_Const.real_op_GT,
@@ -538,8 +513,7 @@ let (prims : prims_t) =
                                                                   uu___45) in
                                                               FStar_SMTEncoding_Util.mkGTE
                                                                 uu___43 in
-                                                            FStar_Compiler_Effect.op_Less_Bar
-                                                              FStar_SMTEncoding_Term.boxBool
+                                                            FStar_SMTEncoding_Term.boxBool
                                                               uu___42 in
                                                           quant xy uu___41 in
                                                         (FStar_Parser_Const.real_op_GTE,
@@ -562,8 +536,7 @@ let (prims : prims_t) =
                                                                     uu___47) in
                                                                 FStar_SMTEncoding_Util.mkSub
                                                                   uu___45 in
-                                                              FStar_Compiler_Effect.op_Less_Bar
-                                                                FStar_SMTEncoding_Term.boxReal
+                                                              FStar_SMTEncoding_Term.boxReal
                                                                 uu___44 in
                                                             quant xy uu___43 in
                                                           (FStar_Parser_Const.real_op_Subtraction,
@@ -587,8 +560,7 @@ let (prims : prims_t) =
                                                                     uu___49) in
                                                                   FStar_SMTEncoding_Util.mkAdd
                                                                     uu___47 in
-                                                                FStar_Compiler_Effect.op_Less_Bar
-                                                                  FStar_SMTEncoding_Term.boxReal
+                                                                FStar_SMTEncoding_Term.boxReal
                                                                   uu___46 in
                                                               quant xy
                                                                 uu___45 in
@@ -614,8 +586,7 @@ let (prims : prims_t) =
                                                                     uu___51) in
                                                                     FStar_SMTEncoding_Util.mkMul
                                                                     uu___49 in
-                                                                  FStar_Compiler_Effect.op_Less_Bar
-                                                                    FStar_SMTEncoding_Term.boxReal
+                                                                  FStar_SMTEncoding_Term.boxReal
                                                                     uu___48 in
                                                                 quant xy
                                                                   uu___47 in
@@ -642,7 +613,6 @@ let (prims : prims_t) =
                                                                     uu___53) in
                                                                     FStar_SMTEncoding_Util.mkRealDiv
                                                                     uu___51 in
-                                                                    FStar_Compiler_Effect.op_Less_Bar
                                                                     FStar_SMTEncoding_Term.boxReal
                                                                     uu___50 in
                                                                   quant xy
@@ -664,7 +634,6 @@ let (prims : prims_t) =
                                                                     FStar_SMTEncoding_Term.mkRealOfInt
                                                                     uu___53
                                                                     FStar_Compiler_Range_Type.dummyRange in
-                                                                    FStar_Compiler_Effect.op_Less_Bar
                                                                     FStar_SMTEncoding_Term.boxReal
                                                                     uu___52 in
                                                                     quant qx
@@ -700,26 +669,23 @@ let (prims : prims_t) =
                 let mk l v =
                   let uu___3 =
                     let uu___4 =
-                      FStar_Compiler_Effect.op_Bar_Greater prims1
-                        (FStar_Compiler_List.find
-                           (fun uu___5 ->
-                              match uu___5 with
-                              | (l', uu___6) -> FStar_Ident.lid_equals l l')) in
-                    FStar_Compiler_Effect.op_Bar_Greater uu___4
-                      (FStar_Compiler_Option.map
-                         (fun uu___5 ->
-                            match uu___5 with
-                            | (uu___6, b) ->
-                                let uu___7 = FStar_Ident.range_of_lid l in
-                                b uu___7 v)) in
-                  FStar_Compiler_Effect.op_Bar_Greater uu___3
-                    FStar_Compiler_Option.get in
+                      FStar_Compiler_List.find
+                        (fun uu___5 ->
+                           match uu___5 with
+                           | (l', uu___6) -> FStar_Ident.lid_equals l l')
+                        prims1 in
+                    FStar_Compiler_Option.map
+                      (fun uu___5 ->
+                         match uu___5 with
+                         | (uu___6, b) ->
+                             let uu___7 = FStar_Ident.range_of_lid l in
+                             b uu___7 v) uu___4 in
+                  FStar_Compiler_Option.get uu___3 in
                 let is l =
-                  FStar_Compiler_Effect.op_Bar_Greater prims1
-                    (FStar_Compiler_Util.for_some
-                       (fun uu___3 ->
-                          match uu___3 with
-                          | (l', uu___4) -> FStar_Ident.lid_equals l l')) in
+                  FStar_Compiler_Util.for_some
+                    (fun uu___3 ->
+                       match uu___3 with
+                       | (l', uu___4) -> FStar_Ident.lid_equals l l') prims1 in
                 { mk; is }))
 let (pretype_axiom :
   FStar_Compiler_Range_Type.range ->
@@ -885,7 +851,7 @@ let (primitive_type_axioms :
           let uu___2 = FStar_Ident.string_of_lid FStar_Parser_Const.lex_t_lid in
           (uu___2, FStar_SMTEncoding_Term.Term_sort) in
         FStar_SMTEncoding_Term.mk_fv uu___1 in
-      FStar_Compiler_Effect.op_Less_Bar FStar_SMTEncoding_Util.mkFreeV uu___ in
+      FStar_SMTEncoding_Util.mkFreeV uu___ in
     let typing_pred = FStar_SMTEncoding_Term.mk_HasType x tt in
     let typing_pred_y = FStar_SMTEncoding_Term.mk_HasType y tt in
     let aa =
@@ -897,7 +863,7 @@ let (primitive_type_axioms :
     let precedes_y_x =
       let uu___ =
         FStar_SMTEncoding_Util.mkApp ("Prims.precedes", [lex_t; lex_t; y; x]) in
-      FStar_Compiler_Effect.op_Less_Bar FStar_SMTEncoding_Term.mk_Valid uu___ in
+      FStar_SMTEncoding_Term.mk_Valid uu___ in
     let uu___ =
       let uu___1 =
         let uu___2 =
@@ -1252,7 +1218,7 @@ let (primitive_type_axioms :
     let valid = FStar_SMTEncoding_Util.mkApp ("Valid", [l_not_a]) in
     let not_valid_a =
       let uu___ = FStar_SMTEncoding_Util.mkApp ("Valid", [a]) in
-      FStar_Compiler_Effect.op_Less_Bar FStar_SMTEncoding_Util.mkNot uu___ in
+      FStar_SMTEncoding_Util.mkNot uu___ in
     let uu___ =
       let uu___1 =
         let uu___2 =
@@ -1365,8 +1331,7 @@ let (encode_smt_lemma :
                     (form, uu___5, uu___6) in
                   FStar_SMTEncoding_Util.mkAssume uu___4 in
                 [uu___3] in
-              FStar_Compiler_Effect.op_Bar_Greater uu___2
-                FStar_SMTEncoding_Term.mk_decls_trivial in
+              FStar_SMTEncoding_Term.mk_decls_trivial uu___2 in
             FStar_Compiler_List.op_At decls uu___1
 let (encode_free_var :
   Prims.bool ->
@@ -1390,8 +1355,8 @@ let (encode_free_var :
                     (FStar_Syntax_Util.is_pure_or_ghost_function t_norm) ||
                       (FStar_SMTEncoding_Util.is_smt_reifiable_function
                          env.FStar_SMTEncoding_Env.tcenv t_norm) in
-                  FStar_Compiler_Effect.op_Less_Bar Prims.op_Negation uu___1)
-                   || (FStar_Syntax_Util.is_lemma t_norm))
+                  Prims.op_Negation uu___1) ||
+                   (FStar_Syntax_Util.is_lemma t_norm))
                   || uninterpreted in
               if uu___
               then
@@ -1404,9 +1369,9 @@ let (encode_free_var :
                       { FStar_Syntax_Syntax.bs1 = binders;
                         FStar_Syntax_Syntax.comp = uu___2;_}
                       ->
-                      FStar_Compiler_Effect.op_Bar_Greater binders
-                        (FStar_Compiler_List.map
-                           (fun uu___3 -> FStar_SMTEncoding_Term.Term_sort))
+                      FStar_Compiler_List.map
+                        (fun uu___3 -> FStar_SMTEncoding_Term.Term_sort)
+                        binders
                   | uu___2 -> [] in
                 let arity = FStar_Compiler_List.length arg_sorts in
                 let uu___1 =
@@ -1425,8 +1390,7 @@ let (encode_free_var :
                           (FStar_Pervasives_Native.Some
                              "Uninterpreted name for impure function")) in
                     let uu___2 =
-                      FStar_Compiler_Effect.op_Bar_Greater [d; dd]
-                        FStar_SMTEncoding_Term.mk_decls_trivial in
+                      FStar_SMTEncoding_Term.mk_decls_trivial [d; dd] in
                     (uu___2, env1)
               else
                 (let uu___2 = prims.is lid in
@@ -1442,8 +1406,7 @@ let (encode_free_var :
                          FStar_SMTEncoding_Env.push_free_var env lid arity
                            vname (FStar_Pervasives_Native.Some tok) in
                        let uu___4 =
-                         FStar_Compiler_Effect.op_Bar_Greater definition
-                           FStar_SMTEncoding_Term.mk_decls_trivial in
+                         FStar_SMTEncoding_Term.mk_decls_trivial definition in
                        (uu___4, env1)
                  else
                    (let encode_non_total_function_typ =
@@ -1596,126 +1559,121 @@ let (encode_free_var :
                     | (formals, (pre_opt, res_t)) ->
                         let mk_disc_proj_axioms guard encoded_res_t vapp vars
                           =
-                          FStar_Compiler_Effect.op_Bar_Greater quals
-                            (FStar_Compiler_List.collect
-                               (fun uu___5 ->
-                                  match uu___5 with
-                                  | FStar_Syntax_Syntax.Discriminator d ->
-                                      let uu___6 =
-                                        FStar_Compiler_Util.prefix vars in
-                                      (match uu___6 with
-                                       | (uu___7, xxv) ->
-                                           let xx =
-                                             let uu___8 =
-                                               let uu___9 =
-                                                 let uu___10 =
-                                                   FStar_SMTEncoding_Term.fv_name
-                                                     xxv in
-                                                 (uu___10,
-                                                   FStar_SMTEncoding_Term.Term_sort) in
-                                               FStar_SMTEncoding_Term.mk_fv
-                                                 uu___9 in
-                                             FStar_Compiler_Effect.op_Less_Bar
-                                               FStar_SMTEncoding_Util.mkFreeV
-                                               uu___8 in
-                                           let uu___8 =
-                                             let uu___9 =
-                                               let uu___10 =
-                                                 let uu___11 =
-                                                   FStar_Syntax_Syntax.range_of_fv
-                                                     fv in
-                                                 let uu___12 =
-                                                   let uu___13 =
-                                                     let uu___14 =
-                                                       let uu___15 =
-                                                         let uu___16 =
-                                                           let uu___17 =
-                                                             let uu___18 =
-                                                               FStar_Ident.string_of_lid
-                                                                 d in
-                                                             FStar_SMTEncoding_Env.escape
-                                                               uu___18 in
-                                                           FStar_SMTEncoding_Term.mk_tester
-                                                             uu___17 xx in
-                                                         FStar_Compiler_Effect.op_Less_Bar
-                                                           FStar_SMTEncoding_Term.boxBool
-                                                           uu___16 in
-                                                       (vapp, uu___15) in
-                                                     FStar_SMTEncoding_Util.mkEq
-                                                       uu___14 in
-                                                   ([[vapp]], vars, uu___13) in
-                                                 FStar_SMTEncoding_Term.mkForall
-                                                   uu___11 uu___12 in
-                                               let uu___11 =
-                                                 let uu___12 =
-                                                   let uu___13 =
-                                                     FStar_Ident.string_of_lid
-                                                       d in
-                                                   FStar_SMTEncoding_Env.escape
-                                                     uu___13 in
-                                                 Prims.strcat
-                                                   "disc_equation_" uu___12 in
-                                               (uu___10,
-                                                 (FStar_Pervasives_Native.Some
-                                                    "Discriminator equation"),
-                                                 uu___11) in
-                                             FStar_SMTEncoding_Util.mkAssume
-                                               uu___9 in
-                                           [uu___8])
-                                  | FStar_Syntax_Syntax.Projector (d, f) ->
-                                      let uu___6 =
-                                        FStar_Compiler_Util.prefix vars in
-                                      (match uu___6 with
-                                       | (uu___7, xxv) ->
-                                           let xx =
-                                             let uu___8 =
-                                               let uu___9 =
-                                                 let uu___10 =
-                                                   FStar_SMTEncoding_Term.fv_name
-                                                     xxv in
-                                                 (uu___10,
-                                                   FStar_SMTEncoding_Term.Term_sort) in
-                                               FStar_SMTEncoding_Term.mk_fv
-                                                 uu___9 in
-                                             FStar_Compiler_Effect.op_Less_Bar
-                                               FStar_SMTEncoding_Util.mkFreeV
-                                               uu___8 in
-                                           let f1 =
-                                             {
-                                               FStar_Syntax_Syntax.ppname = f;
-                                               FStar_Syntax_Syntax.index =
-                                                 Prims.int_zero;
-                                               FStar_Syntax_Syntax.sort =
-                                                 FStar_Syntax_Syntax.tun
-                                             } in
-                                           let tp_name =
-                                             FStar_SMTEncoding_Env.mk_term_projector_name
-                                               d f1 in
-                                           let prim_app =
-                                             FStar_SMTEncoding_Util.mkApp
-                                               (tp_name, [xx]) in
-                                           let uu___8 =
-                                             let uu___9 =
-                                               let uu___10 =
-                                                 let uu___11 =
-                                                   FStar_Syntax_Syntax.range_of_fv
-                                                     fv in
-                                                 let uu___12 =
-                                                   let uu___13 =
-                                                     FStar_SMTEncoding_Util.mkEq
-                                                       (vapp, prim_app) in
-                                                   ([[vapp]], vars, uu___13) in
-                                                 FStar_SMTEncoding_Term.mkForall
-                                                   uu___11 uu___12 in
-                                               (uu___10,
-                                                 (FStar_Pervasives_Native.Some
-                                                    "Projector equation"),
-                                                 (Prims.strcat
-                                                    "proj_equation_" tp_name)) in
-                                             FStar_SMTEncoding_Util.mkAssume
-                                               uu___9 in
-                                           [uu___8])
-                                  | uu___6 -> [])) in
+                          FStar_Compiler_List.collect
+                            (fun uu___5 ->
+                               match uu___5 with
+                               | FStar_Syntax_Syntax.Discriminator d ->
+                                   let uu___6 =
+                                     FStar_Compiler_Util.prefix vars in
+                                   (match uu___6 with
+                                    | (uu___7, xxv) ->
+                                        let xx =
+                                          let uu___8 =
+                                            let uu___9 =
+                                              let uu___10 =
+                                                FStar_SMTEncoding_Term.fv_name
+                                                  xxv in
+                                              (uu___10,
+                                                FStar_SMTEncoding_Term.Term_sort) in
+                                            FStar_SMTEncoding_Term.mk_fv
+                                              uu___9 in
+                                          FStar_SMTEncoding_Util.mkFreeV
+                                            uu___8 in
+                                        let uu___8 =
+                                          let uu___9 =
+                                            let uu___10 =
+                                              let uu___11 =
+                                                FStar_Syntax_Syntax.range_of_fv
+                                                  fv in
+                                              let uu___12 =
+                                                let uu___13 =
+                                                  let uu___14 =
+                                                    let uu___15 =
+                                                      let uu___16 =
+                                                        let uu___17 =
+                                                          let uu___18 =
+                                                            FStar_Ident.string_of_lid
+                                                              d in
+                                                          FStar_SMTEncoding_Env.escape
+                                                            uu___18 in
+                                                        FStar_SMTEncoding_Term.mk_tester
+                                                          uu___17 xx in
+                                                      FStar_SMTEncoding_Term.boxBool
+                                                        uu___16 in
+                                                    (vapp, uu___15) in
+                                                  FStar_SMTEncoding_Util.mkEq
+                                                    uu___14 in
+                                                ([[vapp]], vars, uu___13) in
+                                              FStar_SMTEncoding_Term.mkForall
+                                                uu___11 uu___12 in
+                                            let uu___11 =
+                                              let uu___12 =
+                                                let uu___13 =
+                                                  FStar_Ident.string_of_lid d in
+                                                FStar_SMTEncoding_Env.escape
+                                                  uu___13 in
+                                              Prims.strcat "disc_equation_"
+                                                uu___12 in
+                                            (uu___10,
+                                              (FStar_Pervasives_Native.Some
+                                                 "Discriminator equation"),
+                                              uu___11) in
+                                          FStar_SMTEncoding_Util.mkAssume
+                                            uu___9 in
+                                        [uu___8])
+                               | FStar_Syntax_Syntax.Projector (d, f) ->
+                                   let uu___6 =
+                                     FStar_Compiler_Util.prefix vars in
+                                   (match uu___6 with
+                                    | (uu___7, xxv) ->
+                                        let xx =
+                                          let uu___8 =
+                                            let uu___9 =
+                                              let uu___10 =
+                                                FStar_SMTEncoding_Term.fv_name
+                                                  xxv in
+                                              (uu___10,
+                                                FStar_SMTEncoding_Term.Term_sort) in
+                                            FStar_SMTEncoding_Term.mk_fv
+                                              uu___9 in
+                                          FStar_SMTEncoding_Util.mkFreeV
+                                            uu___8 in
+                                        let f1 =
+                                          {
+                                            FStar_Syntax_Syntax.ppname = f;
+                                            FStar_Syntax_Syntax.index =
+                                              Prims.int_zero;
+                                            FStar_Syntax_Syntax.sort =
+                                              FStar_Syntax_Syntax.tun
+                                          } in
+                                        let tp_name =
+                                          FStar_SMTEncoding_Env.mk_term_projector_name
+                                            d f1 in
+                                        let prim_app =
+                                          FStar_SMTEncoding_Util.mkApp
+                                            (tp_name, [xx]) in
+                                        let uu___8 =
+                                          let uu___9 =
+                                            let uu___10 =
+                                              let uu___11 =
+                                                FStar_Syntax_Syntax.range_of_fv
+                                                  fv in
+                                              let uu___12 =
+                                                let uu___13 =
+                                                  FStar_SMTEncoding_Util.mkEq
+                                                    (vapp, prim_app) in
+                                                ([[vapp]], vars, uu___13) in
+                                              FStar_SMTEncoding_Term.mkForall
+                                                uu___11 uu___12 in
+                                            (uu___10,
+                                              (FStar_Pervasives_Native.Some
+                                                 "Projector equation"),
+                                              (Prims.strcat "proj_equation_"
+                                                 tp_name)) in
+                                          FStar_SMTEncoding_Util.mkAssume
+                                            uu___9 in
+                                        [uu___8])
+                               | uu___6 -> []) quals in
                         let uu___5 =
                           FStar_SMTEncoding_EncodeTerm.encode_binders
                             FStar_Pervasives_Native.None formals env in
@@ -1803,12 +1761,9 @@ let (encode_free_var :
                                            | uu___12 -> false) in
                                     (((let uu___9 = FStar_Ident.nsstr lid in
                                        uu___9 <> "Prims") &&
-                                        (let uu___9 =
-                                           FStar_Compiler_Effect.op_Bar_Greater
-                                             quals
-                                             (FStar_Compiler_List.contains
-                                                FStar_Syntax_Syntax.Logic) in
-                                         Prims.op_Negation uu___9))
+                                        (Prims.op_Negation
+                                           (FStar_Compiler_List.contains
+                                              FStar_Syntax_Syntax.Logic quals)))
                                        &&
                                        (let uu___9 = is_squash t_norm in
                                         Prims.op_Negation uu___9))
@@ -1864,10 +1819,9 @@ let (encode_free_var :
                                               let vname_decl =
                                                 let uu___11 =
                                                   let uu___12 =
-                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                      vars1
-                                                      (FStar_Compiler_List.map
-                                                         FStar_SMTEncoding_Term.fv_sort) in
+                                                    FStar_Compiler_List.map
+                                                      FStar_SMTEncoding_Term.fv_sort
+                                                      vars1 in
                                                   (vname, uu___12,
                                                     FStar_SMTEncoding_Term.Term_sort,
                                                     FStar_Pervasives_Native.None) in
@@ -1939,9 +1893,8 @@ let (encode_free_var :
                                                                  vname)) in
                                                         let uu___13 =
                                                           let uu___14 =
-                                                            FStar_Compiler_Effect.op_Bar_Greater
-                                                              [tok_typing1]
-                                                              FStar_SMTEncoding_Term.mk_decls_trivial in
+                                                            FStar_SMTEncoding_Term.mk_decls_trivial
+                                                              [tok_typing1] in
                                                           FStar_Compiler_List.op_At
                                                             decls2 uu___14 in
                                                         let uu___14 =
@@ -1949,10 +1902,7 @@ let (encode_free_var :
                                                             let uu___16 =
                                                               FStar_SMTEncoding_Util.mkApp
                                                                 (vname, []) in
-                                                            FStar_Compiler_Effect.op_Less_Bar
-                                                              (fun uu___17 ->
-                                                                 FStar_Pervasives_Native.Some
-                                                                   uu___17)
+                                                            FStar_Pervasives_Native.Some
                                                               uu___16 in
                                                           FStar_SMTEncoding_Env.push_free_var
                                                             env1 lid arity
@@ -2047,11 +1997,10 @@ let (encode_free_var :
                                                                  vname)) in
                                                         let uu___14 =
                                                           let uu___15 =
-                                                            FStar_Compiler_Effect.op_Bar_Greater
+                                                            FStar_SMTEncoding_Term.mk_decls_trivial
                                                               [vtok_decl;
                                                               name_tok_corr;
-                                                              tok_typing1]
-                                                              FStar_SMTEncoding_Term.mk_decls_trivial in
+                                                              tok_typing1] in
                                                           FStar_Compiler_List.op_At
                                                             decls2 uu___15 in
                                                         (uu___14, env1) in
@@ -2059,9 +2008,8 @@ let (encode_free_var :
                                                    | (tok_decl, env2) ->
                                                        let uu___13 =
                                                          let uu___14 =
-                                                           FStar_Compiler_Effect.op_Bar_Greater
-                                                             [vname_decl]
-                                                             FStar_SMTEncoding_Term.mk_decls_trivial in
+                                                           FStar_SMTEncoding_Term.mk_decls_trivial
+                                                             [vname_decl] in
                                                          FStar_Compiler_List.op_At
                                                            uu___14 tok_decl in
                                                        (uu___13, env2)) in
@@ -2110,42 +2058,39 @@ let (encode_free_var :
                                                         FStar_SMTEncoding_Util.mkAssume
                                                           uu___12 in
                                                       let freshness =
-                                                        let uu___12 =
-                                                          FStar_Compiler_Effect.op_Bar_Greater
+                                                        if
+                                                          FStar_Compiler_List.contains
+                                                            FStar_Syntax_Syntax.New
                                                             quals
-                                                            (FStar_Compiler_List.contains
-                                                               FStar_Syntax_Syntax.New) in
-                                                        if uu___12
                                                         then
-                                                          let uu___13 =
-                                                            let uu___14 =
+                                                          let uu___12 =
+                                                            let uu___13 =
                                                               FStar_Syntax_Syntax.range_of_fv
                                                                 fv in
-                                                            let uu___15 =
+                                                            let uu___14 =
+                                                              let uu___15 =
+                                                                FStar_Compiler_List.map
+                                                                  FStar_SMTEncoding_Term.fv_sort
+                                                                  vars1 in
                                                               let uu___16 =
-                                                                FStar_Compiler_Effect.op_Bar_Greater
-                                                                  vars1
-                                                                  (FStar_Compiler_List.map
-                                                                    FStar_SMTEncoding_Term.fv_sort) in
-                                                              let uu___17 =
                                                                 FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.next_id
                                                                   () in
                                                               (vname,
-                                                                uu___16,
+                                                                uu___15,
                                                                 FStar_SMTEncoding_Term.Term_sort,
-                                                                uu___17) in
+                                                                uu___16) in
                                                             FStar_SMTEncoding_Term.fresh_constructor
-                                                              uu___14 uu___15 in
-                                                          let uu___14 =
-                                                            let uu___15 =
-                                                              let uu___16 =
+                                                              uu___13 uu___14 in
+                                                          let uu___13 =
+                                                            let uu___14 =
+                                                              let uu___15 =
                                                                 FStar_Syntax_Syntax.range_of_fv
                                                                   fv in
                                                               pretype_axiom
-                                                                uu___16 env2
+                                                                uu___15 env2
                                                                 vapp vars1 in
-                                                            [uu___15] in
-                                                          uu___13 :: uu___14
+                                                            [uu___14] in
+                                                          uu___12 :: uu___13
                                                         else [] in
                                                       let g =
                                                         let uu___12 =
@@ -2165,9 +2110,8 @@ let (encode_free_var :
                                                                 FStar_Compiler_List.op_At
                                                                   freshness
                                                                   uu___16 in
-                                                              FStar_Compiler_Effect.op_Bar_Greater
-                                                                uu___15
-                                                                FStar_SMTEncoding_Term.mk_decls_trivial in
+                                                              FStar_SMTEncoding_Term.mk_decls_trivial
+                                                                uu___15 in
                                                             FStar_Compiler_List.op_At
                                                               decls3 uu___14 in
                                                           FStar_Compiler_List.op_At
@@ -2251,22 +2195,21 @@ let (encode_top_level_vals :
   fun env ->
     fun bindings ->
       fun quals ->
-        FStar_Compiler_Effect.op_Bar_Greater bindings
-          (FStar_Compiler_List.fold_left
-             (fun uu___ ->
-                fun lb ->
-                  match uu___ with
-                  | (decls, env1) ->
-                      let uu___1 =
-                        let uu___2 =
-                          FStar_Compiler_Util.right
-                            lb.FStar_Syntax_Syntax.lbname in
-                        encode_top_level_val false env1 uu___2
-                          lb.FStar_Syntax_Syntax.lbtyp quals in
-                      (match uu___1 with
-                       | (decls', env2) ->
-                           ((FStar_Compiler_List.op_At decls decls'), env2)))
-             ([], env))
+        FStar_Compiler_List.fold_left
+          (fun uu___ ->
+             fun lb ->
+               match uu___ with
+               | (decls, env1) ->
+                   let uu___1 =
+                     let uu___2 =
+                       FStar_Compiler_Util.right
+                         lb.FStar_Syntax_Syntax.lbname in
+                     encode_top_level_val false env1 uu___2
+                       lb.FStar_Syntax_Syntax.lbtyp quals in
+                   (match uu___1 with
+                    | (decls', env2) ->
+                        ((FStar_Compiler_List.op_At decls decls'), env2)))
+          ([], env) bindings
 exception Let_rec_unencodeable 
 let (uu___is_Let_rec_unencodeable : Prims.exn -> Prims.bool) =
   fun projectee ->
@@ -2334,39 +2277,36 @@ let (encode_top_level_let :
                       binders in
                   let extra_formals1 =
                     let uu___2 =
-                      FStar_Compiler_Effect.op_Bar_Greater extra_formals
-                        (FStar_Compiler_List.map
-                           (fun b ->
-                              let uu___3 =
-                                let uu___4 = b.FStar_Syntax_Syntax.binder_bv in
-                                let uu___5 =
-                                  FStar_Syntax_Subst.subst subst
-                                    (b.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort in
-                                {
-                                  FStar_Syntax_Syntax.ppname =
-                                    (uu___4.FStar_Syntax_Syntax.ppname);
-                                  FStar_Syntax_Syntax.index =
-                                    (uu___4.FStar_Syntax_Syntax.index);
-                                  FStar_Syntax_Syntax.sort = uu___5
-                                } in
-                              {
-                                FStar_Syntax_Syntax.binder_bv = uu___3;
-                                FStar_Syntax_Syntax.binder_qual =
-                                  (b.FStar_Syntax_Syntax.binder_qual);
-                                FStar_Syntax_Syntax.binder_positivity =
-                                  (b.FStar_Syntax_Syntax.binder_positivity);
-                                FStar_Syntax_Syntax.binder_attrs =
-                                  (b.FStar_Syntax_Syntax.binder_attrs)
-                              })) in
-                    FStar_Compiler_Effect.op_Bar_Greater uu___2
-                      FStar_Syntax_Util.name_binders in
+                      FStar_Compiler_List.map
+                        (fun b ->
+                           let uu___3 =
+                             let uu___4 = b.FStar_Syntax_Syntax.binder_bv in
+                             let uu___5 =
+                               FStar_Syntax_Subst.subst subst
+                                 (b.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort in
+                             {
+                               FStar_Syntax_Syntax.ppname =
+                                 (uu___4.FStar_Syntax_Syntax.ppname);
+                               FStar_Syntax_Syntax.index =
+                                 (uu___4.FStar_Syntax_Syntax.index);
+                               FStar_Syntax_Syntax.sort = uu___5
+                             } in
+                           {
+                             FStar_Syntax_Syntax.binder_bv = uu___3;
+                             FStar_Syntax_Syntax.binder_qual =
+                               (b.FStar_Syntax_Syntax.binder_qual);
+                             FStar_Syntax_Syntax.binder_positivity =
+                               (b.FStar_Syntax_Syntax.binder_positivity);
+                             FStar_Syntax_Syntax.binder_attrs =
+                               (b.FStar_Syntax_Syntax.binder_attrs)
+                           }) extra_formals in
+                    FStar_Syntax_Util.name_binders uu___2 in
                   let body1 =
                     let uu___2 = FStar_Syntax_Subst.compress body in
                     let uu___3 =
                       let uu___4 =
                         FStar_Syntax_Util.args_of_binders extra_formals1 in
-                      FStar_Compiler_Effect.op_Less_Bar
-                        FStar_Pervasives_Native.snd uu___4 in
+                      FStar_Pervasives_Native.snd uu___4 in
                     FStar_Syntax_Syntax.extend_app_n uu___2 uu___3
                       body.FStar_Syntax_Syntax.pos in
                   ((FStar_Compiler_List.op_At binders extra_formals1), body1) in
@@ -2501,8 +2441,7 @@ let (encode_top_level_let :
               let rec arrow_formals_comp_norm norm t1 =
                 let t2 =
                   let uu___1 = FStar_Syntax_Subst.compress t1 in
-                  FStar_Compiler_Effect.op_Less_Bar
-                    FStar_Syntax_Util.unascribe uu___1 in
+                  FStar_Syntax_Util.unascribe uu___1 in
                 match t2.FStar_Syntax_Syntax.n with
                 | FStar_Syntax_Syntax.Tm_arrow
                     { FStar_Syntax_Syntax.bs1 = formals;
@@ -2578,9 +2517,7 @@ let (encode_top_level_let :
                         comp in
                     if uu___3
                     then
-                      let eff_name =
-                        FStar_Compiler_Effect.op_Bar_Greater comp
-                          FStar_Syntax_Util.comp_effect_name in
+                      let eff_name = FStar_Syntax_Util.comp_effect_name comp in
                       let comp1 =
                         FStar_TypeChecker_Env.reify_comp tcenv1 comp
                           FStar_Syntax_Syntax.U_unknown in
@@ -2608,59 +2545,55 @@ let (encode_top_level_let :
                   match () with
                   | () ->
                       let uu___2 =
-                        FStar_Compiler_Effect.op_Bar_Greater bindings
-                          (FStar_Compiler_Util.for_all
-                             (fun lb ->
-                                FStar_Syntax_Util.is_lemma
-                                  lb.FStar_Syntax_Syntax.lbtyp)) in
+                        FStar_Compiler_Util.for_all
+                          (fun lb ->
+                             FStar_Syntax_Util.is_lemma
+                               lb.FStar_Syntax_Syntax.lbtyp) bindings in
                       if uu___2
                       then encode_top_level_vals env bindings quals
                       else
                         (let uu___4 =
-                           FStar_Compiler_Effect.op_Bar_Greater bindings
-                             (FStar_Compiler_List.fold_left
-                                (fun uu___5 ->
-                                   fun lb ->
-                                     match uu___5 with
-                                     | (toks, typs, decls, env1) ->
-                                         ((let uu___7 =
-                                             FStar_Syntax_Util.is_lemma
-                                               lb.FStar_Syntax_Syntax.lbtyp in
-                                           if uu___7
-                                           then
-                                             FStar_Compiler_Effect.raise
-                                               Let_rec_unencodeable
-                                           else ());
-                                          (let t_norm =
-                                             if is_rec
-                                             then
-                                               FStar_TypeChecker_Normalize.unfold_whnf'
-                                                 [FStar_TypeChecker_Env.AllowUnboundUniverses]
-                                                 env1.FStar_SMTEncoding_Env.tcenv
-                                                 lb.FStar_Syntax_Syntax.lbtyp
-                                             else
-                                               norm_before_encoding env1
-                                                 lb.FStar_Syntax_Syntax.lbtyp in
-                                           let uu___7 =
-                                             let uu___8 =
-                                               FStar_Compiler_Util.right
-                                                 lb.FStar_Syntax_Syntax.lbname in
-                                             declare_top_level_let env1
-                                               uu___8
-                                               lb.FStar_Syntax_Syntax.lbtyp
-                                               t_norm in
-                                           match uu___7 with
-                                           | (tok, decl, env2) ->
-                                               ((tok :: toks), (t_norm ::
-                                                 typs), (decl :: decls),
-                                                 env2)))) ([], [], [], env)) in
+                           FStar_Compiler_List.fold_left
+                             (fun uu___5 ->
+                                fun lb ->
+                                  match uu___5 with
+                                  | (toks, typs, decls, env1) ->
+                                      ((let uu___7 =
+                                          FStar_Syntax_Util.is_lemma
+                                            lb.FStar_Syntax_Syntax.lbtyp in
+                                        if uu___7
+                                        then
+                                          FStar_Compiler_Effect.raise
+                                            Let_rec_unencodeable
+                                        else ());
+                                       (let t_norm =
+                                          if is_rec
+                                          then
+                                            FStar_TypeChecker_Normalize.unfold_whnf'
+                                              [FStar_TypeChecker_Env.AllowUnboundUniverses]
+                                              env1.FStar_SMTEncoding_Env.tcenv
+                                              lb.FStar_Syntax_Syntax.lbtyp
+                                          else
+                                            norm_before_encoding env1
+                                              lb.FStar_Syntax_Syntax.lbtyp in
+                                        let uu___7 =
+                                          let uu___8 =
+                                            FStar_Compiler_Util.right
+                                              lb.FStar_Syntax_Syntax.lbname in
+                                          declare_top_level_let env1 uu___8
+                                            lb.FStar_Syntax_Syntax.lbtyp
+                                            t_norm in
+                                        match uu___7 with
+                                        | (tok, decl, env2) ->
+                                            ((tok :: toks), (t_norm :: typs),
+                                              (decl :: decls), env2))))
+                             ([], [], [], env) bindings in
                          match uu___4 with
                          | (toks, typs, decls, env1) ->
                              let toks_fvbs = FStar_Compiler_List.rev toks in
                              let decls1 =
-                               FStar_Compiler_Effect.op_Bar_Greater
-                                 (FStar_Compiler_List.rev decls)
-                                 FStar_Compiler_List.flatten in
+                               FStar_Compiler_List.flatten
+                                 (FStar_Compiler_List.rev decls) in
                              let env_decls = copy_env env1 in
                              let typs1 = FStar_Compiler_List.rev typs in
                              let encode_non_rec_lbdef bindings1 typs2 toks1
@@ -2734,9 +2667,8 @@ let (encode_top_level_let :
                                                FStar_Syntax_Util.comp_result
                                                  t_body_comp in
                                              ((let uu___12 =
-                                                 FStar_Compiler_Effect.op_Less_Bar
-                                                   (FStar_TypeChecker_Env.debug
-                                                      env2.FStar_SMTEncoding_Env.tcenv)
+                                                 FStar_TypeChecker_Env.debug
+                                                   env2.FStar_SMTEncoding_Env.tcenv
                                                    (FStar_Options.Other
                                                       "SMTEncoding") in
                                                if uu___12
@@ -2823,10 +2755,9 @@ let (encode_top_level_let :
                                                           (Prims.op_Negation
                                                              is_smt_theory_symbol)
                                                             &&
-                                                            ((FStar_Compiler_Effect.op_Bar_Greater
-                                                                quals
-                                                                (FStar_Compiler_List.contains
-                                                                   FStar_Syntax_Syntax.Logic))
+                                                            ((FStar_Compiler_List.contains
+                                                                FStar_Syntax_Syntax.Logic
+                                                                quals)
                                                                || is_logical) in
                                                         let make_eqn name pat
                                                           app1 body1 =
@@ -2955,9 +2886,8 @@ let (encode_top_level_let :
                                                                     FStar_Compiler_List.op_At
                                                                     eqns
                                                                     uu___21 in
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___20
-                                                                    FStar_SMTEncoding_Term.mk_decls_trivial in
+                                                                    FStar_SMTEncoding_Term.mk_decls_trivial
+                                                                    uu___20 in
                                                                    FStar_Compiler_List.op_At
                                                                     decls2
                                                                     uu___19 in
@@ -2985,42 +2915,39 @@ let (encode_top_level_let :
                                  FStar_SMTEncoding_Util.mkFreeV fuel in
                                let env0 = env2 in
                                let uu___5 =
-                                 FStar_Compiler_Effect.op_Bar_Greater toks1
-                                   (FStar_Compiler_List.fold_left
-                                      (fun uu___6 ->
-                                         fun fvb ->
-                                           match uu___6 with
-                                           | (gtoks, env3) ->
-                                               let flid =
-                                                 fvb.FStar_SMTEncoding_Env.fvar_lid in
-                                               let g =
-                                                 let uu___7 =
-                                                   FStar_Ident.lid_add_suffix
-                                                     flid "fuel_instrumented" in
-                                                 FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.new_fvar
-                                                   uu___7 in
-                                               let gtok =
-                                                 let uu___7 =
-                                                   FStar_Ident.lid_add_suffix
-                                                     flid
-                                                     "fuel_instrumented_token" in
-                                                 FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.new_fvar
-                                                   uu___7 in
-                                               let env4 =
-                                                 let uu___7 =
-                                                   let uu___8 =
-                                                     FStar_SMTEncoding_Util.mkApp
-                                                       (g, [fuel_tm]) in
-                                                   FStar_Compiler_Effect.op_Less_Bar
-                                                     (fun uu___9 ->
-                                                        FStar_Pervasives_Native.Some
-                                                          uu___9) uu___8 in
-                                                 FStar_SMTEncoding_Env.push_free_var
-                                                   env3 flid
-                                                   fvb.FStar_SMTEncoding_Env.smt_arity
-                                                   gtok uu___7 in
-                                               (((fvb, g, gtok) :: gtoks),
-                                                 env4)) ([], env2)) in
+                                 FStar_Compiler_List.fold_left
+                                   (fun uu___6 ->
+                                      fun fvb ->
+                                        match uu___6 with
+                                        | (gtoks, env3) ->
+                                            let flid =
+                                              fvb.FStar_SMTEncoding_Env.fvar_lid in
+                                            let g =
+                                              let uu___7 =
+                                                FStar_Ident.lid_add_suffix
+                                                  flid "fuel_instrumented" in
+                                              FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.new_fvar
+                                                uu___7 in
+                                            let gtok =
+                                              let uu___7 =
+                                                FStar_Ident.lid_add_suffix
+                                                  flid
+                                                  "fuel_instrumented_token" in
+                                              FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.new_fvar
+                                                uu___7 in
+                                            let env4 =
+                                              let uu___7 =
+                                                let uu___8 =
+                                                  FStar_SMTEncoding_Util.mkApp
+                                                    (g, [fuel_tm]) in
+                                                FStar_Pervasives_Native.Some
+                                                  uu___8 in
+                                              FStar_SMTEncoding_Env.push_free_var
+                                                env3 flid
+                                                fvb.FStar_SMTEncoding_Env.smt_arity
+                                                gtok uu___7 in
+                                            (((fvb, g, gtok) :: gtoks), env4))
+                                   ([], env2) toks1 in
                                match uu___5 with
                                | (gtoks, env3) ->
                                    let gtoks1 = FStar_Compiler_List.rev gtoks in
@@ -3090,9 +3017,8 @@ let (encode_top_level_let :
                                          (match uu___12 with
                                           | (env', e1, t_norm1) ->
                                               ((let uu___14 =
-                                                  FStar_Compiler_Effect.op_Less_Bar
-                                                    (FStar_TypeChecker_Env.debug
-                                                       env01.FStar_SMTEncoding_Env.tcenv)
+                                                  FStar_TypeChecker_Env.debug
+                                                    env01.FStar_SMTEncoding_Env.tcenv
                                                     (FStar_Options.Other
                                                        "SMTEncoding") in
                                                 if uu___14
@@ -3128,9 +3054,8 @@ let (encode_top_level_let :
                                                     (match uu___15 with
                                                      | (pre_opt, tres) ->
                                                          ((let uu___17 =
-                                                             FStar_Compiler_Effect.op_Less_Bar
-                                                               (FStar_TypeChecker_Env.debug
-                                                                  env01.FStar_SMTEncoding_Env.tcenv)
+                                                             FStar_TypeChecker_Env.debug
+                                                               env01.FStar_SMTEncoding_Env.tcenv
                                                                (FStar_Options.Other
                                                                   "SMTEncoding") in
                                                            if uu___17
@@ -3469,7 +3394,6 @@ let (encode_top_level_let :
                                                                     FStar_SMTEncoding_Term.mk_fv
                                                                     (gtok,
                                                                     FStar_SMTEncoding_Term.Term_sort) in
-                                                                    FStar_Compiler_Effect.op_Less_Bar
                                                                     FStar_SMTEncoding_Util.mkFreeV
                                                                     uu___23 in
                                                                     FStar_SMTEncoding_EncodeTerm.mk_Apply
@@ -3485,7 +3409,6 @@ let (encode_top_level_let :
                                                                     FStar_SMTEncoding_Term.mk_fv
                                                                     (gtok,
                                                                     FStar_SMTEncoding_Term.Term_sort) in
-                                                                    FStar_Compiler_Effect.op_Less_Bar
                                                                     FStar_SMTEncoding_Util.mkFreeV
                                                                     uu___22 in
                                                                     let vars1
@@ -3622,10 +3545,9 @@ let (encode_top_level_let :
                                                                     =
                                                                     let uu___25
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
+                                                                    FStar_SMTEncoding_Term.mk_decls_trivial
                                                                     [decl_g;
-                                                                    decl_g_tok]
-                                                                    FStar_SMTEncoding_Term.mk_decls_trivial in
+                                                                    decl_g_tok] in
                                                                     FStar_Compiler_List.op_At
                                                                     aux_decls
                                                                     uu___25 in
@@ -3637,13 +3559,12 @@ let (encode_top_level_let :
                                                                     uu___23 in
                                                                     let uu___23
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
+                                                                    FStar_SMTEncoding_Term.mk_decls_trivial
                                                                     (FStar_Compiler_List.op_At
                                                                     [eqn_g;
                                                                     eqn_g';
                                                                     eqn_f]
-                                                                    g_typing)
-                                                                    FStar_SMTEncoding_Term.mk_decls_trivial in
+                                                                    g_typing) in
                                                                     (uu___22,
                                                                     uu___23,
                                                                     env02)))))))))) in
@@ -3675,52 +3596,40 @@ let (encode_top_level_let :
                                                 uu___9 -> true
                                             | uu___9 -> false in
                                           let uu___8 =
-                                            FStar_Compiler_Effect.op_Bar_Greater
-                                              decls2
-                                              FStar_Compiler_List.flatten in
-                                          FStar_Compiler_Effect.op_Bar_Greater
-                                            uu___8
-                                            (fun decls3 ->
-                                               let uu___9 =
-                                                 FStar_Compiler_List.fold_left
-                                                   (fun uu___10 ->
-                                                      fun elt ->
-                                                        match uu___10 with
-                                                        | (prefix_decls,
-                                                           elts, rest) ->
-                                                            let uu___11 =
-                                                              (FStar_Compiler_Effect.op_Bar_Greater
-                                                                 elt.FStar_SMTEncoding_Term.key
-                                                                 FStar_Compiler_Util.is_some)
-                                                                &&
-                                                                (FStar_Compiler_List.existsb
-                                                                   isDeclFun
-                                                                   elt.FStar_SMTEncoding_Term.decls) in
-                                                            if uu___11
-                                                            then
-                                                              (prefix_decls,
+                                            FStar_Compiler_List.fold_left
+                                              (fun uu___9 ->
+                                                 fun elt ->
+                                                   match uu___9 with
+                                                   | (prefix_decls, elts,
+                                                      rest) ->
+                                                       let uu___10 =
+                                                         (FStar_Compiler_Util.is_some
+                                                            elt.FStar_SMTEncoding_Term.key)
+                                                           &&
+                                                           (FStar_Compiler_List.existsb
+                                                              isDeclFun
+                                                              elt.FStar_SMTEncoding_Term.decls) in
+                                                       if uu___10
+                                                       then
+                                                         (prefix_decls,
+                                                           (FStar_Compiler_List.op_At
+                                                              elts [elt]),
+                                                           rest)
+                                                       else
+                                                         (let uu___12 =
+                                                            FStar_Compiler_List.partition
+                                                              isDeclFun
+                                                              elt.FStar_SMTEncoding_Term.decls in
+                                                          match uu___12 with
+                                                          | (elt_decl_funs,
+                                                             elt_rest) ->
+                                                              ((FStar_Compiler_List.op_At
+                                                                  prefix_decls
+                                                                  elt_decl_funs),
+                                                                elts,
                                                                 (FStar_Compiler_List.op_At
-                                                                   elts 
-                                                                   [elt]),
-                                                                rest)
-                                                            else
-                                                              (let uu___13 =
-                                                                 FStar_Compiler_List.partition
-                                                                   isDeclFun
-                                                                   elt.FStar_SMTEncoding_Term.decls in
-                                                               match uu___13
-                                                               with
-                                                               | (elt_decl_funs,
-                                                                  elt_rest)
-                                                                   ->
-                                                                   ((FStar_Compiler_List.op_At
-                                                                    prefix_decls
-                                                                    elt_decl_funs),
-                                                                    elts,
-                                                                    (FStar_Compiler_List.op_At
-                                                                    rest
-                                                                    [
-                                                                    {
+                                                                   rest
+                                                                   [{
                                                                     FStar_SMTEncoding_Term.sym_name
                                                                     =
                                                                     (elt.FStar_SMTEncoding_Term.sym_name);
@@ -3734,15 +3643,15 @@ let (encode_top_level_let :
                                                                     =
                                                                     (elt.FStar_SMTEncoding_Term.a_names)
                                                                     }]))))
-                                                   ([], [], []) decls3 in
-                                               match uu___9 with
-                                               | (prefix_decls, elts, rest)
-                                                   ->
-                                                   let uu___10 =
-                                                     FStar_Compiler_Effect.op_Bar_Greater
-                                                       prefix_decls
-                                                       FStar_SMTEncoding_Term.mk_decls_trivial in
-                                                   (uu___10, elts, rest)) in
+                                              ([], [], [])
+                                              (FStar_Compiler_List.flatten
+                                                 decls2) in
+                                          match uu___8 with
+                                          | (prefix_decls, elts, rest) ->
+                                              let uu___9 =
+                                                FStar_SMTEncoding_Term.mk_decls_trivial
+                                                  prefix_decls in
+                                              (uu___9, elts, rest) in
                                         (match uu___7 with
                                          | (prefix_decls, elts, rest) ->
                                              let eqns1 =
@@ -3754,26 +3663,23 @@ let (encode_top_level_let :
                                                     (FStar_Compiler_List.op_At
                                                        rest eqns1))), env01))) in
                              let uu___5 =
-                               (FStar_Compiler_Effect.op_Bar_Greater quals
-                                  (FStar_Compiler_Util.for_some
-                                     (fun uu___6 ->
-                                        match uu___6 with
-                                        | FStar_Syntax_Syntax.HasMaskedEffect
-                                            -> true
-                                        | uu___7 -> false)))
+                               (FStar_Compiler_Util.for_some
+                                  (fun uu___6 ->
+                                     match uu___6 with
+                                     | FStar_Syntax_Syntax.HasMaskedEffect ->
+                                         true
+                                     | uu___7 -> false) quals)
                                  ||
-                                 (FStar_Compiler_Effect.op_Bar_Greater typs1
-                                    (FStar_Compiler_Util.for_some
-                                       (fun t ->
-                                          let uu___6 =
-                                            (FStar_Syntax_Util.is_pure_or_ghost_function
-                                               t)
-                                              ||
-                                              (FStar_SMTEncoding_Util.is_smt_reifiable_function
-                                                 env1.FStar_SMTEncoding_Env.tcenv
-                                                 t) in
-                                          FStar_Compiler_Effect.op_Less_Bar
-                                            Prims.op_Negation uu___6))) in
+                                 (FStar_Compiler_Util.for_some
+                                    (fun t ->
+                                       let uu___6 =
+                                         (FStar_Syntax_Util.is_pure_or_ghost_function
+                                            t)
+                                           ||
+                                           (FStar_SMTEncoding_Util.is_smt_reifiable_function
+                                              env1.FStar_SMTEncoding_Env.tcenv
+                                              t) in
+                                       Prims.op_Negation uu___6) typs1) in
                              if uu___5
                              then (decls1, env_decls)
                              else
@@ -3797,8 +3703,7 @@ let (encode_top_level_let :
                                     let r =
                                       let uu___8 =
                                         FStar_Compiler_List.hd names in
-                                      FStar_Compiler_Effect.op_Bar_Greater
-                                        uu___8 FStar_Pervasives_Native.snd in
+                                      FStar_Pervasives_Native.snd uu___8 in
                                     ((let uu___9 =
                                         let uu___10 =
                                           let uu___11 =
@@ -3809,10 +3714,8 @@ let (encode_top_level_let :
                                                     FStar_Compiler_List.map
                                                       FStar_Pervasives_Native.fst
                                                       names in
-                                                  FStar_Compiler_Effect.op_Bar_Greater
-                                                    uu___15
-                                                    (FStar_Compiler_String.concat
-                                                       ",") in
+                                                  FStar_Compiler_String.concat
+                                                    "," uu___15 in
                                                 FStar_Compiler_Util.format3
                                                   "Definitions of inner let-rec%s %s and %s enclosing top-level letbinding are not encoded to the solver, you will only be able to reason with their types"
                                                   (if plural then "s" else "")
@@ -3820,8 +3723,7 @@ let (encode_top_level_let :
                                                   (if plural
                                                    then "their"
                                                    else "its") in
-                                              FStar_Compiler_Effect.op_Less_Bar
-                                                FStar_Errors_Msg.text uu___13 in
+                                              FStar_Errors_Msg.text uu___13 in
                                             [uu___12] in
                                           let uu___12 =
                                             FStar_Errors.get_ctx () in
@@ -3836,19 +3738,15 @@ let (encode_top_level_let :
              | Let_rec_unencodeable ->
                  let msg =
                    let uu___2 =
-                     FStar_Compiler_Effect.op_Bar_Greater bindings
-                       (FStar_Compiler_List.map
-                          (fun lb ->
-                             FStar_Syntax_Print.lbname_to_string
-                               lb.FStar_Syntax_Syntax.lbname)) in
-                   FStar_Compiler_Effect.op_Bar_Greater uu___2
-                     (FStar_Compiler_String.concat " and ") in
+                     FStar_Compiler_List.map
+                       (fun lb ->
+                          FStar_Syntax_Print.lbname_to_string
+                            lb.FStar_Syntax_Syntax.lbname) bindings in
+                   FStar_Compiler_String.concat " and " uu___2 in
                  let decl =
                    FStar_SMTEncoding_Term.Caption
                      (Prims.strcat "let rec unencodeable: Skipping: " msg) in
-                 let uu___2 =
-                   FStar_Compiler_Effect.op_Bar_Greater [decl]
-                     FStar_SMTEncoding_Term.mk_decls_trivial in
+                 let uu___2 = FStar_SMTEncoding_Term.mk_decls_trivial [decl] in
                  (uu___2, env))
 let rec (encode_sigelt :
   FStar_SMTEncoding_Env.env_t ->
@@ -3874,9 +3772,8 @@ let rec (encode_sigelt :
             match g with
             | [] ->
                 ((let uu___2 =
-                    FStar_Compiler_Effect.op_Less_Bar
-                      (FStar_TypeChecker_Env.debug
-                         env1.FStar_SMTEncoding_Env.tcenv)
+                    FStar_TypeChecker_Env.debug
+                      env1.FStar_SMTEncoding_Env.tcenv
                       (FStar_Options.Other "SMTEncoding") in
                   if uu___2
                   then
@@ -3888,8 +3785,7 @@ let rec (encode_sigelt :
                         FStar_Compiler_Util.format1 "<Skipped %s/>" nm in
                       FStar_SMTEncoding_Term.Caption uu___4 in
                     [uu___3] in
-                  FStar_Compiler_Effect.op_Bar_Greater uu___2
-                    FStar_SMTEncoding_Term.mk_decls_trivial))
+                  FStar_SMTEncoding_Term.mk_decls_trivial uu___2))
             | uu___1 ->
                 let uu___2 =
                   let uu___3 =
@@ -3898,8 +3794,7 @@ let rec (encode_sigelt :
                         FStar_Compiler_Util.format1 "<Start encoding %s>" nm in
                       FStar_SMTEncoding_Term.Caption uu___5 in
                     [uu___4] in
-                  FStar_Compiler_Effect.op_Bar_Greater uu___3
-                    FStar_SMTEncoding_Term.mk_decls_trivial in
+                  FStar_SMTEncoding_Term.mk_decls_trivial uu___3 in
                 let uu___3 =
                   let uu___4 =
                     let uu___5 =
@@ -3908,8 +3803,7 @@ let rec (encode_sigelt :
                           FStar_Compiler_Util.format1 "</end encoding %s>" nm in
                         FStar_SMTEncoding_Term.Caption uu___7 in
                       [uu___6] in
-                    FStar_Compiler_Effect.op_Bar_Greater uu___5
-                      FStar_SMTEncoding_Term.mk_decls_trivial in
+                    FStar_SMTEncoding_Term.mk_decls_trivial uu___5 in
                   FStar_Compiler_List.op_At g uu___4 in
                 FStar_Compiler_List.op_At uu___2 uu___3 in
           (g1, env1)
@@ -3921,8 +3815,7 @@ and (encode_sigelt' :
   fun env ->
     fun se ->
       (let uu___1 =
-         FStar_Compiler_Effect.op_Less_Bar
-           (FStar_TypeChecker_Env.debug env.FStar_SMTEncoding_Env.tcenv)
+         FStar_TypeChecker_Env.debug env.FStar_SMTEncoding_Env.tcenv
            (FStar_Options.Other "SMTEncoding") in
        if uu___1
        then
@@ -4008,11 +3901,10 @@ and (encode_sigelt' :
                                 let uu___7 =
                                   let uu___8 =
                                     let uu___9 =
-                                      FStar_Compiler_Effect.op_Bar_Greater
-                                        formals
-                                        (FStar_Compiler_List.map
-                                           (fun uu___10 ->
-                                              FStar_SMTEncoding_Term.Term_sort)) in
+                                      FStar_Compiler_List.map
+                                        (fun uu___10 ->
+                                           FStar_SMTEncoding_Term.Term_sort)
+                                        formals in
                                     (aname, uu___9,
                                       FStar_SMTEncoding_Term.Term_sort,
                                       (FStar_Pervasives_Native.Some "Action")) in
@@ -4081,9 +3973,7 @@ and (encode_sigelt' :
                                          FStar_SMTEncoding_Term.mk_fv
                                            (atok,
                                              FStar_SMTEncoding_Term.Term_sort) in
-                                       FStar_Compiler_Effect.op_Less_Bar
-                                         FStar_SMTEncoding_Util.mkFreeV
-                                         uu___9 in
+                                       FStar_SMTEncoding_Util.mkFreeV uu___9 in
                                      let tok_app =
                                        FStar_SMTEncoding_EncodeTerm.mk_Apply
                                          tok_term xs_sorts in
@@ -4107,10 +3997,9 @@ and (encode_sigelt' :
                                      FStar_SMTEncoding_Util.mkAssume uu___9 in
                                    let uu___9 =
                                      let uu___10 =
-                                       FStar_Compiler_Effect.op_Bar_Greater
+                                       FStar_SMTEncoding_Term.mk_decls_trivial
                                          (FStar_Compiler_List.op_At a_decls
-                                            [a_eq; tok_correspondence])
-                                         FStar_SMTEncoding_Term.mk_decls_trivial in
+                                            [a_eq; tok_correspondence]) in
                                      FStar_Compiler_List.op_At decls uu___10 in
                                    (env2, uu___9)))) in
               let uu___3 =
@@ -4135,15 +4024,14 @@ and (encode_sigelt' :
            let quals = se.FStar_Syntax_Syntax.sigquals in
            let will_encode_definition =
              let uu___2 =
-               FStar_Compiler_Effect.op_Bar_Greater quals
-                 (FStar_Compiler_Util.for_some
-                    (fun uu___3 ->
-                       match uu___3 with
-                       | FStar_Syntax_Syntax.Assumption -> true
-                       | FStar_Syntax_Syntax.Projector uu___4 -> true
-                       | FStar_Syntax_Syntax.Discriminator uu___4 -> true
-                       | FStar_Syntax_Syntax.Irreducible -> true
-                       | uu___4 -> false)) in
+               FStar_Compiler_Util.for_some
+                 (fun uu___3 ->
+                    match uu___3 with
+                    | FStar_Syntax_Syntax.Assumption -> true
+                    | FStar_Syntax_Syntax.Projector uu___4 -> true
+                    | FStar_Syntax_Syntax.Discriminator uu___4 -> true
+                    | FStar_Syntax_Syntax.Irreducible -> true
+                    | uu___4 -> false) quals in
              Prims.op_Negation uu___2 in
            if will_encode_definition
            then ([], env)
@@ -4153,9 +4041,8 @@ and (encode_sigelt' :
                   FStar_Pervasives_Native.None in
               let uu___3 =
                 let uu___4 =
-                  FStar_Compiler_Effect.op_Bar_Greater
-                    se.FStar_Syntax_Syntax.sigattrs
-                    (FStar_Compiler_Util.for_some is_uninterpreted_by_smt) in
+                  FStar_Compiler_Util.for_some is_uninterpreted_by_smt
+                    se.FStar_Syntax_Syntax.sigattrs in
                 encode_top_level_val uu___4 env fv t quals in
               match uu___3 with
               | (decls, env1) ->
@@ -4169,8 +4056,7 @@ and (encode_sigelt' :
                       let uu___6 =
                         primitive_type_axioms
                           env1.FStar_SMTEncoding_Env.tcenv lid tname tsym in
-                      FStar_Compiler_Effect.op_Bar_Greater uu___6
-                        FStar_SMTEncoding_Term.mk_decls_trivial in
+                      FStar_SMTEncoding_Term.mk_decls_trivial uu___6 in
                     FStar_Compiler_List.op_At decls uu___5 in
                   (uu___4, env1))
        | FStar_Syntax_Syntax.Sig_assume
@@ -4232,20 +4118,17 @@ and (encode_sigelt' :
                              (f3, uu___6, uu___7) in
                            FStar_SMTEncoding_Util.mkAssume uu___5 in
                          [uu___4] in
-                       FStar_Compiler_Effect.op_Bar_Greater uu___3
-                         FStar_SMTEncoding_Term.mk_decls_trivial in
+                       FStar_SMTEncoding_Term.mk_decls_trivial uu___3 in
                      ((FStar_Compiler_List.op_At decls g), env1)))
        | FStar_Syntax_Syntax.Sig_let
            { FStar_Syntax_Syntax.lbs1 = lbs;
              FStar_Syntax_Syntax.lids1 = uu___1;_}
            when
-           (FStar_Compiler_Effect.op_Bar_Greater
-              se.FStar_Syntax_Syntax.sigquals
-              (FStar_Compiler_List.contains FStar_Syntax_Syntax.Irreducible))
+           (FStar_Compiler_List.contains FStar_Syntax_Syntax.Irreducible
+              se.FStar_Syntax_Syntax.sigquals)
              ||
-             (FStar_Compiler_Effect.op_Bar_Greater
-                se.FStar_Syntax_Syntax.sigattrs
-                (FStar_Compiler_Util.for_some is_opaque_to_smt))
+             (FStar_Compiler_Util.for_some is_opaque_to_smt
+                se.FStar_Syntax_Syntax.sigattrs)
            ->
            let attrs = se.FStar_Syntax_Syntax.sigattrs in
            let uu___2 =
@@ -4263,8 +4146,7 @@ and (encode_sigelt' :
                       let uu___4 =
                         FStar_TypeChecker_Env.try_lookup_val_decl
                           env1.FStar_SMTEncoding_Env.tcenv lid in
-                      FStar_Compiler_Effect.op_Less_Bar
-                        FStar_Compiler_Option.isNone uu___4 in
+                      FStar_Compiler_Option.isNone uu___4 in
                     if uu___3
                     then
                       let val_decl =
@@ -4378,22 +4260,17 @@ and (encode_sigelt' :
                        FStar_SMTEncoding_Term.Term_sort,
                        FStar_Pervasives_Native.None))
                     :: uu___10 in
-                let uu___10 =
-                  FStar_Compiler_Effect.op_Bar_Greater decls
-                    FStar_SMTEncoding_Term.mk_decls_trivial in
+                let uu___10 = FStar_SMTEncoding_Term.mk_decls_trivial decls in
                 (uu___10, env1))
        | FStar_Syntax_Syntax.Sig_let uu___1 when
-           FStar_Compiler_Effect.op_Bar_Greater
-             se.FStar_Syntax_Syntax.sigquals
-             (FStar_Compiler_Util.for_some
-                (fun uu___2 ->
-                   match uu___2 with
-                   | FStar_Syntax_Syntax.Discriminator uu___3 -> true
-                   | uu___3 -> false))
+           FStar_Compiler_Util.for_some
+             (fun uu___2 ->
+                match uu___2 with
+                | FStar_Syntax_Syntax.Discriminator uu___3 -> true
+                | uu___3 -> false) se.FStar_Syntax_Syntax.sigquals
            ->
            ((let uu___3 =
-               FStar_Compiler_Effect.op_Less_Bar
-                 (FStar_TypeChecker_Env.debug env.FStar_SMTEncoding_Env.tcenv)
+               FStar_TypeChecker_Env.debug env.FStar_SMTEncoding_Env.tcenv
                  (FStar_Options.Other "SMTEncoding") in
              if uu___3
              then
@@ -4406,28 +4283,24 @@ and (encode_sigelt' :
            { FStar_Syntax_Syntax.lbs1 = uu___1;
              FStar_Syntax_Syntax.lids1 = lids;_}
            when
-           (FStar_Compiler_Effect.op_Bar_Greater lids
-              (FStar_Compiler_Util.for_some
-                 (fun l ->
-                    let uu___2 =
-                      let uu___3 =
-                        let uu___4 = FStar_Ident.ns_of_lid l in
-                        FStar_Compiler_List.hd uu___4 in
-                      FStar_Ident.string_of_id uu___3 in
-                    uu___2 = "Prims")))
+           (FStar_Compiler_Util.for_some
+              (fun l ->
+                 let uu___2 =
+                   let uu___3 =
+                     let uu___4 = FStar_Ident.ns_of_lid l in
+                     FStar_Compiler_List.hd uu___4 in
+                   FStar_Ident.string_of_id uu___3 in
+                 uu___2 = "Prims") lids)
              &&
-             (FStar_Compiler_Effect.op_Bar_Greater
-                se.FStar_Syntax_Syntax.sigquals
-                (FStar_Compiler_Util.for_some
-                   (fun uu___2 ->
-                      match uu___2 with
-                      | FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen
-                          -> true
-                      | uu___3 -> false)))
+             (FStar_Compiler_Util.for_some
+                (fun uu___2 ->
+                   match uu___2 with
+                   | FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen ->
+                       true
+                   | uu___3 -> false) se.FStar_Syntax_Syntax.sigquals)
            ->
            ((let uu___3 =
-               FStar_Compiler_Effect.op_Less_Bar
-                 (FStar_TypeChecker_Env.debug env.FStar_SMTEncoding_Env.tcenv)
+               FStar_TypeChecker_Env.debug env.FStar_SMTEncoding_Env.tcenv
                  (FStar_Options.Other "SMTEncoding") in
              if uu___3
              then
@@ -4440,13 +4313,11 @@ and (encode_sigelt' :
            { FStar_Syntax_Syntax.lbs1 = (false, lb::[]);
              FStar_Syntax_Syntax.lids1 = uu___1;_}
            when
-           FStar_Compiler_Effect.op_Bar_Greater
-             se.FStar_Syntax_Syntax.sigquals
-             (FStar_Compiler_Util.for_some
-                (fun uu___2 ->
-                   match uu___2 with
-                   | FStar_Syntax_Syntax.Projector uu___3 -> true
-                   | uu___3 -> false))
+           FStar_Compiler_Util.for_some
+             (fun uu___2 ->
+                match uu___2 with
+                | FStar_Syntax_Syntax.Projector uu___3 -> true
+                | uu___3 -> false) se.FStar_Syntax_Syntax.sigquals
            ->
            let fv = FStar_Compiler_Util.right lb.FStar_Syntax_Syntax.lbname in
            let l = (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
@@ -4520,24 +4391,23 @@ and (encode_sigelt' :
                          match uu___4 with
                          | (g', inversions) ->
                              let uu___5 =
-                               FStar_Compiler_Effect.op_Bar_Greater
-                                 elt.FStar_SMTEncoding_Term.decls
-                                 (FStar_Compiler_List.partition
-                                    (fun uu___6 ->
-                                       match uu___6 with
-                                       | FStar_SMTEncoding_Term.Assume
-                                           {
-                                             FStar_SMTEncoding_Term.assumption_term
-                                               = uu___7;
-                                             FStar_SMTEncoding_Term.assumption_caption
-                                               = FStar_Pervasives_Native.Some
-                                               "inversion axiom";
-                                             FStar_SMTEncoding_Term.assumption_name
-                                               = uu___8;
-                                             FStar_SMTEncoding_Term.assumption_fact_ids
-                                               = uu___9;_}
-                                           -> false
-                                       | uu___7 -> true)) in
+                               FStar_Compiler_List.partition
+                                 (fun uu___6 ->
+                                    match uu___6 with
+                                    | FStar_SMTEncoding_Term.Assume
+                                        {
+                                          FStar_SMTEncoding_Term.assumption_term
+                                            = uu___7;
+                                          FStar_SMTEncoding_Term.assumption_caption
+                                            = FStar_Pervasives_Native.Some
+                                            "inversion axiom";
+                                          FStar_SMTEncoding_Term.assumption_name
+                                            = uu___8;
+                                          FStar_SMTEncoding_Term.assumption_fact_ids
+                                            = uu___9;_}
+                                        -> false
+                                    | uu___7 -> true)
+                                 elt.FStar_SMTEncoding_Term.decls in
                              (match uu___5 with
                               | (elt_g', elt_inversions) ->
                                   ((FStar_Compiler_List.op_At g'
@@ -4562,9 +4432,8 @@ and (encode_sigelt' :
                               match uu___5 with
                               | (decls, elts, rest) ->
                                   let uu___6 =
-                                    (FStar_Compiler_Effect.op_Bar_Greater
-                                       elt.FStar_SMTEncoding_Term.key
-                                       FStar_Compiler_Util.is_some)
+                                    (FStar_Compiler_Util.is_some
+                                       elt.FStar_SMTEncoding_Term.key)
                                       &&
                                       (FStar_Compiler_List.existsb
                                          (fun uu___7 ->
@@ -4580,14 +4449,13 @@ and (encode_sigelt' :
                                       rest)
                                   else
                                     (let uu___8 =
-                                       FStar_Compiler_Effect.op_Bar_Greater
-                                         elt.FStar_SMTEncoding_Term.decls
-                                         (FStar_Compiler_List.partition
-                                            (fun uu___9 ->
-                                               match uu___9 with
-                                               | FStar_SMTEncoding_Term.DeclFun
-                                                   uu___10 -> true
-                                               | uu___10 -> false)) in
+                                       FStar_Compiler_List.partition
+                                         (fun uu___9 ->
+                                            match uu___9 with
+                                            | FStar_SMTEncoding_Term.DeclFun
+                                                uu___10 -> true
+                                            | uu___10 -> false)
+                                         elt.FStar_SMTEncoding_Term.decls in
                                      match uu___8 with
                                      | (elt_decls, elt_rest) ->
                                          ((FStar_Compiler_List.op_At decls
@@ -4609,14 +4477,12 @@ and (encode_sigelt' :
                       | (decls, elts, rest) ->
                           let uu___5 =
                             let uu___6 =
-                              FStar_Compiler_Effect.op_Bar_Greater decls
-                                FStar_SMTEncoding_Term.mk_decls_trivial in
+                              FStar_SMTEncoding_Term.mk_decls_trivial decls in
                             let uu___7 =
                               let uu___8 =
                                 let uu___9 =
-                                  FStar_Compiler_Effect.op_Bar_Greater
-                                    inversions
-                                    FStar_SMTEncoding_Term.mk_decls_trivial in
+                                  FStar_SMTEncoding_Term.mk_decls_trivial
+                                    inversions in
                                 FStar_Compiler_List.op_At rest uu___9 in
                               FStar_Compiler_List.op_At elts uu___8 in
                             FStar_Compiler_List.op_At uu___6 uu___7 in
@@ -4689,16 +4555,13 @@ and (encode_sigelt' :
                                            universe_leq u v0
                                        | (FStar_Syntax_Syntax.U_max us1,
                                           uu___10) ->
-                                           FStar_Compiler_Effect.op_Bar_Greater
+                                           FStar_Compiler_Util.for_all
+                                             (fun u1 -> universe_leq u1 v)
                                              us1
-                                             (FStar_Compiler_Util.for_all
-                                                (fun u1 -> universe_leq u1 v))
                                        | (uu___10, FStar_Syntax_Syntax.U_max
                                           vs) ->
-                                           FStar_Compiler_Effect.op_Bar_Greater
-                                             vs
-                                             (FStar_Compiler_Util.for_some
-                                                (universe_leq u))
+                                           FStar_Compiler_Util.for_some
+                                             (universe_leq u) vs
                                        | (FStar_Syntax_Syntax.U_unknown,
                                           uu___10) ->
                                            let uu___11 =
@@ -4794,8 +4657,7 @@ and (encode_sigelt' :
                                      FStar_Compiler_List.forall2 tp_ok tps3
                                        us)))) in
            ((let uu___4 =
-               FStar_Compiler_Effect.op_Less_Bar
-                 (FStar_TypeChecker_Env.debug env.FStar_SMTEncoding_Env.tcenv)
+               FStar_TypeChecker_Env.debug env.FStar_SMTEncoding_Env.tcenv
                  (FStar_Options.Other "SMTEncoding") in
              if uu___4
              then
@@ -4805,23 +4667,21 @@ and (encode_sigelt' :
              else ());
             (let quals = se.FStar_Syntax_Syntax.sigquals in
              let is_logical =
-               FStar_Compiler_Effect.op_Bar_Greater quals
-                 (FStar_Compiler_Util.for_some
-                    (fun uu___4 ->
-                       match uu___4 with
-                       | FStar_Syntax_Syntax.Logic -> true
-                       | FStar_Syntax_Syntax.Assumption -> true
-                       | uu___5 -> false)) in
+               FStar_Compiler_Util.for_some
+                 (fun uu___4 ->
+                    match uu___4 with
+                    | FStar_Syntax_Syntax.Logic -> true
+                    | FStar_Syntax_Syntax.Assumption -> true
+                    | uu___5 -> false) quals in
              let constructor_or_logic_type_decl c =
                if is_logical
                then
                  let uu___4 =
                    let uu___5 =
                      let uu___6 =
-                       FStar_Compiler_Effect.op_Bar_Greater
-                         c.FStar_SMTEncoding_Term.constr_fields
-                         (FStar_Compiler_List.map
-                            (fun f -> f.FStar_SMTEncoding_Term.field_sort)) in
+                       FStar_Compiler_List.map
+                         (fun f -> f.FStar_SMTEncoding_Term.field_sort)
+                         c.FStar_SMTEncoding_Term.constr_fields in
                      ((c.FStar_SMTEncoding_Term.constr_name), uu___6,
                        FStar_SMTEncoding_Term.Term_sort,
                        FStar_Pervasives_Native.None) in
@@ -4832,14 +4692,12 @@ and (encode_sigelt' :
                   FStar_SMTEncoding_Term.constructor_to_decl uu___5 c) in
              let inversion_axioms env1 tapp vars =
                let uu___4 =
-                 FStar_Compiler_Effect.op_Bar_Greater datas
-                   (FStar_Compiler_Util.for_some
-                      (fun l ->
-                         let uu___5 =
-                           FStar_TypeChecker_Env.try_lookup_lid
-                             env1.FStar_SMTEncoding_Env.tcenv l in
-                         FStar_Compiler_Effect.op_Bar_Greater uu___5
-                           FStar_Compiler_Option.isNone)) in
+                 FStar_Compiler_Util.for_some
+                   (fun l ->
+                      let uu___5 =
+                        FStar_TypeChecker_Env.try_lookup_lid
+                          env1.FStar_SMTEncoding_Env.tcenv l in
+                      FStar_Compiler_Option.isNone uu___5) datas in
                if uu___4
                then []
                else
@@ -4850,118 +4708,105 @@ and (encode_sigelt' :
                   match uu___6 with
                   | (xxsym, xx) ->
                       let uu___7 =
-                        FStar_Compiler_Effect.op_Bar_Greater datas
-                          (FStar_Compiler_List.fold_left
-                             (fun uu___8 ->
-                                fun l ->
-                                  match uu___8 with
-                                  | (out, decls) ->
-                                      let uu___9 =
-                                        FStar_TypeChecker_Env.lookup_datacon
-                                          env1.FStar_SMTEncoding_Env.tcenv l in
-                                      (match uu___9 with
-                                       | (uu___10, data_t) ->
-                                           let uu___11 =
-                                             FStar_Syntax_Util.arrow_formals
-                                               data_t in
-                                           (match uu___11 with
-                                            | (args, res) ->
-                                                let indices =
-                                                  let uu___12 =
-                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                      res
-                                                      FStar_Syntax_Util.head_and_args_full in
-                                                  FStar_Compiler_Effect.op_Bar_Greater
-                                                    uu___12
-                                                    FStar_Pervasives_Native.snd in
-                                                let env2 =
-                                                  FStar_Compiler_Effect.op_Bar_Greater
-                                                    args
-                                                    (FStar_Compiler_List.fold_left
-                                                       (fun env3 ->
-                                                          fun uu___12 ->
-                                                            match uu___12
-                                                            with
-                                                            | {
-                                                                FStar_Syntax_Syntax.binder_bv
-                                                                  = x;
-                                                                FStar_Syntax_Syntax.binder_qual
-                                                                  = uu___13;
-                                                                FStar_Syntax_Syntax.binder_positivity
-                                                                  = uu___14;
-                                                                FStar_Syntax_Syntax.binder_attrs
-                                                                  = uu___15;_}
-                                                                ->
-                                                                let uu___16 =
-                                                                  let uu___17
-                                                                    =
-                                                                    let uu___18
-                                                                    =
-                                                                    FStar_SMTEncoding_Env.mk_term_projector_name
-                                                                    l x in
-                                                                    (uu___18,
-                                                                    [xx]) in
-                                                                  FStar_SMTEncoding_Util.mkApp
-                                                                    uu___17 in
-                                                                FStar_SMTEncoding_Env.push_term_var
-                                                                  env3 x
-                                                                  uu___16)
-                                                       env1) in
-                                                let uu___12 =
-                                                  FStar_SMTEncoding_EncodeTerm.encode_args
-                                                    indices env2 in
-                                                (match uu___12 with
-                                                 | (indices1, decls') ->
-                                                     (if
-                                                        (FStar_Compiler_List.length
-                                                           indices1)
-                                                          <>
-                                                          (FStar_Compiler_List.length
-                                                             vars)
+                        FStar_Compiler_List.fold_left
+                          (fun uu___8 ->
+                             fun l ->
+                               match uu___8 with
+                               | (out, decls) ->
+                                   let uu___9 =
+                                     FStar_TypeChecker_Env.lookup_datacon
+                                       env1.FStar_SMTEncoding_Env.tcenv l in
+                                   (match uu___9 with
+                                    | (uu___10, data_t) ->
+                                        let uu___11 =
+                                          FStar_Syntax_Util.arrow_formals
+                                            data_t in
+                                        (match uu___11 with
+                                         | (args, res) ->
+                                             let indices =
+                                               let uu___12 =
+                                                 FStar_Syntax_Util.head_and_args_full
+                                                   res in
+                                               FStar_Pervasives_Native.snd
+                                                 uu___12 in
+                                             let env2 =
+                                               FStar_Compiler_List.fold_left
+                                                 (fun env3 ->
+                                                    fun uu___12 ->
+                                                      match uu___12 with
+                                                      | {
+                                                          FStar_Syntax_Syntax.binder_bv
+                                                            = x;
+                                                          FStar_Syntax_Syntax.binder_qual
+                                                            = uu___13;
+                                                          FStar_Syntax_Syntax.binder_positivity
+                                                            = uu___14;
+                                                          FStar_Syntax_Syntax.binder_attrs
+                                                            = uu___15;_}
+                                                          ->
+                                                          let uu___16 =
+                                                            let uu___17 =
+                                                              let uu___18 =
+                                                                FStar_SMTEncoding_Env.mk_term_projector_name
+                                                                  l x in
+                                                              (uu___18, [xx]) in
+                                                            FStar_SMTEncoding_Util.mkApp
+                                                              uu___17 in
+                                                          FStar_SMTEncoding_Env.push_term_var
+                                                            env3 x uu___16)
+                                                 env1 args in
+                                             let uu___12 =
+                                               FStar_SMTEncoding_EncodeTerm.encode_args
+                                                 indices env2 in
+                                             (match uu___12 with
+                                              | (indices1, decls') ->
+                                                  (if
+                                                     (FStar_Compiler_List.length
+                                                        indices1)
+                                                       <>
+                                                       (FStar_Compiler_List.length
+                                                          vars)
+                                                   then
+                                                     FStar_Compiler_Effect.failwith
+                                                       "Impossible"
+                                                   else ();
+                                                   (let eqs =
+                                                      if is_injective
                                                       then
-                                                        FStar_Compiler_Effect.failwith
-                                                          "Impossible"
-                                                      else ();
-                                                      (let eqs =
-                                                         if is_injective
-                                                         then
-                                                           FStar_Compiler_List.map2
-                                                             (fun v ->
-                                                                fun a ->
-                                                                  let uu___14
-                                                                    =
-                                                                    let uu___15
-                                                                    =
-                                                                    FStar_SMTEncoding_Util.mkFreeV
+                                                        FStar_Compiler_List.map2
+                                                          (fun v ->
+                                                             fun a ->
+                                                               let uu___14 =
+                                                                 let uu___15
+                                                                   =
+                                                                   FStar_SMTEncoding_Util.mkFreeV
                                                                     v in
-                                                                    (uu___15,
-                                                                    a) in
-                                                                  FStar_SMTEncoding_Util.mkEq
-                                                                    uu___14)
-                                                             vars indices1
-                                                         else [] in
-                                                       let uu___14 =
-                                                         let uu___15 =
-                                                           let uu___16 =
-                                                             let uu___17 =
-                                                               let uu___18 =
-                                                                 FStar_SMTEncoding_Env.mk_data_tester
-                                                                   env2 l xx in
-                                                               let uu___19 =
-                                                                 FStar_Compiler_Effect.op_Bar_Greater
-                                                                   eqs
-                                                                   FStar_SMTEncoding_Util.mk_and_l in
-                                                               (uu___18,
-                                                                 uu___19) in
-                                                             FStar_SMTEncoding_Util.mkAnd
-                                                               uu___17 in
-                                                           (out, uu___16) in
-                                                         FStar_SMTEncoding_Util.mkOr
-                                                           uu___15 in
-                                                       (uu___14,
-                                                         (FStar_Compiler_List.op_At
-                                                            decls decls'))))))))
-                             (FStar_SMTEncoding_Util.mkFalse, [])) in
+                                                                 (uu___15, a) in
+                                                               FStar_SMTEncoding_Util.mkEq
+                                                                 uu___14)
+                                                          vars indices1
+                                                      else [] in
+                                                    let uu___14 =
+                                                      let uu___15 =
+                                                        let uu___16 =
+                                                          let uu___17 =
+                                                            let uu___18 =
+                                                              FStar_SMTEncoding_Env.mk_data_tester
+                                                                env2 l xx in
+                                                            let uu___19 =
+                                                              FStar_SMTEncoding_Util.mk_and_l
+                                                                eqs in
+                                                            (uu___18,
+                                                              uu___19) in
+                                                          FStar_SMTEncoding_Util.mkAnd
+                                                            uu___17 in
+                                                        (out, uu___16) in
+                                                      FStar_SMTEncoding_Util.mkOr
+                                                        uu___15 in
+                                                    (uu___14,
+                                                      (FStar_Compiler_List.op_At
+                                                         decls decls'))))))))
+                          (FStar_SMTEncoding_Util.mkFalse, []) datas in
                       (match uu___7 with
                        | (data_ax, decls) ->
                            let uu___8 =
@@ -5022,9 +4867,8 @@ and (encode_sigelt' :
                                          "inversion axiom"), uu___11) in
                                   FStar_SMTEncoding_Util.mkAssume uu___9 in
                                 let uu___9 =
-                                  FStar_Compiler_Effect.op_Bar_Greater
-                                    [fuel_guarded_inversion]
-                                    FStar_SMTEncoding_Term.mk_decls_trivial in
+                                  FStar_SMTEncoding_Term.mk_decls_trivial
+                                    [fuel_guarded_inversion] in
                                 FStar_Compiler_List.op_At decls uu___9))) in
              let uu___4 =
                let k1 =
@@ -5069,25 +4913,22 @@ and (encode_sigelt' :
                              let tname_decl =
                                let uu___9 =
                                  let uu___10 =
-                                   FStar_Compiler_Effect.op_Bar_Greater vars
-                                     (FStar_Compiler_List.map
-                                        (fun fv ->
-                                           let uu___11 =
-                                             let uu___12 =
-                                               FStar_SMTEncoding_Term.fv_name
-                                                 fv in
-                                             Prims.strcat tname uu___12 in
-                                           let uu___12 =
-                                             FStar_SMTEncoding_Term.fv_sort
-                                               fv in
-                                           {
-                                             FStar_SMTEncoding_Term.field_name
-                                               = uu___11;
-                                             FStar_SMTEncoding_Term.field_sort
-                                               = uu___12;
-                                             FStar_SMTEncoding_Term.field_projectible
-                                               = false
-                                           })) in
+                                   FStar_Compiler_List.map
+                                     (fun fv ->
+                                        let uu___11 =
+                                          let uu___12 =
+                                            FStar_SMTEncoding_Term.fv_name fv in
+                                          Prims.strcat tname uu___12 in
+                                        let uu___12 =
+                                          FStar_SMTEncoding_Term.fv_sort fv in
+                                        {
+                                          FStar_SMTEncoding_Term.field_name =
+                                            uu___11;
+                                          FStar_SMTEncoding_Term.field_sort =
+                                            uu___12;
+                                          FStar_SMTEncoding_Term.field_projectible
+                                            = false
+                                        }) vars in
                                  let uu___11 =
                                    let uu___12 =
                                      FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.next_id
@@ -5110,10 +4951,7 @@ and (encode_sigelt' :
                                        let uu___12 =
                                          FStar_SMTEncoding_Util.mkApp
                                            (tname, []) in
-                                       FStar_Compiler_Effect.op_Less_Bar
-                                         (fun uu___13 ->
-                                            FStar_Pervasives_Native.Some
-                                              uu___13) uu___12 in
+                                       FStar_Pervasives_Native.Some uu___12 in
                                      FStar_SMTEncoding_Env.push_free_var env1
                                        t arity tname uu___11 in
                                    ([], uu___10)
@@ -5230,9 +5068,8 @@ and (encode_sigelt' :
                                             [uu___13] in
                                           FStar_Compiler_List.op_At karr
                                             uu___12 in
-                                        FStar_Compiler_Effect.op_Bar_Greater
-                                          uu___11
-                                          FStar_SMTEncoding_Term.mk_decls_trivial in
+                                        FStar_SMTEncoding_Term.mk_decls_trivial
+                                          uu___11 in
                                       FStar_Compiler_List.op_At decls1
                                         uu___10 in
                                 let aux =
@@ -5247,16 +5084,14 @@ and (encode_sigelt' :
                                           pretype_axiom uu___14 env2 tapp
                                             vars in
                                         [uu___13] in
-                                      FStar_Compiler_Effect.op_Bar_Greater
-                                        uu___12
-                                        FStar_SMTEncoding_Term.mk_decls_trivial in
+                                      FStar_SMTEncoding_Term.mk_decls_trivial
+                                        uu___12 in
                                     FStar_Compiler_List.op_At uu___10 uu___11 in
                                   FStar_Compiler_List.op_At kindingAx uu___9 in
                                 let g =
                                   let uu___9 =
-                                    FStar_Compiler_Effect.op_Bar_Greater
-                                      decls
-                                      FStar_SMTEncoding_Term.mk_decls_trivial in
+                                    FStar_SMTEncoding_Term.mk_decls_trivial
+                                      decls in
                                   FStar_Compiler_List.op_At uu___9
                                     (FStar_Compiler_List.op_At binder_decls
                                        aux) in
@@ -5294,29 +5129,28 @@ and (encode_sigelt' :
                           (match uu___6 with
                            | (vars, guards, env', binder_decls, names) ->
                                let fields =
-                                 FStar_Compiler_Effect.op_Bar_Greater names
-                                   (FStar_Compiler_List.mapi
-                                      (fun n ->
-                                         fun x ->
-                                           let uu___7 =
-                                             FStar_SMTEncoding_Env.mk_term_projector_name
-                                               d x in
-                                           {
-                                             FStar_SMTEncoding_Term.field_name
-                                               = uu___7;
-                                             FStar_SMTEncoding_Term.field_sort
-                                               =
-                                               FStar_SMTEncoding_Term.Term_sort;
-                                             FStar_SMTEncoding_Term.field_projectible
-                                               = true
-                                           })) in
+                                 FStar_Compiler_List.mapi
+                                   (fun n ->
+                                      fun x ->
+                                        let uu___7 =
+                                          FStar_SMTEncoding_Env.mk_term_projector_name
+                                            d x in
+                                        {
+                                          FStar_SMTEncoding_Term.field_name =
+                                            uu___7;
+                                          FStar_SMTEncoding_Term.field_sort =
+                                            FStar_SMTEncoding_Term.Term_sort;
+                                          FStar_SMTEncoding_Term.field_projectible
+                                            = true
+                                        }) names in
                                let datacons =
-                                 let uu___7 =
-                                   let uu___8 =
-                                     let uu___9 =
+                                 let uu___7 = FStar_Ident.range_of_lid d in
+                                 let uu___8 =
+                                   let uu___9 =
+                                     let uu___10 =
                                        FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.next_id
                                          () in
-                                     FStar_Pervasives_Native.Some uu___9 in
+                                     FStar_Pervasives_Native.Some uu___10 in
                                    {
                                      FStar_SMTEncoding_Term.constr_name =
                                        ddconstrsym;
@@ -5325,14 +5159,10 @@ and (encode_sigelt' :
                                      FStar_SMTEncoding_Term.constr_sort =
                                        FStar_SMTEncoding_Term.Term_sort;
                                      FStar_SMTEncoding_Term.constr_id =
-                                       uu___8
+                                       uu___9
                                    } in
-                                 let uu___8 =
-                                   let uu___9 = FStar_Ident.range_of_lid d in
-                                   FStar_SMTEncoding_Term.constructor_to_decl
-                                     uu___9 in
-                                 FStar_Compiler_Effect.op_Bar_Greater uu___7
-                                   uu___8 in
+                                 FStar_SMTEncoding_Term.constructor_to_decl
+                                   uu___7 uu___8 in
                                let app =
                                  FStar_SMTEncoding_EncodeTerm.mk_Apply
                                    ddtok_tm vars in
@@ -5469,11 +5299,9 @@ and (encode_sigelt' :
                                                                    uu___18
                                                                    orig_arg.FStar_Syntax_Syntax.pos in
                                                            let guards1 =
-                                                             FStar_Compiler_Effect.op_Bar_Greater
-                                                               guards
-                                                               (FStar_Compiler_List.collect
-                                                                  (fun g ->
-                                                                    let uu___17
+                                                             FStar_Compiler_List.collect
+                                                               (fun g ->
+                                                                  let uu___17
                                                                     =
                                                                     let uu___18
                                                                     =
@@ -5482,15 +5310,15 @@ and (encode_sigelt' :
                                                                     FStar_Compiler_List.contains
                                                                     fv1
                                                                     uu___18 in
-                                                                    if
-                                                                    uu___17
-                                                                    then
+                                                                  if uu___17
+                                                                  then
                                                                     let uu___18
                                                                     =
                                                                     FStar_SMTEncoding_Term.subst
                                                                     g fv1 xv in
                                                                     [uu___18]
-                                                                    else [])) in
+                                                                  else [])
+                                                               guards in
                                                            FStar_SMTEncoding_Util.mk_and_l
                                                              guards1 in
                                                          let uu___17 =
@@ -5656,17 +5484,14 @@ and (encode_sigelt' :
                                                                     FStar_SMTEncoding_Term.Term_sort) in
                                                                   FStar_SMTEncoding_Term.mk_fv
                                                                     uu___21 in
-                                                                FStar_Compiler_Effect.op_Less_Bar
-                                                                  FStar_SMTEncoding_Util.mkFreeV
+                                                                FStar_SMTEncoding_Util.mkFreeV
                                                                   uu___20 in
                                                               let subterm_ordering
                                                                 =
                                                                 let prec =
                                                                   let uu___20
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    vars
-                                                                    (FStar_Compiler_List.mapi
+                                                                    FStar_Compiler_List.mapi
                                                                     (fun i ->
                                                                     fun v ->
                                                                     if
@@ -5684,10 +5509,10 @@ and (encode_sigelt' :
                                                                     lex_t
                                                                     uu___23
                                                                     dapp1 in
-                                                                    [uu___22]))) in
-                                                                  FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___20
-                                                                    FStar_Compiler_List.flatten in
+                                                                    [uu___22]))
+                                                                    vars in
+                                                                  FStar_Compiler_List.flatten
+                                                                    uu___20 in
                                                                 let uu___20 =
                                                                   let uu___21
                                                                     =
@@ -6226,11 +6051,9 @@ and (encode_sigelt' :
                                                                    uu___14
                                                                    orig_arg.FStar_Syntax_Syntax.pos in
                                                            let guards1 =
-                                                             FStar_Compiler_Effect.op_Bar_Greater
-                                                               guards
-                                                               (FStar_Compiler_List.collect
-                                                                  (fun g ->
-                                                                    let uu___13
+                                                             FStar_Compiler_List.collect
+                                                               (fun g ->
+                                                                  let uu___13
                                                                     =
                                                                     let uu___14
                                                                     =
@@ -6239,15 +6062,15 @@ and (encode_sigelt' :
                                                                     FStar_Compiler_List.contains
                                                                     fv1
                                                                     uu___14 in
-                                                                    if
-                                                                    uu___13
-                                                                    then
+                                                                  if uu___13
+                                                                  then
                                                                     let uu___14
                                                                     =
                                                                     FStar_SMTEncoding_Term.subst
                                                                     g fv1 xv in
                                                                     [uu___14]
-                                                                    else [])) in
+                                                                  else [])
+                                                               guards in
                                                            FStar_SMTEncoding_Util.mk_and_l
                                                              guards1 in
                                                          let uu___13 =
@@ -6413,17 +6236,14 @@ and (encode_sigelt' :
                                                                     FStar_SMTEncoding_Term.Term_sort) in
                                                                   FStar_SMTEncoding_Term.mk_fv
                                                                     uu___17 in
-                                                                FStar_Compiler_Effect.op_Less_Bar
-                                                                  FStar_SMTEncoding_Util.mkFreeV
+                                                                FStar_SMTEncoding_Util.mkFreeV
                                                                   uu___16 in
                                                               let subterm_ordering
                                                                 =
                                                                 let prec =
                                                                   let uu___16
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    vars
-                                                                    (FStar_Compiler_List.mapi
+                                                                    FStar_Compiler_List.mapi
                                                                     (fun i ->
                                                                     fun v ->
                                                                     if
@@ -6441,10 +6261,10 @@ and (encode_sigelt' :
                                                                     lex_t
                                                                     uu___19
                                                                     dapp1 in
-                                                                    [uu___18]))) in
-                                                                  FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___16
-                                                                    FStar_Compiler_List.flatten in
+                                                                    [uu___18]))
+                                                                    vars in
+                                                                  FStar_Compiler_List.flatten
+                                                                    uu___16 in
                                                                 let uu___16 =
                                                                   let uu___17
                                                                     =
@@ -6981,20 +6801,16 @@ and (encode_sigelt' :
                                                        | (targs, iargs) ->
                                                            let uu___12 =
                                                              let uu___13 =
-                                                               FStar_Compiler_Effect.op_Bar_Greater
-                                                                 iargs
-                                                                 (FStar_Compiler_List.map
-                                                                    (
-                                                                    fun
-                                                                    uu___14
+                                                               FStar_Compiler_List.map
+                                                                 (fun uu___14
                                                                     ->
                                                                     FStar_SMTEncoding_Env.fresh_fvar
                                                                     env1.FStar_SMTEncoding_Env.current_module_name
                                                                     "i"
-                                                                    FStar_SMTEncoding_Term.Term_sort)) in
-                                                             FStar_Compiler_Effect.op_Bar_Greater
-                                                               uu___13
-                                                               FStar_Compiler_List.split in
+                                                                    FStar_SMTEncoding_Term.Term_sort)
+                                                                 iargs in
+                                                             FStar_Compiler_List.split
+                                                               uu___13 in
                                                            (match uu___12
                                                             with
                                                             | (fresh_ivars,
@@ -7040,13 +6856,12 @@ and (encode_sigelt' :
                                                                 let uu___14 =
                                                                   let uu___15
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    fresh_ivars
-                                                                    (FStar_Compiler_List.map
+                                                                    FStar_Compiler_List.map
                                                                     (fun s ->
                                                                     FStar_SMTEncoding_Term.mk_fv
                                                                     (s,
-                                                                    FStar_SMTEncoding_Term.Term_sort))) in
+                                                                    FStar_SMTEncoding_Term.Term_sort))
+                                                                    fresh_ivars in
                                                                   FStar_Compiler_List.op_At
                                                                     vars
                                                                     uu___15 in
@@ -7121,9 +6936,8 @@ and (encode_sigelt' :
                                                           FStar_Compiler_List.op_At
                                                             uu___15
                                                             proxy_fresh in
-                                                        FStar_Compiler_Effect.op_Bar_Greater
-                                                          uu___14
-                                                          FStar_SMTEncoding_Term.mk_decls_trivial in
+                                                        FStar_SMTEncoding_Term.mk_decls_trivial
+                                                          uu___14 in
                                                       let uu___14 =
                                                         let uu___15 =
                                                           let uu___16 =
@@ -7175,9 +6989,8 @@ and (encode_sigelt' :
                                                                 uu___19 in
                                                             FStar_Compiler_List.op_At
                                                               uu___17 elim in
-                                                          FStar_Compiler_Effect.op_Bar_Greater
-                                                            uu___16
-                                                            FStar_SMTEncoding_Term.mk_decls_trivial in
+                                                          FStar_SMTEncoding_Term.mk_decls_trivial
+                                                            uu___16 in
                                                         FStar_Compiler_List.op_At
                                                           decls_pred uu___15 in
                                                       FStar_Compiler_List.op_At
@@ -7190,9 +7003,8 @@ and (encode_sigelt' :
                                                   binder_decls uu___10 in
                                               let uu___10 =
                                                 let uu___11 =
-                                                  FStar_Compiler_Effect.op_Bar_Greater
-                                                    datacons
-                                                    FStar_SMTEncoding_Term.mk_decls_trivial in
+                                                  FStar_SMTEncoding_Term.mk_decls_trivial
+                                                    datacons in
                                                 FStar_Compiler_List.op_At
                                                   uu___11 g in
                                               (uu___10, env1)))))))))
@@ -7203,16 +7015,15 @@ and (encode_sigelts :
   =
   fun env ->
     fun ses ->
-      FStar_Compiler_Effect.op_Bar_Greater ses
-        (FStar_Compiler_List.fold_left
-           (fun uu___ ->
-              fun se ->
-                match uu___ with
-                | (g, env1) ->
-                    let uu___1 = encode_sigelt env1 se in
-                    (match uu___1 with
-                     | (g', env2) -> ((FStar_Compiler_List.op_At g g'), env2)))
-           ([], env))
+      FStar_Compiler_List.fold_left
+        (fun uu___ ->
+           fun se ->
+             match uu___ with
+             | (g, env1) ->
+                 let uu___1 = encode_sigelt env1 se in
+                 (match uu___1 with
+                  | (g', env2) -> ((FStar_Compiler_List.op_At g g'), env2)))
+        ([], env) ses
 let (encode_env_bindings :
   FStar_SMTEncoding_Env.env_t ->
     FStar_Syntax_Syntax.binding Prims.list ->
@@ -7230,9 +7041,8 @@ let (encode_env_bindings :
                  let t1 =
                    norm_before_encoding env1 x.FStar_Syntax_Syntax.sort in
                  ((let uu___2 =
-                     FStar_Compiler_Effect.op_Less_Bar
-                       (FStar_TypeChecker_Env.debug
-                          env1.FStar_SMTEncoding_Env.tcenv)
+                     FStar_TypeChecker_Env.debug
+                       env1.FStar_SMTEncoding_Env.tcenv
                        (FStar_Options.Other "SMTEncoding") in
                    if uu___2
                    then
@@ -7287,17 +7097,15 @@ let (encode_env_bindings :
                                   a_name) in
                             let g =
                               let uu___4 =
-                                FStar_Compiler_Effect.op_Bar_Greater
+                                FStar_SMTEncoding_Term.mk_decls_trivial
                                   [FStar_SMTEncoding_Term.DeclFun
                                      (xxsym, [],
                                        FStar_SMTEncoding_Term.Term_sort,
-                                       caption)]
-                                  FStar_SMTEncoding_Term.mk_decls_trivial in
+                                       caption)] in
                               let uu___5 =
                                 let uu___6 =
-                                  FStar_Compiler_Effect.op_Bar_Greater 
-                                    [ax]
-                                    FStar_SMTEncoding_Term.mk_decls_trivial in
+                                  FStar_SMTEncoding_Term.mk_decls_trivial
+                                    [ax] in
                                 FStar_Compiler_List.op_At decls' uu___6 in
                               FStar_Compiler_List.op_At uu___4 uu___5 in
                             ((i + Prims.int_one),
@@ -7323,33 +7131,29 @@ let (encode_labels :
   =
   fun labs ->
     let prefix =
-      FStar_Compiler_Effect.op_Bar_Greater labs
-        (FStar_Compiler_List.map
-           (fun uu___ ->
-              match uu___ with
-              | (l, uu___1, uu___2) ->
-                  let uu___3 =
-                    let uu___4 = FStar_SMTEncoding_Term.fv_name l in
-                    (uu___4, [], FStar_SMTEncoding_Term.Bool_sort,
-                      FStar_Pervasives_Native.None) in
-                  FStar_SMTEncoding_Term.DeclFun uu___3)) in
+      FStar_Compiler_List.map
+        (fun uu___ ->
+           match uu___ with
+           | (l, uu___1, uu___2) ->
+               let uu___3 =
+                 let uu___4 = FStar_SMTEncoding_Term.fv_name l in
+                 (uu___4, [], FStar_SMTEncoding_Term.Bool_sort,
+                   FStar_Pervasives_Native.None) in
+               FStar_SMTEncoding_Term.DeclFun uu___3) labs in
     let suffix =
-      FStar_Compiler_Effect.op_Bar_Greater labs
-        (FStar_Compiler_List.collect
-           (fun uu___ ->
-              match uu___ with
-              | (l, uu___1, uu___2) ->
-                  let uu___3 =
-                    let uu___4 = FStar_SMTEncoding_Term.fv_name l in
-                    FStar_Compiler_Effect.op_Less_Bar
-                      (fun uu___5 -> FStar_SMTEncoding_Term.Echo uu___5)
-                      uu___4 in
-                  let uu___4 =
-                    let uu___5 =
-                      let uu___6 = FStar_SMTEncoding_Util.mkFreeV l in
-                      FStar_SMTEncoding_Term.Eval uu___6 in
-                    [uu___5] in
-                  uu___3 :: uu___4)) in
+      FStar_Compiler_List.collect
+        (fun uu___ ->
+           match uu___ with
+           | (l, uu___1, uu___2) ->
+               let uu___3 =
+                 let uu___4 = FStar_SMTEncoding_Term.fv_name l in
+                 FStar_SMTEncoding_Term.Echo uu___4 in
+               let uu___4 =
+                 let uu___5 =
+                   let uu___6 = FStar_SMTEncoding_Util.mkFreeV l in
+                   FStar_SMTEncoding_Term.Eval uu___6 in
+                 [uu___5] in
+               uu___3 :: uu___4) labs in
     (prefix, suffix)
 let (last_env :
   FStar_SMTEncoding_Env.env_t Prims.list FStar_Compiler_Effect.ref) =
@@ -7363,8 +7167,7 @@ let (init_env : FStar_TypeChecker_Env.env -> unit) =
           let uu___4 = FStar_Compiler_Util.psmap_empty () in (uu___4, []) in
         let uu___4 =
           let uu___5 = FStar_TypeChecker_Env.current_module tcenv in
-          FStar_Compiler_Effect.op_Bar_Greater uu___5
-            FStar_Ident.string_of_lid in
+          FStar_Ident.string_of_lid uu___5 in
         let uu___5 = FStar_Compiler_Util.smap_create (Prims.of_int (100)) in
         {
           FStar_SMTEncoding_Env.bvar_bindings = uu___2;
@@ -7517,9 +7320,8 @@ let (place_decl_elt_in_fact_dbs :
     fun fact_db_ids ->
       fun elt ->
         let uu___ =
-          FStar_Compiler_Effect.op_Bar_Greater
-            elt.FStar_SMTEncoding_Term.decls
-            (FStar_Compiler_List.map (place_decl_in_fact_dbs env fact_db_ids)) in
+          FStar_Compiler_List.map (place_decl_in_fact_dbs env fact_db_ids)
+            elt.FStar_SMTEncoding_Term.decls in
         {
           FStar_SMTEncoding_Term.sym_name =
             (elt.FStar_SMTEncoding_Term.sym_name);
@@ -7551,16 +7353,14 @@ let (encode_top_level_facts :
   fun env ->
     fun se ->
       let fact_db_ids =
-        FStar_Compiler_Effect.op_Bar_Greater
-          (FStar_Syntax_Util.lids_of_sigelt se)
-          (FStar_Compiler_List.collect (fact_dbs_for_lid env)) in
+        FStar_Compiler_List.collect (fact_dbs_for_lid env)
+          (FStar_Syntax_Util.lids_of_sigelt se) in
       let uu___ = encode_sigelt env se in
       match uu___ with
       | (g, env1) ->
           let g1 =
-            FStar_Compiler_Effect.op_Bar_Greater g
-              (FStar_Compiler_List.map
-                 (place_decl_elt_in_fact_dbs env1 fact_db_ids)) in
+            FStar_Compiler_List.map
+              (place_decl_elt_in_fact_dbs env1 fact_db_ids) g in
           (g1, env1)
 let (recover_caching_and_update_env :
   FStar_SMTEncoding_Env.env_t ->
@@ -7568,34 +7368,27 @@ let (recover_caching_and_update_env :
   =
   fun env ->
     fun decls ->
-      FStar_Compiler_Effect.op_Bar_Greater decls
-        (FStar_Compiler_List.collect
-           (fun elt ->
-              if
-                elt.FStar_SMTEncoding_Term.key = FStar_Pervasives_Native.None
-              then [elt]
-              else
-                (let uu___1 =
-                   let uu___2 =
-                     FStar_Compiler_Effect.op_Bar_Greater
-                       elt.FStar_SMTEncoding_Term.key
-                       FStar_Compiler_Util.must in
-                   FStar_Compiler_Util.smap_try_find
-                     env.FStar_SMTEncoding_Env.global_cache uu___2 in
-                 match uu___1 with
-                 | FStar_Pervasives_Native.Some cache_elt ->
-                     FStar_Compiler_Effect.op_Bar_Greater
-                       [FStar_SMTEncoding_Term.RetainAssumptions
-                          (cache_elt.FStar_SMTEncoding_Term.a_names)]
-                       FStar_SMTEncoding_Term.mk_decls_trivial
-                 | FStar_Pervasives_Native.None ->
-                     ((let uu___3 =
-                         FStar_Compiler_Effect.op_Bar_Greater
-                           elt.FStar_SMTEncoding_Term.key
-                           FStar_Compiler_Util.must in
-                       FStar_Compiler_Util.smap_add
-                         env.FStar_SMTEncoding_Env.global_cache uu___3 elt);
-                      [elt]))))
+      FStar_Compiler_List.collect
+        (fun elt ->
+           if elt.FStar_SMTEncoding_Term.key = FStar_Pervasives_Native.None
+           then [elt]
+           else
+             (let uu___1 =
+                let uu___2 =
+                  FStar_Compiler_Util.must elt.FStar_SMTEncoding_Term.key in
+                FStar_Compiler_Util.smap_try_find
+                  env.FStar_SMTEncoding_Env.global_cache uu___2 in
+              match uu___1 with
+              | FStar_Pervasives_Native.Some cache_elt ->
+                  FStar_SMTEncoding_Term.mk_decls_trivial
+                    [FStar_SMTEncoding_Term.RetainAssumptions
+                       (cache_elt.FStar_SMTEncoding_Term.a_names)]
+              | FStar_Pervasives_Native.None ->
+                  ((let uu___3 =
+                      FStar_Compiler_Util.must elt.FStar_SMTEncoding_Term.key in
+                    FStar_Compiler_Util.smap_add
+                      env.FStar_SMTEncoding_Env.global_cache uu___3 elt);
+                   [elt]))) decls
 let (encode_sig :
   FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.sigelt -> unit) =
   fun tcenv ->
@@ -7608,11 +7401,9 @@ let (encode_sig :
             let uu___2 =
               let uu___3 =
                 let uu___4 =
-                  FStar_Compiler_Effect.op_Bar_Greater
-                    (FStar_Syntax_Util.lids_of_sigelt se)
-                    (FStar_Compiler_List.map FStar_Syntax_Print.lid_to_string) in
-                FStar_Compiler_Effect.op_Bar_Greater uu___4
-                  (FStar_Compiler_String.concat ", ") in
+                  FStar_Compiler_List.map FStar_Syntax_Print.lid_to_string
+                    (FStar_Syntax_Util.lids_of_sigelt se) in
+                FStar_Compiler_String.concat ", " uu___4 in
               Prims.strcat "encoding sigelt " uu___3 in
             FStar_SMTEncoding_Term.Caption uu___2 in
           uu___1 :: decls
@@ -7632,11 +7423,8 @@ let (encode_sig :
            (set_env env1;
             (let uu___3 =
                let uu___4 =
-                 let uu___5 =
-                   FStar_Compiler_Effect.op_Bar_Greater decls
-                     (recover_caching_and_update_env env1) in
-                 FStar_Compiler_Effect.op_Bar_Greater uu___5
-                   FStar_SMTEncoding_Term.decls_list_of in
+                 let uu___5 = recover_caching_and_update_env env1 decls in
+                 FStar_SMTEncoding_Term.decls_list_of uu___5 in
                caption uu___4 in
              FStar_SMTEncoding_Z3.giveZ3 uu___3)))
 let (give_decls_to_z3_and_set_env :
@@ -7681,11 +7469,8 @@ let (give_decls_to_z3_and_set_env :
           };
         (let z3_decls =
            let uu___1 =
-             let uu___2 =
-               FStar_Compiler_Effect.op_Bar_Greater decls
-                 (recover_caching_and_update_env env) in
-             FStar_Compiler_Effect.op_Bar_Greater uu___2
-               FStar_SMTEncoding_Term.decls_list_of in
+             let uu___2 = recover_caching_and_update_env env decls in
+             FStar_SMTEncoding_Term.decls_list_of uu___2 in
            caption uu___1 in
          FStar_SMTEncoding_Z3.giveZ3 z3_decls)
 let (encode_modul :
@@ -7715,31 +7500,27 @@ let (encode_modul :
                  FStar_TypeChecker_Env.debug tcenv FStar_Options.Medium in
                if uu___5
                then
-                 let uu___6 =
-                   FStar_Compiler_Effect.op_Bar_Greater
-                     (FStar_Compiler_List.length
-                        modul.FStar_Syntax_Syntax.declarations)
-                     Prims.string_of_int in
                  FStar_Compiler_Util.print2
                    "+++++++++++Encoding externals for %s ... %s declarations\n"
-                   name uu___6
+                   name
+                   (Prims.string_of_int
+                      (FStar_Compiler_List.length
+                         modul.FStar_Syntax_Syntax.declarations))
                else ());
               (let env =
                  let uu___5 = get_env modul.FStar_Syntax_Syntax.name tcenv in
-                 FStar_Compiler_Effect.op_Bar_Greater uu___5
-                   FStar_SMTEncoding_Env.reset_current_module_fvbs in
+                 FStar_SMTEncoding_Env.reset_current_module_fvbs uu___5 in
                let encode_signature env1 ses =
-                 FStar_Compiler_Effect.op_Bar_Greater ses
-                   (FStar_Compiler_List.fold_left
-                      (fun uu___5 ->
-                         fun se ->
-                           match uu___5 with
-                           | (g, env2) ->
-                               let uu___6 = encode_top_level_facts env2 se in
-                               (match uu___6 with
-                                | (g', env3) ->
-                                    ((FStar_Compiler_List.op_At g g'), env3)))
-                      ([], env1)) in
+                 FStar_Compiler_List.fold_left
+                   (fun uu___5 ->
+                      fun se ->
+                        match uu___5 with
+                        | (g, env2) ->
+                            let uu___6 = encode_top_level_facts env2 se in
+                            (match uu___6 with
+                             | (g', env3) ->
+                                 ((FStar_Compiler_List.op_At g g'), env3)))
+                   ([], env1) ses in
                let uu___5 =
                  encode_signature
                    {
@@ -7775,10 +7556,8 @@ let (encode_modul :
                        FStar_Compiler_Util.print1
                          "Done encoding externals for %s\n" name
                      else ());
-                    (let uu___8 =
-                       FStar_Compiler_Effect.op_Bar_Greater env1
-                         FStar_SMTEncoding_Env.get_current_module_fvbs in
-                     (decls, uu___8))))))
+                    (decls,
+                      (FStar_SMTEncoding_Env.get_current_module_fvbs env1))))))
 let (encode_modul_from_cache :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.modul ->
@@ -7805,27 +7584,20 @@ let (encode_modul_from_cache :
                   FStar_TypeChecker_Env.debug tcenv FStar_Options.Medium in
                 if uu___4
                 then
-                  let uu___5 =
-                    FStar_Compiler_Effect.op_Bar_Greater
-                      (FStar_Compiler_List.length decls) Prims.string_of_int in
                   FStar_Compiler_Util.print2
                     "+++++++++++Encoding externals from cache for %s ... %s decls\n"
-                    name uu___5
+                    name
+                    (Prims.string_of_int (FStar_Compiler_List.length decls))
                 else ());
                (let env =
                   let uu___4 = get_env tcmod.FStar_Syntax_Syntax.name tcenv in
-                  FStar_Compiler_Effect.op_Bar_Greater uu___4
-                    FStar_SMTEncoding_Env.reset_current_module_fvbs in
+                  FStar_SMTEncoding_Env.reset_current_module_fvbs uu___4 in
                 let env1 =
-                  let uu___4 =
-                    FStar_Compiler_Effect.op_Bar_Greater fvbs
-                      FStar_Compiler_List.rev in
-                  FStar_Compiler_Effect.op_Bar_Greater uu___4
-                    (FStar_Compiler_List.fold_left
-                       (fun env2 ->
-                          fun fvb ->
-                            FStar_SMTEncoding_Env.add_fvar_binding_to_env fvb
-                              env2) env) in
+                  FStar_Compiler_List.fold_left
+                    (fun env2 ->
+                       fun fvb ->
+                         FStar_SMTEncoding_Env.add_fvar_binding_to_env fvb
+                           env2) env (FStar_Compiler_List.rev fvbs) in
                 give_decls_to_z3_and_set_env env1 name decls;
                 (let uu___5 =
                    FStar_TypeChecker_Env.debug tcenv FStar_Options.Medium in
@@ -7913,12 +7685,10 @@ let (encode_query :
                            ((FStar_TypeChecker_Env.debug tcenv
                                FStar_Options.Medium)
                               ||
-                              (FStar_Compiler_Effect.op_Less_Bar
-                                 (FStar_TypeChecker_Env.debug tcenv)
+                              (FStar_TypeChecker_Env.debug tcenv
                                  (FStar_Options.Other "SMTEncoding")))
                              ||
-                             (FStar_Compiler_Effect.op_Less_Bar
-                                (FStar_TypeChecker_Env.debug tcenv)
+                             (FStar_TypeChecker_Env.debug tcenv
                                 (FStar_Options.Other "SMTQuery")) in
                          if uu___5
                          then
@@ -7978,27 +7748,22 @@ let (encode_query :
                                            let uu___9 =
                                              let uu___10 =
                                                let uu___11 =
-                                                 FStar_Compiler_Effect.op_Bar_Greater
-                                                   label_prefix
-                                                   FStar_SMTEncoding_Term.mk_decls_trivial in
+                                                 FStar_SMTEncoding_Term.mk_decls_trivial
+                                                   label_prefix in
                                                let uu___12 =
                                                  let uu___13 =
-                                                   FStar_Compiler_Effect.op_Bar_Greater
-                                                     caption
-                                                     FStar_SMTEncoding_Term.mk_decls_trivial in
+                                                   FStar_SMTEncoding_Term.mk_decls_trivial
+                                                     caption in
                                                  FStar_Compiler_List.op_At
                                                    qdecls uu___13 in
                                                FStar_Compiler_List.op_At
                                                  uu___11 uu___12 in
                                              FStar_Compiler_List.op_At
                                                env_decls uu___10 in
-                                           FStar_Compiler_Effect.op_Bar_Greater
-                                             uu___9
-                                             (recover_caching_and_update_env
-                                                env1) in
-                                         FStar_Compiler_Effect.op_Bar_Greater
-                                           uu___8
-                                           FStar_SMTEncoding_Term.decls_list_of in
+                                           recover_caching_and_update_env
+                                             env1 uu___9 in
+                                         FStar_SMTEncoding_Term.decls_list_of
+                                           uu___8 in
                                        let qry =
                                          let uu___8 =
                                            let uu___9 =
@@ -8026,15 +7791,13 @@ let (encode_query :
                                            ((FStar_TypeChecker_Env.debug
                                                tcenv FStar_Options.Medium)
                                               ||
-                                              (FStar_Compiler_Effect.op_Less_Bar
-                                                 (FStar_TypeChecker_Env.debug
-                                                    tcenv)
+                                              (FStar_TypeChecker_Env.debug
+                                                 tcenv
                                                  (FStar_Options.Other
                                                     "SMTEncoding")))
                                              ||
-                                             (FStar_Compiler_Effect.op_Less_Bar
-                                                (FStar_TypeChecker_Env.debug
-                                                   tcenv)
+                                             (FStar_TypeChecker_Env.debug
+                                                tcenv
                                                 (FStar_Options.Other
                                                    "SMTQuery")) in
                                          if uu___9
@@ -8046,21 +7809,18 @@ let (encode_query :
                                            (((FStar_TypeChecker_Env.debug
                                                 tcenv FStar_Options.Medium)
                                                ||
-                                               (FStar_Compiler_Effect.op_Less_Bar
-                                                  (FStar_TypeChecker_Env.debug
-                                                     tcenv)
+                                               (FStar_TypeChecker_Env.debug
+                                                  tcenv
                                                   (FStar_Options.Other
                                                      "SMTEncoding")))
                                               ||
-                                              (FStar_Compiler_Effect.op_Less_Bar
-                                                 (FStar_TypeChecker_Env.debug
-                                                    tcenv)
+                                              (FStar_TypeChecker_Env.debug
+                                                 tcenv
                                                  (FStar_Options.Other
                                                     "SMTQuery")))
                                              ||
-                                             (FStar_Compiler_Effect.op_Less_Bar
-                                                (FStar_TypeChecker_Env.debug
-                                                   tcenv)
+                                             (FStar_TypeChecker_Env.debug
+                                                tcenv
                                                 (FStar_Options.Other "Time")) in
                                          if uu___10
                                          then

--- a/ocaml/fstar-lib/generated/FStar_SMTEncoding_EncodeTerm.ml
+++ b/ocaml/fstar-lib/generated/FStar_SMTEncoding_EncodeTerm.ml
@@ -26,17 +26,15 @@ let mkForall_fuel' :
                  match uu___3 with
                  | (fsym, fterm) ->
                      let add_fuel tms =
-                       FStar_Compiler_Effect.op_Bar_Greater tms
-                         (FStar_Compiler_List.map
-                            (fun p ->
-                               match p.FStar_SMTEncoding_Term.tm with
-                               | FStar_SMTEncoding_Term.App
-                                   (FStar_SMTEncoding_Term.Var "HasType",
-                                    args)
-                                   ->
-                                   FStar_SMTEncoding_Util.mkApp
-                                     ("HasTypeFuel", (fterm :: args))
-                               | uu___4 -> p)) in
+                       FStar_Compiler_List.map
+                         (fun p ->
+                            match p.FStar_SMTEncoding_Term.tm with
+                            | FStar_SMTEncoding_Term.App
+                                (FStar_SMTEncoding_Term.Var "HasType", args)
+                                ->
+                                FStar_SMTEncoding_Util.mkApp
+                                  ("HasTypeFuel", (fterm :: args))
+                            | uu___4 -> p) tms in
                      let pats1 = FStar_Compiler_List.map add_fuel pats in
                      let body1 =
                        match body.FStar_SMTEncoding_Term.tm with
@@ -50,8 +48,7 @@ let mkForall_fuel' :
                                  FStar_SMTEncoding_Util.mk_and_l uu___4
                              | uu___4 ->
                                  let uu___5 = add_fuel [guard] in
-                                 FStar_Compiler_Effect.op_Bar_Greater uu___5
-                                   FStar_Compiler_List.hd in
+                                 FStar_Compiler_List.hd uu___5 in
                            FStar_SMTEncoding_Util.mkImp (guard1, body')
                        | uu___4 -> body in
                      let vars1 =
@@ -85,8 +82,7 @@ let (head_normal :
               [FStar_TypeChecker_Env.Eager_unfolding_only]
               env.FStar_SMTEncoding_Env.tcenv
               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-          FStar_Compiler_Effect.op_Bar_Greater uu___
-            FStar_Compiler_Option.isNone
+          FStar_Compiler_Option.isNone uu___
       | FStar_Syntax_Syntax.Tm_app
           {
             FStar_Syntax_Syntax.hd =
@@ -101,8 +97,7 @@ let (head_normal :
               [FStar_TypeChecker_Env.Eager_unfolding_only]
               env.FStar_SMTEncoding_Env.tcenv
               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-          FStar_Compiler_Effect.op_Bar_Greater uu___4
-            FStar_Compiler_Option.isNone
+          FStar_Compiler_Option.isNone uu___4
       | uu___ -> false
 let (head_redex :
   FStar_SMTEncoding_Env.env_t -> FStar_Syntax_Syntax.term -> Prims.bool) =
@@ -134,8 +129,7 @@ let (head_redex :
               [FStar_TypeChecker_Env.Eager_unfolding_only]
               env.FStar_SMTEncoding_Env.tcenv
               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-          FStar_Compiler_Effect.op_Bar_Greater uu___1
-            FStar_Compiler_Option.isSome
+          FStar_Compiler_Option.isSome uu___1
       | uu___1 -> false
 let (norm_with_steps :
   FStar_TypeChecker_Env.steps ->
@@ -228,26 +222,24 @@ let (mk_Apply :
   =
   fun e ->
     fun vars ->
-      FStar_Compiler_Effect.op_Bar_Greater vars
-        (FStar_Compiler_List.fold_left
-           (fun out ->
-              fun var ->
-                let uu___ = FStar_SMTEncoding_Term.fv_sort var in
-                match uu___ with
-                | FStar_SMTEncoding_Term.Fuel_sort ->
-                    let uu___1 = FStar_SMTEncoding_Util.mkFreeV var in
-                    FStar_SMTEncoding_Term.mk_ApplyTF out uu___1
-                | s ->
-                    let uu___1 = FStar_SMTEncoding_Util.mkFreeV var in
-                    FStar_SMTEncoding_Util.mk_ApplyTT out uu___1) e)
+      FStar_Compiler_List.fold_left
+        (fun out ->
+           fun var ->
+             let uu___ = FStar_SMTEncoding_Term.fv_sort var in
+             match uu___ with
+             | FStar_SMTEncoding_Term.Fuel_sort ->
+                 let uu___1 = FStar_SMTEncoding_Util.mkFreeV var in
+                 FStar_SMTEncoding_Term.mk_ApplyTF out uu___1
+             | s ->
+                 let uu___1 = FStar_SMTEncoding_Util.mkFreeV var in
+                 FStar_SMTEncoding_Util.mk_ApplyTT out uu___1) e vars
 let (mk_Apply_args :
   FStar_SMTEncoding_Term.term ->
     FStar_SMTEncoding_Term.term Prims.list -> FStar_SMTEncoding_Term.term)
   =
   fun e ->
     fun args ->
-      FStar_Compiler_Effect.op_Bar_Greater args
-        (FStar_Compiler_List.fold_left FStar_SMTEncoding_Util.mk_ApplyTT e)
+      FStar_Compiler_List.fold_left FStar_SMTEncoding_Util.mk_ApplyTT e args
 let raise_arity_mismatch :
   'a .
     Prims.string ->
@@ -378,16 +370,15 @@ let check_pattern_vars :
     fun vars ->
       fun pats ->
         let pats1 =
-          FStar_Compiler_Effect.op_Bar_Greater pats
-            (FStar_Compiler_List.map
-               (fun uu___ ->
-                  match uu___ with
-                  | (x, uu___1) ->
-                      norm_with_steps
-                        [FStar_TypeChecker_Env.Beta;
-                        FStar_TypeChecker_Env.AllowUnboundUniverses;
-                        FStar_TypeChecker_Env.EraseUniverses]
-                        env.FStar_SMTEncoding_Env.tcenv x)) in
+          FStar_Compiler_List.map
+            (fun uu___ ->
+               match uu___ with
+               | (x, uu___1) ->
+                   norm_with_steps
+                     [FStar_TypeChecker_Env.Beta;
+                     FStar_TypeChecker_Env.AllowUnboundUniverses;
+                     FStar_TypeChecker_Env.EraseUniverses]
+                     env.FStar_SMTEncoding_Env.tcenv x) pats in
         match pats1 with
         | [] -> ()
         | hd::tl ->
@@ -400,18 +391,17 @@ let check_pattern_vars :
                      FStar_Compiler_Set.union FStar_Syntax_Syntax.ord_bv out
                        uu___1) uu___ tl in
             let uu___ =
-              FStar_Compiler_Effect.op_Bar_Greater vars
-                (FStar_Compiler_Util.find_opt
-                   (fun uu___1 ->
-                      match uu___1 with
-                      | { FStar_Syntax_Syntax.binder_bv = b;
-                          FStar_Syntax_Syntax.binder_qual = uu___2;
-                          FStar_Syntax_Syntax.binder_positivity = uu___3;
-                          FStar_Syntax_Syntax.binder_attrs = uu___4;_} ->
-                          let uu___5 =
-                            FStar_Compiler_Set.mem FStar_Syntax_Syntax.ord_bv
-                              b pat_vars in
-                          Prims.op_Negation uu___5)) in
+              FStar_Compiler_Util.find_opt
+                (fun uu___1 ->
+                   match uu___1 with
+                   | { FStar_Syntax_Syntax.binder_bv = b;
+                       FStar_Syntax_Syntax.binder_qual = uu___2;
+                       FStar_Syntax_Syntax.binder_positivity = uu___3;
+                       FStar_Syntax_Syntax.binder_attrs = uu___4;_} ->
+                       let uu___5 =
+                         FStar_Compiler_Set.mem FStar_Syntax_Syntax.ord_bv b
+                           pat_vars in
+                       Prims.op_Negation uu___5) vars in
             (match uu___ with
              | FStar_Pervasives_Native.None -> ()
              | FStar_Pervasives_Native.Some
@@ -685,8 +675,7 @@ let rec (encode_const :
       | FStar_Const.Const_string (s, uu___) ->
           let uu___1 =
             let uu___2 = FStar_SMTEncoding_Util.mk_String_const s in
-            FStar_Compiler_Effect.op_Less_Bar
-              FStar_SMTEncoding_Term.boxString uu___2 in
+            FStar_SMTEncoding_Term.boxString uu___2 in
           (uu___1, [])
       | FStar_Const.Const_range uu___ ->
           let uu___1 = FStar_SMTEncoding_Term.mk_Range_const () in
@@ -722,34 +711,33 @@ and (encode_binders :
            FStar_Compiler_Util.print1 "Encoding binders %s\n" uu___2
          else ());
         (let uu___1 =
-           FStar_Compiler_Effect.op_Bar_Greater bs
-             (FStar_Compiler_List.fold_left
-                (fun uu___2 ->
-                   fun b ->
-                     match uu___2 with
-                     | (vars, guards, env1, decls, names) ->
-                         let uu___3 =
-                           let x = b.FStar_Syntax_Syntax.binder_bv in
-                           let uu___4 =
-                             FStar_SMTEncoding_Env.gen_term_var env1 x in
-                           match uu___4 with
-                           | (xxsym, xx, env') ->
-                               let uu___5 =
+           FStar_Compiler_List.fold_left
+             (fun uu___2 ->
+                fun b ->
+                  match uu___2 with
+                  | (vars, guards, env1, decls, names) ->
+                      let uu___3 =
+                        let x = b.FStar_Syntax_Syntax.binder_bv in
+                        let uu___4 =
+                          FStar_SMTEncoding_Env.gen_term_var env1 x in
+                        match uu___4 with
+                        | (xxsym, xx, env') ->
+                            let uu___5 =
+                              let uu___6 =
+                                norm env1 x.FStar_Syntax_Syntax.sort in
+                              encode_term_pred fuel_opt uu___6 env1 xx in
+                            (match uu___5 with
+                             | (guard_x_t, decls') ->
                                  let uu___6 =
-                                   norm env1 x.FStar_Syntax_Syntax.sort in
-                                 encode_term_pred fuel_opt uu___6 env1 xx in
-                               (match uu___5 with
-                                | (guard_x_t, decls') ->
-                                    let uu___6 =
-                                      FStar_SMTEncoding_Term.mk_fv
-                                        (xxsym,
-                                          FStar_SMTEncoding_Term.Term_sort) in
-                                    (uu___6, guard_x_t, env', decls', x)) in
-                         (match uu___3 with
-                          | (v, g, env2, decls', n) ->
-                              ((v :: vars), (g :: guards), env2,
-                                (FStar_Compiler_List.op_At decls decls'), (n
-                                :: names)))) ([], [], env, [], [])) in
+                                   FStar_SMTEncoding_Term.mk_fv
+                                     (xxsym,
+                                       FStar_SMTEncoding_Term.Term_sort) in
+                                 (uu___6, guard_x_t, env', decls', x)) in
+                      (match uu___3 with
+                       | (v, g, env2, decls', n) ->
+                           ((v :: vars), (g :: guards), env2,
+                             (FStar_Compiler_List.op_At decls decls'), (n ::
+                             names)))) ([], [], env, [], []) bs in
          match uu___1 with
          | (vars, guards, env1, decls, names) ->
              ((FStar_Compiler_List.rev vars),
@@ -813,7 +801,7 @@ and (encode_arith_term :
               if uu___1
               then
                 let uu___2 = let uu___3 = mk_args ts in op uu___3 in
-                FStar_Compiler_Effect.op_Bar_Greater uu___2 box
+                box uu___2
               else mk_default () in
             let mk_nl box unbox nm op ts =
               let uu___1 = FStar_Options.smtencoding_nl_arith_wrapped () in
@@ -823,13 +811,13 @@ and (encode_arith_term :
                 match uu___2 with
                 | (t1, t2) ->
                     let uu___3 = FStar_SMTEncoding_Util.mkApp (nm, [t1; t2]) in
-                    FStar_Compiler_Effect.op_Bar_Greater uu___3 box
+                    box uu___3
               else
                 (let uu___3 = FStar_Options.smtencoding_nl_arith_native () in
                  if uu___3
                  then
                    let uu___4 = let uu___5 = binary unbox ts in op uu___5 in
-                   FStar_Compiler_Effect.op_Bar_Greater uu___4 box
+                   box uu___4
                  else mk_default ()) in
             let add box unbox =
               mk_l box FStar_SMTEncoding_Util.mkAdd (binary unbox) in
@@ -898,8 +886,7 @@ and (encode_arith_term :
                      match uu___3 with
                      | (l, uu___4) -> FStar_Syntax_Syntax.fv_eq_lid head_fv l)
                   ops in
-              FStar_Compiler_Effect.op_Bar_Greater uu___2
-                FStar_Compiler_Util.must in
+              FStar_Compiler_Util.must uu___2 in
             (match uu___1 with
              | (uu___2, op) -> let uu___3 = op arg_tms in (uu___3, decls))
 and (encode_BitVector_term :
@@ -1041,7 +1028,7 @@ and (encode_BitVector_term :
                         (uu___5, uu___6) in
                       let mk_bv op mk_args resBox ts =
                         let uu___5 = let uu___6 = mk_args ts in op uu___6 in
-                        FStar_Compiler_Effect.op_Bar_Greater uu___5 resBox in
+                        resBox uu___5 in
                       let bv_and =
                         mk_bv FStar_SMTEncoding_Util.mkBvAnd binary
                           (FStar_SMTEncoding_Term.boxBitVec sz) in
@@ -1123,8 +1110,7 @@ and (encode_BitVector_term :
                                | (l, uu___8) ->
                                    FStar_Syntax_Syntax.fv_eq_lid head_fv l)
                             ops in
-                        FStar_Compiler_Effect.op_Bar_Greater uu___6
-                          FStar_Compiler_Util.must in
+                        FStar_Compiler_Util.must uu___6 in
                       (match uu___5 with
                        | (uu___6, op) ->
                            let uu___7 = op arg_tms1 in
@@ -1243,8 +1229,7 @@ and (encode_term :
       (let t1 = FStar_Syntax_Subst.compress t in
        let t0 = t1 in
        (let uu___2 =
-          FStar_Compiler_Effect.op_Less_Bar
-            (FStar_TypeChecker_Env.debug env.FStar_SMTEncoding_Env.tcenv)
+          FStar_TypeChecker_Env.debug env.FStar_SMTEncoding_Env.tcenv
             (FStar_Options.Other "SMTEncoding") in
         if uu___2
         then
@@ -1256,8 +1241,7 @@ and (encode_term :
         | FStar_Syntax_Syntax.Tm_delayed uu___2 ->
             let uu___3 =
               let uu___4 =
-                FStar_Compiler_Effect.op_Less_Bar
-                  FStar_Compiler_Range_Ops.string_of_range
+                FStar_Compiler_Range_Ops.string_of_range
                   t1.FStar_Syntax_Syntax.pos in
               let uu___5 = FStar_Syntax_Print.tag_of_term t1 in
               let uu___6 = FStar_Syntax_Print.term_to_string t1 in
@@ -1267,8 +1251,7 @@ and (encode_term :
         | FStar_Syntax_Syntax.Tm_unknown ->
             let uu___2 =
               let uu___3 =
-                FStar_Compiler_Effect.op_Less_Bar
-                  FStar_Compiler_Range_Ops.string_of_range
+                FStar_Compiler_Range_Ops.string_of_range
                   t1.FStar_Syntax_Syntax.pos in
               let uu___4 = FStar_Syntax_Print.tag_of_term t1 in
               let uu___5 = FStar_Syntax_Print.term_to_string t1 in
@@ -1278,9 +1261,7 @@ and (encode_term :
         | FStar_Syntax_Syntax.Tm_lazy i ->
             let e = FStar_Syntax_Util.unfold_lazy i in
             ((let uu___3 =
-                FStar_Compiler_Effect.op_Less_Bar
-                  (FStar_TypeChecker_Env.debug
-                     env.FStar_SMTEncoding_Env.tcenv)
+                FStar_TypeChecker_Env.debug env.FStar_SMTEncoding_Env.tcenv
                   (FStar_Options.Other "SMTEncoding") in
               if uu___3
               then
@@ -1317,9 +1298,7 @@ and (encode_term :
               uu___3 t1.FStar_Syntax_Syntax.pos FStar_Pervasives_Native.None
                 FStar_Syntax_Embeddings_Base.id_norm_cb in
             ((let uu___4 =
-                FStar_Compiler_Effect.op_Less_Bar
-                  (FStar_TypeChecker_Env.debug
-                     env.FStar_SMTEncoding_Env.tcenv)
+                FStar_TypeChecker_Env.debug env.FStar_SMTEncoding_Env.tcenv
                   (FStar_Options.Other "SMTEncoding") in
               if uu___4
               then
@@ -1420,9 +1399,7 @@ and (encode_term :
               | (aux_decls, sym_name) ->
                   let uu___4 =
                     if aux_decls = []
-                    then
-                      FStar_Compiler_Effect.op_Bar_Greater []
-                        FStar_SMTEncoding_Term.mk_decls_trivial
+                    then FStar_SMTEncoding_Term.mk_decls_trivial []
                     else
                       FStar_SMTEncoding_Term.mk_decls sym_name tkey_hash
                         aux_decls [] in
@@ -1603,13 +1580,11 @@ and (encode_term :
                                    | (guards, guard_decls) ->
                                        let is_pure =
                                          let uu___9 =
-                                           FStar_Compiler_Effect.op_Bar_Greater
-                                             res
-                                             (FStar_TypeChecker_Normalize.maybe_ghost_to_pure
-                                                env.FStar_SMTEncoding_Env.tcenv) in
-                                         FStar_Compiler_Effect.op_Bar_Greater
-                                           uu___9
-                                           FStar_Syntax_Util.is_pure_comp in
+                                           FStar_TypeChecker_Normalize.maybe_ghost_to_pure
+                                             env.FStar_SMTEncoding_Env.tcenv
+                                             res in
+                                         FStar_Syntax_Util.is_pure_comp
+                                           uu___9 in
                                        let t_interp =
                                          let uu___9 =
                                            let uu___10 =
@@ -1629,17 +1604,15 @@ and (encode_term :
                                          let uu___9 =
                                            FStar_SMTEncoding_Term.free_variables
                                              t_interp1 in
-                                         FStar_Compiler_Effect.op_Bar_Greater
-                                           uu___9
-                                           (FStar_Compiler_List.filter
-                                              (fun x ->
-                                                 let uu___10 =
-                                                   FStar_SMTEncoding_Term.fv_name
-                                                     x in
-                                                 let uu___11 =
-                                                   FStar_SMTEncoding_Term.fv_name
-                                                     fsym in
-                                                 uu___10 <> uu___11)) in
+                                         FStar_Compiler_List.filter
+                                           (fun x ->
+                                              let uu___10 =
+                                                FStar_SMTEncoding_Term.fv_name
+                                                  x in
+                                              let uu___11 =
+                                                FStar_SMTEncoding_Term.fv_name
+                                                  fsym in
+                                              uu___10 <> uu___11) uu___9 in
                                        let tkey =
                                          FStar_SMTEncoding_Term.mkForall
                                            t1.FStar_Syntax_Syntax.pos
@@ -1801,19 +1774,15 @@ and (encode_term :
                                   env.FStar_SMTEncoding_Env.tcenv binders1 in
                               FStar_TypeChecker_Env.unfold_effect_abbrev
                                 uu___9 res in
-                            FStar_Compiler_Effect.op_Bar_Greater uu___8
-                              FStar_Syntax_Syntax.mk_Comp in
+                            FStar_Syntax_Syntax.mk_Comp uu___8 in
                           let uu___8 =
-                            let uu___9 =
-                              FStar_Compiler_Effect.op_Bar_Greater c1
-                                FStar_Syntax_Util.comp_result in
-                            encode_term uu___9 env_bs in
+                            encode_term (FStar_Syntax_Util.comp_result c1)
+                              env_bs in
                           (match uu___8 with
                            | (ct, uu___9) ->
                                let uu___10 =
                                  let uu___11 =
-                                   FStar_Compiler_Effect.op_Bar_Greater c1
-                                     FStar_Syntax_Util.comp_effect_args in
+                                   FStar_Syntax_Util.comp_effect_args c1 in
                                  encode_args uu___11 env_bs in
                                (match uu___10 with
                                 | (effect_args, uu___11) ->
@@ -1835,13 +1804,9 @@ and (encode_term :
                                             tkey in
                                         let uu___14 =
                                           let uu___15 =
-                                            let uu___16 =
-                                              FStar_Compiler_Effect.op_Bar_Greater
-                                                c1
-                                                FStar_Syntax_Util.comp_effect_name in
-                                            FStar_Compiler_Effect.op_Bar_Greater
-                                              uu___16
-                                              FStar_Ident.string_of_lid in
+                                            FStar_Ident.string_of_lid
+                                              (FStar_Syntax_Util.comp_effect_name
+                                                 c1) in
                                           Prims.strcat "@Effect=" uu___15 in
                                         Prims.strcat uu___13 uu___14 in
                                       Prims.strcat "Non_total_Tm_arrow"
@@ -1853,9 +1818,8 @@ and (encode_term :
                     let uu___5 =
                       let fvs =
                         let uu___6 = FStar_Syntax_Free.names t0 in
-                        FStar_Compiler_Effect.op_Bar_Greater uu___6
-                          (FStar_Compiler_Set.elems
-                             FStar_Syntax_Syntax.ord_bv) in
+                        FStar_Compiler_Set.elems FStar_Syntax_Syntax.ord_bv
+                          uu___6 in
                       let getfreeV t2 =
                         match t2.FStar_SMTEncoding_Term.tm with
                         | FStar_SMTEncoding_Term.FreeV fv -> fv
@@ -2024,18 +1988,16 @@ and (encode_term :
                                        FStar_Compiler_Util.remove_dups
                                          FStar_SMTEncoding_Term.fv_eq uu___8 in
                                      let cvars1 =
-                                       FStar_Compiler_Effect.op_Bar_Greater
-                                         cvars
-                                         (FStar_Compiler_List.filter
-                                            (fun y ->
-                                               (let uu___8 =
-                                                  FStar_SMTEncoding_Term.fv_name
-                                                    y in
-                                                uu___8 <> x1) &&
-                                                 (let uu___8 =
-                                                    FStar_SMTEncoding_Term.fv_name
-                                                      y in
-                                                  uu___8 <> fsym))) in
+                                       FStar_Compiler_List.filter
+                                         (fun y ->
+                                            (let uu___8 =
+                                               FStar_SMTEncoding_Term.fv_name
+                                                 y in
+                                             uu___8 <> x1) &&
+                                              (let uu___8 =
+                                                 FStar_SMTEncoding_Term.fv_name
+                                                   y in
+                                               uu___8 <> fsym)) cvars in
                                      let xfv =
                                        FStar_SMTEncoding_Term.mk_fv
                                          (x1,
@@ -2203,9 +2165,7 @@ and (encode_term :
                        uu___5) in
                    FStar_SMTEncoding_Util.mkAssume uu___4 in
                  let uu___4 =
-                   let uu___5 =
-                     FStar_Compiler_Effect.op_Bar_Greater [d]
-                       FStar_SMTEncoding_Term.mk_decls_trivial in
+                   let uu___5 = FStar_SMTEncoding_Term.mk_decls_trivial [d] in
                    FStar_Compiler_List.op_At decls uu___5 in
                  (ttm, uu___4))
         | FStar_Syntax_Syntax.Tm_app uu___2 ->
@@ -2336,44 +2296,35 @@ and (encode_term :
                                    let uu___9 =
                                      FStar_SMTEncoding_Term.mk_fv
                                        (f, FStar_SMTEncoding_Term.Term_sort) in
-                                   FStar_Compiler_Effect.op_Less_Bar
-                                     FStar_SMTEncoding_Util.mkFreeV uu___9 in
+                                   FStar_SMTEncoding_Util.mkFreeV uu___9 in
                                  let uu___9 =
-                                   FStar_Compiler_Effect.op_Bar_Greater
-                                     [decl]
-                                     FStar_SMTEncoding_Term.mk_decls_trivial in
+                                   FStar_SMTEncoding_Term.mk_decls_trivial
+                                     [decl] in
                                  (uu___8, uu___9) in
                                (match lopt with
                                 | FStar_Pervasives_Native.None -> fallback ()
                                 | FStar_Pervasives_Native.Some l when
                                     let uu___7 =
-                                      FStar_Compiler_Effect.op_Bar_Greater l
-                                        (FStar_TypeChecker_Env.norm_eff_name
-                                           env.FStar_SMTEncoding_Env.tcenv) in
-                                    FStar_Compiler_Effect.op_Bar_Greater
-                                      uu___7
-                                      (FStar_TypeChecker_Env.is_layered_effect
-                                         env.FStar_SMTEncoding_Env.tcenv)
+                                      FStar_TypeChecker_Env.norm_eff_name
+                                        env.FStar_SMTEncoding_Env.tcenv l in
+                                    FStar_TypeChecker_Env.is_layered_effect
+                                      env.FStar_SMTEncoding_Env.tcenv uu___7
                                     -> fallback ()
                                 | uu___7 ->
                                     let e0 =
                                       let uu___8 =
                                         let uu___9 =
                                           let uu___10 =
-                                            FStar_Compiler_Effect.op_Bar_Greater
-                                              args_e1 FStar_Compiler_List.hd in
-                                          FStar_Compiler_Effect.op_Bar_Greater
-                                            uu___10
-                                            FStar_Pervasives_Native.fst in
+                                            FStar_Compiler_List.hd args_e1 in
+                                          FStar_Pervasives_Native.fst uu___10 in
                                         FStar_Syntax_Util.mk_reify uu___9
                                           lopt in
                                       FStar_TypeChecker_Util.norm_reify
                                         env.FStar_SMTEncoding_Env.tcenv []
                                         uu___8 in
                                     ((let uu___9 =
-                                        FStar_Compiler_Effect.op_Less_Bar
-                                          (FStar_TypeChecker_Env.debug
-                                             env.FStar_SMTEncoding_Env.tcenv)
+                                        FStar_TypeChecker_Env.debug
+                                          env.FStar_SMTEncoding_Env.tcenv
                                           (FStar_Options.Other
                                              "SMTEncodingReify") in
                                       if uu___9
@@ -2494,12 +2445,10 @@ and (encode_term :
                                                 FStar_TypeChecker_Env.lookup_lid
                                                   env.FStar_SMTEncoding_Env.tcenv
                                                   (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                                              FStar_Compiler_Effect.op_Bar_Greater
-                                                uu___14
-                                                FStar_Pervasives_Native.fst in
-                                            FStar_Compiler_Effect.op_Bar_Greater
-                                              uu___13
-                                              FStar_Pervasives_Native.snd in
+                                              FStar_Pervasives_Native.fst
+                                                uu___14 in
+                                            FStar_Pervasives_Native.snd
+                                              uu___13 in
                                           FStar_Pervasives_Native.Some
                                             uu___12
                                       | FStar_Syntax_Syntax.Tm_fvar fv ->
@@ -2509,12 +2458,10 @@ and (encode_term :
                                                 FStar_TypeChecker_Env.lookup_lid
                                                   env.FStar_SMTEncoding_Env.tcenv
                                                   (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                                              FStar_Compiler_Effect.op_Bar_Greater
-                                                uu___10
-                                                FStar_Pervasives_Native.fst in
-                                            FStar_Compiler_Effect.op_Bar_Greater
-                                              uu___9
-                                              FStar_Pervasives_Native.snd in
+                                              FStar_Pervasives_Native.fst
+                                                uu___10 in
+                                            FStar_Pervasives_Native.snd
+                                              uu___9 in
                                           FStar_Pervasives_Native.Some uu___8
                                       | FStar_Syntax_Syntax.Tm_ascribed
                                           { FStar_Syntax_Syntax.tm = uu___8;
@@ -2551,8 +2498,7 @@ and (encode_term :
                                                  FStar_TypeChecker_Env.EraseUniverses]
                                                  env.FStar_SMTEncoding_Env.tcenv
                                                  head_type1 in
-                                             FStar_Compiler_Effect.op_Less_Bar
-                                               FStar_Syntax_Util.unrefine
+                                             FStar_Syntax_Util.unrefine
                                                uu___9 in
                                            let uu___9 =
                                              curried_arrow_formals_comp
@@ -2576,8 +2522,7 @@ and (encode_term :
                                                          FStar_Syntax_Syntax.delta_constant]
                                                        env.FStar_SMTEncoding_Env.tcenv
                                                        head_type2 in
-                                                   FStar_Compiler_Effect.op_Less_Bar
-                                                     FStar_Syntax_Util.unrefine
+                                                   FStar_Syntax_Util.unrefine
                                                      uu___10 in
                                                  let uu___10 =
                                                    curried_arrow_formals_comp
@@ -2669,8 +2614,8 @@ and (encode_term :
                    let uu___4 =
                      let fvs =
                        let uu___5 = FStar_Syntax_Free.names t0 in
-                       FStar_Compiler_Effect.op_Bar_Greater uu___5
-                         (FStar_Compiler_Set.elems FStar_Syntax_Syntax.ord_bv) in
+                       FStar_Compiler_Set.elems FStar_Syntax_Syntax.ord_bv
+                         uu___5 in
                      let tms =
                        FStar_Compiler_List.map
                          (FStar_SMTEncoding_Env.lookup_term_var env) fvs in
@@ -2693,20 +2638,17 @@ and (encode_term :
                          let uu___5 =
                            FStar_SMTEncoding_Term.mk_fv
                              (f, FStar_SMTEncoding_Term.Term_sort) in
-                         FStar_Compiler_Effect.op_Less_Bar
-                           FStar_SMTEncoding_Util.mkFreeV uu___5 in
+                         FStar_SMTEncoding_Util.mkFreeV uu___5 in
                        let fapp = FStar_SMTEncoding_Util.mkApp (f, arg_terms) in
                        let uu___5 =
-                         FStar_Compiler_Effect.op_Bar_Greater [decl]
-                           FStar_SMTEncoding_Term.mk_decls_trivial in
+                         FStar_SMTEncoding_Term.mk_decls_trivial [decl] in
                        (fapp, uu___5) in
                  let is_impure rc =
                    let uu___3 =
                      FStar_TypeChecker_Util.is_pure_or_ghost_effect
                        env.FStar_SMTEncoding_Env.tcenv
                        rc.FStar_Syntax_Syntax.residual_effect in
-                   FStar_Compiler_Effect.op_Bar_Greater uu___3
-                     Prims.op_Negation in
+                   Prims.op_Negation uu___3 in
                  let codomain_eff rc =
                    let res_typ =
                      match rc.FStar_Syntax_Syntax.residual_typ with
@@ -2846,9 +2788,8 @@ and (encode_term :
                                               FStar_SMTEncoding_Term.hash_of_term
                                                 tkey in
                                             ((let uu___11 =
-                                                FStar_Compiler_Effect.op_Less_Bar
-                                                  (FStar_TypeChecker_Env.debug
-                                                     env.FStar_SMTEncoding_Env.tcenv)
+                                                FStar_TypeChecker_Env.debug
+                                                  env.FStar_SMTEncoding_Env.tcenv
                                                   (FStar_Options.Other
                                                      "PartialApp") in
                                               if uu___11
@@ -2858,10 +2799,8 @@ and (encode_term :
                                                     FStar_Compiler_List.map
                                                       FStar_SMTEncoding_Term.fv_name
                                                       vars in
-                                                  FStar_Compiler_Effect.op_Bar_Greater
-                                                    uu___13
-                                                    (FStar_Compiler_String.concat
-                                                       ", ") in
+                                                  FStar_Compiler_String.concat
+                                                    ", " uu___13 in
                                                 let uu___13 =
                                                   FStar_SMTEncoding_Term.print_smt_term
                                                     body3 in
@@ -2901,12 +2840,10 @@ and (encode_term :
                                                     let tot_fun_ax =
                                                       let ax =
                                                         let uu___11 =
-                                                          FStar_Compiler_Effect.op_Bar_Greater
-                                                            vars
-                                                            (FStar_Compiler_List.map
-                                                               (fun uu___12
-                                                                  ->
-                                                                  FStar_SMTEncoding_Util.mkTrue)) in
+                                                          FStar_Compiler_List.map
+                                                            (fun uu___12 ->
+                                                               FStar_SMTEncoding_Util.mkTrue)
+                                                            vars in
                                                         isTotFun_axioms
                                                           t0.FStar_Syntax_Syntax.pos
                                                           f vars uu___11
@@ -3032,24 +2969,23 @@ and (encode_term :
               FStar_Syntax_Syntax.body1 = uu___3;_}
             ->
             let names =
-              FStar_Compiler_Effect.op_Bar_Greater lbs
-                (FStar_Compiler_List.map
-                   (fun lb ->
-                      let uu___4 = lb in
-                      match uu___4 with
-                      | { FStar_Syntax_Syntax.lbname = lbname;
-                          FStar_Syntax_Syntax.lbunivs = uu___5;
-                          FStar_Syntax_Syntax.lbtyp = uu___6;
-                          FStar_Syntax_Syntax.lbeff = uu___7;
-                          FStar_Syntax_Syntax.lbdef = uu___8;
-                          FStar_Syntax_Syntax.lbattrs = uu___9;
-                          FStar_Syntax_Syntax.lbpos = uu___10;_} ->
-                          let x = FStar_Compiler_Util.left lbname in
-                          let uu___11 =
-                            FStar_Ident.string_of_id
-                              x.FStar_Syntax_Syntax.ppname in
-                          let uu___12 = FStar_Syntax_Syntax.range_of_bv x in
-                          (uu___11, uu___12))) in
+              FStar_Compiler_List.map
+                (fun lb ->
+                   let uu___4 = lb in
+                   match uu___4 with
+                   | { FStar_Syntax_Syntax.lbname = lbname;
+                       FStar_Syntax_Syntax.lbunivs = uu___5;
+                       FStar_Syntax_Syntax.lbtyp = uu___6;
+                       FStar_Syntax_Syntax.lbeff = uu___7;
+                       FStar_Syntax_Syntax.lbdef = uu___8;
+                       FStar_Syntax_Syntax.lbattrs = uu___9;
+                       FStar_Syntax_Syntax.lbpos = uu___10;_} ->
+                       let x = FStar_Compiler_Util.left lbname in
+                       let uu___11 =
+                         FStar_Ident.string_of_id
+                           x.FStar_Syntax_Syntax.ppname in
+                       let uu___12 = FStar_Syntax_Syntax.range_of_bv x in
+                       (uu___11, uu___12)) lbs in
             FStar_Compiler_Effect.raise
               (FStar_SMTEncoding_Env.Inner_let_rec names)
         | FStar_Syntax_Syntax.Tm_match
@@ -3144,15 +3080,14 @@ and (encode_match :
                                        let projections =
                                          pattern1.projections scr' in
                                        let env2 =
-                                         FStar_Compiler_Effect.op_Bar_Greater
-                                           projections
-                                           (FStar_Compiler_List.fold_left
-                                              (fun env3 ->
-                                                 fun uu___6 ->
-                                                   match uu___6 with
-                                                   | (x, t) ->
-                                                       FStar_SMTEncoding_Env.push_term_var
-                                                         env3 x t) env1) in
+                                         FStar_Compiler_List.fold_left
+                                           (fun env3 ->
+                                              fun uu___6 ->
+                                                match uu___6 with
+                                                | (x, t) ->
+                                                    FStar_SMTEncoding_Env.push_term_var
+                                                      env3 x t) env1
+                                           projections in
                                        let uu___6 =
                                          match w with
                                          | FStar_Pervasives_Native.None ->
@@ -3224,25 +3159,23 @@ and (encode_pat :
        match uu___1 with
        | (vars, pat_term) ->
            let uu___2 =
-             FStar_Compiler_Effect.op_Bar_Greater vars
-               (FStar_Compiler_List.fold_left
-                  (fun uu___3 ->
-                     fun v ->
-                       match uu___3 with
-                       | (env1, vars1) ->
-                           let uu___4 =
-                             FStar_SMTEncoding_Env.gen_term_var env1 v in
-                           (match uu___4 with
-                            | (xx, uu___5, env2) ->
-                                let uu___6 =
-                                  let uu___7 =
-                                    let uu___8 =
-                                      FStar_SMTEncoding_Term.mk_fv
-                                        (xx,
-                                          FStar_SMTEncoding_Term.Term_sort) in
-                                    (v, uu___8) in
-                                  uu___7 :: vars1 in
-                                (env2, uu___6))) (env, [])) in
+             FStar_Compiler_List.fold_left
+               (fun uu___3 ->
+                  fun v ->
+                    match uu___3 with
+                    | (env1, vars1) ->
+                        let uu___4 =
+                          FStar_SMTEncoding_Env.gen_term_var env1 v in
+                        (match uu___4 with
+                         | (xx, uu___5, env2) ->
+                             let uu___6 =
+                               let uu___7 =
+                                 let uu___8 =
+                                   FStar_SMTEncoding_Term.mk_fv
+                                     (xx, FStar_SMTEncoding_Term.Term_sort) in
+                                 (v, uu___8) in
+                               uu___7 :: vars1 in
+                             (env2, uu___6))) (env, []) vars in
            (match uu___2 with
             | (env1, vars1) ->
                 let rec mk_guard pat1 scrutinee =
@@ -3278,21 +3211,20 @@ and (encode_pat :
                               (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                               scrutinee in
                       let sub_term_guards =
-                        FStar_Compiler_Effect.op_Bar_Greater args
-                          (FStar_Compiler_List.mapi
-                             (fun i ->
-                                fun uu___4 ->
-                                  match uu___4 with
-                                  | (arg, uu___5) ->
-                                      let proj =
-                                        FStar_SMTEncoding_Env.primitive_projector_by_pos
-                                          env1.FStar_SMTEncoding_Env.tcenv
-                                          (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-                                          i in
-                                      let uu___6 =
-                                        FStar_SMTEncoding_Util.mkApp
-                                          (proj, [scrutinee]) in
-                                      mk_guard arg uu___6)) in
+                        FStar_Compiler_List.mapi
+                          (fun i ->
+                             fun uu___4 ->
+                               match uu___4 with
+                               | (arg, uu___5) ->
+                                   let proj =
+                                     FStar_SMTEncoding_Env.primitive_projector_by_pos
+                                       env1.FStar_SMTEncoding_Env.tcenv
+                                       (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
+                                       i in
+                                   let uu___6 =
+                                     FStar_SMTEncoding_Util.mkApp
+                                       (proj, [scrutinee]) in
+                                   mk_guard arg uu___6) args in
                       FStar_SMTEncoding_Util.mk_and_l (is_f ::
                         sub_term_guards) in
                 let rec mk_projections pat1 scrutinee =
@@ -3302,23 +3234,21 @@ and (encode_pat :
                   | FStar_Syntax_Syntax.Pat_constant uu___3 -> []
                   | FStar_Syntax_Syntax.Pat_cons (f, uu___3, args) ->
                       let uu___4 =
-                        FStar_Compiler_Effect.op_Bar_Greater args
-                          (FStar_Compiler_List.mapi
-                             (fun i ->
-                                fun uu___5 ->
-                                  match uu___5 with
-                                  | (arg, uu___6) ->
-                                      let proj =
-                                        FStar_SMTEncoding_Env.primitive_projector_by_pos
-                                          env1.FStar_SMTEncoding_Env.tcenv
-                                          (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-                                          i in
-                                      let uu___7 =
-                                        FStar_SMTEncoding_Util.mkApp
-                                          (proj, [scrutinee]) in
-                                      mk_projections arg uu___7)) in
-                      FStar_Compiler_Effect.op_Bar_Greater uu___4
-                        FStar_Compiler_List.flatten in
+                        FStar_Compiler_List.mapi
+                          (fun i ->
+                             fun uu___5 ->
+                               match uu___5 with
+                               | (arg, uu___6) ->
+                                   let proj =
+                                     FStar_SMTEncoding_Env.primitive_projector_by_pos
+                                       env1.FStar_SMTEncoding_Env.tcenv
+                                       (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
+                                       i in
+                                   let uu___7 =
+                                     FStar_SMTEncoding_Util.mkApp
+                                       (proj, [scrutinee]) in
+                                   mk_projections arg uu___7) args in
+                      FStar_Compiler_List.flatten uu___4 in
                 let pat_term1 uu___3 = encode_term pat_term env1 in
                 let pattern1 =
                   {
@@ -3337,18 +3267,17 @@ and (encode_args :
   fun l ->
     fun env ->
       let uu___ =
-        FStar_Compiler_Effect.op_Bar_Greater l
-          (FStar_Compiler_List.fold_left
-             (fun uu___1 ->
-                fun uu___2 ->
-                  match (uu___1, uu___2) with
-                  | ((tms, decls), (t, uu___3)) ->
-                      let uu___4 = encode_term t env in
-                      (match uu___4 with
-                       | (t1, decls') ->
-                           ((t1 :: tms),
-                             (FStar_Compiler_List.op_At decls decls'))))
-             ([], [])) in
+        FStar_Compiler_List.fold_left
+          (fun uu___1 ->
+             fun uu___2 ->
+               match (uu___1, uu___2) with
+               | ((tms, decls), (t, uu___3)) ->
+                   let uu___4 = encode_term t env in
+                   (match uu___4 with
+                    | (t1, decls') ->
+                        ((t1 :: tms),
+                          (FStar_Compiler_List.op_At decls decls'))))
+          ([], []) l in
       match uu___ with | (l1, decls) -> ((FStar_Compiler_List.rev l1), decls)
 and (encode_smt_patterns :
   FStar_Syntax_Syntax.arg Prims.list Prims.list ->
@@ -3453,8 +3382,7 @@ and (encode_formula :
     fun env ->
       let debug phi1 =
         let uu___ =
-          FStar_Compiler_Effect.op_Less_Bar
-            (FStar_TypeChecker_Env.debug env.FStar_SMTEncoding_Env.tcenv)
+          FStar_TypeChecker_Env.debug env.FStar_SMTEncoding_Env.tcenv
             (FStar_Options.Other "SMTEncoding") in
         if uu___
         then
@@ -3484,9 +3412,7 @@ and (encode_formula :
               } in
             (uu___1, decls) in
       let const_op f r uu___ = let uu___1 = f r in (uu___1, []) in
-      let un_op f l =
-        let uu___ = FStar_Compiler_List.hd l in
-        FStar_Compiler_Effect.op_Less_Bar f uu___ in
+      let un_op f l = let uu___ = FStar_Compiler_List.hd l in f uu___ in
       let bin_op f uu___ =
         match uu___ with
         | t1::t2::[] -> f (t1, t2)
@@ -3846,19 +3772,17 @@ and (encode_formula :
        | FStar_Pervasives_Native.Some (FStar_Syntax_Util.BaseConn (op, arms))
            ->
            let uu___2 =
-             FStar_Compiler_Effect.op_Bar_Greater connectives
-               (FStar_Compiler_List.tryFind
-                  (fun uu___3 ->
-                     match uu___3 with
-                     | (l, uu___4) -> FStar_Ident.lid_equals op l)) in
+             FStar_Compiler_List.tryFind
+               (fun uu___3 ->
+                  match uu___3 with
+                  | (l, uu___4) -> FStar_Ident.lid_equals op l) connectives in
            (match uu___2 with
             | FStar_Pervasives_Native.None -> fallback phi1
             | FStar_Pervasives_Native.Some (uu___3, f) ->
                 f phi1.FStar_Syntax_Syntax.pos arms)
        | FStar_Pervasives_Native.Some (FStar_Syntax_Util.QAll
            (vars, pats, body)) ->
-           (FStar_Compiler_Effect.op_Bar_Greater pats
-              (FStar_Compiler_List.iter (check_pattern_vars env vars));
+           (FStar_Compiler_List.iter (check_pattern_vars env vars) pats;
             (let uu___3 = encode_q_body env vars pats body in
              match uu___3 with
              | (vars1, pats1, guard, body1, decls) ->
@@ -3871,8 +3795,7 @@ and (encode_formula :
                  (tm, decls)))
        | FStar_Pervasives_Native.Some (FStar_Syntax_Util.QEx
            (vars, pats, body)) ->
-           (FStar_Compiler_Effect.op_Bar_Greater pats
-              (FStar_Compiler_List.iter (check_pattern_vars env vars));
+           (FStar_Compiler_List.iter (check_pattern_vars env vars) pats;
             (let uu___3 = encode_q_body env vars pats body in
              match uu___3 with
              | (vars1, pats1, guard, body1, decls) ->

--- a/ocaml/fstar-lib/generated/FStar_SMTEncoding_Env.ml
+++ b/ocaml/fstar-lib/generated/FStar_SMTEncoding_Env.ml
@@ -37,7 +37,7 @@ let (mk_term_projector_name :
         let uu___1 = FStar_Ident.string_of_lid lid in
         let uu___2 = FStar_Ident.string_of_id a.FStar_Syntax_Syntax.ppname in
         FStar_Compiler_Util.format2 "%s_%s" uu___1 uu___2 in
-      FStar_Compiler_Effect.op_Less_Bar escape uu___
+      escape uu___
 let (primitive_projector_by_pos :
   FStar_TypeChecker_Env.env ->
     FStar_Ident.lident -> Prims.int -> Prims.string)
@@ -82,7 +82,7 @@ let (mk_term_projector_name_by_pos :
       let uu___ =
         let uu___1 = FStar_Ident.string_of_lid lid in
         FStar_Compiler_Util.format2 "%s_%s" uu___1 (Prims.string_of_int i) in
-      FStar_Compiler_Effect.op_Less_Bar escape uu___
+      escape uu___
 let (mk_term_projector :
   FStar_Ident.lident -> FStar_Syntax_Syntax.bv -> FStar_SMTEncoding_Term.term)
   =
@@ -96,7 +96,7 @@ let (mk_term_projector :
                (FStar_SMTEncoding_Term.Term_sort,
                  FStar_SMTEncoding_Term.Term_sort))) in
         FStar_SMTEncoding_Term.mk_fv uu___1 in
-      FStar_Compiler_Effect.op_Less_Bar FStar_SMTEncoding_Util.mkFreeV uu___
+      FStar_SMTEncoding_Util.mkFreeV uu___
 let (mk_term_projector_by_pos :
   FStar_Ident.lident -> Prims.int -> FStar_SMTEncoding_Term.term) =
   fun lid ->
@@ -109,7 +109,7 @@ let (mk_term_projector_by_pos :
                (FStar_SMTEncoding_Term.Term_sort,
                  FStar_SMTEncoding_Term.Term_sort))) in
         FStar_SMTEncoding_Term.mk_fv uu___1 in
-      FStar_Compiler_Effect.op_Less_Bar FStar_SMTEncoding_Util.mkFreeV uu___
+      FStar_SMTEncoding_Util.mkFreeV uu___
 let mk_data_tester :
   'uuuuu .
     'uuuuu ->
@@ -221,15 +221,13 @@ let (varops : varops_t) =
     let uu___ =
       let uu___1 = FStar_Ident.string_of_id pp in
       Prims.strcat uu___1 (Prims.strcat "__" (Prims.string_of_int rn)) in
-    FStar_Compiler_Effect.op_Less_Bar mk_unique uu___ in
+    mk_unique uu___ in
   let new_fvar lid =
     let uu___ = FStar_Ident.string_of_lid lid in mk_unique uu___ in
   let next_id uu___ =
     FStar_Compiler_Util.incr ctr; FStar_Compiler_Effect.op_Bang ctr in
   let fresh mname pfx =
-    let uu___ =
-      let uu___1 = next_id () in
-      FStar_Compiler_Effect.op_Less_Bar Prims.string_of_int uu___1 in
+    let uu___ = let uu___1 = next_id () in Prims.string_of_int uu___1 in
     FStar_Compiler_Util.format3 "%s_%s_%s" pfx mname uu___ in
   let reset_fresh uu___ =
     FStar_Compiler_Effect.op_Colon_Equals ctr initial_ctr in
@@ -471,10 +469,8 @@ let (print_env : env_t -> Prims.string) =
                             let uu___1 = FStar_Syntax_Print.bv_to_string x in
                             uu___1 :: acc1) acc) [] in
     let allvars =
-      let uu___ =
-        FStar_Compiler_Effect.op_Bar_Greater e.fvar_bindings
-          FStar_Pervasives_Native.fst in
-      FStar_Compiler_Util.psmap_fold uu___
+      FStar_Compiler_Util.psmap_fold
+        (FStar_Pervasives_Native.fst e.fvar_bindings)
         (fun _k -> fun fvb -> fun acc -> (fvb.fvar_lid) :: acc) [] in
     let last_fvar =
       match FStar_Compiler_List.rev allvars with
@@ -503,11 +499,9 @@ let (lookup_fvar_binding :
   =
   fun env ->
     fun lid ->
-      let uu___ =
-        FStar_Compiler_Effect.op_Bar_Greater env.fvar_bindings
-          FStar_Pervasives_Native.fst in
-      let uu___1 = FStar_Ident.string_of_lid lid in
-      FStar_Compiler_Util.psmap_try_find uu___ uu___1
+      let uu___ = FStar_Ident.string_of_lid lid in
+      FStar_Compiler_Util.psmap_try_find
+        (FStar_Pervasives_Native.fst env.fvar_bindings) uu___
 let add_bvar_binding :
   'uuuuu .
     (FStar_Syntax_Syntax.bv * 'uuuuu) ->
@@ -553,8 +547,7 @@ let (fresh_fvar :
         let xsym = varops.fresh mname x in
         let uu___ =
           let uu___1 = FStar_SMTEncoding_Term.mk_fv (xsym, s) in
-          FStar_Compiler_Effect.op_Less_Bar FStar_SMTEncoding_Util.mkFreeV
-            uu___1 in
+          FStar_SMTEncoding_Util.mkFreeV uu___1 in
         (xsym, uu___)
 let (gen_term_var :
   env_t ->
@@ -568,8 +561,7 @@ let (gen_term_var :
         let uu___ =
           FStar_SMTEncoding_Term.mk_fv
             (ysym, FStar_SMTEncoding_Term.Term_sort) in
-        FStar_Compiler_Effect.op_Less_Bar FStar_SMTEncoding_Util.mkFreeV
-          uu___ in
+        FStar_SMTEncoding_Util.mkFreeV uu___ in
       let uu___ =
         let uu___1 = add_bvar_binding (x, y) env.bvar_bindings in
         let uu___2 = FStar_TypeChecker_Env.push_bv env.tcenv x in
@@ -785,12 +777,9 @@ let fail_fvar_lookup : 'uuuuu . env_t -> FStar_Ident.lident -> 'uuuuu =
           let quals = FStar_TypeChecker_Env.quals_of_qninfo q in
           let uu___1 =
             (FStar_Compiler_Util.is_some quals) &&
-              (let uu___2 =
-                 FStar_Compiler_Effect.op_Bar_Greater quals
-                   FStar_Compiler_Util.must in
-               FStar_Compiler_Effect.op_Bar_Greater uu___2
-                 (FStar_Compiler_List.contains
-                    FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen)) in
+              (let uu___2 = FStar_Compiler_Util.must quals in
+               FStar_Compiler_List.contains
+                 FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen uu___2) in
           if uu___1
           then
             let uu___2 =
@@ -919,7 +908,7 @@ let (force_thunk : fvar_binding -> FStar_SMTEncoding_Term.term) =
       FStar_Compiler_Effect.failwith
         "Forcing a non-thunk in the SMT encoding"
     else ();
-    FStar_Compiler_Effect.op_Less_Bar FStar_SMTEncoding_Util.mkFreeV
+    FStar_SMTEncoding_Util.mkFreeV
       (FStar_SMTEncoding_Term.FV
          ((fvb.smt_id), FStar_SMTEncoding_Term.Term_sort, true))
 let (try_lookup_free_var :
@@ -934,8 +923,7 @@ let (try_lookup_free_var :
       | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
       | FStar_Pervasives_Native.Some fvb ->
           ((let uu___2 =
-              FStar_Compiler_Effect.op_Less_Bar
-                (FStar_TypeChecker_Env.debug env.tcenv)
+              FStar_TypeChecker_Env.debug env.tcenv
                 (FStar_Options.Other "PartialApp") in
             if uu___2
             then
@@ -961,8 +949,7 @@ let (try_lookup_free_var :
                               let uu___6 =
                                 let uu___7 =
                                   FStar_SMTEncoding_Term.fv_of_term fuel in
-                                FStar_Compiler_Effect.op_Bar_Greater uu___7
-                                  FStar_SMTEncoding_Term.fv_name in
+                                FStar_SMTEncoding_Term.fv_name uu___7 in
                               FStar_Compiler_Util.starts_with uu___6 "fuel" in
                             if uu___5
                             then
@@ -972,13 +959,9 @@ let (try_lookup_free_var :
                                     FStar_SMTEncoding_Term.mk_fv
                                       ((fvb.smt_id),
                                         FStar_SMTEncoding_Term.Term_sort) in
-                                  FStar_Compiler_Effect.op_Less_Bar
-                                    FStar_SMTEncoding_Util.mkFreeV uu___8 in
+                                  FStar_SMTEncoding_Util.mkFreeV uu___8 in
                                 FStar_SMTEncoding_Term.mk_ApplyTF uu___7 fuel in
-                              FStar_Compiler_Effect.op_Less_Bar
-                                (fun uu___7 ->
-                                   FStar_Pervasives_Native.Some uu___7)
-                                uu___6
+                              FStar_Pervasives_Native.Some uu___6
                             else FStar_Pervasives_Native.Some t
                         | uu___4 -> FStar_Pervasives_Native.Some t)
                    | uu___4 -> FStar_Pervasives_Native.None)))
@@ -1042,11 +1025,9 @@ let (tok_of_name :
   fun env ->
     fun nm ->
       let uu___ =
-        let uu___1 =
-          FStar_Compiler_Effect.op_Bar_Greater env.fvar_bindings
-            FStar_Pervasives_Native.fst in
-        FStar_Compiler_Util.psmap_find_map uu___1
-          (fun uu___2 ->
+        FStar_Compiler_Util.psmap_find_map
+          (FStar_Pervasives_Native.fst env.fvar_bindings)
+          (fun uu___1 ->
              fun fvb ->
                check_valid_fvb fvb;
                if fvb.smt_id = nm
@@ -1080,14 +1061,9 @@ let (tok_of_name :
                    FStar_Pervasives_Native.None)
 let (reset_current_module_fvbs : env_t -> env_t) =
   fun env ->
-    let uu___ =
-      let uu___1 =
-        FStar_Compiler_Effect.op_Bar_Greater env.fvar_bindings
-          FStar_Pervasives_Native.fst in
-      (uu___1, []) in
     {
       bvar_bindings = (env.bvar_bindings);
-      fvar_bindings = uu___;
+      fvar_bindings = ((FStar_Pervasives_Native.fst env.fvar_bindings), []);
       depth = (env.depth);
       tcenv = (env.tcenv);
       warn = (env.warn);
@@ -1099,9 +1075,7 @@ let (reset_current_module_fvbs : env_t -> env_t) =
       global_cache = (env.global_cache)
     }
 let (get_current_module_fvbs : env_t -> fvar_binding Prims.list) =
-  fun env ->
-    FStar_Compiler_Effect.op_Bar_Greater env.fvar_bindings
-      FStar_Pervasives_Native.snd
+  fun env -> FStar_Pervasives_Native.snd env.fvar_bindings
 let (add_fvar_binding_to_env : fvar_binding -> env_t -> env_t) =
   fun fvb ->
     fun env ->

--- a/ocaml/fstar-lib/generated/FStar_SMTEncoding_ErrorReporting.ml
+++ b/ocaml/fstar-lib/generated/FStar_SMTEncoding_ErrorReporting.ml
@@ -101,8 +101,7 @@ let (label_goals :
               -> true
           | uu___ -> false in
         let is_a_named_continuation lhs =
-          FStar_Compiler_Effect.op_Bar_Greater (conjuncts lhs)
-            (FStar_Compiler_Util.for_some is_guard_free) in
+          FStar_Compiler_Util.for_some is_guard_free (conjuncts lhs) in
         let uu___ =
           match use_env_msg with
           | FStar_Pervasives_Native.None -> (false, "")
@@ -164,9 +163,7 @@ let (label_goals :
                                  let post_name =
                                    let uu___3 =
                                      let uu___4 = FStar_GenSym.next_id () in
-                                     FStar_Compiler_Effect.op_Less_Bar
-                                       FStar_Compiler_Util.string_of_int
-                                       uu___4 in
+                                     FStar_Compiler_Util.string_of_int uu___4 in
                                    Prims.strcat "^^post_condition_" uu___3 in
                                  let names =
                                    let uu___3 =
@@ -180,8 +177,7 @@ let (label_goals :
                                               let uu___7 =
                                                 let uu___8 =
                                                   FStar_GenSym.next_id () in
-                                                FStar_Compiler_Effect.op_Less_Bar
-                                                  FStar_Compiler_Util.string_of_int
+                                                FStar_Compiler_Util.string_of_int
                                                   uu___8 in
                                               Prims.strcat "^^" uu___7 in
                                             (uu___6, s) in
@@ -394,8 +390,7 @@ let (label_goals :
                        let new_post_name =
                          let uu___3 =
                            let uu___4 = FStar_GenSym.next_id () in
-                           FStar_Compiler_Effect.op_Less_Bar
-                             FStar_Compiler_Util.string_of_int uu___4 in
+                           FStar_Compiler_Util.string_of_int uu___4 in
                          Prims.strcat "^^post_condition_" uu___3 in
                        let names =
                          let uu___3 =
@@ -405,8 +400,7 @@ let (label_goals :
                                   let uu___5 =
                                     let uu___6 =
                                       let uu___7 = FStar_GenSym.next_id () in
-                                      FStar_Compiler_Effect.op_Less_Bar
-                                        FStar_Compiler_Util.string_of_int
+                                      FStar_Compiler_Util.string_of_int
                                         uu___7 in
                                     Prims.strcat "^^" uu___6 in
                                   (uu___5, s) in
@@ -509,9 +503,8 @@ let (label_goals :
                                             (uu___8, rhs2) in
                                           FStar_SMTEncoding_Term.mkImp uu___7
                                             rng in
-                                        FStar_Compiler_Effect.op_Bar_Greater
-                                          uu___6
-                                          (FStar_SMTEncoding_Term.abstr names) in
+                                        FStar_SMTEncoding_Term.abstr names
+                                          uu___6 in
                                       let q2 =
                                         FStar_SMTEncoding_Term.mk
                                           (FStar_SMTEncoding_Term.Quant
@@ -808,28 +801,27 @@ let (detail_errors :
                          uu___5) in
                      FStar_Errors.log_issue r uu___4) in
           let elim labs =
-            FStar_Compiler_Effect.op_Bar_Greater labs
-              (FStar_Compiler_List.map
-                 (fun uu___ ->
-                    match uu___ with
-                    | (l, uu___1, uu___2) ->
-                        let a =
-                          let uu___3 =
-                            let uu___4 =
-                              let uu___5 = FStar_SMTEncoding_Util.mkFreeV l in
-                              (uu___5, FStar_SMTEncoding_Util.mkTrue) in
-                            FStar_SMTEncoding_Util.mkEq uu___4 in
-                          let uu___4 =
-                            let uu___5 = FStar_SMTEncoding_Term.fv_name l in
-                            Prims.strcat "@disable_label_" uu___5 in
-                          {
-                            FStar_SMTEncoding_Term.assumption_term = uu___3;
-                            FStar_SMTEncoding_Term.assumption_caption =
-                              (FStar_Pervasives_Native.Some "Disabling label");
-                            FStar_SMTEncoding_Term.assumption_name = uu___4;
-                            FStar_SMTEncoding_Term.assumption_fact_ids = []
-                          } in
-                        FStar_SMTEncoding_Term.Assume a)) in
+            FStar_Compiler_List.map
+              (fun uu___ ->
+                 match uu___ with
+                 | (l, uu___1, uu___2) ->
+                     let a =
+                       let uu___3 =
+                         let uu___4 =
+                           let uu___5 = FStar_SMTEncoding_Util.mkFreeV l in
+                           (uu___5, FStar_SMTEncoding_Util.mkTrue) in
+                         FStar_SMTEncoding_Util.mkEq uu___4 in
+                       let uu___4 =
+                         let uu___5 = FStar_SMTEncoding_Term.fv_name l in
+                         Prims.strcat "@disable_label_" uu___5 in
+                       {
+                         FStar_SMTEncoding_Term.assumption_term = uu___3;
+                         FStar_SMTEncoding_Term.assumption_caption =
+                           (FStar_Pervasives_Native.Some "Disabling label");
+                         FStar_SMTEncoding_Term.assumption_name = uu___4;
+                         FStar_SMTEncoding_Term.assumption_fact_ids = []
+                       } in
+                     FStar_SMTEncoding_Term.Assume a) labs in
           let rec linear_check eliminated errors active =
             FStar_SMTEncoding_Z3.refresh ();
             (match active with
@@ -847,7 +839,7 @@ let (detail_errors :
                        (FStar_Compiler_List.length active) in
                    FStar_Compiler_Util.print1 "%s, " uu___2);
                   (let decls =
-                     FStar_Compiler_Effect.op_Less_Bar elim
+                     elim
                        (FStar_Compiler_List.op_At eliminated
                           (FStar_Compiler_List.op_At errors tl)) in
                    let result = askZ3 decls in
@@ -860,8 +852,7 @@ let (detail_errors :
             (FStar_Options.Int (Prims.of_int (5)));
           (let res = linear_check [] [] all_labels in
            FStar_Compiler_Util.print_string "\n";
-           FStar_Compiler_Effect.op_Bar_Greater res
-             (FStar_Compiler_List.iter print_result);
+           FStar_Compiler_List.iter print_result res;
            (let uu___4 =
               FStar_Compiler_Util.for_all FStar_Pervasives_Native.snd res in
             if uu___4

--- a/ocaml/fstar-lib/generated/FStar_SMTEncoding_Term.ml
+++ b/ocaml/fstar-lib/generated/FStar_SMTEncoding_Term.ml
@@ -492,9 +492,7 @@ let (mk_decls_trivial : decl Prims.list -> decls_t) =
       } in
     [uu___]
 let (decls_list_of : decls_t -> decl Prims.list) =
-  fun l ->
-    FStar_Compiler_Effect.op_Bar_Greater l
-      (FStar_Compiler_List.collect (fun elt -> elt.decls))
+  fun l -> FStar_Compiler_List.collect (fun elt -> elt.decls) l
 let (mk_fv : (Prims.string * sort) -> fv) =
   fun uu___ -> match uu___ with | (x, y) -> FV (x, y, false)
 let (fv_name : fv -> Prims.string) =
@@ -655,8 +653,7 @@ let rec (hash_of_term' : term' -> Prims.string) =
           let uu___2 =
             let uu___3 =
               let uu___4 = FStar_Compiler_List.map hash_of_term tms in
-              FStar_Compiler_Effect.op_Bar_Greater uu___4
-                (FStar_Compiler_String.concat " ") in
+              FStar_Compiler_String.concat " " uu___4 in
             Prims.strcat uu___3 ")" in
           Prims.strcat uu___1 uu___2 in
         Prims.strcat "(" uu___
@@ -677,8 +674,7 @@ let rec (hash_of_term' : term' -> Prims.string) =
             let uu___2 =
               let uu___3 =
                 let uu___4 = FStar_Compiler_List.map strSort sorts in
-                FStar_Compiler_Effect.op_Bar_Greater uu___4
-                  (FStar_Compiler_String.concat " ") in
+                FStar_Compiler_String.concat " " uu___4 in
               let uu___4 =
                 let uu___5 =
                   let uu___6 = hash_of_term body in
@@ -689,17 +685,14 @@ let rec (hash_of_term' : term' -> Prims.string) =
                         let uu___11 =
                           let uu___12 =
                             let uu___13 =
-                              FStar_Compiler_Effect.op_Bar_Greater pats
-                                (FStar_Compiler_List.map
-                                   (fun pats1 ->
-                                      let uu___14 =
-                                        FStar_Compiler_List.map hash_of_term
-                                          pats1 in
-                                      FStar_Compiler_Effect.op_Bar_Greater
-                                        uu___14
-                                        (FStar_Compiler_String.concat " "))) in
-                            FStar_Compiler_Effect.op_Bar_Greater uu___13
-                              (FStar_Compiler_String.concat "; ") in
+                              FStar_Compiler_List.map
+                                (fun pats1 ->
+                                   let uu___14 =
+                                     FStar_Compiler_List.map hash_of_term
+                                       pats1 in
+                                   FStar_Compiler_String.concat " " uu___14)
+                                pats in
+                            FStar_Compiler_String.concat "; " uu___13 in
                           Prims.strcat uu___12 "))" in
                         Prims.strcat " " uu___11 in
                       Prims.strcat uu___9 uu___10 in
@@ -714,8 +707,7 @@ let rec (hash_of_term' : term' -> Prims.string) =
         let uu___ =
           let uu___1 =
             let uu___2 = FStar_Compiler_List.map hash_of_term es in
-            FStar_Compiler_Effect.op_Bar_Greater uu___2
-              (FStar_Compiler_String.concat " ") in
+            FStar_Compiler_String.concat " " uu___2 in
           let uu___2 =
             let uu___3 =
               let uu___4 = hash_of_term body in Prims.strcat uu___4 ")" in
@@ -1084,8 +1076,7 @@ let rec (print_smt_term : term -> Prims.string) =
 and (print_smt_term_list : term Prims.list -> Prims.string) =
   fun l ->
     let uu___ = FStar_Compiler_List.map print_smt_term l in
-    FStar_Compiler_Effect.op_Bar_Greater uu___
-      (FStar_Compiler_String.concat " ")
+    FStar_Compiler_String.concat " " uu___
 and (print_smt_term_list_list : term Prims.list Prims.list -> Prims.string) =
   fun l ->
     FStar_Compiler_List.fold_left
@@ -1195,9 +1186,8 @@ let (abstr : fv Prims.list -> term -> term) =
                  let n = FStar_Compiler_List.length vars in
                  let uu___2 =
                    let uu___3 =
-                     FStar_Compiler_Effect.op_Bar_Greater pats
-                       (FStar_Compiler_List.map
-                          (FStar_Compiler_List.map (aux (ix + n)))) in
+                     FStar_Compiler_List.map
+                       (FStar_Compiler_List.map (aux (ix + n))) pats in
                    let uu___4 = aux (ix + n) body in
                    (qop1, uu___3, wopt, vars, uu___4) in
                  mkQuant t1.rng false uu___2
@@ -1253,9 +1243,8 @@ let (inst : term Prims.list -> term -> term) =
             let shift1 = shift + m in
             let uu___ =
               let uu___1 =
-                FStar_Compiler_Effect.op_Bar_Greater pats
-                  (FStar_Compiler_List.map
-                     (FStar_Compiler_List.map (aux shift1))) in
+                FStar_Compiler_List.map
+                  (FStar_Compiler_List.map (aux shift1)) pats in
               let uu___2 = aux shift1 body in
               (qop1, uu___1, wopt, vars, uu___2) in
             mkQuant t1.rng false uu___
@@ -1289,9 +1278,8 @@ let (mkQuant' :
       | (qop1, pats, wopt, vars, body) ->
           let uu___1 =
             let uu___2 =
-              FStar_Compiler_Effect.op_Bar_Greater pats
-                (FStar_Compiler_List.map
-                   (FStar_Compiler_List.map (abstr vars))) in
+              FStar_Compiler_List.map (FStar_Compiler_List.map (abstr vars))
+                pats in
             let uu___3 = FStar_Compiler_List.map fv_sort vars in
             let uu___4 = abstr vars body in
             (qop1, uu___2, wopt, uu___3, uu___4) in
@@ -1399,18 +1387,17 @@ let (fresh_constructor :
       | (name, arg_sorts, sort1, id) ->
           let id1 = FStar_Compiler_Util.string_of_int id in
           let bvars =
-            FStar_Compiler_Effect.op_Bar_Greater arg_sorts
-              (FStar_Compiler_List.mapi
-                 (fun i ->
-                    fun s ->
-                      let uu___1 =
-                        let uu___2 =
-                          let uu___3 =
-                            let uu___4 = FStar_Compiler_Util.string_of_int i in
-                            Prims.strcat "x_" uu___4 in
-                          (uu___3, s) in
-                        mk_fv uu___2 in
-                      mkFreeV uu___1 norng)) in
+            FStar_Compiler_List.mapi
+              (fun i ->
+                 fun s ->
+                   let uu___1 =
+                     let uu___2 =
+                       let uu___3 =
+                         let uu___4 = FStar_Compiler_Util.string_of_int i in
+                         Prims.strcat "x_" uu___4 in
+                       (uu___3, s) in
+                     mk_fv uu___2 in
+                   mkFreeV uu___1 norng) arg_sorts in
           let bvar_names = FStar_Compiler_List.map fv_of_term bvars in
           let capp = mkApp (name, bvars) norng in
           let cid_app =
@@ -1453,55 +1440,53 @@ let (injective_constructor :
             let uu___1 =
               let uu___2 = let uu___3 = bvar_name i in (uu___3, s) in
               mk_fv uu___2 in
-            FStar_Compiler_Effect.op_Less_Bar mkFreeV uu___1 in
+            mkFreeV uu___1 in
           let bvars =
-            FStar_Compiler_Effect.op_Bar_Greater fields
-              (FStar_Compiler_List.mapi
-                 (fun i ->
-                    fun f -> let uu___1 = bvar i f.field_sort in uu___1 norng)) in
+            FStar_Compiler_List.mapi
+              (fun i ->
+                 fun f -> let uu___1 = bvar i f.field_sort in uu___1 norng)
+              fields in
           let bvar_names = FStar_Compiler_List.map fv_of_term bvars in
           let capp = mkApp (name, bvars) norng in
           let uu___1 =
-            FStar_Compiler_Effect.op_Bar_Greater fields
-              (FStar_Compiler_List.mapi
-                 (fun i ->
-                    fun uu___2 ->
-                      match uu___2 with
-                      | { field_name = name1; field_sort = s;
-                          field_projectible = projectible;_} ->
-                          let cproj_app = mkApp (name1, [capp]) norng in
-                          let proj_name =
-                            DeclFun
-                              (name1, [sort1], s,
-                                (FStar_Pervasives_Native.Some "Projector")) in
-                          if projectible
-                          then
-                            let a =
-                              let uu___3 =
-                                let uu___4 =
-                                  let uu___5 =
-                                    let uu___6 =
-                                      let uu___7 =
-                                        let uu___8 = bvar i s in uu___8 norng in
-                                      (cproj_app, uu___7) in
-                                    mkEq uu___6 norng in
-                                  ([[capp]], bvar_names, uu___5) in
-                                mkForall rng uu___4 in
-                              let uu___4 =
-                                escape
-                                  (Prims.strcat "projection_inverse_" name1) in
-                              {
-                                assumption_term = uu___3;
-                                assumption_caption =
-                                  (FStar_Pervasives_Native.Some
-                                     "Projection inverse");
-                                assumption_name = uu___4;
-                                assumption_fact_ids = []
-                              } in
-                            [proj_name; Assume a]
-                          else [proj_name])) in
-          FStar_Compiler_Effect.op_Bar_Greater uu___1
-            FStar_Compiler_List.flatten
+            FStar_Compiler_List.mapi
+              (fun i ->
+                 fun uu___2 ->
+                   match uu___2 with
+                   | { field_name = name1; field_sort = s;
+                       field_projectible = projectible;_} ->
+                       let cproj_app = mkApp (name1, [capp]) norng in
+                       let proj_name =
+                         DeclFun
+                           (name1, [sort1], s,
+                             (FStar_Pervasives_Native.Some "Projector")) in
+                       if projectible
+                       then
+                         let a =
+                           let uu___3 =
+                             let uu___4 =
+                               let uu___5 =
+                                 let uu___6 =
+                                   let uu___7 =
+                                     let uu___8 = bvar i s in uu___8 norng in
+                                   (cproj_app, uu___7) in
+                                 mkEq uu___6 norng in
+                               ([[capp]], bvar_names, uu___5) in
+                             mkForall rng uu___4 in
+                           let uu___4 =
+                             escape
+                               (Prims.strcat "projection_inverse_" name1) in
+                           {
+                             assumption_term = uu___3;
+                             assumption_caption =
+                               (FStar_Pervasives_Native.Some
+                                  "Projection inverse");
+                             assumption_name = uu___4;
+                             assumption_fact_ids = []
+                           } in
+                         [proj_name; Assume a]
+                       else [proj_name]) fields in
+          FStar_Compiler_List.flatten uu___1
 let (discriminator_name : constructor_t -> Prims.string) =
   fun constr -> Prims.strcat "is-" constr.constr_name
 let (constructor_to_decl :
@@ -1511,8 +1496,7 @@ let (constructor_to_decl :
       let injective = true in
       let sort1 = constr.constr_sort in
       let field_sorts =
-        FStar_Compiler_Effect.op_Bar_Greater constr.constr_fields
-          (FStar_Compiler_List.map (fun f -> f.field_sort)) in
+        FStar_Compiler_List.map (fun f -> f.field_sort) constr.constr_fields in
       let cdecl =
         DeclFun
           ((constr.constr_name), field_sorts, (constr.constr_sort),
@@ -1531,29 +1515,28 @@ let (constructor_to_decl :
         let xx = mkFreeV xfv norng in
         let uu___ =
           let uu___1 =
-            FStar_Compiler_Effect.op_Bar_Greater constr.constr_fields
-              (FStar_Compiler_List.mapi
-                 (fun i ->
-                    fun uu___2 ->
-                      match uu___2 with
-                      | { field_name = proj; field_sort = s;
-                          field_projectible = projectible;_} ->
-                          if projectible
-                          then
-                            let uu___3 = mkApp (proj, [xx]) norng in
-                            (uu___3, [])
-                          else
-                            (let fi =
-                               let uu___4 =
-                                 let uu___5 =
-                                   let uu___6 =
-                                     FStar_Compiler_Util.string_of_int i in
-                                   Prims.strcat "f_" uu___6 in
-                                 (uu___5, s) in
-                               mk_fv uu___4 in
-                             let uu___4 = mkFreeV fi norng in (uu___4, [fi])))) in
-          FStar_Compiler_Effect.op_Bar_Greater uu___1
-            FStar_Compiler_List.split in
+            FStar_Compiler_List.mapi
+              (fun i ->
+                 fun uu___2 ->
+                   match uu___2 with
+                   | { field_name = proj; field_sort = s;
+                       field_projectible = projectible;_} ->
+                       if projectible
+                       then
+                         let uu___3 = mkApp (proj, [xx]) norng in
+                         (uu___3, [])
+                       else
+                         (let fi =
+                            let uu___4 =
+                              let uu___5 =
+                                let uu___6 =
+                                  FStar_Compiler_Util.string_of_int i in
+                                Prims.strcat "f_" uu___6 in
+                              (uu___5, s) in
+                            mk_fv uu___4 in
+                          let uu___4 = mkFreeV fi norng in (uu___4, [fi])))
+              constr.constr_fields in
+          FStar_Compiler_List.split uu___1 in
         match uu___ with
         | (proj_terms, ex_vars) ->
             let ex_vars1 = FStar_Compiler_List.flatten ex_vars in
@@ -1624,29 +1607,28 @@ let (name_binders_inner :
       fun start ->
         fun sorts ->
           let uu___ =
-            FStar_Compiler_Effect.op_Bar_Greater sorts
-              (FStar_Compiler_List.fold_left
-                 (fun uu___1 ->
-                    fun s ->
-                      match uu___1 with
-                      | (names, binders1, n) ->
-                          let prefix =
-                            match s with | Term_sort -> "@x" | uu___2 -> "@u" in
-                          let prefix1 =
-                            match prefix_opt with
-                            | FStar_Pervasives_Native.None -> prefix
-                            | FStar_Pervasives_Native.Some p ->
-                                Prims.strcat p prefix in
-                          let nm =
-                            let uu___2 = FStar_Compiler_Util.string_of_int n in
-                            Prims.strcat prefix1 uu___2 in
-                          let names1 =
-                            let uu___2 = mk_fv (nm, s) in uu___2 :: names in
-                          let b =
-                            let uu___2 = strSort s in
-                            FStar_Compiler_Util.format2 "(%s %s)" nm uu___2 in
-                          (names1, (b :: binders1), (n + Prims.int_one)))
-                 (outer_names, [], start)) in
+            FStar_Compiler_List.fold_left
+              (fun uu___1 ->
+                 fun s ->
+                   match uu___1 with
+                   | (names, binders1, n) ->
+                       let prefix =
+                         match s with | Term_sort -> "@x" | uu___2 -> "@u" in
+                       let prefix1 =
+                         match prefix_opt with
+                         | FStar_Pervasives_Native.None -> prefix
+                         | FStar_Pervasives_Native.Some p ->
+                             Prims.strcat p prefix in
+                       let nm =
+                         let uu___2 = FStar_Compiler_Util.string_of_int n in
+                         Prims.strcat prefix1 uu___2 in
+                       let names1 =
+                         let uu___2 = mk_fv (nm, s) in uu___2 :: names in
+                       let b =
+                         let uu___2 = strSort s in
+                         FStar_Compiler_Util.format2 "(%s %s)" nm uu___2 in
+                       (names1, (b :: binders1), (n + Prims.int_one)))
+              (outer_names, [], start) sorts in
           match uu___ with
           | (names, binders1, n) ->
               (names, (FStar_Compiler_List.rev binders1), n)
@@ -1675,20 +1657,18 @@ let (termToSmt : Prims.bool -> Prims.string -> term -> Prims.string) =
               (let uu___2 = FStar_Compiler_Util.string_of_int n in
                FStar_Compiler_Util.format2 "%s.%s" enclosing_name uu___2) in
         let remove_guard_free pats =
-          FStar_Compiler_Effect.op_Bar_Greater pats
-            (FStar_Compiler_List.map
-               (fun ps ->
-                  FStar_Compiler_Effect.op_Bar_Greater ps
-                    (FStar_Compiler_List.map
-                       (fun tm ->
-                          match tm.tm with
-                          | App
-                              (Var "Prims.guard_free",
-                               { tm = BoundV uu___; freevars = uu___1;
-                                 rng = uu___2;_}::[])
-                              -> tm
-                          | App (Var "Prims.guard_free", p::[]) -> p
-                          | uu___ -> tm)))) in
+          FStar_Compiler_List.map
+            (fun ps ->
+               FStar_Compiler_List.map
+                 (fun tm ->
+                    match tm.tm with
+                    | App
+                        (Var "Prims.guard_free",
+                         { tm = BoundV uu___; freevars = uu___1;
+                           rng = uu___2;_}::[])
+                        -> tm
+                    | App (Var "Prims.guard_free", p::[]) -> p
+                    | uu___ -> tm) ps) pats in
         let rec aux' depth n names t1 =
           let aux1 = aux (depth + Prims.int_one) in
           match t1.tm with
@@ -1702,14 +1682,12 @@ let (termToSmt : Prims.bool -> Prims.string -> term -> Prims.string) =
                    let id =
                      let uu___ =
                        FStar_Compiler_Effect.op_Bang string_id_counter in
-                     FStar_Compiler_Effect.op_Bar_Greater uu___
-                       FStar_Compiler_Util.string_of_int in
+                     FStar_Compiler_Util.string_of_int uu___ in
                    (FStar_Compiler_Util.incr string_id_counter;
                     FStar_Compiler_Util.smap_add string_cache s id;
                     id))
           | BoundV i ->
-              let uu___ = FStar_Compiler_List.nth names i in
-              FStar_Compiler_Effect.op_Bar_Greater uu___ fv_name
+              let uu___ = FStar_Compiler_List.nth names i in fv_name uu___
           | FreeV x when fv_force x ->
               let uu___ =
                 let uu___1 = fv_name x in Prims.strcat uu___1 " Dummy_value)" in
@@ -1720,8 +1698,7 @@ let (termToSmt : Prims.bool -> Prims.string -> term -> Prims.string) =
               let uu___ = op_to_string op1 in
               let uu___1 =
                 let uu___2 = FStar_Compiler_List.map (aux1 n names) tms in
-                FStar_Compiler_Effect.op_Bar_Greater uu___2
-                  (FStar_Compiler_String.concat "\n") in
+                FStar_Compiler_String.concat "\n" uu___2 in
               FStar_Compiler_Util.format2 "(%s %s)" uu___ uu___1
           | Labeled (t2, uu___, uu___1) -> aux1 n names t2
           | LblPos (t2, s) ->
@@ -1733,9 +1710,7 @@ let (termToSmt : Prims.bool -> Prims.string -> term -> Prims.string) =
                 name_binders_inner FStar_Pervasives_Native.None names n sorts in
               (match uu___ with
                | (names1, binders1, n1) ->
-                   let binders2 =
-                     FStar_Compiler_Effect.op_Bar_Greater binders1
-                       (FStar_Compiler_String.concat " ") in
+                   let binders2 = FStar_Compiler_String.concat " " binders1 in
                    let pats1 = remove_guard_free pats in
                    let pats_str =
                      match pats1 with
@@ -1743,21 +1718,19 @@ let (termToSmt : Prims.bool -> Prims.string -> term -> Prims.string) =
                      | [] -> if print_ranges then ";;no pats" else ""
                      | uu___1 ->
                          let uu___2 =
-                           FStar_Compiler_Effect.op_Bar_Greater pats1
-                             (FStar_Compiler_List.map
-                                (fun pats2 ->
-                                   let uu___3 =
-                                     let uu___4 =
-                                       FStar_Compiler_List.map
-                                         (fun p ->
-                                            let uu___5 = aux1 n1 names1 p in
-                                            FStar_Compiler_Util.format1 "%s"
-                                              uu___5) pats2 in
-                                     FStar_Compiler_String.concat " " uu___4 in
-                                   FStar_Compiler_Util.format1
-                                     "\n:pattern (%s)" uu___3)) in
-                         FStar_Compiler_Effect.op_Bar_Greater uu___2
-                           (FStar_Compiler_String.concat "\n") in
+                           FStar_Compiler_List.map
+                             (fun pats2 ->
+                                let uu___3 =
+                                  let uu___4 =
+                                    FStar_Compiler_List.map
+                                      (fun p ->
+                                         let uu___5 = aux1 n1 names1 p in
+                                         FStar_Compiler_Util.format1 "%s"
+                                           uu___5) pats2 in
+                                  FStar_Compiler_String.concat " " uu___4 in
+                                FStar_Compiler_Util.format1 "\n:pattern (%s)"
+                                  uu___3) pats1 in
+                         FStar_Compiler_String.concat "\n" uu___2 in
                    let uu___1 =
                      let uu___2 =
                        let uu___3 =
@@ -1813,11 +1786,9 @@ let (caption_to_string :
       | FStar_Pervasives_Native.Some c when print_captions ->
           let c1 =
             let uu___1 =
-              FStar_Compiler_Effect.op_Bar_Greater
-                (FStar_Compiler_String.split [10] c)
-                (FStar_Compiler_List.map FStar_Compiler_Util.trim_string) in
-            FStar_Compiler_Effect.op_Bar_Greater uu___1
-              (FStar_Compiler_String.concat " ") in
+              FStar_Compiler_List.map FStar_Compiler_Util.trim_string
+                (FStar_Compiler_String.split [10] c) in
+            FStar_Compiler_String.concat " " uu___1 in
           Prims.strcat ";;;;;;;;;;;;;;;;" (Prims.strcat c1 "\n")
       | uu___1 -> ""
 let rec (declToSmt' : Prims.bool -> Prims.string -> decl -> Prims.string) =
@@ -1831,8 +1802,7 @@ let rec (declToSmt' : Prims.bool -> Prims.string -> decl -> Prims.string) =
               let uu___ =
                 FStar_Compiler_List.map (declToSmt' print_captions z3options)
                   decls in
-              FStar_Compiler_Effect.op_Bar_Greater uu___
-                (FStar_Compiler_String.concat "\n") in
+              FStar_Compiler_String.concat "\n" uu___ in
             let uu___ = FStar_Options.keep_query_captions () in
             if uu___
             then
@@ -1851,12 +1821,10 @@ let rec (declToSmt' : Prims.bool -> Prims.string -> decl -> Prims.string) =
             then
               let uu___ =
                 let uu___1 =
-                  FStar_Compiler_Effect.op_Bar_Greater
-                    (FStar_Compiler_Util.splitlines c)
-                    (FStar_Compiler_List.map
-                       (fun s -> Prims.strcat "; " (Prims.strcat s "\n"))) in
-                FStar_Compiler_Effect.op_Bar_Greater uu___1
-                  (FStar_Compiler_String.concat "") in
+                  FStar_Compiler_List.map
+                    (fun s -> Prims.strcat "; " (Prims.strcat s "\n"))
+                    (FStar_Compiler_Util.splitlines c) in
+                FStar_Compiler_String.concat "" uu___1 in
               Prims.strcat "\n" uu___
             else ""
         | DeclFun (f, argsorts, retsort, c) ->
@@ -1883,17 +1851,16 @@ let rec (declToSmt' : Prims.bool -> Prims.string -> decl -> Prims.string) =
                    uu___2 uu___3)
         | Assume a ->
             let fact_ids_to_string ids =
-              FStar_Compiler_Effect.op_Bar_Greater ids
-                (FStar_Compiler_List.map
-                   (fun uu___ ->
-                      match uu___ with
-                      | Name n ->
-                          let uu___1 = FStar_Ident.string_of_lid n in
-                          Prims.strcat "Name " uu___1
-                      | Namespace ns ->
-                          let uu___1 = FStar_Ident.string_of_lid ns in
-                          Prims.strcat "Namespace " uu___1
-                      | Tag t -> Prims.strcat "Tag " t)) in
+              FStar_Compiler_List.map
+                (fun uu___ ->
+                   match uu___ with
+                   | Name n ->
+                       let uu___1 = FStar_Ident.string_of_lid n in
+                       Prims.strcat "Name " uu___1
+                   | Namespace ns ->
+                       let uu___1 = FStar_Ident.string_of_lid ns in
+                       Prims.strcat "Namespace " uu___1
+                   | Tag t -> Prims.strcat "Tag " t) ids in
             let fids =
               if print_captions
               then
@@ -1972,12 +1939,9 @@ and (mkPrelude : Prims.string -> Prims.string) =
     let bcons =
       let uu___ =
         let uu___1 =
-          FStar_Compiler_Effect.op_Bar_Greater constrs
-            (FStar_Compiler_List.collect (constructor_to_decl norng)) in
-        FStar_Compiler_Effect.op_Bar_Greater uu___1
-          (FStar_Compiler_List.map (declToSmt z3options)) in
-      FStar_Compiler_Effect.op_Bar_Greater uu___
-        (FStar_Compiler_String.concat "\n") in
+          FStar_Compiler_List.collect (constructor_to_decl norng) constrs in
+        FStar_Compiler_List.map (declToSmt z3options) uu___1 in
+      FStar_Compiler_String.concat "\n" uu___ in
     let precedes_partial_app =
       "\n(declare-fun Prims.precedes@tok () Term)\n(assert\n(forall ((@x0 Term) (@x1 Term) (@x2 Term) (@x3 Term))\n(! (= (ApplyTT (ApplyTT (ApplyTT (ApplyTT Prims.precedes@tok\n@x0)\n@x1)\n@x2)\n@x3)\n(Prims.precedes @x0 @x1 @x2 @x3))\n\n:pattern ((ApplyTT (ApplyTT (ApplyTT (ApplyTT Prims.precedes@tok\n@x0)\n@x1)\n@x2)\n@x3)))))\n" in
     let lex_ordering =
@@ -2005,8 +1969,7 @@ let (declsToSmt : Prims.string -> decl Prims.list -> Prims.string) =
   fun z3options ->
     fun decls ->
       let uu___ = FStar_Compiler_List.map (declToSmt z3options) decls in
-      FStar_Compiler_Effect.op_Bar_Greater uu___
-        (FStar_Compiler_String.concat "\n")
+      FStar_Compiler_String.concat "\n" uu___
 let (declToSmt_no_caps : Prims.string -> decl -> Prims.string) =
   fun z3options -> fun decl1 -> declToSmt' false z3options decl1
 let (mkBvConstructor :
@@ -2296,7 +2259,7 @@ let (kick_partial_app : term -> term) =
     let uu___ =
       let uu___1 = mkApp ("__uu__PartialApp", []) t.rng in
       mk_ApplyTT uu___1 t t.rng in
-    FStar_Compiler_Effect.op_Bar_Greater uu___ mk_Valid
+    mk_Valid uu___
 let (mk_String_const :
   Prims.string -> FStar_Compiler_Range_Type.range -> term) =
   fun s ->
@@ -2313,7 +2276,7 @@ let (mk_Precedes :
         fun x4 ->
           fun r ->
             let uu___ = mkApp ("Prims.precedes", [x1; x2; x3; x4]) r in
-            FStar_Compiler_Effect.op_Bar_Greater uu___ mk_Valid
+            mk_Valid uu___
 let rec (n_fuel : Prims.int -> term) =
   fun n ->
     if n = Prims.int_zero

--- a/ocaml/fstar-lib/generated/FStar_SMTEncoding_Util.ml
+++ b/ocaml/fstar-lib/generated/FStar_SMTEncoding_Util.ml
@@ -225,11 +225,8 @@ let (is_smt_reifiable_effect :
       let l1 = FStar_TypeChecker_Env.norm_eff_name en l in
       (FStar_TypeChecker_Env.is_reifiable_effect en l1) &&
         (let uu___ =
-           let uu___1 =
-             FStar_Compiler_Effect.op_Bar_Greater l1
-               (FStar_TypeChecker_Env.get_effect_decl en) in
-           FStar_Compiler_Effect.op_Bar_Greater uu___1
-             FStar_Syntax_Util.is_layered in
+           let uu___1 = FStar_TypeChecker_Env.get_effect_decl en l1 in
+           FStar_Syntax_Util.is_layered uu___1 in
          Prims.op_Negation uu___)
 let (is_smt_reifiable_comp :
   FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.comp -> Prims.bool) =
@@ -245,8 +242,7 @@ let (is_smt_reifiable_rc :
   =
   fun en ->
     fun rc ->
-      FStar_Compiler_Effect.op_Bar_Greater
-        rc.FStar_Syntax_Syntax.residual_effect (is_smt_reifiable_effect en)
+      is_smt_reifiable_effect en rc.FStar_Syntax_Syntax.residual_effect
 let (is_smt_reifiable_function :
   FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.term -> Prims.bool) =
   fun en ->
@@ -258,9 +254,5 @@ let (is_smt_reifiable_function :
       | FStar_Syntax_Syntax.Tm_arrow
           { FStar_Syntax_Syntax.bs1 = uu___1; FStar_Syntax_Syntax.comp = c;_}
           ->
-          let uu___2 =
-            FStar_Compiler_Effect.op_Bar_Greater c
-              FStar_Syntax_Util.comp_effect_name in
-          FStar_Compiler_Effect.op_Bar_Greater uu___2
-            (is_smt_reifiable_effect en)
+          is_smt_reifiable_effect en (FStar_Syntax_Util.comp_effect_name c)
       | uu___1 -> false

--- a/ocaml/fstar-lib/generated/FStar_SMTEncoding_Z3.ml
+++ b/ocaml/fstar-lib/generated/FStar_SMTEncoding_Z3.ml
@@ -435,8 +435,7 @@ let (new_z3proc_with_id :
         let uu___1 =
           FStar_Compiler_Util.incr ctr;
           (let uu___3 = FStar_Compiler_Effect.op_Bang ctr in
-           FStar_Compiler_Effect.op_Bar_Greater uu___3
-             FStar_Compiler_Util.string_of_int) in
+           FStar_Compiler_Util.string_of_int uu___3) in
         FStar_Compiler_Util.format1 "z3-bg-%s" uu___1 in
       new_z3proc uu___ cmd_and_args in
     p
@@ -699,9 +698,8 @@ let (doZ3Exe :
             fun queryid ->
               let parse z3out =
                 let lines =
-                  FStar_Compiler_Effect.op_Bar_Greater
-                    (FStar_Compiler_String.split [10] z3out)
-                    (FStar_Compiler_List.map FStar_Compiler_Util.trim_string) in
+                  FStar_Compiler_List.map FStar_Compiler_Util.trim_string
+                    (FStar_Compiler_String.split [10] z3out) in
                 let smt_output1 = smt_output_sections log_file r lines in
                 let unsat_core1 =
                   match smt_output1.smt_unsat_core with
@@ -719,10 +717,9 @@ let (doZ3Exe :
                       then FStar_Pervasives_Native.None
                       else
                         (let uu___1 =
-                           FStar_Compiler_Effect.op_Bar_Greater
-                             (FStar_Compiler_Util.split s2 " ")
-                             (FStar_Compiler_Util.sort_with
-                                FStar_Compiler_String.compare) in
+                           FStar_Compiler_Util.sort_with
+                             FStar_Compiler_String.compare
+                             (FStar_Compiler_Util.split s2 " ") in
                          FStar_Pervasives_Native.Some uu___1) in
                 let labels =
                   match smt_output1.smt_labels with
@@ -738,24 +735,20 @@ let (doZ3Exe :
                             lblnegs rest
                         | uu___ -> [] in
                       let lblnegs1 = lblnegs lines1 in
-                      FStar_Compiler_Effect.op_Bar_Greater lblnegs1
-                        (FStar_Compiler_List.collect
-                           (fun l ->
-                              let uu___ =
-                                FStar_Compiler_Effect.op_Bar_Greater
-                                  label_messages
-                                  (FStar_Compiler_List.tryFind
-                                     (fun uu___1 ->
-                                        match uu___1 with
-                                        | (m, uu___2, uu___3) ->
-                                            let uu___4 =
-                                              FStar_SMTEncoding_Term.fv_name
-                                                m in
-                                            uu___4 = l)) in
-                              match uu___ with
-                              | FStar_Pervasives_Native.None -> []
-                              | FStar_Pervasives_Native.Some (lbl, msg, r1)
-                                  -> [(lbl, msg, r1)])) in
+                      FStar_Compiler_List.collect
+                        (fun l ->
+                           let uu___ =
+                             FStar_Compiler_List.tryFind
+                               (fun uu___1 ->
+                                  match uu___1 with
+                                  | (m, uu___2, uu___3) ->
+                                      let uu___4 =
+                                        FStar_SMTEncoding_Term.fv_name m in
+                                      uu___4 = l) label_messages in
+                           match uu___ with
+                           | FStar_Pervasives_Native.None -> []
+                           | FStar_Pervasives_Native.Some (lbl, msg, r1) ->
+                               [(lbl, msg, r1)]) lblnegs1 in
                 let statistics =
                   let statistics1 =
                     FStar_Compiler_Util.smap_create Prims.int_zero in
@@ -831,8 +824,7 @@ let (doZ3Exe :
                        FStar_Compiler_Util.format1 "Z3 says: %s\n"
                          (FStar_Compiler_String.concat "\n"
                             smt_output1.smt_result) in
-                     FStar_Compiler_Effect.op_Less_Bar
-                       FStar_Compiler_Util.print_string uu___2
+                     FStar_Compiler_Util.print_string uu___2
                    else ());
                   (match smt_output1.smt_result with
                    | "unsat"::[] -> UNSAT unsat_core1
@@ -972,15 +964,14 @@ let (rollback :
       FStar_Common.rollback (fun uu___ -> pop msg) fresh_scope depth
 let (giveZ3 : FStar_SMTEncoding_Term.decl Prims.list -> unit) =
   fun decls ->
-    FStar_Compiler_Effect.op_Bar_Greater decls
-      (FStar_Compiler_List.iter
-         (fun uu___1 ->
-            match uu___1 with
-            | FStar_SMTEncoding_Term.Push ->
-                FStar_Compiler_Effect.failwith "Unexpected push/pop"
-            | FStar_SMTEncoding_Term.Pop ->
-                FStar_Compiler_Effect.failwith "Unexpected push/pop"
-            | uu___2 -> ()));
+    FStar_Compiler_List.iter
+      (fun uu___1 ->
+         match uu___1 with
+         | FStar_SMTEncoding_Term.Push ->
+             FStar_Compiler_Effect.failwith "Unexpected push/pop"
+         | FStar_SMTEncoding_Term.Pop ->
+             FStar_Compiler_Effect.failwith "Unexpected push/pop"
+         | uu___2 -> ()) decls;
     (let uu___2 = FStar_Compiler_Effect.op_Bang fresh_scope in
      match uu___2 with
      | hd::tl ->
@@ -1076,8 +1067,7 @@ let (mk_input :
         let uu___ =
           let uu___1 =
             let uu___2 = FStar_Options.z3_smtopt () in
-            FStar_Compiler_Effect.op_Bar_Greater uu___2
-              (FStar_Compiler_String.concat "\n") in
+            FStar_Compiler_String.concat "\n" uu___2 in
           Prims.strcat uu___1 "\n\n" in
         Prims.strcat options3 uu___ in
       (let uu___1 = FStar_Options.print_z3_statistics () in
@@ -1091,14 +1081,12 @@ let (mk_input :
          then
            let uu___3 =
              let uu___4 =
-               FStar_Compiler_Effect.op_Bar_Greater theory
-                 (FStar_Compiler_Util.prefix_until
-                    (fun uu___5 ->
-                       match uu___5 with
-                       | FStar_SMTEncoding_Term.CheckSat -> true
-                       | uu___6 -> false)) in
-             FStar_Compiler_Effect.op_Bar_Greater uu___4
-               FStar_Compiler_Option.get in
+               FStar_Compiler_Util.prefix_until
+                 (fun uu___5 ->
+                    match uu___5 with
+                    | FStar_SMTEncoding_Term.CheckSat -> true
+                    | uu___6 -> false) theory in
+             FStar_Compiler_Option.get uu___4 in
            match uu___3 with
            | (prefix, check_sat, suffix) ->
                let pp =
@@ -1114,11 +1102,10 @@ let (mk_input :
                  if uu___4
                  then
                    let uu___5 =
-                     FStar_Compiler_Effect.op_Bar_Greater prefix
-                       (FStar_Compiler_List.map
-                          (FStar_SMTEncoding_Term.declToSmt_no_caps options4)) in
-                   FStar_Compiler_Effect.op_Bar_Greater uu___5
-                     (FStar_Compiler_String.concat "\n")
+                     FStar_Compiler_List.map
+                       (FStar_SMTEncoding_Term.declToSmt_no_caps options4)
+                       prefix in
+                   FStar_Compiler_String.concat "\n" uu___5
                  else ps in
                let hs1 = Prims.strcat hs (Prims.strcat "Z3 version: " ver) in
                let uu___4 =
@@ -1130,8 +1117,7 @@ let (mk_input :
               let uu___5 =
                 FStar_Compiler_List.map
                   (FStar_SMTEncoding_Term.declToSmt options4) theory in
-              FStar_Compiler_Effect.op_Bar_Greater uu___5
-                (FStar_Compiler_String.concat "\n") in
+              FStar_Compiler_String.concat "\n" uu___5 in
             (uu___4, FStar_Pervasives_Native.None)) in
        match uu___1 with
        | (r, hash) ->

--- a/ocaml/fstar-lib/generated/FStar_Syntax_DsEnv.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_DsEnv.ml
@@ -393,8 +393,7 @@ let (transitive_exported_ids :
           let uu___1 =
             let uu___2 = exported_id_set1 Exported_id_term_type in
             FStar_Compiler_Effect.op_Bang uu___2 in
-          FStar_Compiler_Effect.op_Bar_Greater uu___1
-            (FStar_Compiler_Set.elems FStar_Class_Ord.ord_string)
+          FStar_Compiler_Set.elems FStar_Class_Ord.ord_string uu___1
 let (opens_and_abbrevs :
   env ->
     (FStar_Syntax_Syntax.open_module_or_namespace,
@@ -462,10 +461,10 @@ let (iface_decls :
   fun env1 ->
     fun l ->
       let uu___ =
-        FStar_Compiler_Effect.op_Bar_Greater env1.remaining_iface_decls
-          (FStar_Compiler_List.tryFind
-             (fun uu___1 ->
-                match uu___1 with | (m, uu___2) -> FStar_Ident.lid_equals l m)) in
+        FStar_Compiler_List.tryFind
+          (fun uu___1 ->
+             match uu___1 with | (m, uu___2) -> FStar_Ident.lid_equals l m)
+          env1.remaining_iface_decls in
       match uu___ with
       | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
       | FStar_Pervasives_Native.Some (uu___1, decls) ->
@@ -1049,12 +1048,11 @@ let (shorten_module_path :
              | [] -> FStar_Pervasives_Native.None
              | ns_last_id::rev_ns_prefix ->
                  let uu___2 = aux rev_ns_prefix ns_last_id in
-                 FStar_Compiler_Effect.op_Bar_Greater uu___2
-                   (FStar_Compiler_Util.map_option
-                      (fun uu___3 ->
-                         match uu___3 with
-                         | (stripped_ids, rev_kept_ids) ->
-                             (stripped_ids, (id :: rev_kept_ids))))) in
+                 FStar_Compiler_Util.map_option
+                   (fun uu___3 ->
+                      match uu___3 with
+                      | (stripped_ids, rev_kept_ids) ->
+                          (stripped_ids, (id :: rev_kept_ids))) uu___2) in
         let do_shorten env2 ids1 =
           match FStar_Compiler_List.rev ids1 with
           | [] -> ([], [])
@@ -1199,7 +1197,7 @@ let (lb_fv :
              if uu___1
              then FStar_Pervasives_Native.Some fv
              else FStar_Pervasives_Native.None) in
-      FStar_Compiler_Effect.op_Bar_Greater uu___ FStar_Compiler_Util.must
+      FStar_Compiler_Util.must uu___
 let (ns_of_lid_equals :
   FStar_Ident.lident -> FStar_Ident.lident -> Prims.bool) =
   fun lid ->
@@ -1225,31 +1223,28 @@ let (delta_depth_of_declaration :
       let dd =
         let uu___ =
           (FStar_Syntax_Util.is_primop_lid lid) ||
-            (FStar_Compiler_Effect.op_Bar_Greater quals
-               (FStar_Compiler_Util.for_some
-                  (fun uu___1 ->
-                     match uu___1 with
-                     | FStar_Syntax_Syntax.Projector uu___2 -> true
-                     | FStar_Syntax_Syntax.Discriminator uu___2 -> true
-                     | uu___2 -> false))) in
+            (FStar_Compiler_Util.for_some
+               (fun uu___1 ->
+                  match uu___1 with
+                  | FStar_Syntax_Syntax.Projector uu___2 -> true
+                  | FStar_Syntax_Syntax.Discriminator uu___2 -> true
+                  | uu___2 -> false) quals) in
         if uu___
         then FStar_Syntax_Syntax.delta_equational
         else FStar_Syntax_Syntax.delta_constant in
       let uu___ =
-        (FStar_Compiler_Effect.op_Bar_Greater quals
-           (FStar_Compiler_Util.for_some
-              (fun uu___1 ->
-                 match uu___1 with
-                 | FStar_Syntax_Syntax.Assumption -> true
-                 | uu___2 -> false)))
+        (FStar_Compiler_Util.for_some
+           (fun uu___1 ->
+              match uu___1 with
+              | FStar_Syntax_Syntax.Assumption -> true
+              | uu___2 -> false) quals)
           &&
           (let uu___1 =
-             FStar_Compiler_Effect.op_Bar_Greater quals
-               (FStar_Compiler_Util.for_some
-                  (fun uu___2 ->
-                     match uu___2 with
-                     | FStar_Syntax_Syntax.New -> true
-                     | uu___3 -> false)) in
+             FStar_Compiler_Util.for_some
+               (fun uu___2 ->
+                  match uu___2 with
+                  | FStar_Syntax_Syntax.New -> true
+                  | uu___3 -> false) quals in
            Prims.op_Negation uu___1) in
       if uu___ then FStar_Syntax_Syntax.Delta_abstract dd else dd
 let (try_lookup_name :
@@ -1297,9 +1292,8 @@ let (try_lookup_name :
                        let uu___5 =
                          let uu___6 =
                            let uu___7 =
-                             FStar_Compiler_Effect.op_Bar_Greater
-                               fv.FStar_Syntax_Syntax.fv_delta
-                               FStar_Compiler_Util.must in
+                             FStar_Compiler_Util.must
+                               fv.FStar_Syntax_Syntax.fv_delta in
                            FStar_Syntax_Syntax.fvar_with_dd source_lid uu___7
                              fv.FStar_Syntax_Syntax.fv_qual in
                          (uu___6, (se.FStar_Syntax_Syntax.sigattrs)) in
@@ -1313,12 +1307,11 @@ let (try_lookup_name :
                      let quals = se.FStar_Syntax_Syntax.sigquals in
                      let uu___4 =
                        any_val ||
-                         (FStar_Compiler_Effect.op_Bar_Greater quals
-                            (FStar_Compiler_Util.for_some
-                               (fun uu___5 ->
-                                  match uu___5 with
-                                  | FStar_Syntax_Syntax.Assumption -> true
-                                  | uu___6 -> false))) in
+                         (FStar_Compiler_Util.for_some
+                            (fun uu___5 ->
+                               match uu___5 with
+                               | FStar_Syntax_Syntax.Assumption -> true
+                               | uu___6 -> false) quals) in
                      if uu___4
                      then
                        let lid2 =
@@ -1641,8 +1634,7 @@ let (try_lookup_let :
             let fv = lb_fv lbs lid1 in
             let uu___10 =
               let uu___11 =
-                FStar_Compiler_Effect.op_Bar_Greater
-                  fv.FStar_Syntax_Syntax.fv_delta FStar_Compiler_Util.must in
+                FStar_Compiler_Util.must fv.FStar_Syntax_Syntax.fv_delta in
               FStar_Syntax_Syntax.fvar_with_dd lid1 uu___11
                 fv.FStar_Syntax_Syntax.fv_qual in
             FStar_Pervasives_Native.Some uu___10
@@ -1729,7 +1721,7 @@ let (try_lookup_lid :
   fun env1 ->
     fun l ->
       let uu___ = try_lookup_lid_with_attributes env1 l in
-      FStar_Compiler_Effect.op_Bar_Greater uu___ drop_attributes
+      drop_attributes uu___
 let (resolve_to_fully_qualified_name :
   env ->
     FStar_Ident.lident -> FStar_Ident.lident FStar_Pervasives_Native.option)
@@ -1859,7 +1851,7 @@ let (try_lookup_lid_no_resolve :
   fun env1 ->
     fun l ->
       let uu___ = try_lookup_lid_with_attributes_no_resolve env1 l in
-      FStar_Compiler_Effect.op_Bar_Greater uu___ drop_attributes
+      drop_attributes uu___
 let (try_lookup_datacon :
   env ->
     FStar_Ident.lident ->
@@ -1880,12 +1872,11 @@ let (try_lookup_datacon :
              FStar_Syntax_Syntax.sigopts = uu___5;_},
            uu___6) ->
             let uu___7 =
-              FStar_Compiler_Effect.op_Bar_Greater quals
-                (FStar_Compiler_Util.for_some
-                   (fun uu___8 ->
-                      match uu___8 with
-                      | FStar_Syntax_Syntax.Assumption -> true
-                      | uu___9 -> false)) in
+              FStar_Compiler_Util.for_some
+                (fun uu___8 ->
+                   match uu___8 with
+                   | FStar_Syntax_Syntax.Assumption -> true
+                   | uu___9 -> false) quals in
             if uu___7
             then
               let uu___8 =
@@ -2051,195 +2042,181 @@ let (extract_record :
                    | FStar_Syntax_Syntax.RecordConstructor uu___2 -> true
                    | uu___2 -> false) in
             let find_dc dc =
-              FStar_Compiler_Effect.op_Bar_Greater sigs
-                (FStar_Compiler_Util.find_opt
-                   (fun uu___1 ->
-                      match uu___1 with
+              FStar_Compiler_Util.find_opt
+                (fun uu___1 ->
+                   match uu___1 with
+                   | {
+                       FStar_Syntax_Syntax.sigel =
+                         FStar_Syntax_Syntax.Sig_datacon
+                         { FStar_Syntax_Syntax.lid1 = lid;
+                           FStar_Syntax_Syntax.us1 = uu___2;
+                           FStar_Syntax_Syntax.t1 = uu___3;
+                           FStar_Syntax_Syntax.ty_lid = uu___4;
+                           FStar_Syntax_Syntax.num_ty_params = uu___5;
+                           FStar_Syntax_Syntax.mutuals1 = uu___6;_};
+                       FStar_Syntax_Syntax.sigrng = uu___7;
+                       FStar_Syntax_Syntax.sigquals = uu___8;
+                       FStar_Syntax_Syntax.sigmeta = uu___9;
+                       FStar_Syntax_Syntax.sigattrs = uu___10;
+                       FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___11;
+                       FStar_Syntax_Syntax.sigopts = uu___12;_} ->
+                       FStar_Ident.lid_equals dc lid
+                   | uu___2 -> false) sigs in
+            FStar_Compiler_List.iter
+              (fun uu___1 ->
+                 match uu___1 with
+                 | {
+                     FStar_Syntax_Syntax.sigel =
+                       FStar_Syntax_Syntax.Sig_inductive_typ
+                       { FStar_Syntax_Syntax.lid = typename;
+                         FStar_Syntax_Syntax.us = univs;
+                         FStar_Syntax_Syntax.params = parms;
+                         FStar_Syntax_Syntax.num_uniform_params = uu___2;
+                         FStar_Syntax_Syntax.t = uu___3;
+                         FStar_Syntax_Syntax.mutuals = uu___4;
+                         FStar_Syntax_Syntax.ds = dc::[];_};
+                     FStar_Syntax_Syntax.sigrng = uu___5;
+                     FStar_Syntax_Syntax.sigquals = typename_quals;
+                     FStar_Syntax_Syntax.sigmeta = uu___6;
+                     FStar_Syntax_Syntax.sigattrs = uu___7;
+                     FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___8;
+                     FStar_Syntax_Syntax.sigopts = uu___9;_} ->
+                     let uu___10 =
+                       let uu___11 = find_dc dc in
+                       FStar_Compiler_Util.must uu___11 in
+                     (match uu___10 with
                       | {
                           FStar_Syntax_Syntax.sigel =
                             FStar_Syntax_Syntax.Sig_datacon
-                            { FStar_Syntax_Syntax.lid1 = lid;
-                              FStar_Syntax_Syntax.us1 = uu___2;
-                              FStar_Syntax_Syntax.t1 = uu___3;
-                              FStar_Syntax_Syntax.ty_lid = uu___4;
-                              FStar_Syntax_Syntax.num_ty_params = uu___5;
-                              FStar_Syntax_Syntax.mutuals1 = uu___6;_};
-                          FStar_Syntax_Syntax.sigrng = uu___7;
-                          FStar_Syntax_Syntax.sigquals = uu___8;
-                          FStar_Syntax_Syntax.sigmeta = uu___9;
-                          FStar_Syntax_Syntax.sigattrs = uu___10;
-                          FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___11;
-                          FStar_Syntax_Syntax.sigopts = uu___12;_} ->
-                          FStar_Ident.lid_equals dc lid
-                      | uu___2 -> false)) in
-            FStar_Compiler_Effect.op_Bar_Greater sigs
-              (FStar_Compiler_List.iter
-                 (fun uu___1 ->
-                    match uu___1 with
-                    | {
-                        FStar_Syntax_Syntax.sigel =
-                          FStar_Syntax_Syntax.Sig_inductive_typ
-                          { FStar_Syntax_Syntax.lid = typename;
-                            FStar_Syntax_Syntax.us = univs;
-                            FStar_Syntax_Syntax.params = parms;
-                            FStar_Syntax_Syntax.num_uniform_params = uu___2;
-                            FStar_Syntax_Syntax.t = uu___3;
-                            FStar_Syntax_Syntax.mutuals = uu___4;
-                            FStar_Syntax_Syntax.ds = dc::[];_};
-                        FStar_Syntax_Syntax.sigrng = uu___5;
-                        FStar_Syntax_Syntax.sigquals = typename_quals;
-                        FStar_Syntax_Syntax.sigmeta = uu___6;
-                        FStar_Syntax_Syntax.sigattrs = uu___7;
-                        FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___8;
-                        FStar_Syntax_Syntax.sigopts = uu___9;_} ->
-                        let uu___10 =
-                          let uu___11 = find_dc dc in
-                          FStar_Compiler_Effect.op_Less_Bar
-                            FStar_Compiler_Util.must uu___11 in
-                        (match uu___10 with
-                         | {
-                             FStar_Syntax_Syntax.sigel =
-                               FStar_Syntax_Syntax.Sig_datacon
-                               { FStar_Syntax_Syntax.lid1 = constrname;
-                                 FStar_Syntax_Syntax.us1 = uu___11;
-                                 FStar_Syntax_Syntax.t1 = t;
-                                 FStar_Syntax_Syntax.ty_lid = uu___12;
-                                 FStar_Syntax_Syntax.num_ty_params = n;
-                                 FStar_Syntax_Syntax.mutuals1 = uu___13;_};
-                             FStar_Syntax_Syntax.sigrng = uu___14;
-                             FStar_Syntax_Syntax.sigquals = uu___15;
-                             FStar_Syntax_Syntax.sigmeta = uu___16;
-                             FStar_Syntax_Syntax.sigattrs = uu___17;
-                             FStar_Syntax_Syntax.sigopens_and_abbrevs =
-                               uu___18;
-                             FStar_Syntax_Syntax.sigopts = uu___19;_} ->
-                             let uu___20 = FStar_Syntax_Util.arrow_formals t in
-                             (match uu___20 with
-                              | (all_formals, uu___21) ->
-                                  let uu___22 =
-                                    FStar_Compiler_Util.first_N n all_formals in
-                                  (match uu___22 with
-                                   | (_params, formals) ->
-                                       let is_rec = is_record typename_quals in
-                                       let formals' =
-                                         FStar_Compiler_Effect.op_Bar_Greater
-                                           formals
-                                           (FStar_Compiler_List.collect
-                                              (fun f ->
-                                                 let uu___23 =
-                                                   (FStar_Syntax_Syntax.is_null_bv
-                                                      f.FStar_Syntax_Syntax.binder_bv)
-                                                     ||
-                                                     (is_rec &&
-                                                        (FStar_Syntax_Syntax.is_bqual_implicit
-                                                           f.FStar_Syntax_Syntax.binder_qual)) in
-                                                 if uu___23 then [] else [f])) in
-                                       let fields' =
-                                         FStar_Compiler_Effect.op_Bar_Greater
-                                           formals'
-                                           (FStar_Compiler_List.map
-                                              (fun f ->
-                                                 (((f.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.ppname),
-                                                   ((f.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort)))) in
-                                       let fields = fields' in
-                                       let record =
-                                         let uu___23 =
-                                           FStar_Ident.ident_of_lid
-                                             constrname in
-                                         {
-                                           typename;
-                                           constrname = uu___23;
-                                           parms;
-                                           fields;
-                                           is_private =
-                                             (FStar_Compiler_List.contains
-                                                FStar_Syntax_Syntax.Private
-                                                typename_quals);
-                                           is_record = is_rec
-                                         } in
-                                       ((let uu___24 =
-                                           let uu___25 =
-                                             FStar_Compiler_Effect.op_Bang
-                                               new_globs in
-                                           (Record_or_dc record) :: uu___25 in
-                                         FStar_Compiler_Effect.op_Colon_Equals
-                                           new_globs uu___24);
-                                        (match () with
-                                         | () ->
-                                             ((let add_field uu___25 =
-                                                 match uu___25 with
-                                                 | (id, uu___26) ->
-                                                     let modul =
-                                                       let uu___27 =
-                                                         let uu___28 =
-                                                           FStar_Ident.ns_of_lid
-                                                             constrname in
-                                                         FStar_Ident.lid_of_ids
-                                                           uu___28 in
-                                                       FStar_Ident.string_of_lid
-                                                         uu___27 in
-                                                     let uu___27 =
-                                                       get_exported_id_set e
-                                                         modul in
-                                                     (match uu___27 with
-                                                      | FStar_Pervasives_Native.Some
-                                                          my_ex ->
-                                                          let my_exported_ids
-                                                            =
-                                                            my_ex
-                                                              Exported_id_field in
-                                                          ((let uu___29 =
-                                                              let uu___30 =
-                                                                FStar_Ident.string_of_id
-                                                                  id in
-                                                              let uu___31 =
-                                                                FStar_Compiler_Effect.op_Bang
-                                                                  my_exported_ids in
-                                                              FStar_Compiler_Set.add
-                                                                FStar_Class_Ord.ord_string
-                                                                uu___30
-                                                                uu___31 in
-                                                            FStar_Compiler_Effect.op_Colon_Equals
-                                                              my_exported_ids
-                                                              uu___29);
-                                                           (match () with
-                                                            | () ->
-                                                                let projname
-                                                                  =
-                                                                  let uu___29
-                                                                    =
-                                                                    let uu___30
-                                                                    =
-                                                                    FStar_Syntax_Util.mk_field_projector_name_from_ident
+                            { FStar_Syntax_Syntax.lid1 = constrname;
+                              FStar_Syntax_Syntax.us1 = uu___11;
+                              FStar_Syntax_Syntax.t1 = t;
+                              FStar_Syntax_Syntax.ty_lid = uu___12;
+                              FStar_Syntax_Syntax.num_ty_params = n;
+                              FStar_Syntax_Syntax.mutuals1 = uu___13;_};
+                          FStar_Syntax_Syntax.sigrng = uu___14;
+                          FStar_Syntax_Syntax.sigquals = uu___15;
+                          FStar_Syntax_Syntax.sigmeta = uu___16;
+                          FStar_Syntax_Syntax.sigattrs = uu___17;
+                          FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___18;
+                          FStar_Syntax_Syntax.sigopts = uu___19;_} ->
+                          let uu___20 = FStar_Syntax_Util.arrow_formals t in
+                          (match uu___20 with
+                           | (all_formals, uu___21) ->
+                               let uu___22 =
+                                 FStar_Compiler_Util.first_N n all_formals in
+                               (match uu___22 with
+                                | (_params, formals) ->
+                                    let is_rec = is_record typename_quals in
+                                    let formals' =
+                                      FStar_Compiler_List.collect
+                                        (fun f ->
+                                           let uu___23 =
+                                             (FStar_Syntax_Syntax.is_null_bv
+                                                f.FStar_Syntax_Syntax.binder_bv)
+                                               ||
+                                               (is_rec &&
+                                                  (FStar_Syntax_Syntax.is_bqual_implicit
+                                                     f.FStar_Syntax_Syntax.binder_qual)) in
+                                           if uu___23 then [] else [f])
+                                        formals in
+                                    let fields' =
+                                      FStar_Compiler_List.map
+                                        (fun f ->
+                                           (((f.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.ppname),
+                                             ((f.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort)))
+                                        formals' in
+                                    let fields = fields' in
+                                    let record =
+                                      let uu___23 =
+                                        FStar_Ident.ident_of_lid constrname in
+                                      {
+                                        typename;
+                                        constrname = uu___23;
+                                        parms;
+                                        fields;
+                                        is_private =
+                                          (FStar_Compiler_List.contains
+                                             FStar_Syntax_Syntax.Private
+                                             typename_quals);
+                                        is_record = is_rec
+                                      } in
+                                    ((let uu___24 =
+                                        let uu___25 =
+                                          FStar_Compiler_Effect.op_Bang
+                                            new_globs in
+                                        (Record_or_dc record) :: uu___25 in
+                                      FStar_Compiler_Effect.op_Colon_Equals
+                                        new_globs uu___24);
+                                     (match () with
+                                      | () ->
+                                          ((let add_field uu___25 =
+                                              match uu___25 with
+                                              | (id, uu___26) ->
+                                                  let modul =
+                                                    let uu___27 =
+                                                      let uu___28 =
+                                                        FStar_Ident.ns_of_lid
+                                                          constrname in
+                                                      FStar_Ident.lid_of_ids
+                                                        uu___28 in
+                                                    FStar_Ident.string_of_lid
+                                                      uu___27 in
+                                                  let uu___27 =
+                                                    get_exported_id_set e
+                                                      modul in
+                                                  (match uu___27 with
+                                                   | FStar_Pervasives_Native.Some
+                                                       my_ex ->
+                                                       let my_exported_ids =
+                                                         my_ex
+                                                           Exported_id_field in
+                                                       ((let uu___29 =
+                                                           let uu___30 =
+                                                             FStar_Ident.string_of_id
+                                                               id in
+                                                           let uu___31 =
+                                                             FStar_Compiler_Effect.op_Bang
+                                                               my_exported_ids in
+                                                           FStar_Compiler_Set.add
+                                                             FStar_Class_Ord.ord_string
+                                                             uu___30 uu___31 in
+                                                         FStar_Compiler_Effect.op_Colon_Equals
+                                                           my_exported_ids
+                                                           uu___29);
+                                                        (match () with
+                                                         | () ->
+                                                             let projname =
+                                                               let uu___29 =
+                                                                 let uu___30
+                                                                   =
+                                                                   FStar_Syntax_Util.mk_field_projector_name_from_ident
                                                                     constrname
                                                                     id in
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___30
-                                                                    FStar_Ident.ident_of_lid in
-                                                                  FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___29
-                                                                    FStar_Ident.string_of_id in
-                                                                let uu___30 =
-                                                                  let uu___31
-                                                                    =
-                                                                    FStar_Compiler_Effect.op_Bang
-                                                                    my_exported_ids in
-                                                                  FStar_Compiler_Set.add
-                                                                    FStar_Class_Ord.ord_string
-                                                                    projname
-                                                                    uu___31 in
-                                                                FStar_Compiler_Effect.op_Colon_Equals
-                                                                  my_exported_ids
-                                                                  uu___30))
-                                                      | FStar_Pervasives_Native.None
-                                                          -> ()) in
-                                               FStar_Compiler_List.iter
-                                                 add_field fields');
-                                              (match () with
-                                               | () ->
-                                                   insert_record_cache record))))))
-                         | uu___11 -> ())
-                    | uu___2 -> ()))
+                                                                 FStar_Ident.ident_of_lid
+                                                                   uu___30 in
+                                                               FStar_Ident.string_of_id
+                                                                 uu___29 in
+                                                             let uu___30 =
+                                                               let uu___31 =
+                                                                 FStar_Compiler_Effect.op_Bang
+                                                                   my_exported_ids in
+                                                               FStar_Compiler_Set.add
+                                                                 FStar_Class_Ord.ord_string
+                                                                 projname
+                                                                 uu___31 in
+                                                             FStar_Compiler_Effect.op_Colon_Equals
+                                                               my_exported_ids
+                                                               uu___30))
+                                                   | FStar_Pervasives_Native.None
+                                                       -> ()) in
+                                            FStar_Compiler_List.iter
+                                              add_field fields');
+                                           (match () with
+                                            | () ->
+                                                insert_record_cache record))))))
+                      | uu___11 -> ())
+                 | uu___2 -> ()) sigs
         | uu___ -> ()
 let (try_lookup_record_or_dc_by_field_name :
   env -> FStar_Ident.lident -> record_or_dc FStar_Pervasives_Native.option) =
@@ -2476,8 +2453,7 @@ let (push_sigelt' : Prims.bool -> env -> FStar_Syntax_Syntax.sigelt -> env) =
                 (match uu___1 with
                  | FStar_Pervasives_Native.Some l1 ->
                      let uu___2 = FStar_Ident.range_of_lid l1 in
-                     FStar_Compiler_Effect.op_Less_Bar
-                       FStar_Compiler_Range_Ops.string_of_range uu___2
+                     FStar_Compiler_Range_Ops.string_of_range uu___2
                  | FStar_Pervasives_Native.None -> "<unknown>")
             | FStar_Pervasives_Native.None -> "<unknown>" in
           let uu___ =
@@ -2572,68 +2548,62 @@ let (push_sigelt' : Prims.bool -> env -> FStar_Syntax_Syntax.sigelt -> env) =
           | uu___1 -> (env3, [((FStar_Syntax_Util.lids_of_sigelt s), s)]) in
         match uu___ with
         | (env4, lss) ->
-            (FStar_Compiler_Effect.op_Bar_Greater lss
-               (FStar_Compiler_List.iter
-                  (fun uu___2 ->
-                     match uu___2 with
-                     | (lids, se) ->
-                         FStar_Compiler_Effect.op_Bar_Greater lids
-                           (FStar_Compiler_List.iter
-                              (fun lid ->
-                                 (let uu___4 =
-                                    let uu___5 =
+            (FStar_Compiler_List.iter
+               (fun uu___2 ->
+                  match uu___2 with
+                  | (lids, se) ->
+                      FStar_Compiler_List.iter
+                        (fun lid ->
+                           (let uu___4 =
+                              let uu___5 =
+                                let uu___6 = FStar_Ident.ident_of_lid lid in
+                                Top_level_def uu___6 in
+                              let uu___6 =
+                                FStar_Compiler_Effect.op_Bang globals in
+                              uu___5 :: uu___6 in
+                            FStar_Compiler_Effect.op_Colon_Equals globals
+                              uu___4);
+                           (match () with
+                            | () ->
+                                let modul =
+                                  let uu___4 =
+                                    let uu___5 = FStar_Ident.ns_of_lid lid in
+                                    FStar_Ident.lid_of_ids uu___5 in
+                                  FStar_Ident.string_of_lid uu___4 in
+                                ((let uu___5 = get_exported_id_set env4 modul in
+                                  match uu___5 with
+                                  | FStar_Pervasives_Native.Some f ->
+                                      let my_exported_ids =
+                                        f Exported_id_term_type in
                                       let uu___6 =
-                                        FStar_Ident.ident_of_lid lid in
-                                      Top_level_def uu___6 in
-                                    let uu___6 =
-                                      FStar_Compiler_Effect.op_Bang globals in
-                                    uu___5 :: uu___6 in
-                                  FStar_Compiler_Effect.op_Colon_Equals
-                                    globals uu___4);
+                                        let uu___7 =
+                                          let uu___8 =
+                                            FStar_Ident.ident_of_lid lid in
+                                          FStar_Ident.string_of_id uu___8 in
+                                        let uu___8 =
+                                          FStar_Compiler_Effect.op_Bang
+                                            my_exported_ids in
+                                        FStar_Compiler_Set.add
+                                          FStar_Class_Ord.ord_string uu___7
+                                          uu___8 in
+                                      FStar_Compiler_Effect.op_Colon_Equals
+                                        my_exported_ids uu___6
+                                  | FStar_Pervasives_Native.None -> ());
                                  (match () with
                                   | () ->
-                                      let modul =
-                                        let uu___4 =
-                                          let uu___5 =
-                                            FStar_Ident.ns_of_lid lid in
-                                          FStar_Ident.lid_of_ids uu___5 in
-                                        FStar_Ident.string_of_lid uu___4 in
-                                      ((let uu___5 =
-                                          get_exported_id_set env4 modul in
-                                        match uu___5 with
-                                        | FStar_Pervasives_Native.Some f ->
-                                            let my_exported_ids =
-                                              f Exported_id_term_type in
-                                            let uu___6 =
-                                              let uu___7 =
-                                                let uu___8 =
-                                                  FStar_Ident.ident_of_lid
-                                                    lid in
-                                                FStar_Ident.string_of_id
-                                                  uu___8 in
-                                              let uu___8 =
-                                                FStar_Compiler_Effect.op_Bang
-                                                  my_exported_ids in
-                                              FStar_Compiler_Set.add
-                                                FStar_Class_Ord.ord_string
-                                                uu___7 uu___8 in
-                                            FStar_Compiler_Effect.op_Colon_Equals
-                                              my_exported_ids uu___6
-                                        | FStar_Pervasives_Native.None -> ());
-                                       (match () with
-                                        | () ->
-                                            let is_iface =
-                                              env4.iface &&
-                                                (Prims.op_Negation
-                                                   env4.admitted_iface) in
-                                            let uu___5 =
-                                              FStar_Ident.string_of_lid lid in
-                                            FStar_Compiler_Util.smap_add
-                                              (sigmap env4) uu___5
-                                              (se,
-                                                (env4.iface &&
-                                                   (Prims.op_Negation
-                                                      env4.admitted_iface))))))))));
+                                      let is_iface =
+                                        env4.iface &&
+                                          (Prims.op_Negation
+                                             env4.admitted_iface) in
+                                      let uu___5 =
+                                        FStar_Ident.string_of_lid lid in
+                                      FStar_Compiler_Util.smap_add
+                                        (sigmap env4) uu___5
+                                        (se,
+                                          (env4.iface &&
+                                             (Prims.op_Negation
+                                                env4.admitted_iface)))))))
+                        lids) lss;
              (let env5 =
                 let uu___2 = FStar_Compiler_Effect.op_Bang globals in
                 {
@@ -2674,16 +2644,16 @@ let (push_namespace : env -> FStar_Ident.lident -> env) =
               | FStar_Pervasives_Native.None -> module_names
               | FStar_Pervasives_Native.Some l -> l :: module_names in
             let uu___2 =
-              FStar_Compiler_Effect.op_Bar_Greater module_names1
-                (FStar_Compiler_Util.for_some
-                   (fun m ->
-                      let uu___3 =
-                        let uu___4 = FStar_Ident.string_of_lid m in
-                        Prims.strcat uu___4 "." in
-                      let uu___4 =
-                        let uu___5 = FStar_Ident.string_of_lid ns in
-                        Prims.strcat uu___5 "." in
-                      FStar_Compiler_Util.starts_with uu___3 uu___4)) in
+              FStar_Compiler_Util.for_some
+                (fun m ->
+                   let uu___3 =
+                     let uu___4 = FStar_Ident.string_of_lid m in
+                     Prims.strcat uu___4 "." in
+                   let uu___4 =
+                     let uu___5 = FStar_Ident.string_of_lid ns in
+                     Prims.strcat uu___5 "." in
+                   FStar_Compiler_Util.starts_with uu___3 uu___4)
+                module_names1 in
             if uu___2
             then (ns, FStar_Syntax_Syntax.Open_namespace)
             else
@@ -2808,234 +2778,212 @@ let (check_admits :
   fun env1 ->
     fun m ->
       let admitted_sig_lids =
-        FStar_Compiler_Effect.op_Bar_Greater env1.sigaccum
-          (FStar_Compiler_List.fold_left
-             (fun lids ->
-                fun se ->
-                  match se.FStar_Syntax_Syntax.sigel with
-                  | FStar_Syntax_Syntax.Sig_declare_typ
-                      { FStar_Syntax_Syntax.lid2 = l;
-                        FStar_Syntax_Syntax.us2 = u;
-                        FStar_Syntax_Syntax.t2 = t;_}
-                      when
-                      let uu___ =
-                        FStar_Compiler_Effect.op_Bar_Greater
-                          se.FStar_Syntax_Syntax.sigquals
-                          (FStar_Compiler_List.contains
-                             FStar_Syntax_Syntax.Assumption) in
-                      Prims.op_Negation uu___ ->
-                      let uu___ =
-                        let uu___1 = FStar_Ident.string_of_lid l in
-                        FStar_Compiler_Util.smap_try_find (sigmap env1)
-                          uu___1 in
-                      (match uu___ with
-                       | FStar_Pervasives_Native.Some
-                           ({
-                              FStar_Syntax_Syntax.sigel =
-                                FStar_Syntax_Syntax.Sig_let uu___1;
-                              FStar_Syntax_Syntax.sigrng = uu___2;
-                              FStar_Syntax_Syntax.sigquals = uu___3;
-                              FStar_Syntax_Syntax.sigmeta = uu___4;
-                              FStar_Syntax_Syntax.sigattrs = uu___5;
-                              FStar_Syntax_Syntax.sigopens_and_abbrevs =
-                                uu___6;
-                              FStar_Syntax_Syntax.sigopts = uu___7;_},
-                            uu___8)
-                           -> lids
-                       | FStar_Pervasives_Native.Some
-                           ({
-                              FStar_Syntax_Syntax.sigel =
-                                FStar_Syntax_Syntax.Sig_inductive_typ uu___1;
-                              FStar_Syntax_Syntax.sigrng = uu___2;
-                              FStar_Syntax_Syntax.sigquals = uu___3;
-                              FStar_Syntax_Syntax.sigmeta = uu___4;
-                              FStar_Syntax_Syntax.sigattrs = uu___5;
-                              FStar_Syntax_Syntax.sigopens_and_abbrevs =
-                                uu___6;
-                              FStar_Syntax_Syntax.sigopts = uu___7;_},
-                            uu___8)
-                           -> lids
-                       | uu___1 ->
-                           ((let uu___3 =
-                               let uu___4 = FStar_Options.interactive () in
-                               Prims.op_Negation uu___4 in
-                             if uu___3
-                             then
-                               let uu___4 = FStar_Ident.range_of_lid l in
-                               let uu___5 =
-                                 let uu___6 =
-                                   let uu___7 = FStar_Ident.string_of_lid l in
-                                   FStar_Compiler_Util.format1
-                                     "%s is declared but no definition was found; add an 'assume' if this is intentional"
-                                     uu___7 in
-                                 (FStar_Errors_Codes.Error_AdmitWithoutDefinition,
-                                   uu___6) in
-                               FStar_Errors.log_issue uu___4 uu___5
-                             else ());
-                            (let quals = FStar_Syntax_Syntax.Assumption ::
-                               (se.FStar_Syntax_Syntax.sigquals) in
-                             (let uu___4 = FStar_Ident.string_of_lid l in
-                              FStar_Compiler_Util.smap_add (sigmap env1)
-                                uu___4
-                                ({
-                                   FStar_Syntax_Syntax.sigel =
-                                     (se.FStar_Syntax_Syntax.sigel);
-                                   FStar_Syntax_Syntax.sigrng =
-                                     (se.FStar_Syntax_Syntax.sigrng);
-                                   FStar_Syntax_Syntax.sigquals = quals;
-                                   FStar_Syntax_Syntax.sigmeta =
-                                     (se.FStar_Syntax_Syntax.sigmeta);
-                                   FStar_Syntax_Syntax.sigattrs =
-                                     (se.FStar_Syntax_Syntax.sigattrs);
-                                   FStar_Syntax_Syntax.sigopens_and_abbrevs =
-                                     (se.FStar_Syntax_Syntax.sigopens_and_abbrevs);
-                                   FStar_Syntax_Syntax.sigopts =
-                                     (se.FStar_Syntax_Syntax.sigopts)
-                                 }, false));
-                             l
-                             ::
-                             lids)))
-                  | uu___ -> lids) []) in
+        FStar_Compiler_List.fold_left
+          (fun lids ->
+             fun se ->
+               match se.FStar_Syntax_Syntax.sigel with
+               | FStar_Syntax_Syntax.Sig_declare_typ
+                   { FStar_Syntax_Syntax.lid2 = l;
+                     FStar_Syntax_Syntax.us2 = u;
+                     FStar_Syntax_Syntax.t2 = t;_}
+                   when
+                   Prims.op_Negation
+                     (FStar_Compiler_List.contains
+                        FStar_Syntax_Syntax.Assumption
+                        se.FStar_Syntax_Syntax.sigquals)
+                   ->
+                   let uu___ =
+                     let uu___1 = FStar_Ident.string_of_lid l in
+                     FStar_Compiler_Util.smap_try_find (sigmap env1) uu___1 in
+                   (match uu___ with
+                    | FStar_Pervasives_Native.Some
+                        ({
+                           FStar_Syntax_Syntax.sigel =
+                             FStar_Syntax_Syntax.Sig_let uu___1;
+                           FStar_Syntax_Syntax.sigrng = uu___2;
+                           FStar_Syntax_Syntax.sigquals = uu___3;
+                           FStar_Syntax_Syntax.sigmeta = uu___4;
+                           FStar_Syntax_Syntax.sigattrs = uu___5;
+                           FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___6;
+                           FStar_Syntax_Syntax.sigopts = uu___7;_},
+                         uu___8)
+                        -> lids
+                    | FStar_Pervasives_Native.Some
+                        ({
+                           FStar_Syntax_Syntax.sigel =
+                             FStar_Syntax_Syntax.Sig_inductive_typ uu___1;
+                           FStar_Syntax_Syntax.sigrng = uu___2;
+                           FStar_Syntax_Syntax.sigquals = uu___3;
+                           FStar_Syntax_Syntax.sigmeta = uu___4;
+                           FStar_Syntax_Syntax.sigattrs = uu___5;
+                           FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___6;
+                           FStar_Syntax_Syntax.sigopts = uu___7;_},
+                         uu___8)
+                        -> lids
+                    | uu___1 ->
+                        ((let uu___3 =
+                            let uu___4 = FStar_Options.interactive () in
+                            Prims.op_Negation uu___4 in
+                          if uu___3
+                          then
+                            let uu___4 = FStar_Ident.range_of_lid l in
+                            let uu___5 =
+                              let uu___6 =
+                                let uu___7 = FStar_Ident.string_of_lid l in
+                                FStar_Compiler_Util.format1
+                                  "%s is declared but no definition was found; add an 'assume' if this is intentional"
+                                  uu___7 in
+                              (FStar_Errors_Codes.Error_AdmitWithoutDefinition,
+                                uu___6) in
+                            FStar_Errors.log_issue uu___4 uu___5
+                          else ());
+                         (let quals = FStar_Syntax_Syntax.Assumption ::
+                            (se.FStar_Syntax_Syntax.sigquals) in
+                          (let uu___4 = FStar_Ident.string_of_lid l in
+                           FStar_Compiler_Util.smap_add (sigmap env1) uu___4
+                             ({
+                                FStar_Syntax_Syntax.sigel =
+                                  (se.FStar_Syntax_Syntax.sigel);
+                                FStar_Syntax_Syntax.sigrng =
+                                  (se.FStar_Syntax_Syntax.sigrng);
+                                FStar_Syntax_Syntax.sigquals = quals;
+                                FStar_Syntax_Syntax.sigmeta =
+                                  (se.FStar_Syntax_Syntax.sigmeta);
+                                FStar_Syntax_Syntax.sigattrs =
+                                  (se.FStar_Syntax_Syntax.sigattrs);
+                                FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                                  (se.FStar_Syntax_Syntax.sigopens_and_abbrevs);
+                                FStar_Syntax_Syntax.sigopts =
+                                  (se.FStar_Syntax_Syntax.sigopts)
+                              }, false));
+                          l
+                          ::
+                          lids)))
+               | uu___ -> lids) [] env1.sigaccum in
       m
 let (finish : env -> FStar_Syntax_Syntax.modul -> env) =
   fun env1 ->
     fun modul ->
-      FStar_Compiler_Effect.op_Bar_Greater
-        modul.FStar_Syntax_Syntax.declarations
-        (FStar_Compiler_List.iter
-           (fun se ->
-              let quals = se.FStar_Syntax_Syntax.sigquals in
-              match se.FStar_Syntax_Syntax.sigel with
-              | FStar_Syntax_Syntax.Sig_bundle
-                  { FStar_Syntax_Syntax.ses = ses;
-                    FStar_Syntax_Syntax.lids = uu___1;_}
-                  ->
-                  if
-                    FStar_Compiler_List.contains FStar_Syntax_Syntax.Private
-                      quals
-                  then
-                    FStar_Compiler_Effect.op_Bar_Greater ses
-                      (FStar_Compiler_List.iter
-                         (fun se1 ->
-                            match se1.FStar_Syntax_Syntax.sigel with
-                            | FStar_Syntax_Syntax.Sig_datacon
-                                { FStar_Syntax_Syntax.lid1 = lid;
-                                  FStar_Syntax_Syntax.us1 = uu___2;
-                                  FStar_Syntax_Syntax.t1 = uu___3;
-                                  FStar_Syntax_Syntax.ty_lid = uu___4;
-                                  FStar_Syntax_Syntax.num_ty_params = uu___5;
-                                  FStar_Syntax_Syntax.mutuals1 = uu___6;_}
-                                ->
-                                let uu___7 = FStar_Ident.string_of_lid lid in
-                                FStar_Compiler_Util.smap_remove (sigmap env1)
-                                  uu___7
-                            | FStar_Syntax_Syntax.Sig_inductive_typ
-                                { FStar_Syntax_Syntax.lid = lid;
-                                  FStar_Syntax_Syntax.us = univ_names;
-                                  FStar_Syntax_Syntax.params = binders;
-                                  FStar_Syntax_Syntax.num_uniform_params =
-                                    uu___2;
-                                  FStar_Syntax_Syntax.t = typ;
-                                  FStar_Syntax_Syntax.mutuals = uu___3;
-                                  FStar_Syntax_Syntax.ds = uu___4;_}
-                                ->
-                                ((let uu___6 = FStar_Ident.string_of_lid lid in
-                                  FStar_Compiler_Util.smap_remove
-                                    (sigmap env1) uu___6);
-                                 if
-                                   Prims.op_Negation
-                                     (FStar_Compiler_List.contains
-                                        FStar_Syntax_Syntax.Private quals)
-                                 then
-                                   (let sigel =
-                                      let uu___6 =
-                                        let uu___7 =
-                                          let uu___8 =
-                                            let uu___9 =
-                                              let uu___10 =
-                                                FStar_Syntax_Syntax.mk_Total
-                                                  typ in
-                                              {
-                                                FStar_Syntax_Syntax.bs1 =
-                                                  binders;
-                                                FStar_Syntax_Syntax.comp =
-                                                  uu___10
-                                              } in
-                                            FStar_Syntax_Syntax.Tm_arrow
-                                              uu___9 in
-                                          let uu___9 =
-                                            FStar_Ident.range_of_lid lid in
-                                          FStar_Syntax_Syntax.mk uu___8
-                                            uu___9 in
-                                        {
-                                          FStar_Syntax_Syntax.lid2 = lid;
-                                          FStar_Syntax_Syntax.us2 =
-                                            univ_names;
-                                          FStar_Syntax_Syntax.t2 = uu___7
-                                        } in
-                                      FStar_Syntax_Syntax.Sig_declare_typ
-                                        uu___6 in
-                                    let se2 =
-                                      {
-                                        FStar_Syntax_Syntax.sigel = sigel;
-                                        FStar_Syntax_Syntax.sigrng =
-                                          (se1.FStar_Syntax_Syntax.sigrng);
-                                        FStar_Syntax_Syntax.sigquals =
-                                          (FStar_Syntax_Syntax.Assumption ::
-                                          quals);
-                                        FStar_Syntax_Syntax.sigmeta =
-                                          (se1.FStar_Syntax_Syntax.sigmeta);
-                                        FStar_Syntax_Syntax.sigattrs =
-                                          (se1.FStar_Syntax_Syntax.sigattrs);
-                                        FStar_Syntax_Syntax.sigopens_and_abbrevs
-                                          =
-                                          (se1.FStar_Syntax_Syntax.sigopens_and_abbrevs);
-                                        FStar_Syntax_Syntax.sigopts =
-                                          (se1.FStar_Syntax_Syntax.sigopts)
-                                      } in
-                                    let uu___6 =
-                                      FStar_Ident.string_of_lid lid in
-                                    FStar_Compiler_Util.smap_add
-                                      (sigmap env1) uu___6 (se2, false))
-                                 else ())
-                            | uu___2 -> ()))
-                  else ()
-              | FStar_Syntax_Syntax.Sig_declare_typ
-                  { FStar_Syntax_Syntax.lid2 = lid;
-                    FStar_Syntax_Syntax.us2 = uu___1;
-                    FStar_Syntax_Syntax.t2 = uu___2;_}
-                  ->
-                  if
-                    FStar_Compiler_List.contains FStar_Syntax_Syntax.Private
-                      quals
-                  then
-                    let uu___3 = FStar_Ident.string_of_lid lid in
-                    FStar_Compiler_Util.smap_remove (sigmap env1) uu___3
-                  else ()
-              | FStar_Syntax_Syntax.Sig_let
-                  { FStar_Syntax_Syntax.lbs1 = (uu___1, lbs);
-                    FStar_Syntax_Syntax.lids1 = uu___2;_}
-                  ->
-                  if
-                    FStar_Compiler_List.contains FStar_Syntax_Syntax.Private
-                      quals
-                  then
-                    FStar_Compiler_Effect.op_Bar_Greater lbs
-                      (FStar_Compiler_List.iter
-                         (fun lb ->
-                            let uu___3 =
-                              let uu___4 =
-                                let uu___5 =
-                                  let uu___6 =
-                                    FStar_Compiler_Util.right
-                                      lb.FStar_Syntax_Syntax.lbname in
-                                  uu___6.FStar_Syntax_Syntax.fv_name in
-                                uu___5.FStar_Syntax_Syntax.v in
-                              FStar_Ident.string_of_lid uu___4 in
+      FStar_Compiler_List.iter
+        (fun se ->
+           let quals = se.FStar_Syntax_Syntax.sigquals in
+           match se.FStar_Syntax_Syntax.sigel with
+           | FStar_Syntax_Syntax.Sig_bundle
+               { FStar_Syntax_Syntax.ses = ses;
+                 FStar_Syntax_Syntax.lids = uu___1;_}
+               ->
+               if
+                 FStar_Compiler_List.contains FStar_Syntax_Syntax.Private
+                   quals
+               then
+                 FStar_Compiler_List.iter
+                   (fun se1 ->
+                      match se1.FStar_Syntax_Syntax.sigel with
+                      | FStar_Syntax_Syntax.Sig_datacon
+                          { FStar_Syntax_Syntax.lid1 = lid;
+                            FStar_Syntax_Syntax.us1 = uu___2;
+                            FStar_Syntax_Syntax.t1 = uu___3;
+                            FStar_Syntax_Syntax.ty_lid = uu___4;
+                            FStar_Syntax_Syntax.num_ty_params = uu___5;
+                            FStar_Syntax_Syntax.mutuals1 = uu___6;_}
+                          ->
+                          let uu___7 = FStar_Ident.string_of_lid lid in
+                          FStar_Compiler_Util.smap_remove (sigmap env1)
+                            uu___7
+                      | FStar_Syntax_Syntax.Sig_inductive_typ
+                          { FStar_Syntax_Syntax.lid = lid;
+                            FStar_Syntax_Syntax.us = univ_names;
+                            FStar_Syntax_Syntax.params = binders;
+                            FStar_Syntax_Syntax.num_uniform_params = uu___2;
+                            FStar_Syntax_Syntax.t = typ;
+                            FStar_Syntax_Syntax.mutuals = uu___3;
+                            FStar_Syntax_Syntax.ds = uu___4;_}
+                          ->
+                          ((let uu___6 = FStar_Ident.string_of_lid lid in
                             FStar_Compiler_Util.smap_remove (sigmap env1)
-                              uu___3))
-                  else ()
-              | uu___1 -> ()));
+                              uu___6);
+                           if
+                             Prims.op_Negation
+                               (FStar_Compiler_List.contains
+                                  FStar_Syntax_Syntax.Private quals)
+                           then
+                             (let sigel =
+                                let uu___6 =
+                                  let uu___7 =
+                                    let uu___8 =
+                                      let uu___9 =
+                                        let uu___10 =
+                                          FStar_Syntax_Syntax.mk_Total typ in
+                                        {
+                                          FStar_Syntax_Syntax.bs1 = binders;
+                                          FStar_Syntax_Syntax.comp = uu___10
+                                        } in
+                                      FStar_Syntax_Syntax.Tm_arrow uu___9 in
+                                    let uu___9 = FStar_Ident.range_of_lid lid in
+                                    FStar_Syntax_Syntax.mk uu___8 uu___9 in
+                                  {
+                                    FStar_Syntax_Syntax.lid2 = lid;
+                                    FStar_Syntax_Syntax.us2 = univ_names;
+                                    FStar_Syntax_Syntax.t2 = uu___7
+                                  } in
+                                FStar_Syntax_Syntax.Sig_declare_typ uu___6 in
+                              let se2 =
+                                {
+                                  FStar_Syntax_Syntax.sigel = sigel;
+                                  FStar_Syntax_Syntax.sigrng =
+                                    (se1.FStar_Syntax_Syntax.sigrng);
+                                  FStar_Syntax_Syntax.sigquals =
+                                    (FStar_Syntax_Syntax.Assumption :: quals);
+                                  FStar_Syntax_Syntax.sigmeta =
+                                    (se1.FStar_Syntax_Syntax.sigmeta);
+                                  FStar_Syntax_Syntax.sigattrs =
+                                    (se1.FStar_Syntax_Syntax.sigattrs);
+                                  FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                                    (se1.FStar_Syntax_Syntax.sigopens_and_abbrevs);
+                                  FStar_Syntax_Syntax.sigopts =
+                                    (se1.FStar_Syntax_Syntax.sigopts)
+                                } in
+                              let uu___6 = FStar_Ident.string_of_lid lid in
+                              FStar_Compiler_Util.smap_add (sigmap env1)
+                                uu___6 (se2, false))
+                           else ())
+                      | uu___2 -> ()) ses
+               else ()
+           | FStar_Syntax_Syntax.Sig_declare_typ
+               { FStar_Syntax_Syntax.lid2 = lid;
+                 FStar_Syntax_Syntax.us2 = uu___1;
+                 FStar_Syntax_Syntax.t2 = uu___2;_}
+               ->
+               if
+                 FStar_Compiler_List.contains FStar_Syntax_Syntax.Private
+                   quals
+               then
+                 let uu___3 = FStar_Ident.string_of_lid lid in
+                 FStar_Compiler_Util.smap_remove (sigmap env1) uu___3
+               else ()
+           | FStar_Syntax_Syntax.Sig_let
+               { FStar_Syntax_Syntax.lbs1 = (uu___1, lbs);
+                 FStar_Syntax_Syntax.lids1 = uu___2;_}
+               ->
+               if
+                 FStar_Compiler_List.contains FStar_Syntax_Syntax.Private
+                   quals
+               then
+                 FStar_Compiler_List.iter
+                   (fun lb ->
+                      let uu___3 =
+                        let uu___4 =
+                          let uu___5 =
+                            let uu___6 =
+                              FStar_Compiler_Util.right
+                                lb.FStar_Syntax_Syntax.lbname in
+                            uu___6.FStar_Syntax_Syntax.fv_name in
+                          uu___5.FStar_Syntax_Syntax.v in
+                        FStar_Ident.string_of_lid uu___4 in
+                      FStar_Compiler_Util.smap_remove (sigmap env1) uu___3)
+                   lbs
+               else ()
+           | uu___1 -> ()) modul.FStar_Syntax_Syntax.declarations;
       (let curmod =
          let uu___1 = current_module env1 in FStar_Ident.string_of_lid uu___1 in
        (let uu___2 =
@@ -3145,41 +3093,39 @@ let (export_interface : FStar_Ident.lident -> env -> env) =
       let env2 = pop () in
       let keys = FStar_Compiler_Util.smap_keys sm in
       let sm' = sigmap env2 in
-      FStar_Compiler_Effect.op_Bar_Greater keys
-        (FStar_Compiler_List.iter
-           (fun k ->
-              let uu___1 = FStar_Compiler_Util.smap_try_find sm' k in
-              match uu___1 with
-              | FStar_Pervasives_Native.Some (se, true) when sigelt_in_m se
-                  ->
-                  (FStar_Compiler_Util.smap_remove sm' k;
-                   (let se1 =
-                      match se.FStar_Syntax_Syntax.sigel with
-                      | FStar_Syntax_Syntax.Sig_declare_typ
-                          { FStar_Syntax_Syntax.lid2 = l;
-                            FStar_Syntax_Syntax.us2 = u;
-                            FStar_Syntax_Syntax.t2 = t;_}
-                          ->
-                          {
-                            FStar_Syntax_Syntax.sigel =
-                              (se.FStar_Syntax_Syntax.sigel);
-                            FStar_Syntax_Syntax.sigrng =
-                              (se.FStar_Syntax_Syntax.sigrng);
-                            FStar_Syntax_Syntax.sigquals =
-                              (FStar_Syntax_Syntax.Assumption ::
-                              (se.FStar_Syntax_Syntax.sigquals));
-                            FStar_Syntax_Syntax.sigmeta =
-                              (se.FStar_Syntax_Syntax.sigmeta);
-                            FStar_Syntax_Syntax.sigattrs =
-                              (se.FStar_Syntax_Syntax.sigattrs);
-                            FStar_Syntax_Syntax.sigopens_and_abbrevs =
-                              (se.FStar_Syntax_Syntax.sigopens_and_abbrevs);
-                            FStar_Syntax_Syntax.sigopts =
-                              (se.FStar_Syntax_Syntax.sigopts)
-                          }
-                      | uu___3 -> se in
-                    FStar_Compiler_Util.smap_add sm' k (se1, false)))
-              | uu___2 -> ()));
+      FStar_Compiler_List.iter
+        (fun k ->
+           let uu___1 = FStar_Compiler_Util.smap_try_find sm' k in
+           match uu___1 with
+           | FStar_Pervasives_Native.Some (se, true) when sigelt_in_m se ->
+               (FStar_Compiler_Util.smap_remove sm' k;
+                (let se1 =
+                   match se.FStar_Syntax_Syntax.sigel with
+                   | FStar_Syntax_Syntax.Sig_declare_typ
+                       { FStar_Syntax_Syntax.lid2 = l;
+                         FStar_Syntax_Syntax.us2 = u;
+                         FStar_Syntax_Syntax.t2 = t;_}
+                       ->
+                       {
+                         FStar_Syntax_Syntax.sigel =
+                           (se.FStar_Syntax_Syntax.sigel);
+                         FStar_Syntax_Syntax.sigrng =
+                           (se.FStar_Syntax_Syntax.sigrng);
+                         FStar_Syntax_Syntax.sigquals =
+                           (FStar_Syntax_Syntax.Assumption ::
+                           (se.FStar_Syntax_Syntax.sigquals));
+                         FStar_Syntax_Syntax.sigmeta =
+                           (se.FStar_Syntax_Syntax.sigmeta);
+                         FStar_Syntax_Syntax.sigattrs =
+                           (se.FStar_Syntax_Syntax.sigattrs);
+                         FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                           (se.FStar_Syntax_Syntax.sigopens_and_abbrevs);
+                         FStar_Syntax_Syntax.sigopts =
+                           (se.FStar_Syntax_Syntax.sigopts)
+                       }
+                   | uu___3 -> se in
+                 FStar_Compiler_Util.smap_add sm' k (se1, false)))
+           | uu___2 -> ()) keys;
       env2
 let (finish_module_or_interface :
   env -> FStar_Syntax_Syntax.modul -> (env * FStar_Syntax_Syntax.modul)) =
@@ -3395,11 +3341,11 @@ let (prepare_module_or_interface :
                                   (FStar_Compiler_List.rev auto_open2);
                                 env')))))) in
             let uu___ =
-              FStar_Compiler_Effect.op_Bar_Greater env1.modules
-                (FStar_Compiler_Util.find_opt
-                   (fun uu___1 ->
-                      match uu___1 with
-                      | (l, uu___2) -> FStar_Ident.lid_equals l mname)) in
+              FStar_Compiler_Util.find_opt
+                (fun uu___1 ->
+                   match uu___1 with
+                   | (l, uu___2) -> FStar_Ident.lid_equals l mname)
+                env1.modules in
             match uu___ with
             | FStar_Pervasives_Native.None ->
                 let uu___1 = prep env1 in (uu___1, false)
@@ -3507,9 +3453,8 @@ let fail_or :
                  match uu___3 with
                  | FStar_Pervasives_Native.None ->
                      let opened_modules1 =
-                       FStar_Compiler_Effect.op_Bar_Greater
-                         (FStar_Compiler_String.concat ", " opened_modules)
-                         FStar_Errors_Msg.text in
+                       FStar_Errors_Msg.text
+                         (FStar_Compiler_String.concat ", " opened_modules) in
                      let uu___4 =
                        let uu___5 =
                          let uu___6 =
@@ -3531,9 +3476,8 @@ let fail_or :
                             m = uu___5) opened_modules in
                      Prims.op_Negation uu___4 ->
                      let opened_modules1 =
-                       FStar_Compiler_Effect.op_Bar_Greater
-                         (FStar_Compiler_String.concat ", " opened_modules)
-                         FStar_Errors_Msg.text in
+                       FStar_Errors_Msg.text
+                         (FStar_Compiler_String.concat ", " opened_modules) in
                      let uu___4 =
                        let uu___5 =
                          let uu___6 =

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Embeddings.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Embeddings.ml
@@ -201,9 +201,7 @@ let (e_any : FStar_Syntax_Syntax.term FStar_Syntax_Embeddings_Base.embedding)
   let un t _n = FStar_Pervasives_Native.Some t in
   let uu___ =
     let uu___1 =
-      let uu___2 =
-        FStar_Compiler_Effect.op_Bar_Greater FStar_Parser_Const.term_lid
-          FStar_Ident.string_of_lid in
+      let uu___2 = FStar_Ident.string_of_lid FStar_Parser_Const.term_lid in
       (uu___2, []) in
     FStar_Syntax_Syntax.ET_app uu___1 in
   FStar_Syntax_Embeddings_Base.mk_emb_full em un FStar_Syntax_Syntax.t_term
@@ -227,9 +225,7 @@ let (e_unit : unit FStar_Syntax_Embeddings_Base.embedding) =
     | uu___ -> FStar_Pervasives_Native.None in
   let uu___ =
     let uu___1 =
-      let uu___2 =
-        FStar_Compiler_Effect.op_Bar_Greater FStar_Parser_Const.unit_lid
-          FStar_Ident.string_of_lid in
+      let uu___2 = FStar_Ident.string_of_lid FStar_Parser_Const.unit_lid in
       (uu___2, []) in
     FStar_Syntax_Syntax.ET_app uu___1 in
   FStar_Syntax_Embeddings_Base.mk_emb_full em un FStar_Syntax_Syntax.t_unit
@@ -256,9 +252,7 @@ let (e_bool : Prims.bool FStar_Syntax_Embeddings_Base.embedding) =
     | uu___1 -> FStar_Pervasives_Native.None in
   let uu___ =
     let uu___1 =
-      let uu___2 =
-        FStar_Compiler_Effect.op_Bar_Greater FStar_Parser_Const.bool_lid
-          FStar_Ident.string_of_lid in
+      let uu___2 = FStar_Ident.string_of_lid FStar_Parser_Const.bool_lid in
       (uu___2, []) in
     FStar_Syntax_Syntax.ET_app uu___1 in
   FStar_Syntax_Embeddings_Base.mk_emb_full em un FStar_Syntax_Syntax.t_bool
@@ -282,9 +276,7 @@ let (e_char : FStar_Char.char FStar_Syntax_Embeddings_Base.embedding) =
     | uu___1 -> FStar_Pervasives_Native.None in
   let uu___ =
     let uu___1 =
-      let uu___2 =
-        FStar_Compiler_Effect.op_Bar_Greater FStar_Parser_Const.char_lid
-          FStar_Ident.string_of_lid in
+      let uu___2 = FStar_Ident.string_of_lid FStar_Parser_Const.char_lid in
       (uu___2, []) in
     FStar_Syntax_Syntax.ET_app uu___1 in
   FStar_Syntax_Embeddings_Base.mk_emb_full em un FStar_Syntax_Syntax.t_char
@@ -293,9 +285,7 @@ let (e_int : FStar_BigInt.t FStar_Syntax_Embeddings_Base.embedding) =
   let ty = FStar_Syntax_Syntax.t_int in
   let emb_t_int =
     let uu___ =
-      let uu___1 =
-        FStar_Compiler_Effect.op_Bar_Greater FStar_Parser_Const.int_lid
-          FStar_Ident.string_of_lid in
+      let uu___1 = FStar_Ident.string_of_lid FStar_Parser_Const.int_lid in
       (uu___1, []) in
     FStar_Syntax_Syntax.ET_app uu___ in
   let em i rng _shadow _norm =
@@ -320,9 +310,7 @@ let (e_fsint : Prims.int FStar_Syntax_Embeddings_Base.embedding) =
 let (e_string : Prims.string FStar_Syntax_Embeddings_Base.embedding) =
   let emb_t_string =
     let uu___ =
-      let uu___1 =
-        FStar_Compiler_Effect.op_Bar_Greater FStar_Parser_Const.string_lid
-          FStar_Ident.string_of_lid in
+      let uu___1 = FStar_Ident.string_of_lid FStar_Parser_Const.string_lid in
       (uu___1, []) in
     FStar_Syntax_Syntax.ET_app uu___ in
   let em s rng _shadow _norm =
@@ -351,9 +339,7 @@ let e_option :
       FStar_Syntax_Syntax.t_option_of uu___ in
     let emb_t_option_a =
       let uu___ =
-        let uu___1 =
-          FStar_Compiler_Effect.op_Bar_Greater FStar_Parser_Const.option_lid
-            FStar_Ident.string_of_lid in
+        let uu___1 = FStar_Ident.string_of_lid FStar_Parser_Const.option_lid in
         let uu___2 =
           let uu___3 = FStar_Syntax_Embeddings_Base.emb_typ_of ea in [uu___3] in
         (uu___1, uu___2) in
@@ -469,8 +455,7 @@ let e_tuple2 :
       let emb_t_pair_a_b =
         let uu___ =
           let uu___1 =
-            FStar_Compiler_Effect.op_Bar_Greater
-              FStar_Parser_Const.lid_tuple2 FStar_Ident.string_of_lid in
+            FStar_Ident.string_of_lid FStar_Parser_Const.lid_tuple2 in
           let uu___2 =
             let uu___3 = FStar_Syntax_Embeddings_Base.emb_typ_of ea in
             let uu___4 =
@@ -605,8 +590,7 @@ let e_tuple3 :
         let emb_t_pair_a_b_c =
           let uu___ =
             let uu___1 =
-              FStar_Compiler_Effect.op_Bar_Greater
-                FStar_Parser_Const.lid_tuple3 FStar_Ident.string_of_lid in
+              FStar_Ident.string_of_lid FStar_Parser_Const.lid_tuple3 in
             let uu___2 =
               let uu___3 = FStar_Syntax_Embeddings_Base.emb_typ_of ea in
               let uu___4 =
@@ -779,8 +763,7 @@ let e_either :
       let emb_t_sum_a_b =
         let uu___ =
           let uu___1 =
-            FStar_Compiler_Effect.op_Bar_Greater
-              FStar_Parser_Const.either_lid FStar_Ident.string_of_lid in
+            FStar_Ident.string_of_lid FStar_Parser_Const.either_lid in
           let uu___2 =
             let uu___3 = FStar_Syntax_Embeddings_Base.emb_typ_of ea in
             let uu___4 =
@@ -970,9 +953,7 @@ let e_list :
       FStar_Syntax_Syntax.t_list_of uu___ in
     let emb_t_list_a =
       let uu___ =
-        let uu___1 =
-          FStar_Compiler_Effect.op_Bar_Greater FStar_Parser_Const.list_lid
-            FStar_Ident.string_of_lid in
+        let uu___1 = FStar_Ident.string_of_lid FStar_Parser_Const.list_lid in
         let uu___2 =
           let uu___3 = FStar_Syntax_Embeddings_Base.emb_typ_of ea in [uu___3] in
         (uu___1, uu___2) in
@@ -983,8 +964,7 @@ let e_list :
           let uu___2 =
             let uu___3 = FStar_Syntax_Embeddings_Base.printer_of ea in
             FStar_Compiler_List.map uu___3 l in
-          FStar_Compiler_Effect.op_Bar_Greater uu___2
-            (FStar_Compiler_String.concat "; ") in
+          FStar_Compiler_String.concat "; " uu___2 in
         Prims.strcat uu___1 "]" in
       Prims.strcat "[" uu___ in
     let rec em l rng shadow_l norm =
@@ -1142,9 +1122,7 @@ let (e_norm_step :
   let typ = FStar_Syntax_Syntax.t_norm_step in
   let emb_t_norm_step =
     let uu___ =
-      let uu___1 =
-        FStar_Compiler_Effect.op_Bar_Greater FStar_Parser_Const.norm_step_lid
-          FStar_Ident.string_of_lid in
+      let uu___1 = FStar_Ident.string_of_lid FStar_Parser_Const.norm_step_lid in
       (uu___1, []) in
     FStar_Syntax_Syntax.ET_app uu___ in
   let printer1 uu___ = "norm_step" in
@@ -1293,8 +1271,7 @@ let (e_norm_step :
                     FStar_Syntax_Embeddings_Base.try_unembed uu___4 l norm in
                   FStar_Compiler_Util.bind_opt uu___3
                     (fun ss ->
-                       FStar_Compiler_Effect.op_Less_Bar
-                         (fun uu___4 -> FStar_Pervasives_Native.Some uu___4)
+                       FStar_Pervasives_Native.Some
                          (FStar_Pervasives.UnfoldOnly ss))
               | (FStar_Syntax_Syntax.Tm_fvar fv, (l, uu___2)::[]) when
                   FStar_Syntax_Syntax.fv_eq_lid fv
@@ -1305,8 +1282,7 @@ let (e_norm_step :
                     FStar_Syntax_Embeddings_Base.try_unembed uu___4 l norm in
                   FStar_Compiler_Util.bind_opt uu___3
                     (fun ss ->
-                       FStar_Compiler_Effect.op_Less_Bar
-                         (fun uu___4 -> FStar_Pervasives_Native.Some uu___4)
+                       FStar_Pervasives_Native.Some
                          (FStar_Pervasives.UnfoldFully ss))
               | (FStar_Syntax_Syntax.Tm_fvar fv, (l, uu___2)::[]) when
                   FStar_Syntax_Syntax.fv_eq_lid fv
@@ -1317,8 +1293,7 @@ let (e_norm_step :
                     FStar_Syntax_Embeddings_Base.try_unembed uu___4 l norm in
                   FStar_Compiler_Util.bind_opt uu___3
                     (fun ss ->
-                       FStar_Compiler_Effect.op_Less_Bar
-                         (fun uu___4 -> FStar_Pervasives_Native.Some uu___4)
+                       FStar_Pervasives_Native.Some
                          (FStar_Pervasives.UnfoldAttr ss))
               | (FStar_Syntax_Syntax.Tm_fvar fv, (l, uu___2)::[]) when
                   FStar_Syntax_Syntax.fv_eq_lid fv
@@ -1329,8 +1304,7 @@ let (e_norm_step :
                     FStar_Syntax_Embeddings_Base.try_unembed uu___4 l norm in
                   FStar_Compiler_Util.bind_opt uu___3
                     (fun ss ->
-                       FStar_Compiler_Effect.op_Less_Bar
-                         (fun uu___4 -> FStar_Pervasives_Native.Some uu___4)
+                       FStar_Pervasives_Native.Some
                          (FStar_Pervasives.UnfoldQual ss))
               | (FStar_Syntax_Syntax.Tm_fvar fv, (l, uu___2)::[]) when
                   FStar_Syntax_Syntax.fv_eq_lid fv
@@ -1341,8 +1315,7 @@ let (e_norm_step :
                     FStar_Syntax_Embeddings_Base.try_unembed uu___4 l norm in
                   FStar_Compiler_Util.bind_opt uu___3
                     (fun ss ->
-                       FStar_Compiler_Effect.op_Less_Bar
-                         (fun uu___4 -> FStar_Pervasives_Native.Some uu___4)
+                       FStar_Pervasives_Native.Some
                          (FStar_Pervasives.UnfoldNamespace ss))
               | uu___2 -> FStar_Pervasives_Native.None)) in
   FStar_Syntax_Embeddings_Base.mk_emb_full em un typ printer1 emb_t_norm_step
@@ -2035,9 +2008,7 @@ let (e_vconfig :
          | uu___2 -> FStar_Pervasives_Native.None) in
   let uu___ =
     let uu___1 =
-      let uu___2 =
-        FStar_Compiler_Effect.op_Bar_Greater FStar_Parser_Const.vconfig_lid
-          FStar_Ident.string_of_lid in
+      let uu___2 = FStar_Ident.string_of_lid FStar_Parser_Const.vconfig_lid in
       (uu___2, []) in
     FStar_Syntax_Syntax.ET_app uu___1 in
   FStar_Syntax_Embeddings_Base.mk_emb_full em un
@@ -2162,9 +2133,7 @@ let e_sealed :
       FStar_Syntax_Syntax.t_sealed_of uu___ in
     let emb_ty_a =
       let uu___ =
-        let uu___1 =
-          FStar_Compiler_Effect.op_Bar_Greater FStar_Parser_Const.sealed_lid
-            FStar_Ident.string_of_lid in
+        let uu___1 = FStar_Ident.string_of_lid FStar_Parser_Const.sealed_lid in
         let uu___2 =
           let uu___3 = FStar_Syntax_Embeddings_Base.emb_typ_of ea in [uu___3] in
         (uu___1, uu___2) in
@@ -2238,9 +2207,7 @@ let (e___range :
     | uu___1 -> FStar_Pervasives_Native.None in
   let uu___ =
     let uu___1 =
-      let uu___2 =
-        FStar_Compiler_Effect.op_Bar_Greater FStar_Parser_Const.range_lid
-          FStar_Ident.string_of_lid in
+      let uu___2 = FStar_Ident.string_of_lid FStar_Parser_Const.range_lid in
       (uu___2, []) in
     FStar_Syntax_Syntax.ET_app uu___1 in
   FStar_Syntax_Embeddings_Base.mk_emb_full em un

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Embeddings_Base.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Embeddings_Base.ml
@@ -93,8 +93,7 @@ let mk_emb :
           let uu___1 =
             let uu___2 =
               let uu___3 = FStar_Syntax_Syntax.lid_of_fv fv in
-              FStar_Compiler_Effect.op_Bar_Greater uu___3
-                FStar_Ident.string_of_lid in
+              FStar_Ident.string_of_lid uu___3 in
             (uu___2, []) in
           FStar_Syntax_Syntax.ET_app uu___1 in
         { em; un; typ; print = (unknown_printer typ); emb_typ = uu___ }

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Free.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Free.ml
@@ -214,40 +214,36 @@ let rec (free_names_and_uvs' :
             FStar_Syntax_Syntax.rc_opt1 = uu___;_}
           ->
           let uu___1 =
-            let uu___2 =
-              let uu___3 = free_names_and_uvars t1 use_cache in
-              let uu___4 =
-                match asc_opt with
-                | FStar_Pervasives_Native.None -> no_free_vars
-                | FStar_Pervasives_Native.Some (b, asc) ->
-                    let uu___5 = free_names_and_uvars_binders [b] use_cache in
-                    let uu___6 =
-                      free_names_and_uvars_ascription asc use_cache in
-                    union uu___5 uu___6 in
-              union uu___3 uu___4 in
-            FStar_Compiler_List.fold_left
-              (fun n ->
-                 fun uu___3 ->
-                   match uu___3 with
-                   | (p, wopt, t2) ->
-                       let n1 =
-                         match wopt with
-                         | FStar_Pervasives_Native.None -> no_free_vars
-                         | FStar_Pervasives_Native.Some w ->
-                             free_names_and_uvars w use_cache in
-                       let n2 = free_names_and_uvars t2 use_cache in
-                       let n3 =
-                         let uu___4 = FStar_Syntax_Syntax.pat_bvs p in
-                         FStar_Compiler_Effect.op_Bar_Greater uu___4
-                           (FStar_Compiler_List.fold_left
-                              (fun n4 ->
-                                 fun x ->
-                                   let uu___5 =
-                                     free_names_and_uvars
-                                       x.FStar_Syntax_Syntax.sort use_cache in
-                                   union n4 uu___5) n) in
-                       let uu___4 = union n1 n2 in union n3 uu___4) uu___2 in
-          FStar_Compiler_Effect.op_Bar_Greater pats uu___1
+            let uu___2 = free_names_and_uvars t1 use_cache in
+            let uu___3 =
+              match asc_opt with
+              | FStar_Pervasives_Native.None -> no_free_vars
+              | FStar_Pervasives_Native.Some (b, asc) ->
+                  let uu___4 = free_names_and_uvars_binders [b] use_cache in
+                  let uu___5 = free_names_and_uvars_ascription asc use_cache in
+                  union uu___4 uu___5 in
+            union uu___2 uu___3 in
+          FStar_Compiler_List.fold_left
+            (fun n ->
+               fun uu___2 ->
+                 match uu___2 with
+                 | (p, wopt, t2) ->
+                     let n1 =
+                       match wopt with
+                       | FStar_Pervasives_Native.None -> no_free_vars
+                       | FStar_Pervasives_Native.Some w ->
+                           free_names_and_uvars w use_cache in
+                     let n2 = free_names_and_uvars t2 use_cache in
+                     let n3 =
+                       let uu___3 = FStar_Syntax_Syntax.pat_bvs p in
+                       FStar_Compiler_List.fold_left
+                         (fun n4 ->
+                            fun x ->
+                              let uu___4 =
+                                free_names_and_uvars
+                                  x.FStar_Syntax_Syntax.sort use_cache in
+                              union n4 uu___4) n uu___3 in
+                     let uu___3 = union n1 n2 in union n3 uu___3) uu___1 pats
       | FStar_Syntax_Syntax.Tm_ascribed
           { FStar_Syntax_Syntax.tm = t1; FStar_Syntax_Syntax.asc = asc;
             FStar_Syntax_Syntax.eff_opt = uu___;_}
@@ -258,22 +254,19 @@ let rec (free_names_and_uvs' :
       | FStar_Syntax_Syntax.Tm_let
           { FStar_Syntax_Syntax.lbs = lbs; FStar_Syntax_Syntax.body1 = t1;_}
           ->
-          let uu___ =
-            let uu___1 = free_names_and_uvars t1 use_cache in
-            FStar_Compiler_List.fold_left
-              (fun n ->
-                 fun lb ->
+          let uu___ = free_names_and_uvars t1 use_cache in
+          FStar_Compiler_List.fold_left
+            (fun n ->
+               fun lb ->
+                 let uu___1 =
                    let uu___2 =
-                     let uu___3 =
-                       free_names_and_uvars lb.FStar_Syntax_Syntax.lbtyp
-                         use_cache in
-                     let uu___4 =
-                       free_names_and_uvars lb.FStar_Syntax_Syntax.lbdef
-                         use_cache in
-                     union uu___3 uu___4 in
-                   union n uu___2) uu___1 in
-          FStar_Compiler_Effect.op_Bar_Greater
-            (FStar_Pervasives_Native.snd lbs) uu___
+                     free_names_and_uvars lb.FStar_Syntax_Syntax.lbtyp
+                       use_cache in
+                   let uu___3 =
+                     free_names_and_uvars lb.FStar_Syntax_Syntax.lbdef
+                       use_cache in
+                   union uu___2 uu___3 in
+                 union n uu___1) uu___ (FStar_Pervasives_Native.snd lbs)
       | FStar_Syntax_Syntax.Tm_quoted (tm1, qi) ->
           (match qi.FStar_Syntax_Syntax.qkind with
            | FStar_Syntax_Syntax.Quote_static ->
@@ -308,15 +301,14 @@ and (free_names_and_uvars_binders :
   FStar_Syntax_Syntax.binders -> use_cache_t -> free_vars_and_fvars) =
   fun bs ->
     fun use_cache ->
-      FStar_Compiler_Effect.op_Bar_Greater bs
-        (FStar_Compiler_List.fold_left
-           (fun n ->
-              fun b ->
-                let uu___ =
-                  free_names_and_uvars
-                    (b.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort
-                    use_cache in
-                union n uu___) no_free_vars)
+      FStar_Compiler_List.fold_left
+        (fun n ->
+           fun b ->
+             let uu___ =
+               free_names_and_uvars
+                 (b.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort
+                 use_cache in
+             union n uu___) no_free_vars bs
 and (free_names_and_uvars_ascription :
   ((FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax,
     FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax)
@@ -376,14 +368,13 @@ and (free_names_and_uvars_args :
   fun args ->
     fun acc ->
       fun use_cache ->
-        FStar_Compiler_Effect.op_Bar_Greater args
-          (FStar_Compiler_List.fold_left
-             (fun n ->
-                fun uu___ ->
-                  match uu___ with
-                  | (x, uu___1) ->
-                      let uu___2 = free_names_and_uvars x use_cache in
-                      union n uu___2) acc)
+        FStar_Compiler_List.fold_left
+          (fun n ->
+             fun uu___ ->
+               match uu___ with
+               | (x, uu___1) ->
+                   let uu___2 = free_names_and_uvars x use_cache in
+                   union n uu___2) acc args
 and (free_names_and_uvars_comp :
   FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax ->
     use_cache_t -> free_vars_and_fvars)
@@ -442,12 +433,11 @@ and (free_names_and_uvars_dec_order :
     fun use_cache ->
       match dec_order with
       | FStar_Syntax_Syntax.Decreases_lex l ->
-          FStar_Compiler_Effect.op_Bar_Greater l
-            (FStar_Compiler_List.fold_left
-               (fun acc ->
-                  fun t ->
-                    let uu___ = free_names_and_uvars t use_cache in
-                    union acc uu___) no_free_vars)
+          FStar_Compiler_List.fold_left
+            (fun acc ->
+               fun t ->
+                 let uu___ = free_names_and_uvars t use_cache in
+                 union acc uu___) no_free_vars l
       | FStar_Syntax_Syntax.Decreases_wf (rel, e) ->
           let uu___ = free_names_and_uvars rel use_cache in
           let uu___1 = free_names_and_uvars e use_cache in union uu___ uu___1
@@ -456,25 +446,22 @@ and (should_invalidate_cache :
   fun n ->
     fun use_cache ->
       ((use_cache <> Def) ||
-         (FStar_Compiler_Effect.op_Bar_Greater
-            n.FStar_Syntax_Syntax.free_uvars
-            (FStar_Compiler_Util.for_some
-               (fun u ->
-                  let uu___ =
-                    FStar_Syntax_Unionfind.find
-                      u.FStar_Syntax_Syntax.ctx_uvar_head in
-                  match uu___ with
-                  | FStar_Pervasives_Native.Some uu___1 -> true
-                  | uu___1 -> false))))
+         (FStar_Compiler_Util.for_some
+            (fun u ->
+               let uu___ =
+                 FStar_Syntax_Unionfind.find
+                   u.FStar_Syntax_Syntax.ctx_uvar_head in
+               match uu___ with
+               | FStar_Pervasives_Native.Some uu___1 -> true
+               | uu___1 -> false) n.FStar_Syntax_Syntax.free_uvars))
         ||
-        (FStar_Compiler_Effect.op_Bar_Greater
-           n.FStar_Syntax_Syntax.free_univs
-           (FStar_Compiler_Util.for_some
-              (fun u ->
-                 let uu___ = FStar_Syntax_Unionfind.univ_find u in
-                 match uu___ with
-                 | FStar_Pervasives_Native.Some uu___1 -> true
-                 | FStar_Pervasives_Native.None -> false)))
+        (FStar_Compiler_Util.for_some
+           (fun u ->
+              let uu___ = FStar_Syntax_Unionfind.univ_find u in
+              match uu___ with
+              | FStar_Pervasives_Native.Some uu___1 -> true
+              | FStar_Pervasives_Native.None -> false)
+           n.FStar_Syntax_Syntax.free_univs)
 let (compare_uv :
   FStar_Syntax_Syntax.ctx_uvar -> FStar_Syntax_Syntax.ctx_uvar -> Prims.int)
   =

--- a/ocaml/fstar-lib/generated/FStar_Syntax_InstFV.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_InstFV.ml
@@ -85,19 +85,18 @@ let rec (inst :
             FStar_Syntax_Syntax.rc_opt1 = lopt;_}
           ->
           let pats1 =
-            FStar_Compiler_Effect.op_Bar_Greater pats
-              (FStar_Compiler_List.map
-                 (fun uu___ ->
-                    match uu___ with
-                    | (p, wopt, t3) ->
-                        let wopt1 =
-                          match wopt with
-                          | FStar_Pervasives_Native.None ->
-                              FStar_Pervasives_Native.None
-                          | FStar_Pervasives_Native.Some w ->
-                              let uu___1 = inst s w in
-                              FStar_Pervasives_Native.Some uu___1 in
-                        let t4 = inst s t3 in (p, wopt1, t4))) in
+            FStar_Compiler_List.map
+              (fun uu___ ->
+                 match uu___ with
+                 | (p, wopt, t3) ->
+                     let wopt1 =
+                       match wopt with
+                       | FStar_Pervasives_Native.None ->
+                           FStar_Pervasives_Native.None
+                       | FStar_Pervasives_Native.Some w ->
+                           let uu___1 = inst s w in
+                           FStar_Pervasives_Native.Some uu___1 in
+                     let t4 = inst s t3 in (p, wopt1, t4)) pats in
           let asc_opt1 =
             match asc_opt with
             | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
@@ -138,26 +137,24 @@ let rec (inst :
           ->
           let lbs1 =
             let uu___ =
-              FStar_Compiler_Effect.op_Bar_Greater
-                (FStar_Pervasives_Native.snd lbs)
-                (FStar_Compiler_List.map
-                   (fun lb ->
-                      let uu___1 = inst s lb.FStar_Syntax_Syntax.lbtyp in
-                      let uu___2 = inst s lb.FStar_Syntax_Syntax.lbdef in
-                      {
-                        FStar_Syntax_Syntax.lbname =
-                          (lb.FStar_Syntax_Syntax.lbname);
-                        FStar_Syntax_Syntax.lbunivs =
-                          (lb.FStar_Syntax_Syntax.lbunivs);
-                        FStar_Syntax_Syntax.lbtyp = uu___1;
-                        FStar_Syntax_Syntax.lbeff =
-                          (lb.FStar_Syntax_Syntax.lbeff);
-                        FStar_Syntax_Syntax.lbdef = uu___2;
-                        FStar_Syntax_Syntax.lbattrs =
-                          (lb.FStar_Syntax_Syntax.lbattrs);
-                        FStar_Syntax_Syntax.lbpos =
-                          (lb.FStar_Syntax_Syntax.lbpos)
-                      })) in
+              FStar_Compiler_List.map
+                (fun lb ->
+                   let uu___1 = inst s lb.FStar_Syntax_Syntax.lbtyp in
+                   let uu___2 = inst s lb.FStar_Syntax_Syntax.lbdef in
+                   {
+                     FStar_Syntax_Syntax.lbname =
+                       (lb.FStar_Syntax_Syntax.lbname);
+                     FStar_Syntax_Syntax.lbunivs =
+                       (lb.FStar_Syntax_Syntax.lbunivs);
+                     FStar_Syntax_Syntax.lbtyp = uu___1;
+                     FStar_Syntax_Syntax.lbeff =
+                       (lb.FStar_Syntax_Syntax.lbeff);
+                     FStar_Syntax_Syntax.lbdef = uu___2;
+                     FStar_Syntax_Syntax.lbattrs =
+                       (lb.FStar_Syntax_Syntax.lbattrs);
+                     FStar_Syntax_Syntax.lbpos =
+                       (lb.FStar_Syntax_Syntax.lbpos)
+                   }) (FStar_Pervasives_Native.snd lbs) in
             ((FStar_Pervasives_Native.fst lbs), uu___) in
           let uu___ =
             let uu___1 =
@@ -178,9 +175,7 @@ let rec (inst :
               let uu___2 = inst s t2 in
               let uu___3 =
                 let uu___4 =
-                  let uu___5 =
-                    FStar_Compiler_Effect.op_Bar_Greater args
-                      (FStar_Compiler_List.map (inst_args s)) in
+                  let uu___5 = FStar_Compiler_List.map (inst_args s) args in
                   (bvs, uu___5) in
                 FStar_Syntax_Syntax.Meta_pattern uu___4 in
               {
@@ -235,9 +230,7 @@ and (inst_binder :
           FStar_Syntax_Syntax.sort = uu___2
         } in
       let uu___1 =
-        FStar_Compiler_Effect.op_Bar_Greater
-          b.FStar_Syntax_Syntax.binder_attrs
-          (FStar_Compiler_List.map (inst s)) in
+        FStar_Compiler_List.map (inst s) b.FStar_Syntax_Syntax.binder_attrs in
       {
         FStar_Syntax_Syntax.binder_bv = uu___;
         FStar_Syntax_Syntax.binder_qual = (b.FStar_Syntax_Syntax.binder_qual);
@@ -249,11 +242,7 @@ and (inst_binders :
   (FStar_Syntax_Syntax.term ->
      FStar_Syntax_Syntax.fv -> FStar_Syntax_Syntax.term)
     -> FStar_Syntax_Syntax.binders -> FStar_Syntax_Syntax.binders)
-  =
-  fun s ->
-    fun bs ->
-      FStar_Compiler_Effect.op_Bar_Greater bs
-        (FStar_Compiler_List.map (inst_binder s))
+  = fun s -> fun bs -> FStar_Compiler_List.map (inst_binder s) bs
 and (inst_args :
   (FStar_Syntax_Syntax.term ->
      FStar_Syntax_Syntax.fv -> FStar_Syntax_Syntax.term)
@@ -267,11 +256,10 @@ and (inst_args :
   =
   fun s ->
     fun args ->
-      FStar_Compiler_Effect.op_Bar_Greater args
-        (FStar_Compiler_List.map
-           (fun uu___ ->
-              match uu___ with
-              | (a, imp) -> let uu___1 = inst s a in (uu___1, imp)))
+      FStar_Compiler_List.map
+        (fun uu___ ->
+           match uu___ with
+           | (a, imp) -> let uu___1 = inst s a in (uu___1, imp)) args
 and (inst_comp :
   (FStar_Syntax_Syntax.term ->
      FStar_Syntax_Syntax.fv -> FStar_Syntax_Syntax.term)
@@ -291,15 +279,13 @@ and (inst_comp :
             let uu___ = inst s ct.FStar_Syntax_Syntax.result_typ in
             let uu___1 = inst_args s ct.FStar_Syntax_Syntax.effect_args in
             let uu___2 =
-              FStar_Compiler_Effect.op_Bar_Greater
-                ct.FStar_Syntax_Syntax.flags
-                (FStar_Compiler_List.map
-                   (fun uu___3 ->
-                      match uu___3 with
-                      | FStar_Syntax_Syntax.DECREASES dec_order ->
-                          let uu___4 = inst_decreases_order s dec_order in
-                          FStar_Syntax_Syntax.DECREASES uu___4
-                      | f -> f)) in
+              FStar_Compiler_List.map
+                (fun uu___3 ->
+                   match uu___3 with
+                   | FStar_Syntax_Syntax.DECREASES dec_order ->
+                       let uu___4 = inst_decreases_order s dec_order in
+                       FStar_Syntax_Syntax.DECREASES uu___4
+                   | f -> f) ct.FStar_Syntax_Syntax.flags in
             {
               FStar_Syntax_Syntax.comp_univs =
                 (ct.FStar_Syntax_Syntax.comp_univs);
@@ -321,9 +307,7 @@ and (inst_decreases_order :
     fun uu___ ->
       match uu___ with
       | FStar_Syntax_Syntax.Decreases_lex l ->
-          let uu___1 =
-            FStar_Compiler_Effect.op_Bar_Greater l
-              (FStar_Compiler_List.map (inst s)) in
+          let uu___1 = FStar_Compiler_List.map (inst s) l in
           FStar_Syntax_Syntax.Decreases_lex uu___1
       | FStar_Syntax_Syntax.Decreases_wf (rel, e) ->
           let uu___1 =

--- a/ocaml/fstar-lib/generated/FStar_Syntax_MutRecTy.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_MutRecTy.ml
@@ -22,29 +22,28 @@ let (disentangle_abbrevs_from_bundle :
                  | uu___ -> []) sigelts in
           let sigattrs1 = FStar_Syntax_Util.deduplicate_terms sigattrs in
           let type_abbrev_sigelts =
-            FStar_Compiler_Effect.op_Bar_Greater sigelts
-              (FStar_Compiler_List.collect
-                 (fun x ->
-                    match x.FStar_Syntax_Syntax.sigel with
-                    | FStar_Syntax_Syntax.Sig_let
-                        {
-                          FStar_Syntax_Syntax.lbs1 =
-                            (false,
-                             {
-                               FStar_Syntax_Syntax.lbname =
-                                 FStar_Pervasives.Inr uu___;
-                               FStar_Syntax_Syntax.lbunivs = uu___1;
-                               FStar_Syntax_Syntax.lbtyp = uu___2;
-                               FStar_Syntax_Syntax.lbeff = uu___3;
-                               FStar_Syntax_Syntax.lbdef = uu___4;
-                               FStar_Syntax_Syntax.lbattrs = uu___5;
-                               FStar_Syntax_Syntax.lbpos = uu___6;_}::[]);
-                          FStar_Syntax_Syntax.lids1 = uu___7;_}
-                        -> [x]
-                    | FStar_Syntax_Syntax.Sig_let uu___ ->
-                        FStar_Compiler_Effect.failwith
-                          "mutrecty: disentangle_abbrevs_from_bundle: type_abbrev_sigelts: impossible"
-                    | uu___ -> [])) in
+            FStar_Compiler_List.collect
+              (fun x ->
+                 match x.FStar_Syntax_Syntax.sigel with
+                 | FStar_Syntax_Syntax.Sig_let
+                     {
+                       FStar_Syntax_Syntax.lbs1 =
+                         (false,
+                          {
+                            FStar_Syntax_Syntax.lbname = FStar_Pervasives.Inr
+                              uu___;
+                            FStar_Syntax_Syntax.lbunivs = uu___1;
+                            FStar_Syntax_Syntax.lbtyp = uu___2;
+                            FStar_Syntax_Syntax.lbeff = uu___3;
+                            FStar_Syntax_Syntax.lbdef = uu___4;
+                            FStar_Syntax_Syntax.lbattrs = uu___5;
+                            FStar_Syntax_Syntax.lbpos = uu___6;_}::[]);
+                       FStar_Syntax_Syntax.lids1 = uu___7;_}
+                     -> [x]
+                 | FStar_Syntax_Syntax.Sig_let uu___ ->
+                     FStar_Compiler_Effect.failwith
+                       "mutrecty: disentangle_abbrevs_from_bundle: type_abbrev_sigelts: impossible"
+                 | uu___ -> []) sigelts in
           match type_abbrev_sigelts with
           | [] ->
               ({
@@ -64,29 +63,29 @@ let (disentangle_abbrevs_from_bundle :
                }, [])
           | uu___ ->
               let type_abbrevs =
-                FStar_Compiler_Effect.op_Bar_Greater type_abbrev_sigelts
-                  (FStar_Compiler_List.map
-                     (fun x ->
-                        match x.FStar_Syntax_Syntax.sigel with
-                        | FStar_Syntax_Syntax.Sig_let
-                            {
-                              FStar_Syntax_Syntax.lbs1 =
-                                (uu___1,
-                                 {
-                                   FStar_Syntax_Syntax.lbname =
-                                     FStar_Pervasives.Inr fv;
-                                   FStar_Syntax_Syntax.lbunivs = uu___2;
-                                   FStar_Syntax_Syntax.lbtyp = uu___3;
-                                   FStar_Syntax_Syntax.lbeff = uu___4;
-                                   FStar_Syntax_Syntax.lbdef = uu___5;
-                                   FStar_Syntax_Syntax.lbattrs = uu___6;
-                                   FStar_Syntax_Syntax.lbpos = uu___7;_}::[]);
-                              FStar_Syntax_Syntax.lids1 = uu___8;_}
-                            ->
-                            (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-                        | uu___1 ->
-                            FStar_Compiler_Effect.failwith
-                              "mutrecty: disentangle_abbrevs_from_bundle: type_abbrevs: impossible")) in
+                FStar_Compiler_List.map
+                  (fun x ->
+                     match x.FStar_Syntax_Syntax.sigel with
+                     | FStar_Syntax_Syntax.Sig_let
+                         {
+                           FStar_Syntax_Syntax.lbs1 =
+                             (uu___1,
+                              {
+                                FStar_Syntax_Syntax.lbname =
+                                  FStar_Pervasives.Inr fv;
+                                FStar_Syntax_Syntax.lbunivs = uu___2;
+                                FStar_Syntax_Syntax.lbtyp = uu___3;
+                                FStar_Syntax_Syntax.lbeff = uu___4;
+                                FStar_Syntax_Syntax.lbdef = uu___5;
+                                FStar_Syntax_Syntax.lbattrs = uu___6;
+                                FStar_Syntax_Syntax.lbpos = uu___7;_}::[]);
+                           FStar_Syntax_Syntax.lids1 = uu___8;_}
+                         ->
+                         (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
+                     | uu___1 ->
+                         FStar_Compiler_Effect.failwith
+                           "mutrecty: disentangle_abbrevs_from_bundle: type_abbrevs: impossible")
+                  type_abbrev_sigelts in
               let unfolded_type_abbrevs =
                 let rev_unfolded_type_abbrevs = FStar_Compiler_Util.mk_ref [] in
                 let in_progress = FStar_Compiler_Util.mk_ref [] in
@@ -96,30 +95,29 @@ let (disentangle_abbrevs_from_bundle :
                   let uu___1 =
                     let uu___2 =
                       FStar_Compiler_Effect.op_Bang not_unfolded_yet in
-                    FStar_Compiler_Effect.op_Bar_Greater uu___2
-                      (FStar_Compiler_List.filter
-                         (fun x ->
-                            match x.FStar_Syntax_Syntax.sigel with
-                            | FStar_Syntax_Syntax.Sig_let
-                                {
-                                  FStar_Syntax_Syntax.lbs1 =
-                                    (uu___3,
-                                     {
-                                       FStar_Syntax_Syntax.lbname =
-                                         FStar_Pervasives.Inr fv;
-                                       FStar_Syntax_Syntax.lbunivs = uu___4;
-                                       FStar_Syntax_Syntax.lbtyp = uu___5;
-                                       FStar_Syntax_Syntax.lbeff = uu___6;
-                                       FStar_Syntax_Syntax.lbdef = uu___7;
-                                       FStar_Syntax_Syntax.lbattrs = uu___8;
-                                       FStar_Syntax_Syntax.lbpos = uu___9;_}::[]);
-                                  FStar_Syntax_Syntax.lids1 = uu___10;_}
-                                ->
-                                let uu___11 =
-                                  FStar_Ident.lid_equals lid
-                                    (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                                Prims.op_Negation uu___11
-                            | uu___3 -> true)) in
+                    FStar_Compiler_List.filter
+                      (fun x ->
+                         match x.FStar_Syntax_Syntax.sigel with
+                         | FStar_Syntax_Syntax.Sig_let
+                             {
+                               FStar_Syntax_Syntax.lbs1 =
+                                 (uu___3,
+                                  {
+                                    FStar_Syntax_Syntax.lbname =
+                                      FStar_Pervasives.Inr fv;
+                                    FStar_Syntax_Syntax.lbunivs = uu___4;
+                                    FStar_Syntax_Syntax.lbtyp = uu___5;
+                                    FStar_Syntax_Syntax.lbeff = uu___6;
+                                    FStar_Syntax_Syntax.lbdef = uu___7;
+                                    FStar_Syntax_Syntax.lbattrs = uu___8;
+                                    FStar_Syntax_Syntax.lbpos = uu___9;_}::[]);
+                               FStar_Syntax_Syntax.lids1 = uu___10;_}
+                             ->
+                             let uu___11 =
+                               FStar_Ident.lid_equals lid
+                                 (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
+                             Prims.op_Negation uu___11
+                         | uu___3 -> true) uu___2 in
                   FStar_Compiler_Effect.op_Colon_Equals not_unfolded_yet
                     uu___1 in
                 let rec unfold_abbrev_fv t fv =
@@ -214,13 +212,11 @@ let (disentangle_abbrevs_from_bundle :
                         FStar_Syntax_Syntax.lids1 = uu___1;_}
                       ->
                       let quals1 =
-                        FStar_Compiler_Effect.op_Bar_Greater
-                          x.FStar_Syntax_Syntax.sigquals
-                          (FStar_Compiler_List.filter
-                             (fun uu___2 ->
-                                match uu___2 with
-                                | FStar_Syntax_Syntax.Noeq -> false
-                                | uu___3 -> true)) in
+                        FStar_Compiler_List.filter
+                          (fun uu___2 ->
+                             match uu___2 with
+                             | FStar_Syntax_Syntax.Noeq -> false
+                             | uu___3 -> true) x.FStar_Syntax_Syntax.sigquals in
                       let lid =
                         match lb.FStar_Syntax_Syntax.lbname with
                         | FStar_Pervasives.Inr fv ->

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Print.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Print.ml
@@ -53,23 +53,19 @@ let filter_imp_args :
         FStar_Pervasives_Native.option) Prims.list
   =
   fun args ->
-    FStar_Compiler_Effect.op_Bar_Greater args
-      (FStar_Compiler_List.filter
-         (fun uu___ ->
-            match uu___ with
-            | (uu___1, FStar_Pervasives_Native.None) -> true
-            | (uu___1, FStar_Pervasives_Native.Some a) ->
-                Prims.op_Negation a.FStar_Syntax_Syntax.aqual_implicit))
+    FStar_Compiler_List.filter
+      (fun uu___ ->
+         match uu___ with
+         | (uu___1, FStar_Pervasives_Native.None) -> true
+         | (uu___1, FStar_Pervasives_Native.Some a) ->
+             Prims.op_Negation a.FStar_Syntax_Syntax.aqual_implicit) args
 let (filter_imp_binders :
   FStar_Syntax_Syntax.binder Prims.list ->
     FStar_Syntax_Syntax.binder Prims.list)
   =
   fun bs ->
-    FStar_Compiler_Effect.op_Bar_Greater bs
-      (FStar_Compiler_List.filter
-         (fun b ->
-            FStar_Compiler_Effect.op_Bar_Greater
-              b.FStar_Syntax_Syntax.binder_qual filter_imp))
+    FStar_Compiler_List.filter
+      (fun b -> filter_imp b.FStar_Syntax_Syntax.binder_qual) bs
 let (const_to_string : FStar_Const.sconst -> Prims.string) =
   FStar_Parser_Const.const_to_string
 let (lbname_to_string : FStar_Syntax_Syntax.lbname -> Prims.string) =
@@ -86,8 +82,7 @@ let (uvar_to_string : FStar_Syntax_Syntax.uvar -> Prims.string) =
     else
       (let uu___2 =
          let uu___3 = FStar_Syntax_Unionfind.uvar_id u in
-         FStar_Compiler_Effect.op_Bar_Greater uu___3
-           FStar_Compiler_Util.string_of_int in
+         FStar_Compiler_Util.string_of_int uu___3 in
        Prims.strcat "?" uu___2)
 let (version_to_string : FStar_Syntax_Syntax.version -> Prims.string) =
   fun v ->
@@ -108,14 +103,10 @@ let (univ_uvar_to_string :
       (let uu___2 =
          let uu___3 =
            let uu___4 = FStar_Syntax_Unionfind.univ_uvar_id u in
-           FStar_Compiler_Effect.op_Bar_Greater uu___4
-             FStar_Compiler_Util.string_of_int in
+           FStar_Compiler_Util.string_of_int uu___4 in
          let uu___4 =
            let uu___5 =
-             FStar_Compiler_Effect.op_Bar_Greater u
-               (fun uu___6 ->
-                  match uu___6 with
-                  | (uu___7, u1, uu___8) -> version_to_string u1) in
+             match u with | (uu___6, u1, uu___7) -> version_to_string u1 in
            Prims.strcat ":" uu___5 in
          Prims.strcat uu___3 uu___4 in
        Prims.strcat "?" uu___2)
@@ -160,21 +151,18 @@ let rec (univ_to_string : FStar_Syntax_Syntax.universe -> Prims.string) =
          | FStar_Syntax_Syntax.U_max us ->
              let uu___2 =
                let uu___3 = FStar_Compiler_List.map univ_to_string us in
-               FStar_Compiler_Effect.op_Bar_Greater uu___3
-                 (FStar_Compiler_String.concat ", ") in
+               FStar_Compiler_String.concat ", " uu___3 in
              FStar_Compiler_Util.format1 "(max %s)" uu___2
          | FStar_Syntax_Syntax.U_unknown -> "unknown")
 let (univs_to_string : FStar_Syntax_Syntax.universes -> Prims.string) =
   fun us ->
     let uu___ = FStar_Compiler_List.map univ_to_string us in
-    FStar_Compiler_Effect.op_Bar_Greater uu___
-      (FStar_Compiler_String.concat ", ")
+    FStar_Compiler_String.concat ", " uu___
 let (univ_names_to_string : FStar_Syntax_Syntax.univ_names -> Prims.string) =
   fun us ->
     let uu___ =
       FStar_Compiler_List.map (fun x -> FStar_Ident.string_of_id x) us in
-    FStar_Compiler_Effect.op_Bar_Greater uu___
-      (FStar_Compiler_String.concat ", ")
+    FStar_Compiler_String.concat ", " uu___
 let (qual_to_string : FStar_Syntax_Syntax.qualifier -> Prims.string) =
   fun uu___ ->
     match uu___ with
@@ -203,22 +191,16 @@ let (qual_to_string : FStar_Syntax_Syntax.qualifier -> Prims.string) =
           let uu___2 = FStar_Ident.path_of_ns ns in
           FStar_Ident.text_of_path uu___2 in
         let uu___2 =
-          let uu___3 =
-            FStar_Compiler_Effect.op_Bar_Greater fns
-              (FStar_Compiler_List.map FStar_Ident.string_of_id) in
-          FStar_Compiler_Effect.op_Bar_Greater uu___3
-            (FStar_Compiler_String.concat ", ") in
+          let uu___3 = FStar_Compiler_List.map FStar_Ident.string_of_id fns in
+          FStar_Compiler_String.concat ", " uu___3 in
         FStar_Compiler_Util.format2 "(RecordType %s %s)" uu___1 uu___2
     | FStar_Syntax_Syntax.RecordConstructor (ns, fns) ->
         let uu___1 =
           let uu___2 = FStar_Ident.path_of_ns ns in
           FStar_Ident.text_of_path uu___2 in
         let uu___2 =
-          let uu___3 =
-            FStar_Compiler_Effect.op_Bar_Greater fns
-              (FStar_Compiler_List.map FStar_Ident.string_of_id) in
-          FStar_Compiler_Effect.op_Bar_Greater uu___3
-            (FStar_Compiler_String.concat ", ") in
+          let uu___3 = FStar_Compiler_List.map FStar_Ident.string_of_id fns in
+          FStar_Compiler_String.concat ", " uu___3 in
         FStar_Compiler_Util.format2 "(RecordConstructor %s %s)" uu___1 uu___2
     | FStar_Syntax_Syntax.Action eff_lid ->
         let uu___1 = lid_to_string eff_lid in
@@ -237,11 +219,8 @@ let (quals_to_string :
     match quals with
     | [] -> ""
     | uu___ ->
-        let uu___1 =
-          FStar_Compiler_Effect.op_Bar_Greater quals
-            (FStar_Compiler_List.map qual_to_string) in
-        FStar_Compiler_Effect.op_Bar_Greater uu___1
-          (FStar_Compiler_String.concat " ")
+        let uu___1 = FStar_Compiler_List.map qual_to_string quals in
+        FStar_Compiler_String.concat " " uu___1
 let (quals_to_string' :
   FStar_Syntax_Syntax.qualifier Prims.list -> Prims.string) =
   fun quals ->
@@ -386,19 +365,15 @@ and (term_to_string : FStar_Syntax_Syntax.term -> Prims.string) =
                ->
                let pats =
                  let uu___4 =
-                   FStar_Compiler_Effect.op_Bar_Greater ps
-                     (FStar_Compiler_List.map
-                        (fun args ->
-                           let uu___5 =
-                             FStar_Compiler_Effect.op_Bar_Greater args
-                               (FStar_Compiler_List.map
-                                  (fun uu___6 ->
-                                     match uu___6 with
-                                     | (t1, uu___7) -> term_to_string t1)) in
-                           FStar_Compiler_Effect.op_Bar_Greater uu___5
-                             (FStar_Compiler_String.concat "; "))) in
-                 FStar_Compiler_Effect.op_Bar_Greater uu___4
-                   (FStar_Compiler_String.concat "\\/") in
+                   FStar_Compiler_List.map
+                     (fun args ->
+                        let uu___5 =
+                          FStar_Compiler_List.map
+                            (fun uu___6 ->
+                               match uu___6 with
+                               | (t1, uu___7) -> term_to_string t1) args in
+                        FStar_Compiler_String.concat "; " uu___5) ps in
+                 FStar_Compiler_String.concat "\\/" uu___4 in
                let uu___4 = term_to_string t in
                FStar_Compiler_Util.format2 "{:pattern %s} %s" pats uu___4
            | FStar_Syntax_Syntax.Tm_meta
@@ -482,8 +457,7 @@ and (term_to_string : FStar_Syntax_Syntax.term -> Prims.string) =
                     let uu___7 =
                       FStar_Syntax_Unionfind.uvar_id
                         u.FStar_Syntax_Syntax.ctx_uvar_head in
-                    FStar_Compiler_Effect.op_Less_Bar
-                      FStar_Compiler_Util.string_of_int uu___7 in
+                    FStar_Compiler_Util.string_of_int uu___7 in
                   Prims.strcat "?" uu___6)
            | FStar_Syntax_Syntax.Tm_uvar (u, s) ->
                let uu___3 =
@@ -496,16 +470,14 @@ and (term_to_string : FStar_Syntax_Syntax.term -> Prims.string) =
                    let uu___6 =
                      FStar_Compiler_List.map subst_to_string
                        (FStar_Pervasives_Native.fst s) in
-                   FStar_Compiler_Effect.op_Bar_Greater uu___6
-                     (FStar_Compiler_String.concat "; ") in
+                   FStar_Compiler_String.concat "; " uu___6 in
                  FStar_Compiler_Util.format2 "(%s @ %s)" uu___4 uu___5
                else
                  (let uu___5 =
                     let uu___6 =
                       FStar_Syntax_Unionfind.uvar_id
                         u.FStar_Syntax_Syntax.ctx_uvar_head in
-                    FStar_Compiler_Effect.op_Less_Bar
-                      FStar_Compiler_Util.string_of_int uu___6 in
+                    FStar_Compiler_Util.string_of_int uu___6 in
                   Prims.strcat "?" uu___5)
            | FStar_Syntax_Syntax.Tm_constant c -> const_to_string c
            | FStar_Syntax_Syntax.Tm_type u ->
@@ -556,11 +528,8 @@ and (term_to_string : FStar_Syntax_Syntax.term -> Prims.string) =
                { FStar_Syntax_Syntax.b = xt; FStar_Syntax_Syntax.phi = f;_}
                ->
                let uu___3 = bv_to_string xt in
-               let uu___4 =
-                 FStar_Compiler_Effect.op_Bar_Greater
-                   xt.FStar_Syntax_Syntax.sort term_to_string in
-               let uu___5 =
-                 FStar_Compiler_Effect.op_Bar_Greater f formula_to_string in
+               let uu___4 = term_to_string xt.FStar_Syntax_Syntax.sort in
+               let uu___5 = formula_to_string f in
                FStar_Compiler_Util.format3 "(%s:%s{%s})" uu___3 uu___4 uu___5
            | FStar_Syntax_Syntax.Tm_app
                { FStar_Syntax_Syntax.hd = t;
@@ -588,8 +557,7 @@ and (term_to_string : FStar_Syntax_Syntax.term -> Prims.string) =
                        let uu___4 =
                          FStar_Compiler_Util.map_opt eff_name
                            FStar_Ident.string_of_lid in
-                       FStar_Compiler_Effect.op_Bar_Greater uu___4
-                         (FStar_Compiler_Util.dflt "default") in
+                       FStar_Compiler_Util.dflt "default" uu___4 in
                      let uu___4 = term_to_string t in
                      FStar_Compiler_Util.format2 "[%s] %s" uu___3 uu___4
                  | FStar_Pervasives.Inr c -> comp_to_string c in
@@ -646,8 +614,7 @@ and (term_to_string : FStar_Syntax_Syntax.term -> Prims.string) =
                        uu___6 uu___7 in
                let uu___5 =
                  let uu___6 =
-                   FStar_Compiler_Effect.op_Bar_Greater branches
-                     (FStar_Compiler_List.map branch_to_string) in
+                   FStar_Compiler_List.map branch_to_string branches in
                  FStar_Compiler_Util.concat_l "\n\t|" uu___6 in
                FStar_Compiler_Util.format4 "(match %s %swith\n\t| %s%s)"
                  uu___3 uu___4 uu___5 lc_str
@@ -664,15 +631,14 @@ and (branch_to_string : FStar_Syntax_Syntax.branch -> Prims.string) =
   fun uu___ ->
     match uu___ with
     | (p, wopt, e) ->
-        let uu___1 = FStar_Compiler_Effect.op_Bar_Greater p pat_to_string in
+        let uu___1 = pat_to_string p in
         let uu___2 =
           match wopt with
           | FStar_Pervasives_Native.None -> ""
           | FStar_Pervasives_Native.Some w ->
-              let uu___3 =
-                FStar_Compiler_Effect.op_Bar_Greater w term_to_string in
+              let uu___3 = term_to_string w in
               FStar_Compiler_Util.format1 "when %s" uu___3 in
-        let uu___3 = FStar_Compiler_Effect.op_Bar_Greater e term_to_string in
+        let uu___3 = term_to_string e in
         FStar_Compiler_Util.format3 "%s %s -> %s" uu___1 uu___2 uu___3
 and (ctx_uvar_to_string_aux :
   Prims.bool -> FStar_Syntax_Syntax.ctx_uvar -> Prims.string) =
@@ -738,11 +704,8 @@ and (subst_elt_to_string : FStar_Syntax_Syntax.subst_elt -> Prims.string) =
         FStar_Compiler_Util.format2 "UD (%s, %s)" uu___1 uu___2
 and (subst_to_string : FStar_Syntax_Syntax.subst_t -> Prims.string) =
   fun s ->
-    let uu___ =
-      FStar_Compiler_Effect.op_Bar_Greater s
-        (FStar_Compiler_List.map subst_elt_to_string) in
-    FStar_Compiler_Effect.op_Bar_Greater uu___
-      (FStar_Compiler_String.concat "; ")
+    let uu___ = FStar_Compiler_List.map subst_elt_to_string s in
+    FStar_Compiler_String.concat "; " uu___
 and (pat_to_string : FStar_Syntax_Syntax.pat -> Prims.string) =
   fun x ->
     let uu___ =
@@ -765,8 +728,7 @@ and (pat_to_string : FStar_Syntax_Syntax.pat -> Prims.string) =
                 | FStar_Pervasives_Native.Some us ->
                     let uu___6 =
                       let uu___7 = FStar_Compiler_List.map univ_to_string us in
-                      FStar_Compiler_Effect.op_Bar_Greater uu___7
-                        (FStar_Compiler_String.concat " ") in
+                      FStar_Compiler_String.concat " " uu___7 in
                     FStar_Compiler_Util.format1 " %s " uu___6) in
            let uu___4 =
              let uu___5 =
@@ -776,8 +738,7 @@ and (pat_to_string : FStar_Syntax_Syntax.pat -> Prims.string) =
                     | (x1, b) ->
                         let p = pat_to_string x1 in
                         if b then Prims.strcat "#" p else p) pats in
-             FStar_Compiler_Effect.op_Bar_Greater uu___5
-               (FStar_Compiler_String.concat " ") in
+             FStar_Compiler_String.concat " " uu___5 in
            FStar_Compiler_Util.format3 "(%s%s%s)" uu___2 uu___3 uu___4
        | FStar_Syntax_Syntax.Pat_dot_term topt ->
            let uu___2 = FStar_Options.print_bound_var_types () in
@@ -787,10 +748,8 @@ and (pat_to_string : FStar_Syntax_Syntax.pat -> Prims.string) =
                if topt = FStar_Pervasives_Native.None
                then "_"
                else
-                 (let uu___5 =
-                    FStar_Compiler_Effect.op_Bar_Greater topt
-                      FStar_Compiler_Util.must in
-                  FStar_Compiler_Effect.op_Bar_Greater uu___5 term_to_string) in
+                 (let uu___5 = FStar_Compiler_Util.must topt in
+                  term_to_string uu___5) in
              FStar_Compiler_Util.format1 ".%s" uu___3
            else "._"
        | FStar_Syntax_Syntax.Pat_var x1 ->
@@ -811,28 +770,24 @@ and (lbs_to_string :
       let uu___ = quals_to_string' quals in
       let uu___1 =
         let uu___2 =
-          FStar_Compiler_Effect.op_Bar_Greater
-            (FStar_Pervasives_Native.snd lbs)
-            (FStar_Compiler_List.map
-               (fun lb ->
-                  let uu___3 = attrs_to_string lb.FStar_Syntax_Syntax.lbattrs in
-                  let uu___4 = lbname_to_string lb.FStar_Syntax_Syntax.lbname in
-                  let uu___5 =
-                    let uu___6 = FStar_Options.print_universes () in
-                    if uu___6
-                    then
-                      let uu___7 =
-                        let uu___8 =
-                          univ_names_to_string lb.FStar_Syntax_Syntax.lbunivs in
-                        Prims.strcat uu___8 ">" in
-                      Prims.strcat "<" uu___7
-                    else "" in
-                  let uu___6 = term_to_string lb.FStar_Syntax_Syntax.lbtyp in
-                  let uu___7 =
-                    FStar_Compiler_Effect.op_Bar_Greater
-                      lb.FStar_Syntax_Syntax.lbdef term_to_string in
-                  FStar_Compiler_Util.format5 "%s%s %s : %s = %s" uu___3
-                    uu___4 uu___5 uu___6 uu___7)) in
+          FStar_Compiler_List.map
+            (fun lb ->
+               let uu___3 = attrs_to_string lb.FStar_Syntax_Syntax.lbattrs in
+               let uu___4 = lbname_to_string lb.FStar_Syntax_Syntax.lbname in
+               let uu___5 =
+                 let uu___6 = FStar_Options.print_universes () in
+                 if uu___6
+                 then
+                   let uu___7 =
+                     let uu___8 =
+                       univ_names_to_string lb.FStar_Syntax_Syntax.lbunivs in
+                     Prims.strcat uu___8 ">" in
+                   Prims.strcat "<" uu___7
+                 else "" in
+               let uu___6 = term_to_string lb.FStar_Syntax_Syntax.lbtyp in
+               let uu___7 = term_to_string lb.FStar_Syntax_Syntax.lbdef in
+               FStar_Compiler_Util.format5 "%s%s %s : %s = %s" uu___3 uu___4
+                 uu___5 uu___6 uu___7) (FStar_Pervasives_Native.snd lbs) in
         FStar_Compiler_Util.concat_l "\n and " uu___2 in
       FStar_Compiler_Util.format3 "%slet %s %s" uu___
         (if FStar_Pervasives_Native.fst lbs then "rec" else "") uu___1
@@ -846,8 +801,7 @@ and (attrs_to_string :
           let uu___2 =
             FStar_Compiler_List.map
               (fun t -> let uu___3 = term_to_string t in paren uu___3) tms in
-          FStar_Compiler_Effect.op_Bar_Greater uu___2
-            (FStar_Compiler_String.concat "; ") in
+          FStar_Compiler_String.concat "; " uu___2 in
         FStar_Compiler_Util.format1 "[@ %s]" uu___1
 and (bqual_to_string' :
   Prims.string ->
@@ -940,17 +894,11 @@ and (binders_to_string :
         if uu___ then bs else filter_imp_binders bs in
       if sep = " -> "
       then
-        let uu___ =
-          FStar_Compiler_Effect.op_Bar_Greater bs1
-            (FStar_Compiler_List.map arrow_binder_to_string) in
-        FStar_Compiler_Effect.op_Bar_Greater uu___
-          (FStar_Compiler_String.concat sep)
+        let uu___ = FStar_Compiler_List.map arrow_binder_to_string bs1 in
+        FStar_Compiler_String.concat sep uu___
       else
-        (let uu___1 =
-           FStar_Compiler_Effect.op_Bar_Greater bs1
-             (FStar_Compiler_List.map binder_to_string) in
-         FStar_Compiler_Effect.op_Bar_Greater uu___1
-           (FStar_Compiler_String.concat sep))
+        (let uu___1 = FStar_Compiler_List.map binder_to_string bs1 in
+         FStar_Compiler_String.concat sep uu___1)
 and (arg_to_string :
   (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.arg_qualifier
     FStar_Pervasives_Native.option) -> Prims.string)
@@ -964,11 +912,8 @@ and (args_to_string : FStar_Syntax_Syntax.args -> Prims.string) =
     let args1 =
       let uu___ = FStar_Options.print_implicits () in
       if uu___ then args else filter_imp_args args in
-    let uu___ =
-      FStar_Compiler_Effect.op_Bar_Greater args1
-        (FStar_Compiler_List.map arg_to_string) in
-    FStar_Compiler_Effect.op_Bar_Greater uu___
-      (FStar_Compiler_String.concat " ")
+    let uu___ = FStar_Compiler_List.map arg_to_string args1 in
+    FStar_Compiler_String.concat " " uu___
 and (comp_to_string : FStar_Syntax_Syntax.comp -> Prims.string) =
   fun c ->
     let uu___ =
@@ -1013,33 +958,27 @@ and (comp_to_string : FStar_Syntax_Syntax.comp -> Prims.string) =
                    let uu___4 = sli c1.FStar_Syntax_Syntax.effect_name in
                    let uu___5 =
                      let uu___6 =
-                       FStar_Compiler_Effect.op_Bar_Greater
-                         c1.FStar_Syntax_Syntax.comp_univs
-                         (FStar_Compiler_List.map univ_to_string) in
-                     FStar_Compiler_Effect.op_Bar_Greater uu___6
-                       (FStar_Compiler_String.concat ", ") in
+                       FStar_Compiler_List.map univ_to_string
+                         c1.FStar_Syntax_Syntax.comp_univs in
+                     FStar_Compiler_String.concat ", " uu___6 in
                    let uu___6 =
                      term_to_string c1.FStar_Syntax_Syntax.result_typ in
                    let uu___7 =
                      let uu___8 =
-                       FStar_Compiler_Effect.op_Bar_Greater
-                         c1.FStar_Syntax_Syntax.effect_args
-                         (FStar_Compiler_List.map arg_to_string) in
-                     FStar_Compiler_Effect.op_Bar_Greater uu___8
-                       (FStar_Compiler_String.concat ", ") in
+                       FStar_Compiler_List.map arg_to_string
+                         c1.FStar_Syntax_Syntax.effect_args in
+                     FStar_Compiler_String.concat ", " uu___8 in
                    let uu___8 = cflags_to_string c1.FStar_Syntax_Syntax.flags in
                    FStar_Compiler_Util.format5
                      "%s<%s> (%s) %s (attributes %s)" uu___4 uu___5 uu___6
                      uu___7 uu___8
                  else
                    (let uu___5 =
-                      (FStar_Compiler_Effect.op_Bar_Greater
-                         c1.FStar_Syntax_Syntax.flags
-                         (FStar_Compiler_Util.for_some
-                            (fun uu___6 ->
-                               match uu___6 with
-                               | FStar_Syntax_Syntax.TOTAL -> true
-                               | uu___7 -> false)))
+                      (FStar_Compiler_Util.for_some
+                         (fun uu___6 ->
+                            match uu___6 with
+                            | FStar_Syntax_Syntax.TOTAL -> true
+                            | uu___7 -> false) c1.FStar_Syntax_Syntax.flags)
                         &&
                         (let uu___6 = FStar_Options.print_effect_args () in
                          Prims.op_Negation uu___6) in
@@ -1064,13 +1003,12 @@ and (comp_to_string : FStar_Syntax_Syntax.comp -> Prims.string) =
                          (let uu___9 =
                             (let uu___10 = FStar_Options.print_effect_args () in
                              Prims.op_Negation uu___10) &&
-                              (FStar_Compiler_Effect.op_Bar_Greater
-                                 c1.FStar_Syntax_Syntax.flags
-                                 (FStar_Compiler_Util.for_some
-                                    (fun uu___10 ->
-                                       match uu___10 with
-                                       | FStar_Syntax_Syntax.MLEFFECT -> true
-                                       | uu___11 -> false))) in
+                              (FStar_Compiler_Util.for_some
+                                 (fun uu___10 ->
+                                    match uu___10 with
+                                    | FStar_Syntax_Syntax.MLEFFECT -> true
+                                    | uu___11 -> false)
+                                 c1.FStar_Syntax_Syntax.flags) in
                           if uu___9
                           then
                             let uu___10 =
@@ -1087,48 +1025,40 @@ and (comp_to_string : FStar_Syntax_Syntax.comp -> Prims.string) =
                                uu___12)))) in
                let dec =
                  let uu___3 =
-                   FStar_Compiler_Effect.op_Bar_Greater
-                     c1.FStar_Syntax_Syntax.flags
-                     (FStar_Compiler_List.collect
-                        (fun uu___4 ->
-                           match uu___4 with
-                           | FStar_Syntax_Syntax.DECREASES dec_order ->
-                               (match dec_order with
-                                | FStar_Syntax_Syntax.Decreases_lex l ->
-                                    let uu___5 =
-                                      let uu___6 =
-                                        match l with
-                                        | [] -> ""
-                                        | hd::tl ->
-                                            let uu___7 =
-                                              let uu___8 = term_to_string hd in
-                                              FStar_Compiler_List.fold_left
-                                                (fun s ->
-                                                   fun t ->
-                                                     let uu___9 =
-                                                       let uu___10 =
-                                                         term_to_string t in
-                                                       Prims.strcat ";"
-                                                         uu___10 in
-                                                     Prims.strcat s uu___9)
-                                                uu___8 in
-                                            FStar_Compiler_Effect.op_Bar_Greater
-                                              tl uu___7 in
-                                      FStar_Compiler_Util.format1
-                                        " (decreases [%s])" uu___6 in
-                                    [uu___5]
-                                | FStar_Syntax_Syntax.Decreases_wf (rel, e)
-                                    ->
-                                    let uu___5 =
-                                      let uu___6 = term_to_string rel in
-                                      let uu___7 = term_to_string e in
-                                      FStar_Compiler_Util.format2
-                                        "(decreases {:well-founded %s %s})"
-                                        uu___6 uu___7 in
-                                    [uu___5])
-                           | uu___5 -> [])) in
-                 FStar_Compiler_Effect.op_Bar_Greater uu___3
-                   (FStar_Compiler_String.concat " ") in
+                   FStar_Compiler_List.collect
+                     (fun uu___4 ->
+                        match uu___4 with
+                        | FStar_Syntax_Syntax.DECREASES dec_order ->
+                            (match dec_order with
+                             | FStar_Syntax_Syntax.Decreases_lex l ->
+                                 let uu___5 =
+                                   let uu___6 =
+                                     match l with
+                                     | [] -> ""
+                                     | hd::tl ->
+                                         let uu___7 = term_to_string hd in
+                                         FStar_Compiler_List.fold_left
+                                           (fun s ->
+                                              fun t ->
+                                                let uu___8 =
+                                                  let uu___9 =
+                                                    term_to_string t in
+                                                  Prims.strcat ";" uu___9 in
+                                                Prims.strcat s uu___8) uu___7
+                                           tl in
+                                   FStar_Compiler_Util.format1
+                                     " (decreases [%s])" uu___6 in
+                                 [uu___5]
+                             | FStar_Syntax_Syntax.Decreases_wf (rel, e) ->
+                                 let uu___5 =
+                                   let uu___6 = term_to_string rel in
+                                   let uu___7 = term_to_string e in
+                                   FStar_Compiler_Util.format2
+                                     "(decreases {:well-founded %s %s})"
+                                     uu___6 uu___7 in
+                                 [uu___5])
+                        | uu___5 -> []) c1.FStar_Syntax_Syntax.flags in
+                 FStar_Compiler_String.concat " " uu___3 in
                FStar_Compiler_Util.format2 "%s%s" basic dec)
 and (cflag_to_string : FStar_Syntax_Syntax.cflag -> Prims.string) =
   fun c ->
@@ -1154,19 +1084,15 @@ and (metadata_to_string : FStar_Syntax_Syntax.metadata -> Prims.string) =
     | FStar_Syntax_Syntax.Meta_pattern (uu___1, ps) ->
         let pats =
           let uu___2 =
-            FStar_Compiler_Effect.op_Bar_Greater ps
-              (FStar_Compiler_List.map
-                 (fun args ->
-                    let uu___3 =
-                      FStar_Compiler_Effect.op_Bar_Greater args
-                        (FStar_Compiler_List.map
-                           (fun uu___4 ->
-                              match uu___4 with
-                              | (t, uu___5) -> term_to_string t)) in
-                    FStar_Compiler_Effect.op_Bar_Greater uu___3
-                      (FStar_Compiler_String.concat "; "))) in
-          FStar_Compiler_Effect.op_Bar_Greater uu___2
-            (FStar_Compiler_String.concat "\\/") in
+            FStar_Compiler_List.map
+              (fun args ->
+                 let uu___3 =
+                   FStar_Compiler_List.map
+                     (fun uu___4 ->
+                        match uu___4 with | (t, uu___5) -> term_to_string t)
+                     args in
+                 FStar_Compiler_String.concat "; " uu___3) ps in
+          FStar_Compiler_String.concat "\\/" uu___2 in
         FStar_Compiler_Util.format1 "{Meta_pattern %s}" pats
     | FStar_Syntax_Syntax.Meta_named lid ->
         let uu___1 = sli lid in
@@ -1241,8 +1167,7 @@ let (tscheme_to_string : FStar_Syntax_Syntax.tscheme -> Prims.string) =
        match uu___2 with
        | (us, t) ->
            let uu___3 =
-             let uu___4 = univ_names_to_string us in
-             FStar_Compiler_Effect.op_Less_Bar enclose_universes uu___4 in
+             let uu___4 = univ_names_to_string us in enclose_universes uu___4 in
            let uu___4 = term_to_string t in
            FStar_Compiler_Util.format2 "%s%s" uu___3 uu___4)
 let (action_to_string : FStar_Syntax_Syntax.action -> Prims.string) =
@@ -1251,7 +1176,7 @@ let (action_to_string : FStar_Syntax_Syntax.action -> Prims.string) =
     let uu___1 = binders_to_string " " a.FStar_Syntax_Syntax.action_params in
     let uu___2 =
       let uu___3 = univ_names_to_string a.FStar_Syntax_Syntax.action_univs in
-      FStar_Compiler_Effect.op_Less_Bar enclose_universes uu___3 in
+      enclose_universes uu___3 in
     let uu___3 = term_to_string a.FStar_Syntax_Syntax.action_typ in
     let uu___4 = term_to_string a.FStar_Syntax_Syntax.action_defn in
     FStar_Compiler_Util.format5 "%s%s %s : %s = %s" uu___ uu___1 uu___2
@@ -1371,10 +1296,9 @@ let (layered_eff_combinators_to_string :
                   else
                     (let uu___13 =
                        let uu___14 =
-                         FStar_Compiler_Effect.op_Bar_Greater
-                           combs.FStar_Syntax_Syntax.l_close
-                           FStar_Compiler_Util.must in
-                       FStar_Compiler_Effect.op_Bar_Greater uu___14 to_str2 in
+                         FStar_Compiler_Util.must
+                           combs.FStar_Syntax_Syntax.l_close in
+                       to_str2 uu___14 in
                      FStar_Compiler_Util.format1 "; l_close = %s\n" uu___13) in
                 [uu___11] in
               uu___9 :: uu___10 in
@@ -1419,11 +1343,8 @@ let (eff_decl_to_string' :
           then FStar_Syntax_Print_Pretty.eff_decl_to_string' for_free r q ed
           else
             (let actions_to_string actions =
-               let uu___2 =
-                 FStar_Compiler_Effect.op_Bar_Greater actions
-                   (FStar_Compiler_List.map action_to_string) in
-               FStar_Compiler_Effect.op_Bar_Greater uu___2
-                 (FStar_Compiler_String.concat ",\n\t") in
+               let uu___2 = FStar_Compiler_List.map action_to_string actions in
+               FStar_Compiler_String.concat ",\n\t" uu___2 in
              let eff_name =
                let uu___2 = FStar_Syntax_Util.is_layered ed in
                if uu___2 then "layered_effect" else "new_effect" in
@@ -1435,19 +1356,16 @@ let (eff_decl_to_string' :
                      let uu___7 =
                        let uu___8 =
                          univ_names_to_string ed.FStar_Syntax_Syntax.univs in
-                       FStar_Compiler_Effect.op_Less_Bar enclose_universes
-                         uu___8 in
+                       enclose_universes uu___8 in
                      let uu___8 =
                        let uu___9 =
                          binders_to_string " " ed.FStar_Syntax_Syntax.binders in
                        let uu___10 =
                          let uu___11 =
                            let uu___12 =
-                             FStar_Compiler_Effect.op_Bar_Greater
-                               ed.FStar_Syntax_Syntax.signature
-                               FStar_Syntax_Util.effect_sig_ts in
-                           FStar_Compiler_Effect.op_Bar_Greater uu___12
-                             tscheme_to_string in
+                             FStar_Syntax_Util.effect_sig_ts
+                               ed.FStar_Syntax_Syntax.signature in
+                           tscheme_to_string uu___12 in
                          let uu___12 =
                            let uu___13 =
                              eff_combinators_to_string
@@ -1477,10 +1395,8 @@ let (sub_eff_to_string : FStar_Syntax_Syntax.sub_eff -> Prims.string) =
     let tsopt_to_string ts_opt =
       if FStar_Compiler_Util.is_some ts_opt
       then
-        let uu___ =
-          FStar_Compiler_Effect.op_Bar_Greater ts_opt
-            FStar_Compiler_Util.must in
-        FStar_Compiler_Effect.op_Bar_Greater uu___ tscheme_to_string
+        let uu___ = FStar_Compiler_Util.must ts_opt in
+        tscheme_to_string uu___
       else "<None>" in
     let uu___ = lid_to_string se.FStar_Syntax_Syntax.source in
     let uu___1 = lid_to_string se.FStar_Syntax_Syntax.target in
@@ -1619,8 +1535,7 @@ let rec (sigelt_to_string : FStar_Syntax_Syntax.sigelt -> Prims.string) =
              ->
              let uu___3 =
                let uu___4 = FStar_Compiler_List.map sigelt_to_string ses in
-               FStar_Compiler_Effect.op_Bar_Greater uu___4
-                 (FStar_Compiler_String.concat "\n") in
+               FStar_Compiler_String.concat "\n" uu___4 in
              Prims.strcat "(* Sig_bundle *)" uu___3
          | FStar_Syntax_Syntax.Sig_fail
              { FStar_Syntax_Syntax.errs = errs;
@@ -1633,8 +1548,7 @@ let rec (sigelt_to_string : FStar_Syntax_Syntax.sigelt -> Prims.string) =
                  FStar_Compiler_Util.string_of_int errs in
              let uu___4 =
                let uu___5 = FStar_Compiler_List.map sigelt_to_string ses in
-               FStar_Compiler_Effect.op_Bar_Greater uu___5
-                 (FStar_Compiler_String.concat "\n") in
+               FStar_Compiler_String.concat "\n" uu___5 in
              FStar_Compiler_Util.format3
                "(* Sig_fail %s %s *)\n%s\n(* / Sig_fail*)\n" uu___2 uu___3
                uu___4
@@ -1694,8 +1608,7 @@ let rec (sigelt_to_string : FStar_Syntax_Syntax.sigelt -> Prims.string) =
              let uu___2 =
                let uu___3 =
                  FStar_Compiler_List.map FStar_Ident.string_of_lid lids in
-               FStar_Compiler_Effect.op_Less_Bar
-                 (FStar_Compiler_String.concat "; ") uu___3 in
+               FStar_Compiler_String.concat "; " uu___3 in
              let uu___3 = term_to_string t in
              FStar_Compiler_Util.format3 "splice%s[%s] (%s)"
                (if is_typed then "_t" else "") uu___2 uu___3
@@ -1824,16 +1737,15 @@ let rec (sigelt_to_string_short : FStar_Syntax_Syntax.sigelt -> Prims.string)
         { FStar_Syntax_Syntax.ses = ses; FStar_Syntax_Syntax.lids = uu___;_}
         ->
         let uu___1 = FStar_Compiler_List.hd ses in
-        FStar_Compiler_Effect.op_Bar_Greater uu___1 sigelt_to_string_short
+        sigelt_to_string_short uu___1
     | FStar_Syntax_Syntax.Sig_fail
         { FStar_Syntax_Syntax.errs = uu___;
           FStar_Syntax_Syntax.fail_in_lax = uu___1;
           FStar_Syntax_Syntax.ses1 = ses;_}
         ->
         let uu___2 =
-          let uu___3 =
-            FStar_Compiler_Effect.op_Bar_Greater ses FStar_Compiler_List.hd in
-          FStar_Compiler_Effect.op_Bar_Greater uu___3 sigelt_to_string_short in
+          let uu___3 = FStar_Compiler_List.hd ses in
+          sigelt_to_string_short uu___3 in
         FStar_Compiler_Util.format1 "[@@expect_failure] %s" uu___2
     | FStar_Syntax_Syntax.Sig_new_effect ed ->
         let kw =
@@ -1865,8 +1777,7 @@ let rec (sigelt_to_string_short : FStar_Syntax_Syntax.sigelt -> Prims.string)
         ->
         let uu___1 =
           let uu___2 = FStar_Compiler_List.map FStar_Ident.string_of_lid lids in
-          FStar_Compiler_Effect.op_Less_Bar
-            (FStar_Compiler_String.concat "; ") uu___2 in
+          FStar_Compiler_String.concat "; " uu___2 in
         FStar_Compiler_Util.format3 "%splice%s[%s] (...)" "%s"
           (if is_typed then "_t" else "") uu___1
     | FStar_Syntax_Syntax.Sig_polymonadic_bind
@@ -1915,14 +1826,12 @@ let (modul_to_string : FStar_Syntax_Syntax.modul -> Prims.string) =
       let uu___2 =
         FStar_Compiler_List.map sigelt_to_string
           m.FStar_Syntax_Syntax.declarations in
-      FStar_Compiler_Effect.op_Bar_Greater uu___2
-        (FStar_Compiler_String.concat "\n") in
+      FStar_Compiler_String.concat "\n" uu___2 in
     let uu___2 =
       let uu___3 =
         FStar_Compiler_List.map sigelt_to_string
           m.FStar_Syntax_Syntax.declarations in
-      FStar_Compiler_Effect.op_Bar_Greater uu___3
-        (FStar_Compiler_String.concat "\n") in
+      FStar_Compiler_String.concat "\n" uu___3 in
     FStar_Compiler_Util.format3
       "module %s\nDeclarations: [\n%s\n]\nExports: [\n%s\n]\n" uu___ uu___1
       uu___2

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Resugar.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Resugar.ml
@@ -52,23 +52,19 @@ let (filter_imp :
 let (filter_imp_args : FStar_Syntax_Syntax.args -> FStar_Syntax_Syntax.args)
   =
   fun args ->
-    FStar_Compiler_Effect.op_Bar_Greater args
-      (FStar_Compiler_List.filter
-         (fun uu___ ->
-            match uu___ with
-            | (uu___1, FStar_Pervasives_Native.None) -> true
-            | (uu___1, FStar_Pervasives_Native.Some arg) ->
-                Prims.op_Negation arg.FStar_Syntax_Syntax.aqual_implicit))
+    FStar_Compiler_List.filter
+      (fun uu___ ->
+         match uu___ with
+         | (uu___1, FStar_Pervasives_Native.None) -> true
+         | (uu___1, FStar_Pervasives_Native.Some arg) ->
+             Prims.op_Negation arg.FStar_Syntax_Syntax.aqual_implicit) args
 let (filter_imp_bs :
   FStar_Syntax_Syntax.binder Prims.list ->
     FStar_Syntax_Syntax.binder Prims.list)
   =
   fun bs ->
-    FStar_Compiler_Effect.op_Bar_Greater bs
-      (FStar_Compiler_List.filter
-         (fun b ->
-            FStar_Compiler_Effect.op_Bar_Greater
-              b.FStar_Syntax_Syntax.binder_qual filter_imp))
+    FStar_Compiler_List.filter
+      (fun b -> filter_imp b.FStar_Syntax_Syntax.binder_qual) bs
 let filter_pattern_imp :
   'uuuuu .
     ('uuuuu * Prims.bool) Prims.list -> ('uuuuu * Prims.bool) Prims.list
@@ -105,8 +101,7 @@ let (universe_to_string : FStar_Ident.ident Prims.list -> Prims.string) =
     then
       let uu___1 =
         FStar_Compiler_List.map (fun x -> FStar_Ident.string_of_id x) univs in
-      FStar_Compiler_Effect.op_Bar_Greater uu___1
-        (FStar_Compiler_String.concat ", ")
+      FStar_Compiler_String.concat ", " uu___1
     else ""
 let rec (resugar_universe :
   FStar_Syntax_Syntax.universe ->
@@ -227,11 +222,10 @@ let rec (resugar_term_as_op :
       (FStar_Parser_Const.calc_finish_lid, "calc_finish")] in
     let fallback fv =
       let uu___ =
-        FStar_Compiler_Effect.op_Bar_Greater infix_prim_ops
-          (FStar_Compiler_Util.find_opt
-             (fun d ->
-                FStar_Syntax_Syntax.fv_eq_lid fv
-                  (FStar_Pervasives_Native.fst d))) in
+        FStar_Compiler_Util.find_opt
+          (fun d ->
+             FStar_Syntax_Syntax.fv_eq_lid fv (FStar_Pervasives_Native.fst d))
+          infix_prim_ops in
       match uu___ with
       | FStar_Pervasives_Native.Some op ->
           FStar_Pervasives_Native.Some
@@ -626,19 +620,15 @@ let rec (resugar_term' :
                  if uu___3
                  then xs1
                  else
-                   FStar_Compiler_Effect.op_Bar_Greater xs1
-                     (FStar_Compiler_List.filter
-                        (fun x ->
-                           FStar_Compiler_Effect.op_Bar_Greater
-                             x.FStar_Syntax_Syntax.binder_qual filter_imp)) in
+                   FStar_Compiler_List.filter
+                     (fun x -> filter_imp x.FStar_Syntax_Syntax.binder_qual)
+                     xs1 in
                let body_bv = FStar_Syntax_Free.names body1 in
                let patterns =
-                 FStar_Compiler_Effect.op_Bar_Greater xs2
-                   (FStar_Compiler_List.choose
-                      (fun x ->
-                         resugar_bv_as_pat env
-                           x.FStar_Syntax_Syntax.binder_bv
-                           x.FStar_Syntax_Syntax.binder_qual body_bv)) in
+                 FStar_Compiler_List.choose
+                   (fun x ->
+                      resugar_bv_as_pat env x.FStar_Syntax_Syntax.binder_bv
+                        x.FStar_Syntax_Syntax.binder_qual body_bv) xs2 in
                let body2 = resugar_term' env body1 in
                if FStar_Compiler_List.isEmpty patterns
                then body2
@@ -669,13 +659,11 @@ let rec (resugar_term' :
                     let body2 = resugar_comp' env body1 in
                     let xs3 =
                       let uu___4 =
-                        FStar_Compiler_Effect.op_Bar_Greater xs2
-                          ((map_opt ())
-                             (fun b ->
-                                resugar_binder' env b
-                                  t.FStar_Syntax_Syntax.pos)) in
-                      FStar_Compiler_Effect.op_Bar_Greater uu___4
-                        FStar_Compiler_List.rev in
+                        (map_opt ())
+                          (fun b ->
+                             resugar_binder' env b t.FStar_Syntax_Syntax.pos)
+                          xs2 in
+                      FStar_Compiler_List.rev uu___4 in
                     let rec aux body3 uu___4 =
                       match uu___4 with
                       | [] -> body3
@@ -981,11 +969,10 @@ let rec (resugar_term' :
                             let uu___6 = FStar_Options.print_implicits () in
                             if uu___6 then xs1 else filter_imp_bs xs1 in
                           let xs3 =
-                            FStar_Compiler_Effect.op_Bar_Greater xs2
-                              ((map_opt ())
-                                 (fun b ->
-                                    resugar_binder' env b
-                                      t.FStar_Syntax_Syntax.pos)) in
+                            (map_opt ())
+                              (fun b ->
+                                 resugar_binder' env b
+                                   t.FStar_Syntax_Syntax.pos) xs2 in
                           let uu___6 =
                             let uu___7 =
                               let uu___8 = FStar_Syntax_Subst.compress body2 in
@@ -1003,14 +990,12 @@ let rec (resugar_term' :
                                       let uu___10 =
                                         FStar_Compiler_List.map
                                           (fun es ->
-                                             FStar_Compiler_Effect.op_Bar_Greater
-                                               es
-                                               (FStar_Compiler_List.map
-                                                  (fun uu___11 ->
-                                                     match uu___11 with
-                                                     | (e2, uu___12) ->
-                                                         resugar_term' env e2)))
-                                          pats in
+                                             FStar_Compiler_List.map
+                                               (fun uu___11 ->
+                                                  match uu___11 with
+                                                  | (e2, uu___12) ->
+                                                      resugar_term' env e2)
+                                               es) pats in
                                       (uu___10, body3)
                                   | FStar_Syntax_Syntax.Meta_labeled
                                       (s, r, p) ->
@@ -1106,14 +1091,13 @@ let rec (resugar_term' :
            | FStar_Pervasives_Native.Some (op, expected_arity1) ->
                let op1 = FStar_Ident.id_of_text op in
                let resugar args2 =
-                 FStar_Compiler_Effect.op_Bar_Greater args2
-                   (FStar_Compiler_List.map
-                      (fun uu___2 ->
-                         match uu___2 with
-                         | (e1, qual) ->
-                             let uu___3 = resugar_term' env e1 in
-                             let uu___4 = resugar_aqual env qual in
-                             (uu___3, uu___4))) in
+                 FStar_Compiler_List.map
+                   (fun uu___2 ->
+                      match uu___2 with
+                      | (e1, qual) ->
+                          let uu___3 = resugar_term' env e1 in
+                          let uu___4 = resugar_aqual env qual in
+                          (uu___3, uu___4)) args2 in
                (match expected_arity1 with
                 | FStar_Pervasives_Native.None ->
                     let resugared_args = resugar args1 in
@@ -1310,32 +1294,28 @@ let rec (resugar_term' :
                                       if is_pat_app
                                       then
                                         let args =
-                                          FStar_Compiler_Effect.op_Bar_Greater
-                                            binders
-                                            ((map_opt ())
-                                               (fun b ->
-                                                  let uu___7 =
-                                                    resugar_bqual env
-                                                      b.FStar_Syntax_Syntax.binder_qual in
-                                                  FStar_Compiler_Util.map_opt
-                                                    uu___7
-                                                    (fun q ->
-                                                       let uu___8 =
-                                                         let uu___9 =
-                                                           let uu___10 =
-                                                             bv_as_unique_ident
-                                                               b.FStar_Syntax_Syntax.binder_bv in
-                                                           let uu___11 =
-                                                             FStar_Compiler_Effect.op_Bar_Greater
-                                                               b.FStar_Syntax_Syntax.binder_attrs
-                                                               (FStar_Compiler_List.map
-                                                                  (resugar_term'
-                                                                    env)) in
-                                                           (uu___10, q,
-                                                             uu___11) in
-                                                         FStar_Parser_AST.PatVar
-                                                           uu___9 in
-                                                       mk_pat uu___8))) in
+                                          (map_opt ())
+                                            (fun b ->
+                                               let uu___7 =
+                                                 resugar_bqual env
+                                                   b.FStar_Syntax_Syntax.binder_qual in
+                                               FStar_Compiler_Util.map_opt
+                                                 uu___7
+                                                 (fun q ->
+                                                    let uu___8 =
+                                                      let uu___9 =
+                                                        let uu___10 =
+                                                          bv_as_unique_ident
+                                                            b.FStar_Syntax_Syntax.binder_bv in
+                                                        let uu___11 =
+                                                          FStar_Compiler_List.map
+                                                            (resugar_term'
+                                                               env)
+                                                            b.FStar_Syntax_Syntax.binder_attrs in
+                                                        (uu___10, q, uu___11) in
+                                                      FStar_Parser_AST.PatVar
+                                                        uu___9 in
+                                                    mk_pat uu___8)) binders in
                                         let uu___7 =
                                           let uu___8 =
                                             mk_pat
@@ -1385,8 +1365,7 @@ let rec (resugar_term' :
               let uu___3 =
                 FStar_Syntax_Unionfind.uvar_id
                   u.FStar_Syntax_Syntax.ctx_uvar_head in
-              FStar_Compiler_Effect.op_Bar_Greater uu___3
-                FStar_Compiler_Util.string_of_int in
+              FStar_Compiler_Util.string_of_int uu___3 in
             Prims.strcat "?u" uu___2 in
           let uu___2 = mk FStar_Parser_AST.Wild in label s uu___2
       | FStar_Syntax_Syntax.Tm_quoted (tm, qi) ->
@@ -1425,12 +1404,10 @@ let rec (resugar_term' :
           (match m with
            | FStar_Syntax_Syntax.Meta_pattern (uu___1, pats) ->
                let pats1 =
-                 FStar_Compiler_Effect.op_Bar_Greater
-                   (FStar_Compiler_List.flatten pats)
-                   (FStar_Compiler_List.map
-                      (fun uu___2 ->
-                         match uu___2 with
-                         | (x, uu___3) -> resugar_term' env x)) in
+                 FStar_Compiler_List.map
+                   (fun uu___2 ->
+                      match uu___2 with | (x, uu___3) -> resugar_term' env x)
+                   (FStar_Compiler_List.flatten pats) in
                mk (FStar_Parser_AST.Attributes pats1)
            | FStar_Syntax_Syntax.Meta_labeled uu___1 -> resugar_term' env e
            | FStar_Syntax_Syntax.Meta_desugared i -> resugar_meta_desugared i
@@ -1557,9 +1534,7 @@ and (resugar_calc :
                              let uu___5 =
                                FStar_Syntax_Util.mk_app e
                                  (FStar_Compiler_List.rev rest) in
-                             FStar_Compiler_Effect.op_Less_Bar
-                               (fun uu___6 ->
-                                  FStar_Pervasives_Native.Some uu___6) uu___5
+                             FStar_Pervasives_Native.Some uu___5
                            else FStar_Pervasives_Native.Some rel
                        | uu___4 -> FStar_Pervasives_Native.Some rel)
                   | uu___4 -> FStar_Pervasives_Native.Some rel))
@@ -1711,9 +1686,7 @@ and (resugar_calc :
                              let uu___5 =
                                build_calc rel x0
                                  (FStar_Compiler_List.rev steps) in
-                             FStar_Compiler_Effect.op_Less_Bar
-                               (fun uu___6 ->
-                                  FStar_Pervasives_Native.Some uu___6) uu___5)))
+                             FStar_Pervasives_Native.Some uu___5)))
 and (resugar_match_returns :
   FStar_Syntax_DsEnv.env ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
@@ -1750,8 +1723,7 @@ and (resugar_match_returns :
                       let uu___3 =
                         let uu___4 =
                           let uu___5 = FStar_Syntax_Subst.compress scrutinee in
-                          FStar_Compiler_Effect.op_Bar_Greater uu___5
-                            FStar_Syntax_Util.unascribe in
+                          FStar_Syntax_Util.unascribe uu___5 in
                         uu___4.FStar_Syntax_Syntax.n in
                       (match uu___3 with
                        | FStar_Syntax_Syntax.Tm_name sbv ->
@@ -1777,8 +1749,7 @@ and (resugar_match_returns :
                           let uu___1 =
                             let uu___2 = resugar_binder' env b1 r in
                             FStar_Compiler_Util.must uu___2 in
-                          FStar_Compiler_Effect.op_Bar_Greater uu___1
-                            (FStar_Parser_AST.ident_of_binder r)) bopt in
+                          FStar_Parser_AST.ident_of_binder r uu___1) bopt in
                    let uu___1 =
                      let uu___2 = resugar_ascription env asc1 in
                      match uu___2 with
@@ -1835,9 +1806,8 @@ and (resugar_comp' :
                          | FStar_Syntax_Syntax.Decreases_lex ts ->
                              let uu___1 =
                                let uu___2 =
-                                 FStar_Compiler_Effect.op_Bar_Greater ts
-                                   (FStar_Compiler_List.map
-                                      (resugar_term' env)) in
+                                 FStar_Compiler_List.map (resugar_term' env)
+                                   ts in
                                FStar_Parser_AST.LexList uu___2 in
                              mk uu___1
                          | FStar_Syntax_Syntax.Decreases_wf (rel, e) ->
@@ -2061,8 +2031,7 @@ and (resugar_bv_as_pat :
                let uu___1 =
                  let uu___2 =
                    FStar_Syntax_Subst.compress x.FStar_Syntax_Syntax.sort in
-                 FStar_Compiler_Effect.op_Less_Bar
-                   (fun uu___3 -> FStar_Pervasives_Native.Some uu___3) uu___2 in
+                 FStar_Pervasives_Native.Some uu___2 in
                resugar_bv_as_pat' env x bq body_bv uu___1)
 and (resugar_pat' :
   FStar_Syntax_DsEnv.env ->
@@ -2162,8 +2131,7 @@ and (resugar_pat' :
                    ((let uu___3 =
                        let uu___4 =
                          let uu___5 =
-                           FStar_Compiler_Effect.op_Less_Bar
-                             FStar_Compiler_Util.string_of_int
+                           FStar_Compiler_Util.string_of_int
                              (FStar_Compiler_List.length args') in
                          FStar_Compiler_Util.format1
                            "Prims.Cons applied to %s explicit arguments"
@@ -2178,17 +2146,16 @@ and (resugar_pat' :
                 && (may_drop_implicits args)
               ->
               let args1 =
-                FStar_Compiler_Effect.op_Bar_Greater args
-                  (FStar_Compiler_List.filter_map
-                     (fun uu___1 ->
-                        match uu___1 with
-                        | (p2, is_implicit) ->
-                            if is_implicit
-                            then FStar_Pervasives_Native.None
-                            else
-                              (let uu___3 =
-                                 aux p2 (FStar_Pervasives_Native.Some false) in
-                               FStar_Pervasives_Native.Some uu___3))) in
+                FStar_Compiler_List.filter_map
+                  (fun uu___1 ->
+                     match uu___1 with
+                     | (p2, is_implicit) ->
+                         if is_implicit
+                         then FStar_Pervasives_Native.None
+                         else
+                           (let uu___3 =
+                              aux p2 (FStar_Pervasives_Native.Some false) in
+                            FStar_Pervasives_Native.Some uu___3)) args in
               let is_dependent_tuple =
                 FStar_Parser_Const.is_dtuple_data_lid'
                   (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
@@ -2202,21 +2169,17 @@ and (resugar_pat' :
               ->
               let fields1 =
                 let uu___3 =
-                  FStar_Compiler_Effect.op_Bar_Greater fields
-                    (FStar_Compiler_List.map
-                       (fun f -> FStar_Ident.lid_of_ids [f])) in
-                FStar_Compiler_Effect.op_Bar_Greater uu___3
-                  FStar_Compiler_List.rev in
+                  FStar_Compiler_List.map
+                    (fun f -> FStar_Ident.lid_of_ids [f]) fields in
+                FStar_Compiler_List.rev uu___3 in
               let args1 =
                 let uu___3 =
-                  FStar_Compiler_Effect.op_Bar_Greater args
-                    (FStar_Compiler_List.map
-                       (fun uu___4 ->
-                          match uu___4 with
-                          | (p2, b) ->
-                              aux p2 (FStar_Pervasives_Native.Some b))) in
-                FStar_Compiler_Effect.op_Bar_Greater uu___3
-                  FStar_Compiler_List.rev in
+                  FStar_Compiler_List.map
+                    (fun uu___4 ->
+                       match uu___4 with
+                       | (p2, b) -> aux p2 (FStar_Pervasives_Native.Some b))
+                    args in
+                FStar_Compiler_List.rev uu___3 in
               let rec map2 l1 l2 =
                 match (l1, l2) with
                 | ([], []) -> []
@@ -2233,8 +2196,7 @@ and (resugar_pat' :
                     let uu___3 = map2 tl1 tl2 in (hd1, hd2) :: uu___3 in
               let args2 =
                 let uu___3 = map2 fields1 args1 in
-                FStar_Compiler_Effect.op_Bar_Greater uu___3
-                  FStar_Compiler_List.rev in
+                FStar_Compiler_List.rev uu___3 in
               mk (FStar_Parser_AST.PatRecord args2)
           | FStar_Syntax_Syntax.Pat_cons (fv, uu___, args) ->
               resugar_plain_pat_cons fv args
@@ -2384,38 +2346,35 @@ let (resugar_typ :
               FStar_Syntax_Syntax.ds = datacons;_}
             ->
             let uu___2 =
-              FStar_Compiler_Effect.op_Bar_Greater datacon_ses
-                (FStar_Compiler_List.partition
-                   (fun se1 ->
-                      match se1.FStar_Syntax_Syntax.sigel with
-                      | FStar_Syntax_Syntax.Sig_datacon
-                          { FStar_Syntax_Syntax.lid1 = uu___3;
-                            FStar_Syntax_Syntax.us1 = uu___4;
-                            FStar_Syntax_Syntax.t1 = uu___5;
-                            FStar_Syntax_Syntax.ty_lid = inductive_lid;
-                            FStar_Syntax_Syntax.num_ty_params = uu___6;
-                            FStar_Syntax_Syntax.mutuals1 = uu___7;_}
-                          -> FStar_Ident.lid_equals inductive_lid tylid
-                      | uu___3 -> FStar_Compiler_Effect.failwith "unexpected")) in
+              FStar_Compiler_List.partition
+                (fun se1 ->
+                   match se1.FStar_Syntax_Syntax.sigel with
+                   | FStar_Syntax_Syntax.Sig_datacon
+                       { FStar_Syntax_Syntax.lid1 = uu___3;
+                         FStar_Syntax_Syntax.us1 = uu___4;
+                         FStar_Syntax_Syntax.t1 = uu___5;
+                         FStar_Syntax_Syntax.ty_lid = inductive_lid;
+                         FStar_Syntax_Syntax.num_ty_params = uu___6;
+                         FStar_Syntax_Syntax.mutuals1 = uu___7;_}
+                       -> FStar_Ident.lid_equals inductive_lid tylid
+                   | uu___3 -> FStar_Compiler_Effect.failwith "unexpected")
+                datacon_ses in
             (match uu___2 with
              | (current_datacons, other_datacons) ->
                  let bs1 =
                    let uu___3 = FStar_Options.print_implicits () in
                    if uu___3 then bs else filter_imp_bs bs in
                  let bs2 =
-                   FStar_Compiler_Effect.op_Bar_Greater bs1
-                     ((map_opt ())
-                        (fun b ->
-                           resugar_binder' env b t.FStar_Syntax_Syntax.pos)) in
+                   (map_opt ())
+                     (fun b ->
+                        resugar_binder' env b t.FStar_Syntax_Syntax.pos) bs1 in
                  let tyc =
                    let uu___3 =
-                     FStar_Compiler_Effect.op_Bar_Greater
-                       se.FStar_Syntax_Syntax.sigquals
-                       (FStar_Compiler_Util.for_some
-                          (fun uu___4 ->
-                             match uu___4 with
-                             | FStar_Syntax_Syntax.RecordType uu___5 -> true
-                             | uu___5 -> false)) in
+                     FStar_Compiler_Util.for_some
+                       (fun uu___4 ->
+                          match uu___4 with
+                          | FStar_Syntax_Syntax.RecordType uu___5 -> true
+                          | uu___5 -> false) se.FStar_Syntax_Syntax.sigquals in
                    if uu___3
                    then
                      let resugar_datacon_as_fields fields se1 =
@@ -2437,31 +2396,27 @@ let (resugar_typ :
                                   FStar_Syntax_Syntax.comp = uu___8;_}
                                 ->
                                 let mfields =
-                                  FStar_Compiler_Effect.op_Bar_Greater bs3
-                                    (FStar_Compiler_List.collect
-                                       (fun b ->
-                                          let uu___9 =
-                                            resugar_bqual env
-                                              b.FStar_Syntax_Syntax.binder_qual in
-                                          match uu___9 with
-                                          | FStar_Pervasives_Native.None ->
-                                              []
-                                          | FStar_Pervasives_Native.Some q ->
-                                              let uu___10 =
-                                                let uu___11 =
-                                                  bv_as_unique_ident
-                                                    b.FStar_Syntax_Syntax.binder_bv in
-                                                let uu___12 =
-                                                  FStar_Compiler_Effect.op_Bar_Greater
-                                                    b.FStar_Syntax_Syntax.binder_attrs
-                                                    (FStar_Compiler_List.map
-                                                       (resugar_term' env)) in
-                                                let uu___13 =
-                                                  resugar_term' env
-                                                    (b.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort in
-                                                (uu___11, q, uu___12,
-                                                  uu___13) in
-                                              [uu___10])) in
+                                  FStar_Compiler_List.collect
+                                    (fun b ->
+                                       let uu___9 =
+                                         resugar_bqual env
+                                           b.FStar_Syntax_Syntax.binder_qual in
+                                       match uu___9 with
+                                       | FStar_Pervasives_Native.None -> []
+                                       | FStar_Pervasives_Native.Some q ->
+                                           let uu___10 =
+                                             let uu___11 =
+                                               bv_as_unique_ident
+                                                 b.FStar_Syntax_Syntax.binder_bv in
+                                             let uu___12 =
+                                               FStar_Compiler_List.map
+                                                 (resugar_term' env)
+                                                 b.FStar_Syntax_Syntax.binder_attrs in
+                                             let uu___13 =
+                                               resugar_term' env
+                                                 (b.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort in
+                                             (uu___11, q, uu___12, uu___13) in
+                                           [uu___10]) bs3 in
                                 FStar_Compiler_List.op_At mfields fields
                             | uu___8 ->
                                 FStar_Compiler_Effect.failwith "unexpected")
@@ -2698,10 +2653,9 @@ let (resugar_eff_decl' :
                        else filter_imp_bs action_params in
                      let action_params2 =
                        let uu___2 =
-                         FStar_Compiler_Effect.op_Bar_Greater action_params1
-                           ((map_opt ()) (fun b -> resugar_binder' env b r)) in
-                       FStar_Compiler_Effect.op_Bar_Greater uu___2
-                         FStar_Compiler_List.rev in
+                         (map_opt ()) (fun b -> resugar_binder' env b r)
+                           action_params1 in
+                       FStar_Compiler_List.rev uu___2 in
                      let action_defn1 = resugar_term' env action_defn in
                      let action_typ1 = resugar_term' env action_typ in
                      if for_free
@@ -2753,11 +2707,8 @@ let (resugar_eff_decl' :
             let sig_ts =
               FStar_Syntax_Util.effect_sig_ts
                 ed.FStar_Syntax_Syntax.signature in
-            let uu___1 =
-              FStar_Compiler_Effect.op_Bar_Greater sig_ts
-                FStar_Pervasives_Native.snd in
             FStar_Syntax_Subst.open_term ed.FStar_Syntax_Syntax.binders
-              uu___1 in
+              (FStar_Pervasives_Native.snd sig_ts) in
           match uu___ with
           | (eff_binders, eff_typ) ->
               let eff_binders1 =
@@ -2765,17 +2716,15 @@ let (resugar_eff_decl' :
                 if uu___1 then eff_binders else filter_imp_bs eff_binders in
               let eff_binders2 =
                 let uu___1 =
-                  FStar_Compiler_Effect.op_Bar_Greater eff_binders1
-                    ((map_opt ()) (fun b -> resugar_binder' env b r)) in
-                FStar_Compiler_Effect.op_Bar_Greater uu___1
-                  FStar_Compiler_List.rev in
+                  (map_opt ()) (fun b -> resugar_binder' env b r)
+                    eff_binders1 in
+                FStar_Compiler_List.rev uu___1 in
               let eff_typ1 = resugar_term' env eff_typ in
               let mandatory_members_decls =
                 resugar_combinators env ed.FStar_Syntax_Syntax.combinators in
               let actions =
-                FStar_Compiler_Effect.op_Bar_Greater
-                  ed.FStar_Syntax_Syntax.actions
-                  (FStar_Compiler_List.map (fun a -> resugar_action a false)) in
+                FStar_Compiler_List.map (fun a -> resugar_action a false)
+                  ed.FStar_Syntax_Syntax.actions in
               let decls =
                 FStar_Compiler_List.op_At mandatory_members_decls actions in
               mk_decl r q
@@ -2795,16 +2744,16 @@ let (resugar_sigelt' :
             FStar_Syntax_Syntax.lids = uu___;_}
           ->
           let uu___1 =
-            FStar_Compiler_Effect.op_Bar_Greater ses
-              (FStar_Compiler_List.partition
-                 (fun se1 ->
-                    match se1.FStar_Syntax_Syntax.sigel with
-                    | FStar_Syntax_Syntax.Sig_inductive_typ uu___2 -> true
-                    | FStar_Syntax_Syntax.Sig_declare_typ uu___2 -> true
-                    | FStar_Syntax_Syntax.Sig_datacon uu___2 -> false
-                    | uu___2 ->
-                        FStar_Compiler_Effect.failwith
-                          "Found a sigelt which is neither a type declaration or a data constructor in a sigelt")) in
+            FStar_Compiler_List.partition
+              (fun se1 ->
+                 match se1.FStar_Syntax_Syntax.sigel with
+                 | FStar_Syntax_Syntax.Sig_inductive_typ uu___2 -> true
+                 | FStar_Syntax_Syntax.Sig_declare_typ uu___2 -> true
+                 | FStar_Syntax_Syntax.Sig_datacon uu___2 -> false
+                 | uu___2 ->
+                     FStar_Compiler_Effect.failwith
+                       "Found a sigelt which is neither a type declaration or a data constructor in a sigelt")
+              ses in
           (match uu___1 with
            | (decl_typ_ses, datacon_ses) ->
                let retrieve_datacons_and_resugar uu___2 se1 =
@@ -2855,14 +2804,12 @@ let (resugar_sigelt' :
             FStar_Syntax_Syntax.lids1 = uu___;_}
           ->
           let uu___1 =
-            FStar_Compiler_Effect.op_Bar_Greater
-              se.FStar_Syntax_Syntax.sigquals
-              (FStar_Compiler_Util.for_some
-                 (fun uu___2 ->
-                    match uu___2 with
-                    | FStar_Syntax_Syntax.Projector (uu___3, uu___4) -> true
-                    | FStar_Syntax_Syntax.Discriminator uu___3 -> true
-                    | uu___3 -> false)) in
+            FStar_Compiler_Util.for_some
+              (fun uu___2 ->
+                 match uu___2 with
+                 | FStar_Syntax_Syntax.Projector (uu___3, uu___4) -> true
+                 | FStar_Syntax_Syntax.Discriminator uu___3 -> true
+                 | uu___3 -> false) se.FStar_Syntax_Syntax.sigquals in
           if uu___1
           then FStar_Pervasives_Native.None
           else
@@ -2890,7 +2837,7 @@ let (resugar_sigelt' :
                               let uu___6 =
                                 FStar_Compiler_Util.right
                                   lb.FStar_Syntax_Syntax.lbname in
-                              FStar_Compiler_Effect.op_Less_Bar nopath uu___6 in
+                              nopath uu___6 in
                             FStar_Pervasives.Inr uu___5 in
                           {
                             FStar_Syntax_Syntax.lbname = uu___4;
@@ -2995,10 +2942,10 @@ let (resugar_sigelt' :
                  let uu___1 = FStar_Options.print_implicits () in
                  if uu___1 then bs1 else filter_imp_bs bs1 in
                let bs3 =
-                 FStar_Compiler_Effect.op_Bar_Greater bs2
-                   ((map_opt ())
-                      (fun b ->
-                         resugar_binder' env b se.FStar_Syntax_Syntax.sigrng)) in
+                 (map_opt ())
+                   (fun b ->
+                      resugar_binder' env b se.FStar_Syntax_Syntax.sigrng)
+                   bs2 in
                let uu___1 =
                  let uu___2 =
                    let uu___3 =
@@ -3024,14 +2971,12 @@ let (resugar_sigelt' :
             FStar_Syntax_Syntax.t2 = t;_}
           ->
           let uu___ =
-            FStar_Compiler_Effect.op_Bar_Greater
-              se.FStar_Syntax_Syntax.sigquals
-              (FStar_Compiler_Util.for_some
-                 (fun uu___1 ->
-                    match uu___1 with
-                    | FStar_Syntax_Syntax.Projector (uu___2, uu___3) -> true
-                    | FStar_Syntax_Syntax.Discriminator uu___2 -> true
-                    | uu___2 -> false)) in
+            FStar_Compiler_Util.for_some
+              (fun uu___1 ->
+                 match uu___1 with
+                 | FStar_Syntax_Syntax.Projector (uu___2, uu___3) -> true
+                 | FStar_Syntax_Syntax.Discriminator uu___2 -> true
+                 | uu___2 -> false) se.FStar_Syntax_Syntax.sigquals in
           if uu___
           then FStar_Pervasives_Native.None
           else

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Subst.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Subst.ml
@@ -3,14 +3,12 @@ let subst_to_string :
   'uuuuu . (FStar_Syntax_Syntax.bv * 'uuuuu) Prims.list -> Prims.string =
   fun s ->
     let uu___ =
-      FStar_Compiler_Effect.op_Bar_Greater s
-        (FStar_Compiler_List.map
-           (fun uu___1 ->
-              match uu___1 with
-              | (b, uu___2) ->
-                  FStar_Ident.string_of_id b.FStar_Syntax_Syntax.ppname)) in
-    FStar_Compiler_Effect.op_Bar_Greater uu___
-      (FStar_Compiler_String.concat ", ")
+      FStar_Compiler_List.map
+        (fun uu___1 ->
+           match uu___1 with
+           | (b, uu___2) ->
+               FStar_Ident.string_of_id b.FStar_Syntax_Syntax.ppname) s in
+    FStar_Compiler_String.concat ", " uu___
 let rec apply_until_some :
   'uuuuu 'uuuuu1 .
     ('uuuuu -> 'uuuuu1 FStar_Pervasives_Native.option) ->
@@ -47,9 +45,7 @@ let apply_until_some_then_map :
   fun f ->
     fun s ->
       fun g ->
-        fun t ->
-          let uu___ = apply_until_some f s in
-          FStar_Compiler_Effect.op_Bar_Greater uu___ (map_some_curry g t)
+        fun t -> let uu___ = apply_until_some f s in map_some_curry g t uu___
 let compose_subst :
   'uuuuu .
     ('uuuuu Prims.list * FStar_Syntax_Syntax.maybe_set_use_range) ->
@@ -370,9 +366,7 @@ let (subst_dec_order' :
     fun uu___ ->
       match uu___ with
       | FStar_Syntax_Syntax.Decreases_lex l ->
-          let uu___1 =
-            FStar_Compiler_Effect.op_Bar_Greater l
-              (FStar_Compiler_List.map (subst' s)) in
+          let uu___1 = FStar_Compiler_List.map (subst' s) l in
           FStar_Syntax_Syntax.Decreases_lex uu___1
       | FStar_Syntax_Syntax.Decreases_wf (rel, e) ->
           let uu___1 =
@@ -386,14 +380,13 @@ let (subst_flags' :
   =
   fun s ->
     fun flags ->
-      FStar_Compiler_Effect.op_Bar_Greater flags
-        (FStar_Compiler_List.map
-           (fun uu___ ->
-              match uu___ with
-              | FStar_Syntax_Syntax.DECREASES dec_order ->
-                  let uu___1 = subst_dec_order' s dec_order in
-                  FStar_Syntax_Syntax.DECREASES uu___1
-              | f -> f))
+      FStar_Compiler_List.map
+        (fun uu___ ->
+           match uu___ with
+           | FStar_Syntax_Syntax.DECREASES dec_order ->
+               let uu___1 = subst_dec_order' s dec_order in
+               FStar_Syntax_Syntax.DECREASES uu___1
+           | f -> f) flags
 let (subst_bqual' :
   FStar_Syntax_Syntax.subst_ts ->
     FStar_Syntax_Syntax.binder_qualifier FStar_Pervasives_Native.option ->
@@ -526,8 +519,8 @@ let shift_subst' :
   fun n ->
     fun s ->
       let uu___ =
-        FStar_Compiler_Effect.op_Bar_Greater (FStar_Pervasives_Native.fst s)
-          (FStar_Compiler_List.map (shift_subst n)) in
+        FStar_Compiler_List.map (shift_subst n)
+          (FStar_Pervasives_Native.fst s) in
       (uu___, (FStar_Pervasives_Native.snd s))
 let (subst_binder' :
   FStar_Syntax_Syntax.subst_ts ->
@@ -546,9 +539,7 @@ let (subst_binder' :
         } in
       let uu___1 = subst_bqual' s b.FStar_Syntax_Syntax.binder_qual in
       let uu___2 =
-        FStar_Compiler_Effect.op_Bar_Greater
-          b.FStar_Syntax_Syntax.binder_attrs
-          (FStar_Compiler_List.map (subst' s)) in
+        FStar_Compiler_List.map (subst' s) b.FStar_Syntax_Syntax.binder_attrs in
       FStar_Syntax_Syntax.mk_binder_with_attrs uu___ uu___1
         b.FStar_Syntax_Syntax.binder_positivity uu___2
 let (subst_binders' :
@@ -559,14 +550,13 @@ let (subst_binders' :
   =
   fun s ->
     fun bs ->
-      FStar_Compiler_Effect.op_Bar_Greater bs
-        (FStar_Compiler_List.mapi
-           (fun i ->
-              fun b ->
-                if i = Prims.int_zero
-                then subst_binder' s b
-                else
-                  (let uu___1 = shift_subst' i s in subst_binder' uu___1 b)))
+      FStar_Compiler_List.mapi
+        (fun i ->
+           fun b ->
+             if i = Prims.int_zero
+             then subst_binder' s b
+             else (let uu___1 = shift_subst' i s in subst_binder' uu___1 b))
+        bs
 let (subst_binders :
   FStar_Syntax_Syntax.subst_elt Prims.list ->
     FStar_Syntax_Syntax.binders -> FStar_Syntax_Syntax.binders)
@@ -617,16 +607,15 @@ let (subst_pat' :
                 FStar_Pervasives_Native.fst uu___1 in
               subst_univs_opt uu___ us_opt in
             let uu___ =
-              FStar_Compiler_Effect.op_Bar_Greater pats
-                (FStar_Compiler_List.fold_left
-                   (fun uu___1 ->
-                      fun uu___2 ->
-                        match (uu___1, uu___2) with
-                        | ((pats1, n1), (p2, imp)) ->
-                            let uu___3 = aux n1 p2 in
-                            (match uu___3 with
-                             | (p3, m) -> (((p3, imp) :: pats1), m))) 
-                   ([], n)) in
+              FStar_Compiler_List.fold_left
+                (fun uu___1 ->
+                   fun uu___2 ->
+                     match (uu___1, uu___2) with
+                     | ((pats1, n1), (p2, imp)) ->
+                         let uu___3 = aux n1 p2 in
+                         (match uu___3 with
+                          | (p3, m) -> (((p3, imp) :: pats1), m))) ([], n)
+                pats in
             (match uu___ with
              | (pats1, n1) ->
                  ({
@@ -688,56 +677,54 @@ let (compose_uvar_subst :
     fun s0 ->
       fun s ->
         let should_retain x =
-          FStar_Compiler_Effect.op_Bar_Greater
-            u.FStar_Syntax_Syntax.ctx_uvar_binders
-            (FStar_Compiler_Util.for_some
-               (fun b ->
-                  FStar_Syntax_Syntax.bv_eq x b.FStar_Syntax_Syntax.binder_bv)) in
+          FStar_Compiler_Util.for_some
+            (fun b ->
+               FStar_Syntax_Syntax.bv_eq x b.FStar_Syntax_Syntax.binder_bv)
+            u.FStar_Syntax_Syntax.ctx_uvar_binders in
         let rec aux uu___ =
           match uu___ with
           | [] -> []
           | hd_subst::rest ->
               let hd =
-                FStar_Compiler_Effect.op_Bar_Greater hd_subst
-                  (FStar_Compiler_List.collect
-                     (fun uu___1 ->
-                        match uu___1 with
-                        | FStar_Syntax_Syntax.NT (x, t) ->
-                            let uu___2 = should_retain x in
-                            if uu___2
-                            then
-                              let uu___3 =
-                                let uu___4 =
-                                  let uu___5 =
-                                    delay t
-                                      (rest, FStar_Syntax_Syntax.NoUseRange) in
-                                  (x, uu___5) in
-                                FStar_Syntax_Syntax.NT uu___4 in
-                              [uu___3]
-                            else []
-                        | FStar_Syntax_Syntax.NM (x, i) ->
-                            let uu___2 = should_retain x in
-                            if uu___2
-                            then
-                              let x_i =
-                                FStar_Syntax_Syntax.bv_to_tm
-                                  {
-                                    FStar_Syntax_Syntax.ppname =
-                                      (x.FStar_Syntax_Syntax.ppname);
-                                    FStar_Syntax_Syntax.index = i;
-                                    FStar_Syntax_Syntax.sort =
-                                      (x.FStar_Syntax_Syntax.sort)
-                                  } in
-                              let t =
-                                subst' (rest, FStar_Syntax_Syntax.NoUseRange)
-                                  x_i in
-                              (match t.FStar_Syntax_Syntax.n with
-                               | FStar_Syntax_Syntax.Tm_bvar x_j ->
-                                   [FStar_Syntax_Syntax.NM
-                                      (x, (x_j.FStar_Syntax_Syntax.index))]
-                               | uu___3 -> [FStar_Syntax_Syntax.NT (x, t)])
-                            else []
-                        | uu___2 -> [])) in
+                FStar_Compiler_List.collect
+                  (fun uu___1 ->
+                     match uu___1 with
+                     | FStar_Syntax_Syntax.NT (x, t) ->
+                         let uu___2 = should_retain x in
+                         if uu___2
+                         then
+                           let uu___3 =
+                             let uu___4 =
+                               let uu___5 =
+                                 delay t
+                                   (rest, FStar_Syntax_Syntax.NoUseRange) in
+                               (x, uu___5) in
+                             FStar_Syntax_Syntax.NT uu___4 in
+                           [uu___3]
+                         else []
+                     | FStar_Syntax_Syntax.NM (x, i) ->
+                         let uu___2 = should_retain x in
+                         if uu___2
+                         then
+                           let x_i =
+                             FStar_Syntax_Syntax.bv_to_tm
+                               {
+                                 FStar_Syntax_Syntax.ppname =
+                                   (x.FStar_Syntax_Syntax.ppname);
+                                 FStar_Syntax_Syntax.index = i;
+                                 FStar_Syntax_Syntax.sort =
+                                   (x.FStar_Syntax_Syntax.sort)
+                               } in
+                           let t =
+                             subst' (rest, FStar_Syntax_Syntax.NoUseRange)
+                               x_i in
+                           (match t.FStar_Syntax_Syntax.n with
+                            | FStar_Syntax_Syntax.Tm_bvar x_j ->
+                                [FStar_Syntax_Syntax.NM
+                                   (x, (x_j.FStar_Syntax_Syntax.index))]
+                            | uu___3 -> [FStar_Syntax_Syntax.NT (x, t)])
+                         else []
+                     | uu___2 -> []) hd_subst in
               let uu___1 = aux rest in FStar_Compiler_List.op_At hd uu___1 in
         let uu___ =
           aux
@@ -896,24 +883,23 @@ let rec (push_subst_aux :
             ->
             let t01 = subst' s t0 in
             let pats1 =
-              FStar_Compiler_Effect.op_Bar_Greater pats
-                (FStar_Compiler_List.map
-                   (fun uu___ ->
-                      match uu___ with
-                      | (pat, wopt, branch) ->
-                          let uu___1 = subst_pat' s pat in
-                          (match uu___1 with
-                           | (pat1, n) ->
-                               let s1 = shift_subst' n s in
-                               let wopt1 =
-                                 match wopt with
-                                 | FStar_Pervasives_Native.None ->
-                                     FStar_Pervasives_Native.None
-                                 | FStar_Pervasives_Native.Some w ->
-                                     let uu___2 = subst' s1 w in
-                                     FStar_Pervasives_Native.Some uu___2 in
-                               let branch1 = subst' s1 branch in
-                               (pat1, wopt1, branch1)))) in
+              FStar_Compiler_List.map
+                (fun uu___ ->
+                   match uu___ with
+                   | (pat, wopt, branch) ->
+                       let uu___1 = subst_pat' s pat in
+                       (match uu___1 with
+                        | (pat1, n) ->
+                            let s1 = shift_subst' n s in
+                            let wopt1 =
+                              match wopt with
+                              | FStar_Pervasives_Native.None ->
+                                  FStar_Pervasives_Native.None
+                              | FStar_Pervasives_Native.Some w ->
+                                  let uu___2 = subst' s1 w in
+                                  FStar_Pervasives_Native.Some uu___2 in
+                            let branch1 = subst' s1 branch in
+                            (pat1, wopt1, branch1))) pats in
             let asc_opt1 =
               match asc_opt with
               | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
@@ -942,45 +928,44 @@ let rec (push_subst_aux :
             let sn = shift_subst' n s in
             let body1 = subst' sn body in
             let lbs1 =
-              FStar_Compiler_Effect.op_Bar_Greater lbs
-                (FStar_Compiler_List.map
-                   (fun lb ->
-                      let lbt = subst' s lb.FStar_Syntax_Syntax.lbtyp in
-                      let lbd =
-                        let uu___ =
-                          is_rec &&
-                            (FStar_Compiler_Util.is_left
-                               lb.FStar_Syntax_Syntax.lbname) in
-                        if uu___
-                        then subst' sn lb.FStar_Syntax_Syntax.lbdef
-                        else subst' s lb.FStar_Syntax_Syntax.lbdef in
-                      let lbname =
-                        match lb.FStar_Syntax_Syntax.lbname with
-                        | FStar_Pervasives.Inl x ->
-                            FStar_Pervasives.Inl
-                              {
-                                FStar_Syntax_Syntax.ppname =
-                                  (x.FStar_Syntax_Syntax.ppname);
-                                FStar_Syntax_Syntax.index =
-                                  (x.FStar_Syntax_Syntax.index);
-                                FStar_Syntax_Syntax.sort = lbt
-                              }
-                        | FStar_Pervasives.Inr fv -> FStar_Pervasives.Inr fv in
-                      let lbattrs =
-                        FStar_Compiler_List.map (subst' s)
-                          lb.FStar_Syntax_Syntax.lbattrs in
-                      {
-                        FStar_Syntax_Syntax.lbname = lbname;
-                        FStar_Syntax_Syntax.lbunivs =
-                          (lb.FStar_Syntax_Syntax.lbunivs);
-                        FStar_Syntax_Syntax.lbtyp = lbt;
-                        FStar_Syntax_Syntax.lbeff =
-                          (lb.FStar_Syntax_Syntax.lbeff);
-                        FStar_Syntax_Syntax.lbdef = lbd;
-                        FStar_Syntax_Syntax.lbattrs = lbattrs;
-                        FStar_Syntax_Syntax.lbpos =
-                          (lb.FStar_Syntax_Syntax.lbpos)
-                      })) in
+              FStar_Compiler_List.map
+                (fun lb ->
+                   let lbt = subst' s lb.FStar_Syntax_Syntax.lbtyp in
+                   let lbd =
+                     let uu___ =
+                       is_rec &&
+                         (FStar_Compiler_Util.is_left
+                            lb.FStar_Syntax_Syntax.lbname) in
+                     if uu___
+                     then subst' sn lb.FStar_Syntax_Syntax.lbdef
+                     else subst' s lb.FStar_Syntax_Syntax.lbdef in
+                   let lbname =
+                     match lb.FStar_Syntax_Syntax.lbname with
+                     | FStar_Pervasives.Inl x ->
+                         FStar_Pervasives.Inl
+                           {
+                             FStar_Syntax_Syntax.ppname =
+                               (x.FStar_Syntax_Syntax.ppname);
+                             FStar_Syntax_Syntax.index =
+                               (x.FStar_Syntax_Syntax.index);
+                             FStar_Syntax_Syntax.sort = lbt
+                           }
+                     | FStar_Pervasives.Inr fv -> FStar_Pervasives.Inr fv in
+                   let lbattrs =
+                     FStar_Compiler_List.map (subst' s)
+                       lb.FStar_Syntax_Syntax.lbattrs in
+                   {
+                     FStar_Syntax_Syntax.lbname = lbname;
+                     FStar_Syntax_Syntax.lbunivs =
+                       (lb.FStar_Syntax_Syntax.lbunivs);
+                     FStar_Syntax_Syntax.lbtyp = lbt;
+                     FStar_Syntax_Syntax.lbeff =
+                       (lb.FStar_Syntax_Syntax.lbeff);
+                     FStar_Syntax_Syntax.lbdef = lbd;
+                     FStar_Syntax_Syntax.lbattrs = lbattrs;
+                     FStar_Syntax_Syntax.lbpos =
+                       (lb.FStar_Syntax_Syntax.lbpos)
+                   }) lbs in
             mk
               (FStar_Syntax_Syntax.Tm_let
                  {
@@ -998,9 +983,7 @@ let rec (push_subst_aux :
                 let uu___3 =
                   let uu___4 =
                     let uu___5 = FStar_Compiler_List.map (subst' s) bs in
-                    let uu___6 =
-                      FStar_Compiler_Effect.op_Bar_Greater ps
-                        (FStar_Compiler_List.map (subst_args' s)) in
+                    let uu___6 = FStar_Compiler_List.map (subst_args' s) ps in
                     (uu___5, uu___6) in
                   FStar_Syntax_Syntax.Meta_pattern uu___4 in
                 {
@@ -1149,9 +1132,7 @@ let (subst_residual_comp :
       | FStar_Pervasives_Native.None -> rc
       | FStar_Pervasives_Native.Some t ->
           let uu___ =
-            let uu___1 = subst s t in
-            FStar_Compiler_Effect.op_Bar_Greater uu___1
-              (fun uu___2 -> FStar_Pervasives_Native.Some uu___2) in
+            let uu___1 = subst s t in FStar_Pervasives_Native.Some uu___1 in
           {
             FStar_Syntax_Syntax.residual_effect =
               (rc.FStar_Syntax_Syntax.residual_effect);
@@ -1171,7 +1152,7 @@ let (closing_subst :
                  (((FStar_Syntax_Syntax.NM
                       ((b.FStar_Syntax_Syntax.binder_bv), n)) :: subst1),
                    (n + Prims.int_one))) bs ([], Prims.int_zero) in
-    FStar_Compiler_Effect.op_Bar_Greater uu___ FStar_Pervasives_Native.fst
+    FStar_Pervasives_Native.fst uu___
 let (open_binders' :
   FStar_Syntax_Syntax.binders ->
     (FStar_Syntax_Syntax.binders * FStar_Syntax_Syntax.subst_t))
@@ -1194,9 +1175,8 @@ let (open_binders' :
             } in
           let imp = subst_bqual o b.FStar_Syntax_Syntax.binder_qual in
           let attrs =
-            FStar_Compiler_Effect.op_Bar_Greater
-              b.FStar_Syntax_Syntax.binder_attrs
-              (FStar_Compiler_List.map (subst o)) in
+            FStar_Compiler_List.map (subst o)
+              b.FStar_Syntax_Syntax.binder_attrs in
           let o1 =
             let uu___ = shift_subst Prims.int_one o in
             (FStar_Syntax_Syntax.DB (Prims.int_zero, x')) :: uu___ in
@@ -1266,16 +1246,15 @@ let (open_pat :
       | FStar_Syntax_Syntax.Pat_cons (fv, us_opt, pats) ->
           let us_opt1 = subst_univs_opt [sub] us_opt in
           let uu___ =
-            FStar_Compiler_Effect.op_Bar_Greater pats
-              (FStar_Compiler_List.fold_left
-                 (fun uu___1 ->
-                    fun uu___2 ->
-                      match (uu___1, uu___2) with
-                      | ((pats1, sub1), (p2, imp)) ->
-                          let uu___3 = open_pat_aux sub1 p2 in
-                          (match uu___3 with
-                           | (p3, sub2) -> (((p3, imp) :: pats1), sub2)))
-                 ([], sub)) in
+            FStar_Compiler_List.fold_left
+              (fun uu___1 ->
+                 fun uu___2 ->
+                   match (uu___1, uu___2) with
+                   | ((pats1, sub1), (p2, imp)) ->
+                       let uu___3 = open_pat_aux sub1 p2 in
+                       (match uu___3 with
+                        | (p3, sub2) -> (((p3, imp) :: pats1), sub2)))
+              ([], sub) pats in
           (match uu___ with
            | (pats1, sub1) ->
                ({
@@ -1355,9 +1334,8 @@ let (close_binders :
             } in
           let imp = subst_bqual s b.FStar_Syntax_Syntax.binder_qual in
           let attrs =
-            FStar_Compiler_Effect.op_Bar_Greater
-              b.FStar_Syntax_Syntax.binder_attrs
-              (FStar_Compiler_List.map (subst s)) in
+            FStar_Compiler_List.map (subst s)
+              b.FStar_Syntax_Syntax.binder_attrs in
           let s' =
             let uu___ = shift_subst Prims.int_one s in
             (FStar_Syntax_Syntax.NM (x, Prims.int_zero)) :: uu___ in
@@ -1384,16 +1362,15 @@ let (close_pat :
       | FStar_Syntax_Syntax.Pat_cons (fv, us_opt, pats) ->
           let us_opt1 = subst_univs_opt [sub] us_opt in
           let uu___ =
-            FStar_Compiler_Effect.op_Bar_Greater pats
-              (FStar_Compiler_List.fold_left
-                 (fun uu___1 ->
-                    fun uu___2 ->
-                      match (uu___1, uu___2) with
-                      | ((pats1, sub1), (p2, imp)) ->
-                          let uu___3 = aux sub1 p2 in
-                          (match uu___3 with
-                           | (p3, sub2) -> (((p3, imp) :: pats1), sub2)))
-                 ([], sub)) in
+            FStar_Compiler_List.fold_left
+              (fun uu___1 ->
+                 fun uu___2 ->
+                   match (uu___1, uu___2) with
+                   | ((pats1, sub1), (p2, imp)) ->
+                       let uu___3 = aux sub1 p2 in
+                       (match uu___3 with
+                        | (p3, sub2) -> (((p3, imp) :: pats1), sub2)))
+              ([], sub) pats in
           (match uu___ with
            | (pats1, sub1) ->
                ({
@@ -1447,21 +1424,19 @@ let (univ_var_opening :
   fun us ->
     let n = (FStar_Compiler_List.length us) - Prims.int_one in
     let s =
-      FStar_Compiler_Effect.op_Bar_Greater us
-        (FStar_Compiler_List.mapi
-           (fun i ->
-              fun u ->
-                FStar_Syntax_Syntax.UN
-                  ((n - i), (FStar_Syntax_Syntax.U_name u)))) in
+      FStar_Compiler_List.mapi
+        (fun i ->
+           fun u ->
+             FStar_Syntax_Syntax.UN ((n - i), (FStar_Syntax_Syntax.U_name u)))
+        us in
     (s, us)
 let (univ_var_closing :
   FStar_Syntax_Syntax.univ_names -> FStar_Syntax_Syntax.subst_elt Prims.list)
   =
   fun us ->
     let n = (FStar_Compiler_List.length us) - Prims.int_one in
-    FStar_Compiler_Effect.op_Bar_Greater us
-      (FStar_Compiler_List.mapi
-         (fun i -> fun u -> FStar_Syntax_Syntax.UD (u, (n - i))))
+    FStar_Compiler_List.mapi
+      (fun i -> fun u -> FStar_Syntax_Syntax.UD (u, (n - i))) us
 let (open_univ_vars :
   FStar_Syntax_Syntax.univ_names ->
     FStar_Syntax_Syntax.term ->
@@ -1493,9 +1468,8 @@ let (close_univ_vars_comp :
     fun c ->
       let n = (FStar_Compiler_List.length us) - Prims.int_one in
       let s =
-        FStar_Compiler_Effect.op_Bar_Greater us
-          (FStar_Compiler_List.mapi
-             (fun i -> fun u -> FStar_Syntax_Syntax.UD (u, (n - i)))) in
+        FStar_Compiler_List.mapi
+          (fun i -> fun u -> FStar_Syntax_Syntax.UD (u, (n - i))) us in
       subst_comp s c
 let (open_let_rec :
   FStar_Syntax_Syntax.letbinding Prims.list ->
@@ -1558,28 +1532,25 @@ let (open_let_rec :
           (match uu___1 with
            | (uu___2, us, u_let_rec_opening) ->
                let lbs2 =
-                 FStar_Compiler_Effect.op_Bar_Greater lbs1
-                   (FStar_Compiler_List.map
-                      (fun lb ->
-                         let uu___3 =
-                           subst u_let_rec_opening
-                             lb.FStar_Syntax_Syntax.lbtyp in
-                         let uu___4 =
-                           subst u_let_rec_opening
-                             lb.FStar_Syntax_Syntax.lbdef in
-                         {
-                           FStar_Syntax_Syntax.lbname =
-                             (lb.FStar_Syntax_Syntax.lbname);
-                           FStar_Syntax_Syntax.lbunivs = us;
-                           FStar_Syntax_Syntax.lbtyp = uu___3;
-                           FStar_Syntax_Syntax.lbeff =
-                             (lb.FStar_Syntax_Syntax.lbeff);
-                           FStar_Syntax_Syntax.lbdef = uu___4;
-                           FStar_Syntax_Syntax.lbattrs =
-                             (lb.FStar_Syntax_Syntax.lbattrs);
-                           FStar_Syntax_Syntax.lbpos =
-                             (lb.FStar_Syntax_Syntax.lbpos)
-                         })) in
+                 FStar_Compiler_List.map
+                   (fun lb ->
+                      let uu___3 =
+                        subst u_let_rec_opening lb.FStar_Syntax_Syntax.lbtyp in
+                      let uu___4 =
+                        subst u_let_rec_opening lb.FStar_Syntax_Syntax.lbdef in
+                      {
+                        FStar_Syntax_Syntax.lbname =
+                          (lb.FStar_Syntax_Syntax.lbname);
+                        FStar_Syntax_Syntax.lbunivs = us;
+                        FStar_Syntax_Syntax.lbtyp = uu___3;
+                        FStar_Syntax_Syntax.lbeff =
+                          (lb.FStar_Syntax_Syntax.lbeff);
+                        FStar_Syntax_Syntax.lbdef = uu___4;
+                        FStar_Syntax_Syntax.lbattrs =
+                          (lb.FStar_Syntax_Syntax.lbattrs);
+                        FStar_Syntax_Syntax.lbpos =
+                          (lb.FStar_Syntax_Syntax.lbpos)
+                      }) lbs1 in
                let t1 = subst let_rec_opening t in (lbs2, t1))
 let (close_let_rec :
   FStar_Syntax_Syntax.letbinding Prims.list ->
@@ -1624,29 +1595,26 @@ let (close_let_rec :
           (match uu___1 with
            | (uu___2, u_let_rec_closing) ->
                let lbs1 =
-                 FStar_Compiler_Effect.op_Bar_Greater lbs
-                   (FStar_Compiler_List.map
-                      (fun lb ->
-                         let uu___3 =
-                           subst u_let_rec_closing
-                             lb.FStar_Syntax_Syntax.lbtyp in
-                         let uu___4 =
-                           subst u_let_rec_closing
-                             lb.FStar_Syntax_Syntax.lbdef in
-                         {
-                           FStar_Syntax_Syntax.lbname =
-                             (lb.FStar_Syntax_Syntax.lbname);
-                           FStar_Syntax_Syntax.lbunivs =
-                             (lb.FStar_Syntax_Syntax.lbunivs);
-                           FStar_Syntax_Syntax.lbtyp = uu___3;
-                           FStar_Syntax_Syntax.lbeff =
-                             (lb.FStar_Syntax_Syntax.lbeff);
-                           FStar_Syntax_Syntax.lbdef = uu___4;
-                           FStar_Syntax_Syntax.lbattrs =
-                             (lb.FStar_Syntax_Syntax.lbattrs);
-                           FStar_Syntax_Syntax.lbpos =
-                             (lb.FStar_Syntax_Syntax.lbpos)
-                         })) in
+                 FStar_Compiler_List.map
+                   (fun lb ->
+                      let uu___3 =
+                        subst u_let_rec_closing lb.FStar_Syntax_Syntax.lbtyp in
+                      let uu___4 =
+                        subst u_let_rec_closing lb.FStar_Syntax_Syntax.lbdef in
+                      {
+                        FStar_Syntax_Syntax.lbname =
+                          (lb.FStar_Syntax_Syntax.lbname);
+                        FStar_Syntax_Syntax.lbunivs =
+                          (lb.FStar_Syntax_Syntax.lbunivs);
+                        FStar_Syntax_Syntax.lbtyp = uu___3;
+                        FStar_Syntax_Syntax.lbeff =
+                          (lb.FStar_Syntax_Syntax.lbeff);
+                        FStar_Syntax_Syntax.lbdef = uu___4;
+                        FStar_Syntax_Syntax.lbattrs =
+                          (lb.FStar_Syntax_Syntax.lbattrs);
+                        FStar_Syntax_Syntax.lbpos =
+                          (lb.FStar_Syntax_Syntax.lbpos)
+                      }) lbs in
                let t1 = subst let_rec_closing t in (lbs1, t1))
 let (close_tscheme :
   FStar_Syntax_Syntax.binders ->
@@ -1695,12 +1663,11 @@ let (opening_of_binders :
   FStar_Syntax_Syntax.binders -> FStar_Syntax_Syntax.subst_t) =
   fun bs ->
     let n = (FStar_Compiler_List.length bs) - Prims.int_one in
-    FStar_Compiler_Effect.op_Bar_Greater bs
-      (FStar_Compiler_List.mapi
-         (fun i ->
-            fun b ->
-              FStar_Syntax_Syntax.DB
-                ((n - i), (b.FStar_Syntax_Syntax.binder_bv))))
+    FStar_Compiler_List.mapi
+      (fun i ->
+         fun b ->
+           FStar_Syntax_Syntax.DB
+             ((n - i), (b.FStar_Syntax_Syntax.binder_bv))) bs
 let (closing_of_binders :
   FStar_Syntax_Syntax.binders -> FStar_Syntax_Syntax.subst_t) =
   fun bs -> closing_subst bs

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Syntax.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Syntax.ml
@@ -1273,8 +1273,7 @@ let rec (emb_typ_to_string : emb_typ -> Prims.string) =
             let uu___3 =
               let uu___4 =
                 let uu___5 = FStar_Compiler_List.map emb_typ_to_string args1 in
-                FStar_Compiler_Effect.op_Bar_Greater uu___5
-                  (FStar_Compiler_String.concat " ") in
+                FStar_Compiler_String.concat " " uu___5 in
               Prims.strcat uu___4 ")" in
             Prims.strcat " " uu___3 in
           Prims.strcat h uu___2 in
@@ -2381,9 +2380,7 @@ let (bv_to_tm : bv -> term) =
 let (bv_to_name : bv -> term) =
   fun bv1 -> let uu___ = range_of_bv bv1 in mk (Tm_name bv1) uu___
 let (binders_to_names : binders -> term Prims.list) =
-  fun bs ->
-    FStar_Compiler_Effect.op_Bar_Greater bs
-      (FStar_Compiler_List.map (fun b -> bv_to_name b.binder_bv))
+  fun bs -> FStar_Compiler_List.map (fun b -> bv_to_name b.binder_bv) bs
 let (mk_Tm_app : term -> args -> FStar_Compiler_Range_Type.range -> term) =
   fun t1 ->
     fun args1 ->
@@ -2579,13 +2576,10 @@ let (freenames_of_binders : binders -> freenames) =
       (fun b -> fun out -> FStar_Compiler_Set.add ord_bv b.binder_bv out) bs
       no_names
 let (binders_of_list : bv Prims.list -> binders) =
-  fun fvs ->
-    FStar_Compiler_Effect.op_Bar_Greater fvs
-      (FStar_Compiler_List.map (fun t -> mk_binder t))
+  fun fvs -> FStar_Compiler_List.map (fun t -> mk_binder t) fvs
 let (binders_of_freenames : freenames -> binders) =
   fun fvs ->
-    let uu___ = FStar_Compiler_Set.elems ord_bv fvs in
-    FStar_Compiler_Effect.op_Bar_Greater uu___ binders_of_list
+    let uu___ = FStar_Compiler_Set.elems ord_bv fvs in binders_of_list uu___
 let (is_bqual_implicit : bqual -> Prims.bool) =
   fun uu___ ->
     match uu___ with
@@ -2627,8 +2621,7 @@ let (pat_bvs : pat -> bv Prims.list) =
             (fun b1 ->
                fun uu___2 -> match uu___2 with | (p2, uu___3) -> aux b1 p2) b
             pats in
-    let uu___ = aux [] p in
-    FStar_Compiler_Effect.op_Less_Bar FStar_Compiler_List.rev uu___
+    let uu___ = aux [] p in FStar_Compiler_List.rev uu___
 let (freshen_binder : binder -> binder) =
   fun b ->
     let uu___ = freshen_bv b.binder_bv in

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Unionfind.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Unionfind.ml
@@ -181,8 +181,7 @@ let (chk_v_t :
         let uvar_to_string u1 =
           let uu___1 =
             let uu___2 = FStar_Unionfind.puf_unique_id u1 in
-            FStar_Compiler_Effect.op_Bar_Greater uu___2
-              FStar_Compiler_Util.string_of_int in
+            FStar_Compiler_Util.string_of_int uu___2 in
           Prims.strcat "?" uu___1 in
         let expected = get_version () in
         if
@@ -289,8 +288,7 @@ let chk_v_u :
         let uvar_to_string u1 =
           let uu___1 =
             let uu___2 = FStar_Unionfind.puf_unique_id u1 in
-            FStar_Compiler_Effect.op_Bar_Greater uu___2
-              FStar_Compiler_Util.string_of_int in
+            FStar_Compiler_Util.string_of_int uu___2 in
           Prims.strcat "?" uu___1 in
         let expected = get_version () in
         if

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Util.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Util.ml
@@ -91,75 +91,73 @@ let (args_of_non_null_binders :
     (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.aqual) Prims.list)
   =
   fun binders ->
-    FStar_Compiler_Effect.op_Bar_Greater binders
-      (FStar_Compiler_List.collect
-         (fun b ->
-            let uu___ = FStar_Syntax_Syntax.is_null_binder b in
-            if uu___
-            then []
-            else (let uu___2 = arg_of_non_null_binder b in [uu___2])))
+    FStar_Compiler_List.collect
+      (fun b ->
+         let uu___ = FStar_Syntax_Syntax.is_null_binder b in
+         if uu___
+         then []
+         else (let uu___2 = arg_of_non_null_binder b in [uu___2])) binders
 let (args_of_binders :
   FStar_Syntax_Syntax.binders ->
     (FStar_Syntax_Syntax.binders * FStar_Syntax_Syntax.args))
   =
   fun binders ->
     let uu___ =
-      FStar_Compiler_Effect.op_Bar_Greater binders
-        (FStar_Compiler_List.map
-           (fun b ->
-              let uu___1 = FStar_Syntax_Syntax.is_null_binder b in
-              if uu___1
-              then
-                let b1 =
-                  let uu___2 =
-                    FStar_Syntax_Syntax.new_bv FStar_Pervasives_Native.None
-                      (b.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort in
-                  {
-                    FStar_Syntax_Syntax.binder_bv = uu___2;
-                    FStar_Syntax_Syntax.binder_qual =
-                      (b.FStar_Syntax_Syntax.binder_qual);
-                    FStar_Syntax_Syntax.binder_positivity =
-                      (b.FStar_Syntax_Syntax.binder_positivity);
-                    FStar_Syntax_Syntax.binder_attrs =
-                      (b.FStar_Syntax_Syntax.binder_attrs)
-                  } in
-                let uu___2 = arg_of_non_null_binder b1 in (b1, uu___2)
-              else (let uu___3 = arg_of_non_null_binder b in (b, uu___3)))) in
-    FStar_Compiler_Effect.op_Bar_Greater uu___ FStar_Compiler_List.unzip
+      FStar_Compiler_List.map
+        (fun b ->
+           let uu___1 = FStar_Syntax_Syntax.is_null_binder b in
+           if uu___1
+           then
+             let b1 =
+               let uu___2 =
+                 FStar_Syntax_Syntax.new_bv FStar_Pervasives_Native.None
+                   (b.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort in
+               {
+                 FStar_Syntax_Syntax.binder_bv = uu___2;
+                 FStar_Syntax_Syntax.binder_qual =
+                   (b.FStar_Syntax_Syntax.binder_qual);
+                 FStar_Syntax_Syntax.binder_positivity =
+                   (b.FStar_Syntax_Syntax.binder_positivity);
+                 FStar_Syntax_Syntax.binder_attrs =
+                   (b.FStar_Syntax_Syntax.binder_attrs)
+               } in
+             let uu___2 = arg_of_non_null_binder b1 in (b1, uu___2)
+           else (let uu___3 = arg_of_non_null_binder b in (b, uu___3)))
+        binders in
+    FStar_Compiler_List.unzip uu___
 let (name_binders :
   FStar_Syntax_Syntax.binder Prims.list ->
     FStar_Syntax_Syntax.binder Prims.list)
   =
   fun binders ->
-    FStar_Compiler_Effect.op_Bar_Greater binders
-      (FStar_Compiler_List.mapi
-         (fun i ->
-            fun b ->
-              let uu___ = FStar_Syntax_Syntax.is_null_binder b in
-              if uu___
-              then
-                let bname =
-                  let uu___1 =
-                    let uu___2 = FStar_Compiler_Util.string_of_int i in
-                    Prims.strcat "_" uu___2 in
-                  FStar_Ident.id_of_text uu___1 in
-                let bv =
-                  {
-                    FStar_Syntax_Syntax.ppname = bname;
-                    FStar_Syntax_Syntax.index = Prims.int_zero;
-                    FStar_Syntax_Syntax.sort =
-                      ((b.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort)
-                  } in
-                {
-                  FStar_Syntax_Syntax.binder_bv = bv;
-                  FStar_Syntax_Syntax.binder_qual =
-                    (b.FStar_Syntax_Syntax.binder_qual);
-                  FStar_Syntax_Syntax.binder_positivity =
-                    (b.FStar_Syntax_Syntax.binder_positivity);
-                  FStar_Syntax_Syntax.binder_attrs =
-                    (b.FStar_Syntax_Syntax.binder_attrs)
-                }
-              else b))
+    FStar_Compiler_List.mapi
+      (fun i ->
+         fun b ->
+           let uu___ = FStar_Syntax_Syntax.is_null_binder b in
+           if uu___
+           then
+             let bname =
+               let uu___1 =
+                 let uu___2 = FStar_Compiler_Util.string_of_int i in
+                 Prims.strcat "_" uu___2 in
+               FStar_Ident.id_of_text uu___1 in
+             let bv =
+               {
+                 FStar_Syntax_Syntax.ppname = bname;
+                 FStar_Syntax_Syntax.index = Prims.int_zero;
+                 FStar_Syntax_Syntax.sort =
+                   ((b.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort)
+               } in
+             {
+               FStar_Syntax_Syntax.binder_bv = bv;
+               FStar_Syntax_Syntax.binder_qual =
+                 (b.FStar_Syntax_Syntax.binder_qual);
+               FStar_Syntax_Syntax.binder_positivity =
+                 (b.FStar_Syntax_Syntax.binder_positivity);
+               FStar_Syntax_Syntax.binder_attrs =
+                 (b.FStar_Syntax_Syntax.binder_attrs)
+             }
+           else b) binders
 let (name_function_binders :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
@@ -185,45 +183,41 @@ let (null_binders_of_tks :
     FStar_Syntax_Syntax.binders)
   =
   fun tks ->
-    FStar_Compiler_Effect.op_Bar_Greater tks
-      (FStar_Compiler_List.map
-         (fun uu___ ->
-            match uu___ with
-            | (t, imp) ->
-                let uu___1 = FStar_Syntax_Syntax.null_binder t in
-                {
-                  FStar_Syntax_Syntax.binder_bv =
-                    (uu___1.FStar_Syntax_Syntax.binder_bv);
-                  FStar_Syntax_Syntax.binder_qual = imp;
-                  FStar_Syntax_Syntax.binder_positivity =
-                    (uu___1.FStar_Syntax_Syntax.binder_positivity);
-                  FStar_Syntax_Syntax.binder_attrs =
-                    (uu___1.FStar_Syntax_Syntax.binder_attrs)
-                }))
+    FStar_Compiler_List.map
+      (fun uu___ ->
+         match uu___ with
+         | (t, imp) ->
+             let uu___1 = FStar_Syntax_Syntax.null_binder t in
+             {
+               FStar_Syntax_Syntax.binder_bv =
+                 (uu___1.FStar_Syntax_Syntax.binder_bv);
+               FStar_Syntax_Syntax.binder_qual = imp;
+               FStar_Syntax_Syntax.binder_positivity =
+                 (uu___1.FStar_Syntax_Syntax.binder_positivity);
+               FStar_Syntax_Syntax.binder_attrs =
+                 (uu___1.FStar_Syntax_Syntax.binder_attrs)
+             }) tks
 let (binders_of_tks :
   (FStar_Syntax_Syntax.typ * FStar_Syntax_Syntax.bqual) Prims.list ->
     FStar_Syntax_Syntax.binders)
   =
   fun tks ->
-    FStar_Compiler_Effect.op_Bar_Greater tks
-      (FStar_Compiler_List.map
-         (fun uu___ ->
-            match uu___ with
-            | (t, imp) ->
-                let uu___1 =
-                  FStar_Syntax_Syntax.new_bv
-                    (FStar_Pervasives_Native.Some (t.FStar_Syntax_Syntax.pos))
-                    t in
-                FStar_Syntax_Syntax.mk_binder_with_attrs uu___1 imp
-                  FStar_Pervasives_Native.None []))
+    FStar_Compiler_List.map
+      (fun uu___ ->
+         match uu___ with
+         | (t, imp) ->
+             let uu___1 =
+               FStar_Syntax_Syntax.new_bv
+                 (FStar_Pervasives_Native.Some (t.FStar_Syntax_Syntax.pos)) t in
+             FStar_Syntax_Syntax.mk_binder_with_attrs uu___1 imp
+               FStar_Pervasives_Native.None []) tks
 let (binders_of_freevars :
   FStar_Syntax_Syntax.bv FStar_Compiler_Set.set ->
     FStar_Syntax_Syntax.binder Prims.list)
   =
   fun fvs ->
     let uu___ = FStar_Compiler_Set.elems FStar_Syntax_Syntax.ord_bv fvs in
-    FStar_Compiler_Effect.op_Bar_Greater uu___
-      (FStar_Compiler_List.map FStar_Syntax_Syntax.mk_binder)
+    FStar_Compiler_List.map FStar_Syntax_Syntax.mk_binder uu___
 let mk_subst : 'uuuuu . 'uuuuu -> 'uuuuu Prims.list = fun s -> [s]
 let (subst_of_list :
   FStar_Syntax_Syntax.binders ->
@@ -459,9 +453,7 @@ let (effect_indices_from_repr :
             | FStar_Syntax_Syntax.Tm_app
                 { FStar_Syntax_Syntax.hd = uu___;
                   FStar_Syntax_Syntax.args = uu___1::is;_}
-                ->
-                FStar_Compiler_Effect.op_Bar_Greater is
-                  (FStar_Compiler_List.map FStar_Pervasives_Native.fst)
+                -> FStar_Compiler_List.map FStar_Pervasives_Native.fst is
             | uu___ -> err1 ()
           else
             (match repr1.FStar_Syntax_Syntax.n with
@@ -469,16 +461,11 @@ let (effect_indices_from_repr :
                  { FStar_Syntax_Syntax.bs1 = uu___1;
                    FStar_Syntax_Syntax.comp = c;_}
                  ->
-                 let uu___2 =
-                   FStar_Compiler_Effect.op_Bar_Greater c
-                     comp_eff_name_res_and_args in
-                 FStar_Compiler_Effect.op_Bar_Greater uu___2
-                   (fun uu___3 ->
-                      match uu___3 with
-                      | (uu___4, uu___5, args) ->
-                          FStar_Compiler_Effect.op_Bar_Greater args
-                            (FStar_Compiler_List.map
-                               FStar_Pervasives_Native.fst))
+                 let uu___2 = comp_eff_name_res_and_args c in
+                 (match uu___2 with
+                  | (uu___3, uu___4, args) ->
+                      FStar_Compiler_List.map FStar_Pervasives_Native.fst
+                        args)
              | uu___1 -> err1 ())
 let (destruct_comp :
   FStar_Syntax_Syntax.comp_typ ->
@@ -494,12 +481,8 @@ let (destruct_comp :
             let uu___2 =
               FStar_Ident.string_of_lid c.FStar_Syntax_Syntax.effect_name in
             let uu___3 =
-              let uu___4 =
-                FStar_Compiler_Effect.op_Bar_Greater
-                  c.FStar_Syntax_Syntax.effect_args
-                  FStar_Compiler_List.length in
-              FStar_Compiler_Effect.op_Bar_Greater uu___4
-                FStar_Compiler_Util.string_of_int in
+              FStar_Compiler_Util.string_of_int
+                (FStar_Compiler_List.length c.FStar_Syntax_Syntax.effect_args) in
             FStar_Compiler_Util.format2
               "Impossible: Got a computation %s with %s effect args" uu___2
               uu___3 in
@@ -521,23 +504,21 @@ let (is_total_comp :
     (FStar_Ident.lid_equals (comp_effect_name c)
        FStar_Parser_Const.effect_Tot_lid)
       ||
-      (FStar_Compiler_Effect.op_Bar_Greater (comp_flags c)
-         (FStar_Compiler_Util.for_some
-            (fun uu___ ->
-               match uu___ with
-               | FStar_Syntax_Syntax.TOTAL -> true
-               | FStar_Syntax_Syntax.RETURN -> true
-               | uu___1 -> false)))
-let (is_partial_return :
-  FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> Prims.bool) =
-  fun c ->
-    FStar_Compiler_Effect.op_Bar_Greater (comp_flags c)
       (FStar_Compiler_Util.for_some
          (fun uu___ ->
             match uu___ with
+            | FStar_Syntax_Syntax.TOTAL -> true
             | FStar_Syntax_Syntax.RETURN -> true
-            | FStar_Syntax_Syntax.PARTIAL_RETURN -> true
-            | uu___1 -> false))
+            | uu___1 -> false) (comp_flags c))
+let (is_partial_return :
+  FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> Prims.bool) =
+  fun c ->
+    FStar_Compiler_Util.for_some
+      (fun uu___ ->
+         match uu___ with
+         | FStar_Syntax_Syntax.RETURN -> true
+         | FStar_Syntax_Syntax.PARTIAL_RETURN -> true
+         | uu___1 -> false) (comp_flags c)
 let (is_tot_or_gtot_comp :
   FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> Prims.bool) =
   fun c ->
@@ -559,12 +540,11 @@ let (is_pure_comp :
         ((is_total_comp c) ||
            (is_pure_effect ct.FStar_Syntax_Syntax.effect_name))
           ||
-          (FStar_Compiler_Effect.op_Bar_Greater ct.FStar_Syntax_Syntax.flags
-             (FStar_Compiler_Util.for_some
-                (fun uu___ ->
-                   match uu___ with
-                   | FStar_Syntax_Syntax.LEMMA -> true
-                   | uu___1 -> false)))
+          (FStar_Compiler_Util.for_some
+             (fun uu___ ->
+                match uu___ with
+                | FStar_Syntax_Syntax.LEMMA -> true
+                | uu___1 -> false) ct.FStar_Syntax_Syntax.flags)
 let (is_ghost_effect : FStar_Ident.lident -> Prims.bool) =
   fun l ->
     ((FStar_Ident.lid_equals FStar_Parser_Const.effect_GTot_lid l) ||
@@ -744,12 +724,11 @@ let (is_ml_comp :
     | FStar_Syntax_Syntax.Comp c1 ->
         (let uu___ = FStar_Parser_Const.effect_ML_lid () in
          FStar_Ident.lid_equals c1.FStar_Syntax_Syntax.effect_name uu___) ||
-          (FStar_Compiler_Effect.op_Bar_Greater c1.FStar_Syntax_Syntax.flags
-             (FStar_Compiler_Util.for_some
-                (fun uu___ ->
-                   match uu___ with
-                   | FStar_Syntax_Syntax.MLEFFECT -> true
-                   | uu___1 -> false)))
+          (FStar_Compiler_Util.for_some
+             (fun uu___ ->
+                match uu___ with
+                | FStar_Syntax_Syntax.MLEFFECT -> true
+                | uu___1 -> false) c1.FStar_Syntax_Syntax.flags)
     | uu___ -> false
 let (comp_result :
   FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax ->
@@ -785,13 +764,12 @@ let (set_result_typ :
 let (is_trivial_wp :
   FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> Prims.bool) =
   fun c ->
-    FStar_Compiler_Effect.op_Bar_Greater (comp_flags c)
-      (FStar_Compiler_Util.for_some
-         (fun uu___ ->
-            match uu___ with
-            | FStar_Syntax_Syntax.TOTAL -> true
-            | FStar_Syntax_Syntax.RETURN -> true
-            | uu___1 -> false))
+    FStar_Compiler_Util.for_some
+      (fun uu___ ->
+         match uu___ with
+         | FStar_Syntax_Syntax.TOTAL -> true
+         | FStar_Syntax_Syntax.RETURN -> true
+         | uu___1 -> false) (comp_flags c)
 let (comp_effect_args : FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.args)
   =
   fun c ->
@@ -816,9 +794,7 @@ let (primops : FStar_Ident.lident Prims.list) =
   FStar_Parser_Const.op_Or;
   FStar_Parser_Const.op_Negation]
 let (is_primop_lid : FStar_Ident.lident -> Prims.bool) =
-  fun l ->
-    FStar_Compiler_Effect.op_Bar_Greater primops
-      (FStar_Compiler_Util.for_some (FStar_Ident.lid_equals l))
+  fun l -> FStar_Compiler_Util.for_some (FStar_Ident.lid_equals l) primops
 let (is_primop :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax -> Prims.bool) =
   fun f ->
@@ -873,8 +849,7 @@ let rec (unlazy : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
       uu___1.FStar_Syntax_Syntax.n in
     match uu___ with
     | FStar_Syntax_Syntax.Tm_lazy i ->
-        let uu___1 = unfold_lazy i in
-        FStar_Compiler_Effect.op_Less_Bar unlazy uu___1
+        let uu___1 = unfold_lazy i in unlazy uu___1
     | uu___1 -> t
 let (unlazy_emb : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
   fun t ->
@@ -885,8 +860,7 @@ let (unlazy_emb : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
     | FStar_Syntax_Syntax.Tm_lazy i ->
         (match i.FStar_Syntax_Syntax.lkind with
          | FStar_Syntax_Syntax.Lazy_embedding uu___1 ->
-             let uu___2 = unfold_lazy i in
-             FStar_Compiler_Effect.op_Less_Bar unlazy uu___2
+             let uu___2 = unfold_lazy i in unlazy uu___2
          | uu___1 -> t)
     | uu___1 -> t
 let unlazy_as_t :
@@ -1012,13 +986,12 @@ let rec (eq_tm :
         if uu___
         then
           let uu___1 = FStar_Compiler_List.zip args1 args2 in
-          FStar_Compiler_Effect.op_Less_Bar
-            (FStar_Compiler_List.fold_left
-               (fun acc ->
-                  fun uu___2 ->
-                    match uu___2 with
-                    | ((a1, q1), (a2, q2)) ->
-                        let uu___3 = eq_tm a1 a2 in eq_inj acc uu___3) Equal)
+          FStar_Compiler_List.fold_left
+            (fun acc ->
+               fun uu___2 ->
+                 match uu___2 with
+                 | ((a1, q1), (a2, q2)) ->
+                     let uu___3 = eq_tm a1 a2 in eq_inj acc uu___3) Equal
             uu___1
         else NotEqual in
       let qual_is_inj uu___ =
@@ -1029,14 +1002,10 @@ let rec (eq_tm :
             uu___1) -> true
         | uu___1 -> false in
       let heads_and_args_in_case_both_data =
-        let uu___ =
-          let uu___1 = FStar_Compiler_Effect.op_Bar_Greater t11 unmeta in
-          FStar_Compiler_Effect.op_Bar_Greater uu___1 head_and_args in
+        let uu___ = let uu___1 = unmeta t11 in head_and_args uu___1 in
         match uu___ with
         | (head1, args1) ->
-            let uu___1 =
-              let uu___2 = FStar_Compiler_Effect.op_Bar_Greater t21 unmeta in
-              FStar_Compiler_Effect.op_Bar_Greater uu___2 head_and_args in
+            let uu___1 = let uu___2 = unmeta t21 in head_and_args uu___2 in
             (match uu___1 with
              | (head2, args2) ->
                  let uu___2 =
@@ -1067,16 +1036,11 @@ let rec (eq_tm :
       | (FStar_Syntax_Syntax.Tm_name a, FStar_Syntax_Syntax.Tm_name b) ->
           let uu___ = FStar_Syntax_Syntax.bv_eq a b in equal_if uu___
       | uu___ when
-          FStar_Compiler_Effect.op_Bar_Greater
-            heads_and_args_in_case_both_data FStar_Compiler_Util.is_some
-          ->
+          FStar_Compiler_Util.is_some heads_and_args_in_case_both_data ->
           let uu___1 =
-            FStar_Compiler_Effect.op_Bar_Greater
-              heads_and_args_in_case_both_data FStar_Compiler_Util.must in
-          FStar_Compiler_Effect.op_Bar_Greater uu___1
-            (fun uu___2 ->
-               match uu___2 with
-               | (f, args1, g, args2) -> equal_data f args1 g args2)
+            FStar_Compiler_Util.must heads_and_args_in_case_both_data in
+          (match uu___1 with
+           | (f, args1, g, args2) -> equal_data f args1 g args2)
       | (FStar_Syntax_Syntax.Tm_fvar f, FStar_Syntax_Syntax.Tm_fvar g) ->
           let uu___ = FStar_Syntax_Syntax.fv_eq f g in equal_if uu___
       | (FStar_Syntax_Syntax.Tm_uinst (f, us), FStar_Syntax_Syntax.Tm_uinst
@@ -1395,10 +1359,8 @@ let rec (is_uvar : FStar_Syntax_Syntax.term -> Prims.bool) =
     | FStar_Syntax_Syntax.Tm_uinst (t1, uu___1) -> is_uvar t1
     | FStar_Syntax_Syntax.Tm_app uu___1 ->
         let uu___2 =
-          let uu___3 = FStar_Compiler_Effect.op_Bar_Greater t head_and_args in
-          FStar_Compiler_Effect.op_Bar_Greater uu___3
-            FStar_Pervasives_Native.fst in
-        FStar_Compiler_Effect.op_Bar_Greater uu___2 is_uvar
+          let uu___3 = head_and_args t in FStar_Pervasives_Native.fst uu___3 in
+        is_uvar uu___2
     | FStar_Syntax_Syntax.Tm_ascribed
         { FStar_Syntax_Syntax.tm = t1; FStar_Syntax_Syntax.asc = uu___1;
           FStar_Syntax_Syntax.eff_opt = uu___2;_}
@@ -1559,11 +1521,10 @@ let range_of_args :
   =
   fun args ->
     fun r ->
-      FStar_Compiler_Effect.op_Bar_Greater args
-        (FStar_Compiler_List.fold_left
-           (fun r1 ->
-              fun a ->
-                FStar_Compiler_Range_Ops.union_ranges r1 (range_of_arg a)) r)
+      FStar_Compiler_List.fold_left
+        (fun r1 ->
+           fun a -> FStar_Compiler_Range_Ops.union_ranges r1 (range_of_arg a))
+        r args
 let (mk_app :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
     (FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax *
@@ -1664,8 +1625,7 @@ let (set_uvar : FStar_Syntax_Syntax.uvar -> FStar_Syntax_Syntax.term -> unit)
           let uu___1 =
             let uu___2 =
               let uu___3 = FStar_Syntax_Unionfind.uvar_id uv in
-              FStar_Compiler_Effect.op_Less_Bar
-                FStar_Compiler_Util.string_of_int uu___3 in
+              FStar_Compiler_Util.string_of_int uu___3 in
             let uu___3 = tts t in
             let uu___4 = tts t' in
             FStar_Compiler_Util.format3
@@ -1908,12 +1868,11 @@ let (has_decreases : FStar_Syntax_Syntax.comp -> Prims.bool) =
     match c.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Comp ct ->
         let uu___ =
-          FStar_Compiler_Effect.op_Bar_Greater ct.FStar_Syntax_Syntax.flags
-            (FStar_Compiler_Util.find_opt
-               (fun uu___1 ->
-                  match uu___1 with
-                  | FStar_Syntax_Syntax.DECREASES uu___2 -> true
-                  | uu___2 -> false)) in
+          FStar_Compiler_Util.find_opt
+            (fun uu___1 ->
+               match uu___1 with
+               | FStar_Syntax_Syntax.DECREASES uu___2 -> true
+               | uu___2 -> false) ct.FStar_Syntax_Syntax.flags in
         (match uu___ with
          | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.DECREASES
              uu___1) -> true
@@ -2000,14 +1959,11 @@ let (let_rec_arity :
           (match uu___ with
            | (bs1, c1) ->
                let uu___1 =
-                 let uu___2 =
-                   FStar_Compiler_Effect.op_Bar_Greater c1 comp_flags in
-                 FStar_Compiler_Effect.op_Bar_Greater uu___2
-                   (FStar_Compiler_Util.find_opt
-                      (fun uu___3 ->
-                         match uu___3 with
-                         | FStar_Syntax_Syntax.DECREASES uu___4 -> true
-                         | uu___4 -> false)) in
+                 FStar_Compiler_Util.find_opt
+                   (fun uu___2 ->
+                      match uu___2 with
+                      | FStar_Syntax_Syntax.DECREASES uu___3 -> true
+                      | uu___3 -> false) (comp_flags c1) in
                (match uu___1 with
                 | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.DECREASES
                     d) -> (bs1, (FStar_Pervasives_Native.Some d))
@@ -2040,16 +1996,13 @@ let (let_rec_arity :
                  match d with
                  | FStar_Syntax_Syntax.Decreases_lex l ->
                      let uu___2 =
-                       let uu___3 =
-                         FStar_Compiler_Set.empty FStar_Syntax_Syntax.ord_bv
-                           () in
-                       FStar_Compiler_List.fold_left
-                         (fun s ->
-                            fun t ->
-                              let uu___4 = FStar_Syntax_Free.names t in
-                              FStar_Compiler_Set.union
-                                FStar_Syntax_Syntax.ord_bv s uu___4) uu___3 in
-                     FStar_Compiler_Effect.op_Bar_Greater l uu___2
+                       FStar_Compiler_Set.empty FStar_Syntax_Syntax.ord_bv () in
+                     FStar_Compiler_List.fold_left
+                       (fun s ->
+                          fun t ->
+                            let uu___3 = FStar_Syntax_Free.names t in
+                            FStar_Compiler_Set.union
+                              FStar_Syntax_Syntax.ord_bv s uu___3) uu___2 l
                  | FStar_Syntax_Syntax.Decreases_wf (rel, e) ->
                      let uu___2 = FStar_Syntax_Free.names rel in
                      let uu___3 = FStar_Syntax_Free.names e in
@@ -2058,11 +2011,10 @@ let (let_rec_arity :
                let uu___2 =
                  FStar_Common.tabulate n_univs (fun uu___3 -> false) in
                let uu___3 =
-                 FStar_Compiler_Effect.op_Bar_Greater bs
-                   (FStar_Compiler_List.map
-                      (fun b ->
-                         FStar_Compiler_Set.mem FStar_Syntax_Syntax.ord_bv
-                           b.FStar_Syntax_Syntax.binder_bv d_bvs)) in
+                 FStar_Compiler_List.map
+                   (fun b ->
+                      FStar_Compiler_Set.mem FStar_Syntax_Syntax.ord_bv
+                        b.FStar_Syntax_Syntax.binder_bv d_bvs) bs in
                FStar_Compiler_List.op_At uu___2 uu___3) in
         ((n_univs + (FStar_Compiler_List.length bs)), uu___1)
 let (abs_formals_maybe_unascribe_body :
@@ -2205,16 +2157,14 @@ let (close_univs_and_mk_letbinding :
                     | (uu___, []) -> def
                     | (FStar_Pervasives_Native.Some fvs, uu___) ->
                         let universes =
-                          FStar_Compiler_Effect.op_Bar_Greater univ_vars
-                            (FStar_Compiler_List.map
-                               (fun uu___1 ->
-                                  FStar_Syntax_Syntax.U_name uu___1)) in
+                          FStar_Compiler_List.map
+                            (fun uu___1 -> FStar_Syntax_Syntax.U_name uu___1)
+                            univ_vars in
                         let inst =
-                          FStar_Compiler_Effect.op_Bar_Greater fvs
-                            (FStar_Compiler_List.map
-                               (fun fv ->
-                                  (((fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v),
-                                    universes))) in
+                          FStar_Compiler_List.map
+                            (fun fv ->
+                               (((fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v),
+                                 universes)) fvs in
                         FStar_Syntax_InstFV.instantiate inst def in
                   let typ1 = FStar_Syntax_Subst.close_univ_vars univ_vars typ in
                   let def2 =
@@ -2355,8 +2305,7 @@ let (type_u :
       let uu___1 =
         FStar_Syntax_Unionfind.univ_fresh
           FStar_Compiler_Range_Type.dummyRange in
-      FStar_Compiler_Effect.op_Less_Bar
-        (fun uu___2 -> FStar_Syntax_Syntax.U_unif uu___2) uu___1 in
+      FStar_Syntax_Syntax.U_unif uu___1 in
     let uu___1 =
       FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_type u)
         FStar_Compiler_Range_Type.dummyRange in
@@ -2854,12 +2803,11 @@ let (residual_comp_of_comp :
   FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.residual_comp) =
   fun c ->
     let uu___ =
-      FStar_Compiler_Effect.op_Less_Bar
-        (FStar_Compiler_List.filter
-           (fun uu___1 ->
-              match uu___1 with
-              | FStar_Syntax_Syntax.DECREASES uu___2 -> false
-              | uu___2 -> true)) (comp_flags c) in
+      FStar_Compiler_List.filter
+        (fun uu___1 ->
+           match uu___1 with
+           | FStar_Syntax_Syntax.DECREASES uu___2 -> false
+           | uu___2 -> true) (comp_flags c) in
     {
       FStar_Syntax_Syntax.residual_effect = (comp_effect_name c);
       FStar_Syntax_Syntax.residual_typ =
@@ -3388,12 +3336,11 @@ let (destruct_typ_as_formula :
         | (t2, args) ->
             let uu___1 = un_uinst t2 in
             let uu___2 =
-              FStar_Compiler_Effect.op_Bar_Greater args
-                (FStar_Compiler_List.map
-                   (fun uu___3 ->
-                      match uu___3 with
-                      | (t3, imp) ->
-                          let uu___4 = unascribe t3 in (uu___4, imp))) in
+              FStar_Compiler_List.map
+                (fun uu___3 ->
+                   match uu___3 with
+                   | (t3, imp) -> let uu___4 = unascribe t3 in (uu___4, imp))
+                args in
             (uu___1, uu___2) in
       let rec aux qopt out t1 =
         let uu___ = let uu___1 = flat t1 in (qopt, uu___1) in
@@ -3507,7 +3454,7 @@ let (destruct_typ_as_formula :
                     let uu___5 = patterns q in
                     match uu___5 with
                     | (pats, q1) ->
-                        FStar_Compiler_Effect.op_Less_Bar maybe_collect
+                        maybe_collect
                           (FStar_Pervasives_Native.Some
                              (QAll ([b], pats, q1)))
                   else
@@ -3563,8 +3510,7 @@ let (destruct_typ_as_formula :
                               let uu___8 = patterns q1 in
                               (match uu___8 with
                                | (pats, q2) ->
-                                   FStar_Compiler_Effect.op_Less_Bar
-                                     maybe_collect
+                                   maybe_collect
                                      (FStar_Pervasives_Native.Some
                                         (QEx ([b1], pats, q2)))))
                      | uu___6 -> FStar_Pervasives_Native.None)
@@ -3575,8 +3521,7 @@ let (destruct_typ_as_formula :
           let uu___ = destruct_sq_forall phi in
           (match uu___ with
            | FStar_Pervasives_Native.Some (QAll (bs', pats', psi)) ->
-               FStar_Compiler_Effect.op_Less_Bar
-                 (fun uu___1 -> FStar_Pervasives_Native.Some uu___1)
+               FStar_Pervasives_Native.Some
                  (QAll
                     ((FStar_Compiler_List.op_At bs bs'),
                       (FStar_Compiler_List.op_At pats pats'), psi))
@@ -3585,8 +3530,7 @@ let (destruct_typ_as_formula :
           let uu___ = destruct_sq_exists phi in
           (match uu___ with
            | FStar_Pervasives_Native.Some (QEx (bs', pats', psi)) ->
-               FStar_Compiler_Effect.op_Less_Bar
-                 (fun uu___1 -> FStar_Pervasives_Native.Some uu___1)
+               FStar_Pervasives_Native.Some
                  (QEx
                     ((FStar_Compiler_List.op_At bs bs'),
                       (FStar_Compiler_List.op_At pats pats'), psi))
@@ -4314,8 +4258,7 @@ let (process_pragma :
        match p with
        | FStar_Syntax_Syntax.SetOptions o -> set_options o
        | FStar_Syntax_Syntax.ResetOptions sopt ->
-           ((let uu___2 = FStar_Options.restore_cmd_line_options false in
-             FStar_Compiler_Effect.op_Bar_Greater uu___2 (fun uu___3 -> ()));
+           ((let uu___2 = FStar_Options.restore_cmd_line_options false in ());
             (match sopt with
              | FStar_Pervasives_Native.None -> ()
              | FStar_Pervasives_Native.Some s -> set_options s))
@@ -4428,19 +4371,18 @@ let rec (unbound_variables :
                      let uu___6 = unbound_variables_ascription asc1 in
                      FStar_Compiler_List.op_At uu___5 uu___6) in
           let uu___4 =
-            FStar_Compiler_Effect.op_Bar_Greater pats
-              (FStar_Compiler_List.collect
-                 (fun br ->
-                    let uu___5 = FStar_Syntax_Subst.open_branch br in
-                    match uu___5 with
-                    | (p, wopt, t2) ->
-                        let uu___6 = unbound_variables t2 in
-                        let uu___7 =
-                          match wopt with
-                          | FStar_Pervasives_Native.None -> []
-                          | FStar_Pervasives_Native.Some t3 ->
-                              unbound_variables t3 in
-                        FStar_Compiler_List.op_At uu___6 uu___7)) in
+            FStar_Compiler_List.collect
+              (fun br ->
+                 let uu___5 = FStar_Syntax_Subst.open_branch br in
+                 match uu___5 with
+                 | (p, wopt, t2) ->
+                     let uu___6 = unbound_variables t2 in
+                     let uu___7 =
+                       match wopt with
+                       | FStar_Pervasives_Native.None -> []
+                       | FStar_Pervasives_Native.Some t3 ->
+                           unbound_variables t3 in
+                     FStar_Compiler_List.op_At uu___6 uu___7) pats in
           FStar_Compiler_List.op_At uu___3 uu___4 in
         FStar_Compiler_List.op_At uu___1 uu___2
     | FStar_Syntax_Syntax.Tm_ascribed
@@ -4692,9 +4634,7 @@ let (smt_lemma_as_forall :
                  "SMT pattern is not a list literal; ignoring the pattern");
              []) in
       let one_pat p =
-        let uu___ =
-          let uu___1 = unmeta p in
-          FStar_Compiler_Effect.op_Bar_Greater uu___1 head_and_args in
+        let uu___ = let uu___1 = unmeta p in head_and_args uu___1 in
         match uu___ with
         | (head, args) ->
             let uu___1 =
@@ -4719,9 +4659,7 @@ let (smt_lemma_as_forall :
       let lemma_pats p =
         let elts = list_elements1 p in
         let smt_pat_or t1 =
-          let uu___ =
-            let uu___1 = unmeta t1 in
-            FStar_Compiler_Effect.op_Bar_Greater uu___1 head_and_args in
+          let uu___ = let uu___1 = unmeta t1 in head_and_args uu___1 in
           match uu___ with
           | (head, args) ->
               let uu___1 =
@@ -4740,22 +4678,15 @@ let (smt_lemma_as_forall :
             (match uu___ with
              | FStar_Pervasives_Native.Some e ->
                  let uu___1 = list_elements1 e in
-                 FStar_Compiler_Effect.op_Bar_Greater uu___1
-                   (FStar_Compiler_List.map
-                      (fun branch1 ->
-                         let uu___2 = list_elements1 branch1 in
-                         FStar_Compiler_Effect.op_Bar_Greater uu___2
-                           (FStar_Compiler_List.map one_pat)))
+                 FStar_Compiler_List.map
+                   (fun branch1 ->
+                      let uu___2 = list_elements1 branch1 in
+                      FStar_Compiler_List.map one_pat uu___2) uu___1
              | uu___1 ->
-                 let uu___2 =
-                   FStar_Compiler_Effect.op_Bar_Greater elts
-                     (FStar_Compiler_List.map one_pat) in
+                 let uu___2 = FStar_Compiler_List.map one_pat elts in
                  [uu___2])
         | uu___ ->
-            let uu___1 =
-              FStar_Compiler_Effect.op_Bar_Greater elts
-                (FStar_Compiler_List.map one_pat) in
-            [uu___1] in
+            let uu___1 = FStar_Compiler_List.map one_pat elts in [uu___1] in
       let uu___ =
         let uu___1 =
           let uu___2 = FStar_Syntax_Subst.compress t in
@@ -4969,9 +4900,8 @@ let (get_eff_repr :
         combs.FStar_Syntax_Syntax.repr
     | FStar_Syntax_Syntax.DM4F_eff combs -> combs.FStar_Syntax_Syntax.repr
     | FStar_Syntax_Syntax.Layered_eff combs ->
-        FStar_Compiler_Effect.op_Bar_Greater
+        FStar_Pervasives_Native.Some
           (FStar_Pervasives_Native.fst combs.FStar_Syntax_Syntax.l_repr)
-          (fun uu___ -> FStar_Pervasives_Native.Some uu___)
 let (get_bind_vc_combinator :
   FStar_Syntax_Syntax.eff_decl ->
     (FStar_Syntax_Syntax.tscheme *
@@ -5009,10 +4939,9 @@ let (get_bind_repr :
     | FStar_Syntax_Syntax.DM4F_eff combs ->
         combs.FStar_Syntax_Syntax.bind_repr
     | FStar_Syntax_Syntax.Layered_eff combs ->
-        FStar_Compiler_Effect.op_Bar_Greater
+        FStar_Pervasives_Native.Some
           (FStar_Pervasives_Native.__proj__Mktuple3__item___1
              combs.FStar_Syntax_Syntax.l_bind)
-          (fun uu___ -> FStar_Pervasives_Native.Some uu___)
 let (get_return_repr :
   FStar_Syntax_Syntax.eff_decl ->
     FStar_Syntax_Syntax.tscheme FStar_Pervasives_Native.option)
@@ -5024,9 +4953,8 @@ let (get_return_repr :
     | FStar_Syntax_Syntax.DM4F_eff combs ->
         combs.FStar_Syntax_Syntax.return_repr
     | FStar_Syntax_Syntax.Layered_eff combs ->
-        FStar_Compiler_Effect.op_Bar_Greater
+        FStar_Pervasives_Native.Some
           (FStar_Pervasives_Native.fst combs.FStar_Syntax_Syntax.l_return)
-          (fun uu___ -> FStar_Pervasives_Native.Some uu___)
 let (get_wp_trivial_combinator :
   FStar_Syntax_Syntax.eff_decl ->
     FStar_Syntax_Syntax.tscheme FStar_Pervasives_Native.option)
@@ -5034,13 +4962,9 @@ let (get_wp_trivial_combinator :
   fun ed ->
     match ed.FStar_Syntax_Syntax.combinators with
     | FStar_Syntax_Syntax.Primitive_eff combs ->
-        FStar_Compiler_Effect.op_Bar_Greater
-          combs.FStar_Syntax_Syntax.trivial
-          (fun uu___ -> FStar_Pervasives_Native.Some uu___)
+        FStar_Pervasives_Native.Some (combs.FStar_Syntax_Syntax.trivial)
     | FStar_Syntax_Syntax.DM4F_eff combs ->
-        FStar_Compiler_Effect.op_Bar_Greater
-          combs.FStar_Syntax_Syntax.trivial
-          (fun uu___ -> FStar_Pervasives_Native.Some uu___)
+        FStar_Pervasives_Native.Some (combs.FStar_Syntax_Syntax.trivial)
     | uu___ -> FStar_Pervasives_Native.None
 let (get_layered_if_then_else_combinator :
   FStar_Syntax_Syntax.eff_decl ->
@@ -5064,13 +4988,9 @@ let (get_wp_if_then_else_combinator :
   fun ed ->
     match ed.FStar_Syntax_Syntax.combinators with
     | FStar_Syntax_Syntax.Primitive_eff combs ->
-        FStar_Compiler_Effect.op_Bar_Greater
-          combs.FStar_Syntax_Syntax.if_then_else
-          (fun uu___ -> FStar_Pervasives_Native.Some uu___)
+        FStar_Pervasives_Native.Some (combs.FStar_Syntax_Syntax.if_then_else)
     | FStar_Syntax_Syntax.DM4F_eff combs ->
-        FStar_Compiler_Effect.op_Bar_Greater
-          combs.FStar_Syntax_Syntax.if_then_else
-          (fun uu___ -> FStar_Pervasives_Native.Some uu___)
+        FStar_Pervasives_Native.Some (combs.FStar_Syntax_Syntax.if_then_else)
     | uu___ -> FStar_Pervasives_Native.None
 let (get_wp_ite_combinator :
   FStar_Syntax_Syntax.eff_decl ->
@@ -5079,11 +4999,9 @@ let (get_wp_ite_combinator :
   fun ed ->
     match ed.FStar_Syntax_Syntax.combinators with
     | FStar_Syntax_Syntax.Primitive_eff combs ->
-        FStar_Compiler_Effect.op_Bar_Greater combs.FStar_Syntax_Syntax.ite_wp
-          (fun uu___ -> FStar_Pervasives_Native.Some uu___)
+        FStar_Pervasives_Native.Some (combs.FStar_Syntax_Syntax.ite_wp)
     | FStar_Syntax_Syntax.DM4F_eff combs ->
-        FStar_Compiler_Effect.op_Bar_Greater combs.FStar_Syntax_Syntax.ite_wp
-          (fun uu___ -> FStar_Pervasives_Native.Some uu___)
+        FStar_Pervasives_Native.Some (combs.FStar_Syntax_Syntax.ite_wp)
     | uu___ -> FStar_Pervasives_Native.None
 let (get_stronger_vc_combinator :
   FStar_Syntax_Syntax.eff_decl ->
@@ -5111,10 +5029,9 @@ let (get_stronger_repr :
     | FStar_Syntax_Syntax.Primitive_eff uu___ -> FStar_Pervasives_Native.None
     | FStar_Syntax_Syntax.DM4F_eff uu___ -> FStar_Pervasives_Native.None
     | FStar_Syntax_Syntax.Layered_eff combs ->
-        FStar_Compiler_Effect.op_Bar_Greater
+        FStar_Pervasives_Native.Some
           (FStar_Pervasives_Native.__proj__Mktuple3__item___1
              combs.FStar_Syntax_Syntax.l_subcomp)
-          (fun uu___ -> FStar_Pervasives_Native.Some uu___)
 let (aqual_is_erasable : FStar_Syntax_Syntax.aqual -> Prims.bool) =
   fun aq ->
     match aq with

--- a/ocaml/fstar-lib/generated/FStar_Tactics_CtrlRewrite.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_CtrlRewrite.ml
@@ -588,9 +588,8 @@ and (on_subterms :
                     (match uu___1 with
                      | (bs_orig, t1, subst) ->
                          let k1 =
-                           FStar_Compiler_Effect.op_Bar_Greater k
-                             (FStar_Compiler_Util.map_option
-                                (FStar_Syntax_Subst.subst_residual_comp subst)) in
+                           FStar_Compiler_Util.map_option
+                             (FStar_Syntax_Subst.subst_residual_comp subst) k in
                          descend_binders tm1 [] []
                            FStar_Tactics_Types.Continue env bs_orig t1 k1
                            (fun bs1 ->
@@ -978,5 +977,4 @@ let (ctrl_rewrite :
                                                 g gt' in
                                             FStar_Tactics_Monad.add_goals
                                               [g1])))))) in
-        FStar_Compiler_Effect.op_Less_Bar
-          (FStar_Tactics_Monad.wrap_err "ctrl_rewrite") uu___
+        FStar_Tactics_Monad.wrap_err "ctrl_rewrite" uu___

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Embedding.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Embedding.ml
@@ -7,7 +7,7 @@ let (fstar_stubs_tactics_lid' : Prims.string Prims.list -> FStar_Ident.lid) =
 let (lid_as_tm : FStar_Ident.lident -> FStar_Syntax_Syntax.term) =
   fun l ->
     let uu___ = FStar_Syntax_Syntax.lid_as_fv l FStar_Pervasives_Native.None in
-    FStar_Compiler_Effect.op_Bar_Greater uu___ FStar_Syntax_Syntax.fv_to_tm
+    FStar_Syntax_Syntax.fv_to_tm uu___
 let (mk_tactic_lid_as_term : Prims.string -> FStar_Syntax_Syntax.term) =
   fun s -> let uu___ = fstar_tactics_lid' ["Effect"; s] in lid_as_tm uu___
 type tac_constant =
@@ -222,7 +222,7 @@ let (e_proofstate_nbe :
     let thunk =
       FStar_Thunk.mk
         (fun uu___ ->
-           FStar_Compiler_Effect.op_Less_Bar FStar_TypeChecker_NBETerm.mk_t
+           FStar_TypeChecker_NBETerm.mk_t
              (FStar_TypeChecker_NBETerm.Constant
                 (FStar_TypeChecker_NBETerm.String
                    ("(((proofstate.nbe)))",
@@ -241,8 +241,7 @@ let (e_proofstate_nbe :
          uu___3)
         ->
         let uu___4 = FStar_Compiler_Dyn.undyn b in
-        FStar_Compiler_Effect.op_Less_Bar
-          (fun uu___5 -> FStar_Pervasives_Native.Some uu___5) uu___4
+        FStar_Pervasives_Native.Some uu___4
     | uu___1 ->
         ((let uu___3 =
             FStar_Compiler_Effect.op_Bang FStar_Options.debug_embedding in
@@ -280,11 +279,11 @@ let (e_goal_nbe :
     let thunk =
       FStar_Thunk.mk
         (fun uu___ ->
-           FStar_Compiler_Effect.op_Less_Bar FStar_TypeChecker_NBETerm.mk_t
+           FStar_TypeChecker_NBETerm.mk_t
              (FStar_TypeChecker_NBETerm.Constant
                 (FStar_TypeChecker_NBETerm.String
                    ("(((goal.nbe)))", FStar_Compiler_Range_Type.dummyRange)))) in
-    FStar_Compiler_Effect.op_Less_Bar FStar_TypeChecker_NBETerm.mk_t
+    FStar_TypeChecker_NBETerm.mk_t
       (FStar_TypeChecker_NBETerm.Lazy ((FStar_Pervasives.Inl li), thunk)) in
   let unembed_goal _cb t =
     let uu___ = FStar_TypeChecker_NBETerm.nbe_t_of_t t in
@@ -298,8 +297,7 @@ let (e_goal_nbe :
          uu___3)
         ->
         let uu___4 = FStar_Compiler_Dyn.undyn b in
-        FStar_Compiler_Effect.op_Less_Bar
-          (fun uu___5 -> FStar_Pervasives_Native.Some uu___5) uu___4
+        FStar_Pervasives_Native.Some uu___4
     | uu___1 ->
         ((let uu___3 =
             FStar_Compiler_Effect.op_Bang FStar_Options.debug_embedding in
@@ -853,18 +851,13 @@ let (t_tref : FStar_Syntax_Syntax.term) =
       let uu___2 =
         FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.tref_lid
           FStar_Pervasives_Native.None in
-      FStar_Compiler_Effect.op_Bar_Greater uu___2
-        FStar_Syntax_Syntax.fv_to_tm in
-    FStar_Compiler_Effect.op_Bar_Greater uu___1
-      (fun tm ->
-         FStar_Syntax_Syntax.mk_Tm_uinst tm [FStar_Syntax_Syntax.U_zero]) in
-  FStar_Compiler_Effect.op_Bar_Greater uu___
-    (fun head ->
-       let uu___1 =
-         let uu___2 = FStar_Syntax_Syntax.iarg FStar_Syntax_Syntax.t_term in
-         [uu___2] in
-       FStar_Syntax_Syntax.mk_Tm_app head uu___1
-         FStar_Compiler_Range_Type.dummyRange)
+      FStar_Syntax_Syntax.fv_to_tm uu___2 in
+    FStar_Syntax_Syntax.mk_Tm_uinst uu___1 [FStar_Syntax_Syntax.U_zero] in
+  let uu___1 =
+    let uu___2 = FStar_Syntax_Syntax.iarg FStar_Syntax_Syntax.t_term in
+    [uu___2] in
+  FStar_Syntax_Syntax.mk_Tm_app uu___ uu___1
+    FStar_Compiler_Range_Type.dummyRange
 let e_tref :
   'a .
     unit ->
@@ -890,9 +883,7 @@ let e_tref :
       | uu___3 -> FStar_Pervasives_Native.None in
     let uu___1 =
       let uu___2 =
-        let uu___3 =
-          FStar_Compiler_Effect.op_Bar_Greater FStar_Parser_Const.tref_lid
-            FStar_Ident.string_of_lid in
+        let uu___3 = FStar_Ident.string_of_lid FStar_Parser_Const.tref_lid in
         (uu___3, [FStar_Syntax_Syntax.ET_abstract]) in
       FStar_Syntax_Syntax.ET_app uu___2 in
     FStar_Syntax_Embeddings_Base.mk_emb_full em un t_tref (fun i -> "tref")
@@ -914,7 +905,7 @@ let e_tref_nbe :
       let thunk =
         FStar_Thunk.mk
           (fun uu___1 ->
-             FStar_Compiler_Effect.op_Less_Bar FStar_TypeChecker_NBETerm.mk_t
+             FStar_TypeChecker_NBETerm.mk_t
                (FStar_TypeChecker_NBETerm.Constant
                   (FStar_TypeChecker_NBETerm.String
                      ("(((tref.nbe)))", FStar_Compiler_Range_Type.dummyRange)))) in
@@ -932,8 +923,7 @@ let e_tref_nbe :
            uu___4)
           ->
           let uu___5 = FStar_Compiler_Dyn.undyn b in
-          FStar_Compiler_Effect.op_Less_Bar
-            (fun uu___6 -> FStar_Pervasives_Native.Some uu___6) uu___5
+          FStar_Pervasives_Native.Some uu___5
       | uu___2 ->
           ((let uu___4 =
               FStar_Compiler_Effect.op_Bang FStar_Options.debug_embedding in
@@ -964,9 +954,7 @@ let e_tref_nbe :
       mkFV uu___2 [FStar_Syntax_Syntax.U_zero] uu___3 in
     let uu___2 =
       let uu___3 =
-        let uu___4 =
-          FStar_Compiler_Effect.op_Bar_Greater FStar_Parser_Const.tref_lid
-            FStar_Ident.string_of_lid in
+        let uu___4 = FStar_Ident.string_of_lid FStar_Parser_Const.tref_lid in
         (uu___4, [FStar_Syntax_Syntax.ET_abstract]) in
       FStar_Syntax_Syntax.ET_app uu___3 in
     {

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Hooks.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Hooks.ml
@@ -169,8 +169,7 @@ let (by_tactic_interp :
                           let uu___4 =
                             let uu___5 =
                               FStar_Tactics_Types.goal_of_goal_ty e assertion in
-                            FStar_Compiler_Effect.op_Less_Bar
-                              FStar_Pervasives_Native.fst uu___5 in
+                            FStar_Pervasives_Native.fst uu___5 in
                           [uu___4] in
                         (FStar_Syntax_Util.t_true, uu___3) in
                       Simplified uu___2
@@ -180,8 +179,7 @@ let (by_tactic_interp :
                           let uu___4 =
                             let uu___5 =
                               FStar_Tactics_Types.goal_of_goal_ty e assertion in
-                            FStar_Compiler_Effect.op_Less_Bar
-                              FStar_Pervasives_Native.fst uu___5 in
+                            FStar_Pervasives_Native.fst uu___5 in
                           [uu___4] in
                         (FStar_Syntax_Util.t_true, uu___3) in
                       Simplified uu___2
@@ -191,8 +189,7 @@ let (by_tactic_interp :
                           let uu___4 =
                             let uu___5 =
                               FStar_Tactics_Types.goal_of_goal_ty e assertion in
-                            FStar_Compiler_Effect.op_Less_Bar
-                              FStar_Pervasives_Native.fst uu___5 in
+                            FStar_Pervasives_Native.fst uu___5 in
                           [uu___4] in
                         (assertion, FStar_Syntax_Util.t_true, uu___3) in
                       Dual uu___2
@@ -568,8 +565,7 @@ let (preprocess :
             then
               let uu___4 =
                 let uu___5 = FStar_TypeChecker_Env.all_binders env in
-                FStar_Compiler_Effect.op_Bar_Greater uu___5
-                  (FStar_Syntax_Print.binders_to_string ",") in
+                FStar_Syntax_Print.binders_to_string "," uu___5 in
               let uu___5 =
                 FStar_Class_Show.show FStar_Syntax_Print.showable_term goal in
               FStar_Compiler_Util.print2 "About to preprocess %s |= %s\n"
@@ -593,8 +589,7 @@ let (preprocess :
                   then
                     let uu___6 =
                       let uu___7 = FStar_TypeChecker_Env.all_binders env in
-                      FStar_Compiler_Effect.op_Bar_Greater uu___7
-                        (FStar_Syntax_Print.binders_to_string ", ") in
+                      FStar_Syntax_Print.binders_to_string ", " uu___7 in
                     let uu___7 =
                       FStar_Class_Show.show FStar_Syntax_Print.showable_term
                         t' in
@@ -1434,8 +1429,7 @@ let (spinoff_strictly_positive_goals :
                            let uu___4 =
                              let uu___5 =
                                FStar_TypeChecker_Env.all_binders env in
-                             FStar_Compiler_Effect.op_Bar_Greater uu___5
-                               (FStar_Syntax_Print.binders_to_string ", ") in
+                             FStar_Syntax_Print.binders_to_string ", " uu___5 in
                            let uu___5 =
                              FStar_Class_Show.show
                                FStar_Syntax_Print.showable_term t1 in
@@ -1469,34 +1463,32 @@ let (spinoff_strictly_positive_goals :
                 | (uu___4, gs1) ->
                     let gs2 = FStar_Compiler_List.rev gs1 in
                     let gs3 =
-                      FStar_Compiler_Effect.op_Bar_Greater gs2
-                        (FStar_Compiler_List.filter_map
-                           (fun uu___5 ->
-                              match uu___5 with
-                              | (env1, t) ->
-                                  let t1 =
-                                    FStar_TypeChecker_Normalize.normalize
-                                      [FStar_TypeChecker_Env.Eager_unfolding;
-                                      FStar_TypeChecker_Env.Simplify;
-                                      FStar_TypeChecker_Env.Primops] env1 t in
-                                  let uu___6 =
-                                    FStar_TypeChecker_Common.check_trivial t1 in
-                                  (match uu___6 with
-                                   | FStar_TypeChecker_Common.Trivial ->
-                                       FStar_Pervasives_Native.None
-                                   | FStar_TypeChecker_Common.NonTrivial t2
-                                       ->
-                                       (if debug
-                                        then
-                                          (let uu___8 =
-                                             FStar_Class_Show.show
-                                               FStar_Syntax_Print.showable_term
-                                               t2 in
-                                           FStar_Compiler_Util.print1
-                                             "Got goal: %s\n" uu___8)
-                                        else ();
-                                        FStar_Pervasives_Native.Some
-                                          (env1, t2))))) in
+                      FStar_Compiler_List.filter_map
+                        (fun uu___5 ->
+                           match uu___5 with
+                           | (env1, t) ->
+                               let t1 =
+                                 FStar_TypeChecker_Normalize.normalize
+                                   [FStar_TypeChecker_Env.Eager_unfolding;
+                                   FStar_TypeChecker_Env.Simplify;
+                                   FStar_TypeChecker_Env.Primops] env1 t in
+                               let uu___6 =
+                                 FStar_TypeChecker_Common.check_trivial t1 in
+                               (match uu___6 with
+                                | FStar_TypeChecker_Common.Trivial ->
+                                    FStar_Pervasives_Native.None
+                                | FStar_TypeChecker_Common.NonTrivial t2 ->
+                                    (if debug
+                                     then
+                                       (let uu___8 =
+                                          FStar_Class_Show.show
+                                            FStar_Syntax_Print.showable_term
+                                            t2 in
+                                        FStar_Compiler_Util.print1
+                                          "Got goal: %s\n" uu___8)
+                                     else ();
+                                     FStar_Pervasives_Native.Some (env1, t2))))
+                        gs2 in
                     ((let uu___6 = FStar_TypeChecker_Env.get_range env in
                       let uu___7 =
                         let uu___8 =
@@ -1617,65 +1609,62 @@ let (solve_implicits :
                  FStar_Options.with_saved_options
                    (fun uu___4 ->
                       let uu___5 = FStar_Options.set_options "--no_tactics" in
-                      FStar_Compiler_Effect.op_Bar_Greater gs
-                        (FStar_Compiler_List.iter
-                           (fun g ->
-                              (let uu___7 = FStar_Tactics_Types.goal_opts g in
-                               FStar_Options.set uu___7);
-                              (let uu___7 =
-                                 let uu___8 = FStar_Tactics_Types.goal_env g in
-                                 let uu___9 = FStar_Tactics_Types.goal_type g in
-                                 getprop uu___8 uu___9 in
-                               match uu___7 with
-                               | FStar_Pervasives_Native.Some vc ->
-                                   ((let uu___9 =
-                                       FStar_Compiler_Effect.op_Bang
-                                         FStar_Tactics_V2_Interpreter.tacdbg in
-                                     if uu___9
-                                     then
-                                       let uu___10 =
-                                         FStar_Class_Show.show
-                                           FStar_Syntax_Print.showable_term
-                                           vc in
-                                       FStar_Compiler_Util.print1
-                                         "Synthesis left a goal: %s\n"
-                                         uu___10
-                                     else ());
-                                    (let uu___9 =
-                                       let uu___10 =
-                                         FStar_Options.admit_smt_queries () in
-                                       Prims.op_Negation uu___10 in
-                                     if uu___9
-                                     then
-                                       let guard =
-                                         {
-                                           FStar_TypeChecker_Common.guard_f =
-                                             (FStar_TypeChecker_Common.NonTrivial
-                                                vc);
-                                           FStar_TypeChecker_Common.deferred_to_tac
-                                             = [];
-                                           FStar_TypeChecker_Common.deferred
-                                             = [];
-                                           FStar_TypeChecker_Common.univ_ineqs
-                                             = ([], []);
-                                           FStar_TypeChecker_Common.implicits
-                                             = []
-                                         } in
-                                       FStar_Profiling.profile
-                                         (fun uu___10 ->
-                                            let uu___11 =
-                                              FStar_Tactics_Types.goal_env g in
-                                            FStar_TypeChecker_Rel.force_trivial_guard
-                                              uu___11 guard)
-                                         FStar_Pervasives_Native.None
-                                         "FStar.TypeChecker.Hooks.force_trivial_guard"
-                                     else ()))
-                               | FStar_Pervasives_Native.None ->
-                                   let uu___8 =
-                                     FStar_TypeChecker_Env.get_range env in
-                                   FStar_Errors.raise_error
-                                     (FStar_Errors_Codes.Fatal_OpenGoalsInSynthesis,
-                                       "synthesis left open goals") uu___8)))))))
+                      FStar_Compiler_List.iter
+                        (fun g ->
+                           (let uu___7 = FStar_Tactics_Types.goal_opts g in
+                            FStar_Options.set uu___7);
+                           (let uu___7 =
+                              let uu___8 = FStar_Tactics_Types.goal_env g in
+                              let uu___9 = FStar_Tactics_Types.goal_type g in
+                              getprop uu___8 uu___9 in
+                            match uu___7 with
+                            | FStar_Pervasives_Native.Some vc ->
+                                ((let uu___9 =
+                                    FStar_Compiler_Effect.op_Bang
+                                      FStar_Tactics_V2_Interpreter.tacdbg in
+                                  if uu___9
+                                  then
+                                    let uu___10 =
+                                      FStar_Class_Show.show
+                                        FStar_Syntax_Print.showable_term vc in
+                                    FStar_Compiler_Util.print1
+                                      "Synthesis left a goal: %s\n" uu___10
+                                  else ());
+                                 (let uu___9 =
+                                    let uu___10 =
+                                      FStar_Options.admit_smt_queries () in
+                                    Prims.op_Negation uu___10 in
+                                  if uu___9
+                                  then
+                                    let guard =
+                                      {
+                                        FStar_TypeChecker_Common.guard_f =
+                                          (FStar_TypeChecker_Common.NonTrivial
+                                             vc);
+                                        FStar_TypeChecker_Common.deferred_to_tac
+                                          = [];
+                                        FStar_TypeChecker_Common.deferred =
+                                          [];
+                                        FStar_TypeChecker_Common.univ_ineqs =
+                                          ([], []);
+                                        FStar_TypeChecker_Common.implicits =
+                                          []
+                                      } in
+                                    FStar_Profiling.profile
+                                      (fun uu___10 ->
+                                         let uu___11 =
+                                           FStar_Tactics_Types.goal_env g in
+                                         FStar_TypeChecker_Rel.force_trivial_guard
+                                           uu___11 guard)
+                                      FStar_Pervasives_Native.None
+                                      "FStar.TypeChecker.Hooks.force_trivial_guard"
+                                  else ()))
+                            | FStar_Pervasives_Native.None ->
+                                let uu___8 =
+                                  FStar_TypeChecker_Env.get_range env in
+                                FStar_Errors.raise_error
+                                  (FStar_Errors_Codes.Fatal_OpenGoalsInSynthesis,
+                                    "synthesis left open goals") uu___8)) gs))))
 let (find_user_tac_for_attr :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
@@ -1686,8 +1675,7 @@ let (find_user_tac_for_attr :
       let hooks =
         FStar_TypeChecker_Env.lookup_attr env
           FStar_Parser_Const.handle_smt_goals_attr_string in
-      FStar_Compiler_Effect.op_Bar_Greater hooks
-        (FStar_Compiler_Util.try_find (fun uu___ -> true))
+      FStar_Compiler_Util.try_find (fun uu___ -> true) hooks
 let (handle_smt_goal :
   FStar_TypeChecker_Env.env ->
     FStar_TypeChecker_Env.goal ->
@@ -1747,40 +1735,38 @@ let (handle_smt_goal :
                            tau env uu___6 in
                        match uu___4 with
                        | (gs1, uu___5) ->
-                           FStar_Compiler_Effect.op_Bar_Greater gs1
-                             (FStar_Compiler_List.map
-                                (fun g ->
-                                   let uu___6 =
-                                     let uu___7 =
-                                       FStar_Tactics_Types.goal_env g in
-                                     let uu___8 =
-                                       FStar_Tactics_Types.goal_type g in
-                                     getprop uu___7 uu___8 in
-                                   match uu___6 with
-                                   | FStar_Pervasives_Native.Some vc ->
-                                       ((let uu___8 =
-                                           FStar_Compiler_Effect.op_Bang
-                                             FStar_Tactics_V2_Interpreter.tacdbg in
-                                         if uu___8
-                                         then
-                                           let uu___9 =
-                                             FStar_Class_Show.show
-                                               FStar_Syntax_Print.showable_term
-                                               vc in
-                                           FStar_Compiler_Util.print1
-                                             "handle_smt_goals left a goal: %s\n"
-                                             uu___9
-                                         else ());
-                                        (let uu___8 =
-                                           FStar_Tactics_Types.goal_env g in
-                                         (uu___8, vc)))
-                                   | FStar_Pervasives_Native.None ->
-                                       let uu___7 =
-                                         FStar_TypeChecker_Env.get_range env in
-                                       FStar_Errors.raise_error
-                                         (FStar_Errors_Codes.Fatal_OpenGoalsInSynthesis,
-                                           "Handling an SMT goal by tactic left non-prop open goals")
-                                         uu___7)))) in
+                           FStar_Compiler_List.map
+                             (fun g ->
+                                let uu___6 =
+                                  let uu___7 = FStar_Tactics_Types.goal_env g in
+                                  let uu___8 =
+                                    FStar_Tactics_Types.goal_type g in
+                                  getprop uu___7 uu___8 in
+                                match uu___6 with
+                                | FStar_Pervasives_Native.Some vc ->
+                                    ((let uu___8 =
+                                        FStar_Compiler_Effect.op_Bang
+                                          FStar_Tactics_V2_Interpreter.tacdbg in
+                                      if uu___8
+                                      then
+                                        let uu___9 =
+                                          FStar_Class_Show.show
+                                            FStar_Syntax_Print.showable_term
+                                            vc in
+                                        FStar_Compiler_Util.print1
+                                          "handle_smt_goals left a goal: %s\n"
+                                          uu___9
+                                      else ());
+                                     (let uu___8 =
+                                        FStar_Tactics_Types.goal_env g in
+                                      (uu___8, vc)))
+                                | FStar_Pervasives_Native.None ->
+                                    let uu___7 =
+                                      FStar_TypeChecker_Env.get_range env in
+                                    FStar_Errors.raise_error
+                                      (FStar_Errors_Codes.Fatal_OpenGoalsInSynthesis,
+                                        "Handling an SMT goal by tactic left non-prop open goals")
+                                      uu___7) gs1)) in
                gs
            | FStar_Pervasives_Native.None -> [(env, goal1)])
 let (splice :
@@ -1961,64 +1947,59 @@ let (splice :
                                match uu___7 with
                                | (gs, sig_blobs) ->
                                    let sigelts =
-                                     FStar_Compiler_Effect.op_Bar_Greater
-                                       sig_blobs
-                                       (FStar_Compiler_List.map
-                                          (fun uu___8 ->
-                                             match uu___8 with
-                                             | (checked, se, blob_opt) ->
-                                                 let uu___9 =
-                                                   let uu___10 =
-                                                     se.FStar_Syntax_Syntax.sigmeta in
-                                                   let uu___11 =
-                                                     match blob_opt with
-                                                     | FStar_Pervasives_Native.Some
-                                                         (s, blob) ->
-                                                         let uu___12 =
-                                                           let uu___13 =
-                                                             FStar_Compiler_Dyn.mkdyn
-                                                               blob in
-                                                           (s, uu___13) in
-                                                         [uu___12]
-                                                     | FStar_Pervasives_Native.None
-                                                         -> [] in
-                                                   {
-                                                     FStar_Syntax_Syntax.sigmeta_active
-                                                       =
-                                                       (uu___10.FStar_Syntax_Syntax.sigmeta_active);
-                                                     FStar_Syntax_Syntax.sigmeta_fact_db_ids
-                                                       =
-                                                       (uu___10.FStar_Syntax_Syntax.sigmeta_fact_db_ids);
-                                                     FStar_Syntax_Syntax.sigmeta_admit
-                                                       =
-                                                       (uu___10.FStar_Syntax_Syntax.sigmeta_admit);
-                                                     FStar_Syntax_Syntax.sigmeta_already_checked
-                                                       = checked;
-                                                     FStar_Syntax_Syntax.sigmeta_extension_data
-                                                       = uu___11
-                                                   } in
-                                                 {
-                                                   FStar_Syntax_Syntax.sigel
-                                                     =
-                                                     (se.FStar_Syntax_Syntax.sigel);
-                                                   FStar_Syntax_Syntax.sigrng
-                                                     =
-                                                     (se.FStar_Syntax_Syntax.sigrng);
-                                                   FStar_Syntax_Syntax.sigquals
-                                                     =
-                                                     (se.FStar_Syntax_Syntax.sigquals);
-                                                   FStar_Syntax_Syntax.sigmeta
-                                                     = uu___9;
-                                                   FStar_Syntax_Syntax.sigattrs
-                                                     =
-                                                     (se.FStar_Syntax_Syntax.sigattrs);
-                                                   FStar_Syntax_Syntax.sigopens_and_abbrevs
-                                                     =
-                                                     (se.FStar_Syntax_Syntax.sigopens_and_abbrevs);
-                                                   FStar_Syntax_Syntax.sigopts
-                                                     =
-                                                     (se.FStar_Syntax_Syntax.sigopts)
-                                                 })) in
+                                     FStar_Compiler_List.map
+                                       (fun uu___8 ->
+                                          match uu___8 with
+                                          | (checked, se, blob_opt) ->
+                                              let uu___9 =
+                                                let uu___10 =
+                                                  se.FStar_Syntax_Syntax.sigmeta in
+                                                let uu___11 =
+                                                  match blob_opt with
+                                                  | FStar_Pervasives_Native.Some
+                                                      (s, blob) ->
+                                                      let uu___12 =
+                                                        let uu___13 =
+                                                          FStar_Compiler_Dyn.mkdyn
+                                                            blob in
+                                                        (s, uu___13) in
+                                                      [uu___12]
+                                                  | FStar_Pervasives_Native.None
+                                                      -> [] in
+                                                {
+                                                  FStar_Syntax_Syntax.sigmeta_active
+                                                    =
+                                                    (uu___10.FStar_Syntax_Syntax.sigmeta_active);
+                                                  FStar_Syntax_Syntax.sigmeta_fact_db_ids
+                                                    =
+                                                    (uu___10.FStar_Syntax_Syntax.sigmeta_fact_db_ids);
+                                                  FStar_Syntax_Syntax.sigmeta_admit
+                                                    =
+                                                    (uu___10.FStar_Syntax_Syntax.sigmeta_admit);
+                                                  FStar_Syntax_Syntax.sigmeta_already_checked
+                                                    = checked;
+                                                  FStar_Syntax_Syntax.sigmeta_extension_data
+                                                    = uu___11
+                                                } in
+                                              {
+                                                FStar_Syntax_Syntax.sigel =
+                                                  (se.FStar_Syntax_Syntax.sigel);
+                                                FStar_Syntax_Syntax.sigrng =
+                                                  (se.FStar_Syntax_Syntax.sigrng);
+                                                FStar_Syntax_Syntax.sigquals
+                                                  =
+                                                  (se.FStar_Syntax_Syntax.sigquals);
+                                                FStar_Syntax_Syntax.sigmeta =
+                                                  uu___9;
+                                                FStar_Syntax_Syntax.sigattrs
+                                                  =
+                                                  (se.FStar_Syntax_Syntax.sigattrs);
+                                                FStar_Syntax_Syntax.sigopens_and_abbrevs
+                                                  =
+                                                  (se.FStar_Syntax_Syntax.sigopens_and_abbrevs);
+                                                FStar_Syntax_Syntax.sigopts =
+                                                  (se.FStar_Syntax_Syntax.sigopts)
+                                              }) sig_blobs in
                                    (gs, sigelts)
                              else
                                (let uu___8 =
@@ -2051,11 +2032,8 @@ let (splice :
                                              let uu___16 =
                                                FStar_Syntax_Util.incr_delta_qualifier
                                                  lbdef in
-                                             FStar_Compiler_Effect.op_Bar_Greater
-                                               uu___16
-                                               (fun uu___17 ->
-                                                  FStar_Pervasives_Native.Some
-                                                    uu___17) in
+                                             FStar_Pervasives_Native.Some
+                                               uu___16 in
                                            {
                                              FStar_Syntax_Syntax.fv_name =
                                                (fv.FStar_Syntax_Syntax.fv_name);
@@ -2226,90 +2204,85 @@ let (splice :
                                       uu___11
                                   else ());
                                  (let sigelts2 =
-                                    FStar_Compiler_Effect.op_Bar_Greater
-                                      sigelts1
-                                      (FStar_Compiler_List.map
-                                         (fun se ->
-                                            (match se.FStar_Syntax_Syntax.sigel
-                                             with
-                                             | FStar_Syntax_Syntax.Sig_datacon
-                                                 uu___11 ->
-                                                 let uu___12 =
-                                                   let uu___13 =
-                                                     let uu___14 =
-                                                       FStar_Syntax_Print.sigelt_to_string_short
-                                                         se in
-                                                     FStar_Compiler_Util.format1
-                                                       "Tactic returned bad sigelt: %s\nIf you wanted to splice an inductive type, call `pack` providing a `Sg_Inductive` to get a proper sigelt."
-                                                       uu___14 in
-                                                   (FStar_Errors_Codes.Error_BadSplice,
-                                                     uu___13) in
-                                                 FStar_Errors.raise_error
-                                                   uu___12 rng
-                                             | FStar_Syntax_Syntax.Sig_inductive_typ
-                                                 uu___11 ->
-                                                 let uu___12 =
-                                                   let uu___13 =
-                                                     let uu___14 =
-                                                       FStar_Syntax_Print.sigelt_to_string_short
-                                                         se in
-                                                     FStar_Compiler_Util.format1
-                                                       "Tactic returned bad sigelt: %s\nIf you wanted to splice an inductive type, call `pack` providing a `Sg_Inductive` to get a proper sigelt."
-                                                       uu___14 in
-                                                   (FStar_Errors_Codes.Error_BadSplice,
-                                                     uu___13) in
-                                                 FStar_Errors.raise_error
-                                                   uu___12 rng
-                                             | uu___11 -> ());
-                                            {
-                                              FStar_Syntax_Syntax.sigel =
-                                                (se.FStar_Syntax_Syntax.sigel);
-                                              FStar_Syntax_Syntax.sigrng =
-                                                rng;
-                                              FStar_Syntax_Syntax.sigquals =
-                                                (se.FStar_Syntax_Syntax.sigquals);
-                                              FStar_Syntax_Syntax.sigmeta =
-                                                (se.FStar_Syntax_Syntax.sigmeta);
-                                              FStar_Syntax_Syntax.sigattrs =
-                                                (se.FStar_Syntax_Syntax.sigattrs);
-                                              FStar_Syntax_Syntax.sigopens_and_abbrevs
-                                                =
-                                                (se.FStar_Syntax_Syntax.sigopens_and_abbrevs);
-                                              FStar_Syntax_Syntax.sigopts =
-                                                (se.FStar_Syntax_Syntax.sigopts)
-                                            })) in
+                                    FStar_Compiler_List.map
+                                      (fun se ->
+                                         (match se.FStar_Syntax_Syntax.sigel
+                                          with
+                                          | FStar_Syntax_Syntax.Sig_datacon
+                                              uu___11 ->
+                                              let uu___12 =
+                                                let uu___13 =
+                                                  let uu___14 =
+                                                    FStar_Syntax_Print.sigelt_to_string_short
+                                                      se in
+                                                  FStar_Compiler_Util.format1
+                                                    "Tactic returned bad sigelt: %s\nIf you wanted to splice an inductive type, call `pack` providing a `Sg_Inductive` to get a proper sigelt."
+                                                    uu___14 in
+                                                (FStar_Errors_Codes.Error_BadSplice,
+                                                  uu___13) in
+                                              FStar_Errors.raise_error
+                                                uu___12 rng
+                                          | FStar_Syntax_Syntax.Sig_inductive_typ
+                                              uu___11 ->
+                                              let uu___12 =
+                                                let uu___13 =
+                                                  let uu___14 =
+                                                    FStar_Syntax_Print.sigelt_to_string_short
+                                                      se in
+                                                  FStar_Compiler_Util.format1
+                                                    "Tactic returned bad sigelt: %s\nIf you wanted to splice an inductive type, call `pack` providing a `Sg_Inductive` to get a proper sigelt."
+                                                    uu___14 in
+                                                (FStar_Errors_Codes.Error_BadSplice,
+                                                  uu___13) in
+                                              FStar_Errors.raise_error
+                                                uu___12 rng
+                                          | uu___11 -> ());
+                                         {
+                                           FStar_Syntax_Syntax.sigel =
+                                             (se.FStar_Syntax_Syntax.sigel);
+                                           FStar_Syntax_Syntax.sigrng = rng;
+                                           FStar_Syntax_Syntax.sigquals =
+                                             (se.FStar_Syntax_Syntax.sigquals);
+                                           FStar_Syntax_Syntax.sigmeta =
+                                             (se.FStar_Syntax_Syntax.sigmeta);
+                                           FStar_Syntax_Syntax.sigattrs =
+                                             (se.FStar_Syntax_Syntax.sigattrs);
+                                           FStar_Syntax_Syntax.sigopens_and_abbrevs
+                                             =
+                                             (se.FStar_Syntax_Syntax.sigopens_and_abbrevs);
+                                           FStar_Syntax_Syntax.sigopts =
+                                             (se.FStar_Syntax_Syntax.sigopts)
+                                         }) sigelts1 in
                                   if is_typed
                                   then ()
                                   else
-                                    FStar_Compiler_Effect.op_Bar_Greater
-                                      sigelts2
-                                      (FStar_Compiler_List.iter
-                                         (fun se ->
-                                            FStar_Compiler_Effect.op_Bar_Greater
-                                              se.FStar_Syntax_Syntax.sigquals
-                                              (FStar_Compiler_List.iter
-                                                 (fun q ->
-                                                    let uu___12 =
-                                                      FStar_Syntax_Syntax.is_internal_qualifier
+                                    FStar_Compiler_List.iter
+                                      (fun se ->
+                                         FStar_Compiler_List.iter
+                                           (fun q ->
+                                              let uu___12 =
+                                                FStar_Syntax_Syntax.is_internal_qualifier
+                                                  q in
+                                              if uu___12
+                                              then
+                                                let uu___13 =
+                                                  let uu___14 =
+                                                    let uu___15 =
+                                                      FStar_Syntax_Print.qual_to_string
                                                         q in
-                                                    if uu___12
-                                                    then
-                                                      let uu___13 =
-                                                        let uu___14 =
-                                                          let uu___15 =
-                                                            FStar_Syntax_Print.qual_to_string
-                                                              q in
-                                                          let uu___16 =
-                                                            FStar_Syntax_Print.sigelt_to_string_short
-                                                              se in
-                                                          FStar_Compiler_Util.format2
-                                                            "The qualifier %s is internal, it cannot be attached to spliced sigelt `%s`."
-                                                            uu___15 uu___16 in
-                                                        (FStar_Errors_Codes.Error_InternalQualifier,
-                                                          uu___14) in
-                                                      FStar_Errors.raise_error
-                                                        uu___13 rng
-                                                    else ()))));
+                                                    let uu___16 =
+                                                      FStar_Syntax_Print.sigelt_to_string_short
+                                                        se in
+                                                    FStar_Compiler_Util.format2
+                                                      "The qualifier %s is internal, it cannot be attached to spliced sigelt `%s`."
+                                                      uu___15 uu___16 in
+                                                  (FStar_Errors_Codes.Error_InternalQualifier,
+                                                    uu___14) in
+                                                FStar_Errors.raise_error
+                                                  uu___13 rng
+                                              else ())
+                                           se.FStar_Syntax_Syntax.sigquals)
+                                      sigelts2;
                                   (match () with | () -> sigelts2)))))))))
 let (mpreprocess :
   FStar_TypeChecker_Env.env ->

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Monad.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Monad.ml
@@ -152,8 +152,7 @@ let (register_goal : FStar_Tactics_Types.goal -> unit) =
                    (env.FStar_TypeChecker_Env.core_check)
                } in
              (let uu___6 =
-                FStar_Compiler_Effect.op_Less_Bar
-                  (FStar_TypeChecker_Env.debug env1)
+                FStar_TypeChecker_Env.debug env1
                   (FStar_Options.Other "CoreEq") in
               if uu___6
               then
@@ -167,12 +166,10 @@ let (register_goal : FStar_Tactics_Types.goal -> unit) =
               if Prims.op_Negation should_register
               then
                 let uu___7 =
-                  (FStar_Compiler_Effect.op_Less_Bar
-                     (FStar_TypeChecker_Env.debug env1)
+                  (FStar_TypeChecker_Env.debug env1
                      (FStar_Options.Other "Core"))
                     ||
-                    (FStar_Compiler_Effect.op_Less_Bar
-                       (FStar_TypeChecker_Env.debug env1)
+                    (FStar_TypeChecker_Env.debug env1
                        (FStar_Options.Other "RegisterGoal")) in
                 (if uu___7
                  then
@@ -186,12 +183,10 @@ let (register_goal : FStar_Tactics_Types.goal -> unit) =
                  else ())
               else
                 ((let uu___8 =
-                    (FStar_Compiler_Effect.op_Less_Bar
-                       (FStar_TypeChecker_Env.debug env1)
+                    (FStar_TypeChecker_Env.debug env1
                        (FStar_Options.Other "Core"))
                       ||
-                      (FStar_Compiler_Effect.op_Less_Bar
-                         (FStar_TypeChecker_Env.debug env1)
+                      (FStar_TypeChecker_Env.debug env1
                          (FStar_Options.Other "RegisterGoal")) in
                   if uu___8
                   then

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Printing.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Printing.ml
@@ -128,41 +128,40 @@ let (goal_to_string :
             | l -> Prims.strcat " (" (Prims.strcat l ")") in
           let uu___ =
             let rename_binders subst bs =
-              FStar_Compiler_Effect.op_Bar_Greater bs
-                (FStar_Compiler_List.map
-                   (fun uu___1 ->
-                      let x = uu___1.FStar_Syntax_Syntax.binder_bv in
-                      let y =
-                        let uu___2 = FStar_Syntax_Syntax.bv_to_name x in
-                        FStar_Syntax_Subst.subst subst uu___2 in
-                      let uu___2 =
-                        let uu___3 = FStar_Syntax_Subst.compress y in
-                        uu___3.FStar_Syntax_Syntax.n in
-                      match uu___2 with
-                      | FStar_Syntax_Syntax.Tm_name y1 ->
-                          let uu___3 =
-                            let uu___4 = uu___1.FStar_Syntax_Syntax.binder_bv in
-                            let uu___5 =
-                              FStar_Syntax_Subst.subst subst
-                                x.FStar_Syntax_Syntax.sort in
-                            {
-                              FStar_Syntax_Syntax.ppname =
-                                (uu___4.FStar_Syntax_Syntax.ppname);
-                              FStar_Syntax_Syntax.index =
-                                (uu___4.FStar_Syntax_Syntax.index);
-                              FStar_Syntax_Syntax.sort = uu___5
-                            } in
-                          {
-                            FStar_Syntax_Syntax.binder_bv = uu___3;
-                            FStar_Syntax_Syntax.binder_qual =
-                              (uu___1.FStar_Syntax_Syntax.binder_qual);
-                            FStar_Syntax_Syntax.binder_positivity =
-                              (uu___1.FStar_Syntax_Syntax.binder_positivity);
-                            FStar_Syntax_Syntax.binder_attrs =
-                              (uu___1.FStar_Syntax_Syntax.binder_attrs)
-                          }
-                      | uu___3 ->
-                          FStar_Compiler_Effect.failwith "Not a renaming")) in
+              FStar_Compiler_List.map
+                (fun uu___1 ->
+                   let x = uu___1.FStar_Syntax_Syntax.binder_bv in
+                   let y =
+                     let uu___2 = FStar_Syntax_Syntax.bv_to_name x in
+                     FStar_Syntax_Subst.subst subst uu___2 in
+                   let uu___2 =
+                     let uu___3 = FStar_Syntax_Subst.compress y in
+                     uu___3.FStar_Syntax_Syntax.n in
+                   match uu___2 with
+                   | FStar_Syntax_Syntax.Tm_name y1 ->
+                       let uu___3 =
+                         let uu___4 = uu___1.FStar_Syntax_Syntax.binder_bv in
+                         let uu___5 =
+                           FStar_Syntax_Subst.subst subst
+                             x.FStar_Syntax_Syntax.sort in
+                         {
+                           FStar_Syntax_Syntax.ppname =
+                             (uu___4.FStar_Syntax_Syntax.ppname);
+                           FStar_Syntax_Syntax.index =
+                             (uu___4.FStar_Syntax_Syntax.index);
+                           FStar_Syntax_Syntax.sort = uu___5
+                         } in
+                       {
+                         FStar_Syntax_Syntax.binder_bv = uu___3;
+                         FStar_Syntax_Syntax.binder_qual =
+                           (uu___1.FStar_Syntax_Syntax.binder_qual);
+                         FStar_Syntax_Syntax.binder_positivity =
+                           (uu___1.FStar_Syntax_Syntax.binder_positivity);
+                         FStar_Syntax_Syntax.binder_attrs =
+                           (uu___1.FStar_Syntax_Syntax.binder_attrs)
+                       }
+                   | uu___3 ->
+                       FStar_Compiler_Effect.failwith "Not a renaming") bs in
             let goal_binders =
               (g.FStar_Tactics_Types.goal_ctx_uvar).FStar_Syntax_Syntax.ctx_uvar_binders in
             let goal_ty = FStar_Tactics_Types.goal_type g in

--- a/ocaml/fstar-lib/generated/FStar_Tactics_V1_Basic.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_V1_Basic.ml
@@ -235,8 +235,7 @@ let (dump_uvars_of :
              let uu___ =
                let uu___1 = FStar_Tactics_Types.goal_type g in
                FStar_Syntax_Free.uvars uu___1 in
-             FStar_Compiler_Effect.op_Bar_Greater uu___
-               (FStar_Compiler_Set.elems FStar_Syntax_Free.ord_ctx_uvar) in
+             FStar_Compiler_Set.elems FStar_Syntax_Free.ord_ctx_uvar uu___ in
            let gs =
              FStar_Compiler_List.map (FStar_Tactics_Types.goal_of_ctx_uvar g)
                uvs in
@@ -558,8 +557,7 @@ let (proc_guard' :
                                                         let uu___8 =
                                                           FStar_TypeChecker_Rel.discharge_guard_no_smt
                                                             e g in
-                                                        FStar_Compiler_Effect.op_Less_Bar
-                                                          FStar_TypeChecker_Env.is_trivial
+                                                        FStar_TypeChecker_Env.is_trivial
                                                           uu___8 in
                                                       Prims.op_Negation
                                                         uu___7 in
@@ -811,9 +809,7 @@ let (tc_unifier_solved_implicits :
                             uu___3 uu___4 uu___5)) in
           if env1.FStar_TypeChecker_Env.phase1
           then FStar_Tactics_Monad.ret ()
-          else
-            FStar_Compiler_Effect.op_Bar_Greater uvs
-              (FStar_Tactics_Monad.iter_tac aux)
+          else FStar_Tactics_Monad.iter_tac aux uvs
 type check_unifier_solved_implicits_side =
   | Check_none 
   | Check_left_only 
@@ -873,8 +869,8 @@ let (__do_unify_wflags :
                          let uu___3 = FStar_Syntax_Free.uvars t2 in
                          FStar_Compiler_Set.union
                            FStar_Syntax_Free.ord_ctx_uvar uu___2 uu___3 in
-                   FStar_Compiler_Effect.op_Bar_Greater uu___1
-                     (FStar_Compiler_Set.elems FStar_Syntax_Free.ord_ctx_uvar) in
+                   FStar_Compiler_Set.elems FStar_Syntax_Free.ord_ctx_uvar
+                     uu___1 in
                  let uu___1 =
                    let uu___2 =
                      let uu___3 =
@@ -1257,8 +1253,7 @@ let (tadmit_t : FStar_Syntax_Syntax.term -> unit FStar_Tactics_Monad.tac) =
                    (FStar_Errors_Codes.Warning_TacAdmit, uu___4) in
                  FStar_Errors.log_issue uu___2 uu___3);
                 solve' g t)) in
-    FStar_Compiler_Effect.op_Less_Bar
-      (FStar_Tactics_Monad.wrap_err "tadmit_t") uu___
+    FStar_Tactics_Monad.wrap_err "tadmit_t" uu___
 let (fresh : unit -> FStar_BigInt.t FStar_Tactics_Monad.tac) =
   fun uu___ ->
     FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
@@ -1296,7 +1291,7 @@ let (curms : unit -> FStar_BigInt.t FStar_Tactics_Monad.tac) =
   fun uu___ ->
     let uu___1 =
       let uu___2 = FStar_Compiler_Util.now_ms () in
-      FStar_Compiler_Effect.op_Bar_Greater uu___2 FStar_BigInt.of_int_fs in
+      FStar_BigInt.of_int_fs uu___2 in
     FStar_Tactics_Monad.ret uu___1
 let (__tc :
   env ->
@@ -1432,8 +1427,7 @@ let (__tc :
                     let uu___4 = tts e1 t in
                     let uu___5 =
                       let uu___6 = FStar_TypeChecker_Env.all_binders e1 in
-                      FStar_Compiler_Effect.op_Bar_Greater uu___6
-                        (FStar_Syntax_Print.binders_to_string ", ") in
+                      FStar_Syntax_Print.binders_to_string ", " uu___6 in
                     let uu___6 = FStar_Errors_Msg.rendermsg msg in
                     fail3 "Cannot type (1) %s in context (%s). Error = (%s)"
                       uu___4 uu___5 uu___6
@@ -1441,8 +1435,7 @@ let (__tc :
                     let uu___5 = tts e1 t in
                     let uu___6 =
                       let uu___7 = FStar_TypeChecker_Env.all_binders e1 in
-                      FStar_Compiler_Effect.op_Bar_Greater uu___7
-                        (FStar_Syntax_Print.binders_to_string ", ") in
+                      FStar_Syntax_Print.binders_to_string ", " uu___7 in
                     let uu___7 = FStar_Errors_Msg.rendermsg msg in
                     fail3 "Cannot type (1) %s in context (%s). Error = (%s)"
                       uu___5 uu___6 uu___7))
@@ -1690,8 +1683,7 @@ let (__tc_ghost :
                     let uu___4 = tts e2 t in
                     let uu___5 =
                       let uu___6 = FStar_TypeChecker_Env.all_binders e2 in
-                      FStar_Compiler_Effect.op_Bar_Greater uu___6
-                        (FStar_Syntax_Print.binders_to_string ", ") in
+                      FStar_Syntax_Print.binders_to_string ", " uu___6 in
                     let uu___6 = FStar_Errors_Msg.rendermsg msg in
                     fail3 "Cannot type (2) %s in context (%s). Error = (%s)"
                       uu___4 uu___5 uu___6
@@ -1699,8 +1691,7 @@ let (__tc_ghost :
                     let uu___5 = tts e2 t in
                     let uu___6 =
                       let uu___7 = FStar_TypeChecker_Env.all_binders e2 in
-                      FStar_Compiler_Effect.op_Bar_Greater uu___7
-                        (FStar_Syntax_Print.binders_to_string ", ") in
+                      FStar_Syntax_Print.binders_to_string ", " uu___7 in
                     let uu___7 = FStar_Errors_Msg.rendermsg msg in
                     fail3 "Cannot type (2) %s in context (%s). Error = (%s)"
                       uu___5 uu___6 uu___7))
@@ -1720,8 +1711,7 @@ let (__tc_lax :
                   FStar_Class_Show.show FStar_Syntax_Print.showable_term t in
                 let uu___2 =
                   let uu___3 = FStar_TypeChecker_Env.all_binders e in
-                  FStar_Compiler_Effect.op_Bar_Greater uu___3
-                    (FStar_Syntax_Print.binders_to_string ", ") in
+                  FStar_Syntax_Print.binders_to_string ", " uu___3 in
                 FStar_Compiler_Util.print2 "Tac> __tc_lax(%s)(Context:%s)\n"
                   uu___1 uu___2)
              (fun uu___ ->
@@ -2055,8 +2045,7 @@ let (__tc_lax :
                     let uu___4 = tts e3 t in
                     let uu___5 =
                       let uu___6 = FStar_TypeChecker_Env.all_binders e3 in
-                      FStar_Compiler_Effect.op_Bar_Greater uu___6
-                        (FStar_Syntax_Print.binders_to_string ", ") in
+                      FStar_Syntax_Print.binders_to_string ", " uu___6 in
                     let uu___6 = FStar_Errors_Msg.rendermsg msg in
                     fail3 "Cannot type (3) %s in context (%s). Error = (%s)"
                       uu___4 uu___5 uu___6
@@ -2064,8 +2053,7 @@ let (__tc_lax :
                     let uu___5 = tts e3 t in
                     let uu___6 =
                       let uu___7 = FStar_TypeChecker_Env.all_binders e3 in
-                      FStar_Compiler_Effect.op_Bar_Greater uu___7
-                        (FStar_Syntax_Print.binders_to_string ", ") in
+                      FStar_Syntax_Print.binders_to_string ", " uu___7 in
                     let uu___7 = FStar_Errors_Msg.rendermsg msg in
                     fail3 "Cannot type (3) %s in context (%s). Error = (%s)"
                       uu___5 uu___6 uu___7))
@@ -2084,11 +2072,9 @@ let (tcc :
              | (uu___3, lc, uu___4) ->
                  let uu___5 =
                    let uu___6 = FStar_TypeChecker_Common.lcomp_comp lc in
-                   FStar_Compiler_Effect.op_Bar_Greater uu___6
-                     FStar_Pervasives_Native.fst in
+                   FStar_Pervasives_Native.fst uu___6 in
                  FStar_Tactics_Monad.ret uu___5) in
-      FStar_Compiler_Effect.op_Less_Bar (FStar_Tactics_Monad.wrap_err "tcc")
-        uu___
+      FStar_Tactics_Monad.wrap_err "tcc" uu___
 let (tc :
   env ->
     FStar_Syntax_Syntax.term ->
@@ -2100,8 +2086,7 @@ let (tc :
         let uu___1 = tcc e t in
         FStar_Tactics_Monad.bind uu___1
           (fun c -> FStar_Tactics_Monad.ret (FStar_Syntax_Util.comp_result c)) in
-      FStar_Compiler_Effect.op_Less_Bar (FStar_Tactics_Monad.wrap_err "tc")
-        uu___
+      FStar_Tactics_Monad.wrap_err "tc" uu___
 let divide :
   'a 'b .
     FStar_BigInt.t ->
@@ -2376,8 +2361,7 @@ let (intro : unit -> FStar_Syntax_Syntax.binder FStar_Tactics_Monad.tac) =
                  let uu___5 = FStar_Tactics_Types.goal_type goal in
                  tts uu___4 uu___5 in
                fail1 "goal is not an arrow (%s)" uu___3) in
-    FStar_Compiler_Effect.op_Less_Bar (FStar_Tactics_Monad.wrap_err "intro")
-      uu___1
+    FStar_Tactics_Monad.wrap_err "intro" uu___1
 let (intro_rec :
   unit ->
     (FStar_Syntax_Syntax.binder * FStar_Syntax_Syntax.binder)
@@ -2548,8 +2532,7 @@ let (norm_term_env :
                                       "norm_term_env: t' = %s\n" uu___9) in
                              FStar_Tactics_Monad.op_let_Bang uu___7
                                (fun uu___8 -> FStar_Tactics_Monad.ret t2)))) in
-        FStar_Compiler_Effect.op_Less_Bar
-          (FStar_Tactics_Monad.wrap_err "norm_term") uu___
+        FStar_Tactics_Monad.wrap_err "norm_term" uu___
 let (refine_intro : unit -> unit FStar_Tactics_Monad.tac) =
   fun uu___ ->
     let uu___1 =
@@ -2604,8 +2587,7 @@ let (refine_intro : unit -> unit FStar_Tactics_Monad.tac) =
                             FStar_Tactics_Monad.dismiss
                             (fun uu___6 ->
                                FStar_Tactics_Monad.add_goals [g1; g2]))))) in
-    FStar_Compiler_Effect.op_Less_Bar
-      (FStar_Tactics_Monad.wrap_err "refine_intro") uu___1
+    FStar_Tactics_Monad.wrap_err "refine_intro" uu___1
 let (__exact_now :
   Prims.bool -> FStar_Syntax_Syntax.term -> unit FStar_Tactics_Monad.tac) =
   fun set_expected_typ ->
@@ -2773,8 +2755,7 @@ let (t_exact :
                                       FStar_Tactics_Monad.op_let_Bang uu___10
                                         (fun uu___11 ->
                                            FStar_Tactics_Monad.traise e))))) in
-        FStar_Compiler_Effect.op_Less_Bar
-          (FStar_Tactics_Monad.wrap_err "exact") uu___
+        FStar_Tactics_Monad.wrap_err "exact" uu___
 let (try_unify_by_application :
   FStar_Syntax_Syntax.should_check_uvar FStar_Pervasives_Native.option ->
     Prims.bool ->
@@ -2898,8 +2879,7 @@ let (apply_implicits_as_goals :
                         let gl2 = bnorm_goal gl1 in
                         FStar_Tactics_Monad.ret [gl2]
                     | uu___4 -> FStar_Tactics_Monad.ret [])) in
-        FStar_Compiler_Effect.op_Bar_Greater imps
-          (FStar_Tactics_Monad.mapM one_implicit_as_goal)
+        FStar_Tactics_Monad.mapM one_implicit_as_goal imps
 let (t_apply :
   Prims.bool ->
     Prims.bool ->
@@ -3055,17 +3035,14 @@ let (t_apply :
                                                       uu___11
                                                       (fun uu___12 ->
                                                          let uvt_uv_l =
-                                                           FStar_Compiler_Effect.op_Bar_Greater
-                                                             uvs
-                                                             (FStar_Compiler_List.map
-                                                                (fun uu___13
-                                                                   ->
-                                                                   match uu___13
-                                                                   with
-                                                                   | 
-                                                                   (uvt, _q,
-                                                                    uv) ->
-                                                                    (uvt, uv))) in
+                                                           FStar_Compiler_List.map
+                                                             (fun uu___13 ->
+                                                                match uu___13
+                                                                with
+                                                                | (uvt, _q,
+                                                                   uv) ->
+                                                                    (uvt, uv))
+                                                             uvs in
                                                          let uu___13 =
                                                            apply_implicits_as_goals
                                                              e
@@ -3080,10 +3057,7 @@ let (t_apply :
                                                                 let uu___14 =
                                                                   let uu___15
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    (FStar_Compiler_List.flatten
-                                                                    sub_goals)
-                                                                    (FStar_Compiler_List.filter
+                                                                    FStar_Compiler_List.filter
                                                                     (fun g ->
                                                                     let uu___16
                                                                     =
@@ -3091,15 +3065,14 @@ let (t_apply :
                                                                     (free_in_some_goal
                                                                     g.FStar_Tactics_Types.goal_ctx_uvar) in
                                                                     Prims.op_Negation
-                                                                    uu___16)) in
-                                                                  FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___15
-                                                                    (
-                                                                    FStar_Compiler_List.map
-                                                                    bnorm_goal) in
-                                                                FStar_Compiler_Effect.op_Bar_Greater
-                                                                  uu___14
-                                                                  FStar_Compiler_List.rev in
+                                                                    uu___16)
+                                                                    (FStar_Compiler_List.flatten
+                                                                    sub_goals) in
+                                                                  FStar_Compiler_List.map
+                                                                    bnorm_goal
+                                                                    uu___15 in
+                                                                FStar_Compiler_List.rev
+                                                                  uu___14 in
                                                               let uu___14 =
                                                                 FStar_Tactics_Monad.add_goals
                                                                   sub_goals1 in
@@ -3114,8 +3087,7 @@ let (t_apply :
                                                                     should_check)
                                                                     (rangeof
                                                                     goal)))))))))))) in
-          FStar_Compiler_Effect.op_Less_Bar
-            (FStar_Tactics_Monad.wrap_err "apply") uu___
+          FStar_Tactics_Monad.wrap_err "apply" uu___
 let (lemma_or_sq :
   FStar_Syntax_Syntax.comp ->
     (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.term)
@@ -3247,8 +3219,7 @@ let (t_apply_lemma :
                                                               is_unit_t b_t in
                                                             if uu___14
                                                             then
-                                                              FStar_Compiler_Effect.op_Less_Bar
-                                                                FStar_Tactics_Monad.ret
+                                                              FStar_Tactics_Monad.ret
                                                                 (((FStar_Syntax_Util.exp_unit,
                                                                     aq) ::
                                                                   uvs), deps,
@@ -3265,15 +3236,9 @@ let (t_apply_lemma :
                                                                     =
                                                                     let uu___19
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    goal
-                                                                    should_check_goal_uvar in
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___19
-                                                                    (fun
-                                                                    uu___20
-                                                                    ->
-                                                                    match uu___20
+                                                                    should_check_goal_uvar
+                                                                    goal in
+                                                                    match uu___19
                                                                     with
                                                                     | 
                                                                     FStar_Syntax_Syntax.Strict
@@ -3281,14 +3246,9 @@ let (t_apply_lemma :
                                                                     FStar_Syntax_Syntax.Allow_ghost
                                                                     "apply lemma uvar"
                                                                     | 
-                                                                    x -> x) in
-                                                                   FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___18
-                                                                    (fun
-                                                                    uu___19
-                                                                    ->
-                                                                    FStar_Pervasives_Native.Some
-                                                                    uu___19) in
+                                                                    x -> x in
+                                                                   FStar_Pervasives_Native.Some
+                                                                    uu___18 in
                                                                  FStar_Tactics_Monad.new_uvar
                                                                    "apply_lemma"
                                                                    env1 b_t
@@ -3308,9 +3268,8 @@ let (t_apply_lemma :
                                                                     ((
                                                                     let uu___19
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Less_Bar
-                                                                    (FStar_TypeChecker_Env.debug
-                                                                    env1)
+                                                                    FStar_TypeChecker_Env.debug
+                                                                    env1
                                                                     (FStar_Options.Other
                                                                     "2635") in
                                                                     if
@@ -3610,8 +3569,7 @@ let (t_apply_lemma :
                                                                     FStar_Tactics_Monad.add_goals
                                                                     sub_goals2)))))))))))))) in
           focus uu___1 in
-        FStar_Compiler_Effect.op_Less_Bar
-          (FStar_Tactics_Monad.wrap_err "apply_lemma") uu___
+        FStar_Tactics_Monad.wrap_err "apply_lemma" uu___
 let (split_env :
   FStar_Syntax_Syntax.bv ->
     env ->
@@ -3849,8 +3807,7 @@ let (rewrite : FStar_Syntax_Syntax.binder -> unit FStar_Tactics_Monad.tac) =
                      | uu___5 ->
                          FStar_Tactics_Monad.fail
                            "Not an equality hypothesis"))) in
-    FStar_Compiler_Effect.op_Less_Bar
-      (FStar_Tactics_Monad.wrap_err "rewrite") uu___
+    FStar_Tactics_Monad.wrap_err "rewrite" uu___
 let (rename_to :
   FStar_Syntax_Syntax.binder ->
     Prims.string -> FStar_Syntax_Syntax.binder FStar_Tactics_Monad.tac)
@@ -3896,8 +3853,7 @@ let (rename_to :
                                FStar_Syntax_Syntax.binder_attrs =
                                  (b.FStar_Syntax_Syntax.binder_attrs)
                              }))) in
-      FStar_Compiler_Effect.op_Less_Bar
-        (FStar_Tactics_Monad.wrap_err "rename_to") uu___
+      FStar_Tactics_Monad.wrap_err "rename_to" uu___
 let (binder_retype :
   FStar_Syntax_Syntax.binder -> unit FStar_Tactics_Monad.tac) =
   fun b ->
@@ -3983,8 +3939,7 @@ let (binder_retype :
                                          uu___8
                                          (FStar_Pervasives_Native.Some
                                             goal_sc)))))) in
-    FStar_Compiler_Effect.op_Less_Bar
-      (FStar_Tactics_Monad.wrap_err "binder_retype") uu___
+    FStar_Tactics_Monad.wrap_err "binder_retype" uu___
 let (norm_binder_type :
   FStar_Pervasives.norm_step Prims.list ->
     FStar_Syntax_Syntax.binder -> unit FStar_Tactics_Monad.tac)
@@ -4020,8 +3975,7 @@ let (norm_binder_type :
                  let env' = FStar_TypeChecker_Env.push_bvs e0 (bv' :: bvs) in
                  let uu___2 = FStar_Tactics_Types.goal_with_env goal env' in
                  FStar_Tactics_Monad.replace_cur uu___2) in
-      FStar_Compiler_Effect.op_Less_Bar
-        (FStar_Tactics_Monad.wrap_err "norm_binder_type") uu___
+      FStar_Tactics_Monad.wrap_err "norm_binder_type" uu___
 let (revert : unit -> unit FStar_Tactics_Monad.tac) =
   fun uu___ ->
     FStar_Tactics_Monad.op_let_Bang FStar_Tactics_Monad.cur_goal
@@ -4092,12 +4046,10 @@ let (clear : FStar_Syntax_Syntax.binder -> unit FStar_Tactics_Monad.tac) =
                     let uu___5 =
                       let uu___6 = FStar_Tactics_Types.goal_env goal in
                       FStar_TypeChecker_Env.all_binders uu___6 in
-                    FStar_Compiler_Effect.op_Bar_Greater uu___5
-                      FStar_Compiler_List.length in
-                  FStar_Compiler_Effect.op_Bar_Greater uu___4
-                    (FStar_Class_Show.show
-                       (FStar_Class_Show.printableshow
-                          FStar_Class_Printable.printable_nat)) in
+                    FStar_Compiler_List.length uu___5 in
+                  FStar_Class_Show.show
+                    (FStar_Class_Show.printableshow
+                       FStar_Class_Printable.printable_nat) uu___4 in
                 FStar_Compiler_Util.print2
                   "Clear of (%s), env has %s binders\n" uu___2 uu___3) in
          FStar_Tactics_Monad.op_let_Bang uu___
@@ -4541,8 +4493,7 @@ let (t_trefl : Prims.bool -> unit FStar_Tactics_Monad.tac) =
            match uu___2 with
            | FStar_Pervasives.Inr v -> FStar_Tactics_Monad.ret ()
            | FStar_Pervasives.Inl exn -> FStar_Tactics_Monad.traise exn) in
-    FStar_Compiler_Effect.op_Less_Bar
-      (FStar_Tactics_Monad.wrap_err "t_trefl") uu___
+    FStar_Tactics_Monad.wrap_err "t_trefl" uu___
 let (dup : unit -> unit FStar_Tactics_Monad.tac) =
   fun uu___ ->
     FStar_Tactics_Monad.op_let_Bang FStar_Tactics_Monad.cur_goal
@@ -4898,14 +4849,11 @@ let (set_options : Prims.string -> unit FStar_Tactics_Monad.tac) =
                  fail2 "Setting options `%s` failed: %s" s err
              | FStar_Getopt.Help ->
                  fail1 "Setting options `%s` failed (got `Help`?)" s))) in
-    FStar_Compiler_Effect.op_Less_Bar
-      (FStar_Tactics_Monad.wrap_err "set_options") uu___
+    FStar_Tactics_Monad.wrap_err "set_options" uu___
 let (top_env : unit -> env FStar_Tactics_Monad.tac) =
   fun uu___ ->
     FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
-      (fun ps ->
-         FStar_Compiler_Effect.op_Less_Bar FStar_Tactics_Monad.ret
-           ps.FStar_Tactics_Types.main_context)
+      (fun ps -> FStar_Tactics_Monad.ret ps.FStar_Tactics_Types.main_context)
 let (lax_on : unit -> Prims.bool FStar_Tactics_Monad.tac) =
   fun uu___ ->
     FStar_Tactics_Monad.op_let_Bang FStar_Tactics_Monad.cur_goal
@@ -4972,8 +4920,7 @@ let (unquote :
                                      FStar_Tactics_Monad.op_let_Bang uu___9
                                        (fun uu___10 ->
                                           FStar_Tactics_Monad.ret tm1)))))) in
-      FStar_Compiler_Effect.op_Less_Bar
-        (FStar_Tactics_Monad.wrap_err "unquote") uu___
+      FStar_Tactics_Monad.wrap_err "unquote" uu___
 let (uvar_env :
   env ->
     FStar_Syntax_Syntax.typ FStar_Pervasives_Native.option ->
@@ -4989,8 +4936,7 @@ let (uvar_env :
                  let env2 =
                    let uu___1 =
                      let uu___2 = FStar_Syntax_Util.type_u () in
-                     FStar_Compiler_Effect.op_Bar_Greater uu___2
-                       FStar_Pervasives_Native.fst in
+                     FStar_Pervasives_Native.fst uu___2 in
                    FStar_TypeChecker_Env.set_expected_typ env1 uu___1 in
                  let uu___1 = __tc_ghost env2 ty1 in
                  FStar_Tactics_Monad.op_let_Bang uu___1
@@ -5003,8 +4949,7 @@ let (uvar_env :
                  let uu___1 =
                    let uu___2 =
                      let uu___3 = FStar_Syntax_Util.type_u () in
-                     FStar_Compiler_Effect.op_Less_Bar
-                       FStar_Pervasives_Native.fst uu___3 in
+                     FStar_Pervasives_Native.fst uu___3 in
                    FStar_Tactics_Monad.new_uvar "uvar_env.2" env1 uu___2
                      FStar_Pervasives_Native.None []
                      ps.FStar_Tactics_Types.entry_range in
@@ -5067,8 +5012,8 @@ let (fresh_universe_uvar :
   fun uu___ ->
     let uu___1 =
       let uu___2 = FStar_Syntax_Util.type_u () in
-      FStar_Compiler_Effect.op_Bar_Greater uu___2 FStar_Pervasives_Native.fst in
-    FStar_Compiler_Effect.op_Bar_Greater uu___1 FStar_Tactics_Monad.ret
+      FStar_Pervasives_Native.fst uu___2 in
+    FStar_Tactics_Monad.ret uu___1
 let (unshelve : FStar_Syntax_Syntax.term -> unit FStar_Tactics_Monad.tac) =
   fun t ->
     let uu___ =
@@ -5199,8 +5144,7 @@ let (unshelve : FStar_Syntax_Syntax.term -> unit FStar_Tactics_Monad.tac) =
                  FStar_Tactics_Types.mk_goal env2 ctx_uvar opts false "" in
                let g1 = bnorm_goal g in FStar_Tactics_Monad.add_goals [g1]
            | uu___2 -> FStar_Tactics_Monad.fail "not a uvar") in
-    FStar_Compiler_Effect.op_Less_Bar
-      (FStar_Tactics_Monad.wrap_err "unshelve") uu___
+    FStar_Tactics_Monad.wrap_err "unshelve" uu___
 let (tac_and :
   Prims.bool FStar_Tactics_Monad.tac ->
     Prims.bool FStar_Tactics_Monad.tac -> Prims.bool FStar_Tactics_Monad.tac)
@@ -5266,8 +5210,7 @@ let (match_env :
                                            let uu___10 =
                                              do_match must_tot e t11 t21 in
                                            tac_and uu___9 uu___10))))) in
-        FStar_Compiler_Effect.op_Less_Bar
-          (FStar_Tactics_Monad.wrap_err "match_env") uu___
+        FStar_Tactics_Monad.wrap_err "match_env" uu___
 let (unify_env :
   env ->
     FStar_Syntax_Syntax.term ->
@@ -5307,8 +5250,7 @@ let (unify_env :
                                            let uu___10 =
                                              do_unify must_tot e t11 t21 in
                                            tac_and uu___9 uu___10))))) in
-        FStar_Compiler_Effect.op_Less_Bar
-          (FStar_Tactics_Monad.wrap_err "unify_env") uu___
+        FStar_Tactics_Monad.wrap_err "unify_env" uu___
 let (unify_guard_env :
   env ->
     FStar_Syntax_Syntax.term ->
@@ -5401,8 +5343,7 @@ let (unify_guard_env :
                                                                     ->
                                                                     FStar_Tactics_Monad.ret
                                                                     true))))))))) in
-        FStar_Compiler_Effect.op_Less_Bar
-          (FStar_Tactics_Monad.wrap_err "unify_guard_env") uu___
+        FStar_Tactics_Monad.wrap_err "unify_guard_env" uu___
 let (launch_process :
   Prims.string ->
     Prims.string Prims.list ->
@@ -5503,8 +5444,7 @@ let (change : FStar_Syntax_Syntax.typ -> unit FStar_Tactics_Monad.tac) =
                                            else
                                              FStar_Tactics_Monad.fail
                                                "not convertible"))))))) in
-    FStar_Compiler_Effect.op_Less_Bar (FStar_Tactics_Monad.wrap_err "change")
-      uu___
+    FStar_Tactics_Monad.wrap_err "change" uu___
 let (failwhen : Prims.bool -> Prims.string -> unit FStar_Tactics_Monad.tac) =
   fun b ->
     fun msg ->
@@ -6357,8 +6297,7 @@ let (t_destruct :
                                             | uu___9 ->
                                                 FStar_Tactics_Monad.fail
                                                   "not an inductive type")))))) in
-    FStar_Compiler_Effect.op_Less_Bar
-      (FStar_Tactics_Monad.wrap_err "destruct") uu___
+    FStar_Tactics_Monad.wrap_err "destruct" uu___
 let (gather_explicit_guards_for_resolved_goals :
   unit -> unit FStar_Tactics_Monad.tac) =
   fun uu___ -> FStar_Tactics_Monad.ret ()
@@ -6391,26 +6330,20 @@ let rec (inspect :
                  FStar_Syntax_Syntax.meta = uu___2;_}
                -> inspect t3
            | FStar_Syntax_Syntax.Tm_name bv ->
-               FStar_Compiler_Effect.op_Less_Bar FStar_Tactics_Monad.ret
-                 (FStar_Reflection_V1_Data.Tv_Var bv)
+               FStar_Tactics_Monad.ret (FStar_Reflection_V1_Data.Tv_Var bv)
            | FStar_Syntax_Syntax.Tm_bvar bv ->
-               FStar_Compiler_Effect.op_Less_Bar FStar_Tactics_Monad.ret
-                 (FStar_Reflection_V1_Data.Tv_BVar bv)
+               FStar_Tactics_Monad.ret (FStar_Reflection_V1_Data.Tv_BVar bv)
            | FStar_Syntax_Syntax.Tm_fvar fv ->
-               FStar_Compiler_Effect.op_Less_Bar FStar_Tactics_Monad.ret
-                 (FStar_Reflection_V1_Data.Tv_FVar fv)
+               FStar_Tactics_Monad.ret (FStar_Reflection_V1_Data.Tv_FVar fv)
            | FStar_Syntax_Syntax.Tm_uinst (t3, us) ->
                let uu___2 =
                  let uu___3 =
-                   let uu___4 =
-                     FStar_Compiler_Effect.op_Bar_Greater t3
-                       FStar_Syntax_Subst.compress in
-                   FStar_Compiler_Effect.op_Bar_Greater uu___4
-                     FStar_Syntax_Util.unascribe in
+                   let uu___4 = FStar_Syntax_Subst.compress t3 in
+                   FStar_Syntax_Util.unascribe uu___4 in
                  uu___3.FStar_Syntax_Syntax.n in
                (match uu___2 with
                 | FStar_Syntax_Syntax.Tm_fvar fv ->
-                    FStar_Compiler_Effect.op_Less_Bar FStar_Tactics_Monad.ret
+                    FStar_Tactics_Monad.ret
                       (FStar_Reflection_V1_Data.Tv_UInst (fv, us))
                 | uu___3 ->
                     FStar_Compiler_Effect.failwith
@@ -6421,7 +6354,7 @@ let rec (inspect :
                    (FStar_Pervasives.Inl ty, tacopt, eq);
                  FStar_Syntax_Syntax.eff_opt = uu___2;_}
                ->
-               FStar_Compiler_Effect.op_Less_Bar FStar_Tactics_Monad.ret
+               FStar_Tactics_Monad.ret
                  (FStar_Reflection_V1_Data.Tv_AscribedT (t3, ty, tacopt, eq))
            | FStar_Syntax_Syntax.Tm_ascribed
                { FStar_Syntax_Syntax.tm = t3;
@@ -6429,7 +6362,7 @@ let rec (inspect :
                    (FStar_Pervasives.Inr cty, tacopt, eq);
                  FStar_Syntax_Syntax.eff_opt = uu___2;_}
                ->
-               FStar_Compiler_Effect.op_Less_Bar FStar_Tactics_Monad.ret
+               FStar_Tactics_Monad.ret
                  (FStar_Reflection_V1_Data.Tv_AscribedC (t3, cty, tacopt, eq))
            | FStar_Syntax_Syntax.Tm_app
                { FStar_Syntax_Syntax.hd = uu___2;
@@ -6451,8 +6384,7 @@ let rec (inspect :
                             t2.FStar_Syntax_Syntax.pos in
                         (uu___5, (a, q')) in
                       FStar_Reflection_V1_Data.Tv_App uu___4 in
-                    FStar_Compiler_Effect.op_Less_Bar FStar_Tactics_Monad.ret
-                      uu___3)
+                    FStar_Tactics_Monad.ret uu___3)
            | FStar_Syntax_Syntax.Tm_abs
                { FStar_Syntax_Syntax.bs = [];
                  FStar_Syntax_Syntax.body = uu___2;
@@ -6473,11 +6405,9 @@ let rec (inspect :
                              let uu___5 = FStar_Syntax_Util.abs bs2 t4 k in
                              (b, uu___5) in
                            FStar_Reflection_V1_Data.Tv_Abs uu___4 in
-                         FStar_Compiler_Effect.op_Less_Bar
-                           FStar_Tactics_Monad.ret uu___3))
+                         FStar_Tactics_Monad.ret uu___3))
            | FStar_Syntax_Syntax.Tm_type u ->
-               FStar_Compiler_Effect.op_Less_Bar FStar_Tactics_Monad.ret
-                 (FStar_Reflection_V1_Data.Tv_Type u)
+               FStar_Tactics_Monad.ret (FStar_Reflection_V1_Data.Tv_Type u)
            | FStar_Syntax_Syntax.Tm_arrow
                { FStar_Syntax_Syntax.bs1 = [];
                  FStar_Syntax_Syntax.comp = uu___2;_}
@@ -6486,7 +6416,7 @@ let rec (inspect :
                let uu___3 = FStar_Syntax_Util.arrow_one t2 in
                (match uu___3 with
                 | FStar_Pervasives_Native.Some (b, c) ->
-                    FStar_Compiler_Effect.op_Less_Bar FStar_Tactics_Monad.ret
+                    FStar_Tactics_Monad.ret
                       (FStar_Reflection_V1_Data.Tv_Arrow (b, c))
                 | FStar_Pervasives_Native.None ->
                     FStar_Compiler_Effect.failwith "impossible")
@@ -6501,7 +6431,7 @@ let rec (inspect :
                       match b' with
                       | b'1::[] -> b'1
                       | uu___3 -> FStar_Compiler_Effect.failwith "impossible" in
-                    FStar_Compiler_Effect.op_Less_Bar FStar_Tactics_Monad.ret
+                    FStar_Tactics_Monad.ret
                       (FStar_Reflection_V1_Data.Tv_Refine
                          ((b1.FStar_Syntax_Syntax.binder_bv),
                            ((b1.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort),
@@ -6510,8 +6440,7 @@ let rec (inspect :
                let uu___2 =
                  let uu___3 = FStar_Reflection_V1_Builtins.inspect_const c in
                  FStar_Reflection_V1_Data.Tv_Const uu___3 in
-               FStar_Compiler_Effect.op_Less_Bar FStar_Tactics_Monad.ret
-                 uu___2
+               FStar_Tactics_Monad.ret uu___2
            | FStar_Syntax_Syntax.Tm_uvar (ctx_u, s) ->
                let uu___2 =
                  let uu___3 =
@@ -6522,21 +6451,18 @@ let rec (inspect :
                      FStar_BigInt.of_int_fs uu___5 in
                    (uu___4, (ctx_u, s)) in
                  FStar_Reflection_V1_Data.Tv_Uvar uu___3 in
-               FStar_Compiler_Effect.op_Less_Bar FStar_Tactics_Monad.ret
-                 uu___2
+               FStar_Tactics_Monad.ret uu___2
            | FStar_Syntax_Syntax.Tm_let
                { FStar_Syntax_Syntax.lbs = (false, lb::[]);
                  FStar_Syntax_Syntax.body1 = t21;_}
                ->
                if lb.FStar_Syntax_Syntax.lbunivs <> []
                then
-                 FStar_Compiler_Effect.op_Less_Bar FStar_Tactics_Monad.ret
-                   FStar_Reflection_V1_Data.Tv_Unsupp
+                 FStar_Tactics_Monad.ret FStar_Reflection_V1_Data.Tv_Unsupp
                else
                  (match lb.FStar_Syntax_Syntax.lbname with
                   | FStar_Pervasives.Inr uu___3 ->
-                      FStar_Compiler_Effect.op_Less_Bar
-                        FStar_Tactics_Monad.ret
+                      FStar_Tactics_Monad.ret
                         FStar_Reflection_V1_Data.Tv_Unsupp
                   | FStar_Pervasives.Inl bv ->
                       let b = FStar_Syntax_Syntax.mk_binder bv in
@@ -6549,8 +6475,7 @@ let rec (inspect :
                              | uu___4 ->
                                  FStar_Compiler_Effect.failwith
                                    "impossible: open_term returned different amount of binders" in
-                           FStar_Compiler_Effect.op_Less_Bar
-                             FStar_Tactics_Monad.ret
+                           FStar_Tactics_Monad.ret
                              (FStar_Reflection_V1_Data.Tv_Let
                                 (false, (lb.FStar_Syntax_Syntax.lbattrs),
                                   (b1.FStar_Syntax_Syntax.binder_bv),
@@ -6562,13 +6487,11 @@ let rec (inspect :
                ->
                if lb.FStar_Syntax_Syntax.lbunivs <> []
                then
-                 FStar_Compiler_Effect.op_Less_Bar FStar_Tactics_Monad.ret
-                   FStar_Reflection_V1_Data.Tv_Unsupp
+                 FStar_Tactics_Monad.ret FStar_Reflection_V1_Data.Tv_Unsupp
                else
                  (match lb.FStar_Syntax_Syntax.lbname with
                   | FStar_Pervasives.Inr uu___3 ->
-                      FStar_Compiler_Effect.op_Less_Bar
-                        FStar_Tactics_Monad.ret
+                      FStar_Tactics_Monad.ret
                         FStar_Reflection_V1_Data.Tv_Unsupp
                   | FStar_Pervasives.Inl bv ->
                       let uu___3 = FStar_Syntax_Subst.open_let_rec [lb] t21 in
@@ -6581,8 +6504,7 @@ let rec (inspect :
                                      FStar_Tactics_Monad.ret
                                        FStar_Reflection_V1_Data.Tv_Unsupp
                                  | FStar_Pervasives.Inl bv1 ->
-                                     FStar_Compiler_Effect.op_Less_Bar
-                                       FStar_Tactics_Monad.ret
+                                     FStar_Tactics_Monad.ret
                                        (FStar_Reflection_V1_Data.Tv_Let
                                           (true,
                                             (lb1.FStar_Syntax_Syntax.lbattrs),
@@ -6629,11 +6551,10 @@ let rec (inspect :
                       match uu___3 with
                       | (pat, uu___4, t4) ->
                           let uu___5 = inspect_pat pat in (uu___5, t4)) brs1 in
-               FStar_Compiler_Effect.op_Less_Bar FStar_Tactics_Monad.ret
+               FStar_Tactics_Monad.ret
                  (FStar_Reflection_V1_Data.Tv_Match (t3, ret_opt, brs2))
            | FStar_Syntax_Syntax.Tm_unknown ->
-               FStar_Compiler_Effect.op_Less_Bar FStar_Tactics_Monad.ret
-                 FStar_Reflection_V1_Data.Tv_Unknown
+               FStar_Tactics_Monad.ret FStar_Reflection_V1_Data.Tv_Unknown
            | uu___2 ->
                ((let uu___4 =
                    let uu___5 =
@@ -6646,8 +6567,7 @@ let rec (inspect :
                        uu___6 uu___7 in
                    (FStar_Errors_Codes.Warning_CantInspect, uu___5) in
                  FStar_Errors.log_issue t2.FStar_Syntax_Syntax.pos uu___4);
-                FStar_Compiler_Effect.op_Less_Bar FStar_Tactics_Monad.ret
-                  FStar_Reflection_V1_Data.Tv_Unsupp)) in
+                FStar_Tactics_Monad.ret FStar_Reflection_V1_Data.Tv_Unsupp)) in
     FStar_Tactics_Monad.wrap_err "inspect" uu___
 let (pack' :
   FStar_Reflection_V1_Data.term_view ->
@@ -6658,26 +6578,26 @@ let (pack' :
       match tv with
       | FStar_Reflection_V1_Data.Tv_Var bv ->
           let uu___ = FStar_Syntax_Syntax.bv_to_name bv in
-          FStar_Compiler_Effect.op_Less_Bar FStar_Tactics_Monad.ret uu___
+          FStar_Tactics_Monad.ret uu___
       | FStar_Reflection_V1_Data.Tv_BVar bv ->
           let uu___ = FStar_Syntax_Syntax.bv_to_tm bv in
-          FStar_Compiler_Effect.op_Less_Bar FStar_Tactics_Monad.ret uu___
+          FStar_Tactics_Monad.ret uu___
       | FStar_Reflection_V1_Data.Tv_FVar fv ->
           let uu___ = FStar_Syntax_Syntax.fv_to_tm fv in
-          FStar_Compiler_Effect.op_Less_Bar FStar_Tactics_Monad.ret uu___
+          FStar_Tactics_Monad.ret uu___
       | FStar_Reflection_V1_Data.Tv_UInst (fv, us) ->
           let uu___ =
             let uu___1 = FStar_Syntax_Syntax.fv_to_tm fv in
             FStar_Syntax_Syntax.mk_Tm_uinst uu___1 us in
-          FStar_Compiler_Effect.op_Less_Bar FStar_Tactics_Monad.ret uu___
+          FStar_Tactics_Monad.ret uu___
       | FStar_Reflection_V1_Data.Tv_App (l, (r, q)) ->
           let q' = FStar_Reflection_V1_Builtins.pack_aqual q in
           let uu___ = FStar_Syntax_Util.mk_app l [(r, q')] in
-          FStar_Compiler_Effect.op_Less_Bar FStar_Tactics_Monad.ret uu___
+          FStar_Tactics_Monad.ret uu___
       | FStar_Reflection_V1_Data.Tv_Abs (b, t) ->
           let uu___ =
             FStar_Syntax_Util.abs [b] t FStar_Pervasives_Native.None in
-          FStar_Compiler_Effect.op_Less_Bar FStar_Tactics_Monad.ret uu___
+          FStar_Tactics_Monad.ret uu___
       | FStar_Reflection_V1_Data.Tv_Arrow (b, c) ->
           let uu___ =
             if leave_curried
@@ -6685,12 +6605,12 @@ let (pack' :
             else
               (let uu___2 = FStar_Syntax_Util.arrow [b] c in
                FStar_Syntax_Util.canon_arrow uu___2) in
-          FStar_Compiler_Effect.op_Less_Bar FStar_Tactics_Monad.ret uu___
+          FStar_Tactics_Monad.ret uu___
       | FStar_Reflection_V1_Data.Tv_Type u ->
           let uu___ =
             FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_type u)
               FStar_Compiler_Range_Type.dummyRange in
-          FStar_Compiler_Effect.op_Less_Bar FStar_Tactics_Monad.ret uu___
+          FStar_Tactics_Monad.ret uu___
       | FStar_Reflection_V1_Data.Tv_Refine (bv, sort, t) ->
           let bv1 =
             {
@@ -6699,7 +6619,7 @@ let (pack' :
               FStar_Syntax_Syntax.sort = sort
             } in
           let uu___ = FStar_Syntax_Util.refine bv1 t in
-          FStar_Compiler_Effect.op_Less_Bar FStar_Tactics_Monad.ret uu___
+          FStar_Tactics_Monad.ret uu___
       | FStar_Reflection_V1_Data.Tv_Const c ->
           let uu___ =
             let uu___1 =
@@ -6707,12 +6627,12 @@ let (pack' :
               FStar_Syntax_Syntax.Tm_constant uu___2 in
             FStar_Syntax_Syntax.mk uu___1
               FStar_Compiler_Range_Type.dummyRange in
-          FStar_Compiler_Effect.op_Less_Bar FStar_Tactics_Monad.ret uu___
+          FStar_Tactics_Monad.ret uu___
       | FStar_Reflection_V1_Data.Tv_Uvar (_u, ctx_u_s) ->
           let uu___ =
             FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_uvar ctx_u_s)
               FStar_Compiler_Range_Type.dummyRange in
-          FStar_Compiler_Effect.op_Less_Bar FStar_Tactics_Monad.ret uu___
+          FStar_Tactics_Monad.ret uu___
       | FStar_Reflection_V1_Data.Tv_Let (false, attrs, bv, ty, t1, t2) ->
           let bv1 =
             {
@@ -6739,7 +6659,7 @@ let (pack' :
               FStar_Syntax_Syntax.Tm_let uu___2 in
             FStar_Syntax_Syntax.mk uu___1
               FStar_Compiler_Range_Type.dummyRange in
-          FStar_Compiler_Effect.op_Less_Bar FStar_Tactics_Monad.ret uu___
+          FStar_Tactics_Monad.ret uu___
       | FStar_Reflection_V1_Data.Tv_Let (true, attrs, bv, ty, t1, t2) ->
           let bv1 =
             {
@@ -6761,8 +6681,7 @@ let (pack' :
                         FStar_Syntax_Syntax.lbs = (true, lbs);
                         FStar_Syntax_Syntax.body1 = body
                       }) FStar_Compiler_Range_Type.dummyRange in
-               FStar_Compiler_Effect.op_Less_Bar FStar_Tactics_Monad.ret
-                 uu___1)
+               FStar_Tactics_Monad.ret uu___1)
       | FStar_Reflection_V1_Data.Tv_Match (t, ret_opt, brs) ->
           let wrap v =
             {
@@ -6775,7 +6694,7 @@ let (pack' :
                 let uu___ =
                   let uu___1 = FStar_Reflection_V1_Builtins.pack_const c in
                   FStar_Syntax_Syntax.Pat_constant uu___1 in
-                FStar_Compiler_Effect.op_Less_Bar wrap uu___
+                wrap uu___
             | FStar_Reflection_V1_Data.Pat_Cons (fv, us_opt, ps) ->
                 let uu___ =
                   let uu___1 =
@@ -6787,13 +6706,11 @@ let (pack' :
                                let uu___4 = pack_pat p1 in (uu___4, b)) ps in
                     (fv, us_opt, uu___2) in
                   FStar_Syntax_Syntax.Pat_cons uu___1 in
-                FStar_Compiler_Effect.op_Less_Bar wrap uu___
+                wrap uu___
             | FStar_Reflection_V1_Data.Pat_Var (bv, _sort) ->
-                FStar_Compiler_Effect.op_Less_Bar wrap
-                  (FStar_Syntax_Syntax.Pat_var bv)
+                wrap (FStar_Syntax_Syntax.Pat_var bv)
             | FStar_Reflection_V1_Data.Pat_Dot_Term eopt ->
-                FStar_Compiler_Effect.op_Less_Bar wrap
-                  (FStar_Syntax_Syntax.Pat_dot_term eopt) in
+                wrap (FStar_Syntax_Syntax.Pat_dot_term eopt) in
           let brs1 =
             FStar_Compiler_List.map
               (fun uu___ ->
@@ -6812,7 +6729,7 @@ let (pack' :
                    FStar_Syntax_Syntax.brs = brs2;
                    FStar_Syntax_Syntax.rc_opt1 = FStar_Pervasives_Native.None
                  }) FStar_Compiler_Range_Type.dummyRange in
-          FStar_Compiler_Effect.op_Less_Bar FStar_Tactics_Monad.ret uu___
+          FStar_Tactics_Monad.ret uu___
       | FStar_Reflection_V1_Data.Tv_AscribedT (e, t, tacopt, use_eq) ->
           let uu___ =
             FStar_Syntax_Syntax.mk
@@ -6823,7 +6740,7 @@ let (pack' :
                      ((FStar_Pervasives.Inl t), tacopt, use_eq);
                    FStar_Syntax_Syntax.eff_opt = FStar_Pervasives_Native.None
                  }) FStar_Compiler_Range_Type.dummyRange in
-          FStar_Compiler_Effect.op_Less_Bar FStar_Tactics_Monad.ret uu___
+          FStar_Tactics_Monad.ret uu___
       | FStar_Reflection_V1_Data.Tv_AscribedC (e, c, tacopt, use_eq) ->
           let uu___ =
             FStar_Syntax_Syntax.mk
@@ -6834,12 +6751,12 @@ let (pack' :
                      ((FStar_Pervasives.Inr c), tacopt, use_eq);
                    FStar_Syntax_Syntax.eff_opt = FStar_Pervasives_Native.None
                  }) FStar_Compiler_Range_Type.dummyRange in
-          FStar_Compiler_Effect.op_Less_Bar FStar_Tactics_Monad.ret uu___
+          FStar_Tactics_Monad.ret uu___
       | FStar_Reflection_V1_Data.Tv_Unknown ->
           let uu___ =
             FStar_Syntax_Syntax.mk FStar_Syntax_Syntax.Tm_unknown
               FStar_Compiler_Range_Type.dummyRange in
-          FStar_Compiler_Effect.op_Less_Bar FStar_Tactics_Monad.ret uu___
+          FStar_Tactics_Monad.ret uu___
       | FStar_Reflection_V1_Data.Tv_Unsupp ->
           FStar_Tactics_Monad.fail "cannot pack Tv_Unsupp"
 let (pack :
@@ -6866,8 +6783,7 @@ let (lget :
              | FStar_Pervasives_Native.None ->
                  FStar_Tactics_Monad.fail "not found"
              | FStar_Pervasives_Native.Some t -> unquote ty t) in
-      FStar_Compiler_Effect.op_Less_Bar (FStar_Tactics_Monad.wrap_err "lget")
-        uu___
+      FStar_Tactics_Monad.wrap_err "lget" uu___
 let (lset :
   FStar_Syntax_Syntax.typ ->
     Prims.string -> FStar_Syntax_Syntax.term -> unit FStar_Tactics_Monad.tac)
@@ -6907,8 +6823,7 @@ let (lset :
                      (ps.FStar_Tactics_Types.urgency)
                  } in
                FStar_Tactics_Monad.set ps1) in
-        FStar_Compiler_Effect.op_Less_Bar
-          (FStar_Tactics_Monad.wrap_err "lset") uu___
+        FStar_Tactics_Monad.wrap_err "lset" uu___
 let (set_urgency : FStar_BigInt.t -> unit FStar_Tactics_Monad.tac) =
   fun u ->
     FStar_Tactics_Monad.op_let_Bang FStar_Tactics_Monad.get
@@ -6974,51 +6889,45 @@ let (t_commute_applied_match : unit -> unit FStar_Tactics_Monad.tac) =
                                       FStar_Syntax_Util.mk_app e1 las in
                                     (p, w, uu___6)) brs in
                          let lopt' =
-                           FStar_Compiler_Effect.op_Bar_Greater lopt
-                             (FStar_Compiler_Util.map_option
-                                (fun rc ->
-                                   let uu___5 =
-                                     FStar_Compiler_Effect.op_Bar_Greater
-                                       rc.FStar_Syntax_Syntax.residual_typ
-                                       (FStar_Compiler_Util.map_option
-                                          (fun t ->
-                                             let uu___6 =
-                                               let uu___7 =
-                                                 FStar_Tactics_Types.goal_env
-                                                   g in
-                                               FStar_TypeChecker_Normalize.get_n_binders
-                                                 uu___7
-                                                 (FStar_Compiler_List.length
-                                                    las) t in
-                                             match uu___6 with
-                                             | (bs, c) ->
-                                                 let uu___7 =
-                                                   FStar_Syntax_Subst.open_comp
-                                                     bs c in
-                                                 (match uu___7 with
-                                                  | (bs1, c1) ->
-                                                      let ss =
-                                                        FStar_Compiler_List.map2
-                                                          (fun b ->
-                                                             fun a ->
-                                                               FStar_Syntax_Syntax.NT
-                                                                 ((b.FStar_Syntax_Syntax.binder_bv),
-                                                                   (FStar_Pervasives_Native.fst
-                                                                    a))) bs1
-                                                          las in
-                                                      let c2 =
-                                                        FStar_Syntax_Subst.subst_comp
-                                                          ss c1 in
-                                                      FStar_Syntax_Util.comp_result
-                                                        c2))) in
-                                   {
-                                     FStar_Syntax_Syntax.residual_effect =
-                                       (rc.FStar_Syntax_Syntax.residual_effect);
-                                     FStar_Syntax_Syntax.residual_typ =
-                                       uu___5;
-                                     FStar_Syntax_Syntax.residual_flags =
-                                       (rc.FStar_Syntax_Syntax.residual_flags)
-                                   })) in
+                           FStar_Compiler_Util.map_option
+                             (fun rc ->
+                                let uu___5 =
+                                  FStar_Compiler_Util.map_option
+                                    (fun t ->
+                                       let uu___6 =
+                                         let uu___7 =
+                                           FStar_Tactics_Types.goal_env g in
+                                         FStar_TypeChecker_Normalize.get_n_binders
+                                           uu___7
+                                           (FStar_Compiler_List.length las) t in
+                                       match uu___6 with
+                                       | (bs, c) ->
+                                           let uu___7 =
+                                             FStar_Syntax_Subst.open_comp bs
+                                               c in
+                                           (match uu___7 with
+                                            | (bs1, c1) ->
+                                                let ss =
+                                                  FStar_Compiler_List.map2
+                                                    (fun b ->
+                                                       fun a ->
+                                                         FStar_Syntax_Syntax.NT
+                                                           ((b.FStar_Syntax_Syntax.binder_bv),
+                                                             (FStar_Pervasives_Native.fst
+                                                                a))) bs1 las in
+                                                let c2 =
+                                                  FStar_Syntax_Subst.subst_comp
+                                                    ss c1 in
+                                                FStar_Syntax_Util.comp_result
+                                                  c2))
+                                    rc.FStar_Syntax_Syntax.residual_typ in
+                                {
+                                  FStar_Syntax_Syntax.residual_effect =
+                                    (rc.FStar_Syntax_Syntax.residual_effect);
+                                  FStar_Syntax_Syntax.residual_typ = uu___5;
+                                  FStar_Syntax_Syntax.residual_flags =
+                                    (rc.FStar_Syntax_Syntax.residual_flags)
+                                }) lopt in
                          let l' =
                            FStar_Syntax_Syntax.mk
                              (FStar_Syntax_Syntax.Tm_match
@@ -7054,8 +6963,7 @@ let (t_commute_applied_match : unit -> unit FStar_Tactics_Monad.tac) =
                          FStar_Tactics_Monad.fail "lhs is not a match"))
            | FStar_Pervasives_Native.None ->
                FStar_Tactics_Monad.fail "not an equality") in
-    FStar_Compiler_Effect.op_Less_Bar
-      (FStar_Tactics_Monad.wrap_err "t_commute_applied_match") uu___1
+    FStar_Tactics_Monad.wrap_err "t_commute_applied_match" uu___1
 let (string_to_term :
   env -> Prims.string -> FStar_Syntax_Syntax.term FStar_Tactics_Monad.tac) =
   fun e ->
@@ -7306,8 +7214,7 @@ let (t_smt_sync : FStar_VConfig.vconfig -> unit FStar_Tactics_Monad.tac) =
                     goal.FStar_Tactics_Types.goal_ctx_uvar;
                   solve goal FStar_Syntax_Util.exp_unit)
                else FStar_Tactics_Monad.fail "SMT did not solve this goal") in
-    FStar_Compiler_Effect.op_Less_Bar
-      (FStar_Tactics_Monad.wrap_err "t_smt_sync") uu___
+    FStar_Tactics_Monad.wrap_err "t_smt_sync" uu___
 let (free_uvars :
   FStar_Syntax_Syntax.term ->
     FStar_BigInt.t Prims.list FStar_Tactics_Monad.tac)
@@ -7318,22 +7225,19 @@ let (free_uvars :
          let uvs =
            let uu___1 =
              let uu___2 = FStar_Syntax_Free.uvars_uncached tm in
-             FStar_Compiler_Effect.op_Bar_Greater uu___2
-               (FStar_Compiler_Set.elems FStar_Syntax_Free.ord_ctx_uvar) in
-           FStar_Compiler_Effect.op_Bar_Greater uu___1
-             (FStar_Compiler_List.map
-                (fun u ->
-                   let uu___2 =
-                     FStar_Syntax_Unionfind.uvar_id
-                       u.FStar_Syntax_Syntax.ctx_uvar_head in
-                   FStar_BigInt.of_int_fs uu___2)) in
+             FStar_Compiler_Set.elems FStar_Syntax_Free.ord_ctx_uvar uu___2 in
+           FStar_Compiler_List.map
+             (fun u ->
+                let uu___2 =
+                  FStar_Syntax_Unionfind.uvar_id
+                    u.FStar_Syntax_Syntax.ctx_uvar_head in
+                FStar_BigInt.of_int_fs uu___2) uu___1 in
          FStar_Tactics_Monad.ret uvs)
 let (dbg_refl : env -> (unit -> Prims.string) -> unit) =
   fun g ->
     fun msg ->
       let uu___ =
-        FStar_Compiler_Effect.op_Less_Bar (FStar_TypeChecker_Env.debug g)
-          (FStar_Options.Other "ReflTc") in
+        FStar_TypeChecker_Env.debug g (FStar_Options.Other "ReflTc") in
       if uu___
       then let uu___1 = msg () in FStar_Compiler_Util.print_string uu___1
       else ()
@@ -7374,24 +7278,18 @@ let refl_typing_builtin_wrapper :
          else FStar_Tactics_Monad.ret (r, errs))
 let (no_uvars_in_term : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t ->
-    (let uu___ =
-       FStar_Compiler_Effect.op_Bar_Greater t FStar_Syntax_Free.uvars in
-     FStar_Compiler_Effect.op_Bar_Greater uu___
-       (FStar_Compiler_Set.is_empty FStar_Syntax_Free.ord_ctx_uvar))
-      &&
-      (let uu___ =
-         FStar_Compiler_Effect.op_Bar_Greater t FStar_Syntax_Free.univs in
-       FStar_Compiler_Effect.op_Bar_Greater uu___
-         (FStar_Compiler_Set.is_empty FStar_Syntax_Free.ord_univ_uvar))
+    (let uu___ = FStar_Syntax_Free.uvars t in
+     FStar_Compiler_Set.is_empty FStar_Syntax_Free.ord_ctx_uvar uu___) &&
+      (let uu___ = FStar_Syntax_Free.univs t in
+       FStar_Compiler_Set.is_empty FStar_Syntax_Free.ord_univ_uvar uu___)
 let (no_uvars_in_g : env -> Prims.bool) =
   fun g ->
-    FStar_Compiler_Effect.op_Bar_Greater g.FStar_TypeChecker_Env.gamma
-      (FStar_Compiler_Util.for_all
-         (fun uu___ ->
-            match uu___ with
-            | FStar_Syntax_Syntax.Binding_var bv ->
-                no_uvars_in_term bv.FStar_Syntax_Syntax.sort
-            | uu___1 -> true))
+    FStar_Compiler_Util.for_all
+      (fun uu___ ->
+         match uu___ with
+         | FStar_Syntax_Syntax.Binding_var bv ->
+             no_uvars_in_term bv.FStar_Syntax_Syntax.sort
+         | uu___1 -> true) g.FStar_TypeChecker_Env.gamma
 type relation =
   | Subtyping 
   | Equality 

--- a/ocaml/fstar-lib/generated/FStar_Tactics_V2_Basic.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_V2_Basic.ml
@@ -244,8 +244,7 @@ let (dump_uvars_of :
              let uu___ =
                let uu___1 = FStar_Tactics_Types.goal_type g in
                FStar_Syntax_Free.uvars uu___1 in
-             FStar_Compiler_Effect.op_Bar_Greater uu___
-               (FStar_Compiler_Set.elems FStar_Syntax_Free.ord_ctx_uvar) in
+             FStar_Compiler_Set.elems FStar_Syntax_Free.ord_ctx_uvar uu___ in
            let gs =
              FStar_Compiler_List.map (FStar_Tactics_Types.goal_of_ctx_uvar g)
                uvs in
@@ -543,8 +542,7 @@ let (proc_guard_formula :
                                        let uu___4 =
                                          FStar_TypeChecker_Rel.discharge_guard_no_smt
                                            e g in
-                                       FStar_Compiler_Effect.op_Less_Bar
-                                         FStar_TypeChecker_Env.is_trivial
+                                       FStar_TypeChecker_Env.is_trivial
                                          uu___4 in
                                      Prims.op_Negation uu___3 in
                                    if uu___2
@@ -830,9 +828,7 @@ let (tc_unifier_solved_implicits :
                             uu___3 uu___4 uu___5)) in
           if env1.FStar_TypeChecker_Env.phase1
           then FStar_Tactics_Monad.ret ()
-          else
-            FStar_Compiler_Effect.op_Bar_Greater uvs
-              (FStar_Tactics_Monad.iter_tac aux)
+          else FStar_Tactics_Monad.iter_tac aux uvs
 type check_unifier_solved_implicits_side =
   | Check_none 
   | Check_left_only 
@@ -892,8 +888,8 @@ let (__do_unify_wflags :
                          let uu___3 = FStar_Syntax_Free.uvars t2 in
                          FStar_Compiler_Set.union
                            FStar_Syntax_Free.ord_ctx_uvar uu___2 uu___3 in
-                   FStar_Compiler_Effect.op_Bar_Greater uu___1
-                     (FStar_Compiler_Set.elems FStar_Syntax_Free.ord_ctx_uvar) in
+                   FStar_Compiler_Set.elems FStar_Syntax_Free.ord_ctx_uvar
+                     uu___1 in
                  let uu___1 =
                    let uu___2 =
                      let uu___3 =
@@ -1277,8 +1273,7 @@ let (tadmit_t : FStar_Syntax_Syntax.term -> unit FStar_Tactics_Monad.tac) =
                    (FStar_Errors_Codes.Warning_TacAdmit, uu___4) in
                  FStar_Errors.log_issue uu___2 uu___3);
                 solve' g t)) in
-    FStar_Compiler_Effect.op_Less_Bar
-      (FStar_Tactics_Monad.wrap_err "tadmit_t") uu___
+    FStar_Tactics_Monad.wrap_err "tadmit_t" uu___
 let (fresh : unit -> FStar_BigInt.t FStar_Tactics_Monad.tac) =
   fun uu___ ->
     FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
@@ -1316,7 +1311,7 @@ let (curms : unit -> FStar_BigInt.t FStar_Tactics_Monad.tac) =
   fun uu___ ->
     let uu___1 =
       let uu___2 = FStar_Compiler_Util.now_ms () in
-      FStar_Compiler_Effect.op_Bar_Greater uu___2 FStar_BigInt.of_int_fs in
+      FStar_BigInt.of_int_fs uu___2 in
     FStar_Tactics_Monad.ret uu___1
 let (__tc :
   env ->
@@ -1452,8 +1447,7 @@ let (__tc :
                     let uu___4 = tts e1 t in
                     let uu___5 =
                       let uu___6 = FStar_TypeChecker_Env.all_binders e1 in
-                      FStar_Compiler_Effect.op_Bar_Greater uu___6
-                        (FStar_Syntax_Print.binders_to_string ", ") in
+                      FStar_Syntax_Print.binders_to_string ", " uu___6 in
                     let uu___6 = FStar_Errors_Msg.rendermsg msg in
                     fail3 "Cannot type (1) %s in context (%s). Error = (%s)"
                       uu___4 uu___5 uu___6
@@ -1461,8 +1455,7 @@ let (__tc :
                     let uu___5 = tts e1 t in
                     let uu___6 =
                       let uu___7 = FStar_TypeChecker_Env.all_binders e1 in
-                      FStar_Compiler_Effect.op_Bar_Greater uu___7
-                        (FStar_Syntax_Print.binders_to_string ", ") in
+                      FStar_Syntax_Print.binders_to_string ", " uu___7 in
                     let uu___7 = FStar_Errors_Msg.rendermsg msg in
                     fail3 "Cannot type (1) %s in context (%s). Error = (%s)"
                       uu___5 uu___6 uu___7))
@@ -1710,8 +1703,7 @@ let (__tc_ghost :
                     let uu___4 = tts e2 t in
                     let uu___5 =
                       let uu___6 = FStar_TypeChecker_Env.all_binders e2 in
-                      FStar_Compiler_Effect.op_Bar_Greater uu___6
-                        (FStar_Syntax_Print.binders_to_string ", ") in
+                      FStar_Syntax_Print.binders_to_string ", " uu___6 in
                     let uu___6 = FStar_Errors_Msg.rendermsg msg in
                     fail3 "Cannot type (2) %s in context (%s). Error = (%s)"
                       uu___4 uu___5 uu___6
@@ -1719,8 +1711,7 @@ let (__tc_ghost :
                     let uu___5 = tts e2 t in
                     let uu___6 =
                       let uu___7 = FStar_TypeChecker_Env.all_binders e2 in
-                      FStar_Compiler_Effect.op_Bar_Greater uu___7
-                        (FStar_Syntax_Print.binders_to_string ", ") in
+                      FStar_Syntax_Print.binders_to_string ", " uu___7 in
                     let uu___7 = FStar_Errors_Msg.rendermsg msg in
                     fail3 "Cannot type (2) %s in context (%s). Error = (%s)"
                       uu___5 uu___6 uu___7))
@@ -1740,8 +1731,7 @@ let (__tc_lax :
                   FStar_Class_Show.show FStar_Syntax_Print.showable_term t in
                 let uu___2 =
                   let uu___3 = FStar_TypeChecker_Env.all_binders e in
-                  FStar_Compiler_Effect.op_Bar_Greater uu___3
-                    (FStar_Syntax_Print.binders_to_string ", ") in
+                  FStar_Syntax_Print.binders_to_string ", " uu___3 in
                 FStar_Compiler_Util.print2 "Tac> __tc_lax(%s)(Context:%s)\n"
                   uu___1 uu___2)
              (fun uu___ ->
@@ -2075,8 +2065,7 @@ let (__tc_lax :
                     let uu___4 = tts e3 t in
                     let uu___5 =
                       let uu___6 = FStar_TypeChecker_Env.all_binders e3 in
-                      FStar_Compiler_Effect.op_Bar_Greater uu___6
-                        (FStar_Syntax_Print.binders_to_string ", ") in
+                      FStar_Syntax_Print.binders_to_string ", " uu___6 in
                     let uu___6 = FStar_Errors_Msg.rendermsg msg in
                     fail3 "Cannot type (3) %s in context (%s). Error = (%s)"
                       uu___4 uu___5 uu___6
@@ -2084,8 +2073,7 @@ let (__tc_lax :
                     let uu___5 = tts e3 t in
                     let uu___6 =
                       let uu___7 = FStar_TypeChecker_Env.all_binders e3 in
-                      FStar_Compiler_Effect.op_Bar_Greater uu___7
-                        (FStar_Syntax_Print.binders_to_string ", ") in
+                      FStar_Syntax_Print.binders_to_string ", " uu___7 in
                     let uu___7 = FStar_Errors_Msg.rendermsg msg in
                     fail3 "Cannot type (3) %s in context (%s). Error = (%s)"
                       uu___5 uu___6 uu___7))
@@ -2104,11 +2092,9 @@ let (tcc :
              | (uu___3, lc, uu___4) ->
                  let uu___5 =
                    let uu___6 = FStar_TypeChecker_Common.lcomp_comp lc in
-                   FStar_Compiler_Effect.op_Bar_Greater uu___6
-                     FStar_Pervasives_Native.fst in
+                   FStar_Pervasives_Native.fst uu___6 in
                  FStar_Tactics_Monad.ret uu___5) in
-      FStar_Compiler_Effect.op_Less_Bar (FStar_Tactics_Monad.wrap_err "tcc")
-        uu___
+      FStar_Tactics_Monad.wrap_err "tcc" uu___
 let (tc :
   env ->
     FStar_Syntax_Syntax.term ->
@@ -2120,8 +2106,7 @@ let (tc :
         let uu___1 = tcc e t in
         FStar_Tactics_Monad.bind uu___1
           (fun c -> FStar_Tactics_Monad.ret (FStar_Syntax_Util.comp_result c)) in
-      FStar_Compiler_Effect.op_Less_Bar (FStar_Tactics_Monad.wrap_err "tc")
-        uu___
+      FStar_Tactics_Monad.wrap_err "tc" uu___
 let divide :
   'a 'b .
     FStar_BigInt.t ->
@@ -2440,8 +2425,7 @@ let (intro :
                  let uu___5 = FStar_Tactics_Types.goal_type goal in
                  tts uu___4 uu___5 in
                fail1 "goal is not an arrow (%s)" uu___3) in
-    FStar_Compiler_Effect.op_Less_Bar (FStar_Tactics_Monad.wrap_err "intro")
-      uu___1
+    FStar_Tactics_Monad.wrap_err "intro" uu___1
 let (intro_rec :
   unit ->
     (FStar_Reflection_V2_Data.binding * FStar_Reflection_V2_Data.binding)
@@ -2616,8 +2600,7 @@ let (norm_term_env :
                                       "norm_term_env: t' = %s\n" uu___9) in
                              FStar_Tactics_Monad.op_let_Bang uu___7
                                (fun uu___8 -> FStar_Tactics_Monad.ret t2)))) in
-        FStar_Compiler_Effect.op_Less_Bar
-          (FStar_Tactics_Monad.wrap_err "norm_term") uu___
+        FStar_Tactics_Monad.wrap_err "norm_term" uu___
 let (refine_intro : unit -> unit FStar_Tactics_Monad.tac) =
   fun uu___ ->
     let uu___1 =
@@ -2672,8 +2655,7 @@ let (refine_intro : unit -> unit FStar_Tactics_Monad.tac) =
                             FStar_Tactics_Monad.dismiss
                             (fun uu___6 ->
                                FStar_Tactics_Monad.add_goals [g1; g2]))))) in
-    FStar_Compiler_Effect.op_Less_Bar
-      (FStar_Tactics_Monad.wrap_err "refine_intro") uu___1
+    FStar_Tactics_Monad.wrap_err "refine_intro" uu___1
 let (__exact_now :
   Prims.bool -> FStar_Syntax_Syntax.term -> unit FStar_Tactics_Monad.tac) =
   fun set_expected_typ ->
@@ -2841,8 +2823,7 @@ let (t_exact :
                                       FStar_Tactics_Monad.op_let_Bang uu___10
                                         (fun uu___11 ->
                                            FStar_Tactics_Monad.traise e))))) in
-        FStar_Compiler_Effect.op_Less_Bar
-          (FStar_Tactics_Monad.wrap_err "exact") uu___
+        FStar_Tactics_Monad.wrap_err "exact" uu___
 let (try_unify_by_application :
   FStar_Syntax_Syntax.should_check_uvar FStar_Pervasives_Native.option ->
     Prims.bool ->
@@ -2966,8 +2947,7 @@ let (apply_implicits_as_goals :
                         let gl2 = bnorm_goal gl1 in
                         FStar_Tactics_Monad.ret [gl2]
                     | uu___4 -> FStar_Tactics_Monad.ret [])) in
-        FStar_Compiler_Effect.op_Bar_Greater imps
-          (FStar_Tactics_Monad.mapM one_implicit_as_goal)
+        FStar_Tactics_Monad.mapM one_implicit_as_goal imps
 let (t_apply :
   Prims.bool ->
     Prims.bool ->
@@ -3148,10 +3128,8 @@ let (t_apply :
                                                            uu___13
                                                            (fun uu___14 ->
                                                               let uvt_uv_l =
-                                                                FStar_Compiler_Effect.op_Bar_Greater
-                                                                  uvs
-                                                                  (FStar_Compiler_List.map
-                                                                    (fun
+                                                                FStar_Compiler_List.map
+                                                                  (fun
                                                                     uu___15
                                                                     ->
                                                                     match uu___15
@@ -3159,7 +3137,8 @@ let (t_apply :
                                                                     | 
                                                                     (uvt, _q,
                                                                     uv) ->
-                                                                    (uvt, uv))) in
+                                                                    (uvt, uv))
+                                                                  uvs in
                                                               let uu___15 =
                                                                 apply_implicits_as_goals
                                                                   e
@@ -3177,10 +3156,7 @@ let (t_apply :
                                                                     =
                                                                     let uu___17
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    (FStar_Compiler_List.flatten
-                                                                    sub_goals)
-                                                                    (FStar_Compiler_List.filter
+                                                                    FStar_Compiler_List.filter
                                                                     (fun g ->
                                                                     let uu___18
                                                                     =
@@ -3188,14 +3164,14 @@ let (t_apply :
                                                                     (free_in_some_goal
                                                                     g.FStar_Tactics_Types.goal_ctx_uvar) in
                                                                     Prims.op_Negation
-                                                                    uu___18)) in
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___17
-                                                                    (FStar_Compiler_List.map
-                                                                    bnorm_goal) in
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___16
-                                                                    FStar_Compiler_List.rev in
+                                                                    uu___18)
+                                                                    (FStar_Compiler_List.flatten
+                                                                    sub_goals) in
+                                                                    FStar_Compiler_List.map
+                                                                    bnorm_goal
+                                                                    uu___17 in
+                                                                    FStar_Compiler_List.rev
+                                                                    uu___16 in
                                                                    let uu___16
                                                                     =
                                                                     FStar_Tactics_Monad.add_goals
@@ -3212,8 +3188,7 @@ let (t_apply :
                                                                     should_check)
                                                                     (rangeof
                                                                     goal))))))))))))) in
-          FStar_Compiler_Effect.op_Less_Bar
-            (FStar_Tactics_Monad.wrap_err "apply") uu___
+          FStar_Tactics_Monad.wrap_err "apply" uu___
 let (lemma_or_sq :
   FStar_Syntax_Syntax.comp ->
     (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.term)
@@ -3345,8 +3320,7 @@ let (t_apply_lemma :
                                                               is_unit_t b_t in
                                                             if uu___14
                                                             then
-                                                              FStar_Compiler_Effect.op_Less_Bar
-                                                                FStar_Tactics_Monad.ret
+                                                              FStar_Tactics_Monad.ret
                                                                 (((FStar_Syntax_Util.exp_unit,
                                                                     aq) ::
                                                                   uvs), deps,
@@ -3363,15 +3337,9 @@ let (t_apply_lemma :
                                                                     =
                                                                     let uu___19
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    goal
-                                                                    should_check_goal_uvar in
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___19
-                                                                    (fun
-                                                                    uu___20
-                                                                    ->
-                                                                    match uu___20
+                                                                    should_check_goal_uvar
+                                                                    goal in
+                                                                    match uu___19
                                                                     with
                                                                     | 
                                                                     FStar_Syntax_Syntax.Strict
@@ -3379,14 +3347,9 @@ let (t_apply_lemma :
                                                                     FStar_Syntax_Syntax.Allow_ghost
                                                                     "apply lemma uvar"
                                                                     | 
-                                                                    x -> x) in
-                                                                   FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___18
-                                                                    (fun
-                                                                    uu___19
-                                                                    ->
-                                                                    FStar_Pervasives_Native.Some
-                                                                    uu___19) in
+                                                                    x -> x in
+                                                                   FStar_Pervasives_Native.Some
+                                                                    uu___18 in
                                                                  FStar_Tactics_Monad.new_uvar
                                                                    "apply_lemma"
                                                                    env1 b_t
@@ -3406,9 +3369,8 @@ let (t_apply_lemma :
                                                                     ((
                                                                     let uu___19
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Less_Bar
-                                                                    (FStar_TypeChecker_Env.debug
-                                                                    env1)
+                                                                    FStar_TypeChecker_Env.debug
+                                                                    env1
                                                                     (FStar_Options.Other
                                                                     "2635") in
                                                                     if
@@ -3699,8 +3661,7 @@ let (t_apply_lemma :
                                                                     FStar_Tactics_Monad.add_goals
                                                                     sub_goals2)))))))))))))) in
           focus uu___1 in
-        FStar_Compiler_Effect.op_Less_Bar
-          (FStar_Tactics_Monad.wrap_err "apply_lemma") uu___
+        FStar_Tactics_Monad.wrap_err "apply_lemma" uu___
 let (split_env :
   FStar_Syntax_Syntax.bv ->
     env ->
@@ -3940,8 +3901,7 @@ let (rewrite :
                      | uu___5 ->
                          FStar_Tactics_Monad.fail
                            "Not an equality hypothesis"))) in
-    FStar_Compiler_Effect.op_Less_Bar
-      (FStar_Tactics_Monad.wrap_err "rewrite") uu___
+    FStar_Tactics_Monad.wrap_err "rewrite" uu___
 let (rename_to :
   FStar_Reflection_V2_Data.binding ->
     Prims.string -> FStar_Reflection_V2_Data.binding FStar_Tactics_Monad.tac)
@@ -3987,8 +3947,7 @@ let (rename_to :
                                  (b.FStar_Reflection_V2_Data.sort3);
                                FStar_Reflection_V2_Data.ppname3 = s
                              }))) in
-      FStar_Compiler_Effect.op_Less_Bar
-        (FStar_Tactics_Monad.wrap_err "rename_to") uu___
+      FStar_Tactics_Monad.wrap_err "rename_to" uu___
 let (var_retype :
   FStar_Reflection_V2_Data.binding -> unit FStar_Tactics_Monad.tac) =
   fun b ->
@@ -4074,8 +4033,7 @@ let (var_retype :
                                          uu___8
                                          (FStar_Pervasives_Native.Some
                                             goal_sc)))))) in
-    FStar_Compiler_Effect.op_Less_Bar
-      (FStar_Tactics_Monad.wrap_err "binder_retype") uu___
+    FStar_Tactics_Monad.wrap_err "binder_retype" uu___
 let (norm_binding_type :
   FStar_Pervasives.norm_step Prims.list ->
     FStar_Reflection_V2_Data.binding -> unit FStar_Tactics_Monad.tac)
@@ -4111,8 +4069,7 @@ let (norm_binding_type :
                  let env' = FStar_TypeChecker_Env.push_bvs e0 (bv' :: bvs) in
                  let uu___2 = FStar_Tactics_Types.goal_with_env goal env' in
                  FStar_Tactics_Monad.replace_cur uu___2) in
-      FStar_Compiler_Effect.op_Less_Bar
-        (FStar_Tactics_Monad.wrap_err "norm_binding_type") uu___
+      FStar_Tactics_Monad.wrap_err "norm_binding_type" uu___
 let (revert : unit -> unit FStar_Tactics_Monad.tac) =
   fun uu___ ->
     FStar_Tactics_Monad.op_let_Bang FStar_Tactics_Monad.cur_goal
@@ -4183,12 +4140,10 @@ let (clear :
                     let uu___5 =
                       let uu___6 = FStar_Tactics_Types.goal_env goal in
                       FStar_TypeChecker_Env.all_binders uu___6 in
-                    FStar_Compiler_Effect.op_Bar_Greater uu___5
-                      FStar_Compiler_List.length in
-                  FStar_Compiler_Effect.op_Bar_Greater uu___4
-                    (FStar_Class_Show.show
-                       (FStar_Class_Show.printableshow
-                          FStar_Class_Printable.printable_nat)) in
+                    FStar_Compiler_List.length uu___5 in
+                  FStar_Class_Show.show
+                    (FStar_Class_Show.printableshow
+                       FStar_Class_Printable.printable_nat) uu___4 in
                 FStar_Compiler_Util.print2
                   "Clear of (%s), env has %s binders\n" uu___2 uu___3) in
          FStar_Tactics_Monad.op_let_Bang uu___
@@ -4630,8 +4585,7 @@ let (t_trefl : Prims.bool -> unit FStar_Tactics_Monad.tac) =
            match uu___2 with
            | FStar_Pervasives.Inr v -> FStar_Tactics_Monad.ret ()
            | FStar_Pervasives.Inl exn -> FStar_Tactics_Monad.traise exn) in
-    FStar_Compiler_Effect.op_Less_Bar
-      (FStar_Tactics_Monad.wrap_err "t_trefl") uu___
+    FStar_Tactics_Monad.wrap_err "t_trefl" uu___
 let (dup : unit -> unit FStar_Tactics_Monad.tac) =
   fun uu___ ->
     FStar_Tactics_Monad.op_let_Bang FStar_Tactics_Monad.cur_goal
@@ -4970,14 +4924,11 @@ let (set_options : Prims.string -> unit FStar_Tactics_Monad.tac) =
                  fail2 "Setting options `%s` failed: %s" s err
              | FStar_Getopt.Help ->
                  fail1 "Setting options `%s` failed (got `Help`?)" s))) in
-    FStar_Compiler_Effect.op_Less_Bar
-      (FStar_Tactics_Monad.wrap_err "set_options") uu___
+    FStar_Tactics_Monad.wrap_err "set_options" uu___
 let (top_env : unit -> env FStar_Tactics_Monad.tac) =
   fun uu___ ->
     FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
-      (fun ps ->
-         FStar_Compiler_Effect.op_Less_Bar FStar_Tactics_Monad.ret
-           ps.FStar_Tactics_Types.main_context)
+      (fun ps -> FStar_Tactics_Monad.ret ps.FStar_Tactics_Types.main_context)
 let (lax_on : unit -> Prims.bool FStar_Tactics_Monad.tac) =
   fun uu___ ->
     FStar_Tactics_Monad.op_let_Bang FStar_Tactics_Monad.idtac
@@ -5058,8 +5009,7 @@ let (unquote :
                                      FStar_Tactics_Monad.op_let_Bang uu___9
                                        (fun uu___10 ->
                                           FStar_Tactics_Monad.ret tm1)))))) in
-      FStar_Compiler_Effect.op_Less_Bar
-        (FStar_Tactics_Monad.wrap_err "unquote") uu___
+      FStar_Tactics_Monad.wrap_err "unquote" uu___
 let (uvar_env :
   env ->
     FStar_Syntax_Syntax.typ FStar_Pervasives_Native.option ->
@@ -5075,8 +5025,7 @@ let (uvar_env :
                  let env2 =
                    let uu___1 =
                      let uu___2 = FStar_Syntax_Util.type_u () in
-                     FStar_Compiler_Effect.op_Bar_Greater uu___2
-                       FStar_Pervasives_Native.fst in
+                     FStar_Pervasives_Native.fst uu___2 in
                    FStar_TypeChecker_Env.set_expected_typ env1 uu___1 in
                  let uu___1 = __tc_ghost env2 ty1 in
                  FStar_Tactics_Monad.op_let_Bang uu___1
@@ -5089,8 +5038,7 @@ let (uvar_env :
                  let uu___1 =
                    let uu___2 =
                      let uu___3 = FStar_Syntax_Util.type_u () in
-                     FStar_Compiler_Effect.op_Less_Bar
-                       FStar_Pervasives_Native.fst uu___3 in
+                     FStar_Pervasives_Native.fst uu___3 in
                    FStar_Tactics_Monad.new_uvar "uvar_env.2" env1 uu___2
                      FStar_Pervasives_Native.None []
                      ps.FStar_Tactics_Types.entry_range in
@@ -5153,8 +5101,8 @@ let (fresh_universe_uvar :
   fun uu___ ->
     let uu___1 =
       let uu___2 = FStar_Syntax_Util.type_u () in
-      FStar_Compiler_Effect.op_Bar_Greater uu___2 FStar_Pervasives_Native.fst in
-    FStar_Compiler_Effect.op_Bar_Greater uu___1 FStar_Tactics_Monad.ret
+      FStar_Pervasives_Native.fst uu___2 in
+    FStar_Tactics_Monad.ret uu___1
 let (unshelve : FStar_Syntax_Syntax.term -> unit FStar_Tactics_Monad.tac) =
   fun t ->
     let uu___ =
@@ -5285,8 +5233,7 @@ let (unshelve : FStar_Syntax_Syntax.term -> unit FStar_Tactics_Monad.tac) =
                  FStar_Tactics_Types.mk_goal env2 ctx_uvar opts false "" in
                let g1 = bnorm_goal g in FStar_Tactics_Monad.add_goals [g1]
            | uu___2 -> FStar_Tactics_Monad.fail "not a uvar") in
-    FStar_Compiler_Effect.op_Less_Bar
-      (FStar_Tactics_Monad.wrap_err "unshelve") uu___
+    FStar_Tactics_Monad.wrap_err "unshelve" uu___
 let (tac_and :
   Prims.bool FStar_Tactics_Monad.tac ->
     Prims.bool FStar_Tactics_Monad.tac -> Prims.bool FStar_Tactics_Monad.tac)
@@ -5352,8 +5299,7 @@ let (match_env :
                                            let uu___10 =
                                              do_match must_tot e t11 t21 in
                                            tac_and uu___9 uu___10))))) in
-        FStar_Compiler_Effect.op_Less_Bar
-          (FStar_Tactics_Monad.wrap_err "match_env") uu___
+        FStar_Tactics_Monad.wrap_err "match_env" uu___
 let (unify_env :
   env ->
     FStar_Syntax_Syntax.term ->
@@ -5393,8 +5339,7 @@ let (unify_env :
                                            let uu___10 =
                                              do_unify must_tot e t11 t21 in
                                            tac_and uu___9 uu___10))))) in
-        FStar_Compiler_Effect.op_Less_Bar
-          (FStar_Tactics_Monad.wrap_err "unify_env") uu___
+        FStar_Tactics_Monad.wrap_err "unify_env" uu___
 let (unify_guard_env :
   env ->
     FStar_Syntax_Syntax.term ->
@@ -5487,8 +5432,7 @@ let (unify_guard_env :
                                                                     ->
                                                                     FStar_Tactics_Monad.ret
                                                                     true))))))))) in
-        FStar_Compiler_Effect.op_Less_Bar
-          (FStar_Tactics_Monad.wrap_err "unify_guard_env") uu___
+        FStar_Tactics_Monad.wrap_err "unify_guard_env" uu___
 let (launch_process :
   Prims.string ->
     Prims.string Prims.list ->
@@ -5589,8 +5533,7 @@ let (change : FStar_Syntax_Syntax.typ -> unit FStar_Tactics_Monad.tac) =
                                            else
                                              FStar_Tactics_Monad.fail
                                                "not convertible"))))))) in
-    FStar_Compiler_Effect.op_Less_Bar (FStar_Tactics_Monad.wrap_err "change")
-      uu___
+    FStar_Tactics_Monad.wrap_err "change" uu___
 let (failwhen : Prims.bool -> Prims.string -> unit FStar_Tactics_Monad.tac) =
   fun b ->
     fun msg ->
@@ -6443,8 +6386,7 @@ let (t_destruct :
                                             | uu___9 ->
                                                 FStar_Tactics_Monad.fail
                                                   "not an inductive type")))))) in
-    FStar_Compiler_Effect.op_Less_Bar
-      (FStar_Tactics_Monad.wrap_err "destruct") uu___
+    FStar_Tactics_Monad.wrap_err "destruct" uu___
 let (gather_explicit_guards_for_resolved_goals :
   unit -> unit FStar_Tactics_Monad.tac) =
   fun uu___ -> FStar_Tactics_Monad.ret ()
@@ -6463,10 +6405,7 @@ let rec init : 'a . 'a Prims.list -> 'a Prims.list =
 let (binder_bv :
   FStar_Syntax_Syntax.binder ->
     FStar_Syntax_Syntax.bv FStar_Tactics_Monad.tac)
-  =
-  fun b ->
-    FStar_Compiler_Effect.op_Less_Bar FStar_Tactics_Monad.ret
-      b.FStar_Syntax_Syntax.binder_bv
+  = fun b -> FStar_Tactics_Monad.ret b.FStar_Syntax_Syntax.binder_bv
 let (lget :
   FStar_Syntax_Syntax.typ ->
     Prims.string -> FStar_Syntax_Syntax.term FStar_Tactics_Monad.tac)
@@ -6483,8 +6422,7 @@ let (lget :
              | FStar_Pervasives_Native.None ->
                  FStar_Tactics_Monad.fail "not found"
              | FStar_Pervasives_Native.Some t -> unquote ty t) in
-      FStar_Compiler_Effect.op_Less_Bar (FStar_Tactics_Monad.wrap_err "lget")
-        uu___
+      FStar_Tactics_Monad.wrap_err "lget" uu___
 let (lset :
   FStar_Syntax_Syntax.typ ->
     Prims.string -> FStar_Syntax_Syntax.term -> unit FStar_Tactics_Monad.tac)
@@ -6524,8 +6462,7 @@ let (lset :
                      (ps.FStar_Tactics_Types.urgency)
                  } in
                FStar_Tactics_Monad.set ps1) in
-        FStar_Compiler_Effect.op_Less_Bar
-          (FStar_Tactics_Monad.wrap_err "lset") uu___
+        FStar_Tactics_Monad.wrap_err "lset" uu___
 let (set_urgency : FStar_BigInt.t -> unit FStar_Tactics_Monad.tac) =
   fun u ->
     FStar_Tactics_Monad.op_let_Bang FStar_Tactics_Monad.get
@@ -6591,51 +6528,45 @@ let (t_commute_applied_match : unit -> unit FStar_Tactics_Monad.tac) =
                                       FStar_Syntax_Util.mk_app e1 las in
                                     (p, w, uu___6)) brs in
                          let lopt' =
-                           FStar_Compiler_Effect.op_Bar_Greater lopt
-                             (FStar_Compiler_Util.map_option
-                                (fun rc ->
-                                   let uu___5 =
-                                     FStar_Compiler_Effect.op_Bar_Greater
-                                       rc.FStar_Syntax_Syntax.residual_typ
-                                       (FStar_Compiler_Util.map_option
-                                          (fun t ->
-                                             let uu___6 =
-                                               let uu___7 =
-                                                 FStar_Tactics_Types.goal_env
-                                                   g in
-                                               FStar_TypeChecker_Normalize.get_n_binders
-                                                 uu___7
-                                                 (FStar_Compiler_List.length
-                                                    las) t in
-                                             match uu___6 with
-                                             | (bs, c) ->
-                                                 let uu___7 =
-                                                   FStar_Syntax_Subst.open_comp
-                                                     bs c in
-                                                 (match uu___7 with
-                                                  | (bs1, c1) ->
-                                                      let ss =
-                                                        FStar_Compiler_List.map2
-                                                          (fun b ->
-                                                             fun a ->
-                                                               FStar_Syntax_Syntax.NT
-                                                                 ((b.FStar_Syntax_Syntax.binder_bv),
-                                                                   (FStar_Pervasives_Native.fst
-                                                                    a))) bs1
-                                                          las in
-                                                      let c2 =
-                                                        FStar_Syntax_Subst.subst_comp
-                                                          ss c1 in
-                                                      FStar_Syntax_Util.comp_result
-                                                        c2))) in
-                                   {
-                                     FStar_Syntax_Syntax.residual_effect =
-                                       (rc.FStar_Syntax_Syntax.residual_effect);
-                                     FStar_Syntax_Syntax.residual_typ =
-                                       uu___5;
-                                     FStar_Syntax_Syntax.residual_flags =
-                                       (rc.FStar_Syntax_Syntax.residual_flags)
-                                   })) in
+                           FStar_Compiler_Util.map_option
+                             (fun rc ->
+                                let uu___5 =
+                                  FStar_Compiler_Util.map_option
+                                    (fun t ->
+                                       let uu___6 =
+                                         let uu___7 =
+                                           FStar_Tactics_Types.goal_env g in
+                                         FStar_TypeChecker_Normalize.get_n_binders
+                                           uu___7
+                                           (FStar_Compiler_List.length las) t in
+                                       match uu___6 with
+                                       | (bs, c) ->
+                                           let uu___7 =
+                                             FStar_Syntax_Subst.open_comp bs
+                                               c in
+                                           (match uu___7 with
+                                            | (bs1, c1) ->
+                                                let ss =
+                                                  FStar_Compiler_List.map2
+                                                    (fun b ->
+                                                       fun a ->
+                                                         FStar_Syntax_Syntax.NT
+                                                           ((b.FStar_Syntax_Syntax.binder_bv),
+                                                             (FStar_Pervasives_Native.fst
+                                                                a))) bs1 las in
+                                                let c2 =
+                                                  FStar_Syntax_Subst.subst_comp
+                                                    ss c1 in
+                                                FStar_Syntax_Util.comp_result
+                                                  c2))
+                                    rc.FStar_Syntax_Syntax.residual_typ in
+                                {
+                                  FStar_Syntax_Syntax.residual_effect =
+                                    (rc.FStar_Syntax_Syntax.residual_effect);
+                                  FStar_Syntax_Syntax.residual_typ = uu___5;
+                                  FStar_Syntax_Syntax.residual_flags =
+                                    (rc.FStar_Syntax_Syntax.residual_flags)
+                                }) lopt in
                          let l' =
                            FStar_Syntax_Syntax.mk
                              (FStar_Syntax_Syntax.Tm_match
@@ -6671,8 +6602,7 @@ let (t_commute_applied_match : unit -> unit FStar_Tactics_Monad.tac) =
                          FStar_Tactics_Monad.fail "lhs is not a match"))
            | FStar_Pervasives_Native.None ->
                FStar_Tactics_Monad.fail "not an equality") in
-    FStar_Compiler_Effect.op_Less_Bar
-      (FStar_Tactics_Monad.wrap_err "t_commute_applied_match") uu___1
+    FStar_Tactics_Monad.wrap_err "t_commute_applied_match" uu___1
 let (string_to_term :
   env -> Prims.string -> FStar_Syntax_Syntax.term FStar_Tactics_Monad.tac) =
   fun e ->
@@ -6955,8 +6885,7 @@ let (t_smt_sync : FStar_VConfig.vconfig -> unit FStar_Tactics_Monad.tac) =
                     goal.FStar_Tactics_Types.goal_ctx_uvar;
                   solve goal FStar_Syntax_Util.exp_unit)
                else FStar_Tactics_Monad.fail "SMT did not solve this goal") in
-    FStar_Compiler_Effect.op_Less_Bar
-      (FStar_Tactics_Monad.wrap_err "t_smt_sync") uu___
+    FStar_Tactics_Monad.wrap_err "t_smt_sync" uu___
 let (free_uvars :
   FStar_Syntax_Syntax.term ->
     FStar_BigInt.t Prims.list FStar_Tactics_Monad.tac)
@@ -6967,15 +6896,13 @@ let (free_uvars :
          let uvs =
            let uu___1 =
              let uu___2 = FStar_Syntax_Free.uvars_uncached tm in
-             FStar_Compiler_Effect.op_Bar_Greater uu___2
-               (FStar_Compiler_Set.elems FStar_Syntax_Free.ord_ctx_uvar) in
-           FStar_Compiler_Effect.op_Bar_Greater uu___1
-             (FStar_Compiler_List.map
-                (fun u ->
-                   let uu___2 =
-                     FStar_Syntax_Unionfind.uvar_id
-                       u.FStar_Syntax_Syntax.ctx_uvar_head in
-                   FStar_BigInt.of_int_fs uu___2)) in
+             FStar_Compiler_Set.elems FStar_Syntax_Free.ord_ctx_uvar uu___2 in
+           FStar_Compiler_List.map
+             (fun u ->
+                let uu___2 =
+                  FStar_Syntax_Unionfind.uvar_id
+                    u.FStar_Syntax_Syntax.ctx_uvar_head in
+                FStar_BigInt.of_int_fs uu___2) uu___1 in
          FStar_Tactics_Monad.ret uvs)
 let (all_ext_options :
   unit -> (Prims.string * Prims.string) Prims.list FStar_Tactics_Monad.tac) =
@@ -7023,8 +6950,7 @@ let (dbg_refl : env -> (unit -> Prims.string) -> unit) =
   fun g ->
     fun msg ->
       let uu___ =
-        FStar_Compiler_Effect.op_Less_Bar (FStar_TypeChecker_Env.debug g)
-          (FStar_Options.Other "ReflTc") in
+        FStar_TypeChecker_Env.debug g (FStar_Options.Other "ReflTc") in
       if uu___
       then let uu___1 = msg () in FStar_Compiler_Util.print_string uu___1
       else ()
@@ -7142,55 +7068,45 @@ let refl_typing_builtin_wrapper :
            match uu___1 with
            | (o, errs) ->
                let errs1 =
-                 FStar_Compiler_Effect.op_Bar_Greater errs
-                   (FStar_Compiler_List.map
-                      (fun is ->
-                         let uu___2 =
-                           let uu___3 =
-                             let uu___4 =
-                               FStar_Errors_Msg.text
-                                 (Prims.strcat "Raised within Tactics." label) in
-                             [uu___4] in
-                           FStar_Compiler_List.op_At
-                             is.FStar_Errors.issue_msg uu___3 in
-                         {
-                           FStar_Errors.issue_msg = uu___2;
-                           FStar_Errors.issue_level =
-                             (is.FStar_Errors.issue_level);
-                           FStar_Errors.issue_range =
-                             (is.FStar_Errors.issue_range);
-                           FStar_Errors.issue_number =
-                             (is.FStar_Errors.issue_number);
-                           FStar_Errors.issue_ctx =
-                             (is.FStar_Errors.issue_ctx)
-                         })) in
+                 FStar_Compiler_List.map
+                   (fun is ->
+                      let uu___2 =
+                        let uu___3 =
+                          let uu___4 =
+                            FStar_Errors_Msg.text
+                              (Prims.strcat "Raised within Tactics." label) in
+                          [uu___4] in
+                        FStar_Compiler_List.op_At is.FStar_Errors.issue_msg
+                          uu___3 in
+                      {
+                        FStar_Errors.issue_msg = uu___2;
+                        FStar_Errors.issue_level =
+                          (is.FStar_Errors.issue_level);
+                        FStar_Errors.issue_range =
+                          (is.FStar_Errors.issue_range);
+                        FStar_Errors.issue_number =
+                          (is.FStar_Errors.issue_number);
+                        FStar_Errors.issue_ctx = (is.FStar_Errors.issue_ctx)
+                      }) errs in
                FStar_Tactics_Monad.ret (o, errs1))
 let (no_uvars_in_term : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t ->
-    (let uu___ =
-       FStar_Compiler_Effect.op_Bar_Greater t FStar_Syntax_Free.uvars in
-     FStar_Compiler_Effect.op_Bar_Greater uu___
-       (FStar_Compiler_Set.is_empty FStar_Syntax_Free.ord_ctx_uvar))
-      &&
-      (let uu___ =
-         FStar_Compiler_Effect.op_Bar_Greater t FStar_Syntax_Free.univs in
-       FStar_Compiler_Effect.op_Bar_Greater uu___
-         (FStar_Compiler_Set.is_empty FStar_Syntax_Free.ord_univ_uvar))
+    (let uu___ = FStar_Syntax_Free.uvars t in
+     FStar_Compiler_Set.is_empty FStar_Syntax_Free.ord_ctx_uvar uu___) &&
+      (let uu___ = FStar_Syntax_Free.univs t in
+       FStar_Compiler_Set.is_empty FStar_Syntax_Free.ord_univ_uvar uu___)
 let (no_univ_uvars_in_term : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t ->
-    let uu___ =
-      FStar_Compiler_Effect.op_Bar_Greater t FStar_Syntax_Free.univs in
-    FStar_Compiler_Effect.op_Bar_Greater uu___
-      (FStar_Compiler_Set.is_empty FStar_Syntax_Free.ord_univ_uvar)
+    let uu___ = FStar_Syntax_Free.univs t in
+    FStar_Compiler_Set.is_empty FStar_Syntax_Free.ord_univ_uvar uu___
 let (no_uvars_in_g : env -> Prims.bool) =
   fun g ->
-    FStar_Compiler_Effect.op_Bar_Greater g.FStar_TypeChecker_Env.gamma
-      (FStar_Compiler_Util.for_all
-         (fun uu___ ->
-            match uu___ with
-            | FStar_Syntax_Syntax.Binding_var bv ->
-                no_uvars_in_term bv.FStar_Syntax_Syntax.sort
-            | uu___1 -> true))
+    FStar_Compiler_Util.for_all
+      (fun uu___ ->
+         match uu___ with
+         | FStar_Syntax_Syntax.Binding_var bv ->
+             no_uvars_in_term bv.FStar_Syntax_Syntax.sort
+         | uu___1 -> true) g.FStar_TypeChecker_Env.gamma
 type relation =
   | Subtyping 
   | Equality 
@@ -7862,10 +7778,9 @@ let (refl_tc_term :
                                   let uu___10 =
                                     let uu___11 =
                                       FStar_TypeChecker_Env.get_range g3 in
-                                    FStar_Compiler_Effect.op_Bar_Greater
-                                      uu___11
-                                      (FStar_Class_Show.show
-                                         FStar_Compiler_Range_Ops.show_range) in
+                                    FStar_Class_Show.show
+                                      FStar_Compiler_Range_Ops.show_range
+                                      uu___11 in
                                   let uu___11 =
                                     FStar_Class_Show.show
                                       FStar_Syntax_Print.showable_term guard in
@@ -8112,8 +8027,7 @@ let (refl_check_match_complete :
                                let uu___6 =
                                  FStar_TypeChecker_Rel.discharge_guard env2
                                    g1 in
-                               FStar_Compiler_Effect.op_Less_Bar
-                                 FStar_TypeChecker_Env.is_trivial uu___6) in
+                               FStar_TypeChecker_Env.is_trivial uu___6) in
                         (match uu___4 with
                          | (errs, b) ->
                              (match (errs, b) with
@@ -8308,51 +8222,45 @@ let (refl_instantiate_implicits :
               | (e1, t, guard) ->
                   let guard1 =
                     let uu___5 =
-                      FStar_Compiler_Effect.op_Bar_Greater guard
-                        (FStar_TypeChecker_Rel.solve_deferred_constraints g2) in
-                    FStar_Compiler_Effect.op_Bar_Greater uu___5
-                      (FStar_TypeChecker_Rel.resolve_implicits g2) in
+                      FStar_TypeChecker_Rel.solve_deferred_constraints g2
+                        guard in
+                    FStar_TypeChecker_Rel.resolve_implicits g2 uu___5 in
                   let bvs_and_ts =
                     match guard1.FStar_TypeChecker_Common.implicits with
                     | [] -> []
                     | uu___5 ->
                         let l =
-                          FStar_Compiler_Effect.op_Bar_Greater
-                            guard1.FStar_TypeChecker_Common.implicits
-                            (FStar_Compiler_List.map
-                               (fun uu___6 ->
-                                  match uu___6 with
-                                  | {
-                                      FStar_TypeChecker_Common.imp_reason =
-                                        uu___7;
-                                      FStar_TypeChecker_Common.imp_uvar =
-                                        imp_uvar;
-                                      FStar_TypeChecker_Common.imp_tm =
-                                        uu___8;
-                                      FStar_TypeChecker_Common.imp_range =
-                                        uu___9;_}
-                                      ->
-                                      let uu___10 =
-                                        FStar_Syntax_Util.ctx_uvar_typ
-                                          imp_uvar in
-                                      let uu___11 =
-                                        let uu___12 =
-                                          FStar_Syntax_Syntax.mk
-                                            FStar_Syntax_Syntax.Tm_unknown
-                                            FStar_Compiler_Range_Type.dummyRange in
-                                        FStar_Syntax_Syntax.new_bv
-                                          FStar_Pervasives_Native.None
-                                          uu___12 in
-                                      ((imp_uvar.FStar_Syntax_Syntax.ctx_uvar_head),
-                                        uu___10, uu___11))) in
-                        (FStar_Compiler_Effect.op_Bar_Greater l
-                           (FStar_Compiler_List.iter
-                              (fun uu___7 ->
-                                 match uu___7 with
-                                 | (uv, uu___8, bv) ->
-                                     let uu___9 =
-                                       FStar_Syntax_Syntax.bv_to_name bv in
-                                     FStar_Syntax_Util.set_uvar uv uu___9));
+                          FStar_Compiler_List.map
+                            (fun uu___6 ->
+                               match uu___6 with
+                               | {
+                                   FStar_TypeChecker_Common.imp_reason =
+                                     uu___7;
+                                   FStar_TypeChecker_Common.imp_uvar =
+                                     imp_uvar;
+                                   FStar_TypeChecker_Common.imp_tm = uu___8;
+                                   FStar_TypeChecker_Common.imp_range =
+                                     uu___9;_}
+                                   ->
+                                   let uu___10 =
+                                     FStar_Syntax_Util.ctx_uvar_typ imp_uvar in
+                                   let uu___11 =
+                                     let uu___12 =
+                                       FStar_Syntax_Syntax.mk
+                                         FStar_Syntax_Syntax.Tm_unknown
+                                         FStar_Compiler_Range_Type.dummyRange in
+                                     FStar_Syntax_Syntax.new_bv
+                                       FStar_Pervasives_Native.None uu___12 in
+                                   ((imp_uvar.FStar_Syntax_Syntax.ctx_uvar_head),
+                                     uu___10, uu___11))
+                            guard1.FStar_TypeChecker_Common.implicits in
+                        (FStar_Compiler_List.iter
+                           (fun uu___7 ->
+                              match uu___7 with
+                              | (uv, uu___8, bv) ->
+                                  let uu___9 =
+                                    FStar_Syntax_Syntax.bv_to_name bv in
+                                  FStar_Syntax_Util.set_uvar uv uu___9) l;
                          FStar_Compiler_List.map
                            (fun uu___7 ->
                               match uu___7 with
@@ -8413,22 +8321,18 @@ let (refl_instantiate_implicits :
                           FStar_Syntax_Compress.deep_compress allow_uvars
                             allow_names e1 in
                         let t1 =
-                          let uu___9 =
-                            FStar_Compiler_Effect.op_Bar_Greater t
-                              (refl_norm_type g3) in
-                          FStar_Compiler_Effect.op_Bar_Greater uu___9
-                            (FStar_Syntax_Compress.deep_compress allow_uvars
-                               allow_names) in
+                          let uu___9 = refl_norm_type g3 t in
+                          FStar_Syntax_Compress.deep_compress allow_uvars
+                            allow_names uu___9 in
                         let bvs_and_ts1 =
-                          FStar_Compiler_Effect.op_Bar_Greater bvs_and_ts
-                            (FStar_Compiler_List.map
-                               (fun uu___9 ->
-                                  match uu___9 with
-                                  | (bv, t2) ->
-                                      let uu___10 =
-                                        FStar_Syntax_Compress.deep_compress
-                                          allow_uvars allow_names t2 in
-                                      (bv, uu___10))) in
+                          FStar_Compiler_List.map
+                            (fun uu___9 ->
+                               match uu___9 with
+                               | (bv, t2) ->
+                                   let uu___10 =
+                                     FStar_Syntax_Compress.deep_compress
+                                       allow_uvars allow_names t2 in
+                                   (bv, uu___10)) bvs_and_ts in
                         dbg_refl g3
                           (fun uu___10 ->
                              let uu___11 =
@@ -8541,10 +8445,7 @@ let (refl_maybe_unfold_head :
                    (FStar_Errors_Codes.Fatal_UnexpectedTerm, uu___5) in
                  FStar_Errors.raise_error uu___4 e.FStar_Syntax_Syntax.pos)
               else
-                (let uu___5 =
-                   FStar_Compiler_Effect.op_Bar_Greater eopt
-                     FStar_Compiler_Util.must in
-                 (uu___5, []))))
+                (let uu___5 = FStar_Compiler_Util.must eopt in (uu___5, []))))
       else
         (let uu___2 =
            let uu___3 =
@@ -8773,21 +8674,18 @@ let (log_issues :
     FStar_Tactics_Monad.op_let_Bang FStar_Tactics_Monad.get
       (fun ps ->
          let is1 =
-           FStar_Compiler_Effect.op_Bar_Greater is
-             (FStar_Compiler_List.map
-                (fun i ->
-                   let uu___ =
-                     let uu___1 =
-                       FStar_Errors_Msg.text "Tactic logged issue:" in
-                     uu___1 :: (i.FStar_Errors.issue_msg) in
-                   {
-                     FStar_Errors.issue_msg = uu___;
-                     FStar_Errors.issue_level = (i.FStar_Errors.issue_level);
-                     FStar_Errors.issue_range = (i.FStar_Errors.issue_range);
-                     FStar_Errors.issue_number =
-                       (i.FStar_Errors.issue_number);
-                     FStar_Errors.issue_ctx = (i.FStar_Errors.issue_ctx)
-                   })) in
+           FStar_Compiler_List.map
+             (fun i ->
+                let uu___ =
+                  let uu___1 = FStar_Errors_Msg.text "Tactic logged issue:" in
+                  uu___1 :: (i.FStar_Errors.issue_msg) in
+                {
+                  FStar_Errors.issue_msg = uu___;
+                  FStar_Errors.issue_level = (i.FStar_Errors.issue_level);
+                  FStar_Errors.issue_range = (i.FStar_Errors.issue_range);
+                  FStar_Errors.issue_number = (i.FStar_Errors.issue_number);
+                  FStar_Errors.issue_ctx = (i.FStar_Errors.issue_ctx)
+                }) is in
          FStar_Errors.add_issues is1; FStar_Tactics_Monad.ret ())
 let (tac_env : FStar_TypeChecker_Env.env -> FStar_TypeChecker_Env.env) =
   fun env1 ->

--- a/ocaml/fstar-lib/generated/FStar_Tactics_V2_Interpreter.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_V2_Interpreter.ml
@@ -3041,79 +3041,77 @@ let (report_implicits :
   =
   fun rng ->
     fun is ->
-      FStar_Compiler_Effect.op_Bar_Greater is
-        (FStar_Compiler_List.iter
-           (fun uu___1 ->
-              match uu___1 with
-              | (imp, tag) ->
-                  (match tag with
-                   | FStar_TypeChecker_Rel.Implicit_unresolved ->
-                       let uu___2 =
-                         let uu___3 =
-                           let uu___4 =
-                             FStar_Class_Show.show
-                               FStar_Syntax_Print.showable_uvar
-                               (imp.FStar_TypeChecker_Common.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_head in
-                           let uu___5 =
-                             let uu___6 =
-                               FStar_Syntax_Util.ctx_uvar_typ
-                                 imp.FStar_TypeChecker_Common.imp_uvar in
-                             FStar_Class_Show.show
-                               FStar_Syntax_Print.showable_term uu___6 in
-                           FStar_Compiler_Util.format3
-                             "Tactic left uninstantiated unification variable %s of type %s (reason = \"%s\")"
-                             uu___4 uu___5
-                             imp.FStar_TypeChecker_Common.imp_reason in
-                         (FStar_Errors_Codes.Error_UninstantiatedUnificationVarInTactic,
-                           uu___3) in
-                       FStar_Errors.log_issue rng uu___2
-                   | FStar_TypeChecker_Rel.Implicit_checking_defers_univ_constraint
-                       ->
-                       let uu___2 =
-                         let uu___3 =
-                           let uu___4 =
-                             FStar_Class_Show.show
-                               FStar_Syntax_Print.showable_uvar
-                               (imp.FStar_TypeChecker_Common.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_head in
-                           let uu___5 =
-                             let uu___6 =
-                               FStar_Syntax_Util.ctx_uvar_typ
-                                 imp.FStar_TypeChecker_Common.imp_uvar in
-                             FStar_Class_Show.show
-                               FStar_Syntax_Print.showable_term uu___6 in
-                           FStar_Compiler_Util.format3
-                             "Tactic left uninstantiated unification variable %s of type %s (reason = \"%s\")"
-                             uu___4 uu___5
-                             imp.FStar_TypeChecker_Common.imp_reason in
-                         (FStar_Errors_Codes.Error_UninstantiatedUnificationVarInTactic,
-                           uu___3) in
-                       FStar_Errors.log_issue rng uu___2
-                   | FStar_TypeChecker_Rel.Implicit_has_typing_guard 
-                       (tm, ty) ->
-                       let uu___2 =
-                         let uu___3 =
-                           let uu___4 =
-                             FStar_Class_Show.show
-                               FStar_Syntax_Print.showable_uvar
-                               (imp.FStar_TypeChecker_Common.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_head in
-                           let uu___5 =
-                             let uu___6 =
-                               FStar_Syntax_Util.ctx_uvar_typ
-                                 imp.FStar_TypeChecker_Common.imp_uvar in
-                             FStar_Class_Show.show
-                               FStar_Syntax_Print.showable_term uu___6 in
-                           let uu___6 =
-                             FStar_Class_Show.show
-                               FStar_Syntax_Print.showable_term tm in
-                           let uu___7 =
-                             FStar_Class_Show.show
-                               FStar_Syntax_Print.showable_term ty in
-                           FStar_Compiler_Util.format4
-                             "Tactic solved goal %s of type %s to %s : %s, but it has a non-trivial typing guard. Use gather_or_solve_explicit_guards_for_resolved_goals to inspect and prove these goals"
-                             uu___4 uu___5 uu___6 uu___7 in
-                         (FStar_Errors_Codes.Error_UninstantiatedUnificationVarInTactic,
-                           uu___3) in
-                       FStar_Errors.log_issue rng uu___2)));
+      FStar_Compiler_List.iter
+        (fun uu___1 ->
+           match uu___1 with
+           | (imp, tag) ->
+               (match tag with
+                | FStar_TypeChecker_Rel.Implicit_unresolved ->
+                    let uu___2 =
+                      let uu___3 =
+                        let uu___4 =
+                          FStar_Class_Show.show
+                            FStar_Syntax_Print.showable_uvar
+                            (imp.FStar_TypeChecker_Common.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_head in
+                        let uu___5 =
+                          let uu___6 =
+                            FStar_Syntax_Util.ctx_uvar_typ
+                              imp.FStar_TypeChecker_Common.imp_uvar in
+                          FStar_Class_Show.show
+                            FStar_Syntax_Print.showable_term uu___6 in
+                        FStar_Compiler_Util.format3
+                          "Tactic left uninstantiated unification variable %s of type %s (reason = \"%s\")"
+                          uu___4 uu___5
+                          imp.FStar_TypeChecker_Common.imp_reason in
+                      (FStar_Errors_Codes.Error_UninstantiatedUnificationVarInTactic,
+                        uu___3) in
+                    FStar_Errors.log_issue rng uu___2
+                | FStar_TypeChecker_Rel.Implicit_checking_defers_univ_constraint
+                    ->
+                    let uu___2 =
+                      let uu___3 =
+                        let uu___4 =
+                          FStar_Class_Show.show
+                            FStar_Syntax_Print.showable_uvar
+                            (imp.FStar_TypeChecker_Common.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_head in
+                        let uu___5 =
+                          let uu___6 =
+                            FStar_Syntax_Util.ctx_uvar_typ
+                              imp.FStar_TypeChecker_Common.imp_uvar in
+                          FStar_Class_Show.show
+                            FStar_Syntax_Print.showable_term uu___6 in
+                        FStar_Compiler_Util.format3
+                          "Tactic left uninstantiated unification variable %s of type %s (reason = \"%s\")"
+                          uu___4 uu___5
+                          imp.FStar_TypeChecker_Common.imp_reason in
+                      (FStar_Errors_Codes.Error_UninstantiatedUnificationVarInTactic,
+                        uu___3) in
+                    FStar_Errors.log_issue rng uu___2
+                | FStar_TypeChecker_Rel.Implicit_has_typing_guard (tm, ty) ->
+                    let uu___2 =
+                      let uu___3 =
+                        let uu___4 =
+                          FStar_Class_Show.show
+                            FStar_Syntax_Print.showable_uvar
+                            (imp.FStar_TypeChecker_Common.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_head in
+                        let uu___5 =
+                          let uu___6 =
+                            FStar_Syntax_Util.ctx_uvar_typ
+                              imp.FStar_TypeChecker_Common.imp_uvar in
+                          FStar_Class_Show.show
+                            FStar_Syntax_Print.showable_term uu___6 in
+                        let uu___6 =
+                          FStar_Class_Show.show
+                            FStar_Syntax_Print.showable_term tm in
+                        let uu___7 =
+                          FStar_Class_Show.show
+                            FStar_Syntax_Print.showable_term ty in
+                        FStar_Compiler_Util.format4
+                          "Tactic solved goal %s of type %s to %s : %s, but it has a non-trivial typing guard. Use gather_or_solve_explicit_guards_for_resolved_goals to inspect and prove these goals"
+                          uu___4 uu___5 uu___6 uu___7 in
+                      (FStar_Errors_Codes.Error_UninstantiatedUnificationVarInTactic,
+                        uu___3) in
+                    FStar_Errors.log_issue rng uu___2)) is;
       FStar_Errors.stop_if_err ()
 let run_tactic_on_ps' :
   'a 'b .

--- a/ocaml/fstar-lib/generated/FStar_ToSyntax_Interleave.ml
+++ b/ocaml/fstar-lib/generated/FStar_ToSyntax_Interleave.ml
@@ -20,11 +20,11 @@ let (is_type : FStar_Ident.ident -> FStar_Parser_AST.decl -> Prims.bool) =
     fun d ->
       match d.FStar_Parser_AST.d with
       | FStar_Parser_AST.Tycon (uu___, uu___1, tys) ->
-          FStar_Compiler_Effect.op_Bar_Greater tys
-            (FStar_Compiler_Util.for_some
-               (fun t ->
-                  let uu___2 = FStar_Parser_AST.id_of_tycon t in
-                  let uu___3 = FStar_Ident.string_of_id x in uu___2 = uu___3))
+          FStar_Compiler_Util.for_some
+            (fun t ->
+               let uu___2 = FStar_Parser_AST.id_of_tycon t in
+               let uu___3 = FStar_Ident.string_of_id x in uu___2 = uu___3)
+            tys
       | uu___ -> false
 let (definition_lids :
   FStar_Parser_AST.decl -> FStar_Ident.lident Prims.list) =
@@ -33,18 +33,17 @@ let (definition_lids :
     | FStar_Parser_AST.TopLevelLet (uu___, defs) ->
         FStar_Parser_AST.lids_of_let defs
     | FStar_Parser_AST.Tycon (uu___, uu___1, tys) ->
-        FStar_Compiler_Effect.op_Bar_Greater tys
-          (FStar_Compiler_List.collect
-             (fun uu___2 ->
-                match uu___2 with
-                | FStar_Parser_AST.TyconAbbrev (id, uu___3, uu___4, uu___5)
-                    -> let uu___6 = FStar_Ident.lid_of_ids [id] in [uu___6]
-                | FStar_Parser_AST.TyconRecord
-                    (id, uu___3, uu___4, uu___5, uu___6) ->
-                    let uu___7 = FStar_Ident.lid_of_ids [id] in [uu___7]
-                | FStar_Parser_AST.TyconVariant (id, uu___3, uu___4, uu___5)
-                    -> let uu___6 = FStar_Ident.lid_of_ids [id] in [uu___6]
-                | uu___3 -> []))
+        FStar_Compiler_List.collect
+          (fun uu___2 ->
+             match uu___2 with
+             | FStar_Parser_AST.TyconAbbrev (id, uu___3, uu___4, uu___5) ->
+                 let uu___6 = FStar_Ident.lid_of_ids [id] in [uu___6]
+             | FStar_Parser_AST.TyconRecord
+                 (id, uu___3, uu___4, uu___5, uu___6) ->
+                 let uu___7 = FStar_Ident.lid_of_ids [id] in [uu___7]
+             | FStar_Parser_AST.TyconVariant (id, uu___3, uu___4, uu___5) ->
+                 let uu___6 = FStar_Ident.lid_of_ids [id] in [uu___6]
+             | uu___3 -> []) tys
     | uu___ -> []
 let (is_definition_of :
   FStar_Ident.ident -> FStar_Parser_AST.decl -> Prims.bool) =
@@ -80,12 +79,11 @@ let rec (prefix_with_iface_decls :
       | iface_hd::iface_tl ->
           (match iface_hd.FStar_Parser_AST.d with
            | FStar_Parser_AST.Tycon (uu___, uu___1, tys) when
-               FStar_Compiler_Effect.op_Bar_Greater tys
-                 (FStar_Compiler_Util.for_some
-                    (fun uu___2 ->
-                       match uu___2 with
-                       | FStar_Parser_AST.TyconAbstract uu___3 -> true
-                       | uu___3 -> false))
+               FStar_Compiler_Util.for_some
+                 (fun uu___2 ->
+                    match uu___2 with
+                    | FStar_Parser_AST.TyconAbstract uu___3 -> true
+                    | uu___3 -> false) tys
                ->
                FStar_Errors.raise_error
                  (FStar_Errors_Codes.Fatal_AbstractTypeDeclarationInInterface,
@@ -98,16 +96,12 @@ let rec (prefix_with_iface_decls :
                if Prims.op_Negation defines_x
                then
                  let uu___ =
-                   FStar_Compiler_Effect.op_Bar_Greater def_ids
-                     (FStar_Compiler_Util.for_some
-                        (fun y ->
-                           let uu___1 =
-                             let uu___2 =
-                               let uu___3 = FStar_Ident.ident_of_lid y in
-                               is_val uu___3 in
-                             FStar_Compiler_Util.for_some uu___2 in
-                           FStar_Compiler_Effect.op_Bar_Greater iface_tl
-                             uu___1)) in
+                   FStar_Compiler_Util.for_some
+                     (fun y ->
+                        let uu___1 =
+                          let uu___2 = FStar_Ident.ident_of_lid y in
+                          is_val uu___2 in
+                        FStar_Compiler_Util.for_some uu___1 iface_tl) def_ids in
                  (if uu___
                   then
                     let uu___1 =
@@ -115,11 +109,9 @@ let rec (prefix_with_iface_decls :
                         let uu___3 = FStar_Ident.string_of_id x in
                         let uu___4 =
                           let uu___5 =
-                            FStar_Compiler_Effect.op_Bar_Greater def_ids
-                              (FStar_Compiler_List.map
-                                 FStar_Ident.string_of_lid) in
-                          FStar_Compiler_Effect.op_Bar_Greater uu___5
-                            (FStar_Compiler_String.concat ", ") in
+                            FStar_Compiler_List.map FStar_Ident.string_of_lid
+                              def_ids in
+                          FStar_Compiler_String.concat ", " uu___5 in
                         FStar_Compiler_Util.format2
                           "Expected the definition of %s to precede %s"
                           uu___3 uu___4 in
@@ -132,11 +124,10 @@ let rec (prefix_with_iface_decls :
                      (iface, uu___2)))
                else
                  (let mutually_defined_with_x =
-                    FStar_Compiler_Effect.op_Bar_Greater def_ids
-                      (FStar_Compiler_List.filter
-                         (fun y ->
-                            let uu___1 = id_eq_lid x y in
-                            Prims.op_Negation uu___1)) in
+                    FStar_Compiler_List.filter
+                      (fun y ->
+                         let uu___1 = id_eq_lid x y in
+                         Prims.op_Negation uu___1) def_ids in
                   let rec aux mutuals iface1 =
                     match (mutuals, iface1) with
                     | ([], uu___1) -> ([], iface1)
@@ -158,8 +149,7 @@ let rec (prefix_with_iface_decls :
                                  let uu___6 = FStar_Ident.ident_of_lid y in
                                  is_val uu___6 in
                                FStar_Compiler_List.tryFind uu___5 iface_tl1 in
-                             FStar_Compiler_Effect.op_Less_Bar
-                               FStar_Compiler_Option.isSome uu___4 in
+                             FStar_Compiler_Option.isSome uu___4 in
                            if uu___3
                            then
                              let uu___4 =
@@ -196,12 +186,11 @@ let (check_initial_interface :
       | hd::tl ->
           (match hd.FStar_Parser_AST.d with
            | FStar_Parser_AST.Tycon (uu___, uu___1, tys) when
-               FStar_Compiler_Effect.op_Bar_Greater tys
-                 (FStar_Compiler_Util.for_some
-                    (fun uu___2 ->
-                       match uu___2 with
-                       | FStar_Parser_AST.TyconAbstract uu___3 -> true
-                       | uu___3 -> false))
+               FStar_Compiler_Util.for_some
+                 (fun uu___2 ->
+                    match uu___2 with
+                    | FStar_Parser_AST.TyconAbstract uu___3 -> true
+                    | uu___3 -> false) tys
                ->
                FStar_Errors.raise_error
                  (FStar_Errors_Codes.Fatal_AbstractTypeDeclarationInInterface,
@@ -223,26 +212,22 @@ let (check_initial_interface :
                      uu___2) in
                  FStar_Errors.raise_error uu___1 hd.FStar_Parser_AST.drange
                else
-                 (let uu___2 =
-                    FStar_Compiler_Effect.op_Bar_Greater
-                      hd.FStar_Parser_AST.quals
-                      (FStar_Compiler_List.contains
-                         FStar_Parser_AST.Assumption) in
-                  if uu___2
-                  then
-                    FStar_Errors.raise_error
-                      (FStar_Errors_Codes.Fatal_AssumeValInInterface,
-                        "Interfaces cannot use `assume val x : t`; just write `val x : t` instead")
-                      hd.FStar_Parser_AST.drange
-                  else ())
+                 if
+                   FStar_Compiler_List.contains FStar_Parser_AST.Assumption
+                     hd.FStar_Parser_AST.quals
+                 then
+                   FStar_Errors.raise_error
+                     (FStar_Errors_Codes.Fatal_AssumeValInInterface,
+                       "Interfaces cannot use `assume val x : t`; just write `val x : t` instead")
+                     hd.FStar_Parser_AST.drange
+                 else ()
            | uu___ -> ()) in
     aux iface;
-    FStar_Compiler_Effect.op_Bar_Greater iface
-      (FStar_Compiler_List.filter
-         (fun d ->
-            match d.FStar_Parser_AST.d with
-            | FStar_Parser_AST.TopLevelModule uu___1 -> false
-            | uu___1 -> true))
+    FStar_Compiler_List.filter
+      (fun d ->
+         match d.FStar_Parser_AST.d with
+         | FStar_Parser_AST.TopLevelModule uu___1 -> false
+         | uu___1 -> true) iface
 let (ml_mode_prefix_with_iface_decls :
   FStar_Parser_AST.decl Prims.list ->
     FStar_Parser_AST.decl ->
@@ -358,11 +343,10 @@ let (ml_mode_prefix_with_iface_decls :
                let maybe_get_iface_vals lids iface2 =
                  FStar_Compiler_List.partition
                    (fun d ->
-                      FStar_Compiler_Effect.op_Bar_Greater lids
-                        (FStar_Compiler_Util.for_some
-                           (fun x ->
-                              let uu___2 = FStar_Ident.ident_of_lid x in
-                              is_val uu___2 d))) iface2 in
+                      FStar_Compiler_Util.for_some
+                        (fun x ->
+                           let uu___2 = FStar_Ident.ident_of_lid x in
+                           is_val uu___2 d) lids) iface2 in
                (match impl.FStar_Parser_AST.d with
                 | FStar_Parser_AST.TopLevelLet uu___2 ->
                     let xs = definition_lids impl in
@@ -390,27 +374,25 @@ let ml_mode_check_initial_interface :
   =
   fun mname ->
     fun iface ->
-      FStar_Compiler_Effect.op_Bar_Greater iface
-        (FStar_Compiler_List.filter
-           (fun d ->
-              match d.FStar_Parser_AST.d with
-              | FStar_Parser_AST.Tycon (uu___, uu___1, tys) when
-                  FStar_Compiler_Effect.op_Bar_Greater tys
-                    (FStar_Compiler_Util.for_some
-                       (fun uu___2 ->
-                          match uu___2 with
-                          | FStar_Parser_AST.TyconAbstract uu___3 -> true
-                          | uu___3 -> false))
-                  ->
-                  FStar_Errors.raise_error
-                    (FStar_Errors_Codes.Fatal_AbstractTypeDeclarationInInterface,
-                      "Interface contains an abstract 'type' declaration; use 'val' instead")
-                    d.FStar_Parser_AST.drange
-              | FStar_Parser_AST.Tycon uu___ -> true
-              | FStar_Parser_AST.Val uu___ -> true
-              | FStar_Parser_AST.Open uu___ -> true
-              | FStar_Parser_AST.ModuleAbbrev uu___ -> true
-              | uu___ -> false))
+      FStar_Compiler_List.filter
+        (fun d ->
+           match d.FStar_Parser_AST.d with
+           | FStar_Parser_AST.Tycon (uu___, uu___1, tys) when
+               FStar_Compiler_Util.for_some
+                 (fun uu___2 ->
+                    match uu___2 with
+                    | FStar_Parser_AST.TyconAbstract uu___3 -> true
+                    | uu___3 -> false) tys
+               ->
+               FStar_Errors.raise_error
+                 (FStar_Errors_Codes.Fatal_AbstractTypeDeclarationInInterface,
+                   "Interface contains an abstract 'type' declaration; use 'val' instead")
+                 d.FStar_Parser_AST.drange
+           | FStar_Parser_AST.Tycon uu___ -> true
+           | FStar_Parser_AST.Val uu___ -> true
+           | FStar_Parser_AST.Open uu___ -> true
+           | FStar_Parser_AST.ModuleAbbrev uu___ -> true
+           | uu___ -> false) iface
 let (ulib_modules : Prims.string Prims.list) =
   ["FStar.Calc";
   "FStar.TSet";
@@ -514,8 +496,7 @@ let (prefix_with_interface_decls :
                   let uu___4 =
                     FStar_Compiler_List.map FStar_Parser_AST.decl_to_string
                       decls in
-                  FStar_Compiler_Effect.op_Bar_Greater uu___4
-                    (FStar_Compiler_String.concat "\n") in
+                  FStar_Compiler_String.concat "\n" uu___4 in
                 FStar_Compiler_Util.print1 "Interleaved decls:\n%s\n" uu___3
               else ());
              (decls, env1))

--- a/ocaml/fstar-lib/generated/FStar_ToSyntax_ToSyntax.ml
+++ b/ocaml/fstar-lib/generated/FStar_ToSyntax_ToSyntax.ml
@@ -2614,6 +2614,18 @@ and (desugar_term_maybe_top :
                 Prims.strcat "Unexpected universe variable " uu___3 in
               (FStar_Errors_Codes.Fatal_UnexpectedUniverseVariable, uu___2) in
             FStar_Errors.raise_error uu___1 top.FStar_Parser_AST.range
+        | FStar_Parser_AST.Op (s, f::e::[]) when
+            let uu___1 = FStar_Ident.string_of_id s in uu___1 = "<|" ->
+            let uu___1 =
+              FStar_Parser_AST.mkApp f [(e, FStar_Parser_AST.Nothing)]
+                top.FStar_Parser_AST.range in
+            desugar_term_maybe_top top_level env uu___1
+        | FStar_Parser_AST.Op (s, e::f::[]) when
+            let uu___1 = FStar_Ident.string_of_id s in uu___1 = "|>" ->
+            let uu___1 =
+              FStar_Parser_AST.mkApp f [(e, FStar_Parser_AST.Nothing)]
+                top.FStar_Parser_AST.range in
+            desugar_term_maybe_top top_level env uu___1
         | FStar_Parser_AST.Op (s, args) ->
             let uu___1 = op_as_term env (FStar_Compiler_List.length args) s in
             (match uu___1 with

--- a/ocaml/fstar-lib/generated/FStar_ToSyntax_ToSyntax.ml
+++ b/ocaml/fstar-lib/generated/FStar_ToSyntax_ToSyntax.ml
@@ -103,39 +103,38 @@ let desugar_disjunctive_pattern :
   fun annotated_pats ->
     fun when_opt ->
       fun branch ->
-        FStar_Compiler_Effect.op_Bar_Greater annotated_pats
-          (FStar_Compiler_List.map
-             (fun uu___ ->
-                match uu___ with
-                | (pat, annots) ->
-                    let branch1 =
-                      FStar_Compiler_List.fold_left
-                        (fun br ->
-                           fun uu___1 ->
-                             match uu___1 with
-                             | (bv, ty, uu___2) ->
-                                 let lb =
-                                   let uu___3 =
-                                     FStar_Syntax_Syntax.bv_to_name bv in
-                                   FStar_Syntax_Util.mk_letbinding
-                                     (FStar_Pervasives.Inl bv) [] ty
-                                     FStar_Parser_Const.effect_Tot_lid uu___3
-                                     [] br.FStar_Syntax_Syntax.pos in
-                                 let branch2 =
-                                   let uu___3 =
-                                     let uu___4 =
-                                       FStar_Syntax_Syntax.mk_binder bv in
-                                     [uu___4] in
-                                   FStar_Syntax_Subst.close uu___3 branch in
-                                 FStar_Syntax_Syntax.mk
-                                   (FStar_Syntax_Syntax.Tm_let
-                                      {
-                                        FStar_Syntax_Syntax.lbs =
-                                          (false, [lb]);
-                                        FStar_Syntax_Syntax.body1 = branch2
-                                      }) br.FStar_Syntax_Syntax.pos) branch
-                        annots in
-                    FStar_Syntax_Util.branch (pat, when_opt, branch1)))
+        FStar_Compiler_List.map
+          (fun uu___ ->
+             match uu___ with
+             | (pat, annots) ->
+                 let branch1 =
+                   FStar_Compiler_List.fold_left
+                     (fun br ->
+                        fun uu___1 ->
+                          match uu___1 with
+                          | (bv, ty, uu___2) ->
+                              let lb =
+                                let uu___3 =
+                                  FStar_Syntax_Syntax.bv_to_name bv in
+                                FStar_Syntax_Util.mk_letbinding
+                                  (FStar_Pervasives.Inl bv) [] ty
+                                  FStar_Parser_Const.effect_Tot_lid uu___3 []
+                                  br.FStar_Syntax_Syntax.pos in
+                              let branch2 =
+                                let uu___3 =
+                                  let uu___4 =
+                                    FStar_Syntax_Syntax.mk_binder bv in
+                                  [uu___4] in
+                                FStar_Syntax_Subst.close uu___3 branch in
+                              FStar_Syntax_Syntax.mk
+                                (FStar_Syntax_Syntax.Tm_let
+                                   {
+                                     FStar_Syntax_Syntax.lbs = (false, [lb]);
+                                     FStar_Syntax_Syntax.body1 = branch2
+                                   }) br.FStar_Syntax_Syntax.pos) branch
+                     annots in
+                 FStar_Syntax_Util.branch (pat, when_opt, branch1))
+          annotated_pats
 let (trans_qual :
   FStar_Compiler_Range_Type.range ->
     FStar_Ident.lident FStar_Pervasives_Native.option ->
@@ -215,12 +214,11 @@ let arg_withimp_t :
   = fun imp -> fun t -> let uu___ = as_imp imp in (t, uu___)
 let (contains_binder : FStar_Parser_AST.binder Prims.list -> Prims.bool) =
   fun binders ->
-    FStar_Compiler_Effect.op_Bar_Greater binders
-      (FStar_Compiler_Util.for_some
-         (fun b ->
-            match b.FStar_Parser_AST.b with
-            | FStar_Parser_AST.Annotated uu___ -> true
-            | uu___ -> false))
+    FStar_Compiler_Util.for_some
+      (fun b ->
+         match b.FStar_Parser_AST.b with
+         | FStar_Parser_AST.Annotated uu___ -> true
+         | uu___ -> false) binders
 let rec (unparen : FStar_Parser_AST.term -> FStar_Parser_AST.term) =
   fun t ->
     match t.FStar_Parser_AST.tm with
@@ -254,12 +252,10 @@ let rec (is_comp_type :
           -> true
       | FStar_Parser_AST.Name l ->
           let uu___1 = FStar_Syntax_DsEnv.try_lookup_effect_name env l in
-          FStar_Compiler_Effect.op_Bar_Greater uu___1
-            FStar_Compiler_Option.isSome
+          FStar_Compiler_Option.isSome uu___1
       | FStar_Parser_AST.Construct (l, uu___1) ->
           let uu___2 = FStar_Syntax_DsEnv.try_lookup_effect_name env l in
-          FStar_Compiler_Effect.op_Bar_Greater uu___2
-            FStar_Compiler_Option.isSome
+          FStar_Compiler_Option.isSome uu___2
       | FStar_Parser_AST.App (head, uu___1, uu___2) -> is_comp_type env head
       | FStar_Parser_AST.Paren t1 ->
           FStar_Compiler_Effect.failwith "impossible"
@@ -321,7 +317,7 @@ let (compile_op_lid :
               let uu___3 = FStar_Parser_AST.compile_op n s r in (uu___3, r) in
             FStar_Ident.mk_ident uu___2 in
           [uu___1] in
-        FStar_Compiler_Effect.op_Bar_Greater uu___ FStar_Ident.lid_of_ids
+        FStar_Ident.lid_of_ids uu___
 let (op_as_term :
   env_t ->
     Prims.int ->
@@ -339,8 +335,7 @@ let (op_as_term :
                 FStar_Ident.set_lid_range l uu___3 in
               FStar_Syntax_Syntax.lid_and_dd_as_fv uu___2 dd
                 FStar_Pervasives_Native.None in
-            FStar_Compiler_Effect.op_Bar_Greater uu___1
-              FStar_Syntax_Syntax.fv_to_tm in
+            FStar_Syntax_Syntax.fv_to_tm uu___1 in
           FStar_Pervasives_Native.Some uu___ in
         let fallback uu___ =
           let uu___1 = FStar_Ident.string_of_id op in
@@ -440,13 +435,12 @@ let (sort_ftv : FStar_Ident.ident Prims.list -> FStar_Ident.ident Prims.list)
            fun y ->
              let uu___1 = FStar_Ident.string_of_id x in
              let uu___2 = FStar_Ident.string_of_id y in uu___1 = uu___2) ftv in
-    FStar_Compiler_Effect.op_Less_Bar
-      (FStar_Compiler_Util.sort_with
-         (fun x ->
-            fun y ->
-              let uu___1 = FStar_Ident.string_of_id x in
-              let uu___2 = FStar_Ident.string_of_id y in
-              FStar_Compiler_String.compare uu___1 uu___2)) uu___
+    FStar_Compiler_Util.sort_with
+      (fun x ->
+         fun y ->
+           let uu___1 = FStar_Ident.string_of_id x in
+           let uu___2 = FStar_Ident.string_of_id y in
+           FStar_Compiler_String.compare uu___1 uu___2) uu___
 let rec (free_vars_b :
   Prims.bool ->
     FStar_Syntax_DsEnv.env ->
@@ -741,27 +735,25 @@ let (close :
   FStar_Syntax_DsEnv.env -> FStar_Parser_AST.term -> FStar_Parser_AST.term) =
   fun env ->
     fun t ->
-      let ftv =
-        let uu___ = free_type_vars env t in
-        FStar_Compiler_Effect.op_Less_Bar sort_ftv uu___ in
+      let ftv = let uu___ = free_type_vars env t in sort_ftv uu___ in
       if (FStar_Compiler_List.length ftv) = Prims.int_zero
       then t
       else
         (let binders =
-           FStar_Compiler_Effect.op_Bar_Greater ftv
-             (FStar_Compiler_List.map
-                (fun x ->
-                   let uu___1 =
-                     let uu___2 =
-                       let uu___3 =
-                         let uu___4 = FStar_Ident.range_of_id x in
-                         tm_type uu___4 in
-                       (x, uu___3) in
-                     FStar_Parser_AST.TAnnotated uu___2 in
-                   let uu___2 = FStar_Ident.range_of_id x in
-                   FStar_Parser_AST.mk_binder uu___1 uu___2
-                     FStar_Parser_AST.Type_level
-                     (FStar_Pervasives_Native.Some FStar_Parser_AST.Implicit))) in
+           FStar_Compiler_List.map
+             (fun x ->
+                let uu___1 =
+                  let uu___2 =
+                    let uu___3 =
+                      let uu___4 = FStar_Ident.range_of_id x in
+                      tm_type uu___4 in
+                    (x, uu___3) in
+                  FStar_Parser_AST.TAnnotated uu___2 in
+                let uu___2 = FStar_Ident.range_of_id x in
+                FStar_Parser_AST.mk_binder uu___1 uu___2
+                  FStar_Parser_AST.Type_level
+                  (FStar_Pervasives_Native.Some FStar_Parser_AST.Implicit))
+             ftv in
          let result =
            FStar_Parser_AST.mk_term (FStar_Parser_AST.Product (binders, t))
              t.FStar_Parser_AST.range t.FStar_Parser_AST.level in
@@ -770,27 +762,25 @@ let (close_fun :
   FStar_Syntax_DsEnv.env -> FStar_Parser_AST.term -> FStar_Parser_AST.term) =
   fun env ->
     fun t ->
-      let ftv =
-        let uu___ = free_type_vars env t in
-        FStar_Compiler_Effect.op_Less_Bar sort_ftv uu___ in
+      let ftv = let uu___ = free_type_vars env t in sort_ftv uu___ in
       if (FStar_Compiler_List.length ftv) = Prims.int_zero
       then t
       else
         (let binders =
-           FStar_Compiler_Effect.op_Bar_Greater ftv
-             (FStar_Compiler_List.map
-                (fun x ->
-                   let uu___1 =
-                     let uu___2 =
-                       let uu___3 =
-                         let uu___4 = FStar_Ident.range_of_id x in
-                         tm_type uu___4 in
-                       (x, uu___3) in
-                     FStar_Parser_AST.TAnnotated uu___2 in
-                   let uu___2 = FStar_Ident.range_of_id x in
-                   FStar_Parser_AST.mk_binder uu___1 uu___2
-                     FStar_Parser_AST.Type_level
-                     (FStar_Pervasives_Native.Some FStar_Parser_AST.Implicit))) in
+           FStar_Compiler_List.map
+             (fun x ->
+                let uu___1 =
+                  let uu___2 =
+                    let uu___3 =
+                      let uu___4 = FStar_Ident.range_of_id x in
+                      tm_type uu___4 in
+                    (x, uu___3) in
+                  FStar_Parser_AST.TAnnotated uu___2 in
+                let uu___2 = FStar_Ident.range_of_id x in
+                FStar_Parser_AST.mk_binder uu___1 uu___2
+                  FStar_Parser_AST.Type_level
+                  (FStar_Pervasives_Native.Some FStar_Parser_AST.Implicit))
+             ftv in
          let t1 =
            let uu___1 = let uu___2 = unparen t in uu___2.FStar_Parser_AST.tm in
            match uu___1 with
@@ -1123,93 +1113,92 @@ let rec (generalize_annotated_univs :
         let uu___1 =
           let uu___2 =
             let uu___3 =
-              FStar_Compiler_Effect.op_Bar_Greater sigs
-                (FStar_Compiler_List.map
-                   (fun se ->
-                      match se.FStar_Syntax_Syntax.sigel with
-                      | FStar_Syntax_Syntax.Sig_inductive_typ
-                          { FStar_Syntax_Syntax.lid = lid;
-                            FStar_Syntax_Syntax.us = uu___4;
-                            FStar_Syntax_Syntax.params = bs;
-                            FStar_Syntax_Syntax.num_uniform_params =
-                              num_uniform;
-                            FStar_Syntax_Syntax.t = t;
-                            FStar_Syntax_Syntax.mutuals = lids1;
-                            FStar_Syntax_Syntax.ds = lids2;_}
-                          ->
-                          let uu___5 =
-                            let uu___6 =
-                              let uu___7 =
-                                FStar_Syntax_Subst.subst_binders usubst bs in
-                              let uu___8 =
-                                let uu___9 =
-                                  FStar_Syntax_Subst.shift_subst
-                                    (FStar_Compiler_List.length bs) usubst in
-                                FStar_Syntax_Subst.subst uu___9 t in
-                              {
-                                FStar_Syntax_Syntax.lid = lid;
-                                FStar_Syntax_Syntax.us = unames;
-                                FStar_Syntax_Syntax.params = uu___7;
-                                FStar_Syntax_Syntax.num_uniform_params =
-                                  num_uniform;
-                                FStar_Syntax_Syntax.t = uu___8;
-                                FStar_Syntax_Syntax.mutuals = lids1;
-                                FStar_Syntax_Syntax.ds = lids2
-                              } in
-                            FStar_Syntax_Syntax.Sig_inductive_typ uu___6 in
-                          {
-                            FStar_Syntax_Syntax.sigel = uu___5;
-                            FStar_Syntax_Syntax.sigrng =
-                              (se.FStar_Syntax_Syntax.sigrng);
-                            FStar_Syntax_Syntax.sigquals =
-                              (se.FStar_Syntax_Syntax.sigquals);
-                            FStar_Syntax_Syntax.sigmeta =
-                              (se.FStar_Syntax_Syntax.sigmeta);
-                            FStar_Syntax_Syntax.sigattrs =
-                              (se.FStar_Syntax_Syntax.sigattrs);
-                            FStar_Syntax_Syntax.sigopens_and_abbrevs =
-                              (se.FStar_Syntax_Syntax.sigopens_and_abbrevs);
-                            FStar_Syntax_Syntax.sigopts =
-                              (se.FStar_Syntax_Syntax.sigopts)
-                          }
-                      | FStar_Syntax_Syntax.Sig_datacon
-                          { FStar_Syntax_Syntax.lid1 = lid;
-                            FStar_Syntax_Syntax.us1 = uu___4;
-                            FStar_Syntax_Syntax.t1 = t;
-                            FStar_Syntax_Syntax.ty_lid = tlid;
-                            FStar_Syntax_Syntax.num_ty_params = n;
-                            FStar_Syntax_Syntax.mutuals1 = lids1;_}
-                          ->
-                          let uu___5 =
-                            let uu___6 =
-                              let uu___7 = FStar_Syntax_Subst.subst usubst t in
-                              {
-                                FStar_Syntax_Syntax.lid1 = lid;
-                                FStar_Syntax_Syntax.us1 = unames;
-                                FStar_Syntax_Syntax.t1 = uu___7;
-                                FStar_Syntax_Syntax.ty_lid = tlid;
-                                FStar_Syntax_Syntax.num_ty_params = n;
-                                FStar_Syntax_Syntax.mutuals1 = lids1
-                              } in
-                            FStar_Syntax_Syntax.Sig_datacon uu___6 in
-                          {
-                            FStar_Syntax_Syntax.sigel = uu___5;
-                            FStar_Syntax_Syntax.sigrng =
-                              (se.FStar_Syntax_Syntax.sigrng);
-                            FStar_Syntax_Syntax.sigquals =
-                              (se.FStar_Syntax_Syntax.sigquals);
-                            FStar_Syntax_Syntax.sigmeta =
-                              (se.FStar_Syntax_Syntax.sigmeta);
-                            FStar_Syntax_Syntax.sigattrs =
-                              (se.FStar_Syntax_Syntax.sigattrs);
-                            FStar_Syntax_Syntax.sigopens_and_abbrevs =
-                              (se.FStar_Syntax_Syntax.sigopens_and_abbrevs);
-                            FStar_Syntax_Syntax.sigopts =
-                              (se.FStar_Syntax_Syntax.sigopts)
-                          }
-                      | uu___4 ->
-                          FStar_Compiler_Effect.failwith
-                            "Impossible: collect_annotated_universes: Sig_bundle should not have a non data/type sigelt")) in
+              FStar_Compiler_List.map
+                (fun se ->
+                   match se.FStar_Syntax_Syntax.sigel with
+                   | FStar_Syntax_Syntax.Sig_inductive_typ
+                       { FStar_Syntax_Syntax.lid = lid;
+                         FStar_Syntax_Syntax.us = uu___4;
+                         FStar_Syntax_Syntax.params = bs;
+                         FStar_Syntax_Syntax.num_uniform_params = num_uniform;
+                         FStar_Syntax_Syntax.t = t;
+                         FStar_Syntax_Syntax.mutuals = lids1;
+                         FStar_Syntax_Syntax.ds = lids2;_}
+                       ->
+                       let uu___5 =
+                         let uu___6 =
+                           let uu___7 =
+                             FStar_Syntax_Subst.subst_binders usubst bs in
+                           let uu___8 =
+                             let uu___9 =
+                               FStar_Syntax_Subst.shift_subst
+                                 (FStar_Compiler_List.length bs) usubst in
+                             FStar_Syntax_Subst.subst uu___9 t in
+                           {
+                             FStar_Syntax_Syntax.lid = lid;
+                             FStar_Syntax_Syntax.us = unames;
+                             FStar_Syntax_Syntax.params = uu___7;
+                             FStar_Syntax_Syntax.num_uniform_params =
+                               num_uniform;
+                             FStar_Syntax_Syntax.t = uu___8;
+                             FStar_Syntax_Syntax.mutuals = lids1;
+                             FStar_Syntax_Syntax.ds = lids2
+                           } in
+                         FStar_Syntax_Syntax.Sig_inductive_typ uu___6 in
+                       {
+                         FStar_Syntax_Syntax.sigel = uu___5;
+                         FStar_Syntax_Syntax.sigrng =
+                           (se.FStar_Syntax_Syntax.sigrng);
+                         FStar_Syntax_Syntax.sigquals =
+                           (se.FStar_Syntax_Syntax.sigquals);
+                         FStar_Syntax_Syntax.sigmeta =
+                           (se.FStar_Syntax_Syntax.sigmeta);
+                         FStar_Syntax_Syntax.sigattrs =
+                           (se.FStar_Syntax_Syntax.sigattrs);
+                         FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                           (se.FStar_Syntax_Syntax.sigopens_and_abbrevs);
+                         FStar_Syntax_Syntax.sigopts =
+                           (se.FStar_Syntax_Syntax.sigopts)
+                       }
+                   | FStar_Syntax_Syntax.Sig_datacon
+                       { FStar_Syntax_Syntax.lid1 = lid;
+                         FStar_Syntax_Syntax.us1 = uu___4;
+                         FStar_Syntax_Syntax.t1 = t;
+                         FStar_Syntax_Syntax.ty_lid = tlid;
+                         FStar_Syntax_Syntax.num_ty_params = n;
+                         FStar_Syntax_Syntax.mutuals1 = lids1;_}
+                       ->
+                       let uu___5 =
+                         let uu___6 =
+                           let uu___7 = FStar_Syntax_Subst.subst usubst t in
+                           {
+                             FStar_Syntax_Syntax.lid1 = lid;
+                             FStar_Syntax_Syntax.us1 = unames;
+                             FStar_Syntax_Syntax.t1 = uu___7;
+                             FStar_Syntax_Syntax.ty_lid = tlid;
+                             FStar_Syntax_Syntax.num_ty_params = n;
+                             FStar_Syntax_Syntax.mutuals1 = lids1
+                           } in
+                         FStar_Syntax_Syntax.Sig_datacon uu___6 in
+                       {
+                         FStar_Syntax_Syntax.sigel = uu___5;
+                         FStar_Syntax_Syntax.sigrng =
+                           (se.FStar_Syntax_Syntax.sigrng);
+                         FStar_Syntax_Syntax.sigquals =
+                           (se.FStar_Syntax_Syntax.sigquals);
+                         FStar_Syntax_Syntax.sigmeta =
+                           (se.FStar_Syntax_Syntax.sigmeta);
+                         FStar_Syntax_Syntax.sigattrs =
+                           (se.FStar_Syntax_Syntax.sigattrs);
+                         FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                           (se.FStar_Syntax_Syntax.sigopens_and_abbrevs);
+                         FStar_Syntax_Syntax.sigopts =
+                           (se.FStar_Syntax_Syntax.sigopts)
+                       }
+                   | uu___4 ->
+                       FStar_Compiler_Effect.failwith
+                         "Impossible: collect_annotated_universes: Sig_bundle should not have a non data/type sigelt")
+                sigs in
             {
               FStar_Syntax_Syntax.ses = uu___3;
               FStar_Syntax_Syntax.lids = lids
@@ -1257,28 +1246,27 @@ let rec (generalize_annotated_univs :
           let uu___2 =
             let uu___3 =
               let uu___4 =
-                FStar_Compiler_Effect.op_Bar_Greater lbs
-                  (FStar_Compiler_List.map
-                     (fun lb ->
-                        let uu___5 =
-                          FStar_Syntax_Subst.subst usubst
-                            lb.FStar_Syntax_Syntax.lbtyp in
-                        let uu___6 =
-                          FStar_Syntax_Subst.subst usubst
-                            lb.FStar_Syntax_Syntax.lbdef in
-                        {
-                          FStar_Syntax_Syntax.lbname =
-                            (lb.FStar_Syntax_Syntax.lbname);
-                          FStar_Syntax_Syntax.lbunivs = unames;
-                          FStar_Syntax_Syntax.lbtyp = uu___5;
-                          FStar_Syntax_Syntax.lbeff =
-                            (lb.FStar_Syntax_Syntax.lbeff);
-                          FStar_Syntax_Syntax.lbdef = uu___6;
-                          FStar_Syntax_Syntax.lbattrs =
-                            (lb.FStar_Syntax_Syntax.lbattrs);
-                          FStar_Syntax_Syntax.lbpos =
-                            (lb.FStar_Syntax_Syntax.lbpos)
-                        })) in
+                FStar_Compiler_List.map
+                  (fun lb ->
+                     let uu___5 =
+                       FStar_Syntax_Subst.subst usubst
+                         lb.FStar_Syntax_Syntax.lbtyp in
+                     let uu___6 =
+                       FStar_Syntax_Subst.subst usubst
+                         lb.FStar_Syntax_Syntax.lbdef in
+                     {
+                       FStar_Syntax_Syntax.lbname =
+                         (lb.FStar_Syntax_Syntax.lbname);
+                       FStar_Syntax_Syntax.lbunivs = unames;
+                       FStar_Syntax_Syntax.lbtyp = uu___5;
+                       FStar_Syntax_Syntax.lbeff =
+                         (lb.FStar_Syntax_Syntax.lbeff);
+                       FStar_Syntax_Syntax.lbdef = uu___6;
+                       FStar_Syntax_Syntax.lbattrs =
+                         (lb.FStar_Syntax_Syntax.lbattrs);
+                       FStar_Syntax_Syntax.lbpos =
+                         (lb.FStar_Syntax_Syntax.lbpos)
+                     }) lbs in
               (b, uu___4) in
             {
               FStar_Syntax_Syntax.lbs1 = uu___3;
@@ -1377,8 +1365,7 @@ let rec (generalize_annotated_univs :
           | FStar_Syntax_Syntax.Layered_eff_sig (n, (uu___1, t)) ->
               let uvs =
                 let uu___2 = FStar_Syntax_Free.univnames t in
-                FStar_Compiler_Effect.op_Bar_Greater uu___2
-                  (FStar_Compiler_Set.elems FStar_Syntax_Syntax.ord_ident) in
+                FStar_Compiler_Set.elems FStar_Syntax_Syntax.ord_ident uu___2 in
               let usubst = FStar_Syntax_Subst.univ_var_closing uvs in
               let uu___2 =
                 let uu___3 =
@@ -1389,8 +1376,7 @@ let rec (generalize_annotated_univs :
           | FStar_Syntax_Syntax.WP_eff_sig (uu___1, t) ->
               let uvs =
                 let uu___2 = FStar_Syntax_Free.univnames t in
-                FStar_Compiler_Effect.op_Bar_Greater uu___2
-                  (FStar_Compiler_Set.elems FStar_Syntax_Syntax.ord_ident) in
+                FStar_Compiler_Set.elems FStar_Syntax_Syntax.ord_ident uu___2 in
               let usubst = FStar_Syntax_Subst.univ_var_closing uvs in
               let uu___2 =
                 let uu___3 = FStar_Syntax_Subst.subst usubst t in
@@ -1664,9 +1650,7 @@ let (check_linear_pattern_variables :
               pats1 in
       match pats with
       | [] -> ()
-      | p::[] ->
-          let uu___ = pat_vars p in
-          FStar_Compiler_Effect.op_Bar_Greater uu___ (fun uu___1 -> ())
+      | p::[] -> let uu___ = pat_vars p in ()
       | p::ps ->
           let pvars = pat_vars p in
           let aux p1 =
@@ -1877,17 +1861,13 @@ let rec (desugar_data_pat :
                             (FStar_Compiler_List.op_At annots' annots))))))
           | FStar_Parser_AST.PatWild (aq, attrs) ->
               let aq1 = trans_bqual env1 aq in
-              let attrs1 =
-                FStar_Compiler_Effect.op_Bar_Greater attrs
-                  (FStar_Compiler_List.map (desugar_term env1)) in
+              let attrs1 = FStar_Compiler_List.map (desugar_term env1) attrs in
               let x =
                 let uu___ = tun_r p1.FStar_Parser_AST.prange in
                 FStar_Syntax_Syntax.new_bv
                   (FStar_Pervasives_Native.Some (p1.FStar_Parser_AST.prange))
                   uu___ in
-              let uu___ =
-                FStar_Compiler_Effect.op_Less_Bar pos
-                  (FStar_Syntax_Syntax.Pat_var x) in
+              let uu___ = pos (FStar_Syntax_Syntax.Pat_var x) in
               (loc, aqs, env1, (LocalBinder (x, aq1, attrs1)), uu___, [])
           | FStar_Parser_AST.PatConst c ->
               let x =
@@ -1895,9 +1875,7 @@ let rec (desugar_data_pat :
                 FStar_Syntax_Syntax.new_bv
                   (FStar_Pervasives_Native.Some (p1.FStar_Parser_AST.prange))
                   uu___ in
-              let uu___ =
-                FStar_Compiler_Effect.op_Less_Bar pos
-                  (FStar_Syntax_Syntax.Pat_constant c) in
+              let uu___ = pos (FStar_Syntax_Syntax.Pat_constant c) in
               (loc, aqs, env1,
                 (LocalBinder (x, FStar_Pervasives_Native.None, [])), uu___,
                 [])
@@ -1917,28 +1895,20 @@ let rec (desugar_data_pat :
                 }
           | FStar_Parser_AST.PatTvar (x, aq, attrs) ->
               let aq1 = trans_bqual env1 aq in
-              let attrs1 =
-                FStar_Compiler_Effect.op_Bar_Greater attrs
-                  (FStar_Compiler_List.map (desugar_term env1)) in
+              let attrs1 = FStar_Compiler_List.map (desugar_term env1) attrs in
               let uu___ = resolvex loc env1 x in
               (match uu___ with
                | (loc1, env2, xbv) ->
-                   let uu___1 =
-                     FStar_Compiler_Effect.op_Less_Bar pos
-                       (FStar_Syntax_Syntax.Pat_var xbv) in
+                   let uu___1 = pos (FStar_Syntax_Syntax.Pat_var xbv) in
                    (loc1, aqs, env2, (LocalBinder (xbv, aq1, attrs1)),
                      uu___1, []))
           | FStar_Parser_AST.PatVar (x, aq, attrs) ->
               let aq1 = trans_bqual env1 aq in
-              let attrs1 =
-                FStar_Compiler_Effect.op_Bar_Greater attrs
-                  (FStar_Compiler_List.map (desugar_term env1)) in
+              let attrs1 = FStar_Compiler_List.map (desugar_term env1) attrs in
               let uu___ = resolvex loc env1 x in
               (match uu___ with
                | (loc1, env2, xbv) ->
-                   let uu___1 =
-                     FStar_Compiler_Effect.op_Less_Bar pos
-                       (FStar_Syntax_Syntax.Pat_var xbv) in
+                   let uu___1 = pos (FStar_Syntax_Syntax.Pat_var xbv) in
                    (loc1, aqs, env2, (LocalBinder (xbv, aq1, attrs1)),
                      uu___1, []))
           | FStar_Parser_AST.PatName l ->
@@ -1951,7 +1921,7 @@ let rec (desugar_data_pat :
                   (FStar_Pervasives_Native.Some (p1.FStar_Parser_AST.prange))
                   uu___ in
               let uu___ =
-                FStar_Compiler_Effect.op_Less_Bar pos
+                pos
                   (FStar_Syntax_Syntax.Pat_cons
                      (l1, FStar_Pervasives_Native.None, [])) in
               (loc, aqs, env1,
@@ -1987,7 +1957,7 @@ let rec (desugar_data_pat :
                        (FStar_Pervasives_Native.Some
                           (p1.FStar_Parser_AST.prange)) uu___2 in
                    let uu___2 =
-                     FStar_Compiler_Effect.op_Less_Bar pos
+                     pos
                        (FStar_Syntax_Syntax.Pat_cons
                           (l1, FStar_Pervasives_Native.None, args1)) in
                    (loc1, aqs1, env2,
@@ -2016,10 +1986,8 @@ let rec (desugar_data_pat :
                    let pat =
                      let uu___1 =
                        let uu___2 =
-                         let uu___3 =
-                           FStar_Compiler_Range_Ops.end_range
-                             p1.FStar_Parser_AST.prange in
-                         pos_r uu___3 in
+                         FStar_Compiler_Range_Ops.end_range
+                           p1.FStar_Parser_AST.prange in
                        let uu___3 =
                          let uu___4 =
                            let uu___5 =
@@ -2030,7 +1998,7 @@ let rec (desugar_data_pat :
                                   FStar_Syntax_Syntax.Data_ctor) in
                            (uu___5, FStar_Pervasives_Native.None, []) in
                          FStar_Syntax_Syntax.Pat_cons uu___4 in
-                       FStar_Compiler_Effect.op_Less_Bar uu___2 uu___3 in
+                       pos_r uu___2 uu___3 in
                      FStar_Compiler_List.fold_right
                        (fun hd ->
                           fun tl ->
@@ -2049,8 +2017,7 @@ let rec (desugar_data_pat :
                                 (uu___4, FStar_Pervasives_Native.None,
                                   [(hd, false); (tl, false)]) in
                               FStar_Syntax_Syntax.Pat_cons uu___3 in
-                            FStar_Compiler_Effect.op_Less_Bar (pos_r r)
-                              uu___2) pats1 uu___1 in
+                            pos_r r uu___2) pats1 uu___1 in
                    let x =
                      let uu___1 = tun_r p1.FStar_Parser_AST.prange in
                      FStar_Syntax_Syntax.new_bv
@@ -2099,7 +2066,7 @@ let rec (desugar_data_pat :
                        (FStar_Pervasives_Native.Some
                           (p1.FStar_Parser_AST.prange)) uu___1 in
                    let uu___1 =
-                     FStar_Compiler_Effect.op_Less_Bar pos
+                     pos
                        (FStar_Syntax_Syntax.Pat_cons
                           (l1, FStar_Pervasives_Native.None, args2)) in
                    (loc1, aqs1, env2,
@@ -2166,7 +2133,7 @@ let rec (desugar_data_pat :
                               | (loc1, aqs1, env2, annots, pats1) ->
                                   let pats2 = FStar_Compiler_List.rev pats1 in
                                   let pat =
-                                    FStar_Compiler_Effect.op_Less_Bar pos
+                                    pos
                                       (FStar_Syntax_Syntax.Pat_cons
                                          (candidate_constructor,
                                            FStar_Pervasives_Native.None,
@@ -2568,8 +2535,7 @@ and (desugar_term_maybe_top :
             (let uu___1 = FStar_Ident.string_of_id op_star in uu___1 = "*")
               &&
               (let uu___1 = op_as_term env (Prims.of_int (2)) op_star in
-               FStar_Compiler_Effect.op_Bar_Greater uu___1
-                 FStar_Compiler_Option.isNone)
+               FStar_Compiler_Option.isNone uu___1)
             ->
             let rec flatten t =
               match t.FStar_Parser_AST.tm with
@@ -2577,8 +2543,7 @@ and (desugar_term_maybe_top :
                   (let uu___1 = FStar_Ident.string_of_id id in uu___1 = "*")
                     &&
                     (let uu___1 = op_as_term env (Prims.of_int (2)) op_star in
-                     FStar_Compiler_Effect.op_Bar_Greater uu___1
-                       FStar_Compiler_Option.isNone)
+                     FStar_Compiler_Option.isNone uu___1)
                   ->
                   let uu___1 = flatten t1 in
                   FStar_Compiler_List.op_At uu___1 [t2]
@@ -2603,7 +2568,7 @@ and (desugar_term_maybe_top :
               let uu___2 =
                 FStar_Syntax_DsEnv.fail_or2
                   (FStar_Syntax_DsEnv.try_lookup_id env) a in
-              FStar_Compiler_Effect.op_Less_Bar setpos uu___2 in
+              setpos uu___2 in
             (uu___1, noaqs)
         | FStar_Parser_AST.Uvar u ->
             let uu___1 =
@@ -2642,15 +2607,14 @@ and (desugar_term_maybe_top :
                  then
                    let uu___2 =
                      let uu___3 =
-                       FStar_Compiler_Effect.op_Bar_Greater args
-                         (FStar_Compiler_List.map
-                            (fun t ->
-                               let uu___4 = desugar_term_aq env t in
-                               match uu___4 with
-                               | (t', s1) ->
-                                   ((t', FStar_Pervasives_Native.None), s1))) in
-                     FStar_Compiler_Effect.op_Bar_Greater uu___3
-                       FStar_Compiler_List.unzip in
+                       FStar_Compiler_List.map
+                         (fun t ->
+                            let uu___4 = desugar_term_aq env t in
+                            match uu___4 with
+                            | (t', s1) ->
+                                ((t', FStar_Pervasives_Native.None), s1))
+                         args in
+                     FStar_Compiler_List.unzip uu___3 in
                    (match uu___2 with
                     | (args1, aqs) ->
                         let uu___3 =
@@ -2882,8 +2846,7 @@ and (desugar_term_maybe_top :
                                              let uu___8 =
                                                arg_withimp_t imp te in
                                              (uu___8, aq))) args1 in
-                             FStar_Compiler_Effect.op_Bar_Greater uu___5
-                               FStar_Compiler_List.unzip in
+                             FStar_Compiler_List.unzip uu___5 in
                            (match uu___4 with
                             | (args2, aqs) ->
                                 let head2 =
@@ -2937,26 +2900,23 @@ and (desugar_term_maybe_top :
             ->
             let terms =
               let uu___1 =
-                FStar_Compiler_Effect.op_Bar_Greater binders
-                  (FStar_Compiler_List.map
-                     (fun uu___2 ->
-                        match uu___2 with
-                        | FStar_Pervasives.Inr x -> x
-                        | FStar_Pervasives.Inl uu___3 ->
-                            FStar_Compiler_Effect.failwith "Impossible")) in
+                FStar_Compiler_List.map
+                  (fun uu___2 ->
+                     match uu___2 with
+                     | FStar_Pervasives.Inr x -> x
+                     | FStar_Pervasives.Inl uu___3 ->
+                         FStar_Compiler_Effect.failwith "Impossible") binders in
               FStar_Compiler_List.op_At uu___1 [t] in
             let uu___1 =
               let uu___2 =
-                FStar_Compiler_Effect.op_Bar_Greater terms
-                  (FStar_Compiler_List.map
-                     (fun t1 ->
-                        let uu___3 = desugar_typ_aq env t1 in
-                        match uu___3 with
-                        | (t', aq) ->
-                            let uu___4 = FStar_Syntax_Syntax.as_arg t' in
-                            (uu___4, aq))) in
-              FStar_Compiler_Effect.op_Bar_Greater uu___2
-                FStar_Compiler_List.unzip in
+                FStar_Compiler_List.map
+                  (fun t1 ->
+                     let uu___3 = desugar_typ_aq env t1 in
+                     match uu___3 with
+                     | (t', aq) ->
+                         let uu___4 = FStar_Syntax_Syntax.as_arg t' in
+                         (uu___4, aq)) terms in
+              FStar_Compiler_List.unzip uu___2 in
             (match uu___1 with
              | (targs, aqs) ->
                  let tup =
@@ -2983,8 +2943,7 @@ and (desugar_term_maybe_top :
                       FStar_Parser_AST.mk_binder (FStar_Parser_AST.NoName t)
                         t.FStar_Parser_AST.range FStar_Parser_AST.Type_level
                         FStar_Pervasives_Native.None in
-                    FStar_Compiler_Effect.op_Less_Bar
-                      (fun uu___6 -> FStar_Pervasives.Inl uu___6) uu___5 in
+                    FStar_Pervasives.Inl uu___5 in
                   [uu___4] in
                 FStar_Compiler_List.op_At binders uu___3 in
               FStar_Compiler_List.fold_left
@@ -3033,8 +2992,7 @@ and (desugar_term_maybe_top :
                                        let uu___9 =
                                          let uu___10 =
                                            no_annot_abs tparams t1 in
-                                         FStar_Compiler_Effect.op_Less_Bar
-                                           FStar_Syntax_Syntax.as_arg uu___10 in
+                                         FStar_Syntax_Syntax.as_arg uu___10 in
                                        [uu___9] in
                                      FStar_Compiler_List.op_At typs uu___8 in
                                    (env2, uu___6, uu___7)))) (env, [], [])
@@ -3049,7 +3007,7 @@ and (desugar_term_maybe_top :
                    FStar_Syntax_DsEnv.fail_or env1
                      (FStar_Syntax_DsEnv.try_lookup_lid env1) uu___3 in
                  let uu___3 =
-                   FStar_Compiler_Effect.op_Less_Bar mk
+                   mk
                      (FStar_Syntax_Syntax.Tm_app
                         {
                           FStar_Syntax_Syntax.hd = tup;
@@ -3069,7 +3027,7 @@ and (desugar_term_maybe_top :
                          let uu___4 =
                            FStar_Syntax_Util.arrow
                              (FStar_Compiler_List.rev bs1) cod in
-                         FStar_Compiler_Effect.op_Less_Bar setpos uu___4 in
+                         setpos uu___4 in
                        (uu___3, aqs)
                    | hd::tl ->
                        let uu___3 = desugar_binder_aq env1 hd in
@@ -3098,7 +3056,7 @@ and (desugar_term_maybe_top :
                         let uu___4 =
                           FStar_Syntax_Util.refine
                             b2.FStar_Syntax_Syntax.binder_bv f1 in
-                        FStar_Compiler_Effect.op_Less_Bar setpos uu___4 in
+                        setpos uu___4 in
                       (uu___3, noaqs)))
         | FStar_Parser_AST.Abs (binders, body) ->
             let bvss =
@@ -3144,8 +3102,7 @@ and (desugar_term_maybe_top :
                   let uu___4 = FStar_Ident.range_of_id id in
                   FStar_Errors.raise_error uu___3 uu___4);
              (let binders1 =
-                FStar_Compiler_Effect.op_Bar_Greater binders
-                  (FStar_Compiler_List.map replace_unit_pattern) in
+                FStar_Compiler_List.map replace_unit_pattern binders in
               let uu___2 =
                 FStar_Compiler_List.fold_left
                   (fun uu___3 ->
@@ -3177,15 +3134,14 @@ and (desugar_term_maybe_top :
                   let ftv1 = sort_ftv ftv in
                   let binders2 =
                     let uu___4 =
-                      FStar_Compiler_Effect.op_Bar_Greater ftv1
-                        (FStar_Compiler_List.map
-                           (fun a ->
-                              FStar_Parser_AST.mk_pattern
-                                (FStar_Parser_AST.PatTvar
-                                   (a,
-                                     (FStar_Pervasives_Native.Some
-                                        FStar_Parser_AST.Implicit), []))
-                                top.FStar_Parser_AST.range)) in
+                      FStar_Compiler_List.map
+                        (fun a ->
+                           FStar_Parser_AST.mk_pattern
+                             (FStar_Parser_AST.PatTvar
+                                (a,
+                                  (FStar_Pervasives_Native.Some
+                                     FStar_Parser_AST.Implicit), []))
+                             top.FStar_Parser_AST.range) ftv1 in
                     FStar_Compiler_List.op_At uu___4 binders1 in
                   let rec aux aqs env1 bs sc_pat_opt pats =
                     match pats with
@@ -3200,10 +3156,8 @@ and (desugar_term_maybe_top :
                                      let uu___5 =
                                        let uu___6 =
                                          FStar_Syntax_Syntax.pat_bvs pat in
-                                       FStar_Compiler_Effect.op_Bar_Greater
-                                         uu___6
-                                         (FStar_Compiler_List.map
-                                            FStar_Syntax_Syntax.mk_binder) in
+                                       FStar_Compiler_List.map
+                                         FStar_Syntax_Syntax.mk_binder uu___6 in
                                      FStar_Syntax_Subst.close uu___5 body1 in
                                    FStar_Syntax_Syntax.mk
                                      (FStar_Syntax_Syntax.Tm_match
@@ -3290,8 +3244,7 @@ and (desugar_term_maybe_top :
                                                           let uu___15 =
                                                             FStar_Syntax_Syntax.bv_to_name
                                                               x in
-                                                          FStar_Compiler_Effect.op_Less_Bar
-                                                            FStar_Syntax_Syntax.as_arg
+                                                          FStar_Syntax_Syntax.as_arg
                                                             uu___15 in
                                                         [uu___14] in
                                                       uu___12 :: uu___13 in
@@ -3351,8 +3304,7 @@ and (desugar_term_maybe_top :
                                                           let uu___15 =
                                                             FStar_Syntax_Syntax.bv_to_name
                                                               x in
-                                                          FStar_Compiler_Effect.op_Less_Bar
-                                                            FStar_Syntax_Syntax.as_arg
+                                                          FStar_Syntax_Syntax.as_arg
                                                             uu___15 in
                                                         [uu___14] in
                                                       FStar_Compiler_List.op_At
@@ -3608,74 +3560,71 @@ and (desugar_term_maybe_top :
             let ds_let_rec_or_app uu___1 =
               let bindings = lbs in
               let funs =
-                FStar_Compiler_Effect.op_Bar_Greater bindings
-                  (FStar_Compiler_List.map
-                     (fun uu___2 ->
-                        match uu___2 with
-                        | (attr_opt, (p, def)) ->
-                            let uu___3 = is_app_pattern p in
-                            if uu___3
-                            then
-                              let uu___4 =
-                                destruct_app_pattern env top_level p in
-                              (attr_opt, uu___4, def)
-                            else
-                              (let uu___5 =
-                                 FStar_Parser_AST.un_function p def in
-                               match uu___5 with
-                               | FStar_Pervasives_Native.Some (p1, def1) ->
-                                   let uu___6 =
-                                     destruct_app_pattern env top_level p1 in
-                                   (attr_opt, uu___6, def1)
-                               | uu___6 ->
-                                   (match p.FStar_Parser_AST.pat with
-                                    | FStar_Parser_AST.PatAscribed
-                                        ({
-                                           FStar_Parser_AST.pat =
-                                             FStar_Parser_AST.PatVar
-                                             (id, uu___7, uu___8);
-                                           FStar_Parser_AST.prange = uu___9;_},
-                                         t)
-                                        ->
-                                        if top_level
-                                        then
-                                          let uu___10 =
-                                            let uu___11 =
-                                              let uu___12 =
-                                                FStar_Syntax_DsEnv.qualify
-                                                  env id in
-                                              FStar_Pervasives.Inr uu___12 in
-                                            (uu___11, [],
-                                              (FStar_Pervasives_Native.Some t)) in
-                                          (attr_opt, uu___10, def)
-                                        else
-                                          (attr_opt,
-                                            ((FStar_Pervasives.Inl id), [],
-                                              (FStar_Pervasives_Native.Some t)),
-                                            def)
-                                    | FStar_Parser_AST.PatVar
-                                        (id, uu___7, uu___8) ->
-                                        if top_level
-                                        then
-                                          let uu___9 =
-                                            let uu___10 =
-                                              let uu___11 =
-                                                FStar_Syntax_DsEnv.qualify
-                                                  env id in
-                                              FStar_Pervasives.Inr uu___11 in
-                                            (uu___10, [],
-                                              FStar_Pervasives_Native.None) in
-                                          (attr_opt, uu___9, def)
-                                        else
-                                          (attr_opt,
-                                            ((FStar_Pervasives.Inl id), [],
-                                              FStar_Pervasives_Native.None),
-                                            def)
-                                    | uu___7 ->
-                                        FStar_Errors.raise_error
-                                          (FStar_Errors_Codes.Fatal_UnexpectedLetBinding,
-                                            "Unexpected let binding")
-                                          p.FStar_Parser_AST.prange)))) in
+                FStar_Compiler_List.map
+                  (fun uu___2 ->
+                     match uu___2 with
+                     | (attr_opt, (p, def)) ->
+                         let uu___3 = is_app_pattern p in
+                         if uu___3
+                         then
+                           let uu___4 = destruct_app_pattern env top_level p in
+                           (attr_opt, uu___4, def)
+                         else
+                           (let uu___5 = FStar_Parser_AST.un_function p def in
+                            match uu___5 with
+                            | FStar_Pervasives_Native.Some (p1, def1) ->
+                                let uu___6 =
+                                  destruct_app_pattern env top_level p1 in
+                                (attr_opt, uu___6, def1)
+                            | uu___6 ->
+                                (match p.FStar_Parser_AST.pat with
+                                 | FStar_Parser_AST.PatAscribed
+                                     ({
+                                        FStar_Parser_AST.pat =
+                                          FStar_Parser_AST.PatVar
+                                          (id, uu___7, uu___8);
+                                        FStar_Parser_AST.prange = uu___9;_},
+                                      t)
+                                     ->
+                                     if top_level
+                                     then
+                                       let uu___10 =
+                                         let uu___11 =
+                                           let uu___12 =
+                                             FStar_Syntax_DsEnv.qualify env
+                                               id in
+                                           FStar_Pervasives.Inr uu___12 in
+                                         (uu___11, [],
+                                           (FStar_Pervasives_Native.Some t)) in
+                                       (attr_opt, uu___10, def)
+                                     else
+                                       (attr_opt,
+                                         ((FStar_Pervasives.Inl id), [],
+                                           (FStar_Pervasives_Native.Some t)),
+                                         def)
+                                 | FStar_Parser_AST.PatVar
+                                     (id, uu___7, uu___8) ->
+                                     if top_level
+                                     then
+                                       let uu___9 =
+                                         let uu___10 =
+                                           let uu___11 =
+                                             FStar_Syntax_DsEnv.qualify env
+                                               id in
+                                           FStar_Pervasives.Inr uu___11 in
+                                         (uu___10, [],
+                                           FStar_Pervasives_Native.None) in
+                                       (attr_opt, uu___9, def)
+                                     else
+                                       (attr_opt,
+                                         ((FStar_Pervasives.Inl id), [],
+                                           FStar_Pervasives_Native.None),
+                                         def)
+                                 | uu___7 ->
+                                     FStar_Errors.raise_error
+                                       (FStar_Errors_Codes.Fatal_UnexpectedLetBinding,
+                                         "Unexpected let binding")
+                                       p.FStar_Parser_AST.prange))) bindings in
               let uu___2 =
                 FStar_Compiler_List.fold_left
                   (fun uu___3 ->
@@ -3723,8 +3672,7 @@ and (desugar_term_maybe_top :
                     match uu___3 with
                     | (attrs_opt, (uu___4, args, result_t), def) ->
                         let args1 =
-                          FStar_Compiler_Effect.op_Bar_Greater args
-                            (FStar_Compiler_List.map replace_unit_pattern) in
+                          FStar_Compiler_List.map replace_unit_pattern args in
                         let pos = def.FStar_Parser_AST.range in
                         let def1 =
                           match result_t with
@@ -3735,12 +3683,10 @@ and (desugar_term_maybe_top :
                                 if uu___5
                                 then
                                   ((let uu___7 =
-                                      FStar_Compiler_Effect.op_Bar_Greater
-                                        args1
-                                        (FStar_Compiler_List.tryFind
-                                           (fun x ->
-                                              let uu___8 = is_var_pattern x in
-                                              Prims.op_Negation uu___8)) in
+                                      FStar_Compiler_List.tryFind
+                                        (fun x ->
+                                           let uu___8 = is_var_pattern x in
+                                           Prims.op_Negation uu___8) args1 in
                                     match uu___7 with
                                     | FStar_Pervasives_Native.None -> ()
                                     | FStar_Pervasives_Native.Some p ->
@@ -3817,8 +3763,7 @@ and (desugar_term_maybe_top :
                       FStar_Compiler_List.map2
                         (desugar_one_def (if is_rec then env' else env))
                         fnames1 funs in
-                    FStar_Compiler_Effect.op_Bar_Greater uu___4
-                      FStar_Compiler_List.unzip in
+                    FStar_Compiler_List.unzip uu___4 in
                   (match uu___3 with
                    | (lbs1, aqss) ->
                        let uu___4 = desugar_term_aq env' body in
@@ -3899,7 +3844,7 @@ and (desugar_term_maybe_top :
                                       FStar_Syntax_Syntax.body1 = uu___9
                                     } in
                                   FStar_Syntax_Syntax.Tm_let uu___8 in
-                                FStar_Compiler_Effect.op_Less_Bar mk uu___7 in
+                                mk uu___7 in
                               (uu___6,
                                 (FStar_Compiler_List.op_At aq
                                    (FStar_Compiler_List.flatten aqss))))))) in
@@ -3920,20 +3865,16 @@ and (desugar_term_maybe_top :
                         (let uu___4 =
                            match binder with
                            | LetBinder (l, (t, tacopt)) ->
-                               ((let uu___6 =
-                                   FStar_Compiler_Effect.op_Bar_Greater
-                                     tacopt FStar_Compiler_Util.is_some in
-                                 if uu___6
-                                 then
-                                   let uu___7 =
-                                     let uu___8 =
-                                       FStar_Compiler_Effect.op_Bar_Greater
-                                         tacopt FStar_Compiler_Util.must in
-                                     uu___8.FStar_Syntax_Syntax.pos in
-                                   FStar_Errors.log_issue uu___7
+                               (if FStar_Compiler_Util.is_some tacopt
+                                then
+                                  (let uu___6 =
+                                     let uu___7 =
+                                       FStar_Compiler_Util.must tacopt in
+                                     uu___7.FStar_Syntax_Syntax.pos in
+                                   FStar_Errors.log_issue uu___6
                                      (FStar_Errors_Codes.Warning_DefinitionNotTranslated,
-                                       "Tactic annotation with a value type is not supported yet, try annotating with a computation type; this tactic annotation will be ignored")
-                                 else ());
+                                       "Tactic annotation with a value type is not supported yet, try annotating with a computation type; this tactic annotation will be ignored"))
+                                else ();
                                 (let uu___6 = desugar_term_aq env1 t2 in
                                  match uu___6 with
                                  | (body1, aq) ->
@@ -3963,8 +3904,7 @@ and (desugar_term_maybe_top :
                                                body1
                                            } in
                                          FStar_Syntax_Syntax.Tm_let uu___9 in
-                                       FStar_Compiler_Effect.op_Less_Bar mk
-                                         uu___8 in
+                                       mk uu___8 in
                                      (uu___7, aq)))
                            | LocalBinder (x, uu___5, uu___6) ->
                                let uu___7 = desugar_term_aq env1 t2 in
@@ -4026,8 +3966,7 @@ and (desugar_term_maybe_top :
                                               uu___12
                                           } in
                                         FStar_Syntax_Syntax.Tm_let uu___10 in
-                                      FStar_Compiler_Effect.op_Less_Bar mk
-                                        uu___9 in
+                                      mk uu___9 in
                                     (uu___8, aq)) in
                          match uu___4 with
                          | (tm, aq1) ->
@@ -4218,16 +4157,13 @@ and (desugar_term_maybe_top :
                         let uu___4 =
                           let uu___5 =
                             FStar_Compiler_List.map desugar_branch branches in
-                          FStar_Compiler_Effect.op_Bar_Greater uu___5
-                            FStar_Compiler_List.unzip in
-                        FStar_Compiler_Effect.op_Bar_Greater uu___4
-                          (fun uu___5 ->
-                             match uu___5 with
-                             | (x, y) -> ((FStar_Compiler_List.flatten x), y)) in
+                          FStar_Compiler_List.unzip uu___5 in
+                        match uu___4 with
+                        | (x, y) -> ((FStar_Compiler_List.flatten x), y) in
                       (match uu___3 with
                        | (brs, aqs) ->
                            let uu___4 =
-                             FStar_Compiler_Effect.op_Less_Bar mk
+                             mk
                                (FStar_Syntax_Syntax.Tm_match
                                   {
                                     FStar_Syntax_Syntax.scrutinee = e1;
@@ -4245,7 +4181,7 @@ and (desugar_term_maybe_top :
                  (match uu___2 with
                   | (e1, aq) ->
                       let uu___3 =
-                        FStar_Compiler_Effect.op_Less_Bar mk
+                        mk
                           (FStar_Syntax_Syntax.Tm_ascribed
                              {
                                FStar_Syntax_Syntax.tm = e1;
@@ -4273,8 +4209,7 @@ and (desugar_term_maybe_top :
                          let uu___4 = desugar_term_aq env fval in
                          (match uu___4 with
                           | (fval1, aq) -> ((fn, fval1), aq))) fields in
-              FStar_Compiler_Effect.op_Bar_Greater uu___2
-                FStar_Compiler_List.unzip in
+              FStar_Compiler_List.unzip uu___2 in
             (match uu___1 with
              | (fields1, aqs) ->
                  let uu___2 = FStar_Compiler_List.unzip fields1 in
@@ -4437,7 +4372,7 @@ and (desugar_term_maybe_top :
                          FStar_Syntax_Syntax.args = uu___5
                        } in
                      FStar_Syntax_Syntax.Tm_app uu___4 in
-                   FStar_Compiler_Effect.op_Less_Bar mk uu___3 in
+                   mk uu___3 in
                  (uu___2, s))
         | FStar_Parser_AST.NamedTyp (n, e) ->
             ((let uu___2 = FStar_Ident.range_of_id n in
@@ -4504,8 +4439,7 @@ and (desugar_term_maybe_top :
                              (Prims.int_zero, vt_tms)
                          } in
                        let uu___3 =
-                         FStar_Compiler_Effect.op_Less_Bar mk
-                           (FStar_Syntax_Syntax.Tm_quoted (tm1, qi)) in
+                         mk (FStar_Syntax_Syntax.Tm_quoted (tm1, qi)) in
                        (uu___3, noaqs))))
         | FStar_Parser_AST.Antiquote e ->
             let bv =
@@ -4525,7 +4459,7 @@ and (desugar_term_maybe_top :
               let uu___2 =
                 let uu___3 = let uu___4 = desugar_term env e in (uu___4, qi) in
                 FStar_Syntax_Syntax.Tm_quoted uu___3 in
-              FStar_Compiler_Effect.op_Less_Bar mk uu___2 in
+              mk uu___2 in
             (uu___1, noaqs)
         | FStar_Parser_AST.CalcProof (rel, init_expr, steps) ->
             let is_impl rel1 =
@@ -5255,8 +5189,7 @@ and (desugar_match_returns :
                            let asc2 =
                              let uu___3 =
                                let uu___4 =
-                                 FStar_Compiler_Effect.op_Bar_Greater
-                                   scrutinee FStar_Syntax_Util.unascribe in
+                                 FStar_Syntax_Util.unascribe scrutinee in
                                uu___4.FStar_Syntax_Syntax.n in
                              match uu___3 with
                              | FStar_Syntax_Syntax.Tm_name sbv ->
@@ -5321,12 +5254,12 @@ and (desugar_args :
   =
   fun env ->
     fun args ->
-      FStar_Compiler_Effect.op_Bar_Greater args
-        (FStar_Compiler_List.map
-           (fun uu___ ->
-              match uu___ with
-              | (a, imp) ->
-                  let uu___1 = desugar_term env a in arg_withimp_t imp uu___1))
+      FStar_Compiler_List.map
+        (fun uu___ ->
+           match uu___ with
+           | (a, imp) ->
+               let uu___1 = desugar_term env a in arg_withimp_t imp uu___1)
+        args
 and (desugar_comp :
   FStar_Compiler_Range_Type.range ->
     Prims.bool ->
@@ -5693,67 +5626,54 @@ and (desugar_comp :
                              match uu___5 with
                              | FStar_Parser_AST.Decreases uu___6 -> true
                              | uu___6 -> false in
-                           FStar_Compiler_Effect.op_Bar_Greater rest
-                             (FStar_Compiler_List.partition is_decrease) in
+                           FStar_Compiler_List.partition is_decrease rest in
                          (match uu___4 with
                           | (dec, rest1) ->
                               let rest2 = desugar_args env rest1 in
                               let decreases_clause =
-                                FStar_Compiler_Effect.op_Bar_Greater dec
-                                  (FStar_Compiler_List.map
-                                     (fun t1 ->
-                                        let uu___5 =
-                                          let uu___6 =
-                                            unparen
-                                              (FStar_Pervasives_Native.fst t1) in
-                                          uu___6.FStar_Parser_AST.tm in
-                                        match uu___5 with
-                                        | FStar_Parser_AST.Decreases
-                                            (t2, uu___6) ->
-                                            let dec_order =
-                                              let t3 = unparen t2 in
-                                              match t3.FStar_Parser_AST.tm
-                                              with
-                                              | FStar_Parser_AST.LexList l ->
-                                                  let uu___7 =
-                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                      l
-                                                      (FStar_Compiler_List.map
-                                                         (desugar_term env)) in
-                                                  FStar_Compiler_Effect.op_Bar_Greater
-                                                    uu___7
-                                                    (fun uu___8 ->
-                                                       FStar_Syntax_Syntax.Decreases_lex
-                                                         uu___8)
-                                              | FStar_Parser_AST.WFOrder
-                                                  (t11, t21) ->
-                                                  let uu___7 =
-                                                    let uu___8 =
-                                                      desugar_term env t11 in
-                                                    let uu___9 =
-                                                      desugar_term env t21 in
-                                                    (uu___8, uu___9) in
-                                                  FStar_Compiler_Effect.op_Bar_Greater
-                                                    uu___7
-                                                    (fun uu___8 ->
-                                                       FStar_Syntax_Syntax.Decreases_wf
-                                                         uu___8)
-                                              | uu___7 ->
-                                                  let uu___8 =
-                                                    let uu___9 =
-                                                      desugar_term env t3 in
-                                                    [uu___9] in
-                                                  FStar_Compiler_Effect.op_Bar_Greater
-                                                    uu___8
-                                                    (fun uu___9 ->
-                                                       FStar_Syntax_Syntax.Decreases_lex
-                                                         uu___9) in
-                                            FStar_Syntax_Syntax.DECREASES
-                                              dec_order
-                                        | uu___6 ->
-                                            fail
-                                              (FStar_Errors_Codes.Fatal_UnexpectedComputationTypeForLetRec,
-                                                "Unexpected decreases clause"))) in
+                                FStar_Compiler_List.map
+                                  (fun t1 ->
+                                     let uu___5 =
+                                       let uu___6 =
+                                         unparen
+                                           (FStar_Pervasives_Native.fst t1) in
+                                       uu___6.FStar_Parser_AST.tm in
+                                     match uu___5 with
+                                     | FStar_Parser_AST.Decreases
+                                         (t2, uu___6) ->
+                                         let dec_order =
+                                           let t3 = unparen t2 in
+                                           match t3.FStar_Parser_AST.tm with
+                                           | FStar_Parser_AST.LexList l ->
+                                               let uu___7 =
+                                                 FStar_Compiler_List.map
+                                                   (desugar_term env) l in
+                                               FStar_Syntax_Syntax.Decreases_lex
+                                                 uu___7
+                                           | FStar_Parser_AST.WFOrder
+                                               (t11, t21) ->
+                                               let uu___7 =
+                                                 let uu___8 =
+                                                   desugar_term env t11 in
+                                                 let uu___9 =
+                                                   desugar_term env t21 in
+                                                 (uu___8, uu___9) in
+                                               FStar_Syntax_Syntax.Decreases_wf
+                                                 uu___7
+                                           | uu___7 ->
+                                               let uu___8 =
+                                                 let uu___9 =
+                                                   desugar_term env t3 in
+                                                 [uu___9] in
+                                               FStar_Syntax_Syntax.Decreases_lex
+                                                 uu___8 in
+                                         FStar_Syntax_Syntax.DECREASES
+                                           dec_order
+                                     | uu___6 ->
+                                         fail
+                                           (FStar_Errors_Codes.Fatal_UnexpectedComputationTypeForLetRec,
+                                             "Unexpected decreases clause"))
+                                  dec in
                               let no_additional_args =
                                 let is_empty l =
                                   match l with | [] -> true | uu___5 -> false in
@@ -5917,33 +5837,29 @@ and (desugar_formula :
                      "Impossible: Annotated pattern without binders in scope"
                | uu___1 ->
                    let names1 =
-                     FStar_Compiler_Effect.op_Bar_Greater names
-                       (FStar_Compiler_List.map
-                          (fun i ->
-                             let uu___2 =
-                               FStar_Syntax_DsEnv.fail_or2
-                                 (FStar_Syntax_DsEnv.try_lookup_id env1) i in
-                             let uu___3 = FStar_Ident.range_of_id i in
-                             {
-                               FStar_Syntax_Syntax.n =
-                                 (uu___2.FStar_Syntax_Syntax.n);
-                               FStar_Syntax_Syntax.pos = uu___3;
-                               FStar_Syntax_Syntax.vars =
-                                 (uu___2.FStar_Syntax_Syntax.vars);
-                               FStar_Syntax_Syntax.hash_code =
-                                 (uu___2.FStar_Syntax_Syntax.hash_code)
-                             })) in
+                     FStar_Compiler_List.map
+                       (fun i ->
+                          let uu___2 =
+                            FStar_Syntax_DsEnv.fail_or2
+                              (FStar_Syntax_DsEnv.try_lookup_id env1) i in
+                          let uu___3 = FStar_Ident.range_of_id i in
+                          {
+                            FStar_Syntax_Syntax.n =
+                              (uu___2.FStar_Syntax_Syntax.n);
+                            FStar_Syntax_Syntax.pos = uu___3;
+                            FStar_Syntax_Syntax.vars =
+                              (uu___2.FStar_Syntax_Syntax.vars);
+                            FStar_Syntax_Syntax.hash_code =
+                              (uu___2.FStar_Syntax_Syntax.hash_code)
+                          }) names in
                    let pats2 =
-                     FStar_Compiler_Effect.op_Bar_Greater pats1
-                       (FStar_Compiler_List.map
-                          (fun es ->
-                             FStar_Compiler_Effect.op_Bar_Greater es
-                               (FStar_Compiler_List.map
-                                  (fun e ->
-                                     let uu___2 = desugar_term env1 e in
-                                     FStar_Compiler_Effect.op_Less_Bar
-                                       (arg_withimp_t
-                                          FStar_Parser_AST.Nothing) uu___2)))) in
+                     FStar_Compiler_List.map
+                       (fun es ->
+                          FStar_Compiler_List.map
+                            (fun e ->
+                               let uu___2 = desugar_term env1 e in
+                               arg_withimp_t FStar_Parser_AST.Nothing uu___2)
+                            es) pats1 in
                    (match pats2 with
                     | [] when Prims.op_Negation should_wrap_with_pat -> body1
                     | uu___2 ->
@@ -5976,7 +5892,7 @@ and (desugar_formula :
                        let uu___4 = FStar_Syntax_Syntax.mk_binder a2 in
                        [uu___4] in
                      no_annot_abs uu___3 body2 in
-                   FStar_Compiler_Effect.op_Less_Bar setpos uu___2 in
+                   setpos uu___2 in
                  let uu___2 =
                    let uu___3 =
                      let uu___4 =
@@ -5987,7 +5903,7 @@ and (desugar_formula :
                        FStar_Syntax_Syntax.args = uu___4
                      } in
                    FStar_Syntax_Syntax.Tm_app uu___3 in
-                 FStar_Compiler_Effect.op_Less_Bar mk uu___2)
+                 mk uu___2)
         | uu___ -> FStar_Compiler_Effect.failwith "impossible" in
       let push_quant q binders pats body =
         match binders with
@@ -6007,7 +5923,7 @@ and (desugar_formula :
       match uu___ with
       | FStar_Parser_AST.Labeled (f1, l, p) ->
           let f2 = desugar_formula env f1 in
-          FStar_Compiler_Effect.op_Less_Bar mk
+          mk
             (FStar_Syntax_Syntax.Tm_meta
                {
                  FStar_Syntax_Syntax.tm2 = f2;
@@ -6091,8 +6007,8 @@ and (desugar_binder_aq :
   fun env ->
     fun b ->
       let attrs =
-        FStar_Compiler_Effect.op_Bar_Greater b.FStar_Parser_AST.battributes
-          (FStar_Compiler_List.map (desugar_term env)) in
+        FStar_Compiler_List.map (desugar_term env)
+          b.FStar_Parser_AST.battributes in
       match b.FStar_Parser_AST.b with
       | FStar_Parser_AST.TAnnotated (x, t) ->
           let uu___ = desugar_typ_aq env t in
@@ -6313,13 +6229,12 @@ let (mk_data_discriminators :
       fun datas ->
         fun attrs ->
           let quals1 =
-            FStar_Compiler_Effect.op_Bar_Greater quals
-              (FStar_Compiler_List.filter
-                 (fun uu___ ->
-                    match uu___ with
-                    | FStar_Syntax_Syntax.NoExtract -> true
-                    | FStar_Syntax_Syntax.Private -> true
-                    | uu___1 -> false)) in
+            FStar_Compiler_List.filter
+              (fun uu___ ->
+                 match uu___ with
+                 | FStar_Syntax_Syntax.NoExtract -> true
+                 | FStar_Syntax_Syntax.Private -> true
+                 | uu___1 -> false) quals in
           let quals2 q =
             let uu___ =
               (let uu___1 = FStar_Syntax_DsEnv.iface env in
@@ -6330,33 +6245,31 @@ let (mk_data_discriminators :
               FStar_Compiler_List.op_At (FStar_Syntax_Syntax.Assumption :: q)
                 quals1
             else FStar_Compiler_List.op_At q quals1 in
-          FStar_Compiler_Effect.op_Bar_Greater datas
-            (FStar_Compiler_List.map
-               (fun d ->
-                  let disc_name = FStar_Syntax_Util.mk_discriminator d in
-                  let uu___ = FStar_Ident.range_of_lid disc_name in
-                  let uu___1 =
-                    quals2
-                      [FStar_Syntax_Syntax.OnlyName;
-                      FStar_Syntax_Syntax.Discriminator d] in
-                  let uu___2 = FStar_Syntax_DsEnv.opens_and_abbrevs env in
-                  {
-                    FStar_Syntax_Syntax.sigel =
-                      (FStar_Syntax_Syntax.Sig_declare_typ
-                         {
-                           FStar_Syntax_Syntax.lid2 = disc_name;
-                           FStar_Syntax_Syntax.us2 = [];
-                           FStar_Syntax_Syntax.t2 = FStar_Syntax_Syntax.tun
-                         });
-                    FStar_Syntax_Syntax.sigrng = uu___;
-                    FStar_Syntax_Syntax.sigquals = uu___1;
-                    FStar_Syntax_Syntax.sigmeta =
-                      FStar_Syntax_Syntax.default_sigmeta;
-                    FStar_Syntax_Syntax.sigattrs = attrs;
-                    FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___2;
-                    FStar_Syntax_Syntax.sigopts =
-                      FStar_Pervasives_Native.None
-                  }))
+          FStar_Compiler_List.map
+            (fun d ->
+               let disc_name = FStar_Syntax_Util.mk_discriminator d in
+               let uu___ = FStar_Ident.range_of_lid disc_name in
+               let uu___1 =
+                 quals2
+                   [FStar_Syntax_Syntax.OnlyName;
+                   FStar_Syntax_Syntax.Discriminator d] in
+               let uu___2 = FStar_Syntax_DsEnv.opens_and_abbrevs env in
+               {
+                 FStar_Syntax_Syntax.sigel =
+                   (FStar_Syntax_Syntax.Sig_declare_typ
+                      {
+                        FStar_Syntax_Syntax.lid2 = disc_name;
+                        FStar_Syntax_Syntax.us2 = [];
+                        FStar_Syntax_Syntax.t2 = FStar_Syntax_Syntax.tun
+                      });
+                 FStar_Syntax_Syntax.sigrng = uu___;
+                 FStar_Syntax_Syntax.sigquals = uu___1;
+                 FStar_Syntax_Syntax.sigmeta =
+                   FStar_Syntax_Syntax.default_sigmeta;
+                 FStar_Syntax_Syntax.sigattrs = attrs;
+                 FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___2;
+                 FStar_Syntax_Syntax.sigopts = FStar_Pervasives_Native.None
+               }) datas
 let (mk_indexed_projector_names :
   FStar_Syntax_Syntax.qualifier Prims.list ->
     FStar_Syntax_Syntax.fv_qual ->
@@ -6374,127 +6287,117 @@ let (mk_indexed_projector_names :
             fun fields ->
               let p = FStar_Ident.range_of_lid lid in
               let uu___ =
-                FStar_Compiler_Effect.op_Bar_Greater fields
-                  (FStar_Compiler_List.mapi
-                     (fun i ->
-                        fun fld ->
-                          let x = fld.FStar_Syntax_Syntax.binder_bv in
-                          let field_name =
-                            FStar_Syntax_Util.mk_field_projector_name lid x i in
-                          let only_decl =
-                            ((let uu___1 =
-                                FStar_Syntax_DsEnv.current_module env in
-                              FStar_Ident.lid_equals
-                                FStar_Parser_Const.prims_lid uu___1)
-                               || (fvq <> FStar_Syntax_Syntax.Data_ctor))
-                              ||
-                              (FStar_Syntax_Util.has_attribute attrs
-                                 FStar_Parser_Const.no_auto_projectors_attr) in
-                          let no_decl =
-                            FStar_Syntax_Syntax.is_type
-                              x.FStar_Syntax_Syntax.sort in
-                          let quals q =
-                            if only_decl
-                            then FStar_Syntax_Syntax.Assumption :: q
-                            else q in
-                          let quals1 =
-                            let iquals1 =
-                              FStar_Compiler_Effect.op_Bar_Greater iquals
-                                (FStar_Compiler_List.filter
-                                   (fun uu___1 ->
-                                      match uu___1 with
-                                      | FStar_Syntax_Syntax.NoExtract -> true
-                                      | FStar_Syntax_Syntax.Private -> true
-                                      | uu___2 -> false)) in
-                            quals (FStar_Syntax_Syntax.OnlyName ::
-                              (FStar_Syntax_Syntax.Projector
-                                 (lid, (x.FStar_Syntax_Syntax.ppname))) ::
-                              iquals1) in
-                          let decl =
-                            let uu___1 = FStar_Ident.range_of_lid field_name in
+                FStar_Compiler_List.mapi
+                  (fun i ->
+                     fun fld ->
+                       let x = fld.FStar_Syntax_Syntax.binder_bv in
+                       let field_name =
+                         FStar_Syntax_Util.mk_field_projector_name lid x i in
+                       let only_decl =
+                         ((let uu___1 = FStar_Syntax_DsEnv.current_module env in
+                           FStar_Ident.lid_equals
+                             FStar_Parser_Const.prims_lid uu___1)
+                            || (fvq <> FStar_Syntax_Syntax.Data_ctor))
+                           ||
+                           (FStar_Syntax_Util.has_attribute attrs
+                              FStar_Parser_Const.no_auto_projectors_attr) in
+                       let no_decl =
+                         FStar_Syntax_Syntax.is_type
+                           x.FStar_Syntax_Syntax.sort in
+                       let quals q =
+                         if only_decl
+                         then FStar_Syntax_Syntax.Assumption :: q
+                         else q in
+                       let quals1 =
+                         let iquals1 =
+                           FStar_Compiler_List.filter
+                             (fun uu___1 ->
+                                match uu___1 with
+                                | FStar_Syntax_Syntax.NoExtract -> true
+                                | FStar_Syntax_Syntax.Private -> true
+                                | uu___2 -> false) iquals in
+                         quals (FStar_Syntax_Syntax.OnlyName ::
+                           (FStar_Syntax_Syntax.Projector
+                              (lid, (x.FStar_Syntax_Syntax.ppname))) ::
+                           iquals1) in
+                       let decl =
+                         let uu___1 = FStar_Ident.range_of_lid field_name in
+                         let uu___2 =
+                           FStar_Syntax_DsEnv.opens_and_abbrevs env in
+                         {
+                           FStar_Syntax_Syntax.sigel =
+                             (FStar_Syntax_Syntax.Sig_declare_typ
+                                {
+                                  FStar_Syntax_Syntax.lid2 = field_name;
+                                  FStar_Syntax_Syntax.us2 = [];
+                                  FStar_Syntax_Syntax.t2 =
+                                    FStar_Syntax_Syntax.tun
+                                });
+                           FStar_Syntax_Syntax.sigrng = uu___1;
+                           FStar_Syntax_Syntax.sigquals = quals1;
+                           FStar_Syntax_Syntax.sigmeta =
+                             FStar_Syntax_Syntax.default_sigmeta;
+                           FStar_Syntax_Syntax.sigattrs = attrs;
+                           FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___2;
+                           FStar_Syntax_Syntax.sigopts =
+                             FStar_Pervasives_Native.None
+                         } in
+                       if only_decl
+                       then [decl]
+                       else
+                         (let dd =
+                            FStar_Syntax_Syntax.Delta_equational_at_level
+                              Prims.int_one in
+                          let lb =
                             let uu___2 =
+                              let uu___3 =
+                                FStar_Syntax_Syntax.lid_and_dd_as_fv
+                                  field_name dd FStar_Pervasives_Native.None in
+                              FStar_Pervasives.Inr uu___3 in
+                            {
+                              FStar_Syntax_Syntax.lbname = uu___2;
+                              FStar_Syntax_Syntax.lbunivs = [];
+                              FStar_Syntax_Syntax.lbtyp =
+                                FStar_Syntax_Syntax.tun;
+                              FStar_Syntax_Syntax.lbeff =
+                                FStar_Parser_Const.effect_Tot_lid;
+                              FStar_Syntax_Syntax.lbdef =
+                                FStar_Syntax_Syntax.tun;
+                              FStar_Syntax_Syntax.lbattrs = [];
+                              FStar_Syntax_Syntax.lbpos =
+                                FStar_Compiler_Range_Type.dummyRange
+                            } in
+                          let impl =
+                            let uu___2 =
+                              let uu___3 =
+                                let uu___4 =
+                                  let uu___5 =
+                                    let uu___6 =
+                                      FStar_Compiler_Util.right
+                                        lb.FStar_Syntax_Syntax.lbname in
+                                    (uu___6.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
+                                  [uu___5] in
+                                {
+                                  FStar_Syntax_Syntax.lbs1 = (false, [lb]);
+                                  FStar_Syntax_Syntax.lids1 = uu___4
+                                } in
+                              FStar_Syntax_Syntax.Sig_let uu___3 in
+                            let uu___3 =
                               FStar_Syntax_DsEnv.opens_and_abbrevs env in
                             {
-                              FStar_Syntax_Syntax.sigel =
-                                (FStar_Syntax_Syntax.Sig_declare_typ
-                                   {
-                                     FStar_Syntax_Syntax.lid2 = field_name;
-                                     FStar_Syntax_Syntax.us2 = [];
-                                     FStar_Syntax_Syntax.t2 =
-                                       FStar_Syntax_Syntax.tun
-                                   });
-                              FStar_Syntax_Syntax.sigrng = uu___1;
+                              FStar_Syntax_Syntax.sigel = uu___2;
+                              FStar_Syntax_Syntax.sigrng = p;
                               FStar_Syntax_Syntax.sigquals = quals1;
                               FStar_Syntax_Syntax.sigmeta =
                                 FStar_Syntax_Syntax.default_sigmeta;
                               FStar_Syntax_Syntax.sigattrs = attrs;
                               FStar_Syntax_Syntax.sigopens_and_abbrevs =
-                                uu___2;
+                                uu___3;
                               FStar_Syntax_Syntax.sigopts =
                                 FStar_Pervasives_Native.None
                             } in
-                          if only_decl
-                          then [decl]
-                          else
-                            (let dd =
-                               FStar_Syntax_Syntax.Delta_equational_at_level
-                                 Prims.int_one in
-                             let lb =
-                               let uu___2 =
-                                 let uu___3 =
-                                   FStar_Syntax_Syntax.lid_and_dd_as_fv
-                                     field_name dd
-                                     FStar_Pervasives_Native.None in
-                                 FStar_Pervasives.Inr uu___3 in
-                               {
-                                 FStar_Syntax_Syntax.lbname = uu___2;
-                                 FStar_Syntax_Syntax.lbunivs = [];
-                                 FStar_Syntax_Syntax.lbtyp =
-                                   FStar_Syntax_Syntax.tun;
-                                 FStar_Syntax_Syntax.lbeff =
-                                   FStar_Parser_Const.effect_Tot_lid;
-                                 FStar_Syntax_Syntax.lbdef =
-                                   FStar_Syntax_Syntax.tun;
-                                 FStar_Syntax_Syntax.lbattrs = [];
-                                 FStar_Syntax_Syntax.lbpos =
-                                   FStar_Compiler_Range_Type.dummyRange
-                               } in
-                             let impl =
-                               let uu___2 =
-                                 let uu___3 =
-                                   let uu___4 =
-                                     let uu___5 =
-                                       let uu___6 =
-                                         FStar_Compiler_Effect.op_Bar_Greater
-                                           lb.FStar_Syntax_Syntax.lbname
-                                           FStar_Compiler_Util.right in
-                                       FStar_Compiler_Effect.op_Bar_Greater
-                                         uu___6
-                                         (fun fv ->
-                                            (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v) in
-                                     [uu___5] in
-                                   {
-                                     FStar_Syntax_Syntax.lbs1 = (false, [lb]);
-                                     FStar_Syntax_Syntax.lids1 = uu___4
-                                   } in
-                                 FStar_Syntax_Syntax.Sig_let uu___3 in
-                               let uu___3 =
-                                 FStar_Syntax_DsEnv.opens_and_abbrevs env in
-                               {
-                                 FStar_Syntax_Syntax.sigel = uu___2;
-                                 FStar_Syntax_Syntax.sigrng = p;
-                                 FStar_Syntax_Syntax.sigquals = quals1;
-                                 FStar_Syntax_Syntax.sigmeta =
-                                   FStar_Syntax_Syntax.default_sigmeta;
-                                 FStar_Syntax_Syntax.sigattrs = attrs;
-                                 FStar_Syntax_Syntax.sigopens_and_abbrevs =
-                                   uu___3;
-                                 FStar_Syntax_Syntax.sigopts =
-                                   FStar_Pervasives_Native.None
-                               } in
-                             if no_decl then [impl] else [decl; impl]))) in
-              FStar_Compiler_Effect.op_Bar_Greater uu___
-                FStar_Compiler_List.flatten
+                          if no_decl then [impl] else [decl; impl])) fields in
+              FStar_Compiler_List.flatten uu___
 let (mk_data_projector_names :
   FStar_Syntax_Syntax.qualifier Prims.list ->
     FStar_Syntax_DsEnv.env ->
@@ -6570,8 +6473,7 @@ let (mk_typ_abbrev :
                         let uu___ =
                           FStar_Syntax_DsEnv.lookup_letbinding_quals_and_attrs
                             env lid in
-                        FStar_Compiler_Effect.op_Bar_Greater uu___
-                          FStar_Pervasives_Native.snd in
+                        FStar_Pervasives_Native.snd uu___ in
                       let dd = FStar_Syntax_Util.incr_delta_qualifier t in
                       let lb =
                         let uu___ =
@@ -6583,9 +6485,7 @@ let (mk_typ_abbrev :
                           if FStar_Compiler_Util.is_some kopt
                           then
                             let uu___2 =
-                              let uu___3 =
-                                FStar_Compiler_Effect.op_Bar_Greater kopt
-                                  FStar_Compiler_Util.must in
+                              let uu___3 = FStar_Compiler_Util.must kopt in
                               FStar_Syntax_Syntax.mk_Total uu___3 in
                             FStar_Syntax_Util.arrow typars uu___2
                           else FStar_Syntax_Syntax.tun in
@@ -6700,10 +6600,7 @@ let rec (desugar_tycon :
                                         let uu___5 =
                                           FStar_Ident.lid_of_ns_and_id []
                                             record_id in
-                                        FStar_Compiler_Effect.op_Bar_Greater
-                                          uu___5
-                                          (fun uu___6 ->
-                                             FStar_Parser_AST.Var uu___6) in
+                                        FStar_Parser_AST.Var uu___5 in
                                       let uu___5 =
                                         FStar_Ident.range_of_id cid in
                                       {
@@ -6724,59 +6621,53 @@ let rec (desugar_tycon :
                                       FStar_Parser_AST.mkApp record_id_t
                                         uu___4 uu___5 in
                                     let uu___4 =
-                                      FStar_Compiler_Effect.op_Bar_Greater
-                                        (FStar_Parser_AST.TyconRecord
-                                           (record_id, bds,
-                                             FStar_Pervasives_Native.None,
-                                             attrs, r))
-                                        (fun uu___5 ->
-                                           FStar_Pervasives_Native.Some
-                                             uu___5) in
-                                    let uu___5 =
-                                      let uu___6 =
-                                        let uu___7 =
+                                      let uu___5 =
+                                        let uu___6 =
                                           match k1 with
                                           | FStar_Pervasives_Native.None ->
                                               FStar_Parser_AST.VpOfNotation
                                                 payload_typ
                                           | FStar_Pervasives_Native.Some k2
                                               ->
-                                              let uu___8 =
-                                                let uu___9 =
-                                                  let uu___10 =
-                                                    let uu___11 =
-                                                      let uu___12 =
-                                                        let uu___13 =
+                                              let uu___7 =
+                                                let uu___8 =
+                                                  let uu___9 =
+                                                    let uu___10 =
+                                                      let uu___11 =
+                                                        let uu___12 =
                                                           FStar_Ident.range_of_id
                                                             record_id in
                                                         FStar_Parser_AST.mk_binder
                                                           (FStar_Parser_AST.NoName
                                                              payload_typ)
-                                                          uu___13
+                                                          uu___12
                                                           FStar_Parser_AST.Type_level
                                                           FStar_Pervasives_Native.None in
-                                                      [uu___12] in
-                                                    (uu___11, k2) in
+                                                      [uu___11] in
+                                                    (uu___10, k2) in
                                                   FStar_Parser_AST.Product
-                                                    uu___10 in
+                                                    uu___9 in
                                                 {
                                                   FStar_Parser_AST.tm =
-                                                    uu___9;
+                                                    uu___8;
                                                   FStar_Parser_AST.range =
                                                     (payload_typ.FStar_Parser_AST.range);
                                                   FStar_Parser_AST.level =
                                                     FStar_Parser_AST.Type_level
                                                 } in
                                               FStar_Parser_AST.VpArbitrary
-                                                uu___8 in
-                                        FStar_Pervasives_Native.Some uu___7 in
-                                      (cid, uu___6, attrs) in
-                                    (uu___4, uu___5)
+                                                uu___7 in
+                                        FStar_Pervasives_Native.Some uu___6 in
+                                      (cid, uu___5, attrs) in
+                                    ((FStar_Pervasives_Native.Some
+                                        (FStar_Parser_AST.TyconRecord
+                                           (record_id, bds,
+                                             FStar_Pervasives_Native.None,
+                                             attrs, r))), uu___4)
                                 | uu___4 ->
                                     (FStar_Pervasives_Native.None,
                                       (cid, payload, attrs)))) variants in
-                    FStar_Compiler_Effect.op_Bar_Greater uu___2
-                      FStar_Compiler_List.unzip in
+                    FStar_Compiler_List.unzip uu___2 in
                   (match uu___1 with
                    | (additional_records, variants1) ->
                        let concat_options =
@@ -6883,11 +6774,10 @@ let rec (desugar_tycon :
                               FStar_Errors.raise_error uu___7 uu___8
                             else ()) fields;
                    (let uu___2 =
-                      FStar_Compiler_Effect.op_Bar_Greater fields
-                        (FStar_Compiler_List.map
-                           (fun uu___3 ->
-                              match uu___3 with
-                              | (f, uu___4, uu___5, uu___6) -> f)) in
+                      FStar_Compiler_List.map
+                        (fun uu___3 ->
+                           match uu___3 with
+                           | (f, uu___4, uu___5, uu___6) -> f) fields in
                     ((FStar_Parser_AST.TyconVariant
                         (id, parms, kopt,
                           [(constrName,
@@ -7094,12 +6984,11 @@ let rec (desugar_tycon :
                      let t0 = t in
                      let quals1 =
                        let uu___1 =
-                         FStar_Compiler_Effect.op_Bar_Greater quals
-                           (FStar_Compiler_Util.for_some
-                              (fun uu___2 ->
-                                 match uu___2 with
-                                 | FStar_Syntax_Syntax.Logic -> true
-                                 | uu___3 -> false)) in
+                         FStar_Compiler_Util.for_some
+                           (fun uu___2 ->
+                              match uu___2 with
+                              | FStar_Syntax_Syntax.Logic -> true
+                              | uu___3 -> false) quals in
                        if uu___1
                        then quals
                        else
@@ -7110,43 +6999,41 @@ let rec (desugar_tycon :
                          else quals in
                      let qlid = FStar_Syntax_DsEnv.qualify env id in
                      let se =
-                       let uu___1 =
-                         FStar_Compiler_Effect.op_Bar_Greater quals1
-                           (FStar_Compiler_List.contains
-                              FStar_Syntax_Syntax.Effect) in
-                       if uu___1
+                       if
+                         FStar_Compiler_List.contains
+                           FStar_Syntax_Syntax.Effect quals1
                        then
-                         let uu___2 =
-                           let uu___3 =
-                             let uu___4 = unparen t in
-                             uu___4.FStar_Parser_AST.tm in
-                           match uu___3 with
+                         let uu___1 =
+                           let uu___2 =
+                             let uu___3 = unparen t in
+                             uu___3.FStar_Parser_AST.tm in
+                           match uu___2 with
                            | FStar_Parser_AST.Construct (head, args) ->
-                               let uu___4 =
+                               let uu___3 =
                                  match FStar_Compiler_List.rev args with
-                                 | (last_arg, uu___5)::args_rev ->
-                                     let uu___6 =
-                                       let uu___7 = unparen last_arg in
-                                       uu___7.FStar_Parser_AST.tm in
-                                     (match uu___6 with
+                                 | (last_arg, uu___4)::args_rev ->
+                                     let uu___5 =
+                                       let uu___6 = unparen last_arg in
+                                       uu___6.FStar_Parser_AST.tm in
+                                     (match uu___5 with
                                       | FStar_Parser_AST.Attributes ts ->
                                           (ts,
                                             (FStar_Compiler_List.rev args_rev))
-                                      | uu___7 -> ([], args))
-                                 | uu___5 -> ([], args) in
-                               (match uu___4 with
+                                      | uu___6 -> ([], args))
+                                 | uu___4 -> ([], args) in
+                               (match uu___3 with
                                 | (cattributes, args1) ->
-                                    let uu___5 =
+                                    let uu___4 =
                                       FStar_Parser_AST.mk_term
                                         (FStar_Parser_AST.Construct
                                            (head, args1))
                                         t.FStar_Parser_AST.range
                                         t.FStar_Parser_AST.level in
-                                    let uu___6 =
+                                    let uu___5 =
                                       desugar_attributes env cattributes in
-                                    (uu___5, uu___6))
-                           | uu___4 -> (t, []) in
-                         match uu___2 with
+                                    (uu___4, uu___5))
+                           | uu___3 -> (t, []) in
+                         match uu___1 with
                          | (t1, cattributes) ->
                              let c =
                                desugar_comp t1.FStar_Parser_AST.range false
@@ -7155,14 +7042,13 @@ let rec (desugar_tycon :
                                FStar_Syntax_Subst.close_binders typars in
                              let c1 = FStar_Syntax_Subst.close_comp typars1 c in
                              let quals2 =
-                               FStar_Compiler_Effect.op_Bar_Greater quals1
-                                 (FStar_Compiler_List.filter
-                                    (fun uu___3 ->
-                                       match uu___3 with
-                                       | FStar_Syntax_Syntax.Effect -> false
-                                       | uu___4 -> true)) in
-                             let uu___3 = FStar_Ident.range_of_id id in
-                             let uu___4 =
+                               FStar_Compiler_List.filter
+                                 (fun uu___2 ->
+                                    match uu___2 with
+                                    | FStar_Syntax_Syntax.Effect -> false
+                                    | uu___3 -> true) quals1 in
+                             let uu___2 = FStar_Ident.range_of_id id in
+                             let uu___3 =
                                FStar_Syntax_DsEnv.opens_and_abbrevs env in
                              {
                                FStar_Syntax_Syntax.sigel =
@@ -7177,21 +7063,21 @@ let rec (desugar_tycon :
                                            cattributes
                                            (FStar_Syntax_Util.comp_flags c1))
                                     });
-                               FStar_Syntax_Syntax.sigrng = uu___3;
+                               FStar_Syntax_Syntax.sigrng = uu___2;
                                FStar_Syntax_Syntax.sigquals = quals2;
                                FStar_Syntax_Syntax.sigmeta =
                                  FStar_Syntax_Syntax.default_sigmeta;
                                FStar_Syntax_Syntax.sigattrs = [];
                                FStar_Syntax_Syntax.sigopens_and_abbrevs =
-                                 uu___4;
+                                 uu___3;
                                FStar_Syntax_Syntax.sigopts =
                                  FStar_Pervasives_Native.None
                              }
                        else
                          (let t1 = desugar_typ env' t in
-                          let uu___3 = FStar_Ident.range_of_id id in
+                          let uu___2 = FStar_Ident.range_of_id id in
                           mk_typ_abbrev env d qlid [] typars kopt1 t1 
-                            [qlid] quals1 uu___3) in
+                            [qlid] quals1 uu___2) in
                      let env1 = FStar_Syntax_DsEnv.push_sigelt env se in
                      (env1, [se]))
             | (FStar_Parser_AST.TyconRecord uu___)::[] ->
@@ -7214,9 +7100,8 @@ let rec (desugar_tycon :
                 let env0 = env in
                 let mutuals =
                   FStar_Compiler_List.map
-                    (fun x ->
-                       FStar_Compiler_Effect.op_Less_Bar
-                         (FStar_Syntax_DsEnv.qualify env) (tycon_id x)) tcs1 in
+                    (fun x -> FStar_Syntax_DsEnv.qualify env (tycon_id x))
+                    tcs1 in
                 let rec collect_tcs quals1 et tc =
                   let uu___2 = et in
                   match uu___2 with
@@ -7274,371 +7159,341 @@ let rec (desugar_tycon :
                  | (env1, tcs2) ->
                      let tcs3 = FStar_Compiler_List.rev tcs2 in
                      let tps_sigelts =
-                       FStar_Compiler_Effect.op_Bar_Greater tcs3
-                         (FStar_Compiler_List.collect
-                            (fun uu___3 ->
-                               match uu___3 with
-                               | FStar_Pervasives.Inr
-                                   ({
-                                      FStar_Syntax_Syntax.sigel =
-                                        FStar_Syntax_Syntax.Sig_inductive_typ
-                                        { FStar_Syntax_Syntax.lid = id;
-                                          FStar_Syntax_Syntax.us = uvs;
-                                          FStar_Syntax_Syntax.params = tpars;
-                                          FStar_Syntax_Syntax.num_uniform_params
-                                            = uu___4;
-                                          FStar_Syntax_Syntax.t = k;
-                                          FStar_Syntax_Syntax.mutuals =
-                                            uu___5;
-                                          FStar_Syntax_Syntax.ds = uu___6;_};
-                                      FStar_Syntax_Syntax.sigrng = uu___7;
-                                      FStar_Syntax_Syntax.sigquals = uu___8;
-                                      FStar_Syntax_Syntax.sigmeta = uu___9;
-                                      FStar_Syntax_Syntax.sigattrs = uu___10;
-                                      FStar_Syntax_Syntax.sigopens_and_abbrevs
-                                        = uu___11;
-                                      FStar_Syntax_Syntax.sigopts = uu___12;_},
-                                    binders, t, quals1)
-                                   ->
-                                   let t1 =
-                                     let uu___13 =
-                                       typars_of_binders env1 binders in
-                                     match uu___13 with
-                                     | (env2, tpars1) ->
-                                         let uu___14 =
-                                           push_tparams env2 tpars1 in
-                                         (match uu___14 with
-                                          | (env_tps, tpars2) ->
-                                              let t2 = desugar_typ env_tps t in
-                                              let tpars3 =
-                                                FStar_Syntax_Subst.close_binders
-                                                  tpars2 in
-                                              FStar_Syntax_Subst.close tpars3
-                                                t2) in
-                                   let uu___13 =
-                                     let uu___14 =
-                                       let uu___15 =
-                                         FStar_Ident.range_of_lid id in
-                                       mk_typ_abbrev env1 d id uvs tpars
-                                         (FStar_Pervasives_Native.Some k) t1
-                                         [id] quals1 uu___15 in
-                                     ([], uu___14) in
-                                   [uu___13]
-                               | FStar_Pervasives.Inl
-                                   ({
-                                      FStar_Syntax_Syntax.sigel =
-                                        FStar_Syntax_Syntax.Sig_inductive_typ
-                                        { FStar_Syntax_Syntax.lid = tname;
-                                          FStar_Syntax_Syntax.us = univs;
-                                          FStar_Syntax_Syntax.params = tpars;
-                                          FStar_Syntax_Syntax.num_uniform_params
-                                            = num_uniform;
-                                          FStar_Syntax_Syntax.t = k;
-                                          FStar_Syntax_Syntax.mutuals =
-                                            mutuals1;
-                                          FStar_Syntax_Syntax.ds = uu___4;_};
-                                      FStar_Syntax_Syntax.sigrng = uu___5;
-                                      FStar_Syntax_Syntax.sigquals =
-                                        tname_quals;
-                                      FStar_Syntax_Syntax.sigmeta = uu___6;
-                                      FStar_Syntax_Syntax.sigattrs = uu___7;
-                                      FStar_Syntax_Syntax.sigopens_and_abbrevs
-                                        = uu___8;
-                                      FStar_Syntax_Syntax.sigopts = uu___9;_},
-                                    constrs, tconstr, quals1)
-                                   ->
-                                   let mk_tot t =
-                                     let tot1 =
-                                       FStar_Parser_AST.mk_term
-                                         (FStar_Parser_AST.Name
-                                            FStar_Parser_Const.effect_Tot_lid)
-                                         t.FStar_Parser_AST.range
-                                         t.FStar_Parser_AST.level in
-                                     FStar_Parser_AST.mk_term
-                                       (FStar_Parser_AST.App
-                                          (tot1, t, FStar_Parser_AST.Nothing))
-                                       t.FStar_Parser_AST.range
-                                       t.FStar_Parser_AST.level in
-                                   let tycon = (tname, tpars, k) in
-                                   let uu___10 = push_tparams env1 tpars in
-                                   (match uu___10 with
-                                    | (env_tps, tps) ->
-                                        let data_tpars =
-                                          FStar_Compiler_List.map
-                                            (fun tp ->
-                                               {
-                                                 FStar_Syntax_Syntax.binder_bv
-                                                   =
-                                                   (tp.FStar_Syntax_Syntax.binder_bv);
-                                                 FStar_Syntax_Syntax.binder_qual
-                                                   =
-                                                   (FStar_Pervasives_Native.Some
-                                                      (FStar_Syntax_Syntax.Implicit
-                                                         true));
-                                                 FStar_Syntax_Syntax.binder_positivity
-                                                   =
-                                                   (tp.FStar_Syntax_Syntax.binder_positivity);
-                                                 FStar_Syntax_Syntax.binder_attrs
-                                                   =
-                                                   (tp.FStar_Syntax_Syntax.binder_attrs)
-                                               }) tps in
-                                        let tot_tconstr = mk_tot tconstr in
-                                        let val_attrs =
-                                          let uu___11 =
-                                            FStar_Syntax_DsEnv.lookup_letbinding_quals_and_attrs
-                                              env0 tname in
-                                          FStar_Compiler_Effect.op_Bar_Greater
-                                            uu___11
-                                            FStar_Pervasives_Native.snd in
-                                        let uu___11 =
-                                          let uu___12 =
-                                            FStar_Compiler_Effect.op_Bar_Greater
-                                              constrs
-                                              (FStar_Compiler_List.map
-                                                 (fun uu___13 ->
-                                                    match uu___13 with
-                                                    | (id, payload,
-                                                       cons_attrs) ->
-                                                        let t =
-                                                          match payload with
-                                                          | FStar_Pervasives_Native.Some
-                                                              (FStar_Parser_AST.VpArbitrary
-                                                              t1) -> t1
-                                                          | FStar_Pervasives_Native.Some
-                                                              (FStar_Parser_AST.VpOfNotation
-                                                              t1) ->
-                                                              let uu___14 =
-                                                                let uu___15 =
-                                                                  let uu___16
-                                                                    =
-                                                                    let uu___17
-                                                                    =
-                                                                    FStar_Parser_AST.mk_binder
-                                                                    (FStar_Parser_AST.NoName
-                                                                    t1)
-                                                                    t1.FStar_Parser_AST.range
-                                                                    t1.FStar_Parser_AST.level
-                                                                    FStar_Pervasives_Native.None in
-                                                                    [uu___17] in
-                                                                  (uu___16,
-                                                                    tot_tconstr) in
-                                                                FStar_Parser_AST.Product
-                                                                  uu___15 in
-                                                              FStar_Parser_AST.mk_term
-                                                                uu___14
-                                                                t1.FStar_Parser_AST.range
-                                                                t1.FStar_Parser_AST.level
-                                                          | FStar_Pervasives_Native.Some
-                                                              (FStar_Parser_AST.VpRecord
-                                                              uu___14) ->
-                                                              FStar_Compiler_Effect.failwith
-                                                                "Impossible: [VpRecord _] should have disappeared after [desugar_tycon_variant_record]"
-                                                          | FStar_Pervasives_Native.None
-                                                              ->
-                                                              let uu___14 =
-                                                                FStar_Ident.range_of_id
-                                                                  id in
-                                                              {
-                                                                FStar_Parser_AST.tm
-                                                                  =
-                                                                  (tconstr.FStar_Parser_AST.tm);
-                                                                FStar_Parser_AST.range
-                                                                  = uu___14;
-                                                                FStar_Parser_AST.level
-                                                                  =
-                                                                  (tconstr.FStar_Parser_AST.level)
-                                                              } in
-                                                        let t1 =
-                                                          let uu___14 =
-                                                            close env_tps t in
-                                                          desugar_term
-                                                            env_tps uu___14 in
-                                                        let name =
-                                                          FStar_Syntax_DsEnv.qualify
-                                                            env1 id in
-                                                        let quals2 =
-                                                          FStar_Compiler_Effect.op_Bar_Greater
-                                                            tname_quals
-                                                            (FStar_Compiler_List.collect
-                                                               (fun uu___14
-                                                                  ->
-                                                                  match uu___14
-                                                                  with
-                                                                  | FStar_Syntax_Syntax.RecordType
-                                                                    fns ->
-                                                                    [
-                                                                    FStar_Syntax_Syntax.RecordConstructor
-                                                                    fns]
-                                                                  | uu___15
-                                                                    -> [])) in
-                                                        let ntps =
-                                                          FStar_Compiler_List.length
-                                                            data_tpars in
+                       FStar_Compiler_List.collect
+                         (fun uu___3 ->
+                            match uu___3 with
+                            | FStar_Pervasives.Inr
+                                ({
+                                   FStar_Syntax_Syntax.sigel =
+                                     FStar_Syntax_Syntax.Sig_inductive_typ
+                                     { FStar_Syntax_Syntax.lid = id;
+                                       FStar_Syntax_Syntax.us = uvs;
+                                       FStar_Syntax_Syntax.params = tpars;
+                                       FStar_Syntax_Syntax.num_uniform_params
+                                         = uu___4;
+                                       FStar_Syntax_Syntax.t = k;
+                                       FStar_Syntax_Syntax.mutuals = uu___5;
+                                       FStar_Syntax_Syntax.ds = uu___6;_};
+                                   FStar_Syntax_Syntax.sigrng = uu___7;
+                                   FStar_Syntax_Syntax.sigquals = uu___8;
+                                   FStar_Syntax_Syntax.sigmeta = uu___9;
+                                   FStar_Syntax_Syntax.sigattrs = uu___10;
+                                   FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                                     uu___11;
+                                   FStar_Syntax_Syntax.sigopts = uu___12;_},
+                                 binders, t, quals1)
+                                ->
+                                let t1 =
+                                  let uu___13 =
+                                    typars_of_binders env1 binders in
+                                  match uu___13 with
+                                  | (env2, tpars1) ->
+                                      let uu___14 = push_tparams env2 tpars1 in
+                                      (match uu___14 with
+                                       | (env_tps, tpars2) ->
+                                           let t2 = desugar_typ env_tps t in
+                                           let tpars3 =
+                                             FStar_Syntax_Subst.close_binders
+                                               tpars2 in
+                                           FStar_Syntax_Subst.close tpars3 t2) in
+                                let uu___13 =
+                                  let uu___14 =
+                                    let uu___15 = FStar_Ident.range_of_lid id in
+                                    mk_typ_abbrev env1 d id uvs tpars
+                                      (FStar_Pervasives_Native.Some k) t1
+                                      [id] quals1 uu___15 in
+                                  ([], uu___14) in
+                                [uu___13]
+                            | FStar_Pervasives.Inl
+                                ({
+                                   FStar_Syntax_Syntax.sigel =
+                                     FStar_Syntax_Syntax.Sig_inductive_typ
+                                     { FStar_Syntax_Syntax.lid = tname;
+                                       FStar_Syntax_Syntax.us = univs;
+                                       FStar_Syntax_Syntax.params = tpars;
+                                       FStar_Syntax_Syntax.num_uniform_params
+                                         = num_uniform;
+                                       FStar_Syntax_Syntax.t = k;
+                                       FStar_Syntax_Syntax.mutuals = mutuals1;
+                                       FStar_Syntax_Syntax.ds = uu___4;_};
+                                   FStar_Syntax_Syntax.sigrng = uu___5;
+                                   FStar_Syntax_Syntax.sigquals = tname_quals;
+                                   FStar_Syntax_Syntax.sigmeta = uu___6;
+                                   FStar_Syntax_Syntax.sigattrs = uu___7;
+                                   FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                                     uu___8;
+                                   FStar_Syntax_Syntax.sigopts = uu___9;_},
+                                 constrs, tconstr, quals1)
+                                ->
+                                let mk_tot t =
+                                  let tot1 =
+                                    FStar_Parser_AST.mk_term
+                                      (FStar_Parser_AST.Name
+                                         FStar_Parser_Const.effect_Tot_lid)
+                                      t.FStar_Parser_AST.range
+                                      t.FStar_Parser_AST.level in
+                                  FStar_Parser_AST.mk_term
+                                    (FStar_Parser_AST.App
+                                       (tot1, t, FStar_Parser_AST.Nothing))
+                                    t.FStar_Parser_AST.range
+                                    t.FStar_Parser_AST.level in
+                                let tycon = (tname, tpars, k) in
+                                let uu___10 = push_tparams env1 tpars in
+                                (match uu___10 with
+                                 | (env_tps, tps) ->
+                                     let data_tpars =
+                                       FStar_Compiler_List.map
+                                         (fun tp ->
+                                            {
+                                              FStar_Syntax_Syntax.binder_bv =
+                                                (tp.FStar_Syntax_Syntax.binder_bv);
+                                              FStar_Syntax_Syntax.binder_qual
+                                                =
+                                                (FStar_Pervasives_Native.Some
+                                                   (FStar_Syntax_Syntax.Implicit
+                                                      true));
+                                              FStar_Syntax_Syntax.binder_positivity
+                                                =
+                                                (tp.FStar_Syntax_Syntax.binder_positivity);
+                                              FStar_Syntax_Syntax.binder_attrs
+                                                =
+                                                (tp.FStar_Syntax_Syntax.binder_attrs)
+                                            }) tps in
+                                     let tot_tconstr = mk_tot tconstr in
+                                     let val_attrs =
+                                       let uu___11 =
+                                         FStar_Syntax_DsEnv.lookup_letbinding_quals_and_attrs
+                                           env0 tname in
+                                       FStar_Pervasives_Native.snd uu___11 in
+                                     let uu___11 =
+                                       let uu___12 =
+                                         FStar_Compiler_List.map
+                                           (fun uu___13 ->
+                                              match uu___13 with
+                                              | (id, payload, cons_attrs) ->
+                                                  let t =
+                                                    match payload with
+                                                    | FStar_Pervasives_Native.Some
+                                                        (FStar_Parser_AST.VpArbitrary
+                                                        t1) -> t1
+                                                    | FStar_Pervasives_Native.Some
+                                                        (FStar_Parser_AST.VpOfNotation
+                                                        t1) ->
                                                         let uu___14 =
                                                           let uu___15 =
                                                             let uu___16 =
                                                               let uu___17 =
-                                                                let uu___18 =
-                                                                  let uu___19
-                                                                    =
-                                                                    let uu___20
-                                                                    =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    t1
-                                                                    FStar_Syntax_Util.name_function_binders in
-                                                                    FStar_Syntax_Syntax.mk_Total
-                                                                    uu___20 in
-                                                                  FStar_Syntax_Util.arrow
-                                                                    data_tpars
-                                                                    uu___19 in
-                                                                {
-                                                                  FStar_Syntax_Syntax.lid1
-                                                                    = name;
-                                                                  FStar_Syntax_Syntax.us1
-                                                                    = univs;
-                                                                  FStar_Syntax_Syntax.t1
-                                                                    = uu___18;
-                                                                  FStar_Syntax_Syntax.ty_lid
-                                                                    = tname;
-                                                                  FStar_Syntax_Syntax.num_ty_params
-                                                                    = ntps;
-                                                                  FStar_Syntax_Syntax.mutuals1
-                                                                    =
-                                                                    mutuals1
-                                                                } in
-                                                              FStar_Syntax_Syntax.Sig_datacon
-                                                                uu___17 in
-                                                            let uu___17 =
-                                                              FStar_Ident.range_of_lid
-                                                                name in
-                                                            let uu___18 =
-                                                              let uu___19 =
-                                                                let uu___20 =
-                                                                  let uu___21
-                                                                    =
-                                                                    FStar_Compiler_List.map
-                                                                    (desugar_term
-                                                                    env1)
-                                                                    cons_attrs in
-                                                                  FStar_Compiler_List.op_At
-                                                                    d_attrs
-                                                                    uu___21 in
-                                                                FStar_Compiler_List.op_At
-                                                                  val_attrs
-                                                                  uu___20 in
-                                                              FStar_Syntax_Util.deduplicate_terms
-                                                                uu___19 in
+                                                                FStar_Parser_AST.mk_binder
+                                                                  (FStar_Parser_AST.NoName
+                                                                    t1)
+                                                                  t1.FStar_Parser_AST.range
+                                                                  t1.FStar_Parser_AST.level
+                                                                  FStar_Pervasives_Native.None in
+                                                              [uu___17] in
+                                                            (uu___16,
+                                                              tot_tconstr) in
+                                                          FStar_Parser_AST.Product
+                                                            uu___15 in
+                                                        FStar_Parser_AST.mk_term
+                                                          uu___14
+                                                          t1.FStar_Parser_AST.range
+                                                          t1.FStar_Parser_AST.level
+                                                    | FStar_Pervasives_Native.Some
+                                                        (FStar_Parser_AST.VpRecord
+                                                        uu___14) ->
+                                                        FStar_Compiler_Effect.failwith
+                                                          "Impossible: [VpRecord _] should have disappeared after [desugar_tycon_variant_record]"
+                                                    | FStar_Pervasives_Native.None
+                                                        ->
+                                                        let uu___14 =
+                                                          FStar_Ident.range_of_id
+                                                            id in
+                                                        {
+                                                          FStar_Parser_AST.tm
+                                                            =
+                                                            (tconstr.FStar_Parser_AST.tm);
+                                                          FStar_Parser_AST.range
+                                                            = uu___14;
+                                                          FStar_Parser_AST.level
+                                                            =
+                                                            (tconstr.FStar_Parser_AST.level)
+                                                        } in
+                                                  let t1 =
+                                                    let uu___14 =
+                                                      close env_tps t in
+                                                    desugar_term env_tps
+                                                      uu___14 in
+                                                  let name =
+                                                    FStar_Syntax_DsEnv.qualify
+                                                      env1 id in
+                                                  let quals2 =
+                                                    FStar_Compiler_List.collect
+                                                      (fun uu___14 ->
+                                                         match uu___14 with
+                                                         | FStar_Syntax_Syntax.RecordType
+                                                             fns ->
+                                                             [FStar_Syntax_Syntax.RecordConstructor
+                                                                fns]
+                                                         | uu___15 -> [])
+                                                      tname_quals in
+                                                  let ntps =
+                                                    FStar_Compiler_List.length
+                                                      data_tpars in
+                                                  let uu___14 =
+                                                    let uu___15 =
+                                                      let uu___16 =
+                                                        let uu___17 =
+                                                          let uu___18 =
                                                             let uu___19 =
-                                                              FStar_Syntax_DsEnv.opens_and_abbrevs
-                                                                env1 in
-                                                            {
-                                                              FStar_Syntax_Syntax.sigel
-                                                                = uu___16;
-                                                              FStar_Syntax_Syntax.sigrng
-                                                                = uu___17;
-                                                              FStar_Syntax_Syntax.sigquals
-                                                                = quals2;
-                                                              FStar_Syntax_Syntax.sigmeta
-                                                                =
-                                                                FStar_Syntax_Syntax.default_sigmeta;
-                                                              FStar_Syntax_Syntax.sigattrs
-                                                                = uu___18;
-                                                              FStar_Syntax_Syntax.sigopens_and_abbrevs
-                                                                = uu___19;
-                                                              FStar_Syntax_Syntax.sigopts
-                                                                =
-                                                                FStar_Pervasives_Native.None
-                                                            } in
-                                                          (tps, uu___15) in
-                                                        (name, uu___14))) in
-                                          FStar_Compiler_Effect.op_Less_Bar
-                                            FStar_Compiler_List.split uu___12 in
-                                        (match uu___11 with
-                                         | (constrNames, constrs1) ->
-                                             ((let uu___13 =
-                                                 FStar_Options.debug_at_level_no_module
-                                                   (FStar_Options.Other
-                                                      "attrs") in
-                                               if uu___13
-                                               then
-                                                 let uu___14 =
-                                                   FStar_Ident.string_of_lid
-                                                     tname in
-                                                 let uu___15 =
-                                                   let uu___16 =
-                                                     FStar_Compiler_List.map
-                                                       FStar_Syntax_Print.term_to_string
-                                                       val_attrs in
-                                                   FStar_Compiler_String.concat
-                                                     ", " uu___16 in
-                                                 let uu___16 =
-                                                   let uu___17 =
-                                                     FStar_Compiler_List.map
-                                                       FStar_Syntax_Print.term_to_string
-                                                       d_attrs in
-                                                   FStar_Compiler_String.concat
-                                                     ", " uu___17 in
-                                                 FStar_Compiler_Util.print3
-                                                   "Adding attributes to type %s: val_attrs=[@@%s] attrs=[@@%s]\n"
-                                                   uu___14 uu___15 uu___16
-                                               else ());
-                                              (let uu___13 =
-                                                 let uu___14 =
-                                                   let uu___15 =
-                                                     FStar_Ident.range_of_lid
-                                                       tname in
-                                                   let uu___16 =
-                                                     FStar_Syntax_Util.deduplicate_terms
-                                                       (FStar_Compiler_List.op_At
-                                                          val_attrs d_attrs) in
-                                                   let uu___17 =
-                                                     FStar_Syntax_DsEnv.opens_and_abbrevs
-                                                       env1 in
-                                                   {
-                                                     FStar_Syntax_Syntax.sigel
-                                                       =
-                                                       (FStar_Syntax_Syntax.Sig_inductive_typ
+                                                              let uu___20 =
+                                                                FStar_Syntax_Util.name_function_binders
+                                                                  t1 in
+                                                              FStar_Syntax_Syntax.mk_Total
+                                                                uu___20 in
+                                                            FStar_Syntax_Util.arrow
+                                                              data_tpars
+                                                              uu___19 in
                                                           {
-                                                            FStar_Syntax_Syntax.lid
-                                                              = tname;
-                                                            FStar_Syntax_Syntax.us
+                                                            FStar_Syntax_Syntax.lid1
+                                                              = name;
+                                                            FStar_Syntax_Syntax.us1
                                                               = univs;
-                                                            FStar_Syntax_Syntax.params
-                                                              = tpars;
-                                                            FStar_Syntax_Syntax.num_uniform_params
-                                                              = num_uniform;
-                                                            FStar_Syntax_Syntax.t
-                                                              = k;
-                                                            FStar_Syntax_Syntax.mutuals
-                                                              = mutuals1;
-                                                            FStar_Syntax_Syntax.ds
-                                                              = constrNames
-                                                          });
-                                                     FStar_Syntax_Syntax.sigrng
-                                                       = uu___15;
-                                                     FStar_Syntax_Syntax.sigquals
-                                                       = tname_quals;
-                                                     FStar_Syntax_Syntax.sigmeta
-                                                       =
-                                                       FStar_Syntax_Syntax.default_sigmeta;
-                                                     FStar_Syntax_Syntax.sigattrs
-                                                       = uu___16;
-                                                     FStar_Syntax_Syntax.sigopens_and_abbrevs
-                                                       = uu___17;
-                                                     FStar_Syntax_Syntax.sigopts
-                                                       =
-                                                       FStar_Pervasives_Native.None
-                                                   } in
-                                                 ([], uu___14) in
-                                               uu___13 :: constrs1))))
-                               | uu___4 ->
-                                   FStar_Compiler_Effect.failwith
-                                     "impossible")) in
+                                                            FStar_Syntax_Syntax.t1
+                                                              = uu___18;
+                                                            FStar_Syntax_Syntax.ty_lid
+                                                              = tname;
+                                                            FStar_Syntax_Syntax.num_ty_params
+                                                              = ntps;
+                                                            FStar_Syntax_Syntax.mutuals1
+                                                              = mutuals1
+                                                          } in
+                                                        FStar_Syntax_Syntax.Sig_datacon
+                                                          uu___17 in
+                                                      let uu___17 =
+                                                        FStar_Ident.range_of_lid
+                                                          name in
+                                                      let uu___18 =
+                                                        let uu___19 =
+                                                          let uu___20 =
+                                                            let uu___21 =
+                                                              FStar_Compiler_List.map
+                                                                (desugar_term
+                                                                   env1)
+                                                                cons_attrs in
+                                                            FStar_Compiler_List.op_At
+                                                              d_attrs uu___21 in
+                                                          FStar_Compiler_List.op_At
+                                                            val_attrs uu___20 in
+                                                        FStar_Syntax_Util.deduplicate_terms
+                                                          uu___19 in
+                                                      let uu___19 =
+                                                        FStar_Syntax_DsEnv.opens_and_abbrevs
+                                                          env1 in
+                                                      {
+                                                        FStar_Syntax_Syntax.sigel
+                                                          = uu___16;
+                                                        FStar_Syntax_Syntax.sigrng
+                                                          = uu___17;
+                                                        FStar_Syntax_Syntax.sigquals
+                                                          = quals2;
+                                                        FStar_Syntax_Syntax.sigmeta
+                                                          =
+                                                          FStar_Syntax_Syntax.default_sigmeta;
+                                                        FStar_Syntax_Syntax.sigattrs
+                                                          = uu___18;
+                                                        FStar_Syntax_Syntax.sigopens_and_abbrevs
+                                                          = uu___19;
+                                                        FStar_Syntax_Syntax.sigopts
+                                                          =
+                                                          FStar_Pervasives_Native.None
+                                                      } in
+                                                    (tps, uu___15) in
+                                                  (name, uu___14)) constrs in
+                                       FStar_Compiler_List.split uu___12 in
+                                     (match uu___11 with
+                                      | (constrNames, constrs1) ->
+                                          ((let uu___13 =
+                                              FStar_Options.debug_at_level_no_module
+                                                (FStar_Options.Other "attrs") in
+                                            if uu___13
+                                            then
+                                              let uu___14 =
+                                                FStar_Ident.string_of_lid
+                                                  tname in
+                                              let uu___15 =
+                                                let uu___16 =
+                                                  FStar_Compiler_List.map
+                                                    FStar_Syntax_Print.term_to_string
+                                                    val_attrs in
+                                                FStar_Compiler_String.concat
+                                                  ", " uu___16 in
+                                              let uu___16 =
+                                                let uu___17 =
+                                                  FStar_Compiler_List.map
+                                                    FStar_Syntax_Print.term_to_string
+                                                    d_attrs in
+                                                FStar_Compiler_String.concat
+                                                  ", " uu___17 in
+                                              FStar_Compiler_Util.print3
+                                                "Adding attributes to type %s: val_attrs=[@@%s] attrs=[@@%s]\n"
+                                                uu___14 uu___15 uu___16
+                                            else ());
+                                           (let uu___13 =
+                                              let uu___14 =
+                                                let uu___15 =
+                                                  FStar_Ident.range_of_lid
+                                                    tname in
+                                                let uu___16 =
+                                                  FStar_Syntax_Util.deduplicate_terms
+                                                    (FStar_Compiler_List.op_At
+                                                       val_attrs d_attrs) in
+                                                let uu___17 =
+                                                  FStar_Syntax_DsEnv.opens_and_abbrevs
+                                                    env1 in
+                                                {
+                                                  FStar_Syntax_Syntax.sigel =
+                                                    (FStar_Syntax_Syntax.Sig_inductive_typ
+                                                       {
+                                                         FStar_Syntax_Syntax.lid
+                                                           = tname;
+                                                         FStar_Syntax_Syntax.us
+                                                           = univs;
+                                                         FStar_Syntax_Syntax.params
+                                                           = tpars;
+                                                         FStar_Syntax_Syntax.num_uniform_params
+                                                           = num_uniform;
+                                                         FStar_Syntax_Syntax.t
+                                                           = k;
+                                                         FStar_Syntax_Syntax.mutuals
+                                                           = mutuals1;
+                                                         FStar_Syntax_Syntax.ds
+                                                           = constrNames
+                                                       });
+                                                  FStar_Syntax_Syntax.sigrng
+                                                    = uu___15;
+                                                  FStar_Syntax_Syntax.sigquals
+                                                    = tname_quals;
+                                                  FStar_Syntax_Syntax.sigmeta
+                                                    =
+                                                    FStar_Syntax_Syntax.default_sigmeta;
+                                                  FStar_Syntax_Syntax.sigattrs
+                                                    = uu___16;
+                                                  FStar_Syntax_Syntax.sigopens_and_abbrevs
+                                                    = uu___17;
+                                                  FStar_Syntax_Syntax.sigopts
+                                                    =
+                                                    FStar_Pervasives_Native.None
+                                                } in
+                                              ([], uu___14) in
+                                            uu___13 :: constrs1))))
+                            | uu___4 ->
+                                FStar_Compiler_Effect.failwith "impossible")
+                         tcs3 in
                      let sigelts =
-                       FStar_Compiler_Effect.op_Bar_Greater tps_sigelts
-                         (FStar_Compiler_List.map
-                            (fun uu___3 ->
-                               match uu___3 with | (uu___4, se) -> se)) in
+                       FStar_Compiler_List.map
+                         (fun uu___3 ->
+                            match uu___3 with | (uu___4, se) -> se)
+                         tps_sigelts in
                      let uu___3 =
                        let uu___4 =
                          FStar_Compiler_List.collect
@@ -7663,88 +7518,74 @@ let rec (desugar_tycon :
                               FStar_Compiler_List.fold_left
                                 FStar_Syntax_DsEnv.push_sigelt env2 abbrevs in
                             let data_ops =
-                              FStar_Compiler_Effect.op_Bar_Greater
-                                tps_sigelts
-                                (FStar_Compiler_List.collect
-                                   (fun uu___5 ->
-                                      match uu___5 with
-                                      | (tps, se) ->
-                                          mk_data_projector_names quals env3
-                                            se)) in
+                              FStar_Compiler_List.collect
+                                (fun uu___5 ->
+                                   match uu___5 with
+                                   | (tps, se) ->
+                                       mk_data_projector_names quals env3 se)
+                                tps_sigelts in
                             let discs =
-                              FStar_Compiler_Effect.op_Bar_Greater sigelts
-                                (FStar_Compiler_List.collect
-                                   (fun se ->
-                                      match se.FStar_Syntax_Syntax.sigel with
-                                      | FStar_Syntax_Syntax.Sig_inductive_typ
-                                          { FStar_Syntax_Syntax.lid = tname;
-                                            FStar_Syntax_Syntax.us = uu___5;
-                                            FStar_Syntax_Syntax.params = tps;
-                                            FStar_Syntax_Syntax.num_uniform_params
-                                              = uu___6;
-                                            FStar_Syntax_Syntax.t = k;
-                                            FStar_Syntax_Syntax.mutuals =
-                                              uu___7;
-                                            FStar_Syntax_Syntax.ds = constrs;_}
-                                          ->
-                                          let quals1 =
-                                            se.FStar_Syntax_Syntax.sigquals in
-                                          let uu___8 =
-                                            FStar_Compiler_Effect.op_Bar_Greater
-                                              constrs
-                                              (FStar_Compiler_List.filter
-                                                 (fun data_lid ->
-                                                    let data_quals =
-                                                      let data_se =
-                                                        let uu___9 =
-                                                          FStar_Compiler_Effect.op_Bar_Greater
-                                                            sigelts
-                                                            (FStar_Compiler_List.find
-                                                               (fun se1 ->
-                                                                  match 
-                                                                    se1.FStar_Syntax_Syntax.sigel
-                                                                  with
-                                                                  | FStar_Syntax_Syntax.Sig_datacon
-                                                                    {
-                                                                    FStar_Syntax_Syntax.lid1
-                                                                    = name;
-                                                                    FStar_Syntax_Syntax.us1
-                                                                    = uu___10;
-                                                                    FStar_Syntax_Syntax.t1
-                                                                    = uu___11;
-                                                                    FStar_Syntax_Syntax.ty_lid
-                                                                    = uu___12;
-                                                                    FStar_Syntax_Syntax.num_ty_params
-                                                                    = uu___13;
-                                                                    FStar_Syntax_Syntax.mutuals1
-                                                                    = uu___14;_}
-                                                                    ->
-                                                                    FStar_Ident.lid_equals
-                                                                    name
-                                                                    data_lid
-                                                                  | uu___10
-                                                                    -> false)) in
-                                                        FStar_Compiler_Effect.op_Bar_Greater
-                                                          uu___9
-                                                          FStar_Compiler_Util.must in
-                                                      data_se.FStar_Syntax_Syntax.sigquals in
-                                                    let uu___9 =
-                                                      FStar_Compiler_Effect.op_Bar_Greater
-                                                        data_quals
-                                                        (FStar_Compiler_List.existsb
-                                                           (fun uu___10 ->
-                                                              match uu___10
-                                                              with
-                                                              | FStar_Syntax_Syntax.RecordConstructor
-                                                                  uu___11 ->
-                                                                  true
-                                                              | uu___11 ->
-                                                                  false)) in
-                                                    Prims.op_Negation uu___9)) in
-                                          mk_data_discriminators quals1 env3
-                                            uu___8
-                                            se.FStar_Syntax_Syntax.sigattrs
-                                      | uu___5 -> [])) in
+                              FStar_Compiler_List.collect
+                                (fun se ->
+                                   match se.FStar_Syntax_Syntax.sigel with
+                                   | FStar_Syntax_Syntax.Sig_inductive_typ
+                                       { FStar_Syntax_Syntax.lid = tname;
+                                         FStar_Syntax_Syntax.us = uu___5;
+                                         FStar_Syntax_Syntax.params = tps;
+                                         FStar_Syntax_Syntax.num_uniform_params
+                                           = uu___6;
+                                         FStar_Syntax_Syntax.t = k;
+                                         FStar_Syntax_Syntax.mutuals = uu___7;
+                                         FStar_Syntax_Syntax.ds = constrs;_}
+                                       ->
+                                       let quals1 =
+                                         se.FStar_Syntax_Syntax.sigquals in
+                                       let uu___8 =
+                                         FStar_Compiler_List.filter
+                                           (fun data_lid ->
+                                              let data_quals =
+                                                let data_se =
+                                                  let uu___9 =
+                                                    FStar_Compiler_List.find
+                                                      (fun se1 ->
+                                                         match se1.FStar_Syntax_Syntax.sigel
+                                                         with
+                                                         | FStar_Syntax_Syntax.Sig_datacon
+                                                             {
+                                                               FStar_Syntax_Syntax.lid1
+                                                                 = name;
+                                                               FStar_Syntax_Syntax.us1
+                                                                 = uu___10;
+                                                               FStar_Syntax_Syntax.t1
+                                                                 = uu___11;
+                                                               FStar_Syntax_Syntax.ty_lid
+                                                                 = uu___12;
+                                                               FStar_Syntax_Syntax.num_ty_params
+                                                                 = uu___13;
+                                                               FStar_Syntax_Syntax.mutuals1
+                                                                 = uu___14;_}
+                                                             ->
+                                                             FStar_Ident.lid_equals
+                                                               name data_lid
+                                                         | uu___10 -> false)
+                                                      sigelts in
+                                                  FStar_Compiler_Util.must
+                                                    uu___9 in
+                                                data_se.FStar_Syntax_Syntax.sigquals in
+                                              let uu___9 =
+                                                FStar_Compiler_List.existsb
+                                                  (fun uu___10 ->
+                                                     match uu___10 with
+                                                     | FStar_Syntax_Syntax.RecordConstructor
+                                                         uu___11 -> true
+                                                     | uu___11 -> false)
+                                                  data_quals in
+                                              Prims.op_Negation uu___9)
+                                           constrs in
+                                       mk_data_discriminators quals1 env3
+                                         uu___8
+                                         se.FStar_Syntax_Syntax.sigattrs
+                                   | uu___5 -> []) sigelts in
                             let ops =
                               FStar_Compiler_List.op_At discs data_ops in
                             let env4 =
@@ -7793,12 +7634,11 @@ let (push_reflect_effect :
       fun effect_name ->
         fun range ->
           let uu___ =
-            FStar_Compiler_Effect.op_Bar_Greater quals
-              (FStar_Compiler_Util.for_some
-                 (fun uu___1 ->
-                    match uu___1 with
-                    | FStar_Syntax_Syntax.Reflectable uu___2 -> true
-                    | uu___2 -> false)) in
+            FStar_Compiler_Util.for_some
+              (fun uu___1 ->
+                 match uu___1 with
+                 | FStar_Syntax_Syntax.Reflectable uu___2 -> true
+                 | uu___2 -> false) quals in
           if uu___
           then
             let monad_env =
@@ -7806,8 +7646,7 @@ let (push_reflect_effect :
               FStar_Syntax_DsEnv.enter_monad_scope env uu___1 in
             let reflect_lid =
               let uu___1 = FStar_Ident.id_of_text "reflect" in
-              FStar_Compiler_Effect.op_Bar_Greater uu___1
-                (FStar_Syntax_DsEnv.qualify monad_env) in
+              FStar_Syntax_DsEnv.qualify monad_env uu___1 in
             let quals1 =
               [FStar_Syntax_Syntax.Assumption;
               FStar_Syntax_Syntax.Reflectable effect_name] in
@@ -8035,142 +7874,134 @@ let rec (desugar_effect :
                           match uu___2 with
                           | (mandatory_members_decls, actions) ->
                               let uu___3 =
-                                FStar_Compiler_Effect.op_Bar_Greater
-                                  mandatory_members_decls
-                                  (FStar_Compiler_List.fold_left
-                                     (fun uu___4 ->
-                                        fun decl ->
-                                          match uu___4 with
-                                          | (env2, out) ->
-                                              let uu___5 =
-                                                desugar_decl env2 decl in
-                                              (match uu___5 with
-                                               | (env3, ses) ->
-                                                   let uu___6 =
-                                                     let uu___7 =
-                                                       FStar_Compiler_List.hd
-                                                         ses in
-                                                     uu___7 :: out in
-                                                   (env3, uu___6)))
-                                     (env1, [])) in
+                                FStar_Compiler_List.fold_left
+                                  (fun uu___4 ->
+                                     fun decl ->
+                                       match uu___4 with
+                                       | (env2, out) ->
+                                           let uu___5 =
+                                             desugar_decl env2 decl in
+                                           (match uu___5 with
+                                            | (env3, ses) ->
+                                                let uu___6 =
+                                                  let uu___7 =
+                                                    FStar_Compiler_List.hd
+                                                      ses in
+                                                  uu___7 :: out in
+                                                (env3, uu___6))) (env1, [])
+                                  mandatory_members_decls in
                               (match uu___3 with
                                | (env2, decls) ->
                                    let binders1 =
                                      FStar_Syntax_Subst.close_binders binders in
                                    let actions1 =
-                                     FStar_Compiler_Effect.op_Bar_Greater
-                                       actions
-                                       (FStar_Compiler_List.map
-                                          (fun d1 ->
-                                             match d1.FStar_Parser_AST.d with
-                                             | FStar_Parser_AST.Tycon
-                                                 (uu___4, uu___5,
-                                                  (FStar_Parser_AST.TyconAbbrev
-                                                  (name, action_params,
-                                                   uu___6,
+                                     FStar_Compiler_List.map
+                                       (fun d1 ->
+                                          match d1.FStar_Parser_AST.d with
+                                          | FStar_Parser_AST.Tycon
+                                              (uu___4, uu___5,
+                                               (FStar_Parser_AST.TyconAbbrev
+                                               (name, action_params, uu___6,
+                                                {
+                                                  FStar_Parser_AST.tm =
+                                                    FStar_Parser_AST.Construct
+                                                    (uu___7,
+                                                     (def, uu___8)::(cps_type,
+                                                                    uu___9)::[]);
+                                                  FStar_Parser_AST.range =
+                                                    uu___10;
+                                                  FStar_Parser_AST.level =
+                                                    uu___11;_}))::[])
+                                              when Prims.op_Negation for_free
+                                              ->
+                                              let uu___12 =
+                                                desugar_binders env2
+                                                  action_params in
+                                              (match uu___12 with
+                                               | (env3, action_params1) ->
+                                                   let action_params2 =
+                                                     FStar_Syntax_Subst.close_binders
+                                                       action_params1 in
+                                                   let uu___13 =
+                                                     FStar_Syntax_DsEnv.qualify
+                                                       env3 name in
+                                                   let uu___14 =
+                                                     let uu___15 =
+                                                       desugar_term env3 def in
+                                                     FStar_Syntax_Subst.close
+                                                       (FStar_Compiler_List.op_At
+                                                          binders1
+                                                          action_params2)
+                                                       uu___15 in
+                                                   let uu___15 =
+                                                     let uu___16 =
+                                                       desugar_typ env3
+                                                         cps_type in
+                                                     FStar_Syntax_Subst.close
+                                                       (FStar_Compiler_List.op_At
+                                                          binders1
+                                                          action_params2)
+                                                       uu___16 in
                                                    {
-                                                     FStar_Parser_AST.tm =
-                                                       FStar_Parser_AST.Construct
-                                                       (uu___7,
-                                                        (def, uu___8)::
-                                                        (cps_type, uu___9)::[]);
-                                                     FStar_Parser_AST.range =
-                                                       uu___10;
-                                                     FStar_Parser_AST.level =
-                                                       uu___11;_}))::[])
-                                                 when
-                                                 Prims.op_Negation for_free
-                                                 ->
-                                                 let uu___12 =
-                                                   desugar_binders env2
-                                                     action_params in
-                                                 (match uu___12 with
-                                                  | (env3, action_params1) ->
-                                                      let action_params2 =
-                                                        FStar_Syntax_Subst.close_binders
-                                                          action_params1 in
-                                                      let uu___13 =
-                                                        FStar_Syntax_DsEnv.qualify
-                                                          env3 name in
-                                                      let uu___14 =
-                                                        let uu___15 =
-                                                          desugar_term env3
-                                                            def in
-                                                        FStar_Syntax_Subst.close
-                                                          (FStar_Compiler_List.op_At
-                                                             binders1
-                                                             action_params2)
-                                                          uu___15 in
-                                                      let uu___15 =
-                                                        let uu___16 =
-                                                          desugar_typ env3
-                                                            cps_type in
-                                                        FStar_Syntax_Subst.close
-                                                          (FStar_Compiler_List.op_At
-                                                             binders1
-                                                             action_params2)
-                                                          uu___16 in
-                                                      {
-                                                        FStar_Syntax_Syntax.action_name
-                                                          = uu___13;
-                                                        FStar_Syntax_Syntax.action_unqualified_name
-                                                          = name;
-                                                        FStar_Syntax_Syntax.action_univs
-                                                          = [];
-                                                        FStar_Syntax_Syntax.action_params
-                                                          = action_params2;
-                                                        FStar_Syntax_Syntax.action_defn
-                                                          = uu___14;
-                                                        FStar_Syntax_Syntax.action_typ
-                                                          = uu___15
-                                                      })
-                                             | FStar_Parser_AST.Tycon
-                                                 (uu___4, uu___5,
-                                                  (FStar_Parser_AST.TyconAbbrev
-                                                  (name, action_params,
-                                                   uu___6, defn))::[])
-                                                 when for_free || is_layered
-                                                 ->
-                                                 let uu___7 =
-                                                   desugar_binders env2
-                                                     action_params in
-                                                 (match uu___7 with
-                                                  | (env3, action_params1) ->
-                                                      let action_params2 =
-                                                        FStar_Syntax_Subst.close_binders
-                                                          action_params1 in
-                                                      let uu___8 =
-                                                        FStar_Syntax_DsEnv.qualify
-                                                          env3 name in
-                                                      let uu___9 =
-                                                        let uu___10 =
-                                                          desugar_term env3
-                                                            defn in
-                                                        FStar_Syntax_Subst.close
-                                                          (FStar_Compiler_List.op_At
-                                                             binders1
-                                                             action_params2)
-                                                          uu___10 in
-                                                      {
-                                                        FStar_Syntax_Syntax.action_name
-                                                          = uu___8;
-                                                        FStar_Syntax_Syntax.action_unqualified_name
-                                                          = name;
-                                                        FStar_Syntax_Syntax.action_univs
-                                                          = [];
-                                                        FStar_Syntax_Syntax.action_params
-                                                          = action_params2;
-                                                        FStar_Syntax_Syntax.action_defn
-                                                          = uu___9;
-                                                        FStar_Syntax_Syntax.action_typ
-                                                          =
-                                                          FStar_Syntax_Syntax.tun
-                                                      })
-                                             | uu___4 ->
-                                                 FStar_Errors.raise_error
-                                                   (FStar_Errors_Codes.Fatal_MalformedActionDeclaration,
-                                                     "Malformed action declaration; if this is an \"effect for free\", just provide the direct-style declaration. If this is not an \"effect for free\", please provide a pair of the definition and its cps-type with arrows inserted in the right place (see examples).")
-                                                   d1.FStar_Parser_AST.drange)) in
+                                                     FStar_Syntax_Syntax.action_name
+                                                       = uu___13;
+                                                     FStar_Syntax_Syntax.action_unqualified_name
+                                                       = name;
+                                                     FStar_Syntax_Syntax.action_univs
+                                                       = [];
+                                                     FStar_Syntax_Syntax.action_params
+                                                       = action_params2;
+                                                     FStar_Syntax_Syntax.action_defn
+                                                       = uu___14;
+                                                     FStar_Syntax_Syntax.action_typ
+                                                       = uu___15
+                                                   })
+                                          | FStar_Parser_AST.Tycon
+                                              (uu___4, uu___5,
+                                               (FStar_Parser_AST.TyconAbbrev
+                                               (name, action_params, uu___6,
+                                                defn))::[])
+                                              when for_free || is_layered ->
+                                              let uu___7 =
+                                                desugar_binders env2
+                                                  action_params in
+                                              (match uu___7 with
+                                               | (env3, action_params1) ->
+                                                   let action_params2 =
+                                                     FStar_Syntax_Subst.close_binders
+                                                       action_params1 in
+                                                   let uu___8 =
+                                                     FStar_Syntax_DsEnv.qualify
+                                                       env3 name in
+                                                   let uu___9 =
+                                                     let uu___10 =
+                                                       desugar_term env3 defn in
+                                                     FStar_Syntax_Subst.close
+                                                       (FStar_Compiler_List.op_At
+                                                          binders1
+                                                          action_params2)
+                                                       uu___10 in
+                                                   {
+                                                     FStar_Syntax_Syntax.action_name
+                                                       = uu___8;
+                                                     FStar_Syntax_Syntax.action_unqualified_name
+                                                       = name;
+                                                     FStar_Syntax_Syntax.action_univs
+                                                       = [];
+                                                     FStar_Syntax_Syntax.action_params
+                                                       = action_params2;
+                                                     FStar_Syntax_Syntax.action_defn
+                                                       = uu___9;
+                                                     FStar_Syntax_Syntax.action_typ
+                                                       =
+                                                       FStar_Syntax_Syntax.tun
+                                                   })
+                                          | uu___4 ->
+                                              FStar_Errors.raise_error
+                                                (FStar_Errors_Codes.Fatal_MalformedActionDeclaration,
+                                                  "Malformed action declaration; if this is an \"effect for free\", just provide the direct-style declaration. If this is not an \"effect for free\", please provide a pair of the definition and its cps-type with arrows inserted in the right place (see examples).")
+                                                d1.FStar_Parser_AST.drange)
+                                       actions in
                                    let eff_t1 =
                                      FStar_Syntax_Subst.close binders1 eff_t in
                                    let lookup s =
@@ -8184,8 +8015,7 @@ let rec (desugar_effect :
                                          FStar_Syntax_DsEnv.fail_or env2
                                            (FStar_Syntax_DsEnv.try_lookup_definition
                                               env2) l in
-                                       FStar_Compiler_Effect.op_Less_Bar
-                                         (FStar_Syntax_Subst.close binders1)
+                                       FStar_Syntax_Subst.close binders1
                                          uu___5 in
                                      ([], uu___4) in
                                    let mname =
@@ -8386,15 +8216,13 @@ let rec (desugar_effect :
                                                   let uu___11 =
                                                     let uu___12 =
                                                       lookup "bind" in
-                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                      uu___12 to_comb in
+                                                    to_comb uu___12 in
                                                   let uu___12 =
                                                     if has_subcomp
                                                     then
                                                       let uu___13 =
                                                         lookup "subcomp" in
-                                                      FStar_Compiler_Effect.op_Bar_Greater
-                                                        uu___13 to_comb
+                                                      to_comb uu___13
                                                     else
                                                       (dummy_tscheme,
                                                         dummy_tscheme,
@@ -8404,8 +8232,7 @@ let rec (desugar_effect :
                                                     then
                                                       let uu___14 =
                                                         lookup "if_then_else" in
-                                                      FStar_Compiler_Effect.op_Bar_Greater
-                                                        uu___14 to_comb
+                                                      to_comb uu___14
                                                     else
                                                       (dummy_tscheme,
                                                         dummy_tscheme,
@@ -8582,17 +8409,15 @@ let rec (desugar_effect :
                                           FStar_Syntax_DsEnv.push_sigelt env0
                                             se in
                                         let env4 =
-                                          FStar_Compiler_Effect.op_Bar_Greater
-                                            actions1
-                                            (FStar_Compiler_List.fold_left
-                                               (fun env5 ->
-                                                  fun a ->
-                                                    let uu___5 =
-                                                      FStar_Syntax_Util.action_as_lb
-                                                        mname a
-                                                        (a.FStar_Syntax_Syntax.action_defn).FStar_Syntax_Syntax.pos in
-                                                    FStar_Syntax_DsEnv.push_sigelt
-                                                      env5 uu___5) env3) in
+                                          FStar_Compiler_List.fold_left
+                                            (fun env5 ->
+                                               fun a ->
+                                                 let uu___5 =
+                                                   FStar_Syntax_Util.action_as_lb
+                                                     mname a
+                                                     (a.FStar_Syntax_Syntax.action_defn).FStar_Syntax_Syntax.pos in
+                                                 FStar_Syntax_DsEnv.push_sigelt
+                                                   env5 uu___5) env3 actions1 in
                                         let env5 =
                                           push_reflect_effect env4 qualifiers
                                             mname d.FStar_Parser_AST.drange in
@@ -8799,37 +8624,31 @@ and (desugar_redefine_effect :
                                  let env3 =
                                    FStar_Syntax_DsEnv.push_sigelt env0 se in
                                  let env4 =
-                                   FStar_Compiler_Effect.op_Bar_Greater
-                                     ed1.FStar_Syntax_Syntax.actions
-                                     (FStar_Compiler_List.fold_left
-                                        (fun env5 ->
-                                           fun a ->
-                                             let uu___5 =
-                                               FStar_Syntax_Util.action_as_lb
-                                                 mname a
-                                                 (a.FStar_Syntax_Syntax.action_defn).FStar_Syntax_Syntax.pos in
-                                             FStar_Syntax_DsEnv.push_sigelt
-                                               env5 uu___5) env3) in
+                                   FStar_Compiler_List.fold_left
+                                     (fun env5 ->
+                                        fun a ->
+                                          let uu___5 =
+                                            FStar_Syntax_Util.action_as_lb
+                                              mname a
+                                              (a.FStar_Syntax_Syntax.action_defn).FStar_Syntax_Syntax.pos in
+                                          FStar_Syntax_DsEnv.push_sigelt env5
+                                            uu___5) env3
+                                     ed1.FStar_Syntax_Syntax.actions in
                                  let env5 =
-                                   let uu___5 =
-                                     FStar_Compiler_Effect.op_Bar_Greater
-                                       quals
-                                       (FStar_Compiler_List.contains
-                                          FStar_Parser_AST.Reflectable) in
-                                   if uu___5
+                                   if
+                                     FStar_Compiler_List.contains
+                                       FStar_Parser_AST.Reflectable quals
                                    then
                                      let reflect_lid =
-                                       let uu___6 =
+                                       let uu___5 =
                                          FStar_Ident.id_of_text "reflect" in
-                                       FStar_Compiler_Effect.op_Bar_Greater
-                                         uu___6
-                                         (FStar_Syntax_DsEnv.qualify
-                                            monad_env) in
+                                       FStar_Syntax_DsEnv.qualify monad_env
+                                         uu___5 in
                                      let quals1 =
                                        [FStar_Syntax_Syntax.Assumption;
                                        FStar_Syntax_Syntax.Reflectable mname] in
                                      let refl_decl =
-                                       let uu___6 =
+                                       let uu___5 =
                                          FStar_Syntax_DsEnv.opens_and_abbrevs
                                            env4 in
                                        {
@@ -8850,7 +8669,7 @@ and (desugar_redefine_effect :
                                            FStar_Syntax_Syntax.default_sigmeta;
                                          FStar_Syntax_Syntax.sigattrs = [];
                                          FStar_Syntax_Syntax.sigopens_and_abbrevs
-                                           = uu___6;
+                                           = uu___5;
                                          FStar_Syntax_Syntax.sigopts =
                                            FStar_Pervasives_Native.None
                                        } in
@@ -8871,8 +8690,7 @@ and (desugar_decl_maybe_fail_attr :
              FStar_Compiler_Option.isNone uu___) ats in
       let env0 =
         let uu___ = FStar_Syntax_DsEnv.snapshot env in
-        FStar_Compiler_Effect.op_Bar_Greater uu___
-          FStar_Pervasives_Native.snd in
+        FStar_Pervasives_Native.snd uu___ in
       let uu___ =
         let attrs =
           let uu___1 =
@@ -8989,9 +8807,7 @@ and (desugar_decl :
       let uu___ = desugar_decl_maybe_fail_attr env d in
       match uu___ with
       | (env1, ses) ->
-          let uu___1 =
-            FStar_Compiler_Effect.op_Bar_Greater ses
-              (FStar_Compiler_List.map generalize_annotated_univs) in
+          let uu___1 = FStar_Compiler_List.map generalize_annotated_univs ses in
           (env1, uu___1)
 and (desugar_decl_core :
   FStar_Syntax_DsEnv.env ->
@@ -9401,9 +9217,7 @@ and (desugar_decl_core :
                | (ds_lets, aq) ->
                    (check_no_aq aq;
                     (let uu___2 =
-                       let uu___3 =
-                         FStar_Compiler_Effect.op_Less_Bar
-                           FStar_Syntax_Subst.compress ds_lets in
+                       let uu___3 = FStar_Syntax_Subst.compress ds_lets in
                        uu___3.FStar_Syntax_Syntax.n in
                      match uu___2 with
                      | FStar_Syntax_Syntax.Tm_let
@@ -9411,12 +9225,11 @@ and (desugar_decl_core :
                            FStar_Syntax_Syntax.body1 = uu___3;_}
                          ->
                          let fvs =
-                           FStar_Compiler_Effect.op_Bar_Greater
-                             (FStar_Pervasives_Native.snd lbs)
-                             (FStar_Compiler_List.map
-                                (fun lb ->
-                                   FStar_Compiler_Util.right
-                                     lb.FStar_Syntax_Syntax.lbname)) in
+                           FStar_Compiler_List.map
+                             (fun lb ->
+                                FStar_Compiler_Util.right
+                                  lb.FStar_Syntax_Syntax.lbname)
+                             (FStar_Pervasives_Native.snd lbs) in
                          let uu___4 =
                            FStar_Compiler_List.fold_right
                              (fun fv ->
@@ -9440,32 +9253,30 @@ and (desugar_decl_core :
                                 match uu___5 with
                                 | (isrec1, lbs0) ->
                                     let lbs01 =
-                                      FStar_Compiler_Effect.op_Bar_Greater
-                                        lbs0
-                                        (FStar_Compiler_List.map
-                                           (fun lb ->
-                                              let uu___6 =
-                                                FStar_Syntax_Util.deduplicate_terms
+                                      FStar_Compiler_List.map
+                                        (fun lb ->
+                                           let uu___6 =
+                                             FStar_Syntax_Util.deduplicate_terms
+                                               (FStar_Compiler_List.op_At
+                                                  lb.FStar_Syntax_Syntax.lbattrs
                                                   (FStar_Compiler_List.op_At
-                                                     lb.FStar_Syntax_Syntax.lbattrs
-                                                     (FStar_Compiler_List.op_At
-                                                        val_attrs top_attrs)) in
-                                              {
-                                                FStar_Syntax_Syntax.lbname =
-                                                  (lb.FStar_Syntax_Syntax.lbname);
-                                                FStar_Syntax_Syntax.lbunivs =
-                                                  (lb.FStar_Syntax_Syntax.lbunivs);
-                                                FStar_Syntax_Syntax.lbtyp =
-                                                  (lb.FStar_Syntax_Syntax.lbtyp);
-                                                FStar_Syntax_Syntax.lbeff =
-                                                  (lb.FStar_Syntax_Syntax.lbeff);
-                                                FStar_Syntax_Syntax.lbdef =
-                                                  (lb.FStar_Syntax_Syntax.lbdef);
-                                                FStar_Syntax_Syntax.lbattrs =
-                                                  uu___6;
-                                                FStar_Syntax_Syntax.lbpos =
-                                                  (lb.FStar_Syntax_Syntax.lbpos)
-                                              })) in
+                                                     val_attrs top_attrs)) in
+                                           {
+                                             FStar_Syntax_Syntax.lbname =
+                                               (lb.FStar_Syntax_Syntax.lbname);
+                                             FStar_Syntax_Syntax.lbunivs =
+                                               (lb.FStar_Syntax_Syntax.lbunivs);
+                                             FStar_Syntax_Syntax.lbtyp =
+                                               (lb.FStar_Syntax_Syntax.lbtyp);
+                                             FStar_Syntax_Syntax.lbeff =
+                                               (lb.FStar_Syntax_Syntax.lbeff);
+                                             FStar_Syntax_Syntax.lbdef =
+                                               (lb.FStar_Syntax_Syntax.lbdef);
+                                             FStar_Syntax_Syntax.lbattrs =
+                                               uu___6;
+                                             FStar_Syntax_Syntax.lbpos =
+                                               (lb.FStar_Syntax_Syntax.lbpos)
+                                           }) lbs0 in
                                     (isrec1, lbs01) in
                               let quals1 =
                                 match quals with
@@ -9476,21 +9287,20 @@ and (desugar_decl_core :
                                 | uu___5 -> val_quals in
                               let quals2 =
                                 let uu___5 =
-                                  FStar_Compiler_Effect.op_Bar_Greater lets1
-                                    (FStar_Compiler_Util.for_some
-                                       (fun uu___6 ->
-                                          match uu___6 with
-                                          | (uu___7, (uu___8, t)) ->
-                                              t.FStar_Parser_AST.level =
-                                                FStar_Parser_AST.Formula)) in
+                                  FStar_Compiler_Util.for_some
+                                    (fun uu___6 ->
+                                       match uu___6 with
+                                       | (uu___7, (uu___8, t)) ->
+                                           t.FStar_Parser_AST.level =
+                                             FStar_Parser_AST.Formula) lets1 in
                                 if uu___5
                                 then FStar_Syntax_Syntax.Logic :: quals1
                                 else quals1 in
                               let names =
-                                FStar_Compiler_Effect.op_Bar_Greater fvs
-                                  (FStar_Compiler_List.map
-                                     (fun fv ->
-                                        (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v)) in
+                                FStar_Compiler_List.map
+                                  (fun fv ->
+                                     (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v)
+                                  fvs in
                               let s =
                                 let uu___5 =
                                   FStar_Syntax_Util.deduplicate_terms
@@ -9667,9 +9477,8 @@ and (desugar_decl_core :
                            FStar_Pervasives_Native.None in
                    let bvs =
                      let uu___2 = gather_pattern_bound_vars pat in
-                     FStar_Compiler_Effect.op_Bar_Greater uu___2
-                       (FStar_Compiler_Set.elems
-                          FStar_Syntax_Syntax.ord_ident) in
+                     FStar_Compiler_Set.elems FStar_Syntax_Syntax.ord_ident
+                       uu___2 in
                    let uu___2 =
                      (FStar_Compiler_List.isEmpty bvs) &&
                        (let uu___3 = is_var_pattern pat in
@@ -9752,8 +9561,7 @@ and (desugar_decl_core :
                       FStar_Syntax_DsEnv.fail_or env
                         (FStar_Syntax_DsEnv.try_lookup_lid env)
                         FStar_Parser_Const.exn_lid in
-                    FStar_Compiler_Effect.op_Less_Bar
-                      FStar_Syntax_Syntax.mk_Total uu___2 in
+                    FStar_Syntax_Syntax.mk_Total uu___2 in
                   FStar_Syntax_Util.arrow uu___ uu___1 in
             let l = FStar_Syntax_DsEnv.qualify env id in
             let qual = [FStar_Syntax_Syntax.ExceptionConstructor] in
@@ -10329,8 +10137,7 @@ let (add_modul_to_env_core :
                             let uu___3 =
                               FStar_Syntax_Subst.subst_binders opening
                                 action.FStar_Syntax_Syntax.action_params in
-                            FStar_Compiler_Effect.op_Less_Bar erase_binders
-                              uu___3 in
+                            erase_binders uu___3 in
                           let t =
                             FStar_Syntax_Syntax.mk
                               (FStar_Syntax_Syntax.Tm_abs

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Cfg.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Cfg.ml
@@ -382,141 +382,107 @@ let (steps_to_string : fsteps -> Prims.string) =
           FStar_Compiler_String.op_Hat "Some (" uu___ in
     let b = FStar_Compiler_Util.string_of_bool in
     let uu___ =
-      let uu___1 = FStar_Compiler_Effect.op_Bar_Greater f.beta b in
+      let uu___1 = b f.beta in
       let uu___2 =
-        let uu___3 = FStar_Compiler_Effect.op_Bar_Greater f.iota b in
+        let uu___3 = b f.iota in
         let uu___4 =
-          let uu___5 = FStar_Compiler_Effect.op_Bar_Greater f.zeta b in
+          let uu___5 = b f.zeta in
           let uu___6 =
-            let uu___7 = FStar_Compiler_Effect.op_Bar_Greater f.zeta_full b in
+            let uu___7 = b f.zeta_full in
             let uu___8 =
-              let uu___9 = FStar_Compiler_Effect.op_Bar_Greater f.weak b in
+              let uu___9 = b f.weak in
               let uu___10 =
-                let uu___11 = FStar_Compiler_Effect.op_Bar_Greater f.hnf b in
+                let uu___11 = b f.hnf in
                 let uu___12 =
-                  let uu___13 =
-                    FStar_Compiler_Effect.op_Bar_Greater f.primops b in
+                  let uu___13 = b f.primops in
                   let uu___14 =
-                    let uu___15 =
-                      FStar_Compiler_Effect.op_Bar_Greater
-                        f.do_not_unfold_pure_lets b in
+                    let uu___15 = b f.do_not_unfold_pure_lets in
                     let uu___16 =
                       let uu___17 =
-                        FStar_Compiler_Effect.op_Bar_Greater f.unfold_until
-                          (format_opt
-                             (FStar_Class_Show.show
-                                FStar_Syntax_Syntax.showable_delta_depth)) in
+                        format_opt
+                          (FStar_Class_Show.show
+                             FStar_Syntax_Syntax.showable_delta_depth)
+                          f.unfold_until in
                       let uu___18 =
                         let uu___19 =
-                          FStar_Compiler_Effect.op_Bar_Greater f.unfold_only
-                            (format_opt
-                               (fun x ->
-                                  let uu___20 =
-                                    FStar_Compiler_List.map
-                                      FStar_Ident.string_of_lid x in
-                                  FStar_Compiler_Effect.op_Bar_Greater
-                                    uu___20
-                                    (FStar_Compiler_String.concat ", "))) in
+                          format_opt
+                            (fun x ->
+                               let uu___20 =
+                                 FStar_Compiler_List.map
+                                   FStar_Ident.string_of_lid x in
+                               FStar_Compiler_String.concat ", " uu___20)
+                            f.unfold_only in
                         let uu___20 =
                           let uu___21 =
-                            FStar_Compiler_Effect.op_Bar_Greater
-                              f.unfold_fully
-                              (format_opt
-                                 (fun x ->
-                                    let uu___22 =
-                                      FStar_Compiler_List.map
-                                        FStar_Ident.string_of_lid x in
-                                    FStar_Compiler_Effect.op_Bar_Greater
-                                      uu___22
-                                      (FStar_Compiler_String.concat ", "))) in
+                            format_opt
+                              (fun x ->
+                                 let uu___22 =
+                                   FStar_Compiler_List.map
+                                     FStar_Ident.string_of_lid x in
+                                 FStar_Compiler_String.concat ", " uu___22)
+                              f.unfold_fully in
                           let uu___22 =
                             let uu___23 =
-                              FStar_Compiler_Effect.op_Bar_Greater
-                                f.unfold_attr
-                                (format_opt
-                                   (fun x ->
-                                      let uu___24 =
-                                        FStar_Compiler_List.map
-                                          FStar_Ident.string_of_lid x in
-                                      FStar_Compiler_Effect.op_Bar_Greater
-                                        uu___24
-                                        (FStar_Compiler_String.concat ", "))) in
+                              format_opt
+                                (fun x ->
+                                   let uu___24 =
+                                     FStar_Compiler_List.map
+                                       FStar_Ident.string_of_lid x in
+                                   FStar_Compiler_String.concat ", " uu___24)
+                                f.unfold_attr in
                             let uu___24 =
                               let uu___25 =
-                                FStar_Compiler_Effect.op_Bar_Greater
-                                  f.unfold_qual
-                                  (format_opt
-                                     (FStar_Compiler_String.concat ", ")) in
+                                format_opt
+                                  (FStar_Compiler_String.concat ", ")
+                                  f.unfold_qual in
                               let uu___26 =
                                 let uu___27 =
-                                  FStar_Compiler_Effect.op_Bar_Greater
-                                    f.unfold_namespace
-                                    (format_opt
-                                       (FStar_Compiler_String.concat ", ")) in
+                                  format_opt
+                                    (FStar_Compiler_String.concat ", ")
+                                    f.unfold_namespace in
                                 let uu___28 =
-                                  let uu___29 =
-                                    FStar_Compiler_Effect.op_Bar_Greater
-                                      f.unfold_tac b in
+                                  let uu___29 = b f.unfold_tac in
                                   let uu___30 =
                                     let uu___31 =
-                                      FStar_Compiler_Effect.op_Bar_Greater
-                                        f.pure_subterms_within_computations b in
+                                      b f.pure_subterms_within_computations in
                                     let uu___32 =
-                                      let uu___33 =
-                                        FStar_Compiler_Effect.op_Bar_Greater
-                                          f.simplify b in
+                                      let uu___33 = b f.simplify in
                                       let uu___34 =
-                                        let uu___35 =
-                                          FStar_Compiler_Effect.op_Bar_Greater
-                                            f.erase_universes b in
+                                        let uu___35 = b f.erase_universes in
                                         let uu___36 =
                                           let uu___37 =
-                                            FStar_Compiler_Effect.op_Bar_Greater
-                                              f.allow_unbound_universes b in
+                                            b f.allow_unbound_universes in
                                           let uu___38 =
-                                            let uu___39 =
-                                              FStar_Compiler_Effect.op_Bar_Greater
-                                                f.reify_ b in
+                                            let uu___39 = b f.reify_ in
                                             let uu___40 =
                                               let uu___41 =
-                                                FStar_Compiler_Effect.op_Bar_Greater
-                                                  f.compress_uvars b in
+                                                b f.compress_uvars in
                                               let uu___42 =
                                                 let uu___43 =
-                                                  FStar_Compiler_Effect.op_Bar_Greater
-                                                    f.no_full_norm b in
+                                                  b f.no_full_norm in
                                                 let uu___44 =
                                                   let uu___45 =
-                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                      f.check_no_uvars b in
+                                                    b f.check_no_uvars in
                                                   let uu___46 =
-                                                    let uu___47 =
-                                                      FStar_Compiler_Effect.op_Bar_Greater
-                                                        f.unmeta b in
+                                                    let uu___47 = b f.unmeta in
                                                     let uu___48 =
                                                       let uu___49 =
-                                                        FStar_Compiler_Effect.op_Bar_Greater
-                                                          f.unascribe b in
+                                                        b f.unascribe in
                                                       let uu___50 =
                                                         let uu___51 =
-                                                          FStar_Compiler_Effect.op_Bar_Greater
-                                                            f.in_full_norm_request
-                                                            b in
+                                                          b
+                                                            f.in_full_norm_request in
                                                         let uu___52 =
                                                           let uu___53 =
-                                                            FStar_Compiler_Effect.op_Bar_Greater
-                                                              f.weakly_reduce_scrutinee
-                                                              b in
+                                                            b
+                                                              f.weakly_reduce_scrutinee in
                                                           let uu___54 =
                                                             let uu___55 =
-                                                              FStar_Compiler_Effect.op_Bar_Greater
-                                                                f.for_extraction
-                                                                b in
+                                                              b
+                                                                f.for_extraction in
                                                             let uu___56 =
                                                               let uu___57 =
-                                                                FStar_Compiler_Effect.op_Bar_Greater
-                                                                  f.unrefine
-                                                                  b in
+                                                                b f.unrefine in
                                                               [uu___57] in
                                                             uu___55 ::
                                                               uu___56 in
@@ -2063,31 +2029,26 @@ let (config' :
       fun e ->
         let d =
           let uu___ =
-            FStar_Compiler_Effect.op_Bar_Greater s
-              (FStar_Compiler_List.collect
-                 (fun uu___1 ->
-                    match uu___1 with
-                    | FStar_TypeChecker_Env.UnfoldUntil k ->
-                        [FStar_TypeChecker_Env.Unfold k]
-                    | FStar_TypeChecker_Env.Eager_unfolding ->
-                        [FStar_TypeChecker_Env.Eager_unfolding_only]
-                    | FStar_TypeChecker_Env.UnfoldQual l when
-                        FStar_Compiler_List.contains "unfold" l ->
-                        [FStar_TypeChecker_Env.Eager_unfolding_only]
-                    | FStar_TypeChecker_Env.Inlining ->
-                        [FStar_TypeChecker_Env.InliningDelta]
-                    | FStar_TypeChecker_Env.UnfoldQual l when
-                        FStar_Compiler_List.contains "inline_for_extraction"
-                          l
-                        -> [FStar_TypeChecker_Env.InliningDelta]
-                    | uu___2 -> [])) in
-          FStar_Compiler_Effect.op_Bar_Greater uu___
-            FStar_Compiler_List.unique in
+            FStar_Compiler_List.collect
+              (fun uu___1 ->
+                 match uu___1 with
+                 | FStar_TypeChecker_Env.UnfoldUntil k ->
+                     [FStar_TypeChecker_Env.Unfold k]
+                 | FStar_TypeChecker_Env.Eager_unfolding ->
+                     [FStar_TypeChecker_Env.Eager_unfolding_only]
+                 | FStar_TypeChecker_Env.UnfoldQual l when
+                     FStar_Compiler_List.contains "unfold" l ->
+                     [FStar_TypeChecker_Env.Eager_unfolding_only]
+                 | FStar_TypeChecker_Env.Inlining ->
+                     [FStar_TypeChecker_Env.InliningDelta]
+                 | FStar_TypeChecker_Env.UnfoldQual l when
+                     FStar_Compiler_List.contains "inline_for_extraction" l
+                     -> [FStar_TypeChecker_Env.InliningDelta]
+                 | uu___2 -> []) s in
+          FStar_Compiler_List.unique uu___ in
         let d1 =
           match d with | [] -> [FStar_TypeChecker_Env.NoDelta] | uu___ -> d in
-        let steps =
-          let uu___ = to_fsteps s in
-          FStar_Compiler_Effect.op_Bar_Greater uu___ add_nbe in
+        let steps = let uu___ = to_fsteps s in add_nbe uu___ in
         let psteps1 = let uu___ = cached_steps () in add_steps uu___ psteps in
         let dbg_flag =
           FStar_Compiler_List.contains FStar_TypeChecker_Env.NormDebug s in

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Common.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Common.ml
@@ -398,10 +398,8 @@ let (id_info__insert :
                    FStar_Compiler_Util.pimap_find_default rows row [] in
                  let uu___1 =
                    let uu___2 = insert_col_info col info1 cols in
-                   FStar_Compiler_Effect.op_Bar_Greater uu___2
-                     (FStar_Compiler_Util.pimap_add rows row) in
-                 FStar_Compiler_Effect.op_Bar_Greater uu___1
-                   (FStar_Compiler_Util.psmap_add db fn))
+                   FStar_Compiler_Util.pimap_add rows row uu___2 in
+                 FStar_Compiler_Util.psmap_add db fn uu___1)
 let (id_info_insert :
   id_info_table ->
     (FStar_Syntax_Syntax.bv, FStar_Syntax_Syntax.fv) FStar_Pervasives.either
@@ -801,9 +799,7 @@ let (lcomp_to_string : lcomp -> Prims.string) =
     if uu___
     then
       let uu___1 =
-        let uu___2 = FStar_Compiler_Effect.op_Bar_Greater lc lcomp_comp in
-        FStar_Compiler_Effect.op_Bar_Greater uu___2
-          FStar_Pervasives_Native.fst in
+        let uu___2 = lcomp_comp lc in FStar_Pervasives_Native.fst uu___2 in
       FStar_Syntax_Print.comp_to_string uu___1
     else
       (let uu___2 = FStar_Syntax_Print.lid_to_string lc.eff_name in
@@ -839,51 +835,45 @@ let (lcomp_set_flags :
             } in
       mk_lcomp lc.eff_name lc.res_typ fs
         (fun uu___ ->
-           let uu___1 = FStar_Compiler_Effect.op_Bar_Greater lc lcomp_comp in
-           FStar_Compiler_Effect.op_Bar_Greater uu___1
-             (fun uu___2 ->
-                match uu___2 with | (c, g) -> ((comp_typ_set_flags c), g)))
+           let uu___1 = lcomp_comp lc in
+           match uu___1 with | (c, g) -> ((comp_typ_set_flags c), g))
 let (is_total_lcomp : lcomp -> Prims.bool) =
   fun c ->
     (FStar_Ident.lid_equals c.eff_name FStar_Parser_Const.effect_Tot_lid) ||
-      (FStar_Compiler_Effect.op_Bar_Greater c.cflags
-         (FStar_Compiler_Util.for_some
-            (fun uu___ ->
-               match uu___ with
-               | FStar_Syntax_Syntax.TOTAL -> true
-               | FStar_Syntax_Syntax.RETURN -> true
-               | uu___1 -> false)))
+      (FStar_Compiler_Util.for_some
+         (fun uu___ ->
+            match uu___ with
+            | FStar_Syntax_Syntax.TOTAL -> true
+            | FStar_Syntax_Syntax.RETURN -> true
+            | uu___1 -> false) c.cflags)
 let (is_tot_or_gtot_lcomp : lcomp -> Prims.bool) =
   fun c ->
     ((FStar_Ident.lid_equals c.eff_name FStar_Parser_Const.effect_Tot_lid) ||
        (FStar_Ident.lid_equals c.eff_name FStar_Parser_Const.effect_GTot_lid))
       ||
-      (FStar_Compiler_Effect.op_Bar_Greater c.cflags
-         (FStar_Compiler_Util.for_some
-            (fun uu___ ->
-               match uu___ with
-               | FStar_Syntax_Syntax.TOTAL -> true
-               | FStar_Syntax_Syntax.RETURN -> true
-               | uu___1 -> false)))
-let (is_lcomp_partial_return : lcomp -> Prims.bool) =
-  fun c ->
-    FStar_Compiler_Effect.op_Bar_Greater c.cflags
       (FStar_Compiler_Util.for_some
          (fun uu___ ->
             match uu___ with
+            | FStar_Syntax_Syntax.TOTAL -> true
             | FStar_Syntax_Syntax.RETURN -> true
-            | FStar_Syntax_Syntax.PARTIAL_RETURN -> true
-            | uu___1 -> false))
+            | uu___1 -> false) c.cflags)
+let (is_lcomp_partial_return : lcomp -> Prims.bool) =
+  fun c ->
+    FStar_Compiler_Util.for_some
+      (fun uu___ ->
+         match uu___ with
+         | FStar_Syntax_Syntax.RETURN -> true
+         | FStar_Syntax_Syntax.PARTIAL_RETURN -> true
+         | uu___1 -> false) c.cflags
 let (is_pure_lcomp : lcomp -> Prims.bool) =
   fun lc ->
     ((is_total_lcomp lc) || (FStar_Syntax_Util.is_pure_effect lc.eff_name))
       ||
-      (FStar_Compiler_Effect.op_Bar_Greater lc.cflags
-         (FStar_Compiler_Util.for_some
-            (fun uu___ ->
-               match uu___ with
-               | FStar_Syntax_Syntax.LEMMA -> true
-               | uu___1 -> false)))
+      (FStar_Compiler_Util.for_some
+         (fun uu___ ->
+            match uu___ with
+            | FStar_Syntax_Syntax.LEMMA -> true
+            | uu___1 -> false) lc.cflags)
 let (is_pure_or_ghost_lcomp : lcomp -> Prims.bool) =
   fun lc ->
     (is_pure_lcomp lc) || (FStar_Syntax_Util.is_ghost_effect lc.eff_name)
@@ -892,13 +882,11 @@ let (set_result_typ_lc : lcomp -> FStar_Syntax_Syntax.typ -> lcomp) =
     fun t ->
       mk_lcomp lc.eff_name t lc.cflags
         (fun uu___ ->
-           let uu___1 = FStar_Compiler_Effect.op_Bar_Greater lc lcomp_comp in
-           FStar_Compiler_Effect.op_Bar_Greater uu___1
-             (fun uu___2 ->
-                match uu___2 with
-                | (c, g) ->
-                    let uu___3 = FStar_Syntax_Util.set_result_typ c t in
-                    (uu___3, g)))
+           let uu___1 = lcomp_comp lc in
+           match uu___1 with
+           | (c, g) ->
+               let uu___2 = FStar_Syntax_Util.set_result_typ c t in
+               (uu___2, g))
 let (residual_comp_of_lcomp : lcomp -> FStar_Syntax_Syntax.residual_comp) =
   fun lc ->
     {
@@ -1102,9 +1090,7 @@ let (simplify :
             FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.and_lid in
           if uu___8
           then
-            let uu___9 =
-              FStar_Compiler_Effect.op_Bar_Greater args
-                (FStar_Compiler_List.map simplify1) in
+            let uu___9 = FStar_Compiler_List.map simplify1 args in
             (match uu___9 with
              | (FStar_Pervasives_Native.Some (true), uu___10)::(uu___11,
                                                                 (arg,
@@ -1123,9 +1109,7 @@ let (simplify :
                FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.or_lid in
              if uu___10
              then
-               let uu___11 =
-                 FStar_Compiler_Effect.op_Bar_Greater args
-                   (FStar_Compiler_List.map simplify1) in
+               let uu___11 = FStar_Compiler_List.map simplify1 args in
                match uu___11 with
                | (FStar_Pervasives_Native.Some (true), uu___12)::uu___13::[]
                    -> w FStar_Syntax_Util.t_true
@@ -1144,9 +1128,7 @@ let (simplify :
                   FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.imp_lid in
                 if uu___12
                 then
-                  let uu___13 =
-                    FStar_Compiler_Effect.op_Bar_Greater args
-                      (FStar_Compiler_List.map simplify1) in
+                  let uu___13 = FStar_Compiler_List.map simplify1 args in
                   match uu___13 with
                   | uu___14::(FStar_Pervasives_Native.Some (true), uu___15)::[]
                       -> w FStar_Syntax_Util.t_true
@@ -1168,9 +1150,7 @@ let (simplify :
                        FStar_Parser_Const.iff_lid in
                    if uu___14
                    then
-                     let uu___15 =
-                       FStar_Compiler_Effect.op_Bar_Greater args
-                         (FStar_Compiler_List.map simplify1) in
+                     let uu___15 = FStar_Compiler_List.map simplify1 args in
                      match uu___15 with
                      | (FStar_Pervasives_Native.Some (true), uu___16)::
                          (FStar_Pervasives_Native.Some (true), uu___17)::[]
@@ -1212,9 +1192,7 @@ let (simplify :
                           FStar_Parser_Const.not_lid in
                       if uu___16
                       then
-                        let uu___17 =
-                          FStar_Compiler_Effect.op_Bar_Greater args
-                            (FStar_Compiler_List.map simplify1) in
+                        let uu___17 = FStar_Compiler_List.map simplify1 args in
                         match uu___17 with
                         | (FStar_Pervasives_Native.Some (true), uu___18)::[]
                             -> w FStar_Syntax_Util.t_false
@@ -1365,12 +1343,10 @@ let (simplify :
                                         uu___26.FStar_Syntax_Syntax.n in
                                       match uu___25 with
                                       | FStar_Syntax_Syntax.Tm_fvar fv1 when
-                                          FStar_Compiler_Effect.op_Bar_Greater
-                                            haseq_lids
-                                            (FStar_Compiler_List.existsb
-                                               (fun l ->
-                                                  FStar_Syntax_Syntax.fv_eq_lid
-                                                    fv1 l))
+                                          FStar_Compiler_List.existsb
+                                            (fun l ->
+                                               FStar_Syntax_Syntax.fv_eq_lid
+                                                 fv1 l) haseq_lids
                                           -> true
                                       | uu___26 -> false in
                                     (if
@@ -1379,14 +1355,9 @@ let (simplify :
                                      then
                                        let t =
                                          let uu___25 =
-                                           FStar_Compiler_Effect.op_Bar_Greater
-                                             args FStar_Compiler_List.hd in
-                                         FStar_Compiler_Effect.op_Bar_Greater
-                                           uu___25
-                                           FStar_Pervasives_Native.fst in
-                                       let uu___25 =
-                                         FStar_Compiler_Effect.op_Bar_Greater
-                                           t t_has_eq_for_sure in
+                                           FStar_Compiler_List.hd args in
+                                         FStar_Pervasives_Native.fst uu___25 in
+                                       let uu___25 = t_has_eq_for_sure t in
                                        (if uu___25
                                         then w FStar_Syntax_Util.t_true
                                         else
@@ -1400,8 +1371,7 @@ let (simplify :
                                                let t1 =
                                                  FStar_Syntax_Util.unrefine t in
                                                let uu___29 =
-                                                 FStar_Compiler_Effect.op_Bar_Greater
-                                                   t1 t_has_eq_for_sure in
+                                                 t_has_eq_for_sure t1 in
                                                if uu___29
                                                then
                                                  w FStar_Syntax_Util.t_true
@@ -1425,9 +1395,8 @@ let (simplify :
                                                           "Impossible! We have already checked that this is a Tm_app" in
                                                   let uu___31 =
                                                     let uu___32 =
-                                                      FStar_Compiler_Effect.op_Bar_Greater
-                                                        t1
-                                                        FStar_Syntax_Syntax.as_arg in
+                                                      FStar_Syntax_Syntax.as_arg
+                                                        t1 in
                                                     [uu___32] in
                                                   FStar_Syntax_Util.mk_app
                                                     haseq_tm uu___31)
@@ -1475,9 +1444,7 @@ let (simplify :
             FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.and_lid in
           if uu___4
           then
-            let uu___5 =
-              FStar_Compiler_Effect.op_Bar_Greater args
-                (FStar_Compiler_List.map simplify1) in
+            let uu___5 = FStar_Compiler_List.map simplify1 args in
             (match uu___5 with
              | (FStar_Pervasives_Native.Some (true), uu___6)::(uu___7,
                                                                (arg, uu___8))::[]
@@ -1495,9 +1462,7 @@ let (simplify :
                FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.or_lid in
              if uu___6
              then
-               let uu___7 =
-                 FStar_Compiler_Effect.op_Bar_Greater args
-                   (FStar_Compiler_List.map simplify1) in
+               let uu___7 = FStar_Compiler_List.map simplify1 args in
                match uu___7 with
                | (FStar_Pervasives_Native.Some (true), uu___8)::uu___9::[] ->
                    w FStar_Syntax_Util.t_true
@@ -1516,9 +1481,7 @@ let (simplify :
                   FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.imp_lid in
                 if uu___8
                 then
-                  let uu___9 =
-                    FStar_Compiler_Effect.op_Bar_Greater args
-                      (FStar_Compiler_List.map simplify1) in
+                  let uu___9 = FStar_Compiler_List.map simplify1 args in
                   match uu___9 with
                   | uu___10::(FStar_Pervasives_Native.Some (true), uu___11)::[]
                       -> w FStar_Syntax_Util.t_true
@@ -1540,9 +1503,7 @@ let (simplify :
                        FStar_Parser_Const.iff_lid in
                    if uu___10
                    then
-                     let uu___11 =
-                       FStar_Compiler_Effect.op_Bar_Greater args
-                         (FStar_Compiler_List.map simplify1) in
+                     let uu___11 = FStar_Compiler_List.map simplify1 args in
                      match uu___11 with
                      | (FStar_Pervasives_Native.Some (true), uu___12)::
                          (FStar_Pervasives_Native.Some (true), uu___13)::[]
@@ -1584,9 +1545,7 @@ let (simplify :
                           FStar_Parser_Const.not_lid in
                       if uu___12
                       then
-                        let uu___13 =
-                          FStar_Compiler_Effect.op_Bar_Greater args
-                            (FStar_Compiler_List.map simplify1) in
+                        let uu___13 = FStar_Compiler_List.map simplify1 args in
                         match uu___13 with
                         | (FStar_Pervasives_Native.Some (true), uu___14)::[]
                             -> w FStar_Syntax_Util.t_false
@@ -1737,12 +1696,10 @@ let (simplify :
                                         uu___22.FStar_Syntax_Syntax.n in
                                       match uu___21 with
                                       | FStar_Syntax_Syntax.Tm_fvar fv1 when
-                                          FStar_Compiler_Effect.op_Bar_Greater
-                                            haseq_lids
-                                            (FStar_Compiler_List.existsb
-                                               (fun l ->
-                                                  FStar_Syntax_Syntax.fv_eq_lid
-                                                    fv1 l))
+                                          FStar_Compiler_List.existsb
+                                            (fun l ->
+                                               FStar_Syntax_Syntax.fv_eq_lid
+                                                 fv1 l) haseq_lids
                                           -> true
                                       | uu___22 -> false in
                                     (if
@@ -1751,14 +1708,9 @@ let (simplify :
                                      then
                                        let t =
                                          let uu___21 =
-                                           FStar_Compiler_Effect.op_Bar_Greater
-                                             args FStar_Compiler_List.hd in
-                                         FStar_Compiler_Effect.op_Bar_Greater
-                                           uu___21
-                                           FStar_Pervasives_Native.fst in
-                                       let uu___21 =
-                                         FStar_Compiler_Effect.op_Bar_Greater
-                                           t t_has_eq_for_sure in
+                                           FStar_Compiler_List.hd args in
+                                         FStar_Pervasives_Native.fst uu___21 in
+                                       let uu___21 = t_has_eq_for_sure t in
                                        (if uu___21
                                         then w FStar_Syntax_Util.t_true
                                         else
@@ -1772,8 +1724,7 @@ let (simplify :
                                                let t1 =
                                                  FStar_Syntax_Util.unrefine t in
                                                let uu___25 =
-                                                 FStar_Compiler_Effect.op_Bar_Greater
-                                                   t1 t_has_eq_for_sure in
+                                                 t_has_eq_for_sure t1 in
                                                if uu___25
                                                then
                                                  w FStar_Syntax_Util.t_true
@@ -1797,9 +1748,8 @@ let (simplify :
                                                           "Impossible! We have already checked that this is a Tm_app" in
                                                   let uu___27 =
                                                     let uu___28 =
-                                                      FStar_Compiler_Effect.op_Bar_Greater
-                                                        t1
-                                                        FStar_Syntax_Syntax.as_arg in
+                                                      FStar_Syntax_Syntax.as_arg
+                                                        t1 in
                                                     [uu___28] in
                                                   FStar_Syntax_Util.mk_app
                                                     haseq_tm uu___27)

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Core.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Core.ml
@@ -1142,11 +1142,8 @@ let no_guard : 'a . 'a result -> 'a result =
 let (equatable : env -> FStar_Syntax_Syntax.term -> Prims.bool) =
   fun g ->
     fun t ->
-      let uu___ =
-        FStar_Compiler_Effect.op_Bar_Greater t
-          FStar_Syntax_Util.leftmost_head in
-      FStar_Compiler_Effect.op_Bar_Greater uu___
-        (FStar_TypeChecker_Rel.may_relate_with_logical_guard g.tcenv true)
+      let uu___ = FStar_Syntax_Util.leftmost_head t in
+      FStar_TypeChecker_Rel.may_relate_with_logical_guard g.tcenv true uu___
 let (apply_predicate :
   FStar_Syntax_Syntax.binder ->
     FStar_Syntax_Syntax.term ->
@@ -5235,12 +5232,10 @@ and (do_check :
                                                                     FStar_TypeChecker_PatternUtils.raw_pat_as_exp
                                                                     g.tcenv
                                                                     p1 in
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___21
-                                                                    FStar_Compiler_Util.must in
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___20
-                                                                    FStar_Pervasives_Native.fst in
+                                                                    FStar_Compiler_Util.must
+                                                                    uu___21 in
+                                                                    FStar_Pervasives_Native.fst
+                                                                    uu___20 in
                                                                     FStar_Syntax_Util.mk_eq2
                                                                     x1 t_sc
                                                                     sc
@@ -5997,12 +5992,10 @@ and (do_check :
                                                                     FStar_TypeChecker_PatternUtils.raw_pat_as_exp
                                                                     g.tcenv
                                                                     p1 in
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___30
-                                                                    FStar_Compiler_Util.must in
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___29
-                                                                    FStar_Pervasives_Native.fst in
+                                                                    FStar_Compiler_Util.must
+                                                                    uu___30 in
+                                                                    FStar_Pervasives_Native.fst
+                                                                    uu___29 in
                                                                     FStar_Syntax_Util.mk_eq2
                                                                     x1 t_sc
                                                                     sc
@@ -6578,12 +6571,11 @@ and (check_comp :
                                         let uu___10 =
                                           FStar_TypeChecker_Env.lookup_effect_quals
                                             g.tcenv c_lid in
-                                        FStar_Compiler_Effect.op_Bar_Greater
-                                          uu___10
-                                          (FStar_Compiler_List.existsb
-                                             (fun q ->
-                                                q =
-                                                  FStar_Syntax_Syntax.TotalEffect)) in
+                                        FStar_Compiler_List.existsb
+                                          (fun q ->
+                                             q =
+                                               FStar_Syntax_Syntax.TotalEffect)
+                                          uu___10 in
                                       if Prims.op_Negation is_total
                                       then
                                         fun uu___10 ->
@@ -6667,11 +6659,9 @@ and (check_pat :
       fun t_sc ->
         let unrefine_tsc t_sc1 =
           let uu___ =
-            FStar_Compiler_Effect.op_Bar_Greater t_sc1
-              (FStar_TypeChecker_Normalize.normalize_refinement
-                 FStar_TypeChecker_Normalize.whnf_steps g.tcenv) in
-          FStar_Compiler_Effect.op_Bar_Greater uu___
-            FStar_Syntax_Util.unrefine in
+            FStar_TypeChecker_Normalize.normalize_refinement
+              FStar_TypeChecker_Normalize.whnf_steps g.tcenv t_sc1 in
+          FStar_Syntax_Util.unrefine uu___ in
         match p.FStar_Syntax_Syntax.v with
         | FStar_Syntax_Syntax.Pat_constant c ->
             let e =
@@ -6765,39 +6755,32 @@ and (check_pat :
             let us =
               if FStar_Compiler_Util.is_none usopt
               then []
-              else
-                FStar_Compiler_Effect.op_Bar_Greater usopt
-                  FStar_Compiler_Util.must in
+              else FStar_Compiler_Util.must usopt in
             let uu___ =
               let uu___1 =
                 let uu___2 = FStar_Syntax_Syntax.lid_of_fv fv in
                 FStar_TypeChecker_Env.lookup_and_inst_datacon g.tcenv us
                   uu___2 in
-              FStar_Compiler_Effect.op_Bar_Greater uu___1
-                FStar_Syntax_Util.arrow_formals in
+              FStar_Syntax_Util.arrow_formals uu___1 in
             (match uu___ with
              | (formals, t_pat) ->
                  let uu___1 =
                    let pats1 =
-                     FStar_Compiler_Effect.op_Bar_Greater pats
-                       (FStar_Compiler_List.map FStar_Pervasives_Native.fst) in
+                     FStar_Compiler_List.map FStar_Pervasives_Native.fst pats in
                    let uu___2 =
                      let uu___3 =
-                       FStar_Compiler_Effect.op_Bar_Greater pats1
-                         (FStar_Compiler_Util.prefix_until
-                            (fun p1 ->
-                               match p1.FStar_Syntax_Syntax.v with
-                               | FStar_Syntax_Syntax.Pat_dot_term uu___4 ->
-                                   false
-                               | uu___4 -> true)) in
-                     FStar_Compiler_Effect.op_Bar_Greater uu___3
-                       (FStar_Compiler_Util.map_option
-                          (fun uu___4 ->
-                             match uu___4 with
-                             | (dot_pats, pat, rest_pats) ->
-                                 (dot_pats, (pat :: rest_pats)))) in
-                   FStar_Compiler_Effect.op_Bar_Greater uu___2
-                     (FStar_Compiler_Util.dflt (pats1, [])) in
+                       FStar_Compiler_Util.prefix_until
+                         (fun p1 ->
+                            match p1.FStar_Syntax_Syntax.v with
+                            | FStar_Syntax_Syntax.Pat_dot_term uu___4 ->
+                                false
+                            | uu___4 -> true) pats1 in
+                     FStar_Compiler_Util.map_option
+                       (fun uu___4 ->
+                          match uu___4 with
+                          | (dot_pats, pat, rest_pats) ->
+                              (dot_pats, (pat :: rest_pats))) uu___3 in
+                   FStar_Compiler_Util.dflt (pats1, []) uu___2 in
                  (match uu___1 with
                   | (dot_pats, rest_pats) ->
                       let uu___2 =
@@ -6994,12 +6977,10 @@ and (check_pat :
                                                                     FStar_TypeChecker_PatternUtils.raw_pat_as_exp
                                                                     g2.tcenv
                                                                     p1 in
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___18
-                                                                    FStar_Compiler_Util.must in
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___17
-                                                                    FStar_Pervasives_Native.fst in
+                                                                    FStar_Compiler_Util.must
+                                                                    uu___18 in
+                                                                    FStar_Pervasives_Native.fst
+                                                                    uu___17 in
                                                                     let uu___17
                                                                     =
                                                                     let uu___18
@@ -7808,9 +7789,8 @@ let (check_term_top_gh :
                            uu___7 uu___8 uu___9);
                         (let guard_names =
                            let uu___7 = FStar_Syntax_Free.names guard1 in
-                           FStar_Compiler_Effect.op_Bar_Greater uu___7
-                             (FStar_Compiler_Set.elems
-                                FStar_Syntax_Syntax.ord_bv) in
+                           FStar_Compiler_Set.elems
+                             FStar_Syntax_Syntax.ord_bv uu___7 in
                          let uu___7 =
                            FStar_Compiler_List.tryFind
                              (fun bv ->

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_DMFF.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_DMFF.ml
@@ -1484,8 +1484,8 @@ let (double_star : FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ) =
         [uu___1] in
       let uu___1 = FStar_Syntax_Syntax.mk_Total FStar_Syntax_Util.ktype0 in
       FStar_Syntax_Util.arrow uu___ uu___1 in
-    let uu___ = FStar_Compiler_Effect.op_Bar_Greater typ star_once in
-    FStar_Compiler_Effect.op_Less_Bar star_once uu___
+    let uu___ = FStar_Compiler_Effect.op_Less_Bar star_once typ in
+    FStar_Compiler_Effect.op_Bar_Greater uu___ star_once
 let rec (mk_star_to_type :
   (FStar_Syntax_Syntax.term' ->
      FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_DMFF.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_DMFF.ml
@@ -148,8 +148,7 @@ let (gen_wps_for_free :
              let mk_lid name = FStar_Syntax_Util.dm4f_lid ed name in
              let gamma =
                let uu___1 = collect_binders wp_a1 in
-               FStar_Compiler_Effect.op_Bar_Greater uu___1
-                 FStar_Syntax_Util.name_binders in
+               FStar_Syntax_Util.name_binders uu___1 in
              (let uu___2 =
                 FStar_TypeChecker_Env.debug env1 (FStar_Options.Other "ED") in
               if uu___2
@@ -752,8 +751,7 @@ let (gen_wps_for_free :
                         let uu___5 =
                           FStar_Syntax_Syntax.mk_GTotal
                             FStar_Syntax_Util.ktype in
-                        FStar_Compiler_Effect.op_Less_Bar
-                          FStar_TypeChecker_Common.lcomp_of_comp uu___5 in
+                        FStar_TypeChecker_Common.lcomp_of_comp uu___5 in
                       FStar_TypeChecker_Common.residual_comp_of_lcomp uu___4 in
                     FStar_Pervasives_Native.Some uu___3 in
                   let mk_forall x body =
@@ -1285,8 +1283,7 @@ let (gen_wps_for_free :
                         let body =
                           let uu___4 =
                             let uu___5 =
-                              FStar_Compiler_Effect.op_Less_Bar
-                                FStar_Syntax_Syntax.bv_to_name
+                              FStar_Syntax_Syntax.bv_to_name
                                 post.FStar_Syntax_Syntax.binder_bv in
                             let uu___6 =
                               let uu___7 =
@@ -1431,12 +1428,11 @@ let (nm_of_comp : FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> nm)
     match c.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Total t -> N t
     | FStar_Syntax_Syntax.Comp c1 when
-        FStar_Compiler_Effect.op_Bar_Greater c1.FStar_Syntax_Syntax.flags
-          (FStar_Compiler_Util.for_some
-             (fun uu___ ->
-                match uu___ with
-                | FStar_Syntax_Syntax.CPS -> true
-                | uu___1 -> false))
+        FStar_Compiler_Util.for_some
+          (fun uu___ ->
+             match uu___ with
+             | FStar_Syntax_Syntax.CPS -> true
+             | uu___1 -> false) c1.FStar_Syntax_Syntax.flags
         -> M (c1.FStar_Syntax_Syntax.result_typ)
     | uu___ ->
         let uu___1 =
@@ -1479,13 +1475,11 @@ let (double_star : FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ) =
         let uu___1 =
           let uu___2 =
             FStar_Syntax_Syntax.new_bv FStar_Pervasives_Native.None typ1 in
-          FStar_Compiler_Effect.op_Less_Bar FStar_Syntax_Syntax.mk_binder
-            uu___2 in
+          FStar_Syntax_Syntax.mk_binder uu___2 in
         [uu___1] in
       let uu___1 = FStar_Syntax_Syntax.mk_Total FStar_Syntax_Util.ktype0 in
       FStar_Syntax_Util.arrow uu___ uu___1 in
-    let uu___ = FStar_Compiler_Effect.op_Less_Bar star_once typ in
-    FStar_Compiler_Effect.op_Bar_Greater uu___ star_once
+    let uu___ = star_once typ in star_once uu___
 let rec (mk_star_to_type :
   (FStar_Syntax_Syntax.term' ->
      FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
@@ -2000,13 +1994,11 @@ let (is_monadic :
     | FStar_Pervasives_Native.None ->
         FStar_Compiler_Effect.failwith "un-annotated lambda?!"
     | FStar_Pervasives_Native.Some rc ->
-        FStar_Compiler_Effect.op_Bar_Greater
-          rc.FStar_Syntax_Syntax.residual_flags
-          (FStar_Compiler_Util.for_some
-             (fun uu___1 ->
-                match uu___1 with
-                | FStar_Syntax_Syntax.CPS -> true
-                | uu___2 -> false))
+        FStar_Compiler_Util.for_some
+          (fun uu___1 ->
+             match uu___1 with
+             | FStar_Syntax_Syntax.CPS -> true
+             | uu___2 -> false) rc.FStar_Syntax_Syntax.residual_flags
 let rec (is_C : FStar_Syntax_Syntax.typ -> Prims.bool) =
   fun t ->
     let uu___ =
@@ -2457,13 +2449,12 @@ and (infer :
                            | FStar_Pervasives_Native.None ->
                                let rc1 =
                                  let uu___3 =
-                                   FStar_Compiler_Effect.op_Bar_Greater
-                                     rc.FStar_Syntax_Syntax.residual_flags
-                                     (FStar_Compiler_Util.for_some
-                                        (fun uu___4 ->
-                                           match uu___4 with
-                                           | FStar_Syntax_Syntax.CPS -> true
-                                           | uu___5 -> false)) in
+                                   FStar_Compiler_Util.for_some
+                                     (fun uu___4 ->
+                                        match uu___4 with
+                                        | FStar_Syntax_Syntax.CPS -> true
+                                        | uu___5 -> false)
+                                     rc.FStar_Syntax_Syntax.residual_flags in
                                  if uu___3
                                  then
                                    let uu___4 =
@@ -2489,13 +2480,12 @@ and (infer :
                                    FStar_TypeChecker_Env.EraseUniverses]
                                    uu___3 rt in
                                let uu___3 =
-                                 FStar_Compiler_Effect.op_Bar_Greater
-                                   rc.FStar_Syntax_Syntax.residual_flags
-                                   (FStar_Compiler_Util.for_some
-                                      (fun uu___4 ->
-                                         match uu___4 with
-                                         | FStar_Syntax_Syntax.CPS -> true
-                                         | uu___5 -> false)) in
+                                 FStar_Compiler_Util.for_some
+                                   (fun uu___4 ->
+                                      match uu___4 with
+                                      | FStar_Syntax_Syntax.CPS -> true
+                                      | uu___5 -> false)
+                                   rc.FStar_Syntax_Syntax.residual_flags in
                                if uu___3
                                then
                                  let flags =
@@ -2594,8 +2584,7 @@ and (infer :
           ->
           let uu___4 =
             let uu___5 = FStar_TypeChecker_Env.lookup_lid env1.tcenv lid in
-            FStar_Compiler_Effect.op_Less_Bar FStar_Pervasives_Native.fst
-              uu___5 in
+            FStar_Pervasives_Native.fst uu___5 in
           (match uu___4 with
            | (uu___5, t) ->
                let uu___6 = let uu___7 = normalize t in N uu___7 in
@@ -3209,8 +3198,7 @@ and (mk_match :
                                 let uu___6 =
                                   FStar_Syntax_Syntax.new_bv
                                     FStar_Pervasives_Native.None p_type in
-                                FStar_Compiler_Effect.op_Less_Bar
-                                  FStar_Syntax_Syntax.mk_binder uu___6 in
+                                FStar_Syntax_Syntax.mk_binder uu___6 in
                               [uu___5] in
                             let uu___5 =
                               FStar_Syntax_Syntax.mk_Total
@@ -3905,11 +3893,8 @@ let (cps_and_elaborate :
       let uu___ =
         let uu___1 =
           let uu___2 =
-            FStar_Compiler_Effect.op_Bar_Greater
-              ed.FStar_Syntax_Syntax.signature
-              FStar_Syntax_Util.effect_sig_ts in
-          FStar_Compiler_Effect.op_Bar_Greater uu___2
-            FStar_Pervasives_Native.snd in
+            FStar_Syntax_Util.effect_sig_ts ed.FStar_Syntax_Syntax.signature in
+          FStar_Pervasives_Native.snd uu___2 in
         FStar_Syntax_Subst.open_term ed.FStar_Syntax_Syntax.binders uu___1 in
       match uu___ with
       | (effect_binders_un, signature_un) ->
@@ -3998,13 +3983,9 @@ let (cps_and_elaborate :
                          let uu___6 =
                            let uu___7 =
                              let uu___8 =
-                               let uu___9 =
-                                 FStar_Compiler_Effect.op_Bar_Greater ed
-                                   FStar_Syntax_Util.get_eff_repr in
-                               FStar_Compiler_Effect.op_Bar_Greater uu___9
-                                 FStar_Compiler_Util.must in
-                             FStar_Compiler_Effect.op_Bar_Greater uu___8
-                               FStar_Pervasives_Native.snd in
+                               let uu___9 = FStar_Syntax_Util.get_eff_repr ed in
+                               FStar_Compiler_Util.must uu___9 in
+                             FStar_Pervasives_Native.snd uu___8 in
                            open_and_check env2 [] uu___7 in
                          (match uu___6 with
                           | (repr, _comp) ->
@@ -4064,9 +4045,7 @@ let (cps_and_elaborate :
                                           FStar_Syntax_Syntax.gen_bv
                                             "dijkstra_wp"
                                             FStar_Pervasives_Native.None wp_a in
-                                        FStar_Compiler_Effect.op_Bar_Greater
-                                          uu___12
-                                          FStar_Syntax_Syntax.mk_binder in
+                                        FStar_Syntax_Syntax.mk_binder uu___12 in
                                       [uu___11] in
                                     uu___9 :: uu___10 in
                                   let binders1 =
@@ -4134,21 +4113,17 @@ let (cps_and_elaborate :
                                 let uu___10 =
                                   let uu___11 =
                                     let uu___12 =
-                                      FStar_Compiler_Effect.op_Bar_Greater ed
-                                        FStar_Syntax_Util.get_bind_repr in
-                                    FStar_Compiler_Effect.op_Bar_Greater
-                                      uu___12 FStar_Compiler_Util.must in
+                                      FStar_Syntax_Util.get_bind_repr ed in
+                                    FStar_Compiler_Util.must uu___12 in
                                   elaborate_and_star dmff_env [] uu___11 in
                                 match uu___10 with
                                 | (dmff_env1, uu___11, bind_wp, bind_elab) ->
                                     let uu___12 =
                                       let uu___13 =
                                         let uu___14 =
-                                          FStar_Compiler_Effect.op_Bar_Greater
-                                            ed
-                                            FStar_Syntax_Util.get_return_repr in
-                                        FStar_Compiler_Effect.op_Bar_Greater
-                                          uu___14 FStar_Compiler_Util.must in
+                                          FStar_Syntax_Util.get_return_repr
+                                            ed in
+                                        FStar_Compiler_Util.must uu___14 in
                                       elaborate_and_star dmff_env1 [] uu___13 in
                                     (match uu___12 with
                                      | (dmff_env2, uu___13, return_wp,
@@ -4234,8 +4209,7 @@ let (cps_and_elaborate :
                                                             wp_b1 in
                                                         FStar_TypeChecker_Normalize.eta_expand_with_type
                                                           env0 body1 uu___18 in
-                                                      FStar_Compiler_Effect.op_Less_Bar
-                                                        FStar_Syntax_Util.abs_formals
+                                                      FStar_Syntax_Util.abs_formals
                                                         uu___17 in
                                                     (match uu___16 with
                                                      | (bs1, body2, what') ->
@@ -4299,11 +4273,7 @@ let (cps_and_elaborate :
                                                                     FStar_Pervasives_Native.None
                                                                     ->
                                                                     fail ()) in
-                                                                 FStar_Compiler_Effect.op_Bar_Greater
-                                                                   uu___19
-                                                                   (fun
-                                                                    uu___20
-                                                                    -> ()))));
+                                                                 ())));
                                                           (let wp =
                                                              let t2 =
                                                                (b21.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort in
@@ -4698,9 +4668,8 @@ let (cps_and_elaborate :
                                                                     uu___20 in
                                                                 ((let uu___20
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Less_Bar
-                                                                    (FStar_TypeChecker_Env.debug
-                                                                    env2)
+                                                                    FStar_TypeChecker_Env.debug
+                                                                    env2
                                                                     (FStar_Options.Other
                                                                     "ED") in
                                                                   if uu___20
@@ -4843,8 +4812,7 @@ let (cps_and_elaborate :
                                                     let uu___19 =
                                                       FStar_Syntax_Subst.compress
                                                         wp_type in
-                                                    FStar_Compiler_Effect.op_Less_Bar
-                                                      FStar_Syntax_Util.unascribe
+                                                    FStar_Syntax_Util.unascribe
                                                       uu___19 in
                                                   uu___18.FStar_Syntax_Syntax.n in
                                                 match uu___17 with
@@ -4878,8 +4846,7 @@ let (cps_and_elaborate :
                                                              let uu___22 =
                                                                FStar_Syntax_Subst.compress
                                                                  arrow1 in
-                                                             FStar_Compiler_Effect.op_Less_Bar
-                                                               FStar_Syntax_Util.unascribe
+                                                             FStar_Syntax_Util.unascribe
                                                                uu___22 in
                                                            uu___21.FStar_Syntax_Syntax.n in
                                                          (match uu___20 with
@@ -4924,14 +4891,12 @@ let (cps_and_elaborate :
                                                                     =
                                                                     FStar_Syntax_Free.names
                                                                     bv.FStar_Syntax_Syntax.sort in
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___28
-                                                                    (FStar_Compiler_Set.mem
+                                                                    FStar_Compiler_Set.mem
                                                                     FStar_Syntax_Syntax.ord_bv
-                                                                    type_param1.FStar_Syntax_Syntax.binder_bv) in
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___27
-                                                                    Prims.op_Negation)
+                                                                    type_param1.FStar_Syntax_Syntax.binder_bv
+                                                                    uu___28 in
+                                                                    Prims.op_Negation
+                                                                    uu___27)
                                                                     wp_binders1 in
                                                                    (match uu___22
                                                                     with

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_DeferredImplicits.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_DeferredImplicits.ml
@@ -108,18 +108,15 @@ let (print_uvar_set :
   fun s ->
     let uu___ =
       let uu___1 = FStar_Compiler_Set.elems FStar_Syntax_Free.ord_ctx_uvar s in
-      FStar_Compiler_Effect.op_Bar_Greater uu___1
-        (FStar_Compiler_List.map
-           (fun u ->
-              let uu___2 =
-                let uu___3 =
-                  FStar_Syntax_Unionfind.uvar_id
-                    u.FStar_Syntax_Syntax.ctx_uvar_head in
-                FStar_Compiler_Effect.op_Less_Bar
-                  FStar_Compiler_Util.string_of_int uu___3 in
-              Prims.strcat "?" uu___2)) in
-    FStar_Compiler_Effect.op_Bar_Greater uu___
-      (FStar_Compiler_String.concat "; ")
+      FStar_Compiler_List.map
+        (fun u ->
+           let uu___2 =
+             let uu___3 =
+               FStar_Syntax_Unionfind.uvar_id
+                 u.FStar_Syntax_Syntax.ctx_uvar_head in
+             FStar_Compiler_Util.string_of_int uu___3 in
+           Prims.strcat "?" uu___2) uu___1 in
+    FStar_Compiler_String.concat "; " uu___
 let (print_goal_dep : goal_dep -> Prims.string) =
   fun gd ->
     let uu___ = FStar_Compiler_Util.string_of_int gd.goal_dep_id in
@@ -130,8 +127,7 @@ let (print_goal_dep : goal_dep -> Prims.string) =
         FStar_Compiler_List.map
           (fun gd1 -> FStar_Compiler_Util.string_of_int gd1.goal_dep_id)
           uu___4 in
-      FStar_Compiler_Effect.op_Bar_Greater uu___3
-        (FStar_Compiler_String.concat "; ") in
+      FStar_Compiler_String.concat "; " uu___3 in
     let uu___3 =
       FStar_Syntax_Print.ctx_uvar_to_string
         (gd.goal_imp).FStar_TypeChecker_Common.imp_uvar in
@@ -194,10 +190,8 @@ let (find_user_tac_for_uvar :
           let uu___1 =
             FStar_Compiler_List.collect FStar_Syntax_Util.lids_of_sigelt
               candidates in
-          FStar_Compiler_Effect.op_Bar_Greater uu___1
-            (FStar_Compiler_List.map FStar_Ident.string_of_lid) in
-        FStar_Compiler_Effect.op_Bar_Greater uu___
-          (FStar_Compiler_String.concat ", ") in
+          FStar_Compiler_List.map FStar_Ident.string_of_lid uu___1 in
+        FStar_Compiler_String.concat ", " uu___ in
       match u.FStar_Syntax_Syntax.ctx_uvar_meta with
       | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Ctx_uvar_meta_attr
           a) ->
@@ -205,13 +199,10 @@ let (find_user_tac_for_uvar :
             FStar_TypeChecker_Env.lookup_attr env
               FStar_Parser_Const.resolve_implicits_attr_string in
           let candidates =
-            FStar_Compiler_Effect.op_Bar_Greater hooks
-              (FStar_Compiler_List.filter
-                 (fun hook ->
-                    FStar_Compiler_Effect.op_Bar_Greater
-                      hook.FStar_Syntax_Syntax.sigattrs
-                      (FStar_Compiler_Util.for_some
-                         (FStar_Syntax_Util.attr_eq a)))) in
+            FStar_Compiler_List.filter
+              (fun hook ->
+                 FStar_Compiler_Util.for_some (FStar_Syntax_Util.attr_eq a)
+                   hook.FStar_Syntax_Syntax.sigattrs) hooks in
           let candidates1 =
             FStar_Compiler_Util.remove_dups
               (fun s0 ->
@@ -228,77 +219,63 @@ let (find_user_tac_for_uvar :
                    else false) candidates in
           let is_overridden candidate =
             let candidate_lids = FStar_Syntax_Util.lids_of_sigelt candidate in
-            FStar_Compiler_Effect.op_Bar_Greater candidates1
-              (FStar_Compiler_Util.for_some
-                 (fun other ->
-                    FStar_Compiler_Effect.op_Bar_Greater
-                      other.FStar_Syntax_Syntax.sigattrs
-                      (FStar_Compiler_Util.for_some
-                         (fun attr ->
-                            let uu___ = FStar_Syntax_Util.head_and_args attr in
-                            match uu___ with
-                            | (head, args) ->
-                                let uu___1 =
-                                  let uu___2 =
-                                    let uu___3 =
-                                      FStar_Syntax_Util.un_uinst head in
-                                    uu___3.FStar_Syntax_Syntax.n in
-                                  (uu___2, args) in
-                                (match uu___1 with
-                                 | (FStar_Syntax_Syntax.Tm_fvar fv,
-                                    uu___2::(a', uu___3)::(overrides, uu___4)::[])
-                                     when
-                                     (FStar_Syntax_Syntax.fv_eq_lid fv
-                                        FStar_Parser_Const.override_resolve_implicits_handler_lid)
-                                       && (FStar_Syntax_Util.attr_eq a a')
-                                     ->
-                                     let uu___5 =
-                                       attr_list_elements overrides in
-                                     (match uu___5 with
-                                      | FStar_Pervasives_Native.None -> false
-                                      | FStar_Pervasives_Native.Some names ->
-                                          FStar_Compiler_Effect.op_Bar_Greater
-                                            names
-                                            (FStar_Compiler_Util.for_some
-                                               (fun n ->
-                                                  FStar_Compiler_Effect.op_Bar_Greater
-                                                    candidate_lids
-                                                    (FStar_Compiler_Util.for_some
-                                                       (fun l ->
-                                                          let uu___6 =
-                                                            FStar_Ident.string_of_lid
-                                                              l in
-                                                          uu___6 = n)))))
-                                 | (FStar_Syntax_Syntax.Tm_fvar fv,
-                                    (a', uu___2)::(overrides, uu___3)::[])
-                                     when
-                                     (FStar_Syntax_Syntax.fv_eq_lid fv
-                                        FStar_Parser_Const.override_resolve_implicits_handler_lid)
-                                       && (FStar_Syntax_Util.attr_eq a a')
-                                     ->
-                                     let uu___4 =
-                                       attr_list_elements overrides in
-                                     (match uu___4 with
-                                      | FStar_Pervasives_Native.None -> false
-                                      | FStar_Pervasives_Native.Some names ->
-                                          FStar_Compiler_Effect.op_Bar_Greater
-                                            names
-                                            (FStar_Compiler_Util.for_some
-                                               (fun n ->
-                                                  FStar_Compiler_Effect.op_Bar_Greater
-                                                    candidate_lids
-                                                    (FStar_Compiler_Util.for_some
-                                                       (fun l ->
-                                                          let uu___5 =
-                                                            FStar_Ident.string_of_lid
-                                                              l in
-                                                          uu___5 = n)))))
-                                 | uu___2 -> false))))) in
+            FStar_Compiler_Util.for_some
+              (fun other ->
+                 FStar_Compiler_Util.for_some
+                   (fun attr ->
+                      let uu___ = FStar_Syntax_Util.head_and_args attr in
+                      match uu___ with
+                      | (head, args) ->
+                          let uu___1 =
+                            let uu___2 =
+                              let uu___3 = FStar_Syntax_Util.un_uinst head in
+                              uu___3.FStar_Syntax_Syntax.n in
+                            (uu___2, args) in
+                          (match uu___1 with
+                           | (FStar_Syntax_Syntax.Tm_fvar fv,
+                              uu___2::(a', uu___3)::(overrides, uu___4)::[])
+                               when
+                               (FStar_Syntax_Syntax.fv_eq_lid fv
+                                  FStar_Parser_Const.override_resolve_implicits_handler_lid)
+                                 && (FStar_Syntax_Util.attr_eq a a')
+                               ->
+                               let uu___5 = attr_list_elements overrides in
+                               (match uu___5 with
+                                | FStar_Pervasives_Native.None -> false
+                                | FStar_Pervasives_Native.Some names ->
+                                    FStar_Compiler_Util.for_some
+                                      (fun n ->
+                                         FStar_Compiler_Util.for_some
+                                           (fun l ->
+                                              let uu___6 =
+                                                FStar_Ident.string_of_lid l in
+                                              uu___6 = n) candidate_lids)
+                                      names)
+                           | (FStar_Syntax_Syntax.Tm_fvar fv,
+                              (a', uu___2)::(overrides, uu___3)::[]) when
+                               (FStar_Syntax_Syntax.fv_eq_lid fv
+                                  FStar_Parser_Const.override_resolve_implicits_handler_lid)
+                                 && (FStar_Syntax_Util.attr_eq a a')
+                               ->
+                               let uu___4 = attr_list_elements overrides in
+                               (match uu___4 with
+                                | FStar_Pervasives_Native.None -> false
+                                | FStar_Pervasives_Native.Some names ->
+                                    FStar_Compiler_Util.for_some
+                                      (fun n ->
+                                         FStar_Compiler_Util.for_some
+                                           (fun l ->
+                                              let uu___5 =
+                                                FStar_Ident.string_of_lid l in
+                                              uu___5 = n) candidate_lids)
+                                      names)
+                           | uu___2 -> false))
+                   other.FStar_Syntax_Syntax.sigattrs) candidates1 in
           let candidates2 =
-            FStar_Compiler_Effect.op_Bar_Greater candidates1
-              (FStar_Compiler_List.filter
-                 (fun c ->
-                    let uu___ = is_overridden c in Prims.op_Negation uu___)) in
+            FStar_Compiler_List.filter
+              (fun c ->
+                 let uu___ = is_overridden c in Prims.op_Negation uu___)
+              candidates1 in
           (match candidates2 with
            | [] -> FStar_Pervasives_Native.None
            | c::[] -> FStar_Pervasives_Native.Some c

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Env.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Env.ml
@@ -1489,34 +1489,32 @@ let (rename_gamma :
   =
   fun subst ->
     fun gamma ->
-      FStar_Compiler_Effect.op_Bar_Greater gamma
-        (FStar_Compiler_List.map
-           (fun uu___ ->
-              match uu___ with
-              | FStar_Syntax_Syntax.Binding_var x ->
-                  let y =
-                    let uu___1 = FStar_Syntax_Syntax.bv_to_name x in
-                    FStar_Syntax_Subst.subst subst uu___1 in
-                  let uu___1 =
-                    let uu___2 = FStar_Syntax_Subst.compress y in
-                    uu___2.FStar_Syntax_Syntax.n in
-                  (match uu___1 with
-                   | FStar_Syntax_Syntax.Tm_name y1 ->
-                       let uu___2 =
-                         let uu___3 =
-                           FStar_Syntax_Subst.subst subst
-                             x.FStar_Syntax_Syntax.sort in
-                         {
-                           FStar_Syntax_Syntax.ppname =
-                             (y1.FStar_Syntax_Syntax.ppname);
-                           FStar_Syntax_Syntax.index =
-                             (y1.FStar_Syntax_Syntax.index);
-                           FStar_Syntax_Syntax.sort = uu___3
-                         } in
-                       FStar_Syntax_Syntax.Binding_var uu___2
-                   | uu___2 ->
-                       FStar_Compiler_Effect.failwith "Not a renaming")
-              | b -> b))
+      FStar_Compiler_List.map
+        (fun uu___ ->
+           match uu___ with
+           | FStar_Syntax_Syntax.Binding_var x ->
+               let y =
+                 let uu___1 = FStar_Syntax_Syntax.bv_to_name x in
+                 FStar_Syntax_Subst.subst subst uu___1 in
+               let uu___1 =
+                 let uu___2 = FStar_Syntax_Subst.compress y in
+                 uu___2.FStar_Syntax_Syntax.n in
+               (match uu___1 with
+                | FStar_Syntax_Syntax.Tm_name y1 ->
+                    let uu___2 =
+                      let uu___3 =
+                        FStar_Syntax_Subst.subst subst
+                          x.FStar_Syntax_Syntax.sort in
+                      {
+                        FStar_Syntax_Syntax.ppname =
+                          (y1.FStar_Syntax_Syntax.ppname);
+                        FStar_Syntax_Syntax.index =
+                          (y1.FStar_Syntax_Syntax.index);
+                        FStar_Syntax_Syntax.sort = uu___3
+                      } in
+                    FStar_Syntax_Syntax.Binding_var uu___2
+                | uu___2 -> FStar_Compiler_Effect.failwith "Not a renaming")
+           | b -> b) gamma
 let (rename_env : FStar_Syntax_Syntax.subst_t -> env -> env) =
   fun subst ->
     fun env1 ->
@@ -1957,14 +1955,9 @@ let (push_stack : env -> env) =
      let uu___3 = FStar_Compiler_Util.smap_copy (attrtab env1) in
      let uu___4 =
        let uu___5 =
-         FStar_Compiler_Effect.op_Bar_Greater env1.qtbl_name_and_index
-           FStar_Pervasives_Native.fst in
-       let uu___6 =
-         let uu___7 =
-           FStar_Compiler_Effect.op_Bar_Greater env1.qtbl_name_and_index
-             FStar_Pervasives_Native.snd in
-         FStar_Compiler_Util.smap_copy uu___7 in
-       (uu___5, uu___6) in
+         FStar_Compiler_Util.smap_copy
+           (FStar_Pervasives_Native.snd env1.qtbl_name_and_index) in
+       ((FStar_Pervasives_Native.fst env1.qtbl_name_and_index), uu___5) in
      let uu___5 = FStar_Compiler_Util.smap_copy env1.normalized_eff_names in
      let uu___6 = FStar_Compiler_Util.smap_copy env1.fv_delta_depths in
      let uu___7 =
@@ -2173,11 +2166,10 @@ let (incr_query_index : env -> env) =
     | (FStar_Pervasives_Native.None, uu___) -> env1
     | (FStar_Pervasives_Native.Some (l, typ, n), tbl) ->
         let uu___ =
-          FStar_Compiler_Effect.op_Bar_Greater qix
-            (FStar_Compiler_List.tryFind
-               (fun uu___1 ->
-                  match uu___1 with
-                  | (m, uu___2) -> FStar_Ident.lid_equals l m)) in
+          FStar_Compiler_List.tryFind
+            (fun uu___1 ->
+               match uu___1 with | (m, uu___2) -> FStar_Ident.lid_equals l m)
+            qix in
         (match uu___ with
          | FStar_Pervasives_Native.None ->
              let next = n + Prims.int_one in
@@ -2469,11 +2461,11 @@ let (set_current_module : env -> FStar_Ident.lident -> env) =
 let (has_interface : env -> FStar_Ident.lident -> Prims.bool) =
   fun env1 ->
     fun l ->
-      FStar_Compiler_Effect.op_Bar_Greater env1.modules
-        (FStar_Compiler_Util.for_some
-           (fun m ->
-              m.FStar_Syntax_Syntax.is_interface &&
-                (FStar_Ident.lid_equals m.FStar_Syntax_Syntax.name l)))
+      FStar_Compiler_Util.for_some
+        (fun m ->
+           m.FStar_Syntax_Syntax.is_interface &&
+             (FStar_Ident.lid_equals m.FStar_Syntax_Syntax.name l))
+        env1.modules
 let (find_in_sigtab :
   env ->
     FStar_Ident.lident ->
@@ -2509,9 +2501,8 @@ let (mk_univ_subst :
   fun formals ->
     fun us ->
       let n = (FStar_Compiler_List.length formals) - Prims.int_one in
-      FStar_Compiler_Effect.op_Bar_Greater us
-        (FStar_Compiler_List.mapi
-           (fun i -> fun u -> FStar_Syntax_Syntax.UN ((n - i), u)))
+      FStar_Compiler_List.mapi
+        (fun i -> fun u -> FStar_Syntax_Syntax.UN ((n - i), u)) us
 let (inst_tscheme_with :
   FStar_Syntax_Syntax.tscheme ->
     FStar_Syntax_Syntax.universes ->
@@ -2532,9 +2523,7 @@ let (inst_tscheme :
     match uu___ with
     | ([], t) -> ([], t)
     | (us, t) ->
-        let us' =
-          FStar_Compiler_Effect.op_Bar_Greater us
-            (FStar_Compiler_List.map (fun uu___1 -> new_u_univ ())) in
+        let us' = FStar_Compiler_List.map (fun uu___1 -> new_u_univ ()) us in
         inst_tscheme_with (us, t) us'
 let (inst_tscheme_with_range :
   FStar_Compiler_Range_Type.range ->
@@ -2589,12 +2578,10 @@ let (inst_effect_fun_with :
                then
                  (let uu___3 =
                     let uu___4 =
-                      FStar_Compiler_Effect.op_Less_Bar
-                        FStar_Compiler_Util.string_of_int
+                      FStar_Compiler_Util.string_of_int
                         (FStar_Compiler_List.length us) in
                     let uu___5 =
-                      FStar_Compiler_Effect.op_Less_Bar
-                        FStar_Compiler_Util.string_of_int
+                      FStar_Compiler_Util.string_of_int
                         (FStar_Compiler_List.length insts) in
                     let uu___6 =
                       FStar_Syntax_Print.lid_to_string
@@ -2706,10 +2693,9 @@ let (lookup_qname : env -> FStar_Ident.lident -> qninfo) =
                             FStar_Compiler_Util.find_map ses
                               (fun se ->
                                  let uu___12 =
-                                   FStar_Compiler_Effect.op_Bar_Greater
-                                     (FStar_Syntax_Util.lids_of_sigelt se)
-                                     (FStar_Compiler_Util.for_some
-                                        (FStar_Ident.lid_equals lid)) in
+                                   FStar_Compiler_Util.for_some
+                                     (FStar_Ident.lid_equals lid)
+                                     (FStar_Syntax_Util.lids_of_sigelt se) in
                                  if uu___12
                                  then
                                    cache
@@ -2863,9 +2849,7 @@ and (add_sigelts :
   Prims.bool -> env -> FStar_Syntax_Syntax.sigelt Prims.list -> unit) =
   fun force ->
     fun env1 ->
-      fun ses ->
-        FStar_Compiler_Effect.op_Bar_Greater ses
-          (FStar_Compiler_List.iter (add_sigelt force env1))
+      fun ses -> FStar_Compiler_List.iter (add_sigelt force env1) ses
 let (try_lookup_bv :
   env ->
     FStar_Syntax_Syntax.bv ->
@@ -3072,17 +3056,15 @@ let (try_lookup_lid_aux :
                      let uu___7 = in_cur_mod env1 l in uu___7 = Yes in
                    if uu___6
                    then
-                     let uu___7 =
-                       (FStar_Compiler_Effect.op_Bar_Greater qs
-                          (FStar_Compiler_List.contains
-                             FStar_Syntax_Syntax.Assumption))
-                         || env1.is_iface in
-                     (if uu___7
+                     (if
+                        (FStar_Compiler_List.contains
+                           FStar_Syntax_Syntax.Assumption qs)
+                          || env1.is_iface
                       then
-                        let uu___8 =
-                          let uu___9 = inst_tscheme1 (uvs, t) in
-                          (uu___9, rng) in
-                        FStar_Pervasives_Native.Some uu___8
+                        let uu___7 =
+                          let uu___8 = inst_tscheme1 (uvs, t) in
+                          (uu___8, rng) in
+                        FStar_Pervasives_Native.Some uu___7
                       else FStar_Pervasives_Native.None)
                    else
                      (let uu___8 =
@@ -3178,10 +3160,10 @@ let (try_lookup_lid_aux :
                      | uu___2 ->
                          effect_signature us_opt
                            (FStar_Pervasives_Native.fst se) env1.range in
-                   FStar_Compiler_Effect.op_Bar_Greater uu___1
-                     (FStar_Compiler_Util.map_option
-                        (fun uu___2 ->
-                           match uu___2 with | (us_t, rng1) -> (us_t, rng1)))) in
+                   FStar_Compiler_Util.map_option
+                     (fun uu___2 ->
+                        match uu___2 with | (us_t, rng1) -> (us_t, rng1))
+                     uu___1) in
         let uu___ =
           let uu___1 = lookup_qname env1 lid in
           FStar_Compiler_Util.bind_opt uu___1 mapper in
@@ -3299,7 +3281,7 @@ let (lookup_univ : env -> FStar_Syntax_Syntax.univ_name -> Prims.bool) =
                  let uu___2 = FStar_Ident.string_of_id x in
                  let uu___3 = FStar_Ident.string_of_id y in uu___2 = uu___3
              | uu___2 -> false) env1.gamma in
-      FStar_Compiler_Effect.op_Bar_Greater uu___ FStar_Compiler_Option.isSome
+      FStar_Compiler_Option.isSome uu___
 let (try_lookup_val_decl :
   env ->
     FStar_Ident.lident ->
@@ -3429,8 +3411,7 @@ let (lookup_and_inst_datacon :
              uu___11)
             ->
             let uu___12 = inst_tscheme_with (uvs, t) us in
-            FStar_Compiler_Effect.op_Bar_Greater uu___12
-              FStar_Pervasives_Native.snd
+            FStar_Pervasives_Native.snd uu___12
         | uu___1 ->
             let uu___2 = name_not_found lid in
             let uu___3 = FStar_Ident.range_of_lid lid in
@@ -3507,11 +3488,9 @@ let (lookup_definition_qninfo_aux :
       fun lid ->
         fun qninfo1 ->
           let visible quals =
-            FStar_Compiler_Effect.op_Bar_Greater delta_levels
-              (FStar_Compiler_Util.for_some
-                 (fun dl ->
-                    FStar_Compiler_Effect.op_Bar_Greater quals
-                      (FStar_Compiler_Util.for_some (visible_at dl)))) in
+            FStar_Compiler_Util.for_some
+              (fun dl -> FStar_Compiler_Util.for_some (visible_at dl) quals)
+              delta_levels in
           match qninfo1 with
           | FStar_Pervasives_Native.Some
               (FStar_Pervasives.Inr (se, FStar_Pervasives_Native.None),
@@ -3561,8 +3540,7 @@ let (lookup_definition :
     fun env1 ->
       fun lid ->
         let uu___ = lookup_qname env1 lid in
-        FStar_Compiler_Effect.op_Less_Bar
-          (lookup_definition_qninfo delta_levels lid) uu___
+        lookup_definition_qninfo delta_levels lid uu___
 let (lookup_nonrec_definition :
   delta_level Prims.list ->
     env ->
@@ -3574,8 +3552,7 @@ let (lookup_nonrec_definition :
     fun env1 ->
       fun lid ->
         let uu___ = lookup_qname env1 lid in
-        FStar_Compiler_Effect.op_Less_Bar
-          (lookup_definition_qninfo_aux false delta_levels lid) uu___
+        lookup_definition_qninfo_aux false delta_levels lid uu___
 let (delta_depth_of_qninfo_lid :
   FStar_Ident.lident ->
     qninfo -> FStar_Syntax_Syntax.delta_depth FStar_Pervasives_Native.option)
@@ -3688,64 +3665,53 @@ let (delta_depth_of_fv :
           (FStar_Pervasives_Native.uu___is_Some
              fv.FStar_Syntax_Syntax.fv_delta) in
       if uu___
-      then
-        FStar_Compiler_Effect.op_Bar_Greater fv.FStar_Syntax_Syntax.fv_delta
-          FStar_Compiler_Util.must
+      then FStar_Compiler_Util.must fv.FStar_Syntax_Syntax.fv_delta
       else
         (let uu___2 =
            let uu___3 = FStar_Ident.string_of_lid lid in
-           FStar_Compiler_Effect.op_Bar_Greater uu___3
-             (FStar_Compiler_Util.smap_try_find env1.fv_delta_depths) in
-         FStar_Compiler_Effect.op_Bar_Greater uu___2
-           (fun d_opt ->
-              let uu___3 =
-                FStar_Compiler_Effect.op_Bar_Greater d_opt
-                  FStar_Compiler_Util.is_some in
-              if uu___3
-              then
-                FStar_Compiler_Effect.op_Bar_Greater d_opt
-                  FStar_Compiler_Util.must
-              else
-                (let uu___5 =
-                   let uu___6 =
-                     lookup_qname env1
-                       (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                   delta_depth_of_qninfo fv uu___6 in
-                 match uu___5 with
-                 | FStar_Pervasives_Native.None ->
-                     let uu___6 =
-                       let uu___7 = FStar_Syntax_Print.fv_to_string fv in
-                       FStar_Compiler_Util.format1
-                         "Delta depth not found for %s" uu___7 in
-                     FStar_Compiler_Effect.failwith uu___6
-                 | FStar_Pervasives_Native.Some d ->
-                     ((let uu___7 =
-                         ((FStar_Pervasives_Native.uu___is_Some
-                             fv.FStar_Syntax_Syntax.fv_delta)
-                            &&
-                            (d <>
-                               (FStar_Pervasives_Native.__proj__Some__item__v
-                                  fv.FStar_Syntax_Syntax.fv_delta)))
-                           && (FStar_Options.debug_any ()) in
-                       if uu___7
-                       then
-                         let uu___8 = FStar_Syntax_Print.fv_to_string fv in
-                         let uu___9 =
-                           FStar_Class_Show.show
-                             FStar_Syntax_Syntax.showable_delta_depth
-                             (FStar_Pervasives_Native.__proj__Some__item__v
-                                fv.FStar_Syntax_Syntax.fv_delta) in
-                         let uu___10 =
-                           FStar_Class_Show.show
-                             FStar_Syntax_Syntax.showable_delta_depth d in
-                         FStar_Compiler_Util.print3
-                           "WARNING WARNING WARNING fv=%s, delta_depth=%s, env.delta_depth=%s\n"
-                           uu___8 uu___9 uu___10
-                       else ());
-                      (let uu___8 = FStar_Ident.string_of_lid lid in
-                       FStar_Compiler_Util.smap_add env1.fv_delta_depths
-                         uu___8 d);
-                      d))))
+           FStar_Compiler_Util.smap_try_find env1.fv_delta_depths uu___3 in
+         if FStar_Compiler_Util.is_some uu___2
+         then FStar_Compiler_Util.must uu___2
+         else
+           (let uu___4 =
+              let uu___5 =
+                lookup_qname env1
+                  (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
+              delta_depth_of_qninfo fv uu___5 in
+            match uu___4 with
+            | FStar_Pervasives_Native.None ->
+                let uu___5 =
+                  let uu___6 = FStar_Syntax_Print.fv_to_string fv in
+                  FStar_Compiler_Util.format1 "Delta depth not found for %s"
+                    uu___6 in
+                FStar_Compiler_Effect.failwith uu___5
+            | FStar_Pervasives_Native.Some d ->
+                ((let uu___6 =
+                    ((FStar_Pervasives_Native.uu___is_Some
+                        fv.FStar_Syntax_Syntax.fv_delta)
+                       &&
+                       (d <>
+                          (FStar_Pervasives_Native.__proj__Some__item__v
+                             fv.FStar_Syntax_Syntax.fv_delta)))
+                      && (FStar_Options.debug_any ()) in
+                  if uu___6
+                  then
+                    let uu___7 = FStar_Syntax_Print.fv_to_string fv in
+                    let uu___8 =
+                      FStar_Class_Show.show
+                        FStar_Syntax_Syntax.showable_delta_depth
+                        (FStar_Pervasives_Native.__proj__Some__item__v
+                           fv.FStar_Syntax_Syntax.fv_delta) in
+                    let uu___9 =
+                      FStar_Class_Show.show
+                        FStar_Syntax_Syntax.showable_delta_depth d in
+                    FStar_Compiler_Util.print3
+                      "WARNING WARNING WARNING fv=%s, delta_depth=%s, env.delta_depth=%s\n"
+                      uu___7 uu___8 uu___9
+                  else ());
+                 (let uu___7 = FStar_Ident.string_of_lid lid in
+                  FStar_Compiler_Util.smap_add env1.fv_delta_depths uu___7 d);
+                 d)))
 let (quals_of_qninfo :
   qninfo ->
     FStar_Syntax_Syntax.qualifier Prims.list FStar_Pervasives_Native.option)
@@ -3770,9 +3736,7 @@ let (lookup_attrs_of_lid :
       FStar_Syntax_Syntax.attribute Prims.list FStar_Pervasives_Native.option)
   =
   fun env1 ->
-    fun lid ->
-      let uu___ = lookup_qname env1 lid in
-      FStar_Compiler_Effect.op_Less_Bar attrs_of_qninfo uu___
+    fun lid -> let uu___ = lookup_qname env1 lid in attrs_of_qninfo uu___
 let (fv_exists_and_has_attr :
   env -> FStar_Ident.lid -> FStar_Ident.lident -> (Prims.bool * Prims.bool))
   =
@@ -3784,16 +3748,15 @@ let (fv_exists_and_has_attr :
         | FStar_Pervasives_Native.None -> (false, false)
         | FStar_Pervasives_Native.Some attrs ->
             let uu___1 =
-              FStar_Compiler_Effect.op_Bar_Greater attrs
-                (FStar_Compiler_Util.for_some
-                   (fun tm ->
-                      let uu___2 =
-                        let uu___3 = FStar_Syntax_Util.un_uinst tm in
-                        uu___3.FStar_Syntax_Syntax.n in
-                      match uu___2 with
-                      | FStar_Syntax_Syntax.Tm_fvar fv ->
-                          FStar_Syntax_Syntax.fv_eq_lid fv attr_lid
-                      | uu___3 -> false)) in
+              FStar_Compiler_Util.for_some
+                (fun tm ->
+                   let uu___2 =
+                     let uu___3 = FStar_Syntax_Util.un_uinst tm in
+                     uu___3.FStar_Syntax_Syntax.n in
+                   match uu___2 with
+                   | FStar_Syntax_Syntax.Tm_fvar fv ->
+                       FStar_Syntax_Syntax.fv_eq_lid fv attr_lid
+                   | uu___3 -> false) attrs in
             (true, uu___1)
 let (fv_with_lid_has_attr :
   env -> FStar_Ident.lid -> FStar_Ident.lid -> Prims.bool) =
@@ -3938,12 +3901,11 @@ let (lookup_effect_abbrev :
                 FStar_Compiler_Range_Type.set_use_range uu___9 uu___10 in
               FStar_Ident.set_lid_range lid uu___8 in
             let uu___8 =
-              FStar_Compiler_Effect.op_Bar_Greater quals
-                (FStar_Compiler_Util.for_some
-                   (fun uu___9 ->
-                      match uu___9 with
-                      | FStar_Syntax_Syntax.Irreducible -> true
-                      | uu___10 -> false)) in
+              FStar_Compiler_Util.for_some
+                (fun uu___9 ->
+                   match uu___9 with
+                   | FStar_Syntax_Syntax.Irreducible -> true
+                   | uu___10 -> false) quals in
             if uu___8
             then FStar_Pervasives_Native.None
             else
@@ -3959,9 +3921,8 @@ let (lookup_effect_abbrev :
                         FStar_Compiler_Range_Ops.string_of_range uu___13 in
                       let uu___13 = FStar_Syntax_Print.lid_to_string lid1 in
                       let uu___14 =
-                        FStar_Compiler_Effect.op_Bar_Greater
-                          (FStar_Compiler_List.length univ_insts)
-                          FStar_Compiler_Util.string_of_int in
+                        FStar_Compiler_Util.string_of_int
+                          (FStar_Compiler_List.length univ_insts) in
                       FStar_Compiler_Util.format3
                         "(%s) Unexpected instantiation of effect %s with %s universes"
                         uu___12 uu___13 uu___14 in
@@ -3974,8 +3935,7 @@ let (lookup_effect_abbrev :
                    let uu___14 =
                      let uu___15 = FStar_Syntax_Print.lid_to_string lid1 in
                      let uu___16 =
-                       FStar_Compiler_Effect.op_Less_Bar
-                         FStar_Compiler_Util.string_of_int
+                       FStar_Compiler_Util.string_of_int
                          (FStar_Compiler_List.length univs) in
                      FStar_Compiler_Util.format2
                        "Unexpected effect abbreviation %s; polymorphic in %s universes"
@@ -4039,14 +3999,11 @@ let (norm_eff_name : env -> FStar_Ident.lident -> FStar_Ident.lident) =
 let (is_erasable_effect : env -> FStar_Ident.lident -> Prims.bool) =
   fun env1 ->
     fun l ->
-      let uu___ = FStar_Compiler_Effect.op_Bar_Greater l (norm_eff_name env1) in
-      FStar_Compiler_Effect.op_Bar_Greater uu___
-        (fun l1 ->
-           (FStar_Ident.lid_equals l1 FStar_Parser_Const.effect_GHOST_lid) ||
-             (let uu___1 =
-                FStar_Syntax_Syntax.lid_as_fv l1 FStar_Pervasives_Native.None in
-              FStar_Compiler_Effect.op_Bar_Greater uu___1
-                (fv_has_erasable_attr env1)))
+      let uu___ = norm_eff_name env1 l in
+      (FStar_Ident.lid_equals uu___ FStar_Parser_Const.effect_GHOST_lid) ||
+        (let uu___1 =
+           FStar_Syntax_Syntax.lid_as_fv uu___ FStar_Pervasives_Native.None in
+         fv_has_erasable_attr env1 uu___1)
 let rec (non_informative : env -> FStar_Syntax_Syntax.typ -> Prims.bool) =
   fun env1 ->
     fun t ->
@@ -4081,11 +4038,8 @@ let (num_effect_indices :
     fun name ->
       fun r ->
         let sig_t =
-          let uu___ =
-            FStar_Compiler_Effect.op_Bar_Greater name
-              (lookup_effect_lid env1) in
-          FStar_Compiler_Effect.op_Bar_Greater uu___
-            FStar_Syntax_Subst.compress in
+          let uu___ = lookup_effect_lid env1 name in
+          FStar_Syntax_Subst.compress uu___ in
         match sig_t.FStar_Syntax_Syntax.n with
         | FStar_Syntax_Syntax.Tm_arrow
             { FStar_Syntax_Syntax.bs1 = _a::bs;
@@ -4249,9 +4203,7 @@ let (qninfo_is_action : qninfo -> Prims.bool) =
     | uu___ -> false
 let (is_action : env -> FStar_Ident.lident -> Prims.bool) =
   fun env1 ->
-    fun lid ->
-      let uu___ = lookup_qname env1 lid in
-      FStar_Compiler_Effect.op_Less_Bar qninfo_is_action uu___
+    fun lid -> let uu___ = lookup_qname env1 lid in qninfo_is_action uu___
 let (is_interpreted : env -> FStar_Syntax_Syntax.term -> Prims.bool) =
   let interpreted_symbols =
     [FStar_Parser_Const.op_Eq;
@@ -4396,12 +4348,12 @@ let (effect_decl_opt :
   =
   fun env1 ->
     fun l ->
-      FStar_Compiler_Effect.op_Bar_Greater (env1.effects).decls
-        (FStar_Compiler_Util.find_opt
-           (fun uu___ ->
-              match uu___ with
-              | (d, uu___1) ->
-                  FStar_Ident.lid_equals d.FStar_Syntax_Syntax.mname l))
+      FStar_Compiler_Util.find_opt
+        (fun uu___ ->
+           match uu___ with
+           | (d, uu___1) ->
+               FStar_Ident.lid_equals d.FStar_Syntax_Syntax.mname l)
+        (env1.effects).decls
 let (get_effect_decl :
   env -> FStar_Ident.lident -> FStar_Syntax_Syntax.eff_decl) =
   fun env1 ->
@@ -4427,54 +4379,40 @@ let (get_lid_valued_effect_attr :
           let attr_args =
             let uu___ =
               let uu___1 =
-                let uu___2 =
-                  FStar_Compiler_Effect.op_Bar_Greater eff_lid
-                    (norm_eff_name env1) in
-                FStar_Compiler_Effect.op_Bar_Greater uu___2
-                  (lookup_attrs_of_lid env1) in
-              FStar_Compiler_Effect.op_Bar_Greater uu___1
-                (FStar_Compiler_Util.dflt []) in
-            FStar_Compiler_Effect.op_Bar_Greater uu___
-              (FStar_Syntax_Util.get_attribute attr_name_lid) in
+                let uu___2 = norm_eff_name env1 eff_lid in
+                lookup_attrs_of_lid env1 uu___2 in
+              FStar_Compiler_Util.dflt [] uu___1 in
+            FStar_Syntax_Util.get_attribute attr_name_lid uu___ in
           match attr_args with
           | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
           | FStar_Pervasives_Native.Some args ->
               if (FStar_Compiler_List.length args) = Prims.int_zero
               then default_if_attr_has_no_arg
               else
-                (let uu___1 =
-                   FStar_Compiler_Effect.op_Bar_Greater args
-                     FStar_Compiler_List.hd in
-                 FStar_Compiler_Effect.op_Bar_Greater uu___1
-                   (fun uu___2 ->
-                      match uu___2 with
-                      | (t, uu___3) ->
-                          let uu___4 =
-                            let uu___5 = FStar_Syntax_Subst.compress t in
-                            uu___5.FStar_Syntax_Syntax.n in
-                          (match uu___4 with
-                           | FStar_Syntax_Syntax.Tm_constant
-                               (FStar_Const.Const_string (s, uu___5)) ->
-                               let uu___6 =
-                                 FStar_Compiler_Effect.op_Bar_Greater s
-                                   FStar_Ident.lid_of_str in
-                               FStar_Compiler_Effect.op_Bar_Greater uu___6
-                                 (fun uu___7 ->
-                                    FStar_Pervasives_Native.Some uu___7)
-                           | uu___5 ->
-                               let uu___6 =
-                                 let uu___7 =
-                                   let uu___8 =
-                                     FStar_Ident.string_of_lid eff_lid in
-                                   let uu___9 =
-                                     FStar_Syntax_Print.term_to_string t in
-                                   FStar_Compiler_Util.format2
-                                     "The argument for the effect attribute for %s is not a constant string, it is %s\n"
-                                     uu___8 uu___9 in
-                                 (FStar_Errors_Codes.Fatal_UnexpectedEffect,
-                                   uu___7) in
-                               FStar_Errors.raise_error uu___6
-                                 t.FStar_Syntax_Syntax.pos)))
+                (let uu___1 = FStar_Compiler_List.hd args in
+                 match uu___1 with
+                 | (t, uu___2) ->
+                     let uu___3 =
+                       let uu___4 = FStar_Syntax_Subst.compress t in
+                       uu___4.FStar_Syntax_Syntax.n in
+                     (match uu___3 with
+                      | FStar_Syntax_Syntax.Tm_constant
+                          (FStar_Const.Const_string (s, uu___4)) ->
+                          let uu___5 = FStar_Ident.lid_of_str s in
+                          FStar_Pervasives_Native.Some uu___5
+                      | uu___4 ->
+                          let uu___5 =
+                            let uu___6 =
+                              let uu___7 = FStar_Ident.string_of_lid eff_lid in
+                              let uu___8 =
+                                FStar_Syntax_Print.term_to_string t in
+                              FStar_Compiler_Util.format2
+                                "The argument for the effect attribute for %s is not a constant string, it is %s\n"
+                                uu___7 uu___8 in
+                            (FStar_Errors_Codes.Fatal_UnexpectedEffect,
+                              uu___6) in
+                          FStar_Errors.raise_error uu___5
+                            t.FStar_Syntax_Syntax.pos))
 let (get_default_effect :
   env ->
     FStar_Ident.lident -> FStar_Ident.lident FStar_Pervasives_Native.option)
@@ -4495,9 +4433,8 @@ let (get_top_level_effect :
 let (is_layered_effect : env -> FStar_Ident.lident -> Prims.bool) =
   fun env1 ->
     fun l ->
-      let uu___ =
-        FStar_Compiler_Effect.op_Bar_Greater l (get_effect_decl env1) in
-      FStar_Compiler_Effect.op_Bar_Greater uu___ FStar_Syntax_Util.is_layered
+      let uu___ = get_effect_decl env1 l in
+      FStar_Syntax_Util.is_layered uu___
 let (identity_mlift : mlift) =
   {
     mlift_wp =
@@ -4537,13 +4474,13 @@ let (join_opt :
                  identity_mlift)
            else
              (let uu___4 =
-                FStar_Compiler_Effect.op_Bar_Greater (env1.effects).joins
-                  (FStar_Compiler_Util.find_opt
-                     (fun uu___5 ->
-                        match uu___5 with
-                        | (m1, m2, uu___6, uu___7, uu___8) ->
-                            (FStar_Ident.lid_equals l1 m1) &&
-                              (FStar_Ident.lid_equals l2 m2))) in
+                FStar_Compiler_Util.find_opt
+                  (fun uu___5 ->
+                     match uu___5 with
+                     | (m1, m2, uu___6, uu___7, uu___8) ->
+                         (FStar_Ident.lid_equals l1 m1) &&
+                           (FStar_Ident.lid_equals l2 m2))
+                  (env1.effects).joins in
               match uu___4 with
               | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
               | FStar_Pervasives_Native.Some (uu___5, uu___6, m3, j1, j2) ->
@@ -4586,11 +4523,10 @@ let (monad_leq :
             { msource = l1; mtarget = l2; mlift = identity_mlift; mpath = []
             }
         else
-          FStar_Compiler_Effect.op_Bar_Greater (env1.effects).order
-            (FStar_Compiler_Util.find_opt
-               (fun e ->
-                  (FStar_Ident.lid_equals l1 e.msource) &&
-                    (FStar_Ident.lid_equals l2 e.mtarget)))
+          FStar_Compiler_Util.find_opt
+            (fun e ->
+               (FStar_Ident.lid_equals l1 e.msource) &&
+                 (FStar_Ident.lid_equals l2 e.mtarget)) (env1.effects).order
 let wp_sig_aux :
   'uuuuu .
     (FStar_Syntax_Syntax.eff_decl * 'uuuuu) Prims.list ->
@@ -4601,12 +4537,11 @@ let wp_sig_aux :
   fun decls ->
     fun m ->
       let uu___ =
-        FStar_Compiler_Effect.op_Bar_Greater decls
-          (FStar_Compiler_Util.find_opt
-             (fun uu___1 ->
-                match uu___1 with
-                | (d, uu___2) ->
-                    FStar_Ident.lid_equals d.FStar_Syntax_Syntax.mname m)) in
+        FStar_Compiler_Util.find_opt
+          (fun uu___1 ->
+             match uu___1 with
+             | (d, uu___2) ->
+                 FStar_Ident.lid_equals d.FStar_Syntax_Syntax.mname m) decls in
       match uu___ with
       | FStar_Pervasives_Native.None ->
           let uu___1 =
@@ -4617,10 +4552,9 @@ let wp_sig_aux :
       | FStar_Pervasives_Native.Some (md, _q) ->
           let uu___1 =
             let uu___2 =
-              FStar_Compiler_Effect.op_Bar_Greater
-                md.FStar_Syntax_Syntax.signature
-                FStar_Syntax_Util.effect_sig_ts in
-            FStar_Compiler_Effect.op_Bar_Greater uu___2 inst_tscheme in
+              FStar_Syntax_Util.effect_sig_ts
+                md.FStar_Syntax_Syntax.signature in
+            inst_tscheme uu___2 in
           (match uu___1 with
            | (uu___2, s) ->
                let s1 = FStar_Syntax_Subst.compress s in
@@ -4645,21 +4579,19 @@ let (bound_vars_of_bindings :
   FStar_Syntax_Syntax.binding Prims.list -> FStar_Syntax_Syntax.bv Prims.list)
   =
   fun bs ->
-    FStar_Compiler_Effect.op_Bar_Greater bs
-      (FStar_Compiler_List.collect
-         (fun uu___ ->
-            match uu___ with
-            | FStar_Syntax_Syntax.Binding_var x -> [x]
-            | FStar_Syntax_Syntax.Binding_lid uu___1 -> []
-            | FStar_Syntax_Syntax.Binding_univ uu___1 -> []))
+    FStar_Compiler_List.collect
+      (fun uu___ ->
+         match uu___ with
+         | FStar_Syntax_Syntax.Binding_var x -> [x]
+         | FStar_Syntax_Syntax.Binding_lid uu___1 -> []
+         | FStar_Syntax_Syntax.Binding_univ uu___1 -> []) bs
 let (binders_of_bindings :
   FStar_Syntax_Syntax.binding Prims.list -> FStar_Syntax_Syntax.binders) =
   fun bs ->
     let uu___ =
       let uu___1 = bound_vars_of_bindings bs in
-      FStar_Compiler_Effect.op_Bar_Greater uu___1
-        (FStar_Compiler_List.map FStar_Syntax_Syntax.mk_binder) in
-    FStar_Compiler_Effect.op_Bar_Greater uu___ FStar_Compiler_List.rev
+      FStar_Compiler_List.map FStar_Syntax_Syntax.mk_binder uu___1 in
+    FStar_Compiler_List.rev uu___
 let (all_binders : env -> FStar_Syntax_Syntax.binders) =
   fun env1 -> binders_of_bindings env1.gamma
 let (bound_vars : env -> FStar_Syntax_Syntax.bv Prims.list) =
@@ -4847,8 +4779,7 @@ let rec (unfold_effect_abbrev :
                         FStar_Syntax_Syntax.flags =
                           (c.FStar_Syntax_Syntax.flags)
                       } in
-                    FStar_Compiler_Effect.op_Bar_Greater uu___4
-                      FStar_Syntax_Syntax.mk_Comp in
+                    FStar_Syntax_Syntax.mk_Comp uu___4 in
                   unfold_effect_abbrev env1 c2))))
 let effect_repr_aux :
   'uuuuu .
@@ -4889,9 +4820,7 @@ let effect_repr_aux :
           match uu___ with
           | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
           | FStar_Pervasives_Native.Some (ed, uu___1) ->
-              let uu___2 =
-                FStar_Compiler_Effect.op_Bar_Greater ed
-                  FStar_Syntax_Util.get_eff_repr in
+              let uu___2 = FStar_Syntax_Util.get_eff_repr ed in
               (match uu___2 with
                | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
                | FStar_Pervasives_Native.Some ts ->
@@ -4904,9 +4833,7 @@ let effect_repr_aux :
                        let uu___5 =
                          let uu___6 =
                            let uu___7 =
-                             let uu___8 =
-                               FStar_Compiler_Effect.op_Bar_Greater res_typ
-                                 FStar_Syntax_Syntax.as_arg in
+                             let uu___8 = FStar_Syntax_Syntax.as_arg res_typ in
                              uu___8 :: (c1.FStar_Syntax_Syntax.effect_args) in
                            {
                              FStar_Syntax_Syntax.hd = repr;
@@ -4933,12 +4860,11 @@ let (is_user_reflectable_effect : env -> FStar_Ident.lident -> Prims.bool) =
     fun effect_lid ->
       let effect_lid1 = norm_eff_name env1 effect_lid in
       let quals = lookup_effect_quals env1 effect_lid1 in
-      FStar_Compiler_Effect.op_Bar_Greater quals
-        (FStar_Compiler_List.existsb
-           (fun uu___ ->
-              match uu___ with
-              | FStar_Syntax_Syntax.Reflectable uu___1 -> true
-              | uu___1 -> false))
+      FStar_Compiler_List.existsb
+        (fun uu___ ->
+           match uu___ with
+           | FStar_Syntax_Syntax.Reflectable uu___1 -> true
+           | uu___1 -> false) quals
 let (is_total_effect : env -> FStar_Ident.lident -> Prims.bool) =
   fun env1 ->
     fun effect_lid ->
@@ -5155,14 +5081,13 @@ let (exists_polymonadic_bind :
     fun m ->
       fun n ->
         let uu___ =
-          FStar_Compiler_Effect.op_Bar_Greater
-            (env1.effects).polymonadic_binds
-            (FStar_Compiler_Util.find_opt
-               (fun uu___1 ->
-                  match uu___1 with
-                  | (m1, n1, uu___2, uu___3) ->
-                      (FStar_Ident.lid_equals m m1) &&
-                        (FStar_Ident.lid_equals n n1))) in
+          FStar_Compiler_Util.find_opt
+            (fun uu___1 ->
+               match uu___1 with
+               | (m1, n1, uu___2, uu___3) ->
+                   (FStar_Ident.lid_equals m m1) &&
+                     (FStar_Ident.lid_equals n n1))
+            (env1.effects).polymonadic_binds in
         match uu___ with
         | FStar_Pervasives_Native.Some (uu___1, uu___2, p, t) ->
             FStar_Pervasives_Native.Some (p, t)
@@ -5179,14 +5104,13 @@ let (exists_polymonadic_subcomp :
     fun m ->
       fun n ->
         let uu___ =
-          FStar_Compiler_Effect.op_Bar_Greater
-            (env1.effects).polymonadic_subcomps
-            (FStar_Compiler_Util.find_opt
-               (fun uu___1 ->
-                  match uu___1 with
-                  | (m1, n1, uu___2, uu___3) ->
-                      (FStar_Ident.lid_equals m m1) &&
-                        (FStar_Ident.lid_equals n n1))) in
+          FStar_Compiler_Util.find_opt
+            (fun uu___1 ->
+               match uu___1 with
+               | (m1, n1, uu___2, uu___3) ->
+                   (FStar_Ident.lid_equals m m1) &&
+                     (FStar_Ident.lid_equals n n1))
+            (env1.effects).polymonadic_subcomps in
         match uu___ with
         | FStar_Pervasives_Native.Some (uu___1, uu___2, ts, k) ->
             FStar_Pervasives_Native.Some (ts, k)
@@ -5194,64 +5118,59 @@ let (exists_polymonadic_subcomp :
 let (print_effects_graph : env -> Prims.string) =
   fun env1 ->
     let eff_name lid =
-      let uu___ =
-        FStar_Compiler_Effect.op_Bar_Greater lid FStar_Ident.ident_of_lid in
-      FStar_Compiler_Effect.op_Bar_Greater uu___ FStar_Ident.string_of_id in
+      let uu___ = FStar_Ident.ident_of_lid lid in
+      FStar_Ident.string_of_id uu___ in
     let path_str path =
-      let uu___ =
-        FStar_Compiler_Effect.op_Bar_Greater path
-          (FStar_Compiler_List.map eff_name) in
-      FStar_Compiler_Effect.op_Bar_Greater uu___
-        (FStar_Compiler_String.concat ";") in
+      let uu___ = FStar_Compiler_List.map eff_name path in
+      FStar_Compiler_String.concat ";" uu___ in
     let pbinds = FStar_Compiler_Util.smap_create (Prims.of_int (10)) in
     let lifts = FStar_Compiler_Util.smap_create (Prims.of_int (20)) in
     let psubcomps = FStar_Compiler_Util.smap_create (Prims.of_int (10)) in
-    FStar_Compiler_Effect.op_Bar_Greater (env1.effects).order
-      (FStar_Compiler_List.iter
-         (fun uu___1 ->
-            match uu___1 with
-            | { msource = src; mtarget = tgt; mlift = uu___2; mpath = path;_}
-                ->
-                let key = eff_name src in
-                let m =
-                  let uu___3 = FStar_Compiler_Util.smap_try_find lifts key in
-                  match uu___3 with
-                  | FStar_Pervasives_Native.None ->
-                      let m1 =
-                        FStar_Compiler_Util.smap_create (Prims.of_int (10)) in
-                      (FStar_Compiler_Util.smap_add lifts key m1; m1)
-                  | FStar_Pervasives_Native.Some m1 -> m1 in
-                let uu___3 =
+    FStar_Compiler_List.iter
+      (fun uu___1 ->
+         match uu___1 with
+         | { msource = src; mtarget = tgt; mlift = uu___2; mpath = path;_} ->
+             let key = eff_name src in
+             let m =
+               let uu___3 = FStar_Compiler_Util.smap_try_find lifts key in
+               match uu___3 with
+               | FStar_Pervasives_Native.None ->
+                   let m1 =
+                     FStar_Compiler_Util.smap_create (Prims.of_int (10)) in
+                   (FStar_Compiler_Util.smap_add lifts key m1; m1)
+               | FStar_Pervasives_Native.Some m1 -> m1 in
+             let uu___3 =
+               let uu___4 = eff_name tgt in
+               FStar_Compiler_Util.smap_try_find m uu___4 in
+             (match uu___3 with
+              | FStar_Pervasives_Native.Some uu___4 -> ()
+              | FStar_Pervasives_Native.None ->
                   let uu___4 = eff_name tgt in
-                  FStar_Compiler_Util.smap_try_find m uu___4 in
-                (match uu___3 with
-                 | FStar_Pervasives_Native.Some uu___4 -> ()
-                 | FStar_Pervasives_Native.None ->
-                     let uu___4 = eff_name tgt in
-                     let uu___5 = path_str path in
-                     FStar_Compiler_Util.smap_add m uu___4 uu___5)));
-    FStar_Compiler_Effect.op_Bar_Greater (env1.effects).polymonadic_binds
-      (FStar_Compiler_List.iter
-         (fun uu___2 ->
-            match uu___2 with
-            | (m, n, p, uu___3) ->
-                let key =
-                  let uu___4 = eff_name m in
-                  let uu___5 = eff_name n in
-                  let uu___6 = eff_name p in
-                  FStar_Compiler_Util.format3 "%s, %s |> %s" uu___4 uu___5
-                    uu___6 in
-                FStar_Compiler_Util.smap_add pbinds key ""));
-    FStar_Compiler_Effect.op_Bar_Greater (env1.effects).polymonadic_subcomps
-      (FStar_Compiler_List.iter
-         (fun uu___3 ->
-            match uu___3 with
-            | (m, n, uu___4, uu___5) ->
-                let key =
-                  let uu___6 = eff_name m in
-                  let uu___7 = eff_name n in
-                  FStar_Compiler_Util.format2 "%s <: %s" uu___6 uu___7 in
-                FStar_Compiler_Util.smap_add psubcomps key ""));
+                  let uu___5 = path_str path in
+                  FStar_Compiler_Util.smap_add m uu___4 uu___5))
+      (env1.effects).order;
+    FStar_Compiler_List.iter
+      (fun uu___2 ->
+         match uu___2 with
+         | (m, n, p, uu___3) ->
+             let key =
+               let uu___4 = eff_name m in
+               let uu___5 = eff_name n in
+               let uu___6 = eff_name p in
+               FStar_Compiler_Util.format3 "%s, %s |> %s" uu___4 uu___5
+                 uu___6 in
+             FStar_Compiler_Util.smap_add pbinds key "")
+      (env1.effects).polymonadic_binds;
+    FStar_Compiler_List.iter
+      (fun uu___3 ->
+         match uu___3 with
+         | (m, n, uu___4, uu___5) ->
+             let key =
+               let uu___6 = eff_name m in
+               let uu___7 = eff_name n in
+               FStar_Compiler_Util.format2 "%s <: %s" uu___6 uu___7 in
+             FStar_Compiler_Util.smap_add psubcomps key "")
+      (env1.effects).polymonadic_subcomps;
     (let uu___3 =
        let uu___4 =
          FStar_Compiler_Util.smap_fold lifts
@@ -5266,8 +5185,7 @@ let (print_effects_graph : env -> Prims.string) =
                              FStar_Compiler_Util.format3
                                "%s -> %s [label=\"%s\"]" src tgt path in
                            uu___5 :: s1) s) [] in
-       FStar_Compiler_Effect.op_Bar_Greater uu___4
-         (FStar_Compiler_String.concat "\n") in
+       FStar_Compiler_String.concat "\n" uu___4 in
      let uu___4 =
        let uu___5 =
          FStar_Compiler_Util.smap_fold pbinds
@@ -5278,8 +5196,7 @@ let (print_effects_graph : env -> Prims.string) =
                     FStar_Compiler_Util.format1
                       "\"%s\" [shape=\"plaintext\"]" k in
                   uu___7 :: s) [] in
-       FStar_Compiler_Effect.op_Bar_Greater uu___5
-         (FStar_Compiler_String.concat "\n") in
+       FStar_Compiler_String.concat "\n" uu___5 in
      let uu___5 =
        let uu___6 =
          FStar_Compiler_Util.smap_fold psubcomps
@@ -5290,8 +5207,7 @@ let (print_effects_graph : env -> Prims.string) =
                     FStar_Compiler_Util.format1
                       "\"%s\" [shape=\"plaintext\"]" k in
                   uu___8 :: s) [] in
-       FStar_Compiler_Effect.op_Bar_Greater uu___6
-         (FStar_Compiler_String.concat "\n") in
+       FStar_Compiler_String.concat "\n" uu___6 in
      FStar_Compiler_Util.format3
        "digraph {\nlabel=\"Effects ordering\"\nsubgraph cluster_lifts {\nlabel = \"Lifts\"\n\n      %s\n}\nsubgraph cluster_polymonadic_binds {\nlabel = \"Polymonadic binds\"\n%s\n}\nsubgraph cluster_polymonadic_subcomps {\nlabel = \"Polymonadic subcomps\"\n%s\n}}\n"
        uu___3 uu___4 uu___5)
@@ -5304,23 +5220,15 @@ let (update_effect_lattice :
           let compose_edges e1 e2 =
             let composed_lift =
               let mlift_wp env2 c =
-                let uu___ =
-                  FStar_Compiler_Effect.op_Bar_Greater c
-                    ((e1.mlift).mlift_wp env2) in
-                FStar_Compiler_Effect.op_Bar_Greater uu___
-                  (fun uu___1 ->
-                     match uu___1 with
-                     | (c1, g1) ->
+                let uu___ = (e1.mlift).mlift_wp env2 c in
+                match uu___ with
+                | (c1, g1) ->
+                    let uu___1 = (e2.mlift).mlift_wp env2 c1 in
+                    (match uu___1 with
+                     | (c2, g2) ->
                          let uu___2 =
-                           FStar_Compiler_Effect.op_Bar_Greater c1
-                             ((e2.mlift).mlift_wp env2) in
-                         FStar_Compiler_Effect.op_Bar_Greater uu___2
-                           (fun uu___3 ->
-                              match uu___3 with
-                              | (c2, g2) ->
-                                  let uu___4 =
-                                    FStar_TypeChecker_Common.conj_guard g1 g2 in
-                                  (c2, uu___4))) in
+                           FStar_TypeChecker_Common.conj_guard g1 g2 in
+                         (c2, uu___2)) in
               let mlift_term =
                 match (((e1.mlift).mlift_term), ((e2.mlift).mlift_term)) with
                 | (FStar_Pervasives_Native.Some l1,
@@ -5353,51 +5261,44 @@ let (update_effect_lattice :
             | (i, j) ->
                 let uu___1 = FStar_Ident.lid_equals i j in
                 if uu___1
-                then
-                  FStar_Compiler_Effect.op_Bar_Greater (id_edge i)
-                    (fun uu___2 -> FStar_Pervasives_Native.Some uu___2)
+                then FStar_Pervasives_Native.Some (id_edge i)
                 else
-                  FStar_Compiler_Effect.op_Bar_Greater order
-                    (FStar_Compiler_Util.find_opt
-                       (fun e ->
-                          (FStar_Ident.lid_equals e.msource i) &&
-                            (FStar_Ident.lid_equals e.mtarget j))) in
+                  FStar_Compiler_Util.find_opt
+                    (fun e ->
+                       (FStar_Ident.lid_equals e.msource i) &&
+                         (FStar_Ident.lid_equals e.mtarget j)) order in
           let ms =
-            FStar_Compiler_Effect.op_Bar_Greater (env1.effects).decls
-              (FStar_Compiler_List.map
-                 (fun uu___ ->
-                    match uu___ with
-                    | (e, uu___1) -> e.FStar_Syntax_Syntax.mname)) in
+            FStar_Compiler_List.map
+              (fun uu___ ->
+                 match uu___ with
+                 | (e, uu___1) -> e.FStar_Syntax_Syntax.mname)
+              (env1.effects).decls in
           let all_i_src =
-            FStar_Compiler_Effect.op_Bar_Greater ms
-              (FStar_Compiler_List.fold_left
-                 (fun edges ->
-                    fun i ->
-                      let uu___ = FStar_Ident.lid_equals i edge1.msource in
-                      if uu___
-                      then edges
-                      else
-                        (let uu___2 =
-                           find_edge (env1.effects).order
-                             (i, (edge1.msource)) in
-                         match uu___2 with
-                         | FStar_Pervasives_Native.Some e -> e :: edges
-                         | FStar_Pervasives_Native.None -> edges)) []) in
+            FStar_Compiler_List.fold_left
+              (fun edges ->
+                 fun i ->
+                   let uu___ = FStar_Ident.lid_equals i edge1.msource in
+                   if uu___
+                   then edges
+                   else
+                     (let uu___2 =
+                        find_edge (env1.effects).order (i, (edge1.msource)) in
+                      match uu___2 with
+                      | FStar_Pervasives_Native.Some e -> e :: edges
+                      | FStar_Pervasives_Native.None -> edges)) [] ms in
           let all_tgt_j =
-            FStar_Compiler_Effect.op_Bar_Greater ms
-              (FStar_Compiler_List.fold_left
-                 (fun edges ->
-                    fun j ->
-                      let uu___ = FStar_Ident.lid_equals edge1.mtarget j in
-                      if uu___
-                      then edges
-                      else
-                        (let uu___2 =
-                           find_edge (env1.effects).order
-                             ((edge1.mtarget), j) in
-                         match uu___2 with
-                         | FStar_Pervasives_Native.Some e -> e :: edges
-                         | FStar_Pervasives_Native.None -> edges)) []) in
+            FStar_Compiler_List.fold_left
+              (fun edges ->
+                 fun j ->
+                   let uu___ = FStar_Ident.lid_equals edge1.mtarget j in
+                   if uu___
+                   then edges
+                   else
+                     (let uu___2 =
+                        find_edge (env1.effects).order ((edge1.mtarget), j) in
+                      match uu___2 with
+                      | FStar_Pervasives_Native.Some e -> e :: edges
+                      | FStar_Pervasives_Native.None -> edges)) [] ms in
           let check_cycle src1 tgt1 =
             let uu___ = FStar_Ident.lid_equals src1 tgt1 in
             if uu___
@@ -5444,30 +5345,28 @@ let (update_effect_lattice :
                (FStar_Compiler_List.op_At new_edge_source_j new_i_j)) in
           let order =
             FStar_Compiler_List.op_At new_edges (env1.effects).order in
-          FStar_Compiler_Effect.op_Bar_Greater order
-            (FStar_Compiler_List.iter
-               (fun edge2 ->
-                  let uu___1 =
-                    (FStar_Ident.lid_equals edge2.msource
-                       FStar_Parser_Const.effect_DIV_lid)
-                      &&
-                      (let uu___2 = lookup_effect_quals env1 edge2.mtarget in
-                       FStar_Compiler_Effect.op_Bar_Greater uu___2
-                         (FStar_Compiler_List.contains
-                            FStar_Syntax_Syntax.TotalEffect)) in
-                  if uu___1
-                  then
-                    let uu___2 =
-                      let uu___3 =
-                        let uu___4 = FStar_Ident.string_of_lid edge2.mtarget in
-                        FStar_Compiler_Util.format1
-                          "Divergent computations cannot be included in an effect %s marked 'total'"
-                          uu___4 in
-                      (FStar_Errors_Codes.Fatal_DivergentComputationCannotBeIncludedInTotal,
-                        uu___3) in
-                    let uu___3 = get_range env1 in
-                    FStar_Errors.raise_error uu___2 uu___3
-                  else ()));
+          FStar_Compiler_List.iter
+            (fun edge2 ->
+               let uu___1 =
+                 (FStar_Ident.lid_equals edge2.msource
+                    FStar_Parser_Const.effect_DIV_lid)
+                   &&
+                   (let uu___2 = lookup_effect_quals env1 edge2.mtarget in
+                    FStar_Compiler_List.contains
+                      FStar_Syntax_Syntax.TotalEffect uu___2) in
+               if uu___1
+               then
+                 let uu___2 =
+                   let uu___3 =
+                     let uu___4 = FStar_Ident.string_of_lid edge2.mtarget in
+                     FStar_Compiler_Util.format1
+                       "Divergent computations cannot be included in an effect %s marked 'total'"
+                       uu___4 in
+                   (FStar_Errors_Codes.Fatal_DivergentComputationCannotBeIncludedInTotal,
+                     uu___3) in
+                 let uu___3 = get_range env1 in
+                 FStar_Errors.raise_error uu___2 uu___3
+               else ()) order;
           (let joins =
              let ubs = FStar_Compiler_Util.smap_create (Prims.of_int (10)) in
              let add_ub i j k ik jk =
@@ -5484,28 +5383,25 @@ let (update_effect_lattice :
                      ubs1
                  | FStar_Pervasives_Native.None -> [(i, j, k, ik, jk)] in
                FStar_Compiler_Util.smap_add ubs key v in
-             FStar_Compiler_Effect.op_Bar_Greater ms
-               (FStar_Compiler_List.iter
-                  (fun i ->
-                     FStar_Compiler_Effect.op_Bar_Greater ms
-                       (FStar_Compiler_List.iter
-                          (fun j ->
-                             let uu___2 = FStar_Ident.lid_equals i j in
-                             if uu___2
-                             then ()
-                             else
-                               FStar_Compiler_Effect.op_Bar_Greater ms
-                                 (FStar_Compiler_List.iter
-                                    (fun k ->
-                                       let uu___4 =
-                                         let uu___5 = find_edge order (i, k) in
-                                         let uu___6 = find_edge order (j, k) in
-                                         (uu___5, uu___6) in
-                                       match uu___4 with
-                                       | (FStar_Pervasives_Native.Some ik,
-                                          FStar_Pervasives_Native.Some jk) ->
-                                           add_ub i j k ik.mlift jk.mlift
-                                       | uu___5 -> ()))))));
+             FStar_Compiler_List.iter
+               (fun i ->
+                  FStar_Compiler_List.iter
+                    (fun j ->
+                       let uu___2 = FStar_Ident.lid_equals i j in
+                       if uu___2
+                       then ()
+                       else
+                         FStar_Compiler_List.iter
+                           (fun k ->
+                              let uu___4 =
+                                let uu___5 = find_edge order (i, k) in
+                                let uu___6 = find_edge order (j, k) in
+                                (uu___5, uu___6) in
+                              match uu___4 with
+                              | (FStar_Pervasives_Native.Some ik,
+                                 FStar_Pervasives_Native.Some jk) ->
+                                  add_ub i j k ik.mlift jk.mlift
+                              | uu___5 -> ()) ms) ms) ms;
              FStar_Compiler_Util.smap_fold ubs
                (fun s ->
                   fun l ->
@@ -5522,9 +5418,8 @@ let (update_effect_lattice :
                                           ->
                                           let uu___8 =
                                             find_edge order (k, k') in
-                                          FStar_Compiler_Effect.op_Bar_Greater
-                                            uu___8
-                                            FStar_Compiler_Util.is_some) l) l in
+                                          FStar_Compiler_Util.is_some uu___8)
+                                   l) l in
                       if (FStar_Compiler_List.length lubs) <> Prims.int_one
                       then
                         let uu___2 =
@@ -6135,9 +6030,9 @@ let (finish_module : env -> FStar_Syntax_Syntax.modul -> env) =
         if uu___
         then
           let uu___1 =
-            FStar_Compiler_Effect.op_Bar_Greater env1.gamma_sig
-              (FStar_Compiler_List.map FStar_Pervasives_Native.snd) in
-          FStar_Compiler_Effect.op_Bar_Greater uu___1 FStar_Compiler_List.rev
+            FStar_Compiler_List.map FStar_Pervasives_Native.snd
+              env1.gamma_sig in
+          FStar_Compiler_List.rev uu___1
         else m.FStar_Syntax_Syntax.declarations in
       {
         solver = (env1.solver);
@@ -6464,9 +6359,8 @@ let (string_of_proof_ns : env -> Prims.string) =
              Prims.strcat (if b then "+" else "-") uu___2) in
     let uu___ =
       let uu___1 = FStar_Compiler_List.map aux env1.proof_ns in
-      FStar_Compiler_Effect.op_Bar_Greater uu___1 FStar_Compiler_List.rev in
-    FStar_Compiler_Effect.op_Bar_Greater uu___
-      (FStar_Compiler_String.concat " ")
+      FStar_Compiler_List.rev uu___1 in
+    FStar_Compiler_String.concat " " uu___
 let (guard_of_guard_formula :
   FStar_TypeChecker_Common.guard_formula -> guard_t) =
   fun g ->
@@ -6487,19 +6381,18 @@ let (is_trivial : guard_t -> Prims.bool) =
         FStar_TypeChecker_Common.deferred = [];
         FStar_TypeChecker_Common.univ_ineqs = ([], []);
         FStar_TypeChecker_Common.implicits = i;_} ->
-        FStar_Compiler_Effect.op_Bar_Greater i
-          (FStar_Compiler_Util.for_all
-             (fun imp ->
-                (let uu___1 =
-                   FStar_Syntax_Util.ctx_uvar_should_check
-                     imp.FStar_TypeChecker_Common.imp_uvar in
-                 FStar_Syntax_Syntax.uu___is_Allow_unresolved uu___1) ||
-                  (let uu___1 =
-                     FStar_Syntax_Unionfind.find
-                       (imp.FStar_TypeChecker_Common.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_head in
-                   match uu___1 with
-                   | FStar_Pervasives_Native.Some uu___2 -> true
-                   | FStar_Pervasives_Native.None -> false)))
+        FStar_Compiler_Util.for_all
+          (fun imp ->
+             (let uu___1 =
+                FStar_Syntax_Util.ctx_uvar_should_check
+                  imp.FStar_TypeChecker_Common.imp_uvar in
+              FStar_Syntax_Syntax.uu___is_Allow_unresolved uu___1) ||
+               (let uu___1 =
+                  FStar_Syntax_Unionfind.find
+                    (imp.FStar_TypeChecker_Common.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_head in
+                match uu___1 with
+                | FStar_Pervasives_Native.Some uu___2 -> true
+                | FStar_Pervasives_Native.None -> false)) i
     | uu___ -> false
 let (is_trivial_guard_formula : guard_t -> Prims.bool) =
   fun g ->
@@ -6558,9 +6451,7 @@ let (apply_guard : guard_t -> FStar_Syntax_Syntax.term -> guard_t) =
                   } in
                 FStar_Syntax_Syntax.Tm_app uu___3 in
               FStar_Syntax_Syntax.mk uu___2 f.FStar_Syntax_Syntax.pos in
-            FStar_Compiler_Effect.op_Less_Bar
-              (fun uu___2 -> FStar_TypeChecker_Common.NonTrivial uu___2)
-              uu___1 in
+            FStar_TypeChecker_Common.NonTrivial uu___1 in
           {
             FStar_TypeChecker_Common.guard_f = uu___;
             FStar_TypeChecker_Common.deferred_to_tac =
@@ -6708,10 +6599,8 @@ let (close_forall :
                            let e' =
                              let uu___4 =
                                let uu___5 = pop_bv e in
-                               FStar_Compiler_Effect.op_Bar_Greater uu___5
-                                 FStar_Compiler_Util.must in
-                             FStar_Compiler_Effect.op_Bar_Greater uu___4
-                               FStar_Pervasives_Native.snd in
+                               FStar_Compiler_Util.must uu___5 in
+                             FStar_Pervasives_Native.snd uu___4 in
                            (FStar_Defensive.def_check_scoped hasBinders_env
                               FStar_Class_Binders.hasNames_term
                               FStar_Syntax_Print.pretty_term
@@ -6858,70 +6747,64 @@ let (uvars_for_binders :
         fun reason ->
           fun r ->
             let uu___ =
-              FStar_Compiler_Effect.op_Bar_Greater bs
-                (FStar_Compiler_List.fold_left
-                   (fun uu___1 ->
-                      fun b ->
-                        match uu___1 with
-                        | (substs1, uvars, g) ->
-                            let sort =
-                              FStar_Syntax_Subst.subst substs1
-                                (b.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort in
-                            let ctx_uvar_meta_t =
-                              match ((b.FStar_Syntax_Syntax.binder_qual),
-                                      (b.FStar_Syntax_Syntax.binder_attrs))
-                              with
-                              | (FStar_Pervasives_Native.Some
-                                 (FStar_Syntax_Syntax.Meta t), []) ->
-                                  FStar_Pervasives_Native.Some
-                                    (FStar_Syntax_Syntax.Ctx_uvar_meta_tac t)
-                              | (uu___2, t::uu___3) ->
-                                  FStar_Pervasives_Native.Some
-                                    (FStar_Syntax_Syntax.Ctx_uvar_meta_attr t)
-                              | uu___2 -> FStar_Pervasives_Native.None in
-                            let uu___2 =
-                              let uu___3 = reason b in
-                              let uu___4 =
-                                let uu___5 =
-                                  FStar_Options.compat_pre_typed_indexed_effects
-                                    () in
-                                if uu___5
+              FStar_Compiler_List.fold_left
+                (fun uu___1 ->
+                   fun b ->
+                     match uu___1 with
+                     | (substs1, uvars, g) ->
+                         let sort =
+                           FStar_Syntax_Subst.subst substs1
+                             (b.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort in
+                         let ctx_uvar_meta_t =
+                           match ((b.FStar_Syntax_Syntax.binder_qual),
+                                   (b.FStar_Syntax_Syntax.binder_attrs))
+                           with
+                           | (FStar_Pervasives_Native.Some
+                              (FStar_Syntax_Syntax.Meta t), []) ->
+                               FStar_Pervasives_Native.Some
+                                 (FStar_Syntax_Syntax.Ctx_uvar_meta_tac t)
+                           | (uu___2, t::uu___3) ->
+                               FStar_Pervasives_Native.Some
+                                 (FStar_Syntax_Syntax.Ctx_uvar_meta_attr t)
+                           | uu___2 -> FStar_Pervasives_Native.None in
+                         let uu___2 =
+                           let uu___3 = reason b in
+                           let uu___4 =
+                             let uu___5 =
+                               FStar_Options.compat_pre_typed_indexed_effects
+                                 () in
+                             if uu___5
+                             then
+                               FStar_Syntax_Syntax.Allow_untyped
+                                 "indexed effect uvar in compat mode"
+                             else FStar_Syntax_Syntax.Strict in
+                           new_implicit_var_aux uu___3 r env1 sort uu___4
+                             ctx_uvar_meta_t in
+                         (match uu___2 with
+                          | (t, l_ctx_uvars, g_t) ->
+                              ((let uu___4 =
+                                  debug env1
+                                    (FStar_Options.Other "LayeredEffectsEqns") in
+                                if uu___4
                                 then
-                                  FStar_Syntax_Syntax.Allow_untyped
-                                    "indexed effect uvar in compat mode"
-                                else FStar_Syntax_Syntax.Strict in
-                              new_implicit_var_aux uu___3 r env1 sort uu___4
-                                ctx_uvar_meta_t in
-                            (match uu___2 with
-                             | (t, l_ctx_uvars, g_t) ->
-                                 ((let uu___4 =
-                                     FStar_Compiler_Effect.op_Less_Bar
-                                       (debug env1)
-                                       (FStar_Options.Other
-                                          "LayeredEffectsEqns") in
-                                   if uu___4
-                                   then
-                                     FStar_Compiler_List.iter
-                                       (fun uu___5 ->
-                                          match uu___5 with
-                                          | (ctx_uvar, uu___6) ->
-                                              let uu___7 =
-                                                FStar_Syntax_Print.ctx_uvar_to_string
-                                                  ctx_uvar in
-                                              FStar_Compiler_Util.print1
-                                                "Layered Effect uvar : %s\n"
-                                                uu___7) l_ctx_uvars
-                                   else ());
-                                  (let uu___4 = conj_guards [g; g_t] in
-                                   ((FStar_Compiler_List.op_At substs1
-                                       [FStar_Syntax_Syntax.NT
-                                          ((b.FStar_Syntax_Syntax.binder_bv),
-                                            t)]),
-                                     (FStar_Compiler_List.op_At uvars [t]),
-                                     uu___4))))) (substs, [], trivial_guard)) in
-            FStar_Compiler_Effect.op_Bar_Greater uu___
-              (fun uu___1 ->
-                 match uu___1 with | (uu___2, uvars, g) -> (uvars, g))
+                                  FStar_Compiler_List.iter
+                                    (fun uu___5 ->
+                                       match uu___5 with
+                                       | (ctx_uvar, uu___6) ->
+                                           let uu___7 =
+                                             FStar_Syntax_Print.ctx_uvar_to_string
+                                               ctx_uvar in
+                                           FStar_Compiler_Util.print1
+                                             "Layered Effect uvar : %s\n"
+                                             uu___7) l_ctx_uvars
+                                else ());
+                               (let uu___4 = conj_guards [g; g_t] in
+                                ((FStar_Compiler_List.op_At substs1
+                                    [FStar_Syntax_Syntax.NT
+                                       ((b.FStar_Syntax_Syntax.binder_bv), t)]),
+                                  (FStar_Compiler_List.op_At uvars [t]),
+                                  uu___4))))) (substs, [], trivial_guard) bs in
+            match uu___ with | (uu___1, uvars, g) -> (uvars, g)
 let (pure_precondition_for_trivial_post :
   env ->
     FStar_Syntax_Syntax.universe ->
@@ -6939,21 +6822,15 @@ let (pure_precondition_for_trivial_post :
                 let uu___ =
                   lookup_definition [NoDelta] env1
                     FStar_Parser_Const.trivial_pure_post_lid in
-                FStar_Compiler_Effect.op_Bar_Greater uu___
-                  FStar_Compiler_Util.must in
+                FStar_Compiler_Util.must uu___ in
               let uu___ = inst_tscheme_with post_ts [u] in
               match uu___ with
               | (uu___1, post) ->
                   let uu___2 =
-                    let uu___3 =
-                      FStar_Compiler_Effect.op_Bar_Greater t
-                        FStar_Syntax_Syntax.as_arg in
-                    [uu___3] in
+                    let uu___3 = FStar_Syntax_Syntax.as_arg t in [uu___3] in
                   FStar_Syntax_Syntax.mk_Tm_app post uu___2 r in
             let uu___ =
-              let uu___1 =
-                FStar_Compiler_Effect.op_Bar_Greater trivial_post
-                  FStar_Syntax_Syntax.as_arg in
+              let uu___1 = FStar_Syntax_Syntax.as_arg trivial_post in
               [uu___1] in
             FStar_Syntax_Syntax.mk_Tm_app wp uu___ r
 let (get_letrec_arity :

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Err.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Err.ml
@@ -105,70 +105,64 @@ let (errors_smt_detail :
     fun errs ->
       fun smt_detail ->
         let errs1 =
-          FStar_Compiler_Effect.op_Bar_Greater errs
-            (FStar_Compiler_List.map
-               (fun uu___ ->
-                  match uu___ with
-                  | (e, msg, r, ctx) ->
-                      let uu___1 =
-                        let msg1 = FStar_Compiler_List.op_At msg smt_detail in
-                        if r = FStar_Compiler_Range_Type.dummyRange
+          FStar_Compiler_List.map
+            (fun uu___ ->
+               match uu___ with
+               | (e, msg, r, ctx) ->
+                   let uu___1 =
+                     let msg1 = FStar_Compiler_List.op_At msg smt_detail in
+                     if r = FStar_Compiler_Range_Type.dummyRange
+                     then
+                       let uu___2 = FStar_TypeChecker_Env.get_range env in
+                       (e, msg1, uu___2, ctx)
+                     else
+                       (let r' =
+                          let uu___3 = FStar_Compiler_Range_Type.use_range r in
+                          FStar_Compiler_Range_Type.set_def_range r uu___3 in
+                        let uu___3 =
+                          let uu___4 =
+                            FStar_Compiler_Range_Ops.file_of_range r' in
+                          let uu___5 =
+                            let uu___6 = FStar_TypeChecker_Env.get_range env in
+                            FStar_Compiler_Range_Ops.file_of_range uu___6 in
+                          uu___4 <> uu___5 in
+                        if uu___3
                         then
-                          let uu___2 = FStar_TypeChecker_Env.get_range env in
-                          (e, msg1, uu___2, ctx)
-                        else
-                          (let r' =
-                             let uu___3 =
-                               FStar_Compiler_Range_Type.use_range r in
-                             FStar_Compiler_Range_Type.set_def_range r uu___3 in
-                           let uu___3 =
-                             let uu___4 =
-                               FStar_Compiler_Range_Ops.file_of_range r' in
-                             let uu___5 =
-                               let uu___6 =
-                                 FStar_TypeChecker_Env.get_range env in
-                               FStar_Compiler_Range_Ops.file_of_range uu___6 in
-                             uu___4 <> uu___5 in
-                           if uu___3
-                           then
-                             let msg2 =
-                               let uu___4 =
-                                 let uu___5 =
-                                   let uu___6 =
-                                     let uu___7 =
-                                       FStar_Compiler_Range_Ops.string_of_use_range
-                                         r in
-                                     Prims.strcat "Also see: " uu___7 in
-                                   FStar_Pprint.doc_of_string uu___6 in
-                                 let uu___6 =
-                                   let uu___7 =
-                                     let uu___8 =
-                                       let uu___9 =
-                                         FStar_Compiler_Range_Type.use_range
-                                           r in
-                                       let uu___10 =
-                                         FStar_Compiler_Range_Type.def_range
-                                           r in
-                                       uu___9 <> uu___10 in
-                                     if uu___8
-                                     then
-                                       let uu___9 =
-                                         let uu___10 =
-                                           FStar_Compiler_Range_Ops.string_of_def_range
-                                             r in
-                                         Prims.strcat
-                                           "Other related locations: "
-                                           uu___10 in
-                                       FStar_Pprint.doc_of_string uu___9
-                                     else FStar_Pprint.empty in
-                                   [uu___7] in
-                                 uu___5 :: uu___6 in
-                               FStar_Compiler_List.op_At msg1 uu___4 in
-                             let uu___4 = FStar_TypeChecker_Env.get_range env in
-                             (e, msg2, uu___4, ctx)
-                           else (e, msg1, r, ctx)) in
-                      (match uu___1 with
-                       | (e1, msg1, r1, ctx1) -> (e1, msg1, r1, ctx1)))) in
+                          let msg2 =
+                            let uu___4 =
+                              let uu___5 =
+                                let uu___6 =
+                                  let uu___7 =
+                                    FStar_Compiler_Range_Ops.string_of_use_range
+                                      r in
+                                  Prims.strcat "Also see: " uu___7 in
+                                FStar_Pprint.doc_of_string uu___6 in
+                              let uu___6 =
+                                let uu___7 =
+                                  let uu___8 =
+                                    let uu___9 =
+                                      FStar_Compiler_Range_Type.use_range r in
+                                    let uu___10 =
+                                      FStar_Compiler_Range_Type.def_range r in
+                                    uu___9 <> uu___10 in
+                                  if uu___8
+                                  then
+                                    let uu___9 =
+                                      let uu___10 =
+                                        FStar_Compiler_Range_Ops.string_of_def_range
+                                          r in
+                                      Prims.strcat
+                                        "Other related locations: " uu___10 in
+                                    FStar_Pprint.doc_of_string uu___9
+                                  else FStar_Pprint.empty in
+                                [uu___7] in
+                              uu___5 :: uu___6 in
+                            FStar_Compiler_List.op_At msg1 uu___4 in
+                          let uu___4 = FStar_TypeChecker_Env.get_range env in
+                          (e, msg2, uu___4, ctx)
+                        else (e, msg1, r, ctx)) in
+                   (match uu___1 with
+                    | (e1, msg1, r1, ctx1) -> (e1, msg1, r1, ctx1))) errs in
         errs1
 let (add_errors :
   FStar_TypeChecker_Env.env -> FStar_Errors.error Prims.list -> unit) =
@@ -441,11 +435,8 @@ let (disjunctive_pattern_vars :
   fun v1 ->
     fun v2 ->
       let vars v =
-        let uu___ =
-          FStar_Compiler_Effect.op_Bar_Greater v
-            (FStar_Compiler_List.map FStar_Syntax_Print.bv_to_string) in
-        FStar_Compiler_Effect.op_Bar_Greater uu___
-          (FStar_Compiler_String.concat ", ") in
+        let uu___ = FStar_Compiler_List.map FStar_Syntax_Print.bv_to_string v in
+        FStar_Compiler_String.concat ", " uu___ in
       let uu___ =
         let uu___1 = vars v1 in
         let uu___2 = vars v2 in
@@ -541,8 +532,7 @@ let (expected_pure_expression :
           let uu___1 = FStar_Syntax_Print.term_to_string e in
           let uu___2 =
             let uu___3 = name_and_result c in
-            FStar_Compiler_Effect.op_Less_Bar FStar_Pervasives_Native.fst
-              uu___3 in
+            FStar_Pervasives_Native.fst uu___3 in
           FStar_Compiler_Util.format2
             (Prims.strcat msg1
                "; got an expression \"%s\" with effect \"%s\"") uu___1 uu___2 in
@@ -564,8 +554,7 @@ let (expected_ghost_expression :
           let uu___1 = FStar_Syntax_Print.term_to_string e in
           let uu___2 =
             let uu___3 = name_and_result c in
-            FStar_Compiler_Effect.op_Less_Bar FStar_Pervasives_Native.fst
-              uu___3 in
+            FStar_Pervasives_Native.fst uu___3 in
           FStar_Compiler_Util.format2
             (Prims.strcat msg1
                "; got an expression \"%s\" with effect \"%s\"") uu___1 uu___2 in
@@ -591,12 +580,9 @@ let (failed_to_prove_specification_of :
     fun lbls ->
       let uu___ =
         let uu___1 = FStar_Syntax_Print.lbname_to_string l in
-        let uu___2 =
-          FStar_Compiler_Effect.op_Bar_Greater lbls
-            (FStar_Compiler_String.concat ", ") in
         FStar_Compiler_Util.format2
           "Failed to prove specification of %s; assertions at [%s] may fail"
-          uu___1 uu___2 in
+          uu___1 (FStar_Compiler_String.concat ", " lbls) in
       (FStar_Errors_Codes.Error_TypeCheckerFailToProve, uu___)
 let (failed_to_prove_specification :
   Prims.string Prims.list -> (FStar_Errors_Codes.raw_error * Prims.string)) =
@@ -606,11 +592,9 @@ let (failed_to_prove_specification :
       | [] ->
           "An unknown assertion in the term at this location was not provable"
       | uu___ ->
-          let uu___1 =
-            FStar_Compiler_Effect.op_Bar_Greater lbls
-              (FStar_Compiler_String.concat "\n\t") in
           FStar_Compiler_Util.format1
-            "The following problems were found:\n\t%s" uu___1 in
+            "The following problems were found:\n\t%s"
+            (FStar_Compiler_String.concat "\n\t" lbls) in
     (FStar_Errors_Codes.Error_TypeCheckerFailToProve, msg)
 let (top_level_effect : (FStar_Errors_Codes.raw_error * Prims.string)) =
   (FStar_Errors_Codes.Warning_TopLevelEffect,

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Generalize.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Generalize.ml
@@ -23,11 +23,9 @@ let (gen_univs :
            let uu___2 =
              let uu___3 = FStar_TypeChecker_Env.univ_vars env in
              FStar_Compiler_Set.diff FStar_Syntax_Free.ord_univ_uvar x uu___3 in
-           FStar_Compiler_Effect.op_Bar_Greater uu___2
-             (FStar_Compiler_Set.elems FStar_Syntax_Free.ord_univ_uvar) in
+           FStar_Compiler_Set.elems FStar_Syntax_Free.ord_univ_uvar uu___2 in
          (let uu___3 =
-            FStar_Compiler_Effect.op_Less_Bar
-              (FStar_TypeChecker_Env.debug env) (FStar_Options.Other "Gen") in
+            FStar_TypeChecker_Env.debug env (FStar_Options.Other "Gen") in
           if uu___3
           then
             let uu___4 =
@@ -41,34 +39,29 @@ let (gen_univs :
             let uu___3 = FStar_TypeChecker_Env.get_range env in
             FStar_Pervasives_Native.Some uu___3 in
           let u_names =
-            FStar_Compiler_Effect.op_Bar_Greater s
-              (FStar_Compiler_List.map
-                 (fun u ->
-                    let u_name = FStar_Syntax_Syntax.new_univ_name r in
-                    (let uu___4 =
-                       FStar_Compiler_Effect.op_Less_Bar
-                         (FStar_TypeChecker_Env.debug env)
-                         (FStar_Options.Other "Gen") in
-                     if uu___4
-                     then
-                       let uu___5 =
-                         let uu___6 = FStar_Syntax_Unionfind.univ_uvar_id u in
-                         FStar_Compiler_Effect.op_Less_Bar
-                           FStar_Compiler_Util.string_of_int uu___6 in
-                       let uu___6 =
-                         FStar_Class_Show.show
-                           FStar_Syntax_Print.showable_univ
-                           (FStar_Syntax_Syntax.U_unif u) in
-                       let uu___7 =
-                         FStar_Class_Show.show
-                           FStar_Syntax_Print.showable_univ
-                           (FStar_Syntax_Syntax.U_name u_name) in
-                       FStar_Compiler_Util.print3 "Setting ?%s (%s) to %s\n"
-                         uu___5 uu___6 uu___7
-                     else ());
-                    FStar_Syntax_Unionfind.univ_change u
-                      (FStar_Syntax_Syntax.U_name u_name);
-                    u_name)) in
+            FStar_Compiler_List.map
+              (fun u ->
+                 let u_name = FStar_Syntax_Syntax.new_univ_name r in
+                 (let uu___4 =
+                    FStar_TypeChecker_Env.debug env
+                      (FStar_Options.Other "Gen") in
+                  if uu___4
+                  then
+                    let uu___5 =
+                      let uu___6 = FStar_Syntax_Unionfind.univ_uvar_id u in
+                      FStar_Compiler_Util.string_of_int uu___6 in
+                    let uu___6 =
+                      FStar_Class_Show.show FStar_Syntax_Print.showable_univ
+                        (FStar_Syntax_Syntax.U_unif u) in
+                    let uu___7 =
+                      FStar_Class_Show.show FStar_Syntax_Print.showable_univ
+                        (FStar_Syntax_Syntax.U_name u_name) in
+                    FStar_Compiler_Util.print3 "Setting ?%s (%s) to %s\n"
+                      uu___5 uu___6 uu___7
+                  else ());
+                 FStar_Syntax_Unionfind.univ_change u
+                   (FStar_Syntax_Syntax.U_name u_name);
+                 u_name) s in
           u_names))
 let (gather_free_univnames :
   FStar_TypeChecker_Env.env ->
@@ -122,8 +115,7 @@ let (generalize_universes :
              let uu___1 = gather_free_univnames env t in
              FStar_Compiler_Set.elems FStar_Syntax_Syntax.ord_ident uu___1 in
            (let uu___2 =
-              FStar_Compiler_Effect.op_Less_Bar
-                (FStar_TypeChecker_Env.debug env) (FStar_Options.Other "Gen") in
+              FStar_TypeChecker_Env.debug env (FStar_Options.Other "Gen") in
             if uu___2
             then
               let uu___3 =
@@ -138,9 +130,7 @@ let (generalize_universes :
             else ());
            (let univs = FStar_Syntax_Free.univs t in
             (let uu___3 =
-               FStar_Compiler_Effect.op_Less_Bar
-                 (FStar_TypeChecker_Env.debug env)
-                 (FStar_Options.Other "Gen") in
+               FStar_TypeChecker_Env.debug env (FStar_Options.Other "Gen") in
              if uu___3
              then
                let uu___4 =
@@ -152,9 +142,7 @@ let (generalize_universes :
              else ());
             (let gen = gen_univs env univs in
              (let uu___4 =
-                FStar_Compiler_Effect.op_Less_Bar
-                  (FStar_TypeChecker_Env.debug env)
-                  (FStar_Options.Other "Gen") in
+                FStar_TypeChecker_Env.debug env (FStar_Options.Other "Gen") in
               if uu___4
               then
                 let uu___5 =
@@ -191,7 +179,7 @@ let (gen :
                  match uu___2 with
                  | (uu___3, uu___4, c) ->
                      FStar_Syntax_Util.is_pure_or_ghost_comp c) lecs in
-          FStar_Compiler_Effect.op_Less_Bar Prims.op_Negation uu___1 in
+          Prims.op_Negation uu___1 in
         if uu___
         then FStar_Pervasives_Native.None
         else
@@ -225,8 +213,7 @@ let (gen :
              let uu___2 =
                FStar_Compiler_Set.diff FStar_Syntax_Free.ord_ctx_uvar uvs
                  env_uvars in
-             FStar_Compiler_Effect.op_Bar_Greater uu___2
-               (FStar_Compiler_Set.elems FStar_Syntax_Free.ord_ctx_uvar) in
+             FStar_Compiler_Set.elems FStar_Syntax_Free.ord_ctx_uvar uu___2 in
            let univs_and_uvars_of_lec uu___2 =
              match uu___2 with
              | (lbname, e, c) ->
@@ -235,8 +222,7 @@ let (gen :
                  let univs = FStar_Syntax_Free.univs t in
                  let uvt = FStar_Syntax_Free.uvars t in
                  ((let uu___4 =
-                     FStar_Compiler_Effect.op_Less_Bar
-                       (FStar_TypeChecker_Env.debug env)
+                     FStar_TypeChecker_Env.debug env
                        (FStar_Options.Other "Gen") in
                    if uu___4
                    then
@@ -269,8 +255,7 @@ let (gen :
                        univs uu___4 in
                    let uvs = gen_uvars uvt in
                    (let uu___5 =
-                      FStar_Compiler_Effect.op_Less_Bar
-                        (FStar_TypeChecker_Env.debug env)
+                      FStar_TypeChecker_Env.debug env
                         (FStar_Options.Other "Gen") in
                     if uu___5
                     then
@@ -324,15 +309,13 @@ let (gen :
                                  msg) uu___11)) in
                let force_uvars_eq lec2 u1 u2 =
                  let uvars_subseteq u11 u21 =
-                   FStar_Compiler_Effect.op_Bar_Greater u11
-                     (FStar_Compiler_Util.for_all
-                        (fun u ->
-                           FStar_Compiler_Effect.op_Bar_Greater u21
-                             (FStar_Compiler_Util.for_some
-                                (fun u' ->
-                                   FStar_Syntax_Unionfind.equiv
-                                     u.FStar_Syntax_Syntax.ctx_uvar_head
-                                     u'.FStar_Syntax_Syntax.ctx_uvar_head)))) in
+                   FStar_Compiler_Util.for_all
+                     (fun u ->
+                        FStar_Compiler_Util.for_some
+                          (fun u' ->
+                             FStar_Syntax_Unionfind.equiv
+                               u.FStar_Syntax_Syntax.ctx_uvar_head
+                               u'.FStar_Syntax_Syntax.ctx_uvar_head) u21) u11 in
                  let uu___3 =
                    (uvars_subseteq u1 u2) && (uvars_subseteq u2 u1) in
                  if uu___3
@@ -372,195 +355,183 @@ let (gen :
                              lecs2)) uu___3 [] in
                let lecs2 = lec_hd :: lecs1 in
                let gen_types uvs1 =
-                 FStar_Compiler_Effect.op_Bar_Greater uvs1
-                   (FStar_Compiler_List.concatMap
-                      (fun u ->
-                         if
-                           FStar_Pervasives_Native.uu___is_Some
-                             u.FStar_Syntax_Syntax.ctx_uvar_meta
-                         then []
-                         else
-                           (let uu___4 =
-                              FStar_Syntax_Unionfind.find
-                                u.FStar_Syntax_Syntax.ctx_uvar_head in
-                            match uu___4 with
-                            | FStar_Pervasives_Native.Some uu___5 ->
-                                FStar_Compiler_Effect.failwith
-                                  "Unexpected instantiation of mutually recursive uvar"
-                            | uu___5 ->
-                                let k =
-                                  let uu___6 =
-                                    FStar_Syntax_Util.ctx_uvar_typ u in
-                                  FStar_TypeChecker_Normalize.normalize
-                                    [FStar_TypeChecker_Env.Beta;
-                                    FStar_TypeChecker_Env.Exclude
-                                      FStar_TypeChecker_Env.Zeta] env uu___6 in
-                                let uu___6 =
-                                  FStar_Syntax_Util.arrow_formals k in
-                                (match uu___6 with
-                                 | (bs, kres) ->
-                                     let uu___7 =
-                                       let uu___8 =
-                                         let uu___9 =
-                                           FStar_TypeChecker_Normalize.unfold_whnf
-                                             env kres in
-                                         FStar_Syntax_Util.unrefine uu___9 in
-                                       uu___8.FStar_Syntax_Syntax.n in
-                                     (match uu___7 with
-                                      | FStar_Syntax_Syntax.Tm_type uu___8 ->
-                                          let free =
-                                            FStar_Syntax_Free.names kres in
-                                          let uu___9 =
-                                            let uu___10 =
-                                              FStar_Compiler_Set.is_empty
-                                                FStar_Syntax_Syntax.ord_bv
-                                                free in
-                                            Prims.op_Negation uu___10 in
-                                          if uu___9
-                                          then []
-                                          else
-                                            (let a =
-                                               let uu___11 =
-                                                 let uu___12 =
-                                                   FStar_TypeChecker_Env.get_range
-                                                     env in
-                                                 FStar_Compiler_Effect.op_Less_Bar
-                                                   (fun uu___13 ->
-                                                      FStar_Pervasives_Native.Some
-                                                        uu___13) uu___12 in
-                                               FStar_Syntax_Syntax.new_bv
-                                                 uu___11 kres in
-                                             let t =
-                                               match bs with
-                                               | [] ->
-                                                   FStar_Syntax_Syntax.bv_to_name
-                                                     a
-                                               | uu___11 ->
-                                                   let uu___12 =
-                                                     FStar_Syntax_Syntax.bv_to_name
-                                                       a in
-                                                   FStar_Syntax_Util.abs bs
-                                                     uu___12
-                                                     (FStar_Pervasives_Native.Some
-                                                        (FStar_Syntax_Util.residual_tot
-                                                           kres)) in
-                                             FStar_Syntax_Util.set_uvar
-                                               u.FStar_Syntax_Syntax.ctx_uvar_head
-                                               t;
-                                             (let uu___12 =
-                                                let uu___13 =
-                                                  FStar_Syntax_Syntax.as_bqual_implicit
-                                                    true in
-                                                (a, uu___13) in
-                                              [uu___12]))
-                                      | uu___8 -> []))))) in
+                 FStar_Compiler_List.concatMap
+                   (fun u ->
+                      if
+                        FStar_Pervasives_Native.uu___is_Some
+                          u.FStar_Syntax_Syntax.ctx_uvar_meta
+                      then []
+                      else
+                        (let uu___4 =
+                           FStar_Syntax_Unionfind.find
+                             u.FStar_Syntax_Syntax.ctx_uvar_head in
+                         match uu___4 with
+                         | FStar_Pervasives_Native.Some uu___5 ->
+                             FStar_Compiler_Effect.failwith
+                               "Unexpected instantiation of mutually recursive uvar"
+                         | uu___5 ->
+                             let k =
+                               let uu___6 = FStar_Syntax_Util.ctx_uvar_typ u in
+                               FStar_TypeChecker_Normalize.normalize
+                                 [FStar_TypeChecker_Env.Beta;
+                                 FStar_TypeChecker_Env.Exclude
+                                   FStar_TypeChecker_Env.Zeta] env uu___6 in
+                             let uu___6 = FStar_Syntax_Util.arrow_formals k in
+                             (match uu___6 with
+                              | (bs, kres) ->
+                                  let uu___7 =
+                                    let uu___8 =
+                                      let uu___9 =
+                                        FStar_TypeChecker_Normalize.unfold_whnf
+                                          env kres in
+                                      FStar_Syntax_Util.unrefine uu___9 in
+                                    uu___8.FStar_Syntax_Syntax.n in
+                                  (match uu___7 with
+                                   | FStar_Syntax_Syntax.Tm_type uu___8 ->
+                                       let free =
+                                         FStar_Syntax_Free.names kres in
+                                       let uu___9 =
+                                         let uu___10 =
+                                           FStar_Compiler_Set.is_empty
+                                             FStar_Syntax_Syntax.ord_bv free in
+                                         Prims.op_Negation uu___10 in
+                                       if uu___9
+                                       then []
+                                       else
+                                         (let a =
+                                            let uu___11 =
+                                              let uu___12 =
+                                                FStar_TypeChecker_Env.get_range
+                                                  env in
+                                              FStar_Pervasives_Native.Some
+                                                uu___12 in
+                                            FStar_Syntax_Syntax.new_bv
+                                              uu___11 kres in
+                                          let t =
+                                            match bs with
+                                            | [] ->
+                                                FStar_Syntax_Syntax.bv_to_name
+                                                  a
+                                            | uu___11 ->
+                                                let uu___12 =
+                                                  FStar_Syntax_Syntax.bv_to_name
+                                                    a in
+                                                FStar_Syntax_Util.abs bs
+                                                  uu___12
+                                                  (FStar_Pervasives_Native.Some
+                                                     (FStar_Syntax_Util.residual_tot
+                                                        kres)) in
+                                          FStar_Syntax_Util.set_uvar
+                                            u.FStar_Syntax_Syntax.ctx_uvar_head
+                                            t;
+                                          (let uu___12 =
+                                             let uu___13 =
+                                               FStar_Syntax_Syntax.as_bqual_implicit
+                                                 true in
+                                             (a, uu___13) in
+                                           [uu___12]))
+                                   | uu___8 -> [])))) uvs1 in
                let gen_univs1 = gen_univs env univs in
                let gen_tvars = gen_types uvs in
                let ecs =
-                 FStar_Compiler_Effect.op_Bar_Greater lecs2
-                   (FStar_Compiler_List.map
-                      (fun uu___3 ->
-                         match uu___3 with
-                         | (lbname, e, c) ->
-                             let uu___4 =
-                               match (gen_tvars, gen_univs1) with
-                               | ([], []) -> (e, c, [])
-                               | uu___5 ->
-                                   let uu___6 = (e, c) in
-                                   (match uu___6 with
-                                    | (e0, c0) ->
-                                        let c1 =
-                                          FStar_TypeChecker_Normalize.normalize_comp
-                                            [FStar_TypeChecker_Env.Beta;
-                                            FStar_TypeChecker_Env.DoNotUnfoldPureLets;
-                                            FStar_TypeChecker_Env.CompressUvars;
-                                            FStar_TypeChecker_Env.NoFullNorm;
-                                            FStar_TypeChecker_Env.Exclude
-                                              FStar_TypeChecker_Env.Zeta] env
-                                            c in
-                                        let e1 =
-                                          FStar_TypeChecker_Normalize.reduce_uvar_solutions
-                                            env e in
-                                        let e2 =
-                                          if is_rec
-                                          then
-                                            let tvar_args =
-                                              FStar_Compiler_List.map
-                                                (fun uu___7 ->
-                                                   match uu___7 with
-                                                   | (x, uu___8) ->
-                                                       let uu___9 =
-                                                         FStar_Syntax_Syntax.bv_to_name
-                                                           x in
-                                                       FStar_Syntax_Syntax.iarg
-                                                         uu___9) gen_tvars in
-                                            let instantiate_lbname_with_app
-                                              tm fv =
-                                              let uu___7 =
-                                                let uu___8 =
-                                                  FStar_Compiler_Util.right
-                                                    lbname in
-                                                FStar_Syntax_Syntax.fv_eq fv
-                                                  uu___8 in
-                                              if uu___7
-                                              then
-                                                FStar_Syntax_Syntax.mk_Tm_app
-                                                  tm tvar_args
-                                                  tm.FStar_Syntax_Syntax.pos
-                                              else tm in
-                                            FStar_Syntax_InstFV.inst
-                                              instantiate_lbname_with_app e1
-                                          else e1 in
-                                        let tvars_bs =
-                                          FStar_Compiler_Effect.op_Bar_Greater
-                                            gen_tvars
-                                            (FStar_Compiler_List.map
-                                               (fun uu___7 ->
-                                                  match uu___7 with
-                                                  | (x, q) ->
-                                                      FStar_Syntax_Syntax.mk_binder_with_attrs
-                                                        x q
-                                                        FStar_Pervasives_Native.None
-                                                        [])) in
-                                        let t =
-                                          let uu___7 =
-                                            let uu___8 =
-                                              FStar_Syntax_Subst.compress
-                                                (FStar_Syntax_Util.comp_result
-                                                   c1) in
-                                            uu___8.FStar_Syntax_Syntax.n in
-                                          match uu___7 with
-                                          | FStar_Syntax_Syntax.Tm_arrow
-                                              { FStar_Syntax_Syntax.bs1 = bs;
-                                                FStar_Syntax_Syntax.comp =
-                                                  cod;_}
-                                              ->
-                                              let uu___8 =
-                                                FStar_Syntax_Subst.open_comp
-                                                  bs cod in
-                                              (match uu___8 with
-                                               | (bs1, cod1) ->
-                                                   FStar_Syntax_Util.arrow
-                                                     (FStar_Compiler_List.op_At
-                                                        tvars_bs bs1) cod1)
-                                          | uu___8 ->
-                                              FStar_Syntax_Util.arrow
-                                                tvars_bs c1 in
-                                        let e' =
-                                          let uu___7 =
-                                            let uu___8 =
-                                              FStar_Syntax_Util.residual_comp_of_comp
-                                                c1 in
-                                            FStar_Pervasives_Native.Some
-                                              uu___8 in
-                                          FStar_Syntax_Util.abs tvars_bs e2
-                                            uu___7 in
-                                        let uu___7 =
-                                          FStar_Syntax_Syntax.mk_Total t in
-                                        (e', uu___7, tvars_bs)) in
-                             (match uu___4 with
-                              | (e1, c1, gvs) ->
-                                  (lbname, gen_univs1, e1, c1, gvs)))) in
+                 FStar_Compiler_List.map
+                   (fun uu___3 ->
+                      match uu___3 with
+                      | (lbname, e, c) ->
+                          let uu___4 =
+                            match (gen_tvars, gen_univs1) with
+                            | ([], []) -> (e, c, [])
+                            | uu___5 ->
+                                let uu___6 = (e, c) in
+                                (match uu___6 with
+                                 | (e0, c0) ->
+                                     let c1 =
+                                       FStar_TypeChecker_Normalize.normalize_comp
+                                         [FStar_TypeChecker_Env.Beta;
+                                         FStar_TypeChecker_Env.DoNotUnfoldPureLets;
+                                         FStar_TypeChecker_Env.CompressUvars;
+                                         FStar_TypeChecker_Env.NoFullNorm;
+                                         FStar_TypeChecker_Env.Exclude
+                                           FStar_TypeChecker_Env.Zeta] env c in
+                                     let e1 =
+                                       FStar_TypeChecker_Normalize.reduce_uvar_solutions
+                                         env e in
+                                     let e2 =
+                                       if is_rec
+                                       then
+                                         let tvar_args =
+                                           FStar_Compiler_List.map
+                                             (fun uu___7 ->
+                                                match uu___7 with
+                                                | (x, uu___8) ->
+                                                    let uu___9 =
+                                                      FStar_Syntax_Syntax.bv_to_name
+                                                        x in
+                                                    FStar_Syntax_Syntax.iarg
+                                                      uu___9) gen_tvars in
+                                         let instantiate_lbname_with_app tm
+                                           fv =
+                                           let uu___7 =
+                                             let uu___8 =
+                                               FStar_Compiler_Util.right
+                                                 lbname in
+                                             FStar_Syntax_Syntax.fv_eq fv
+                                               uu___8 in
+                                           if uu___7
+                                           then
+                                             FStar_Syntax_Syntax.mk_Tm_app tm
+                                               tvar_args
+                                               tm.FStar_Syntax_Syntax.pos
+                                           else tm in
+                                         FStar_Syntax_InstFV.inst
+                                           instantiate_lbname_with_app e1
+                                       else e1 in
+                                     let tvars_bs =
+                                       FStar_Compiler_List.map
+                                         (fun uu___7 ->
+                                            match uu___7 with
+                                            | (x, q) ->
+                                                FStar_Syntax_Syntax.mk_binder_with_attrs
+                                                  x q
+                                                  FStar_Pervasives_Native.None
+                                                  []) gen_tvars in
+                                     let t =
+                                       let uu___7 =
+                                         let uu___8 =
+                                           FStar_Syntax_Subst.compress
+                                             (FStar_Syntax_Util.comp_result
+                                                c1) in
+                                         uu___8.FStar_Syntax_Syntax.n in
+                                       match uu___7 with
+                                       | FStar_Syntax_Syntax.Tm_arrow
+                                           { FStar_Syntax_Syntax.bs1 = bs;
+                                             FStar_Syntax_Syntax.comp = cod;_}
+                                           ->
+                                           let uu___8 =
+                                             FStar_Syntax_Subst.open_comp bs
+                                               cod in
+                                           (match uu___8 with
+                                            | (bs1, cod1) ->
+                                                FStar_Syntax_Util.arrow
+                                                  (FStar_Compiler_List.op_At
+                                                     tvars_bs bs1) cod1)
+                                       | uu___8 ->
+                                           FStar_Syntax_Util.arrow tvars_bs
+                                             c1 in
+                                     let e' =
+                                       let uu___7 =
+                                         let uu___8 =
+                                           FStar_Syntax_Util.residual_comp_of_comp
+                                             c1 in
+                                         FStar_Pervasives_Native.Some uu___8 in
+                                       FStar_Syntax_Util.abs tvars_bs e2
+                                         uu___7 in
+                                     let uu___7 =
+                                       FStar_Syntax_Syntax.mk_Total t in
+                                     (e', uu___7, tvars_bs)) in
+                          (match uu___4 with
+                           | (e1, c1, gvs) ->
+                               (lbname, gen_univs1, e1, c1, gvs))) lecs2 in
                FStar_Pervasives_Native.Some ecs)
 let (generalize' :
   FStar_TypeChecker_Env.env ->
@@ -584,8 +555,7 @@ let (generalize' :
                     match uu___5 with
                     | (lb, uu___6, uu___7) ->
                         FStar_Syntax_Print.lbname_to_string lb) lecs in
-             FStar_Compiler_Effect.op_Bar_Greater uu___4
-               (FStar_Compiler_String.concat ", ") in
+             FStar_Compiler_String.concat ", " uu___4 in
            FStar_Compiler_Util.print1 "Generalizing: %s\n" uu___3
          else ());
         (let univnames_lecs =
@@ -606,39 +576,36 @@ let (generalize' :
            let uu___2 = gen env is_rec lecs in
            match uu___2 with
            | FStar_Pervasives_Native.None ->
-               FStar_Compiler_Effect.op_Bar_Greater lecs
-                 (FStar_Compiler_List.map
-                    (fun uu___3 ->
-                       match uu___3 with | (l, t, c) -> (l, [], t, c, [])))
+               FStar_Compiler_List.map
+                 (fun uu___3 ->
+                    match uu___3 with | (l, t, c) -> (l, [], t, c, [])) lecs
            | FStar_Pervasives_Native.Some luecs ->
                ((let uu___4 =
                    FStar_TypeChecker_Env.debug env FStar_Options.Medium in
                  if uu___4
                  then
-                   FStar_Compiler_Effect.op_Bar_Greater luecs
-                     (FStar_Compiler_List.iter
-                        (fun uu___5 ->
-                           match uu___5 with
-                           | (l, us, e, c, gvs) ->
-                               let uu___6 =
-                                 FStar_Class_Show.show
-                                   FStar_Compiler_Range_Ops.show_range
-                                   e.FStar_Syntax_Syntax.pos in
-                               let uu___7 =
-                                 FStar_Syntax_Print.lbname_to_string l in
-                               let uu___8 =
-                                 FStar_Class_Show.show
-                                   FStar_Syntax_Print.showable_term
-                                   (FStar_Syntax_Util.comp_result c) in
-                               let uu___9 =
-                                 FStar_Class_Show.show
-                                   FStar_Syntax_Print.showable_term e in
-                               let uu___10 =
-                                 FStar_Syntax_Print.binders_to_string ", "
-                                   gvs in
-                               FStar_Compiler_Util.print5
-                                 "(%s) Generalized %s at type %s\n%s\nVars = (%s)\n"
-                                 uu___6 uu___7 uu___8 uu___9 uu___10))
+                   FStar_Compiler_List.iter
+                     (fun uu___5 ->
+                        match uu___5 with
+                        | (l, us, e, c, gvs) ->
+                            let uu___6 =
+                              FStar_Class_Show.show
+                                FStar_Compiler_Range_Ops.show_range
+                                e.FStar_Syntax_Syntax.pos in
+                            let uu___7 =
+                              FStar_Syntax_Print.lbname_to_string l in
+                            let uu___8 =
+                              FStar_Class_Show.show
+                                FStar_Syntax_Print.showable_term
+                                (FStar_Syntax_Util.comp_result c) in
+                            let uu___9 =
+                              FStar_Class_Show.show
+                                FStar_Syntax_Print.showable_term e in
+                            let uu___10 =
+                              FStar_Syntax_Print.binders_to_string ", " gvs in
+                            FStar_Compiler_Util.print5
+                              "(%s) Generalized %s at type %s\n%s\nVars = (%s)\n"
+                              uu___6 uu___7 uu___8 uu___9 uu___10) luecs
                  else ());
                 luecs) in
          FStar_Compiler_List.map

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_NBE.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_NBE.ml
@@ -577,7 +577,7 @@ let rec (translate :
              let uu___2 =
                let uu___3 = translate_constant c in
                FStar_TypeChecker_NBETerm.Constant uu___3 in
-             FStar_Compiler_Effect.op_Less_Bar mk_t1 uu___2
+             mk_t1 uu___2
          | FStar_Syntax_Syntax.Tm_bvar db ->
              if
                db.FStar_Syntax_Syntax.index < (FStar_Compiler_List.length bs)
@@ -591,8 +591,7 @@ let rec (translate :
                        let uu___6 =
                          FStar_Compiler_List.map
                            FStar_TypeChecker_NBETerm.t_to_string bs in
-                       FStar_Compiler_Effect.op_Bar_Greater uu___6
-                         (FStar_Compiler_String.concat "; ") in
+                       FStar_Compiler_String.concat "; " uu___6 in
                      FStar_Compiler_Util.print2
                        "Resolved bvar to %s\n\tcontext is [%s]\n" uu___4
                        uu___5);
@@ -607,8 +606,7 @@ let rec (translate :
                      let uu___6 =
                        FStar_Compiler_List.map
                          FStar_Syntax_Print.univ_to_string us in
-                     FStar_Compiler_Effect.op_Bar_Greater uu___6
-                       (FStar_Compiler_String.concat ", ") in
+                     FStar_Compiler_String.concat ", " uu___6 in
                    FStar_Compiler_Util.print2 "Uinst term : %s\nUnivs : %s\n"
                      uu___4 uu___5);
               (let uu___3 = translate cfg bs t in
@@ -619,14 +617,14 @@ let rec (translate :
                         let uu___6 =
                           let uu___7 = translate_univ cfg bs x in
                           FStar_TypeChecker_NBETerm.Univ uu___7 in
-                        FStar_Compiler_Effect.op_Less_Bar mk_t1 uu___6 in
+                        mk_t1 uu___6 in
                       FStar_TypeChecker_NBETerm.as_arg uu___5) us in
                iapp cfg uu___3 uu___4))
          | FStar_Syntax_Syntax.Tm_type u ->
              let uu___2 =
                let uu___3 = translate_univ cfg bs u in
                FStar_TypeChecker_NBETerm.Type_t uu___3 in
-             FStar_Compiler_Effect.op_Less_Bar mk_t1 uu___2
+             mk_t1 uu___2
          | FStar_Syntax_Syntax.Tm_arrow
              { FStar_Syntax_Syntax.bs1 = xs; FStar_Syntax_Syntax.comp = c;_}
              ->
@@ -677,7 +675,7 @@ let rec (translate :
                  let uu___4 = FStar_Thunk.mk norm in
                  FStar_Pervasives.Inl uu___4 in
                FStar_TypeChecker_NBETerm.Arrow uu___3 in
-             FStar_Compiler_Effect.op_Less_Bar mk_t1 uu___2
+             mk_t1 uu___2
          | FStar_Syntax_Syntax.Tm_refine
              { FStar_Syntax_Syntax.b = bv; FStar_Syntax_Syntax.phi = tm;_} ->
              if
@@ -686,7 +684,7 @@ let rec (translate :
                  ((cfg.core_cfg).FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unrefine
              then translate cfg bs bv.FStar_Syntax_Syntax.sort
              else
-               FStar_Compiler_Effect.op_Less_Bar mk_t1
+               mk_t1
                  (FStar_TypeChecker_NBETerm.Refinement
                     ((fun y -> translate cfg (y :: bs) tm),
                       (fun uu___3 ->
@@ -747,7 +745,7 @@ let rec (translate :
                    FStar_TypeChecker_NBETerm.UVar uu___5 in
                  (uu___4, []) in
                FStar_TypeChecker_NBETerm.Accu uu___3 in
-             FStar_Compiler_Effect.op_Less_Bar mk_t1 uu___2
+             mk_t1 uu___2
          | FStar_Syntax_Syntax.Tm_name x ->
              FStar_TypeChecker_NBETerm.mkAccuVar x
          | FStar_Syntax_Syntax.Tm_abs
@@ -761,7 +759,7 @@ let rec (translate :
              { FStar_Syntax_Syntax.bs = xs; FStar_Syntax_Syntax.body = body;
                FStar_Syntax_Syntax.rc_opt = resc;_}
              ->
-             FStar_Compiler_Effect.op_Less_Bar mk_t1
+             mk_t1
                (FStar_TypeChecker_NBETerm.Lam
                   ((fun ys ->
                       let uu___2 =
@@ -851,7 +849,7 @@ let rec (translate :
                let uu___7 =
                  translate cfg bs (FStar_Pervasives_Native.fst arg) in
                FStar_TypeChecker_NBETerm.Reflect uu___7 in
-             FStar_Compiler_Effect.op_Less_Bar mk_t1 uu___6
+             mk_t1 uu___6
          | FStar_Syntax_Syntax.Tm_app
              {
                FStar_Syntax_Syntax.hd =
@@ -882,7 +880,7 @@ let rec (translate :
                let uu___7 =
                  translate cfg bs (FStar_Pervasives_Native.fst arg) in
                FStar_TypeChecker_NBETerm.Reflect uu___7 in
-             FStar_Compiler_Effect.op_Less_Bar mk_t1 uu___6
+             mk_t1 uu___6
          | FStar_Syntax_Syntax.Tm_app
              {
                FStar_Syntax_Syntax.hd =
@@ -1104,20 +1102,18 @@ let rec (translate :
                       (fun uu___4 ->
                          let uu___5 =
                            let uu___6 =
-                             FStar_Compiler_Effect.op_Bar_Greater args
-                               (FStar_Compiler_List.map
-                                  (fun uu___7 ->
-                                     match uu___7 with
-                                     | (x, q) ->
-                                         let uu___8 =
-                                           FStar_TypeChecker_NBETerm.t_to_string
-                                             x in
-                                         Prims.strcat
-                                           (if FStar_Compiler_Util.is_some q
-                                            then "#"
-                                            else "") uu___8)) in
-                           FStar_Compiler_Effect.op_Bar_Greater uu___6
-                             (FStar_Compiler_String.concat "; ") in
+                             FStar_Compiler_List.map
+                               (fun uu___7 ->
+                                  match uu___7 with
+                                  | (x, q) ->
+                                      let uu___8 =
+                                        FStar_TypeChecker_NBETerm.t_to_string
+                                          x in
+                                      Prims.strcat
+                                        (if FStar_Compiler_Util.is_some q
+                                         then "#"
+                                         else "") uu___8) args in
+                           FStar_Compiler_String.concat "; " uu___6 in
                          FStar_Compiler_Util.print1 "Match args: %s\n" uu___5);
                     (let uu___4 = pickBranch cfg scrut2 branches in
                      match uu___4 with
@@ -1197,7 +1193,7 @@ let rec (translate :
                  let uu___4 = translate cfg bs e1 in
                  let uu___5 = FStar_Thunk.mk norm_meta in (uu___4, uu___5) in
                FStar_TypeChecker_NBETerm.Meta uu___3 in
-             FStar_Compiler_Effect.op_Less_Bar mk_t1 uu___2
+             mk_t1 uu___2
          | FStar_Syntax_Syntax.Tm_let
              { FStar_Syntax_Syntax.lbs = (false, lb::[]);
                FStar_Syntax_Syntax.body1 = body;_}
@@ -1242,7 +1238,7 @@ let rec (translate :
                          lb.FStar_Syntax_Syntax.lbeff) in
                   if uu___5
                   then
-                    FStar_Compiler_Effect.op_Less_Bar mk_t1
+                    mk_t1
                       (FStar_TypeChecker_NBETerm.Constant
                          FStar_TypeChecker_NBETerm.Unit)
                   else translate cfg bs lb.FStar_Syntax_Syntax.lbdef in
@@ -1271,7 +1267,7 @@ let rec (translate :
                       FStar_TypeChecker_NBETerm.UnreducedLet uu___7 in
                     (uu___6, []) in
                   FStar_TypeChecker_NBETerm.Accu uu___5 in
-                FStar_Compiler_Effect.op_Less_Bar mk_t1 uu___4)
+                mk_t1 uu___4)
          | FStar_Syntax_Syntax.Tm_let
              { FStar_Syntax_Syntax.lbs = (_rec, lbs);
                FStar_Syntax_Syntax.body1 = body;_}
@@ -1297,10 +1293,8 @@ let rec (translate :
                  let uu___2 =
                    FStar_Compiler_List.map
                      (fun v ->
-                        let uu___3 =
-                          let uu___4 = FStar_Syntax_Syntax.range_of_bv v in
-                          mk_rt uu___4 in
-                        FStar_Compiler_Effect.op_Less_Bar uu___3
+                        let uu___3 = FStar_Syntax_Syntax.range_of_bv v in
+                        mk_rt uu___3
                           (FStar_TypeChecker_NBETerm.Accu
                              ((FStar_TypeChecker_NBETerm.Var v), []))) vars in
                  FStar_Compiler_List.op_At uu___2 bs in
@@ -1318,7 +1312,7 @@ let rec (translate :
                      FStar_TypeChecker_NBETerm.UnreducedLetRec uu___5 in
                    (uu___4, []) in
                  FStar_TypeChecker_NBETerm.Accu uu___3 in
-               FStar_Compiler_Effect.op_Less_Bar mk_t1 uu___2
+               mk_t1 uu___2
              else
                (let uu___3 = make_rec_env lbs bs in translate cfg uu___3 body)
          | FStar_Syntax_Syntax.Tm_quoted (qt, qi) ->
@@ -1345,12 +1339,10 @@ let rec (translate :
              (match qi.FStar_Syntax_Syntax.qkind with
               | FStar_Syntax_Syntax.Quote_dynamic ->
                   let qt1 = close qt in
-                  FStar_Compiler_Effect.op_Less_Bar mk_t1
-                    (FStar_TypeChecker_NBETerm.Quote (qt1, qi))
+                  mk_t1 (FStar_TypeChecker_NBETerm.Quote (qt1, qi))
               | FStar_Syntax_Syntax.Quote_static ->
                   let qi1 = FStar_Syntax_Syntax.on_antiquoted close qi in
-                  FStar_Compiler_Effect.op_Less_Bar mk_t1
-                    (FStar_TypeChecker_NBETerm.Quote (qt, qi1)))
+                  mk_t1 (FStar_TypeChecker_NBETerm.Quote (qt, qi1)))
          | FStar_Syntax_Syntax.Tm_lazy li ->
              let f uu___2 =
                let t = FStar_Syntax_Util.unfold_lazy li in
@@ -1365,7 +1357,7 @@ let rec (translate :
                  let uu___4 = FStar_Thunk.mk f in
                  ((FStar_Pervasives.Inl li), uu___4) in
                FStar_TypeChecker_NBETerm.Lazy uu___3 in
-             FStar_Compiler_Effect.op_Less_Bar mk_t1 uu___2)
+             mk_t1 uu___2)
 and (translate_comp :
   config ->
     FStar_TypeChecker_NBETerm.t Prims.list ->
@@ -1418,7 +1410,7 @@ and (iapp :
                                FStar_Pervasives_Native.fst arg_values_rev in
                            FStar_Compiler_List.append uu___3 ctx in
                          FStar_Pervasives.Inl (ctx1, xs1, rc)) in
-              FStar_Compiler_Effect.op_Less_Bar mk
+              mk
                 (FStar_TypeChecker_NBETerm.Lam
                    ((fun l ->
                        f1 (FStar_Compiler_List.append l arg_values_rev)),
@@ -1435,7 +1427,7 @@ and (iapp :
                      let uu___4 = f1 (FStar_Compiler_List.rev args1) in
                      iapp cfg uu___4 args')
         | FStar_TypeChecker_NBETerm.Accu (a, ts) ->
-            FStar_Compiler_Effect.op_Less_Bar mk
+            mk
               (FStar_TypeChecker_NBETerm.Accu
                  (a, (FStar_Compiler_List.rev_append args ts)))
         | FStar_TypeChecker_NBETerm.Construct (i, us, ts) ->
@@ -1451,8 +1443,7 @@ and (iapp :
             let uu___1 = aux args us ts in
             (match uu___1 with
              | (us', ts') ->
-                 FStar_Compiler_Effect.op_Less_Bar mk
-                   (FStar_TypeChecker_NBETerm.Construct (i, us', ts')))
+                 mk (FStar_TypeChecker_NBETerm.Construct (i, us', ts')))
         | FStar_TypeChecker_NBETerm.FV (i, us, ts) ->
             let rec aux args1 us1 ts1 =
               match args1 with
@@ -1465,9 +1456,7 @@ and (iapp :
               | [] -> (us1, ts1) in
             let uu___1 = aux args us ts in
             (match uu___1 with
-             | (us', ts') ->
-                 FStar_Compiler_Effect.op_Less_Bar mk
-                   (FStar_TypeChecker_NBETerm.FV (i, us', ts')))
+             | (us', ts') -> mk (FStar_TypeChecker_NBETerm.FV (i, us', ts')))
         | FStar_TypeChecker_NBETerm.TopLevelLet (lb, arity, args_rev) ->
             let args_rev1 = FStar_Compiler_List.rev_append args args_rev in
             let n_args_rev = FStar_Compiler_List.length args_rev1 in
@@ -1522,9 +1511,7 @@ and (iapp :
                                           | (x, uu___11) ->
                                               FStar_TypeChecker_NBETerm.t_to_string
                                                 x) args_rev2 in
-                                   FStar_Compiler_Effect.op_Bar_Greater
-                                     uu___9
-                                     (FStar_Compiler_String.concat ", ") in
+                                   FStar_Compiler_String.concat ", " uu___9 in
                                  FStar_Compiler_Util.print3
                                    "Reducing body of %s = %s,\n\twith args = %s\n"
                                    uu___6 uu___7 uu___8);
@@ -1551,7 +1538,7 @@ and (iapp :
                                lb.FStar_Syntax_Syntax.lbdef in
                            iapp cfg uu___5 (FStar_Compiler_List.rev extra)))
              else
-               FStar_Compiler_Effect.op_Less_Bar mk
+               mk
                  (FStar_TypeChecker_NBETerm.TopLevelLet
                     (lb, arity, args_rev1)))
         | FStar_TypeChecker_NBETerm.TopLevelRec
@@ -1606,7 +1593,7 @@ and (iapp :
                                lb.FStar_Syntax_Syntax.lbdef in
                            iapp cfg uu___7 rest)))
             else
-              FStar_Compiler_Effect.op_Less_Bar mk
+              mk
                 (FStar_TypeChecker_NBETerm.TopLevelRec
                    (lb, arity, decreases_list, args1))
         | FStar_TypeChecker_NBETerm.LocalLetRec
@@ -1615,7 +1602,7 @@ and (iapp :
             ->
             if remaining_arity = Prims.int_zero
             then
-              FStar_Compiler_Effect.op_Less_Bar mk
+              mk
                 (FStar_TypeChecker_NBETerm.LocalLetRec
                    (i, lb, mutual_lbs, local_env,
                      (FStar_Compiler_List.op_At acc_args args),
@@ -1624,7 +1611,7 @@ and (iapp :
               (let n_args = FStar_Compiler_List.length args in
                if n_args < remaining_arity
                then
-                 FStar_Compiler_Effect.op_Less_Bar mk
+                 mk
                    (FStar_TypeChecker_NBETerm.LocalLetRec
                       (i, lb, mutual_lbs, local_env,
                         (FStar_Compiler_List.op_At acc_args args),
@@ -1637,7 +1624,7 @@ and (iapp :
                   | (should_reduce, uu___4, uu___5) ->
                       if Prims.op_Negation should_reduce
                       then
-                        FStar_Compiler_Effect.op_Less_Bar mk
+                        mk
                           (FStar_TypeChecker_NBETerm.LocalLetRec
                              (i, lb, mutual_lbs, local_env, args1,
                                Prims.int_zero, decreases_list))
@@ -1787,9 +1774,8 @@ and (translate_fv :
                                              | (x, uu___14) ->
                                                  FStar_TypeChecker_NBETerm.t_to_string
                                                    x) args' in
-                                      FStar_Compiler_Effect.op_Bar_Greater
-                                        uu___12
-                                        (FStar_Compiler_String.concat "; ") in
+                                      FStar_Compiler_String.concat "; "
+                                        uu___12 in
                                     FStar_Compiler_Util.print1
                                       "Caling primop with args = [%s]\n"
                                       uu___11);
@@ -1854,7 +1840,7 @@ and (translate_fv :
                                            iapp cfg uu___13 args'))))),
                              uu___8, arity) in
                          FStar_TypeChecker_NBETerm.Lam uu___7 in
-                       FStar_Compiler_Effect.op_Less_Bar mk_t uu___6))
+                       mk_t uu___6))
                  | FStar_Pervasives_Native.Some uu___5 ->
                      (debug1
                         (fun uu___7 ->
@@ -1914,10 +1900,8 @@ and (translate_fv :
                                (match uu___10 with
                                 | (ar, lst) ->
                                     let uu___11 =
-                                      let uu___12 =
-                                        FStar_Syntax_Syntax.range_of_fv fvar in
-                                      mk_rt uu___12 in
-                                    FStar_Compiler_Effect.op_Less_Bar uu___11
+                                      FStar_Syntax_Syntax.range_of_fv fvar in
+                                    mk_rt uu___11
                                       (FStar_TypeChecker_NBETerm.TopLevelRec
                                          (lb, ar, lst, [])))
                              else translate_letbinding cfg bs lb
@@ -1986,10 +1970,8 @@ and (translate_fv :
                                (match uu___10 with
                                 | (ar, lst) ->
                                     let uu___11 =
-                                      let uu___12 =
-                                        FStar_Syntax_Syntax.range_of_fv fvar in
-                                      mk_rt uu___12 in
-                                    FStar_Compiler_Effect.op_Less_Bar uu___11
+                                      FStar_Syntax_Syntax.range_of_fv fvar in
+                                    mk_rt uu___11
                                       (FStar_TypeChecker_NBETerm.TopLevelRec
                                          (lb, ar, lst, [])))
                              else translate_letbinding cfg bs lb
@@ -2047,11 +2029,9 @@ and (translate_letbinding :
                          "Making TopLevelLet for %s with arity %s\n" uu___6
                          uu___7);
                   (let uu___5 =
-                     let uu___6 =
-                       FStar_Syntax_Syntax.range_of_lbname
-                         lb.FStar_Syntax_Syntax.lbname in
-                     mk_rt uu___6 in
-                   FStar_Compiler_Effect.op_Less_Bar uu___5
+                     FStar_Syntax_Syntax.range_of_lbname
+                       lb.FStar_Syntax_Syntax.lbname in
+                   mk_rt uu___5
                      (FStar_TypeChecker_NBETerm.TopLevelLet (lb, arity, []))))
                else translate cfg bs lb.FStar_Syntax_Syntax.lbdef)
 and (mkRec :
@@ -2067,7 +2047,7 @@ and (mkRec :
           let uu___ = let_rec_arity b in
           match uu___ with
           | (ar, ar_lst) ->
-              FStar_Compiler_Effect.op_Less_Bar mk_t
+              mk_t
                 (FStar_TypeChecker_NBETerm.LocalLetRec
                    (i, b, bs, env, [], ar, ar_lst))
 and (make_rec_env :
@@ -2243,9 +2223,7 @@ and (translate_flag :
         | FStar_Syntax_Syntax.CPS -> FStar_TypeChecker_NBETerm.CPS
         | FStar_Syntax_Syntax.DECREASES (FStar_Syntax_Syntax.Decreases_lex l)
             ->
-            let uu___ =
-              FStar_Compiler_Effect.op_Bar_Greater l
-                (FStar_Compiler_List.map (translate cfg bs)) in
+            let uu___ = FStar_Compiler_List.map (translate cfg bs) l in
             FStar_TypeChecker_NBETerm.DECREASES_lex uu___
         | FStar_Syntax_Syntax.DECREASES (FStar_Syntax_Syntax.Decreases_wf
             (rel, e)) ->
@@ -2273,9 +2251,7 @@ and (readback_flag :
       | FStar_TypeChecker_NBETerm.CPS -> FStar_Syntax_Syntax.CPS
       | FStar_TypeChecker_NBETerm.DECREASES_lex l ->
           let uu___ =
-            let uu___1 =
-              FStar_Compiler_Effect.op_Bar_Greater l
-                (FStar_Compiler_List.map (readback cfg)) in
+            let uu___1 = FStar_Compiler_List.map (readback cfg) l in
             FStar_Syntax_Syntax.Decreases_lex uu___1 in
           FStar_Syntax_Syntax.DECREASES uu___
       | FStar_TypeChecker_NBETerm.DECREASES_wf (rel, e) ->
@@ -2383,31 +2359,20 @@ and (translate_monadic :
                                 let uu___5 =
                                   let uu___6 =
                                     let uu___7 =
-                                      FStar_Compiler_Effect.op_Bar_Greater ed
-                                        FStar_Syntax_Util.get_bind_repr in
-                                    FStar_Compiler_Effect.op_Bar_Greater
-                                      uu___7 FStar_Compiler_Util.must in
-                                  FStar_Compiler_Effect.op_Bar_Greater uu___6
-                                    FStar_Pervasives_Native.snd in
+                                      FStar_Syntax_Util.get_bind_repr ed in
+                                    FStar_Compiler_Util.must uu___7 in
+                                  FStar_Pervasives_Native.snd uu___6 in
                                 FStar_Syntax_Util.un_uinst uu___5 in
                               translate cfg' [] uu___4 in
-                            let uu___4 =
-                              let uu___5 =
-                                let uu___6 =
-                                  FStar_Compiler_Effect.op_Less_Bar mk_t
-                                    (FStar_TypeChecker_NBETerm.Univ
-                                       FStar_Syntax_Syntax.U_unknown) in
-                                (uu___6, FStar_Pervasives_Native.None) in
-                              let uu___6 =
-                                let uu___7 =
-                                  let uu___8 =
-                                    FStar_Compiler_Effect.op_Less_Bar mk_t
-                                      (FStar_TypeChecker_NBETerm.Univ
-                                         FStar_Syntax_Syntax.U_unknown) in
-                                  (uu___8, FStar_Pervasives_Native.None) in
-                                [uu___7] in
-                              uu___5 :: uu___6 in
-                            iapp cfg uu___3 uu___4 in
+                            iapp cfg uu___3
+                              [((mk_t
+                                   (FStar_TypeChecker_NBETerm.Univ
+                                      FStar_Syntax_Syntax.U_unknown)),
+                                 FStar_Pervasives_Native.None);
+                              ((mk_t
+                                  (FStar_TypeChecker_NBETerm.Univ
+                                     FStar_Syntax_Syntax.U_unknown)),
+                                FStar_Pervasives_Native.None)] in
                           let uu___3 =
                             let uu___4 =
                               let uu___5 =
@@ -2533,15 +2498,14 @@ and (translate_monadic :
                      FStar_Syntax_Syntax.rc_opt1 = lopt;_}
                    ->
                    let branches1 =
-                     FStar_Compiler_Effect.op_Bar_Greater branches
-                       (FStar_Compiler_List.map
-                          (fun uu___1 ->
-                             match uu___1 with
-                             | (pat, wopt, tm) ->
-                                 let uu___2 =
-                                   FStar_Syntax_Util.mk_reify tm
-                                     (FStar_Pervasives_Native.Some m) in
-                                 (pat, wopt, uu___2))) in
+                     FStar_Compiler_List.map
+                       (fun uu___1 ->
+                          match uu___1 with
+                          | (pat, wopt, tm) ->
+                              let uu___2 =
+                                FStar_Syntax_Util.mk_reify tm
+                                  (FStar_Pervasives_Native.Some m) in
+                              (pat, wopt, uu___2)) branches in
                    let tm =
                      FStar_Syntax_Syntax.mk
                        (FStar_Syntax_Syntax.Tm_match
@@ -2600,13 +2564,9 @@ and (translate_monadic_lift :
                     let uu___3 =
                       let uu___4 =
                         let uu___5 =
-                          let uu___6 =
-                            FStar_Compiler_Effect.op_Bar_Greater ed
-                              FStar_Syntax_Util.get_return_repr in
-                          FStar_Compiler_Effect.op_Bar_Greater uu___6
-                            FStar_Compiler_Util.must in
-                        FStar_Compiler_Effect.op_Bar_Greater uu___5
-                          FStar_Pervasives_Native.snd in
+                          let uu___6 = FStar_Syntax_Util.get_return_repr ed in
+                          FStar_Compiler_Util.must uu___6 in
+                        FStar_Pervasives_Native.snd uu___5 in
                       FStar_Syntax_Subst.compress uu___4 in
                     uu___3.FStar_Syntax_Syntax.n in
                   match uu___2 with
@@ -2622,15 +2582,11 @@ and (translate_monadic_lift :
                 let t =
                   let uu___2 =
                     let uu___3 = translate cfg' [] ret in
-                    let uu___4 =
-                      let uu___5 =
-                        let uu___6 =
-                          FStar_Compiler_Effect.op_Less_Bar mk_t
-                            (FStar_TypeChecker_NBETerm.Univ
-                               FStar_Syntax_Syntax.U_unknown) in
-                        (uu___6, FStar_Pervasives_Native.None) in
-                      [uu___5] in
-                    iapp cfg' uu___3 uu___4 in
+                    iapp cfg' uu___3
+                      [((mk_t
+                           (FStar_TypeChecker_NBETerm.Univ
+                              FStar_Syntax_Syntax.U_unknown)),
+                         FStar_Pervasives_Native.None)] in
                   let uu___3 =
                     let uu___4 =
                       let uu___5 = translate cfg' bs ty in

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_NBETerm.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_NBETerm.ml
@@ -388,11 +388,7 @@ let (nbe_t_of_t : t -> t') = fun t1 -> t1.nbe_t
 let (mkConstruct :
   FStar_Syntax_Syntax.fv ->
     FStar_Syntax_Syntax.universe Prims.list -> args -> t)
-  =
-  fun i ->
-    fun us ->
-      fun ts ->
-        FStar_Compiler_Effect.op_Less_Bar mk_t (Construct (i, us, ts))
+  = fun i -> fun us -> fun ts -> mk_t (Construct (i, us, ts))
 let (mkFV :
   FStar_Syntax_Syntax.fv ->
     FStar_Syntax_Syntax.universe Prims.list -> args -> t)
@@ -418,11 +414,7 @@ let (mkAccuMatch :
           -> t)
   =
   fun s ->
-    fun ret ->
-      fun bs ->
-        fun rc ->
-          FStar_Compiler_Effect.op_Less_Bar mk_t
-            (Accu ((Match (s, ret, bs, rc)), []))
+    fun ret -> fun bs -> fun rc -> mk_t (Accu ((Match (s, ret, bs, rc)), []))
 let (equal_if : Prims.bool -> FStar_Syntax_Util.eq_result) =
   fun uu___ ->
     if uu___ then FStar_Syntax_Util.Equal else FStar_Syntax_Util.Unknown
@@ -482,14 +474,13 @@ let rec (eq_t : t -> t -> FStar_Syntax_Util.eq_result) =
                  "eq_t, different number of args on Construct"
              else ();
              (let uu___2 = FStar_Compiler_List.zip args1 args2 in
-              FStar_Compiler_Effect.op_Less_Bar
-                (FStar_Compiler_List.fold_left
-                   (fun acc ->
-                      fun uu___3 ->
-                        match uu___3 with
-                        | ((a1, uu___4), (a2, uu___5)) ->
-                            let uu___6 = eq_t a1 a2 in eq_inj acc uu___6)
-                   FStar_Syntax_Util.Equal) uu___2))
+              FStar_Compiler_List.fold_left
+                (fun acc ->
+                   fun uu___3 ->
+                     match uu___3 with
+                     | ((a1, uu___4), (a2, uu___5)) ->
+                         let uu___6 = eq_t a1 a2 in eq_inj acc uu___6)
+                FStar_Syntax_Util.Equal uu___2))
           else FStar_Syntax_Util.NotEqual
       | (FV (v1, us1, args1), FV (v2, us2, args2)) ->
           let uu___ = FStar_Syntax_Syntax.fv_eq v1 v2 in
@@ -714,17 +705,11 @@ and (atom_to_string : atom -> Prims.string) =
         Prims.strcat "UnreducedLetRec(" uu___1
     | UVar uu___ -> "UVar"
 let (arg_to_string : arg -> Prims.string) =
-  fun a ->
-    let uu___ =
-      FStar_Compiler_Effect.op_Bar_Greater a FStar_Pervasives_Native.fst in
-    FStar_Compiler_Effect.op_Bar_Greater uu___ t_to_string
+  fun a -> t_to_string (FStar_Pervasives_Native.fst a)
 let (args_to_string : args -> Prims.string) =
   fun args1 ->
-    let uu___ =
-      FStar_Compiler_Effect.op_Bar_Greater args1
-        (FStar_Compiler_List.map arg_to_string) in
-    FStar_Compiler_Effect.op_Bar_Greater uu___
-      (FStar_Compiler_String.concat " ")
+    let uu___ = FStar_Compiler_List.map arg_to_string args1 in
+    FStar_Compiler_String.concat " " uu___
 let (iapp_cb : nbe_cbs -> t -> args -> t) =
   fun cbs -> fun h -> fun a -> cbs.iapp h a
 let (translate_cb : nbe_cbs -> FStar_Syntax_Syntax.term -> t) =
@@ -752,11 +737,7 @@ let mk_emb' :
   =
   fun em ->
     fun un ->
-      mk_emb
-        (fun cbs ->
-           fun t1 ->
-             let uu___ = em cbs t1 in
-             FStar_Compiler_Effect.op_Less_Bar mk_t uu___)
+      mk_emb (fun cbs -> fun t1 -> let uu___ = em cbs t1 in mk_t uu___)
         (fun cbs -> fun t1 -> un cbs t1.nbe_t)
 let embed_as :
   'a 'b .
@@ -800,10 +781,7 @@ let (as_iarg : t -> arg) =
     let uu___ = FStar_Syntax_Syntax.as_aqual_implicit true in (a, uu___)
 let (as_arg : t -> arg) = fun a -> (a, FStar_Pervasives_Native.None)
 let (make_arrow1 : t -> arg -> t) =
-  fun t1 ->
-    fun a ->
-      FStar_Compiler_Effect.op_Less_Bar mk_t
-        (Arrow (FStar_Pervasives.Inr ([a], (Tot t1))))
+  fun t1 -> fun a -> mk_t (Arrow (FStar_Pervasives.Inr ([a], (Tot t1))))
 let lazy_embed : 'a . FStar_Syntax_Syntax.emb_typ -> 'a -> (unit -> t) -> t =
   fun et ->
     fun x ->
@@ -823,8 +801,7 @@ let lazy_embed : 'a . FStar_Syntax_Syntax.emb_typ -> 'a -> (unit -> t) -> t =
          else
            (let thunk = FStar_Thunk.mk f in
             let li = let uu___3 = FStar_Compiler_Dyn.mkdyn x in (uu___3, et) in
-            FStar_Compiler_Effect.op_Less_Bar mk_t
-              (Lazy ((FStar_Pervasives.Inr li), thunk))))
+            mk_t (Lazy ((FStar_Pervasives.Inr li), thunk))))
 let lazy_unembed :
   'a .
     FStar_Syntax_Syntax.emb_typ ->
@@ -964,9 +941,7 @@ let e_option :
   fun ea ->
     let etyp =
       let uu___ =
-        let uu___1 =
-          FStar_Compiler_Effect.op_Bar_Greater FStar_Parser_Const.option_lid
-            FStar_Ident.string_of_lid in
+        let uu___1 = FStar_Ident.string_of_lid FStar_Parser_Const.option_lid in
         (uu___1, [ea.emb_typ]) in
       FStar_Syntax_Syntax.ET_app uu___ in
     let em cb o =
@@ -1016,8 +991,7 @@ let e_tuple2 : 'a 'b . 'a embedding -> 'b embedding -> ('a * 'b) embedding =
       let etyp =
         let uu___ =
           let uu___1 =
-            FStar_Compiler_Effect.op_Bar_Greater
-              FStar_Parser_Const.lid_tuple2 FStar_Ident.string_of_lid in
+            FStar_Ident.string_of_lid FStar_Parser_Const.lid_tuple2 in
           (uu___1, [ea.emb_typ; eb.emb_typ]) in
         FStar_Syntax_Syntax.ET_app uu___ in
       let em cb x =
@@ -1078,8 +1052,7 @@ let e_tuple3 :
         let etyp =
           let uu___ =
             let uu___1 =
-              FStar_Compiler_Effect.op_Bar_Greater
-                FStar_Parser_Const.lid_tuple3 FStar_Ident.string_of_lid in
+              FStar_Ident.string_of_lid FStar_Parser_Const.lid_tuple3 in
             (uu___1, [ea.emb_typ; eb.emb_typ; ec.emb_typ]) in
           FStar_Syntax_Syntax.ET_app uu___ in
         let em cb uu___ =
@@ -1162,8 +1135,7 @@ let e_either :
       let etyp =
         let uu___ =
           let uu___1 =
-            FStar_Compiler_Effect.op_Bar_Greater
-              FStar_Parser_Const.either_lid FStar_Ident.string_of_lid in
+            FStar_Ident.string_of_lid FStar_Parser_Const.either_lid in
           (uu___1, [ea.emb_typ; eb.emb_typ]) in
         FStar_Syntax_Syntax.ET_app uu___ in
       let em cb s =
@@ -1326,9 +1298,7 @@ let e_list : 'a . 'a embedding -> 'a Prims.list embedding =
   fun ea ->
     let etyp =
       let uu___ =
-        let uu___1 =
-          FStar_Compiler_Effect.op_Bar_Greater FStar_Parser_Const.list_lid
-            FStar_Ident.string_of_lid in
+        let uu___1 = FStar_Ident.string_of_lid FStar_Parser_Const.list_lid in
         (uu___1, [ea.emb_typ]) in
       FStar_Syntax_Syntax.ET_app uu___ in
     let em cb l =
@@ -1409,11 +1379,8 @@ let e_arrow : 'a 'b . 'a embedding -> 'b embedding -> ('a -> 'b) embedding =
                  ((fun tas ->
                      let uu___4 =
                        let uu___5 =
-                         let uu___6 =
-                           FStar_Compiler_Effect.op_Bar_Greater tas
-                             FStar_Compiler_List.hd in
-                         FStar_Compiler_Effect.op_Bar_Greater uu___6
-                           FStar_Pervasives_Native.fst in
+                         let uu___6 = FStar_Compiler_List.hd tas in
+                         FStar_Pervasives_Native.fst uu___6 in
                        unembed ea cb uu___5 in
                      match uu___4 with
                      | FStar_Pervasives_Native.Some a1 ->
@@ -1423,7 +1390,7 @@ let e_arrow : 'a 'b . 'a embedding -> 'b embedding -> ('a -> 'b) embedding =
                            "cannot unembed function argument"), uu___3,
                    Prims.int_one) in
                Lam uu___2 in
-             FStar_Compiler_Effect.op_Less_Bar mk_t uu___1) in
+             mk_t uu___1) in
       let un cb lam =
         let k lam1 =
           FStar_Pervasives_Native.Some
@@ -1604,36 +1571,28 @@ let (e_norm_step : FStar_Pervasives.norm_step embedding) =
         let uu___2 = let uu___3 = e_list e_string in unembed uu___3 cb l in
         FStar_Compiler_Util.bind_opt uu___2
           (fun ss ->
-             FStar_Compiler_Effect.op_Less_Bar
-               (fun uu___3 -> FStar_Pervasives_Native.Some uu___3)
-               (FStar_Pervasives.UnfoldOnly ss))
+             FStar_Pervasives_Native.Some (FStar_Pervasives.UnfoldOnly ss))
     | FV (fv, uu___, (l, uu___1)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.steps_unfoldfully
         ->
         let uu___2 = let uu___3 = e_list e_string in unembed uu___3 cb l in
         FStar_Compiler_Util.bind_opt uu___2
           (fun ss ->
-             FStar_Compiler_Effect.op_Less_Bar
-               (fun uu___3 -> FStar_Pervasives_Native.Some uu___3)
-               (FStar_Pervasives.UnfoldFully ss))
+             FStar_Pervasives_Native.Some (FStar_Pervasives.UnfoldFully ss))
     | FV (fv, uu___, (l, uu___1)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.steps_unfoldattr
         ->
         let uu___2 = let uu___3 = e_list e_string in unembed uu___3 cb l in
         FStar_Compiler_Util.bind_opt uu___2
           (fun ss ->
-             FStar_Compiler_Effect.op_Less_Bar
-               (fun uu___3 -> FStar_Pervasives_Native.Some uu___3)
-               (FStar_Pervasives.UnfoldAttr ss))
+             FStar_Pervasives_Native.Some (FStar_Pervasives.UnfoldAttr ss))
     | FV (fv, uu___, (l, uu___1)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.steps_unfoldqual
         ->
         let uu___2 = let uu___3 = e_list e_string in unembed uu___3 cb l in
         FStar_Compiler_Util.bind_opt uu___2
           (fun ss ->
-             FStar_Compiler_Effect.op_Less_Bar
-               (fun uu___3 -> FStar_Pervasives_Native.Some uu___3)
-               (FStar_Pervasives.UnfoldQual ss))
+             FStar_Pervasives_Native.Some (FStar_Pervasives.UnfoldQual ss))
     | FV (fv, uu___, (l, uu___1)::[]) when
         FStar_Syntax_Syntax.fv_eq_lid fv
           FStar_Parser_Const.steps_unfoldnamespace
@@ -1641,8 +1600,7 @@ let (e_norm_step : FStar_Pervasives.norm_step embedding) =
         let uu___2 = let uu___3 = e_list e_string in unembed uu___3 cb l in
         FStar_Compiler_Util.bind_opt uu___2
           (fun ss ->
-             FStar_Compiler_Effect.op_Less_Bar
-               (fun uu___3 -> FStar_Pervasives_Native.Some uu___3)
+             FStar_Pervasives_Native.Some
                (FStar_Pervasives.UnfoldNamespace ss))
     | uu___ ->
         ((let uu___2 =
@@ -1666,9 +1624,7 @@ let e_sealed : 'a . 'a embedding -> 'a embedding =
   fun ea ->
     let etyp =
       let uu___ =
-        let uu___1 =
-          FStar_Compiler_Effect.op_Bar_Greater FStar_Parser_Const.sealed_lid
-            FStar_Ident.string_of_lid in
+        let uu___1 = FStar_Ident.string_of_lid FStar_Parser_Const.sealed_lid in
         (uu___1, [ea.emb_typ]) in
       FStar_Syntax_Syntax.ET_app uu___ in
     let em cb x =
@@ -1703,33 +1659,22 @@ let (bogus_cbs : nbe_cbs) =
       (fun uu___ -> FStar_Compiler_Effect.failwith "bogus_cbs translate")
   }
 let (arg_as_int : arg -> FStar_BigInt.t FStar_Pervasives_Native.option) =
-  fun a ->
-    FStar_Compiler_Effect.op_Bar_Greater (FStar_Pervasives_Native.fst a)
-      (unembed e_int bogus_cbs)
+  fun a -> unembed e_int bogus_cbs (FStar_Pervasives_Native.fst a)
 let (arg_as_bool : arg -> Prims.bool FStar_Pervasives_Native.option) =
-  fun a ->
-    FStar_Compiler_Effect.op_Bar_Greater (FStar_Pervasives_Native.fst a)
-      (unembed e_bool bogus_cbs)
+  fun a -> unembed e_bool bogus_cbs (FStar_Pervasives_Native.fst a)
 let (arg_as_char : arg -> FStar_Char.char FStar_Pervasives_Native.option) =
-  fun a ->
-    FStar_Compiler_Effect.op_Bar_Greater (FStar_Pervasives_Native.fst a)
-      (unembed e_char bogus_cbs)
+  fun a -> unembed e_char bogus_cbs (FStar_Pervasives_Native.fst a)
 let (arg_as_string : arg -> Prims.string FStar_Pervasives_Native.option) =
-  fun a ->
-    FStar_Compiler_Effect.op_Bar_Greater (FStar_Pervasives_Native.fst a)
-      (unembed e_string bogus_cbs)
+  fun a -> unembed e_string bogus_cbs (FStar_Pervasives_Native.fst a)
 let arg_as_list :
   'a . 'a embedding -> arg -> 'a Prims.list FStar_Pervasives_Native.option =
   fun e ->
     fun a1 ->
-      let uu___ = let uu___1 = e_list e in unembed uu___1 bogus_cbs in
-      FStar_Compiler_Effect.op_Bar_Greater (FStar_Pervasives_Native.fst a1)
-        uu___
+      let uu___ = e_list e in
+      unembed uu___ bogus_cbs (FStar_Pervasives_Native.fst a1)
 let (arg_as_doc :
   arg -> FStar_Pprint.document FStar_Pervasives_Native.option) =
-  fun a ->
-    FStar_Compiler_Effect.op_Bar_Greater (FStar_Pervasives_Native.fst a)
-      (unembed e_document bogus_cbs)
+  fun a -> unembed e_document bogus_cbs (FStar_Pervasives_Native.fst a)
 let (arg_as_bounded_int :
   arg ->
     (FStar_Syntax_Syntax.fv * FStar_BigInt.t *
@@ -1765,8 +1710,7 @@ let (int_as_bounded : FStar_Syntax_Syntax.fv -> FStar_BigInt.t -> t) =
   fun int_to_t ->
     fun n ->
       let c = embed e_int bogus_cbs n in
-      let int_to_t1 args1 =
-        FStar_Compiler_Effect.op_Less_Bar mk_t (FV (int_to_t, [], args1)) in
+      let int_to_t1 args1 = mk_t (FV (int_to_t, [], args1)) in
       let uu___ = let uu___1 = as_arg c in [uu___1] in int_to_t1 uu___
 let (with_meta_ds :
   t ->
@@ -1948,8 +1892,7 @@ let (list_of_string' : Prims.string -> t) =
 let (string_of_list' : FStar_String.char Prims.list -> t) =
   fun l ->
     let s = FStar_String.string_of_list l in
-    FStar_Compiler_Effect.op_Less_Bar mk_t
-      (Constant (String (s, FStar_Compiler_Range_Type.dummyRange)))
+    mk_t (Constant (String (s, FStar_Compiler_Range_Type.dummyRange)))
 let (string_compare' : Prims.string -> Prims.string -> t) =
   fun s1 ->
     fun s2 ->

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Normalize.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Normalize.ml
@@ -229,9 +229,7 @@ let (closure_to_string : closure -> Prims.string) =
     match uu___ with
     | Clos (env1, t, uu___1, uu___2) ->
         let uu___3 =
-          FStar_Compiler_Effect.op_Bar_Greater
-            (FStar_Compiler_List.length env1)
-            FStar_Compiler_Util.string_of_int in
+          FStar_Compiler_Util.string_of_int (FStar_Compiler_List.length env1) in
         let uu___4 = FStar_Syntax_Print.term_to_string t in
         FStar_Compiler_Util.format2 "(env=%s elts; %s)" uu___3 uu___4
     | Univ uu___1 -> "Univ"
@@ -253,8 +251,7 @@ let (env_to_string :
                      FStar_Syntax_Print.binder_to_string x in
                let uu___3 = closure_to_string c in
                FStar_Compiler_Util.format2 "(%s, %s)" uu___2 uu___3) env1 in
-    FStar_Compiler_Effect.op_Bar_Greater uu___
-      (FStar_Compiler_String.concat "; ")
+    FStar_Compiler_String.concat "; " uu___
 let (stack_elt_to_string : stack_elt -> Prims.string) =
   fun uu___ ->
     match uu___ with
@@ -264,8 +261,7 @@ let (stack_elt_to_string : stack_elt -> Prims.string) =
     | MemoLazy uu___1 -> "MemoLazy"
     | Abs (uu___1, bs, uu___2, uu___3, uu___4) ->
         let uu___5 =
-          FStar_Compiler_Effect.op_Less_Bar FStar_Compiler_Util.string_of_int
-            (FStar_Compiler_List.length bs) in
+          FStar_Compiler_Util.string_of_int (FStar_Compiler_List.length bs) in
         FStar_Compiler_Util.format1 "Abs %s" uu___5
     | UnivArgs uu___1 -> "UnivArgs"
     | Match uu___1 -> "Match"
@@ -281,8 +277,7 @@ let (stack_elt_to_string : stack_elt -> Prims.string) =
 let (stack_to_string : stack_elt Prims.list -> Prims.string) =
   fun s ->
     let uu___ = FStar_Compiler_List.map stack_elt_to_string s in
-    FStar_Compiler_Effect.op_Bar_Greater uu___
-      (FStar_Compiler_String.concat "; ")
+    FStar_Compiler_String.concat "; " uu___
 let is_empty : 'uuuuu . 'uuuuu Prims.list -> Prims.bool =
   fun uu___ -> match uu___ with | [] -> true | uu___1 -> false
 let (lookup_bvar :
@@ -366,9 +361,8 @@ let (norm_universe :
                         (match uu___1 with
                          | Univ u3 ->
                              ((let uu___3 =
-                                 FStar_Compiler_Effect.op_Less_Bar
-                                   (FStar_TypeChecker_Env.debug
-                                      cfg.FStar_TypeChecker_Cfg.tcenv)
+                                 FStar_TypeChecker_Env.debug
+                                   cfg.FStar_TypeChecker_Cfg.tcenv
                                    (FStar_Options.Other "univ_norm") in
                                if uu___3
                                then
@@ -408,7 +402,7 @@ let (norm_universe :
           | FStar_Syntax_Syntax.U_max us ->
               let us1 =
                 let uu___ = FStar_Compiler_List.collect aux us in
-                FStar_Compiler_Effect.op_Bar_Greater uu___ norm_univs_for_max in
+                norm_univs_for_max uu___ in
               (match us1 with
                | u_k::hd::rest ->
                    let rest1 = hd :: rest in
@@ -416,12 +410,11 @@ let (norm_universe :
                    (match uu___ with
                     | (FStar_Syntax_Syntax.U_zero, n) ->
                         let uu___1 =
-                          FStar_Compiler_Effect.op_Bar_Greater rest1
-                            (FStar_Compiler_List.for_all
-                               (fun u3 ->
-                                  let uu___2 =
-                                    FStar_Syntax_Util.univ_kernel u3 in
-                                  match uu___2 with | (uu___3, m) -> n <= m)) in
+                          FStar_Compiler_List.for_all
+                            (fun u3 ->
+                               let uu___2 = FStar_Syntax_Util.univ_kernel u3 in
+                               match uu___2 with | (uu___3, m) -> n <= m)
+                            rest1 in
                         if uu___1 then rest1 else us1
                     | uu___1 -> us1)
                | uu___ -> us1)
@@ -461,7 +454,7 @@ let rec (inline_closure_env :
                  ">>> %s (env=%s)\nClosure_as_term %s\n" uu___2 uu___3 uu___4);
           (match env1 with
            | [] when
-               FStar_Compiler_Effect.op_Less_Bar Prims.op_Negation
+               Prims.op_Negation
                  (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.compress_uvars
                -> rebuild_closure cfg env1 stack1 t
            | uu___1 ->
@@ -499,49 +492,40 @@ let rec (inline_closure_env :
                        | uu___2 -> inline_closure_env cfg env1 stack1 t1)
                     else
                       (let s' =
-                         FStar_Compiler_Effect.op_Bar_Greater
-                           (FStar_Pervasives_Native.fst s)
-                           (FStar_Compiler_List.map
-                              (fun s1 ->
-                                 FStar_Compiler_Effect.op_Bar_Greater s1
-                                   (FStar_Compiler_List.map
-                                      (fun uu___3 ->
-                                         match uu___3 with
-                                         | FStar_Syntax_Syntax.NT (x, t1) ->
-                                             let uu___4 =
-                                               let uu___5 =
-                                                 inline_closure_env cfg env1
-                                                   [] t1 in
-                                               (x, uu___5) in
-                                             FStar_Syntax_Syntax.NT uu___4
-                                         | FStar_Syntax_Syntax.NM (x, i) ->
-                                             let x_i =
-                                               FStar_Syntax_Syntax.bv_to_tm
-                                                 {
-                                                   FStar_Syntax_Syntax.ppname
-                                                     =
-                                                     (x.FStar_Syntax_Syntax.ppname);
-                                                   FStar_Syntax_Syntax.index
-                                                     = i;
-                                                   FStar_Syntax_Syntax.sort =
-                                                     (x.FStar_Syntax_Syntax.sort)
-                                                 } in
-                                             let t1 =
-                                               inline_closure_env cfg env1 []
-                                                 x_i in
-                                             (match t1.FStar_Syntax_Syntax.n
-                                              with
-                                              | FStar_Syntax_Syntax.Tm_bvar
-                                                  x_j ->
-                                                  FStar_Syntax_Syntax.NM
-                                                    (x,
-                                                      (x_j.FStar_Syntax_Syntax.index))
-                                              | uu___4 ->
-                                                  FStar_Syntax_Syntax.NT
-                                                    (x, t1))
-                                         | uu___4 ->
-                                             FStar_Compiler_Effect.failwith
-                                               "Impossible: subst invariant of uvar nodes")))) in
+                         FStar_Compiler_List.map
+                           (fun s1 ->
+                              FStar_Compiler_List.map
+                                (fun uu___3 ->
+                                   match uu___3 with
+                                   | FStar_Syntax_Syntax.NT (x, t1) ->
+                                       let uu___4 =
+                                         let uu___5 =
+                                           inline_closure_env cfg env1 [] t1 in
+                                         (x, uu___5) in
+                                       FStar_Syntax_Syntax.NT uu___4
+                                   | FStar_Syntax_Syntax.NM (x, i) ->
+                                       let x_i =
+                                         FStar_Syntax_Syntax.bv_to_tm
+                                           {
+                                             FStar_Syntax_Syntax.ppname =
+                                               (x.FStar_Syntax_Syntax.ppname);
+                                             FStar_Syntax_Syntax.index = i;
+                                             FStar_Syntax_Syntax.sort =
+                                               (x.FStar_Syntax_Syntax.sort)
+                                           } in
+                                       let t1 =
+                                         inline_closure_env cfg env1 [] x_i in
+                                       (match t1.FStar_Syntax_Syntax.n with
+                                        | FStar_Syntax_Syntax.Tm_bvar x_j ->
+                                            FStar_Syntax_Syntax.NM
+                                              (x,
+                                                (x_j.FStar_Syntax_Syntax.index))
+                                        | uu___4 ->
+                                            FStar_Syntax_Syntax.NT (x, t1))
+                                   | uu___4 ->
+                                       FStar_Compiler_Effect.failwith
+                                         "Impossible: subst invariant of uvar nodes")
+                                s1) (FStar_Pervasives_Native.fst s) in
                        let t1 =
                          {
                            FStar_Syntax_Syntax.n =
@@ -596,25 +580,24 @@ let rec (inline_closure_env :
                       FStar_Syntax_Syntax.args = args;_}
                     ->
                     let stack2 =
-                      FStar_Compiler_Effect.op_Bar_Greater stack1
-                        (FStar_Compiler_List.fold_right
-                           (fun uu___2 ->
-                              fun stack3 ->
-                                match uu___2 with
-                                | (a, aq) ->
-                                    let uu___3 =
-                                      let uu___4 =
-                                        let uu___5 =
-                                          let uu___6 =
-                                            let uu___7 =
-                                              FStar_Compiler_Util.mk_ref
-                                                FStar_Pervasives_Native.None in
-                                            (env1, a, uu___7, false) in
-                                          Clos uu___6 in
-                                        (uu___5, aq,
-                                          (t.FStar_Syntax_Syntax.pos)) in
-                                      Arg uu___4 in
-                                    uu___3 :: stack3) args) in
+                      FStar_Compiler_List.fold_right
+                        (fun uu___2 ->
+                           fun stack3 ->
+                             match uu___2 with
+                             | (a, aq) ->
+                                 let uu___3 =
+                                   let uu___4 =
+                                     let uu___5 =
+                                       let uu___6 =
+                                         let uu___7 =
+                                           FStar_Compiler_Util.mk_ref
+                                             FStar_Pervasives_Native.None in
+                                         (env1, a, uu___7, false) in
+                                       Clos uu___6 in
+                                     (uu___5, aq,
+                                       (t.FStar_Syntax_Syntax.pos)) in
+                                   Arg uu___4 in
+                                 uu___3 :: stack3) args stack1 in
                     inline_closure_env cfg env1 stack2 head
                 | FStar_Syntax_Syntax.Tm_abs
                     { FStar_Syntax_Syntax.bs = bs;
@@ -622,12 +605,10 @@ let rec (inline_closure_env :
                       FStar_Syntax_Syntax.rc_opt = lopt;_}
                     ->
                     let env' =
-                      FStar_Compiler_Effect.op_Bar_Greater env1
-                        (FStar_Compiler_List.fold_right
-                           (fun _b ->
-                              fun env2 ->
-                                (FStar_Pervasives_Native.None, Dummy) :: env2)
-                           bs) in
+                      FStar_Compiler_List.fold_right
+                        (fun _b ->
+                           fun env2 -> (FStar_Pervasives_Native.None, Dummy)
+                             :: env2) bs env1 in
                     let stack2 =
                       (Abs
                          (env1, bs, env', lopt, (t.FStar_Syntax_Syntax.pos)))
@@ -844,9 +825,7 @@ let rec (inline_closure_env :
                         FStar_Syntax_Syntax.lbpos =
                           (lb.FStar_Syntax_Syntax.lbpos)
                       } in
-                    let lbs1 =
-                      FStar_Compiler_Effect.op_Bar_Greater lbs
-                        (FStar_Compiler_List.map (norm_one_lb env1)) in
+                    let lbs1 = FStar_Compiler_List.map (norm_one_lb env1) lbs in
                     let body1 =
                       let body_env =
                         FStar_Compiler_List.fold_right
@@ -949,17 +928,16 @@ and (rebuild_closure :
                                         (norm_universe cfg1 env4) us in
                                     FStar_Pervasives_Native.Some uu___3) in
                            let uu___2 =
-                             FStar_Compiler_Effect.op_Bar_Greater pats
-                               (FStar_Compiler_List.fold_left
-                                  (fun uu___3 ->
-                                     fun uu___4 ->
-                                       match (uu___3, uu___4) with
-                                       | ((pats1, env5), (p1, b)) ->
-                                           let uu___5 = norm_pat env5 p1 in
-                                           (match uu___5 with
-                                            | (p2, env6) ->
-                                                (((p2, b) :: pats1), env6)))
-                                  ([], env4)) in
+                             FStar_Compiler_List.fold_left
+                               (fun uu___3 ->
+                                  fun uu___4 ->
+                                    match (uu___3, uu___4) with
+                                    | ((pats1, env5), (p1, b)) ->
+                                        let uu___5 = norm_pat env5 p1 in
+                                        (match uu___5 with
+                                         | (p2, env6) ->
+                                             (((p2, b) :: pats1), env6)))
+                               ([], env4) pats in
                            (match uu___2 with
                             | (pats1, env5) ->
                                 ({
@@ -1016,8 +994,8 @@ and (rebuild_closure :
                    let uu___2 =
                      let uu___3 = close_match_returns cfg1 env2 asc_opt in
                      let uu___4 =
-                       FStar_Compiler_Effect.op_Bar_Greater branches1
-                         (FStar_Compiler_List.map (close_one_branch env2)) in
+                       FStar_Compiler_List.map (close_one_branch env2)
+                         branches1 in
                      {
                        FStar_Syntax_Syntax.scrutinee = t;
                        FStar_Syntax_Syntax.ret_opt = uu___3;
@@ -1033,22 +1011,19 @@ and (rebuild_closure :
                  | FStar_Syntax_Syntax.Meta_pattern (names, args) ->
                      let uu___1 =
                        let uu___2 =
-                         FStar_Compiler_Effect.op_Bar_Greater names
-                           (FStar_Compiler_List.map
-                              (non_tail_inline_closure_env cfg env_m)) in
+                         FStar_Compiler_List.map
+                           (non_tail_inline_closure_env cfg env_m) names in
                        let uu___3 =
-                         FStar_Compiler_Effect.op_Bar_Greater args
-                           (FStar_Compiler_List.map
-                              (fun args1 ->
-                                 FStar_Compiler_Effect.op_Bar_Greater args1
-                                   (FStar_Compiler_List.map
-                                      (fun uu___4 ->
-                                         match uu___4 with
-                                         | (a, q) ->
-                                             let uu___5 =
-                                               non_tail_inline_closure_env
-                                                 cfg env_m a in
-                                             (uu___5, q))))) in
+                         FStar_Compiler_List.map
+                           (fun args1 ->
+                              FStar_Compiler_List.map
+                                (fun uu___4 ->
+                                   match uu___4 with
+                                   | (a, q) ->
+                                       let uu___5 =
+                                         non_tail_inline_closure_env cfg
+                                           env_m a in
+                                       (uu___5, q)) args1) args in
                        (uu___2, uu___3) in
                      FStar_Syntax_Syntax.Meta_pattern uu___1
                  | FStar_Syntax_Syntax.Meta_monadic (m2, tbody) ->
@@ -1157,39 +1132,38 @@ and (close_binders :
     fun env1 ->
       fun bs ->
         let uu___ =
-          FStar_Compiler_Effect.op_Bar_Greater bs
-            (FStar_Compiler_List.fold_left
-               (fun uu___1 ->
-                  fun uu___2 ->
-                    match (uu___1, uu___2) with
-                    | ((env2, out),
-                       { FStar_Syntax_Syntax.binder_bv = b;
-                         FStar_Syntax_Syntax.binder_qual = imp;
-                         FStar_Syntax_Syntax.binder_positivity = pqual;
-                         FStar_Syntax_Syntax.binder_attrs = attrs;_})
-                        ->
-                        let b1 =
-                          let uu___3 =
-                            inline_closure_env cfg env2 []
-                              b.FStar_Syntax_Syntax.sort in
-                          {
-                            FStar_Syntax_Syntax.ppname =
-                              (b.FStar_Syntax_Syntax.ppname);
-                            FStar_Syntax_Syntax.index =
-                              (b.FStar_Syntax_Syntax.index);
-                            FStar_Syntax_Syntax.sort = uu___3
-                          } in
-                        let imp1 = close_imp cfg env2 imp in
-                        let attrs1 =
-                          FStar_Compiler_List.map
-                            (non_tail_inline_closure_env cfg env2) attrs in
-                        let env3 = dummy :: env2 in
-                        let uu___3 =
-                          let uu___4 =
-                            FStar_Syntax_Syntax.mk_binder_with_attrs b1 imp1
-                              pqual attrs1 in
-                          uu___4 :: out in
-                        (env3, uu___3)) (env1, [])) in
+          FStar_Compiler_List.fold_left
+            (fun uu___1 ->
+               fun uu___2 ->
+                 match (uu___1, uu___2) with
+                 | ((env2, out),
+                    { FStar_Syntax_Syntax.binder_bv = b;
+                      FStar_Syntax_Syntax.binder_qual = imp;
+                      FStar_Syntax_Syntax.binder_positivity = pqual;
+                      FStar_Syntax_Syntax.binder_attrs = attrs;_})
+                     ->
+                     let b1 =
+                       let uu___3 =
+                         inline_closure_env cfg env2 []
+                           b.FStar_Syntax_Syntax.sort in
+                       {
+                         FStar_Syntax_Syntax.ppname =
+                           (b.FStar_Syntax_Syntax.ppname);
+                         FStar_Syntax_Syntax.index =
+                           (b.FStar_Syntax_Syntax.index);
+                         FStar_Syntax_Syntax.sort = uu___3
+                       } in
+                     let imp1 = close_imp cfg env2 imp in
+                     let attrs1 =
+                       FStar_Compiler_List.map
+                         (non_tail_inline_closure_env cfg env2) attrs in
+                     let env3 = dummy :: env2 in
+                     let uu___3 =
+                       let uu___4 =
+                         FStar_Syntax_Syntax.mk_binder_with_attrs b1 imp1
+                           pqual attrs1 in
+                       uu___4 :: out in
+                     (env3, uu___3)) (env1, []) bs in
         match uu___ with
         | (env2, bs1) -> ((FStar_Compiler_List.rev bs1), env2)
 and (close_comp :
@@ -1203,7 +1177,7 @@ and (close_comp :
       fun c ->
         match env1 with
         | [] when
-            FStar_Compiler_Effect.op_Less_Bar Prims.op_Negation
+            Prims.op_Negation
               (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.compress_uvars
             -> c
         | uu___ ->
@@ -1219,44 +1193,35 @@ and (close_comp :
                    inline_closure_env cfg env1 []
                      c1.FStar_Syntax_Syntax.result_typ in
                  let args =
-                   FStar_Compiler_Effect.op_Bar_Greater
-                     c1.FStar_Syntax_Syntax.effect_args
-                     (FStar_Compiler_List.map
-                        (fun uu___1 ->
-                           match uu___1 with
-                           | (a, q) ->
-                               let uu___2 = inline_closure_env cfg env1 [] a in
-                               (uu___2, q))) in
+                   FStar_Compiler_List.map
+                     (fun uu___1 ->
+                        match uu___1 with
+                        | (a, q) ->
+                            let uu___2 = inline_closure_env cfg env1 [] a in
+                            (uu___2, q)) c1.FStar_Syntax_Syntax.effect_args in
                  let flags =
-                   FStar_Compiler_Effect.op_Bar_Greater
-                     c1.FStar_Syntax_Syntax.flags
-                     (FStar_Compiler_List.map
-                        (fun uu___1 ->
-                           match uu___1 with
-                           | FStar_Syntax_Syntax.DECREASES
-                               (FStar_Syntax_Syntax.Decreases_lex l) ->
-                               let uu___2 =
-                                 let uu___3 =
-                                   FStar_Compiler_Effect.op_Bar_Greater l
-                                     (FStar_Compiler_List.map
-                                        (inline_closure_env cfg env1 [])) in
-                                 FStar_Compiler_Effect.op_Bar_Greater uu___3
-                                   (fun uu___4 ->
-                                      FStar_Syntax_Syntax.Decreases_lex
-                                        uu___4) in
-                               FStar_Syntax_Syntax.DECREASES uu___2
-                           | FStar_Syntax_Syntax.DECREASES
-                               (FStar_Syntax_Syntax.Decreases_wf (rel, e)) ->
-                               let uu___2 =
-                                 let uu___3 =
-                                   let uu___4 =
-                                     inline_closure_env cfg env1 [] rel in
-                                   let uu___5 =
-                                     inline_closure_env cfg env1 [] e in
-                                   (uu___4, uu___5) in
-                                 FStar_Syntax_Syntax.Decreases_wf uu___3 in
-                               FStar_Syntax_Syntax.DECREASES uu___2
-                           | f -> f)) in
+                   FStar_Compiler_List.map
+                     (fun uu___1 ->
+                        match uu___1 with
+                        | FStar_Syntax_Syntax.DECREASES
+                            (FStar_Syntax_Syntax.Decreases_lex l) ->
+                            let uu___2 =
+                              let uu___3 =
+                                FStar_Compiler_List.map
+                                  (inline_closure_env cfg env1 []) l in
+                              FStar_Syntax_Syntax.Decreases_lex uu___3 in
+                            FStar_Syntax_Syntax.DECREASES uu___2
+                        | FStar_Syntax_Syntax.DECREASES
+                            (FStar_Syntax_Syntax.Decreases_wf (rel, e)) ->
+                            let uu___2 =
+                              let uu___3 =
+                                let uu___4 =
+                                  inline_closure_env cfg env1 [] rel in
+                                let uu___5 = inline_closure_env cfg env1 [] e in
+                                (uu___4, uu___5) in
+                              FStar_Syntax_Syntax.Decreases_wf uu___3 in
+                            FStar_Syntax_Syntax.DECREASES uu___2
+                        | f -> f) c1.FStar_Syntax_Syntax.flags in
                  let uu___1 =
                    let uu___2 =
                      FStar_Compiler_List.map (norm_universe cfg env1)
@@ -1282,13 +1247,11 @@ and (close_lcomp_opt :
         match lopt with
         | FStar_Pervasives_Native.Some rc ->
             let flags =
-              FStar_Compiler_Effect.op_Bar_Greater
-                rc.FStar_Syntax_Syntax.residual_flags
-                (FStar_Compiler_List.filter
-                   (fun uu___ ->
-                      match uu___ with
-                      | FStar_Syntax_Syntax.DECREASES uu___1 -> false
-                      | uu___1 -> true)) in
+              FStar_Compiler_List.filter
+                (fun uu___ ->
+                   match uu___ with
+                   | FStar_Syntax_Syntax.DECREASES uu___1 -> false
+                   | uu___1 -> true) rc.FStar_Syntax_Syntax.residual_flags in
             let rc1 =
               let uu___ =
                 FStar_Compiler_Util.map_opt
@@ -1307,12 +1270,11 @@ let (filter_out_lcomp_cflags :
     FStar_Syntax_Syntax.cflag Prims.list)
   =
   fun flags ->
-    FStar_Compiler_Effect.op_Bar_Greater flags
-      (FStar_Compiler_List.filter
-         (fun uu___ ->
-            match uu___ with
-            | FStar_Syntax_Syntax.DECREASES uu___1 -> false
-            | uu___1 -> true))
+    FStar_Compiler_List.filter
+      (fun uu___ ->
+         match uu___ with
+         | FStar_Syntax_Syntax.DECREASES uu___1 -> false
+         | uu___1 -> true) flags
 let (closure_as_term :
   FStar_TypeChecker_Cfg.cfg ->
     env ->
@@ -1696,17 +1658,12 @@ let (is_norm_request :
   fun hd ->
     fun args ->
       let aux min_args =
-        let uu___ =
-          FStar_Compiler_Effect.op_Bar_Greater args
-            FStar_Compiler_List.length in
-        FStar_Compiler_Effect.op_Bar_Greater uu___
-          (fun n ->
-             if n < min_args
-             then Norm_request_none
-             else
-               if n = min_args
-               then Norm_request_ready
-               else Norm_request_requires_rejig) in
+        if (FStar_Compiler_List.length args) < min_args
+        then Norm_request_none
+        else
+          if (FStar_Compiler_List.length args) = min_args
+          then Norm_request_ready
+          else Norm_request_requires_rejig in
       let uu___ =
         let uu___1 = FStar_Syntax_Util.un_uinst hd in
         uu___1.FStar_Syntax_Syntax.n in
@@ -1865,14 +1822,13 @@ let (nbe_eval :
       fun tm ->
         let delta_level =
           let uu___ =
-            FStar_Compiler_Effect.op_Bar_Greater s
-              (FStar_Compiler_Util.for_some
-                 (fun uu___1 ->
-                    match uu___1 with
-                    | FStar_TypeChecker_Env.UnfoldUntil uu___2 -> true
-                    | FStar_TypeChecker_Env.UnfoldOnly uu___2 -> true
-                    | FStar_TypeChecker_Env.UnfoldFully uu___2 -> true
-                    | uu___2 -> false)) in
+            FStar_Compiler_Util.for_some
+              (fun uu___1 ->
+                 match uu___1 with
+                 | FStar_TypeChecker_Env.UnfoldUntil uu___2 -> true
+                 | FStar_TypeChecker_Env.UnfoldOnly uu___2 -> true
+                 | FStar_TypeChecker_Env.UnfoldFully uu___2 -> true
+                 | uu___2 -> false) s in
           if uu___
           then
             [FStar_TypeChecker_Env.Unfold FStar_Syntax_Syntax.delta_constant]
@@ -1956,10 +1912,10 @@ let rec (maybe_weakly_reduced :
     | FStar_Syntax_Syntax.Tm_app
         { FStar_Syntax_Syntax.hd = t1; FStar_Syntax_Syntax.args = args;_} ->
         (maybe_weakly_reduced t1) ||
-          (FStar_Compiler_Effect.op_Bar_Greater args
-             (FStar_Compiler_Util.for_some
-                (fun uu___ ->
-                   match uu___ with | (a, uu___1) -> maybe_weakly_reduced a)))
+          (FStar_Compiler_Util.for_some
+             (fun uu___ ->
+                match uu___ with | (a, uu___1) -> maybe_weakly_reduced a)
+             args)
     | FStar_Syntax_Syntax.Tm_ascribed
         { FStar_Syntax_Syntax.tm = t1; FStar_Syntax_Syntax.asc = asc;
           FStar_Syntax_Syntax.eff_opt = uu___;_}
@@ -2052,21 +2008,19 @@ let (should_unfold :
                    "should_unfold: Reached a %s with delta_depth = %s\n >> Our delta_level is %s\n"
                    uu___3 uu___4 uu___5);
             (let uu___2 =
-               FStar_Compiler_Effect.op_Bar_Greater
-                 cfg.FStar_TypeChecker_Cfg.delta_level
-                 (FStar_Compiler_Util.for_some
-                    (fun uu___3 ->
-                       match uu___3 with
-                       | FStar_TypeChecker_Env.NoDelta -> false
-                       | FStar_TypeChecker_Env.InliningDelta -> true
-                       | FStar_TypeChecker_Env.Eager_unfolding_only -> true
-                       | FStar_TypeChecker_Env.Unfold l ->
-                           let uu___4 =
-                             FStar_TypeChecker_Env.delta_depth_of_fv
-                               cfg.FStar_TypeChecker_Cfg.tcenv fv in
-                           FStar_TypeChecker_Common.delta_depth_greater_than
-                             uu___4 l)) in
-             FStar_Compiler_Effect.op_Less_Bar yesno uu___2) in
+               FStar_Compiler_Util.for_some
+                 (fun uu___3 ->
+                    match uu___3 with
+                    | FStar_TypeChecker_Env.NoDelta -> false
+                    | FStar_TypeChecker_Env.InliningDelta -> true
+                    | FStar_TypeChecker_Env.Eager_unfolding_only -> true
+                    | FStar_TypeChecker_Env.Unfold l ->
+                        let uu___4 =
+                          FStar_TypeChecker_Env.delta_depth_of_fv
+                            cfg.FStar_TypeChecker_Cfg.tcenv fv in
+                        FStar_TypeChecker_Common.delta_depth_greater_than
+                          uu___4 l) cfg.FStar_TypeChecker_Cfg.delta_level in
+             yesno uu___2) in
           let res =
             if FStar_TypeChecker_Env.qninfo_is_action qninfo
             then
@@ -2171,7 +2125,7 @@ let (should_unfold :
                                      (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                                      qninfo in
                                  FStar_Compiler_Option.isSome uu___10 in
-                               FStar_Compiler_Effect.op_Less_Bar yesno uu___9
+                               yesno uu___9
                              else no in
                            let uu___9 =
                              let uu___10 =
@@ -2183,8 +2137,7 @@ let (should_unfold :
                                      FStar_Compiler_Util.for_some
                                        (FStar_Syntax_Syntax.fv_eq_lid fv)
                                        lids in
-                                   FStar_Compiler_Effect.op_Less_Bar yesno
-                                     uu___11 in
+                                   yesno uu___11 in
                              let uu___11 =
                                let uu___12 =
                                  match (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_attr
@@ -2198,8 +2151,7 @@ let (should_unfold :
                                               (fun lid ->
                                                  FStar_Syntax_Util.is_fvar
                                                    lid at) lids) attrs in
-                                     FStar_Compiler_Effect.op_Less_Bar yesno
-                                       uu___13 in
+                                     yesno uu___13 in
                                let uu___13 =
                                  let uu___14 =
                                    match (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_fully
@@ -2210,8 +2162,7 @@ let (should_unfold :
                                          FStar_Compiler_Util.for_some
                                            (FStar_Syntax_Syntax.fv_eq_lid fv)
                                            lids in
-                                       FStar_Compiler_Effect.op_Less_Bar
-                                         fullyno uu___15 in
+                                       fullyno uu___15 in
                                  let uu___15 =
                                    let uu___16 =
                                      match (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_qual
@@ -2227,8 +2178,7 @@ let (should_unfold :
                                                        FStar_Syntax_Print.qual_to_string
                                                          qual in
                                                      uu___18 = q) quals) qs in
-                                         FStar_Compiler_Effect.op_Less_Bar
-                                           yesno uu___17 in
+                                         yesno uu___17 in
                                    let uu___17 =
                                      let uu___18 =
                                        match (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_namespace
@@ -2251,8 +2201,7 @@ let (should_unfold :
                                                     uu___20
                                                     (Prims.strcat ns "."))
                                                namespaces in
-                                           FStar_Compiler_Effect.op_Less_Bar
-                                             yesno uu___19 in
+                                           yesno uu___19 in
                                      [uu___18] in
                                    uu___16 :: uu___17 in
                                  uu___14 :: uu___15 in
@@ -2283,7 +2232,7 @@ let (should_unfold :
                                      (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                                      qninfo in
                                  FStar_Compiler_Option.isSome uu___10 in
-                               FStar_Compiler_Effect.op_Less_Bar yesno uu___9
+                               yesno uu___9
                              else no in
                            let uu___9 =
                              let uu___10 =
@@ -2295,8 +2244,7 @@ let (should_unfold :
                                      FStar_Compiler_Util.for_some
                                        (FStar_Syntax_Syntax.fv_eq_lid fv)
                                        lids in
-                                   FStar_Compiler_Effect.op_Less_Bar yesno
-                                     uu___11 in
+                                   yesno uu___11 in
                              let uu___11 =
                                let uu___12 =
                                  match (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_attr
@@ -2310,8 +2258,7 @@ let (should_unfold :
                                               (fun lid ->
                                                  FStar_Syntax_Util.is_fvar
                                                    lid at) lids) attrs in
-                                     FStar_Compiler_Effect.op_Less_Bar yesno
-                                       uu___13 in
+                                     yesno uu___13 in
                                let uu___13 =
                                  let uu___14 =
                                    match (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_fully
@@ -2322,8 +2269,7 @@ let (should_unfold :
                                          FStar_Compiler_Util.for_some
                                            (FStar_Syntax_Syntax.fv_eq_lid fv)
                                            lids in
-                                       FStar_Compiler_Effect.op_Less_Bar
-                                         fullyno uu___15 in
+                                       fullyno uu___15 in
                                  let uu___15 =
                                    let uu___16 =
                                      match (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_qual
@@ -2339,8 +2285,7 @@ let (should_unfold :
                                                        FStar_Syntax_Print.qual_to_string
                                                          qual in
                                                      uu___18 = q) quals) qs in
-                                         FStar_Compiler_Effect.op_Less_Bar
-                                           yesno uu___17 in
+                                         yesno uu___17 in
                                    let uu___17 =
                                      let uu___18 =
                                        match (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_namespace
@@ -2363,8 +2308,7 @@ let (should_unfold :
                                                     uu___20
                                                     (Prims.strcat ns "."))
                                                namespaces in
-                                           FStar_Compiler_Effect.op_Less_Bar
-                                             yesno uu___19 in
+                                           yesno uu___19 in
                                      [uu___18] in
                                    uu___16 :: uu___17 in
                                  uu___14 :: uu___15 in
@@ -2395,7 +2339,7 @@ let (should_unfold :
                                      (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                                      qninfo in
                                  FStar_Compiler_Option.isSome uu___10 in
-                               FStar_Compiler_Effect.op_Less_Bar yesno uu___9
+                               yesno uu___9
                              else no in
                            let uu___9 =
                              let uu___10 =
@@ -2407,8 +2351,7 @@ let (should_unfold :
                                      FStar_Compiler_Util.for_some
                                        (FStar_Syntax_Syntax.fv_eq_lid fv)
                                        lids in
-                                   FStar_Compiler_Effect.op_Less_Bar yesno
-                                     uu___11 in
+                                   yesno uu___11 in
                              let uu___11 =
                                let uu___12 =
                                  match (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_attr
@@ -2422,8 +2365,7 @@ let (should_unfold :
                                               (fun lid ->
                                                  FStar_Syntax_Util.is_fvar
                                                    lid at) lids) attrs in
-                                     FStar_Compiler_Effect.op_Less_Bar yesno
-                                       uu___13 in
+                                     yesno uu___13 in
                                let uu___13 =
                                  let uu___14 =
                                    match (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_fully
@@ -2434,8 +2376,7 @@ let (should_unfold :
                                          FStar_Compiler_Util.for_some
                                            (FStar_Syntax_Syntax.fv_eq_lid fv)
                                            lids in
-                                       FStar_Compiler_Effect.op_Less_Bar
-                                         fullyno uu___15 in
+                                       fullyno uu___15 in
                                  let uu___15 =
                                    let uu___16 =
                                      match (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_qual
@@ -2451,8 +2392,7 @@ let (should_unfold :
                                                        FStar_Syntax_Print.qual_to_string
                                                          qual in
                                                      uu___18 = q) quals) qs in
-                                         FStar_Compiler_Effect.op_Less_Bar
-                                           yesno uu___17 in
+                                         yesno uu___17 in
                                    let uu___17 =
                                      let uu___18 =
                                        match (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_namespace
@@ -2475,8 +2415,7 @@ let (should_unfold :
                                                     uu___20
                                                     (Prims.strcat ns "."))
                                                namespaces in
-                                           FStar_Compiler_Effect.op_Less_Bar
-                                             yesno uu___19 in
+                                           yesno uu___19 in
                                      [uu___18] in
                                    uu___16 :: uu___17 in
                                  uu___14 :: uu___15 in
@@ -2507,7 +2446,7 @@ let (should_unfold :
                                      (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                                      qninfo in
                                  FStar_Compiler_Option.isSome uu___10 in
-                               FStar_Compiler_Effect.op_Less_Bar yesno uu___9
+                               yesno uu___9
                              else no in
                            let uu___9 =
                              let uu___10 =
@@ -2519,8 +2458,7 @@ let (should_unfold :
                                      FStar_Compiler_Util.for_some
                                        (FStar_Syntax_Syntax.fv_eq_lid fv)
                                        lids in
-                                   FStar_Compiler_Effect.op_Less_Bar yesno
-                                     uu___11 in
+                                   yesno uu___11 in
                              let uu___11 =
                                let uu___12 =
                                  match (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_attr
@@ -2534,8 +2472,7 @@ let (should_unfold :
                                               (fun lid ->
                                                  FStar_Syntax_Util.is_fvar
                                                    lid at) lids) attrs in
-                                     FStar_Compiler_Effect.op_Less_Bar yesno
-                                       uu___13 in
+                                     yesno uu___13 in
                                let uu___13 =
                                  let uu___14 =
                                    match (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_fully
@@ -2546,8 +2483,7 @@ let (should_unfold :
                                          FStar_Compiler_Util.for_some
                                            (FStar_Syntax_Syntax.fv_eq_lid fv)
                                            lids in
-                                       FStar_Compiler_Effect.op_Less_Bar
-                                         fullyno uu___15 in
+                                       fullyno uu___15 in
                                  let uu___15 =
                                    let uu___16 =
                                      match (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_qual
@@ -2563,8 +2499,7 @@ let (should_unfold :
                                                        FStar_Syntax_Print.qual_to_string
                                                          qual in
                                                      uu___18 = q) quals) qs in
-                                         FStar_Compiler_Effect.op_Less_Bar
-                                           yesno uu___17 in
+                                         yesno uu___17 in
                                    let uu___17 =
                                      let uu___18 =
                                        match (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_namespace
@@ -2587,8 +2522,7 @@ let (should_unfold :
                                                     uu___20
                                                     (Prims.strcat ns "."))
                                                namespaces in
-                                           FStar_Compiler_Effect.op_Less_Bar
-                                             yesno uu___19 in
+                                           yesno uu___19 in
                                      [uu___18] in
                                    uu___16 :: uu___17 in
                                  uu___14 :: uu___15 in
@@ -2619,7 +2553,7 @@ let (should_unfold :
                                      (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                                      qninfo in
                                  FStar_Compiler_Option.isSome uu___10 in
-                               FStar_Compiler_Effect.op_Less_Bar yesno uu___9
+                               yesno uu___9
                              else no in
                            let uu___9 =
                              let uu___10 =
@@ -2631,8 +2565,7 @@ let (should_unfold :
                                      FStar_Compiler_Util.for_some
                                        (FStar_Syntax_Syntax.fv_eq_lid fv)
                                        lids in
-                                   FStar_Compiler_Effect.op_Less_Bar yesno
-                                     uu___11 in
+                                   yesno uu___11 in
                              let uu___11 =
                                let uu___12 =
                                  match (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_attr
@@ -2646,8 +2579,7 @@ let (should_unfold :
                                               (fun lid ->
                                                  FStar_Syntax_Util.is_fvar
                                                    lid at) lids) attrs in
-                                     FStar_Compiler_Effect.op_Less_Bar yesno
-                                       uu___13 in
+                                     yesno uu___13 in
                                let uu___13 =
                                  let uu___14 =
                                    match (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_fully
@@ -2658,8 +2590,7 @@ let (should_unfold :
                                          FStar_Compiler_Util.for_some
                                            (FStar_Syntax_Syntax.fv_eq_lid fv)
                                            lids in
-                                       FStar_Compiler_Effect.op_Less_Bar
-                                         fullyno uu___15 in
+                                       fullyno uu___15 in
                                  let uu___15 =
                                    let uu___16 =
                                      match (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_qual
@@ -2675,8 +2606,7 @@ let (should_unfold :
                                                        FStar_Syntax_Print.qual_to_string
                                                          qual in
                                                      uu___18 = q) quals) qs in
-                                         FStar_Compiler_Effect.op_Less_Bar
-                                           yesno uu___17 in
+                                         yesno uu___17 in
                                    let uu___17 =
                                      let uu___18 =
                                        match (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_namespace
@@ -2699,8 +2629,7 @@ let (should_unfold :
                                                     uu___20
                                                     (Prims.strcat ns "."))
                                                namespaces in
-                                           FStar_Compiler_Effect.op_Less_Bar
-                                             yesno uu___19 in
+                                           yesno uu___19 in
                                      [uu___18] in
                                    uu___16 :: uu___17 in
                                  uu___14 :: uu___15 in
@@ -2743,8 +2672,7 @@ let (should_unfold :
                    let uu___3 = string_of_res res in
                    FStar_Compiler_Util.format1
                      "Unexpected unfolding result: %s" uu___3 in
-                 FStar_Compiler_Effect.op_Less_Bar
-                   FStar_Compiler_Effect.failwith uu___2 in
+                 FStar_Compiler_Effect.failwith uu___2 in
            (let uu___2 =
               ((((cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_tac
                    &&
@@ -2924,9 +2852,8 @@ let (is_fext_on_domain :
   =
   fun t ->
     let is_on_dom fv =
-      FStar_Compiler_Effect.op_Bar_Greater on_domain_lids
-        (FStar_Compiler_List.existsb
-           (fun l -> FStar_Syntax_Syntax.fv_eq_lid fv l)) in
+      FStar_Compiler_List.existsb
+        (fun l -> FStar_Syntax_Syntax.fv_eq_lid fv l) on_domain_lids in
     let uu___ =
       let uu___1 = FStar_Syntax_Subst.compress t in
       uu___1.FStar_Syntax_Syntax.n in
@@ -2944,15 +2871,10 @@ let (is_fext_on_domain :
              let f =
                let uu___2 =
                  let uu___3 =
-                   let uu___4 =
-                     FStar_Compiler_Effect.op_Bar_Greater args
-                       FStar_Compiler_List.tl in
-                   FStar_Compiler_Effect.op_Bar_Greater uu___4
-                     FStar_Compiler_List.tl in
-                 FStar_Compiler_Effect.op_Bar_Greater uu___3
-                   FStar_Compiler_List.hd in
-               FStar_Compiler_Effect.op_Bar_Greater uu___2
-                 FStar_Pervasives_Native.fst in
+                   let uu___4 = FStar_Compiler_List.tl args in
+                   FStar_Compiler_List.tl uu___4 in
+                 FStar_Compiler_List.hd uu___3 in
+               FStar_Pervasives_Native.fst uu___2 in
              FStar_Pervasives_Native.Some f
          | uu___2 -> FStar_Pervasives_Native.None)
     | uu___1 -> FStar_Pervasives_Native.None
@@ -3049,8 +2971,7 @@ let rec (norm :
                let uu___6 =
                  let uu___7 =
                    let uu___8 = firstn (Prims.of_int (4)) stack2 in
-                   FStar_Compiler_Effect.op_Less_Bar
-                     FStar_Pervasives_Native.fst uu___8 in
+                   FStar_Pervasives_Native.fst uu___8 in
                  stack_to_string uu___7 in
                FStar_Compiler_Util.print5
                  ">>> %s (no_full_norm=%s)\nNorm %s with %s env elements; top of the stack = %s\n"
@@ -3256,30 +3177,28 @@ let rec (norm :
                           "Norm request None ... \n"
                       else ();
                       (let stack3 =
-                         FStar_Compiler_Effect.op_Bar_Greater stack2
-                           (FStar_Compiler_List.fold_right
-                              (fun uu___5 ->
-                                 fun stack4 ->
-                                   match uu___5 with
-                                   | (a, aq) ->
-                                       let uu___6 =
-                                         let uu___7 =
-                                           let uu___8 =
-                                             let uu___9 =
-                                               let uu___10 =
-                                                 FStar_Compiler_Util.mk_ref
-                                                   FStar_Pervasives_Native.None in
-                                               (env1, a, uu___10, false) in
-                                             Clos uu___9 in
-                                           (uu___8, aq,
-                                             (t1.FStar_Syntax_Syntax.pos)) in
-                                         Arg uu___7 in
-                                       uu___6 :: stack4) args) in
+                         FStar_Compiler_List.fold_right
+                           (fun uu___5 ->
+                              fun stack4 ->
+                                match uu___5 with
+                                | (a, aq) ->
+                                    let uu___6 =
+                                      let uu___7 =
+                                        let uu___8 =
+                                          let uu___9 =
+                                            let uu___10 =
+                                              FStar_Compiler_Util.mk_ref
+                                                FStar_Pervasives_Native.None in
+                                            (env1, a, uu___10, false) in
+                                          Clos uu___9 in
+                                        (uu___8, aq,
+                                          (t1.FStar_Syntax_Syntax.pos)) in
+                                      Arg uu___7 in
+                                    uu___6 :: stack4) args stack2 in
                        FStar_TypeChecker_Cfg.log cfg
                          (fun uu___6 ->
                             let uu___7 =
-                              FStar_Compiler_Effect.op_Less_Bar
-                                FStar_Compiler_Util.string_of_int
+                              FStar_Compiler_Util.string_of_int
                                 (FStar_Compiler_List.length args) in
                             FStar_Compiler_Util.print1
                               "\tPushed %s arguments\n" uu___7);
@@ -3315,17 +3234,16 @@ let rec (norm :
                  | FStar_Pervasives_Native.Some (s, tm) ->
                      let delta_level =
                        let uu___4 =
-                         FStar_Compiler_Effect.op_Bar_Greater s
-                           (FStar_Compiler_Util.for_some
-                              (fun uu___5 ->
-                                 match uu___5 with
-                                 | FStar_TypeChecker_Env.UnfoldUntil uu___6
-                                     -> true
-                                 | FStar_TypeChecker_Env.UnfoldOnly uu___6 ->
-                                     true
-                                 | FStar_TypeChecker_Env.UnfoldFully uu___6
-                                     -> true
-                                 | uu___6 -> false)) in
+                         FStar_Compiler_Util.for_some
+                           (fun uu___5 ->
+                              match uu___5 with
+                              | FStar_TypeChecker_Env.UnfoldUntil uu___6 ->
+                                  true
+                              | FStar_TypeChecker_Env.UnfoldOnly uu___6 ->
+                                  true
+                              | FStar_TypeChecker_Env.UnfoldFully uu___6 ->
+                                  true
+                              | uu___6 -> false) s in
                        if uu___4
                        then
                          [FStar_TypeChecker_Env.Unfold
@@ -3531,33 +3449,30 @@ let rec (norm :
                     match uu___4 with
                     | (bs1, body1, opening) ->
                         let env' =
-                          FStar_Compiler_Effect.op_Bar_Greater bs1
-                            (FStar_Compiler_List.fold_left
-                               (fun env2 -> fun uu___5 -> dummy :: env2) env1) in
+                          FStar_Compiler_List.fold_left
+                            (fun env2 -> fun uu___5 -> dummy :: env2) env1
+                            bs1 in
                         let lopt1 =
                           let uu___5 =
-                            FStar_Compiler_Effect.op_Bar_Greater lopt
-                              (FStar_Compiler_Util.map_option
-                                 (maybe_drop_rc_typ cfg)) in
-                          FStar_Compiler_Effect.op_Bar_Greater uu___5
-                            (FStar_Compiler_Util.map_option
-                               (fun rc ->
-                                  let uu___6 =
-                                    FStar_Compiler_Util.map_option
-                                      (FStar_Syntax_Subst.subst opening)
-                                      rc.FStar_Syntax_Syntax.residual_typ in
-                                  {
-                                    FStar_Syntax_Syntax.residual_effect =
-                                      (rc.FStar_Syntax_Syntax.residual_effect);
-                                    FStar_Syntax_Syntax.residual_typ = uu___6;
-                                    FStar_Syntax_Syntax.residual_flags =
-                                      (rc.FStar_Syntax_Syntax.residual_flags)
-                                  })) in
+                            FStar_Compiler_Util.map_option
+                              (maybe_drop_rc_typ cfg) lopt in
+                          FStar_Compiler_Util.map_option
+                            (fun rc ->
+                               let uu___6 =
+                                 FStar_Compiler_Util.map_option
+                                   (FStar_Syntax_Subst.subst opening)
+                                   rc.FStar_Syntax_Syntax.residual_typ in
+                               {
+                                 FStar_Syntax_Syntax.residual_effect =
+                                   (rc.FStar_Syntax_Syntax.residual_effect);
+                                 FStar_Syntax_Syntax.residual_typ = uu___6;
+                                 FStar_Syntax_Syntax.residual_flags =
+                                   (rc.FStar_Syntax_Syntax.residual_flags)
+                               }) uu___5 in
                         (FStar_TypeChecker_Cfg.log cfg
                            (fun uu___6 ->
                               let uu___7 =
-                                FStar_Compiler_Effect.op_Less_Bar
-                                  FStar_Compiler_Util.string_of_int
+                                FStar_Compiler_Util.string_of_int
                                   (FStar_Compiler_List.length bs1) in
                               FStar_Compiler_Util.print1
                                 "\tShifted %s dummies\n" uu___7);
@@ -3656,11 +3571,8 @@ let rec (norm :
                let strict_args =
                  let uu___2 =
                    let uu___3 =
-                     let uu___4 =
-                       FStar_Compiler_Effect.op_Bar_Greater head
-                         FStar_Syntax_Util.unascribe in
-                     FStar_Compiler_Effect.op_Bar_Greater uu___4
-                       FStar_Syntax_Util.un_uinst in
+                     let uu___4 = FStar_Syntax_Util.unascribe head in
+                     FStar_Syntax_Util.un_uinst uu___4 in
                    uu___3.FStar_Syntax_Syntax.n in
                  match uu___2 with
                  | FStar_Syntax_Syntax.Tm_fvar fv ->
@@ -3721,88 +3633,77 @@ let rec (norm :
                     (FStar_TypeChecker_Cfg.log cfg
                        (fun uu___3 ->
                           let uu___4 =
-                            FStar_Compiler_Effect.op_Less_Bar
-                              FStar_Compiler_Util.string_of_int
+                            FStar_Compiler_Util.string_of_int
                               (FStar_Compiler_List.length args) in
                           FStar_Compiler_Util.print1
                             "\tPushed %s arguments\n" uu___4);
                      norm cfg env1 stack3 head)
                 | FStar_Pervasives_Native.Some strict_args1 ->
                     let norm_args =
-                      FStar_Compiler_Effect.op_Bar_Greater args
-                        (FStar_Compiler_List.map
-                           (fun uu___2 ->
-                              match uu___2 with
-                              | (a, i) ->
-                                  let uu___3 = norm cfg env1 [] a in
-                                  (uu___3, i))) in
+                      FStar_Compiler_List.map
+                        (fun uu___2 ->
+                           match uu___2 with
+                           | (a, i) ->
+                               let uu___3 = norm cfg env1 [] a in (uu___3, i))
+                        args in
                     let norm_args_len = FStar_Compiler_List.length norm_args in
                     let uu___2 =
-                      FStar_Compiler_Effect.op_Bar_Greater strict_args1
-                        (FStar_Compiler_List.for_all
-                           (fun i ->
-                              if i >= norm_args_len
-                              then false
-                              else
-                                (let uu___4 =
-                                   FStar_Compiler_List.nth norm_args i in
-                                 match uu___4 with
-                                 | (arg_i, uu___5) ->
-                                     let uu___6 =
-                                       let uu___7 =
-                                         FStar_Compiler_Effect.op_Bar_Greater
-                                           arg_i
-                                           FStar_Syntax_Util.unmeta_safe in
-                                       FStar_Compiler_Effect.op_Bar_Greater
-                                         uu___7
-                                         FStar_Syntax_Util.head_and_args in
-                                     (match uu___6 with
-                                      | (head1, uu___7) ->
-                                          let uu___8 =
+                      FStar_Compiler_List.for_all
+                        (fun i ->
+                           if i >= norm_args_len
+                           then false
+                           else
+                             (let uu___4 =
+                                FStar_Compiler_List.nth norm_args i in
+                              match uu___4 with
+                              | (arg_i, uu___5) ->
+                                  let uu___6 =
+                                    let uu___7 =
+                                      FStar_Syntax_Util.unmeta_safe arg_i in
+                                    FStar_Syntax_Util.head_and_args uu___7 in
+                                  (match uu___6 with
+                                   | (head1, uu___7) ->
+                                       let uu___8 =
+                                         let uu___9 =
+                                           FStar_Syntax_Util.un_uinst head1 in
+                                         uu___9.FStar_Syntax_Syntax.n in
+                                       (match uu___8 with
+                                        | FStar_Syntax_Syntax.Tm_constant
+                                            uu___9 -> true
+                                        | FStar_Syntax_Syntax.Tm_fvar fv ->
                                             let uu___9 =
-                                              FStar_Syntax_Util.un_uinst
-                                                head1 in
-                                            uu___9.FStar_Syntax_Syntax.n in
-                                          (match uu___8 with
-                                           | FStar_Syntax_Syntax.Tm_constant
-                                               uu___9 -> true
-                                           | FStar_Syntax_Syntax.Tm_fvar fv
-                                               ->
-                                               let uu___9 =
-                                                 FStar_Syntax_Syntax.lid_of_fv
-                                                   fv in
-                                               FStar_TypeChecker_Env.is_datacon
-                                                 cfg.FStar_TypeChecker_Cfg.tcenv
-                                                 uu___9
-                                           | uu___9 -> false))))) in
+                                              FStar_Syntax_Syntax.lid_of_fv
+                                                fv in
+                                            FStar_TypeChecker_Env.is_datacon
+                                              cfg.FStar_TypeChecker_Cfg.tcenv
+                                              uu___9
+                                        | uu___9 -> false)))) strict_args1 in
                     if uu___2
                     then
                       let stack3 =
-                        FStar_Compiler_Effect.op_Bar_Greater stack2
-                          (FStar_Compiler_List.fold_right
-                             (fun uu___3 ->
-                                fun stack4 ->
-                                  match uu___3 with
-                                  | (a, aq) ->
-                                      let uu___4 =
-                                        let uu___5 =
-                                          let uu___6 =
-                                            let uu___7 =
-                                              let uu___8 =
-                                                FStar_Compiler_Util.mk_ref
-                                                  (FStar_Pervasives_Native.Some
-                                                     (cfg, ([], a))) in
-                                              (env1, a, uu___8, false) in
-                                            Clos uu___7 in
-                                          (uu___6, aq,
-                                            (t1.FStar_Syntax_Syntax.pos)) in
-                                        Arg uu___5 in
-                                      uu___4 :: stack4) norm_args) in
+                        FStar_Compiler_List.fold_right
+                          (fun uu___3 ->
+                             fun stack4 ->
+                               match uu___3 with
+                               | (a, aq) ->
+                                   let uu___4 =
+                                     let uu___5 =
+                                       let uu___6 =
+                                         let uu___7 =
+                                           let uu___8 =
+                                             FStar_Compiler_Util.mk_ref
+                                               (FStar_Pervasives_Native.Some
+                                                  (cfg, ([], a))) in
+                                           (env1, a, uu___8, false) in
+                                         Clos uu___7 in
+                                       (uu___6, aq,
+                                         (t1.FStar_Syntax_Syntax.pos)) in
+                                     Arg uu___5 in
+                                   uu___4 :: stack4) norm_args stack2 in
                       (FStar_TypeChecker_Cfg.log cfg
                          (fun uu___4 ->
                             let uu___5 =
-                              FStar_Compiler_Effect.op_Less_Bar
-                                FStar_Compiler_Util.string_of_int
+                              FStar_Compiler_Util.string_of_int
                                 (FStar_Compiler_List.length args) in
                             FStar_Compiler_Util.print1
                               "\tPushed %s arguments\n" uu___5);
@@ -3891,9 +3792,9 @@ let rec (norm :
                   | (bs1, c1) ->
                       let c2 =
                         let uu___4 =
-                          FStar_Compiler_Effect.op_Bar_Greater bs1
-                            (FStar_Compiler_List.fold_left
-                               (fun env2 -> fun uu___5 -> dummy :: env2) env1) in
+                          FStar_Compiler_List.fold_left
+                            (fun env2 -> fun uu___5 -> dummy :: env2) env1
+                            bs1 in
                         norm_comp cfg uu___4 c1 in
                       let t2 =
                         let uu___4 = norm_binders cfg env1 bs1 in
@@ -4112,62 +4013,59 @@ let rec (norm :
                  (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.compress_uvars
                ->
                let lbs1 =
-                 FStar_Compiler_Effect.op_Bar_Greater lbs
-                   (FStar_Compiler_List.map
-                      (fun lb ->
-                         let uu___2 =
-                           FStar_Syntax_Subst.univ_var_opening
-                             lb.FStar_Syntax_Syntax.lbunivs in
-                         match uu___2 with
-                         | (openings, lbunivs) ->
-                             let cfg1 =
-                               let uu___3 =
-                                 FStar_TypeChecker_Env.push_univ_vars
-                                   cfg.FStar_TypeChecker_Cfg.tcenv lbunivs in
-                               {
-                                 FStar_TypeChecker_Cfg.steps =
-                                   (cfg.FStar_TypeChecker_Cfg.steps);
-                                 FStar_TypeChecker_Cfg.tcenv = uu___3;
-                                 FStar_TypeChecker_Cfg.debug =
-                                   (cfg.FStar_TypeChecker_Cfg.debug);
-                                 FStar_TypeChecker_Cfg.delta_level =
-                                   (cfg.FStar_TypeChecker_Cfg.delta_level);
-                                 FStar_TypeChecker_Cfg.primitive_steps =
-                                   (cfg.FStar_TypeChecker_Cfg.primitive_steps);
-                                 FStar_TypeChecker_Cfg.strong =
-                                   (cfg.FStar_TypeChecker_Cfg.strong);
-                                 FStar_TypeChecker_Cfg.memoize_lazy =
-                                   (cfg.FStar_TypeChecker_Cfg.memoize_lazy);
-                                 FStar_TypeChecker_Cfg.normalize_pure_lets =
-                                   (cfg.FStar_TypeChecker_Cfg.normalize_pure_lets);
-                                 FStar_TypeChecker_Cfg.reifying =
-                                   (cfg.FStar_TypeChecker_Cfg.reifying);
-                                 FStar_TypeChecker_Cfg.compat_memo_ignore_cfg
-                                   =
-                                   (cfg.FStar_TypeChecker_Cfg.compat_memo_ignore_cfg)
-                               } in
-                             let norm1 t2 =
-                               let uu___3 =
-                                 let uu___4 =
-                                   FStar_Syntax_Subst.subst openings t2 in
-                                 norm cfg1 env1 [] uu___4 in
-                               FStar_Syntax_Subst.close_univ_vars lbunivs
-                                 uu___3 in
-                             let lbtyp = norm1 lb.FStar_Syntax_Syntax.lbtyp in
-                             let lbdef = norm1 lb.FStar_Syntax_Syntax.lbdef in
-                             {
-                               FStar_Syntax_Syntax.lbname =
-                                 (lb.FStar_Syntax_Syntax.lbname);
-                               FStar_Syntax_Syntax.lbunivs = lbunivs;
-                               FStar_Syntax_Syntax.lbtyp = lbtyp;
-                               FStar_Syntax_Syntax.lbeff =
-                                 (lb.FStar_Syntax_Syntax.lbeff);
-                               FStar_Syntax_Syntax.lbdef = lbdef;
-                               FStar_Syntax_Syntax.lbattrs =
-                                 (lb.FStar_Syntax_Syntax.lbattrs);
-                               FStar_Syntax_Syntax.lbpos =
-                                 (lb.FStar_Syntax_Syntax.lbpos)
-                             })) in
+                 FStar_Compiler_List.map
+                   (fun lb ->
+                      let uu___2 =
+                        FStar_Syntax_Subst.univ_var_opening
+                          lb.FStar_Syntax_Syntax.lbunivs in
+                      match uu___2 with
+                      | (openings, lbunivs) ->
+                          let cfg1 =
+                            let uu___3 =
+                              FStar_TypeChecker_Env.push_univ_vars
+                                cfg.FStar_TypeChecker_Cfg.tcenv lbunivs in
+                            {
+                              FStar_TypeChecker_Cfg.steps =
+                                (cfg.FStar_TypeChecker_Cfg.steps);
+                              FStar_TypeChecker_Cfg.tcenv = uu___3;
+                              FStar_TypeChecker_Cfg.debug =
+                                (cfg.FStar_TypeChecker_Cfg.debug);
+                              FStar_TypeChecker_Cfg.delta_level =
+                                (cfg.FStar_TypeChecker_Cfg.delta_level);
+                              FStar_TypeChecker_Cfg.primitive_steps =
+                                (cfg.FStar_TypeChecker_Cfg.primitive_steps);
+                              FStar_TypeChecker_Cfg.strong =
+                                (cfg.FStar_TypeChecker_Cfg.strong);
+                              FStar_TypeChecker_Cfg.memoize_lazy =
+                                (cfg.FStar_TypeChecker_Cfg.memoize_lazy);
+                              FStar_TypeChecker_Cfg.normalize_pure_lets =
+                                (cfg.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                              FStar_TypeChecker_Cfg.reifying =
+                                (cfg.FStar_TypeChecker_Cfg.reifying);
+                              FStar_TypeChecker_Cfg.compat_memo_ignore_cfg =
+                                (cfg.FStar_TypeChecker_Cfg.compat_memo_ignore_cfg)
+                            } in
+                          let norm1 t2 =
+                            let uu___3 =
+                              let uu___4 =
+                                FStar_Syntax_Subst.subst openings t2 in
+                              norm cfg1 env1 [] uu___4 in
+                            FStar_Syntax_Subst.close_univ_vars lbunivs uu___3 in
+                          let lbtyp = norm1 lb.FStar_Syntax_Syntax.lbtyp in
+                          let lbdef = norm1 lb.FStar_Syntax_Syntax.lbdef in
+                          {
+                            FStar_Syntax_Syntax.lbname =
+                              (lb.FStar_Syntax_Syntax.lbname);
+                            FStar_Syntax_Syntax.lbunivs = lbunivs;
+                            FStar_Syntax_Syntax.lbtyp = lbtyp;
+                            FStar_Syntax_Syntax.lbeff =
+                              (lb.FStar_Syntax_Syntax.lbeff);
+                            FStar_Syntax_Syntax.lbdef = lbdef;
+                            FStar_Syntax_Syntax.lbattrs =
+                              (lb.FStar_Syntax_Syntax.lbattrs);
+                            FStar_Syntax_Syntax.lbpos =
+                              (lb.FStar_Syntax_Syntax.lbpos)
+                          }) lbs in
                let uu___2 =
                  FStar_Syntax_Syntax.mk
                    (FStar_Syntax_Syntax.Tm_let
@@ -4238,9 +4136,8 @@ let rec (norm :
                           let uu___7 =
                             let uu___8 =
                               let uu___9 =
-                                FStar_Compiler_Effect.op_Bar_Greater
-                                  lb.FStar_Syntax_Syntax.lbname
-                                  FStar_Compiler_Util.left in
+                                FStar_Compiler_Util.left
+                                  lb.FStar_Syntax_Syntax.lbname in
                               FStar_Syntax_Syntax.mk_binder uu___9 in
                             [uu___8] in
                           {
@@ -4277,11 +4174,9 @@ let rec (norm :
                          let uu___8 =
                            let uu___9 =
                              let uu___10 =
-                               FStar_Compiler_Effect.op_Bar_Greater
-                                 lb.FStar_Syntax_Syntax.lbname
-                                 FStar_Compiler_Util.left in
-                             FStar_Compiler_Effect.op_Bar_Greater uu___10
-                               FStar_Syntax_Syntax.mk_binder in
+                               FStar_Compiler_Util.left
+                                 lb.FStar_Syntax_Syntax.lbname in
+                             FStar_Syntax_Syntax.mk_binder uu___10 in
                            [uu___9] in
                          FStar_Syntax_Subst.open_term uu___8 body in
                        match uu___7 with
@@ -4328,10 +4223,9 @@ let rec (norm :
                                     (lb.FStar_Syntax_Syntax.lbpos)
                                 } in
                               let env' =
-                                FStar_Compiler_Effect.op_Bar_Greater bs
-                                  (FStar_Compiler_List.fold_left
-                                     (fun env2 ->
-                                        fun uu___10 -> dummy :: env2) env1) in
+                                FStar_Compiler_List.fold_left
+                                  (fun env2 -> fun uu___10 -> dummy :: env2)
+                                  env1 bs in
                               let stack3 =
                                 (Cfg (cfg, FStar_Pervasives_Native.None)) ::
                                 stack2 in
@@ -4645,9 +4539,8 @@ let rec (norm :
                                  ->
                                  let args1 = norm_pattern_args cfg env1 args in
                                  let names1 =
-                                   FStar_Compiler_Effect.op_Bar_Greater names
-                                     (FStar_Compiler_List.map
-                                        (norm cfg env1 [])) in
+                                   FStar_Compiler_List.map (norm cfg env1 [])
+                                     names in
                                  norm cfg env1
                                    ((Meta
                                        (env1,
@@ -4680,10 +4573,8 @@ let rec (norm :
                               | FStar_Syntax_Syntax.Meta_pattern
                                   (names, args) ->
                                   let names1 =
-                                    FStar_Compiler_Effect.op_Bar_Greater
-                                      names
-                                      (FStar_Compiler_List.map
-                                         (norm cfg env1 [])) in
+                                    FStar_Compiler_List.map
+                                      (norm cfg env1 []) names in
                                   let uu___5 =
                                     let uu___6 =
                                       norm_pattern_args cfg env1 args in
@@ -4764,9 +4655,8 @@ and (do_unfold_fv :
                     match stack1 with
                     | (UnivArgs (us', uu___2))::stack2 ->
                         ((let uu___4 =
-                            FStar_Compiler_Effect.op_Less_Bar
-                              (FStar_TypeChecker_Env.debug
-                                 cfg.FStar_TypeChecker_Cfg.tcenv)
+                            FStar_TypeChecker_Env.debug
+                              cfg.FStar_TypeChecker_Cfg.tcenv
                               (FStar_Options.Other "univ_norm") in
                           if uu___4
                           then
@@ -4778,13 +4668,11 @@ and (do_unfold_fv :
                                    "Univ (normalizer) %s\n" uu___5) us'
                           else ());
                          (let env1 =
-                            FStar_Compiler_Effect.op_Bar_Greater us'
-                              (FStar_Compiler_List.fold_left
-                                 (fun env2 ->
-                                    fun u ->
-                                      (FStar_Pervasives_Native.None,
-                                        (Univ u))
-                                      :: env2) empty_env) in
+                            FStar_Compiler_List.fold_left
+                              (fun env2 ->
+                                 fun u ->
+                                   (FStar_Pervasives_Native.None, (Univ u))
+                                   :: env2) empty_env us' in
                           norm cfg env1 stack2 t1))
                     | uu___2 when
                         (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.erase_universes
@@ -4886,19 +4774,13 @@ and (do_reify_monadic :
                         FStar_TypeChecker_Env.get_effect_decl
                           cfg.FStar_TypeChecker_Cfg.tcenv eff_name in
                       let uu___3 =
-                        let uu___4 =
-                          FStar_Compiler_Effect.op_Bar_Greater ed
-                            FStar_Syntax_Util.get_eff_repr in
-                        FStar_Compiler_Effect.op_Bar_Greater uu___4
-                          FStar_Compiler_Util.must in
+                        let uu___4 = FStar_Syntax_Util.get_eff_repr ed in
+                        FStar_Compiler_Util.must uu___4 in
                       (match uu___3 with
                        | (uu___4, repr) ->
                            let uu___5 =
-                             let uu___6 =
-                               FStar_Compiler_Effect.op_Bar_Greater ed
-                                 FStar_Syntax_Util.get_bind_repr in
-                             FStar_Compiler_Effect.op_Bar_Greater uu___6
-                               FStar_Compiler_Util.must in
+                             let uu___6 = FStar_Syntax_Util.get_bind_repr ed in
+                             FStar_Compiler_Util.must uu___6 in
                            (match uu___5 with
                             | (uu___6, bind_repr) ->
                                 (match lb.FStar_Syntax_Syntax.lbname with
@@ -5112,18 +4994,14 @@ and (do_reify_monadic :
                                                        let uu___13 =
                                                          let uu___14 =
                                                            let uu___15 =
-                                                             FStar_Compiler_Effect.op_Bar_Greater
-                                                               ed
-                                                               FStar_Syntax_Util.get_bind_vc_combinator in
-                                                           FStar_Compiler_Effect.op_Bar_Greater
-                                                             uu___15
-                                                             FStar_Pervasives_Native.fst in
-                                                         FStar_Compiler_Effect.op_Bar_Greater
-                                                           uu___14
-                                                           FStar_Pervasives_Native.snd in
-                                                       FStar_Compiler_Effect.op_Bar_Greater
-                                                         uu___13
-                                                         FStar_Syntax_Subst.compress in
+                                                             FStar_Syntax_Util.get_bind_vc_combinator
+                                                               ed in
+                                                           FStar_Pervasives_Native.fst
+                                                             uu___15 in
+                                                         FStar_Pervasives_Native.snd
+                                                           uu___14 in
+                                                       FStar_Syntax_Subst.compress
+                                                         uu___13 in
                                                      uu___12.FStar_Syntax_Syntax.n in
                                                    match uu___11 with
                                                    | FStar_Syntax_Syntax.Tm_arrow
@@ -5140,22 +5018,19 @@ and (do_reify_monadic :
                                                        ->
                                                        let uu___15 =
                                                          let uu___16 =
-                                                           FStar_Compiler_Effect.op_Bar_Greater
-                                                             bs
-                                                             (FStar_Compiler_List.splitAt
-                                                                ((FStar_Compiler_List.length
-                                                                    bs)
-                                                                   -
-                                                                   num_fixed_binders)) in
-                                                         FStar_Compiler_Effect.op_Bar_Greater
-                                                           uu___16
-                                                           FStar_Pervasives_Native.fst in
-                                                       FStar_Compiler_Effect.op_Bar_Greater
+                                                           FStar_Compiler_List.splitAt
+                                                             ((FStar_Compiler_List.length
+                                                                 bs)
+                                                                -
+                                                                num_fixed_binders)
+                                                             bs in
+                                                         FStar_Pervasives_Native.fst
+                                                           uu___16 in
+                                                       FStar_Compiler_List.map
+                                                         (fun uu___16 ->
+                                                            FStar_Syntax_Syntax.as_arg
+                                                              FStar_Syntax_Syntax.unit_const)
                                                          uu___15
-                                                         (FStar_Compiler_List.map
-                                                            (fun uu___16 ->
-                                                               FStar_Syntax_Syntax.as_arg
-                                                                 FStar_Syntax_Syntax.unit_const))
                                                    | uu___12 ->
                                                        let uu___13 =
                                                          let uu___14 =
@@ -5170,18 +5045,14 @@ and (do_reify_monadic :
                                                                let uu___19 =
                                                                  let uu___20
                                                                    =
-                                                                   FStar_Compiler_Effect.op_Bar_Greater
-                                                                    ed
-                                                                    FStar_Syntax_Util.get_bind_vc_combinator in
-                                                                 FStar_Compiler_Effect.op_Bar_Greater
-                                                                   uu___20
-                                                                   FStar_Pervasives_Native.fst in
-                                                               FStar_Compiler_Effect.op_Bar_Greater
-                                                                 uu___19
-                                                                 FStar_Pervasives_Native.snd in
-                                                             FStar_Compiler_Effect.op_Bar_Greater
-                                                               uu___18
-                                                               FStar_Syntax_Print.term_to_string in
+                                                                   FStar_Syntax_Util.get_bind_vc_combinator
+                                                                    ed in
+                                                                 FStar_Pervasives_Native.fst
+                                                                   uu___20 in
+                                                               FStar_Pervasives_Native.snd
+                                                                 uu___19 in
+                                                             FStar_Syntax_Print.term_to_string
+                                                               uu___18 in
                                                            FStar_Compiler_Util.format3
                                                              "bind_wp for layered effect %s is not an arrow with >= %s arguments (%s)"
                                                              uu___15 uu___16
@@ -5374,12 +5245,9 @@ and (do_reify_monadic :
                                                           let uu___14 =
                                                             let uu___15 =
                                                               let uu___16 =
-                                                                let uu___17 =
-                                                                  FStar_Syntax_Syntax.mk_binder
-                                                                    head_bv in
-                                                                [uu___17] in
-                                                              FStar_Syntax_Subst.close
-                                                                uu___16 in
+                                                                FStar_Syntax_Syntax.mk_binder
+                                                                  head_bv in
+                                                              [uu___16] in
                                                             let uu___16 =
                                                               let uu___17 =
                                                                 let uu___18 =
@@ -5398,7 +5266,7 @@ and (do_reify_monadic :
                                                                   uu___18 in
                                                               FStar_Syntax_Syntax.mk
                                                                 uu___17 rng in
-                                                            FStar_Compiler_Effect.op_Less_Bar
+                                                            FStar_Syntax_Subst.close
                                                               uu___15 uu___16 in
                                                           {
                                                             FStar_Syntax_Syntax.lbs
@@ -5564,15 +5432,14 @@ and (do_reify_monadic :
                         FStar_Syntax_Syntax.rc_opt1 = lopt;_}
                       ->
                       let branches2 =
-                        FStar_Compiler_Effect.op_Bar_Greater branches1
-                          (FStar_Compiler_List.map
-                             (fun uu___3 ->
-                                match uu___3 with
-                                | (pat, wopt, tm) ->
-                                    let uu___4 =
-                                      FStar_Syntax_Util.mk_reify tm
-                                        (FStar_Pervasives_Native.Some m) in
-                                    (pat, wopt, uu___4))) in
+                        FStar_Compiler_List.map
+                          (fun uu___3 ->
+                             match uu___3 with
+                             | (pat, wopt, tm) ->
+                                 let uu___4 =
+                                   FStar_Syntax_Util.mk_reify tm
+                                     (FStar_Pervasives_Native.Some m) in
+                                 (pat, wopt, uu___4)) branches1 in
                       let tm =
                         FStar_Syntax_Syntax.mk
                           (FStar_Syntax_Syntax.Tm_match
@@ -5611,8 +5478,7 @@ and (reify_lift :
                   (FStar_Syntax_Util.is_div_effect msrc))
                  &&
                  (let uu___2 =
-                    FStar_Compiler_Effect.op_Bar_Greater mtgt
-                      (FStar_TypeChecker_Env.is_layered_effect env1) in
+                    FStar_TypeChecker_Env.is_layered_effect env1 mtgt in
                   Prims.op_Negation uu___2) in
              if uu___1
              then
@@ -5622,19 +5488,13 @@ and (reify_lift :
                      cfg.FStar_TypeChecker_Cfg.tcenv mtgt in
                  FStar_TypeChecker_Env.get_effect_decl env1 uu___2 in
                let uu___2 =
-                 let uu___3 =
-                   FStar_Compiler_Effect.op_Bar_Greater ed
-                     FStar_Syntax_Util.get_eff_repr in
-                 FStar_Compiler_Effect.op_Bar_Greater uu___3
-                   FStar_Compiler_Util.must in
+                 let uu___3 = FStar_Syntax_Util.get_eff_repr ed in
+                 FStar_Compiler_Util.must uu___3 in
                match uu___2 with
                | (uu___3, repr) ->
                    let uu___4 =
-                     let uu___5 =
-                       FStar_Compiler_Effect.op_Bar_Greater ed
-                         FStar_Syntax_Util.get_return_repr in
-                     FStar_Compiler_Effect.op_Bar_Greater uu___5
-                       FStar_Compiler_Util.must in
+                     let uu___5 = FStar_Syntax_Util.get_return_repr ed in
+                     FStar_Compiler_Util.must uu___5 in
                    (match uu___4 with
                     | (uu___5, return_repr) ->
                         let return_inst =
@@ -5689,10 +5549,8 @@ and (reify_lift :
                                  let uu___9 =
                                    let uu___10 =
                                      let uu___11 =
-                                       let uu___12 =
-                                         FStar_Syntax_Syntax.mk_binder e_bv in
-                                       [uu___12] in
-                                     FStar_Syntax_Subst.close uu___11 in
+                                       FStar_Syntax_Syntax.mk_binder e_bv in
+                                     [uu___11] in
                                    let uu___11 =
                                      let uu___12 =
                                        let uu___13 =
@@ -5712,8 +5570,7 @@ and (reify_lift :
                                        FStar_Syntax_Syntax.Tm_app uu___13 in
                                      FStar_Syntax_Syntax.mk uu___12
                                        e1.FStar_Syntax_Syntax.pos in
-                                   FStar_Compiler_Effect.op_Less_Bar uu___10
-                                     uu___11 in
+                                   FStar_Syntax_Subst.close uu___10 uu___11 in
                                  {
                                    FStar_Syntax_Syntax.lbs = (false, [lb_e]);
                                    FStar_Syntax_Syntax.body1 = uu___9
@@ -5804,13 +5661,12 @@ and (norm_pattern_args :
   fun cfg ->
     fun env1 ->
       fun args ->
-        FStar_Compiler_Effect.op_Bar_Greater args
+        FStar_Compiler_List.map
           (FStar_Compiler_List.map
-             (FStar_Compiler_List.map
-                (fun uu___ ->
-                   match uu___ with
-                   | (a, imp) ->
-                       let uu___1 = norm cfg env1 [] a in (uu___1, imp))))
+             (fun uu___ ->
+                match uu___ with
+                | (a, imp) ->
+                    let uu___1 = norm cfg env1 [] a in (uu___1, imp))) args
 and (norm_comp :
   FStar_TypeChecker_Cfg.cfg ->
     env -> FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.comp)
@@ -5863,9 +5719,8 @@ and (norm_comp :
                  then
                    FStar_Compiler_List.map
                      (fun uu___3 ->
-                        FStar_Compiler_Effect.op_Bar_Greater
-                          FStar_Syntax_Syntax.unit_const
-                          FStar_Syntax_Syntax.as_arg)
+                        FStar_Syntax_Syntax.as_arg
+                          FStar_Syntax_Syntax.unit_const)
                  else
                    FStar_Compiler_List.mapi
                      (fun idx ->
@@ -5873,34 +5728,28 @@ and (norm_comp :
                           match uu___4 with
                           | (a, i) ->
                               let uu___5 = norm cfg env1 [] a in (uu___5, i)) in
-               FStar_Compiler_Effect.op_Bar_Greater
-                 ct.FStar_Syntax_Syntax.effect_args uu___1 in
+               uu___1 ct.FStar_Syntax_Syntax.effect_args in
              let flags =
-               FStar_Compiler_Effect.op_Bar_Greater
-                 ct.FStar_Syntax_Syntax.flags
-                 (FStar_Compiler_List.map
-                    (fun uu___1 ->
-                       match uu___1 with
-                       | FStar_Syntax_Syntax.DECREASES
-                           (FStar_Syntax_Syntax.Decreases_lex l) ->
-                           let uu___2 =
-                             let uu___3 =
-                               FStar_Compiler_Effect.op_Bar_Greater l
-                                 (FStar_Compiler_List.map (norm cfg env1 [])) in
-                             FStar_Compiler_Effect.op_Bar_Greater uu___3
-                               (fun uu___4 ->
-                                  FStar_Syntax_Syntax.Decreases_lex uu___4) in
-                           FStar_Syntax_Syntax.DECREASES uu___2
-                       | FStar_Syntax_Syntax.DECREASES
-                           (FStar_Syntax_Syntax.Decreases_wf (rel, e)) ->
-                           let uu___2 =
-                             let uu___3 =
-                               let uu___4 = norm cfg env1 [] rel in
-                               let uu___5 = norm cfg env1 [] e in
-                               (uu___4, uu___5) in
-                             FStar_Syntax_Syntax.Decreases_wf uu___3 in
-                           FStar_Syntax_Syntax.DECREASES uu___2
-                       | f -> f)) in
+               FStar_Compiler_List.map
+                 (fun uu___1 ->
+                    match uu___1 with
+                    | FStar_Syntax_Syntax.DECREASES
+                        (FStar_Syntax_Syntax.Decreases_lex l) ->
+                        let uu___2 =
+                          let uu___3 =
+                            FStar_Compiler_List.map (norm cfg env1 []) l in
+                          FStar_Syntax_Syntax.Decreases_lex uu___3 in
+                        FStar_Syntax_Syntax.DECREASES uu___2
+                    | FStar_Syntax_Syntax.DECREASES
+                        (FStar_Syntax_Syntax.Decreases_wf (rel, e)) ->
+                        let uu___2 =
+                          let uu___3 =
+                            let uu___4 = norm cfg env1 [] rel in
+                            let uu___5 = norm cfg env1 [] e in
+                            (uu___4, uu___5) in
+                          FStar_Syntax_Syntax.Decreases_wf uu___3 in
+                        FStar_Syntax_Syntax.DECREASES uu___2
+                    | f -> f) ct.FStar_Syntax_Syntax.flags in
              let comp_univs =
                FStar_Compiler_List.map (norm_universe cfg env1)
                  ct.FStar_Syntax_Syntax.comp_univs in
@@ -6026,10 +5875,9 @@ and (maybe_simplify_aux :
             let uu___1 = norm_cb cfg in reduce_primops uu___1 cfg env1 tm in
           match uu___ with
           | (tm1, renorm) ->
-              let uu___1 =
-                FStar_Compiler_Effect.op_Less_Bar Prims.op_Negation
-                  (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.simplify in
-              if uu___1
+              if
+                Prims.op_Negation
+                  (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.simplify
               then (tm1, renorm)
               else
                 (let w t =
@@ -6041,10 +5889,10 @@ and (maybe_simplify_aux :
                        (t.FStar_Syntax_Syntax.hash_code)
                    } in
                  let simp_t t =
-                   let uu___3 =
-                     let uu___4 = FStar_Syntax_Util.unmeta t in
-                     uu___4.FStar_Syntax_Syntax.n in
-                   match uu___3 with
+                   let uu___2 =
+                     let uu___3 = FStar_Syntax_Util.unmeta t in
+                     uu___3.FStar_Syntax_Syntax.n in
+                   match uu___2 with
                    | FStar_Syntax_Syntax.Tm_fvar fv when
                        FStar_Syntax_Syntax.fv_eq_lid fv
                          FStar_Parser_Const.true_lid
@@ -6053,97 +5901,97 @@ and (maybe_simplify_aux :
                        FStar_Syntax_Syntax.fv_eq_lid fv
                          FStar_Parser_Const.false_lid
                        -> FStar_Pervasives_Native.Some false
-                   | uu___4 -> FStar_Pervasives_Native.None in
+                   | uu___3 -> FStar_Pervasives_Native.None in
                  let rec args_are_binders args bs =
                    match (args, bs) with
-                   | ((t, uu___3)::args1, b::bs1) ->
-                       let uu___4 =
-                         let uu___5 = FStar_Syntax_Subst.compress t in
-                         uu___5.FStar_Syntax_Syntax.n in
-                       (match uu___4 with
+                   | ((t, uu___2)::args1, b::bs1) ->
+                       let uu___3 =
+                         let uu___4 = FStar_Syntax_Subst.compress t in
+                         uu___4.FStar_Syntax_Syntax.n in
+                       (match uu___3 with
                         | FStar_Syntax_Syntax.Tm_name bv' ->
                             (FStar_Syntax_Syntax.bv_eq
                                b.FStar_Syntax_Syntax.binder_bv bv')
                               && (args_are_binders args1 bs1)
-                        | uu___5 -> false)
+                        | uu___4 -> false)
                    | ([], []) -> true
-                   | (uu___3, uu___4) -> false in
+                   | (uu___2, uu___3) -> false in
                  let is_applied bs t =
                    if
                      (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.wpe
                    then
-                     (let uu___4 = FStar_Syntax_Print.term_to_string t in
-                      let uu___5 = FStar_Syntax_Print.tag_of_term t in
+                     (let uu___3 = FStar_Syntax_Print.term_to_string t in
+                      let uu___4 = FStar_Syntax_Print.tag_of_term t in
                       FStar_Compiler_Util.print2 "WPE> is_applied %s -- %s\n"
-                        uu___4 uu___5)
+                        uu___3 uu___4)
                    else ();
-                   (let uu___4 = FStar_Syntax_Util.head_and_args_full t in
-                    match uu___4 with
+                   (let uu___3 = FStar_Syntax_Util.head_and_args_full t in
+                    match uu___3 with
                     | (hd, args) ->
-                        let uu___5 =
-                          let uu___6 = FStar_Syntax_Subst.compress hd in
-                          uu___6.FStar_Syntax_Syntax.n in
-                        (match uu___5 with
+                        let uu___4 =
+                          let uu___5 = FStar_Syntax_Subst.compress hd in
+                          uu___5.FStar_Syntax_Syntax.n in
+                        (match uu___4 with
                          | FStar_Syntax_Syntax.Tm_name bv when
                              args_are_binders args bs ->
                              (if
                                 (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.wpe
                               then
-                                (let uu___7 =
+                                (let uu___6 =
                                    FStar_Syntax_Print.term_to_string t in
-                                 let uu___8 =
+                                 let uu___7 =
                                    FStar_Syntax_Print.bv_to_string bv in
-                                 let uu___9 =
+                                 let uu___8 =
                                    FStar_Syntax_Print.term_to_string hd in
                                  FStar_Compiler_Util.print3
                                    "WPE> got it\n>>>>top = %s\n>>>>b = %s\n>>>>hd = %s\n"
-                                   uu___7 uu___8 uu___9)
+                                   uu___6 uu___7 uu___8)
                               else ();
                               FStar_Pervasives_Native.Some bv)
-                         | uu___6 -> FStar_Pervasives_Native.None)) in
+                         | uu___5 -> FStar_Pervasives_Native.None)) in
                  let is_applied_maybe_squashed bs t =
                    if
                      (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.wpe
                    then
-                     (let uu___4 = FStar_Syntax_Print.term_to_string t in
-                      let uu___5 = FStar_Syntax_Print.tag_of_term t in
+                     (let uu___3 = FStar_Syntax_Print.term_to_string t in
+                      let uu___4 = FStar_Syntax_Print.tag_of_term t in
                       FStar_Compiler_Util.print2
-                        "WPE> is_applied_maybe_squashed %s -- %s\n" uu___4
-                        uu___5)
+                        "WPE> is_applied_maybe_squashed %s -- %s\n" uu___3
+                        uu___4)
                    else ();
-                   (let uu___4 = FStar_Syntax_Util.is_squash t in
-                    match uu___4 with
-                    | FStar_Pervasives_Native.Some (uu___5, t') ->
+                   (let uu___3 = FStar_Syntax_Util.is_squash t in
+                    match uu___3 with
+                    | FStar_Pervasives_Native.Some (uu___4, t') ->
                         is_applied bs t'
-                    | uu___5 ->
-                        let uu___6 = FStar_Syntax_Util.is_auto_squash t in
-                        (match uu___6 with
-                         | FStar_Pervasives_Native.Some (uu___7, t') ->
+                    | uu___4 ->
+                        let uu___5 = FStar_Syntax_Util.is_auto_squash t in
+                        (match uu___5 with
+                         | FStar_Pervasives_Native.Some (uu___6, t') ->
                              is_applied bs t'
-                         | uu___7 -> is_applied bs t)) in
+                         | uu___6 -> is_applied bs t)) in
                  let is_quantified_const bv phi =
-                   let uu___3 = FStar_Syntax_Util.destruct_typ_as_formula phi in
-                   match uu___3 with
+                   let uu___2 = FStar_Syntax_Util.destruct_typ_as_formula phi in
+                   match uu___2 with
                    | FStar_Pervasives_Native.Some (FStar_Syntax_Util.BaseConn
-                       (lid, (p, uu___4)::(q, uu___5)::[])) when
+                       (lid, (p, uu___3)::(q, uu___4)::[])) when
                        FStar_Ident.lid_equals lid FStar_Parser_Const.imp_lid
                        ->
                        (if
                           (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.wpe
                         then
-                          (let uu___7 = FStar_Syntax_Print.term_to_string p in
-                           let uu___8 = FStar_Syntax_Print.term_to_string q in
+                          (let uu___6 = FStar_Syntax_Print.term_to_string p in
+                           let uu___7 = FStar_Syntax_Print.term_to_string q in
                            FStar_Compiler_Util.print2
-                             "WPE> p = (%s); q = (%s)\n" uu___7 uu___8)
+                             "WPE> p = (%s); q = (%s)\n" uu___6 uu___7)
                         else ();
-                        (let uu___7 =
+                        (let uu___6 =
                            FStar_Syntax_Util.destruct_typ_as_formula p in
-                         match uu___7 with
+                         match uu___6 with
                          | FStar_Pervasives_Native.None ->
-                             let uu___8 =
-                               let uu___9 = FStar_Syntax_Subst.compress p in
-                               uu___9.FStar_Syntax_Syntax.n in
-                             (match uu___8 with
+                             let uu___7 =
+                               let uu___8 = FStar_Syntax_Subst.compress p in
+                               uu___8.FStar_Syntax_Syntax.n in
+                             (match uu___7 with
                               | FStar_Syntax_Syntax.Tm_bvar bv' when
                                   FStar_Syntax_Syntax.bv_eq bv bv' ->
                                   (if
@@ -6152,22 +6000,22 @@ and (maybe_simplify_aux :
                                      FStar_Compiler_Util.print_string
                                        "WPE> Case 1\n"
                                    else ();
-                                   (let uu___10 =
+                                   (let uu___9 =
                                       FStar_Syntax_Subst.subst
                                         [FStar_Syntax_Syntax.NT
                                            (bv, FStar_Syntax_Util.t_true)] q in
-                                    FStar_Pervasives_Native.Some uu___10))
-                              | uu___9 -> FStar_Pervasives_Native.None)
+                                    FStar_Pervasives_Native.Some uu___9))
+                              | uu___8 -> FStar_Pervasives_Native.None)
                          | FStar_Pervasives_Native.Some
                              (FStar_Syntax_Util.BaseConn
-                             (lid1, (p1, uu___8)::[])) when
+                             (lid1, (p1, uu___7)::[])) when
                              FStar_Ident.lid_equals lid1
                                FStar_Parser_Const.not_lid
                              ->
-                             let uu___9 =
-                               let uu___10 = FStar_Syntax_Subst.compress p1 in
-                               uu___10.FStar_Syntax_Syntax.n in
-                             (match uu___9 with
+                             let uu___8 =
+                               let uu___9 = FStar_Syntax_Subst.compress p1 in
+                               uu___9.FStar_Syntax_Syntax.n in
+                             (match uu___8 with
                               | FStar_Syntax_Syntax.Tm_bvar bv' when
                                   FStar_Syntax_Syntax.bv_eq bv bv' ->
                                   (if
@@ -6176,21 +6024,21 @@ and (maybe_simplify_aux :
                                      FStar_Compiler_Util.print_string
                                        "WPE> Case 2\n"
                                    else ();
-                                   (let uu___11 =
+                                   (let uu___10 =
                                       FStar_Syntax_Subst.subst
                                         [FStar_Syntax_Syntax.NT
                                            (bv, FStar_Syntax_Util.t_false)] q in
-                                    FStar_Pervasives_Native.Some uu___11))
-                              | uu___10 -> FStar_Pervasives_Native.None)
+                                    FStar_Pervasives_Native.Some uu___10))
+                              | uu___9 -> FStar_Pervasives_Native.None)
                          | FStar_Pervasives_Native.Some
                              (FStar_Syntax_Util.QAll (bs, pats, phi1)) ->
-                             let uu___8 =
+                             let uu___7 =
                                FStar_Syntax_Util.destruct_typ_as_formula phi1 in
-                             (match uu___8 with
+                             (match uu___7 with
                               | FStar_Pervasives_Native.None ->
-                                  let uu___9 =
+                                  let uu___8 =
                                     is_applied_maybe_squashed bs phi1 in
-                                  (match uu___9 with
+                                  (match uu___8 with
                                    | FStar_Pervasives_Native.Some bv' when
                                        FStar_Syntax_Syntax.bv_eq bv bv' ->
                                        (if
@@ -6205,21 +6053,21 @@ and (maybe_simplify_aux :
                                              (FStar_Pervasives_Native.Some
                                                 (FStar_Syntax_Util.residual_tot
                                                    FStar_Syntax_Util.ktype0)) in
-                                         let uu___11 =
+                                         let uu___10 =
                                            FStar_Syntax_Subst.subst
                                              [FStar_Syntax_Syntax.NT
                                                 (bv, ftrue)] q in
-                                         FStar_Pervasives_Native.Some uu___11))
-                                   | uu___10 -> FStar_Pervasives_Native.None)
+                                         FStar_Pervasives_Native.Some uu___10))
+                                   | uu___9 -> FStar_Pervasives_Native.None)
                               | FStar_Pervasives_Native.Some
                                   (FStar_Syntax_Util.BaseConn
-                                  (lid1, (p1, uu___9)::[])) when
+                                  (lid1, (p1, uu___8)::[])) when
                                   FStar_Ident.lid_equals lid1
                                     FStar_Parser_Const.not_lid
                                   ->
-                                  let uu___10 =
+                                  let uu___9 =
                                     is_applied_maybe_squashed bs p1 in
-                                  (match uu___10 with
+                                  (match uu___9 with
                                    | FStar_Pervasives_Native.Some bv' when
                                        FStar_Syntax_Syntax.bv_eq bv bv' ->
                                        (if
@@ -6234,103 +6082,103 @@ and (maybe_simplify_aux :
                                              (FStar_Pervasives_Native.Some
                                                 (FStar_Syntax_Util.residual_tot
                                                    FStar_Syntax_Util.ktype0)) in
-                                         let uu___12 =
+                                         let uu___11 =
                                            FStar_Syntax_Subst.subst
                                              [FStar_Syntax_Syntax.NT
                                                 (bv, ffalse)] q in
-                                         FStar_Pervasives_Native.Some uu___12))
-                                   | uu___11 -> FStar_Pervasives_Native.None)
-                              | uu___9 -> FStar_Pervasives_Native.None)
-                         | uu___8 -> FStar_Pervasives_Native.None))
-                   | uu___4 -> FStar_Pervasives_Native.None in
+                                         FStar_Pervasives_Native.Some uu___11))
+                                   | uu___10 -> FStar_Pervasives_Native.None)
+                              | uu___8 -> FStar_Pervasives_Native.None)
+                         | uu___7 -> FStar_Pervasives_Native.None))
+                   | uu___3 -> FStar_Pervasives_Native.None in
                  let is_forall_const phi =
-                   let uu___3 = FStar_Syntax_Util.destruct_typ_as_formula phi in
-                   match uu___3 with
+                   let uu___2 = FStar_Syntax_Util.destruct_typ_as_formula phi in
+                   match uu___2 with
                    | FStar_Pervasives_Native.Some (FStar_Syntax_Util.QAll
-                       (b::[], uu___4, phi')) ->
+                       (b::[], uu___3, phi')) ->
                        (if
                           (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.wpe
                         then
-                          (let uu___6 =
+                          (let uu___5 =
                              FStar_Syntax_Print.bv_to_string
                                b.FStar_Syntax_Syntax.binder_bv in
-                           let uu___7 =
+                           let uu___6 =
                              FStar_Syntax_Print.term_to_string phi' in
                            FStar_Compiler_Util.print2 "WPE> QAll [%s] %s\n"
-                             uu___6 uu___7)
+                             uu___5 uu___6)
                         else ();
                         is_quantified_const b.FStar_Syntax_Syntax.binder_bv
                           phi')
-                   | uu___4 -> FStar_Pervasives_Native.None in
+                   | uu___3 -> FStar_Pervasives_Native.None in
                  let is_const_match phi =
-                   let uu___3 =
-                     let uu___4 = FStar_Syntax_Subst.compress phi in
-                     uu___4.FStar_Syntax_Syntax.n in
-                   match uu___3 with
+                   let uu___2 =
+                     let uu___3 = FStar_Syntax_Subst.compress phi in
+                     uu___3.FStar_Syntax_Syntax.n in
+                   match uu___2 with
                    | FStar_Syntax_Syntax.Tm_match
-                       { FStar_Syntax_Syntax.scrutinee = uu___4;
-                         FStar_Syntax_Syntax.ret_opt = uu___5;
+                       { FStar_Syntax_Syntax.scrutinee = uu___3;
+                         FStar_Syntax_Syntax.ret_opt = uu___4;
                          FStar_Syntax_Syntax.brs = br::brs;
-                         FStar_Syntax_Syntax.rc_opt1 = uu___6;_}
+                         FStar_Syntax_Syntax.rc_opt1 = uu___5;_}
                        ->
-                       let uu___7 = br in
-                       (match uu___7 with
-                        | (uu___8, uu___9, e) ->
+                       let uu___6 = br in
+                       (match uu___6 with
+                        | (uu___7, uu___8, e) ->
                             let r =
-                              let uu___10 = simp_t e in
-                              match uu___10 with
+                              let uu___9 = simp_t e in
+                              match uu___9 with
                               | FStar_Pervasives_Native.None ->
                                   FStar_Pervasives_Native.None
                               | FStar_Pervasives_Native.Some b ->
-                                  let uu___11 =
+                                  let uu___10 =
                                     FStar_Compiler_List.for_all
-                                      (fun uu___12 ->
-                                         match uu___12 with
-                                         | (uu___13, uu___14, e') ->
-                                             let uu___15 = simp_t e' in
-                                             uu___15 =
+                                      (fun uu___11 ->
+                                         match uu___11 with
+                                         | (uu___12, uu___13, e') ->
+                                             let uu___14 = simp_t e' in
+                                             uu___14 =
                                                (FStar_Pervasives_Native.Some
                                                   b)) brs in
-                                  if uu___11
+                                  if uu___10
                                   then FStar_Pervasives_Native.Some b
                                   else FStar_Pervasives_Native.None in
                             r)
-                   | uu___4 -> FStar_Pervasives_Native.None in
+                   | uu___3 -> FStar_Pervasives_Native.None in
                  let maybe_auto_squash t =
-                   let uu___3 = FStar_Syntax_Util.is_sub_singleton t in
-                   if uu___3
+                   let uu___2 = FStar_Syntax_Util.is_sub_singleton t in
+                   if uu___2
                    then t
                    else
                      FStar_Syntax_Util.mk_auto_squash
                        FStar_Syntax_Syntax.U_zero t in
                  let squashed_head_un_auto_squash_args t =
-                   let maybe_un_auto_squash_arg uu___3 =
-                     match uu___3 with
+                   let maybe_un_auto_squash_arg uu___2 =
+                     match uu___2 with
                      | (t1, q) ->
-                         let uu___4 = FStar_Syntax_Util.is_auto_squash t1 in
-                         (match uu___4 with
+                         let uu___3 = FStar_Syntax_Util.is_auto_squash t1 in
+                         (match uu___3 with
                           | FStar_Pervasives_Native.Some
                               (FStar_Syntax_Syntax.U_zero, t2) -> (t2, q)
-                          | uu___5 -> (t1, q)) in
-                   let uu___3 = FStar_Syntax_Util.head_and_args t in
-                   match uu___3 with
+                          | uu___4 -> (t1, q)) in
+                   let uu___2 = FStar_Syntax_Util.head_and_args t in
+                   match uu___2 with
                    | (head, args) ->
                        let args1 =
                          FStar_Compiler_List.map maybe_un_auto_squash_arg
                            args in
-                       let uu___4 =
+                       let uu___3 =
                          FStar_Syntax_Syntax.mk_Tm_app head args1
                            t.FStar_Syntax_Syntax.pos in
-                       (uu___4, false) in
+                       (uu___3, false) in
                  let rec clearly_inhabited ty =
-                   let uu___3 =
-                     let uu___4 = FStar_Syntax_Util.unmeta ty in
-                     uu___4.FStar_Syntax_Syntax.n in
-                   match uu___3 with
-                   | FStar_Syntax_Syntax.Tm_uinst (t, uu___4) ->
+                   let uu___2 =
+                     let uu___3 = FStar_Syntax_Util.unmeta ty in
+                     uu___3.FStar_Syntax_Syntax.n in
+                   match uu___2 with
+                   | FStar_Syntax_Syntax.Tm_uinst (t, uu___3) ->
                        clearly_inhabited t
                    | FStar_Syntax_Syntax.Tm_arrow
-                       { FStar_Syntax_Syntax.bs1 = uu___4;
+                       { FStar_Syntax_Syntax.bs1 = uu___3;
                          FStar_Syntax_Syntax.comp = c;_}
                        -> clearly_inhabited (FStar_Syntax_Util.comp_result c)
                    | FStar_Syntax_Syntax.Tm_fvar fv ->
@@ -6344,28 +6192,28 @@ and (maybe_simplify_aux :
                              FStar_Parser_Const.string_lid))
                          ||
                          (FStar_Ident.lid_equals l FStar_Parser_Const.exn_lid)
-                   | uu___4 -> false in
+                   | uu___3 -> false in
                  let simplify arg =
-                   let uu___3 = simp_t (FStar_Pervasives_Native.fst arg) in
-                   (uu___3, arg) in
-                 let uu___3 = is_forall_const tm1 in
-                 match uu___3 with
+                   let uu___2 = simp_t (FStar_Pervasives_Native.fst arg) in
+                   (uu___2, arg) in
+                 let uu___2 = is_forall_const tm1 in
+                 match uu___2 with
                  | FStar_Pervasives_Native.Some tm' ->
                      (if
                         (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.wpe
                       then
-                        (let uu___5 = FStar_Syntax_Print.term_to_string tm1 in
-                         let uu___6 = FStar_Syntax_Print.term_to_string tm' in
-                         FStar_Compiler_Util.print2 "WPE> %s ~> %s\n" uu___5
-                           uu___6)
+                        (let uu___4 = FStar_Syntax_Print.term_to_string tm1 in
+                         let uu___5 = FStar_Syntax_Print.term_to_string tm' in
+                         FStar_Compiler_Util.print2 "WPE> %s ~> %s\n" uu___4
+                           uu___5)
                       else ();
-                      (let uu___5 = norm cfg env1 [] tm' in
-                       maybe_simplify_aux cfg env1 stack1 uu___5))
+                      (let uu___4 = norm cfg env1 [] tm' in
+                       maybe_simplify_aux cfg env1 stack1 uu___4))
                  | FStar_Pervasives_Native.None ->
-                     let uu___4 =
-                       let uu___5 = FStar_Syntax_Subst.compress tm1 in
-                       uu___5.FStar_Syntax_Syntax.n in
-                     (match uu___4 with
+                     let uu___3 =
+                       let uu___4 = FStar_Syntax_Subst.compress tm1 in
+                       uu___4.FStar_Syntax_Syntax.n in
+                     (match uu___3 with
                       | FStar_Syntax_Syntax.Tm_app
                           {
                             FStar_Syntax_Syntax.hd =
@@ -6375,213 +6223,240 @@ and (maybe_simplify_aux :
                                   ({
                                      FStar_Syntax_Syntax.n =
                                        FStar_Syntax_Syntax.Tm_fvar fv;
-                                     FStar_Syntax_Syntax.pos = uu___5;
-                                     FStar_Syntax_Syntax.vars = uu___6;
-                                     FStar_Syntax_Syntax.hash_code = uu___7;_},
-                                   uu___8);
-                                FStar_Syntax_Syntax.pos = uu___9;
-                                FStar_Syntax_Syntax.vars = uu___10;
-                                FStar_Syntax_Syntax.hash_code = uu___11;_};
+                                     FStar_Syntax_Syntax.pos = uu___4;
+                                     FStar_Syntax_Syntax.vars = uu___5;
+                                     FStar_Syntax_Syntax.hash_code = uu___6;_},
+                                   uu___7);
+                                FStar_Syntax_Syntax.pos = uu___8;
+                                FStar_Syntax_Syntax.vars = uu___9;
+                                FStar_Syntax_Syntax.hash_code = uu___10;_};
                             FStar_Syntax_Syntax.args = args;_}
                           ->
-                          let uu___12 =
+                          let uu___11 =
                             FStar_Syntax_Syntax.fv_eq_lid fv
                               FStar_Parser_Const.and_lid in
-                          if uu___12
+                          if uu___11
                           then
-                            let uu___13 =
-                              FStar_Compiler_Effect.op_Bar_Greater args
-                                (FStar_Compiler_List.map simplify) in
-                            (match uu___13 with
-                             | (FStar_Pervasives_Native.Some (true), uu___14)::
-                                 (uu___15, (arg, uu___16))::[] ->
-                                 let uu___17 = maybe_auto_squash arg in
-                                 (uu___17, false)
-                             | (uu___14, (arg, uu___15))::(FStar_Pervasives_Native.Some
-                                                           (true), uu___16)::[]
+                            let uu___12 =
+                              FStar_Compiler_List.map simplify args in
+                            (match uu___12 with
+                             | (FStar_Pervasives_Native.Some (true), uu___13)::
+                                 (uu___14, (arg, uu___15))::[] ->
+                                 let uu___16 = maybe_auto_squash arg in
+                                 (uu___16, false)
+                             | (uu___13, (arg, uu___14))::(FStar_Pervasives_Native.Some
+                                                           (true), uu___15)::[]
                                  ->
-                                 let uu___17 = maybe_auto_squash arg in
-                                 (uu___17, false)
+                                 let uu___16 = maybe_auto_squash arg in
+                                 (uu___16, false)
                              | (FStar_Pervasives_Native.Some (false),
-                                uu___14)::uu___15::[] ->
+                                uu___13)::uu___14::[] ->
                                  ((w FStar_Syntax_Util.t_false), false)
-                             | uu___14::(FStar_Pervasives_Native.Some
-                                         (false), uu___15)::[]
+                             | uu___13::(FStar_Pervasives_Native.Some
+                                         (false), uu___14)::[]
                                  -> ((w FStar_Syntax_Util.t_false), false)
-                             | uu___14 ->
+                             | uu___13 ->
                                  squashed_head_un_auto_squash_args tm1)
                           else
-                            (let uu___14 =
+                            (let uu___13 =
                                FStar_Syntax_Syntax.fv_eq_lid fv
                                  FStar_Parser_Const.or_lid in
-                             if uu___14
+                             if uu___13
                              then
-                               let uu___15 =
-                                 FStar_Compiler_Effect.op_Bar_Greater args
-                                   (FStar_Compiler_List.map simplify) in
-                               match uu___15 with
+                               let uu___14 =
+                                 FStar_Compiler_List.map simplify args in
+                               match uu___14 with
                                | (FStar_Pervasives_Native.Some (true),
-                                  uu___16)::uu___17::[] ->
+                                  uu___15)::uu___16::[] ->
                                    ((w FStar_Syntax_Util.t_true), false)
-                               | uu___16::(FStar_Pervasives_Native.Some
-                                           (true), uu___17)::[]
+                               | uu___15::(FStar_Pervasives_Native.Some
+                                           (true), uu___16)::[]
                                    -> ((w FStar_Syntax_Util.t_true), false)
                                | (FStar_Pervasives_Native.Some (false),
-                                  uu___16)::(uu___17, (arg, uu___18))::[] ->
-                                   let uu___19 = maybe_auto_squash arg in
-                                   (uu___19, false)
-                               | (uu___16, (arg, uu___17))::(FStar_Pervasives_Native.Some
+                                  uu___15)::(uu___16, (arg, uu___17))::[] ->
+                                   let uu___18 = maybe_auto_squash arg in
+                                   (uu___18, false)
+                               | (uu___15, (arg, uu___16))::(FStar_Pervasives_Native.Some
                                                              (false),
-                                                             uu___18)::[]
+                                                             uu___17)::[]
                                    ->
-                                   let uu___19 = maybe_auto_squash arg in
-                                   (uu___19, false)
-                               | uu___16 ->
+                                   let uu___18 = maybe_auto_squash arg in
+                                   (uu___18, false)
+                               | uu___15 ->
                                    squashed_head_un_auto_squash_args tm1
                              else
-                               (let uu___16 =
+                               (let uu___15 =
                                   FStar_Syntax_Syntax.fv_eq_lid fv
                                     FStar_Parser_Const.imp_lid in
-                                if uu___16
+                                if uu___15
                                 then
-                                  let uu___17 =
-                                    FStar_Compiler_Effect.op_Bar_Greater args
-                                      (FStar_Compiler_List.map simplify) in
-                                  match uu___17 with
-                                  | uu___18::(FStar_Pervasives_Native.Some
-                                              (true), uu___19)::[]
+                                  let uu___16 =
+                                    FStar_Compiler_List.map simplify args in
+                                  match uu___16 with
+                                  | uu___17::(FStar_Pervasives_Native.Some
+                                              (true), uu___18)::[]
                                       ->
                                       ((w FStar_Syntax_Util.t_true), false)
                                   | (FStar_Pervasives_Native.Some (false),
-                                     uu___18)::uu___19::[] ->
+                                     uu___17)::uu___18::[] ->
                                       ((w FStar_Syntax_Util.t_true), false)
                                   | (FStar_Pervasives_Native.Some (true),
-                                     uu___18)::(uu___19, (arg, uu___20))::[]
+                                     uu___17)::(uu___18, (arg, uu___19))::[]
                                       ->
-                                      let uu___21 = maybe_auto_squash arg in
-                                      (uu___21, false)
-                                  | (uu___18, (p, uu___19))::(uu___20,
-                                                              (q, uu___21))::[]
+                                      let uu___20 = maybe_auto_squash arg in
+                                      (uu___20, false)
+                                  | (uu___17, (p, uu___18))::(uu___19,
+                                                              (q, uu___20))::[]
                                       ->
-                                      let uu___22 =
+                                      let uu___21 =
                                         FStar_Syntax_Util.term_eq p q in
-                                      (if uu___22
+                                      (if uu___21
                                        then
                                          ((w FStar_Syntax_Util.t_true),
                                            false)
                                        else
                                          squashed_head_un_auto_squash_args
                                            tm1)
-                                  | uu___18 ->
+                                  | uu___17 ->
                                       squashed_head_un_auto_squash_args tm1
                                 else
-                                  (let uu___18 =
+                                  (let uu___17 =
                                      FStar_Syntax_Syntax.fv_eq_lid fv
                                        FStar_Parser_Const.iff_lid in
-                                   if uu___18
+                                   if uu___17
                                    then
-                                     let uu___19 =
-                                       FStar_Compiler_Effect.op_Bar_Greater
-                                         args
-                                         (FStar_Compiler_List.map simplify) in
-                                     match uu___19 with
+                                     let uu___18 =
+                                       FStar_Compiler_List.map simplify args in
+                                     match uu___18 with
                                      | (FStar_Pervasives_Native.Some (true),
-                                        uu___20)::(FStar_Pervasives_Native.Some
-                                                   (true), uu___21)::[]
+                                        uu___19)::(FStar_Pervasives_Native.Some
+                                                   (true), uu___20)::[]
                                          ->
                                          ((w FStar_Syntax_Util.t_true),
                                            false)
                                      | (FStar_Pervasives_Native.Some (false),
-                                        uu___20)::(FStar_Pervasives_Native.Some
-                                                   (false), uu___21)::[]
+                                        uu___19)::(FStar_Pervasives_Native.Some
+                                                   (false), uu___20)::[]
                                          ->
                                          ((w FStar_Syntax_Util.t_true),
                                            false)
                                      | (FStar_Pervasives_Native.Some (true),
-                                        uu___20)::(FStar_Pervasives_Native.Some
-                                                   (false), uu___21)::[]
+                                        uu___19)::(FStar_Pervasives_Native.Some
+                                                   (false), uu___20)::[]
                                          ->
                                          ((w FStar_Syntax_Util.t_false),
                                            false)
                                      | (FStar_Pervasives_Native.Some (false),
-                                        uu___20)::(FStar_Pervasives_Native.Some
-                                                   (true), uu___21)::[]
+                                        uu___19)::(FStar_Pervasives_Native.Some
+                                                   (true), uu___20)::[]
                                          ->
                                          ((w FStar_Syntax_Util.t_false),
                                            false)
-                                     | (uu___20, (arg, uu___21))::(FStar_Pervasives_Native.Some
+                                     | (uu___19, (arg, uu___20))::(FStar_Pervasives_Native.Some
                                                                    (true),
-                                                                   uu___22)::[]
+                                                                   uu___21)::[]
                                          ->
-                                         let uu___23 = maybe_auto_squash arg in
-                                         (uu___23, false)
+                                         let uu___22 = maybe_auto_squash arg in
+                                         (uu___22, false)
                                      | (FStar_Pervasives_Native.Some (true),
-                                        uu___20)::(uu___21, (arg, uu___22))::[]
+                                        uu___19)::(uu___20, (arg, uu___21))::[]
                                          ->
-                                         let uu___23 = maybe_auto_squash arg in
-                                         (uu___23, false)
-                                     | (uu___20, (arg, uu___21))::(FStar_Pervasives_Native.Some
+                                         let uu___22 = maybe_auto_squash arg in
+                                         (uu___22, false)
+                                     | (uu___19, (arg, uu___20))::(FStar_Pervasives_Native.Some
                                                                    (false),
-                                                                   uu___22)::[]
+                                                                   uu___21)::[]
                                          ->
-                                         let uu___23 =
-                                           let uu___24 =
+                                         let uu___22 =
+                                           let uu___23 =
                                              FStar_Syntax_Util.mk_neg arg in
-                                           maybe_auto_squash uu___24 in
-                                         (uu___23, false)
+                                           maybe_auto_squash uu___23 in
+                                         (uu___22, false)
                                      | (FStar_Pervasives_Native.Some (false),
-                                        uu___20)::(uu___21, (arg, uu___22))::[]
+                                        uu___19)::(uu___20, (arg, uu___21))::[]
+                                         ->
+                                         let uu___22 =
+                                           let uu___23 =
+                                             FStar_Syntax_Util.mk_neg arg in
+                                           maybe_auto_squash uu___23 in
+                                         (uu___22, false)
+                                     | (uu___19, (p, uu___20))::(uu___21,
+                                                                 (q, uu___22))::[]
                                          ->
                                          let uu___23 =
-                                           let uu___24 =
-                                             FStar_Syntax_Util.mk_neg arg in
-                                           maybe_auto_squash uu___24 in
-                                         (uu___23, false)
-                                     | (uu___20, (p, uu___21))::(uu___22,
-                                                                 (q, uu___23))::[]
-                                         ->
-                                         let uu___24 =
                                            FStar_Syntax_Util.term_eq p q in
-                                         (if uu___24
+                                         (if uu___23
                                           then
                                             ((w FStar_Syntax_Util.t_true),
                                               false)
                                           else
                                             squashed_head_un_auto_squash_args
                                               tm1)
-                                     | uu___20 ->
+                                     | uu___19 ->
                                          squashed_head_un_auto_squash_args
                                            tm1
                                    else
-                                     (let uu___20 =
+                                     (let uu___19 =
                                         FStar_Syntax_Syntax.fv_eq_lid fv
                                           FStar_Parser_Const.not_lid in
-                                      if uu___20
+                                      if uu___19
                                       then
-                                        let uu___21 =
-                                          FStar_Compiler_Effect.op_Bar_Greater
-                                            args
-                                            (FStar_Compiler_List.map simplify) in
-                                        match uu___21 with
+                                        let uu___20 =
+                                          FStar_Compiler_List.map simplify
+                                            args in
+                                        match uu___20 with
                                         | (FStar_Pervasives_Native.Some
-                                           (true), uu___22)::[] ->
+                                           (true), uu___21)::[] ->
                                             ((w FStar_Syntax_Util.t_false),
                                               false)
                                         | (FStar_Pervasives_Native.Some
-                                           (false), uu___22)::[] ->
+                                           (false), uu___21)::[] ->
                                             ((w FStar_Syntax_Util.t_true),
                                               false)
-                                        | uu___22 ->
+                                        | uu___21 ->
                                             squashed_head_un_auto_squash_args
                                               tm1
                                       else
-                                        (let uu___22 =
+                                        (let uu___21 =
                                            FStar_Syntax_Syntax.fv_eq_lid fv
                                              FStar_Parser_Const.forall_lid in
-                                         if uu___22
+                                         if uu___21
                                          then
                                            match args with
-                                           | (t, uu___23)::[] ->
+                                           | (t, uu___22)::[] ->
+                                               let uu___23 =
+                                                 let uu___24 =
+                                                   FStar_Syntax_Subst.compress
+                                                     t in
+                                                 uu___24.FStar_Syntax_Syntax.n in
+                                               (match uu___23 with
+                                                | FStar_Syntax_Syntax.Tm_abs
+                                                    {
+                                                      FStar_Syntax_Syntax.bs
+                                                        = uu___24::[];
+                                                      FStar_Syntax_Syntax.body
+                                                        = body;
+                                                      FStar_Syntax_Syntax.rc_opt
+                                                        = uu___25;_}
+                                                    ->
+                                                    let uu___26 = simp_t body in
+                                                    (match uu___26 with
+                                                     | FStar_Pervasives_Native.Some
+                                                         (true) ->
+                                                         ((w
+                                                             FStar_Syntax_Util.t_true),
+                                                           false)
+                                                     | uu___27 ->
+                                                         (tm1, false))
+                                                | uu___24 -> (tm1, false))
+                                           | (ty,
+                                              FStar_Pervasives_Native.Some
+                                              {
+                                                FStar_Syntax_Syntax.aqual_implicit
+                                                  = true;
+                                                FStar_Syntax_Syntax.aqual_attributes
+                                                  = uu___22;_})::(t, uu___23)::[]
+                                               ->
                                                let uu___24 =
                                                  let uu___25 =
                                                    FStar_Syntax_Subst.compress
@@ -6604,39 +6479,6 @@ and (maybe_simplify_aux :
                                                          ((w
                                                              FStar_Syntax_Util.t_true),
                                                            false)
-                                                     | uu___28 ->
-                                                         (tm1, false))
-                                                | uu___25 -> (tm1, false))
-                                           | (ty,
-                                              FStar_Pervasives_Native.Some
-                                              {
-                                                FStar_Syntax_Syntax.aqual_implicit
-                                                  = true;
-                                                FStar_Syntax_Syntax.aqual_attributes
-                                                  = uu___23;_})::(t, uu___24)::[]
-                                               ->
-                                               let uu___25 =
-                                                 let uu___26 =
-                                                   FStar_Syntax_Subst.compress
-                                                     t in
-                                                 uu___26.FStar_Syntax_Syntax.n in
-                                               (match uu___25 with
-                                                | FStar_Syntax_Syntax.Tm_abs
-                                                    {
-                                                      FStar_Syntax_Syntax.bs
-                                                        = uu___26::[];
-                                                      FStar_Syntax_Syntax.body
-                                                        = body;
-                                                      FStar_Syntax_Syntax.rc_opt
-                                                        = uu___27;_}
-                                                    ->
-                                                    let uu___28 = simp_t body in
-                                                    (match uu___28 with
-                                                     | FStar_Pervasives_Native.Some
-                                                         (true) ->
-                                                         ((w
-                                                             FStar_Syntax_Util.t_true),
-                                                           false)
                                                      | FStar_Pervasives_Native.Some
                                                          (false) when
                                                          clearly_inhabited ty
@@ -6644,19 +6486,54 @@ and (maybe_simplify_aux :
                                                          ((w
                                                              FStar_Syntax_Util.t_false),
                                                            false)
-                                                     | uu___29 ->
+                                                     | uu___28 ->
                                                          (tm1, false))
-                                                | uu___26 -> (tm1, false))
-                                           | uu___23 -> (tm1, false)
+                                                | uu___25 -> (tm1, false))
+                                           | uu___22 -> (tm1, false)
                                          else
-                                           (let uu___24 =
+                                           (let uu___23 =
                                               FStar_Syntax_Syntax.fv_eq_lid
                                                 fv
                                                 FStar_Parser_Const.exists_lid in
-                                            if uu___24
+                                            if uu___23
                                             then
                                               match args with
-                                              | (t, uu___25)::[] ->
+                                              | (t, uu___24)::[] ->
+                                                  let uu___25 =
+                                                    let uu___26 =
+                                                      FStar_Syntax_Subst.compress
+                                                        t in
+                                                    uu___26.FStar_Syntax_Syntax.n in
+                                                  (match uu___25 with
+                                                   | FStar_Syntax_Syntax.Tm_abs
+                                                       {
+                                                         FStar_Syntax_Syntax.bs
+                                                           = uu___26::[];
+                                                         FStar_Syntax_Syntax.body
+                                                           = body;
+                                                         FStar_Syntax_Syntax.rc_opt
+                                                           = uu___27;_}
+                                                       ->
+                                                       let uu___28 =
+                                                         simp_t body in
+                                                       (match uu___28 with
+                                                        | FStar_Pervasives_Native.Some
+                                                            (false) ->
+                                                            ((w
+                                                                FStar_Syntax_Util.t_false),
+                                                              false)
+                                                        | uu___29 ->
+                                                            (tm1, false))
+                                                   | uu___26 -> (tm1, false))
+                                              | (ty,
+                                                 FStar_Pervasives_Native.Some
+                                                 {
+                                                   FStar_Syntax_Syntax.aqual_implicit
+                                                     = true;
+                                                   FStar_Syntax_Syntax.aqual_attributes
+                                                     = uu___24;_})::(t,
+                                                                    uu___25)::[]
+                                                  ->
                                                   let uu___26 =
                                                     let uu___27 =
                                                       FStar_Syntax_Subst.compress
@@ -6680,41 +6557,6 @@ and (maybe_simplify_aux :
                                                             ((w
                                                                 FStar_Syntax_Util.t_false),
                                                               false)
-                                                        | uu___30 ->
-                                                            (tm1, false))
-                                                   | uu___27 -> (tm1, false))
-                                              | (ty,
-                                                 FStar_Pervasives_Native.Some
-                                                 {
-                                                   FStar_Syntax_Syntax.aqual_implicit
-                                                     = true;
-                                                   FStar_Syntax_Syntax.aqual_attributes
-                                                     = uu___25;_})::(t,
-                                                                    uu___26)::[]
-                                                  ->
-                                                  let uu___27 =
-                                                    let uu___28 =
-                                                      FStar_Syntax_Subst.compress
-                                                        t in
-                                                    uu___28.FStar_Syntax_Syntax.n in
-                                                  (match uu___27 with
-                                                   | FStar_Syntax_Syntax.Tm_abs
-                                                       {
-                                                         FStar_Syntax_Syntax.bs
-                                                           = uu___28::[];
-                                                         FStar_Syntax_Syntax.body
-                                                           = body;
-                                                         FStar_Syntax_Syntax.rc_opt
-                                                           = uu___29;_}
-                                                       ->
-                                                       let uu___30 =
-                                                         simp_t body in
-                                                       (match uu___30 with
-                                                        | FStar_Pervasives_Native.Some
-                                                            (false) ->
-                                                            ((w
-                                                                FStar_Syntax_Util.t_false),
-                                                              false)
                                                         | FStar_Pervasives_Native.Some
                                                             (true) when
                                                             clearly_inhabited
@@ -6723,16 +6565,16 @@ and (maybe_simplify_aux :
                                                             ((w
                                                                 FStar_Syntax_Util.t_true),
                                                               false)
-                                                        | uu___31 ->
+                                                        | uu___30 ->
                                                             (tm1, false))
-                                                   | uu___28 -> (tm1, false))
-                                              | uu___25 -> (tm1, false)
+                                                   | uu___27 -> (tm1, false))
+                                              | uu___24 -> (tm1, false)
                                             else
-                                              (let uu___26 =
+                                              (let uu___25 =
                                                  FStar_Syntax_Syntax.fv_eq_lid
                                                    fv
                                                    FStar_Parser_Const.b2t_lid in
-                                               if uu___26
+                                               if uu___25
                                                then
                                                  match args with
                                                  | ({
@@ -6741,12 +6583,12 @@ and (maybe_simplify_aux :
                                                         (FStar_Const.Const_bool
                                                         (true));
                                                       FStar_Syntax_Syntax.pos
-                                                        = uu___27;
+                                                        = uu___26;
                                                       FStar_Syntax_Syntax.vars
-                                                        = uu___28;
+                                                        = uu___27;
                                                       FStar_Syntax_Syntax.hash_code
-                                                        = uu___29;_},
-                                                    uu___30)::[] ->
+                                                        = uu___28;_},
+                                                    uu___29)::[] ->
                                                      ((w
                                                          FStar_Syntax_Util.t_true),
                                                        false)
@@ -6756,22 +6598,22 @@ and (maybe_simplify_aux :
                                                         (FStar_Const.Const_bool
                                                         (false));
                                                       FStar_Syntax_Syntax.pos
-                                                        = uu___27;
+                                                        = uu___26;
                                                       FStar_Syntax_Syntax.vars
-                                                        = uu___28;
+                                                        = uu___27;
                                                       FStar_Syntax_Syntax.hash_code
-                                                        = uu___29;_},
-                                                    uu___30)::[] ->
+                                                        = uu___28;_},
+                                                    uu___29)::[] ->
                                                      ((w
                                                          FStar_Syntax_Util.t_false),
                                                        false)
-                                                 | uu___27 -> (tm1, false)
+                                                 | uu___26 -> (tm1, false)
                                                else
-                                                 (let uu___28 =
+                                                 (let uu___27 =
                                                     FStar_Syntax_Syntax.fv_eq_lid
                                                       fv
                                                       FStar_Parser_Const.haseq_lid in
-                                                  if uu___28
+                                                  if uu___27
                                                   then
                                                     let t_has_eq_for_sure t =
                                                       let haseq_lids =
@@ -6779,61 +6621,55 @@ and (maybe_simplify_aux :
                                                         FStar_Parser_Const.bool_lid;
                                                         FStar_Parser_Const.unit_lid;
                                                         FStar_Parser_Const.string_lid] in
-                                                      let uu___29 =
-                                                        let uu___30 =
+                                                      let uu___28 =
+                                                        let uu___29 =
                                                           FStar_Syntax_Subst.compress
                                                             t in
-                                                        uu___30.FStar_Syntax_Syntax.n in
-                                                      match uu___29 with
+                                                        uu___29.FStar_Syntax_Syntax.n in
+                                                      match uu___28 with
                                                       | FStar_Syntax_Syntax.Tm_fvar
                                                           fv1 when
-                                                          FStar_Compiler_Effect.op_Bar_Greater
+                                                          FStar_Compiler_List.existsb
+                                                            (fun l ->
+                                                               FStar_Syntax_Syntax.fv_eq_lid
+                                                                 fv1 l)
                                                             haseq_lids
-                                                            (FStar_Compiler_List.existsb
-                                                               (fun l ->
-                                                                  FStar_Syntax_Syntax.fv_eq_lid
-                                                                    fv1 l))
                                                           -> true
-                                                      | uu___30 -> false in
+                                                      | uu___29 -> false in
                                                     (if
                                                        (FStar_Compiler_List.length
                                                           args)
                                                          = Prims.int_one
                                                      then
                                                        let t =
-                                                         let uu___29 =
-                                                           FStar_Compiler_Effect.op_Bar_Greater
-                                                             args
-                                                             FStar_Compiler_List.hd in
-                                                         FStar_Compiler_Effect.op_Bar_Greater
-                                                           uu___29
-                                                           FStar_Pervasives_Native.fst in
-                                                       let uu___29 =
-                                                         FStar_Compiler_Effect.op_Bar_Greater
-                                                           t
-                                                           t_has_eq_for_sure in
-                                                       (if uu___29
+                                                         let uu___28 =
+                                                           FStar_Compiler_List.hd
+                                                             args in
+                                                         FStar_Pervasives_Native.fst
+                                                           uu___28 in
+                                                       let uu___28 =
+                                                         t_has_eq_for_sure t in
+                                                       (if uu___28
                                                         then
                                                           ((w
                                                               FStar_Syntax_Util.t_true),
                                                             false)
                                                         else
-                                                          (let uu___31 =
-                                                             let uu___32 =
+                                                          (let uu___30 =
+                                                             let uu___31 =
                                                                FStar_Syntax_Subst.compress
                                                                  t in
-                                                             uu___32.FStar_Syntax_Syntax.n in
-                                                           match uu___31 with
+                                                             uu___31.FStar_Syntax_Syntax.n in
+                                                           match uu___30 with
                                                            | FStar_Syntax_Syntax.Tm_refine
-                                                               uu___32 ->
+                                                               uu___31 ->
                                                                let t1 =
                                                                  FStar_Syntax_Util.unrefine
                                                                    t in
-                                                               let uu___33 =
-                                                                 FStar_Compiler_Effect.op_Bar_Greater
-                                                                   t1
-                                                                   t_has_eq_for_sure in
-                                                               if uu___33
+                                                               let uu___32 =
+                                                                 t_has_eq_for_sure
+                                                                   t1 in
+                                                               if uu___32
                                                                then
                                                                  ((w
                                                                     FStar_Syntax_Util.t_true),
@@ -6841,14 +6677,14 @@ and (maybe_simplify_aux :
                                                                else
                                                                  (let haseq_tm
                                                                     =
-                                                                    let uu___35
+                                                                    let uu___34
                                                                     =
-                                                                    let uu___36
+                                                                    let uu___35
                                                                     =
                                                                     FStar_Syntax_Subst.compress
                                                                     tm1 in
-                                                                    uu___36.FStar_Syntax_Syntax.n in
-                                                                    match uu___35
+                                                                    uu___35.FStar_Syntax_Syntax.n in
+                                                                    match uu___34
                                                                     with
                                                                     | 
                                                                     FStar_Syntax_Syntax.Tm_app
@@ -6856,54 +6692,53 @@ and (maybe_simplify_aux :
                                                                     FStar_Syntax_Syntax.hd
                                                                     = hd;
                                                                     FStar_Syntax_Syntax.args
-                                                                    = uu___36;_}
+                                                                    = uu___35;_}
                                                                     -> hd
                                                                     | 
-                                                                    uu___36
+                                                                    uu___35
                                                                     ->
                                                                     FStar_Compiler_Effect.failwith
                                                                     "Impossible! We have already checked that this is a Tm_app" in
-                                                                  let uu___35
+                                                                  let uu___34
+                                                                    =
+                                                                    let uu___35
                                                                     =
                                                                     let uu___36
                                                                     =
-                                                                    let uu___37
-                                                                    =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    t1
-                                                                    FStar_Syntax_Syntax.as_arg in
-                                                                    [uu___37] in
+                                                                    FStar_Syntax_Syntax.as_arg
+                                                                    t1 in
+                                                                    [uu___36] in
                                                                     FStar_Syntax_Util.mk_app
                                                                     haseq_tm
-                                                                    uu___36 in
-                                                                  (uu___35,
+                                                                    uu___35 in
+                                                                  (uu___34,
                                                                     false))
-                                                           | uu___32 ->
+                                                           | uu___31 ->
                                                                (tm1, false)))
                                                      else (tm1, false))
                                                   else
-                                                    (let uu___30 =
+                                                    (let uu___29 =
                                                        FStar_Syntax_Syntax.fv_eq_lid
                                                          fv
                                                          FStar_Parser_Const.subtype_of_lid in
-                                                     if uu___30
+                                                     if uu___29
                                                      then
                                                        let is_unit ty =
-                                                         let uu___31 =
-                                                           let uu___32 =
+                                                         let uu___30 =
+                                                           let uu___31 =
                                                              FStar_Syntax_Subst.compress
                                                                ty in
-                                                           uu___32.FStar_Syntax_Syntax.n in
-                                                         match uu___31 with
+                                                           uu___31.FStar_Syntax_Syntax.n in
+                                                         match uu___30 with
                                                          | FStar_Syntax_Syntax.Tm_fvar
                                                              fv1 ->
                                                              FStar_Syntax_Syntax.fv_eq_lid
                                                                fv1
                                                                FStar_Parser_Const.unit_lid
-                                                         | uu___32 -> false in
+                                                         | uu___31 -> false in
                                                        match args with
-                                                       | (t, uu___31)::
-                                                           (ty, uu___32)::[]
+                                                       | (t, uu___30)::
+                                                           (ty, uu___31)::[]
                                                            when
                                                            (is_unit ty) &&
                                                              (FStar_Syntax_Util.is_sub_singleton
@@ -6912,13 +6747,13 @@ and (maybe_simplify_aux :
                                                            ((w
                                                                FStar_Syntax_Util.t_true),
                                                              false)
-                                                       | uu___31 ->
+                                                       | uu___30 ->
                                                            (tm1, false)
                                                      else
-                                                       (let uu___32 =
+                                                       (let uu___31 =
                                                           FStar_Syntax_Util.is_auto_squash
                                                             tm1 in
-                                                        match uu___32 with
+                                                        match uu___31 with
                                                         | FStar_Pervasives_Native.Some
                                                             (FStar_Syntax_Syntax.U_zero,
                                                              t)
@@ -6926,11 +6761,11 @@ and (maybe_simplify_aux :
                                                             FStar_Syntax_Util.is_sub_singleton
                                                               t
                                                             -> (t, false)
-                                                        | uu___33 ->
-                                                            let uu___34 =
+                                                        | uu___32 ->
+                                                            let uu___33 =
                                                               norm_cb cfg in
                                                             reduce_equality
-                                                              uu___34 cfg
+                                                              uu___33 cfg
                                                               env1 tm1))))))))))
                       | FStar_Syntax_Syntax.Tm_app
                           {
@@ -6938,209 +6773,235 @@ and (maybe_simplify_aux :
                               {
                                 FStar_Syntax_Syntax.n =
                                   FStar_Syntax_Syntax.Tm_fvar fv;
-                                FStar_Syntax_Syntax.pos = uu___5;
-                                FStar_Syntax_Syntax.vars = uu___6;
-                                FStar_Syntax_Syntax.hash_code = uu___7;_};
+                                FStar_Syntax_Syntax.pos = uu___4;
+                                FStar_Syntax_Syntax.vars = uu___5;
+                                FStar_Syntax_Syntax.hash_code = uu___6;_};
                             FStar_Syntax_Syntax.args = args;_}
                           ->
-                          let uu___8 =
+                          let uu___7 =
                             FStar_Syntax_Syntax.fv_eq_lid fv
                               FStar_Parser_Const.and_lid in
-                          if uu___8
+                          if uu___7
                           then
-                            let uu___9 =
-                              FStar_Compiler_Effect.op_Bar_Greater args
-                                (FStar_Compiler_List.map simplify) in
-                            (match uu___9 with
-                             | (FStar_Pervasives_Native.Some (true), uu___10)::
-                                 (uu___11, (arg, uu___12))::[] ->
-                                 let uu___13 = maybe_auto_squash arg in
-                                 (uu___13, false)
-                             | (uu___10, (arg, uu___11))::(FStar_Pervasives_Native.Some
-                                                           (true), uu___12)::[]
+                            let uu___8 =
+                              FStar_Compiler_List.map simplify args in
+                            (match uu___8 with
+                             | (FStar_Pervasives_Native.Some (true), uu___9)::
+                                 (uu___10, (arg, uu___11))::[] ->
+                                 let uu___12 = maybe_auto_squash arg in
+                                 (uu___12, false)
+                             | (uu___9, (arg, uu___10))::(FStar_Pervasives_Native.Some
+                                                          (true), uu___11)::[]
                                  ->
-                                 let uu___13 = maybe_auto_squash arg in
-                                 (uu___13, false)
-                             | (FStar_Pervasives_Native.Some (false),
-                                uu___10)::uu___11::[] ->
-                                 ((w FStar_Syntax_Util.t_false), false)
-                             | uu___10::(FStar_Pervasives_Native.Some
-                                         (false), uu___11)::[]
+                                 let uu___12 = maybe_auto_squash arg in
+                                 (uu___12, false)
+                             | (FStar_Pervasives_Native.Some (false), uu___9)::uu___10::[]
                                  -> ((w FStar_Syntax_Util.t_false), false)
-                             | uu___10 ->
+                             | uu___9::(FStar_Pervasives_Native.Some (false),
+                                        uu___10)::[]
+                                 -> ((w FStar_Syntax_Util.t_false), false)
+                             | uu___9 ->
                                  squashed_head_un_auto_squash_args tm1)
                           else
-                            (let uu___10 =
+                            (let uu___9 =
                                FStar_Syntax_Syntax.fv_eq_lid fv
                                  FStar_Parser_Const.or_lid in
-                             if uu___10
+                             if uu___9
                              then
-                               let uu___11 =
-                                 FStar_Compiler_Effect.op_Bar_Greater args
-                                   (FStar_Compiler_List.map simplify) in
-                               match uu___11 with
+                               let uu___10 =
+                                 FStar_Compiler_List.map simplify args in
+                               match uu___10 with
                                | (FStar_Pervasives_Native.Some (true),
-                                  uu___12)::uu___13::[] ->
+                                  uu___11)::uu___12::[] ->
                                    ((w FStar_Syntax_Util.t_true), false)
-                               | uu___12::(FStar_Pervasives_Native.Some
-                                           (true), uu___13)::[]
+                               | uu___11::(FStar_Pervasives_Native.Some
+                                           (true), uu___12)::[]
                                    -> ((w FStar_Syntax_Util.t_true), false)
                                | (FStar_Pervasives_Native.Some (false),
-                                  uu___12)::(uu___13, (arg, uu___14))::[] ->
-                                   let uu___15 = maybe_auto_squash arg in
-                                   (uu___15, false)
-                               | (uu___12, (arg, uu___13))::(FStar_Pervasives_Native.Some
+                                  uu___11)::(uu___12, (arg, uu___13))::[] ->
+                                   let uu___14 = maybe_auto_squash arg in
+                                   (uu___14, false)
+                               | (uu___11, (arg, uu___12))::(FStar_Pervasives_Native.Some
                                                              (false),
-                                                             uu___14)::[]
+                                                             uu___13)::[]
                                    ->
-                                   let uu___15 = maybe_auto_squash arg in
-                                   (uu___15, false)
-                               | uu___12 ->
+                                   let uu___14 = maybe_auto_squash arg in
+                                   (uu___14, false)
+                               | uu___11 ->
                                    squashed_head_un_auto_squash_args tm1
                              else
-                               (let uu___12 =
+                               (let uu___11 =
                                   FStar_Syntax_Syntax.fv_eq_lid fv
                                     FStar_Parser_Const.imp_lid in
-                                if uu___12
+                                if uu___11
                                 then
-                                  let uu___13 =
-                                    FStar_Compiler_Effect.op_Bar_Greater args
-                                      (FStar_Compiler_List.map simplify) in
-                                  match uu___13 with
-                                  | uu___14::(FStar_Pervasives_Native.Some
-                                              (true), uu___15)::[]
+                                  let uu___12 =
+                                    FStar_Compiler_List.map simplify args in
+                                  match uu___12 with
+                                  | uu___13::(FStar_Pervasives_Native.Some
+                                              (true), uu___14)::[]
                                       ->
                                       ((w FStar_Syntax_Util.t_true), false)
                                   | (FStar_Pervasives_Native.Some (false),
-                                     uu___14)::uu___15::[] ->
+                                     uu___13)::uu___14::[] ->
                                       ((w FStar_Syntax_Util.t_true), false)
                                   | (FStar_Pervasives_Native.Some (true),
-                                     uu___14)::(uu___15, (arg, uu___16))::[]
+                                     uu___13)::(uu___14, (arg, uu___15))::[]
                                       ->
-                                      let uu___17 = maybe_auto_squash arg in
-                                      (uu___17, false)
-                                  | (uu___14, (p, uu___15))::(uu___16,
-                                                              (q, uu___17))::[]
+                                      let uu___16 = maybe_auto_squash arg in
+                                      (uu___16, false)
+                                  | (uu___13, (p, uu___14))::(uu___15,
+                                                              (q, uu___16))::[]
                                       ->
-                                      let uu___18 =
+                                      let uu___17 =
                                         FStar_Syntax_Util.term_eq p q in
-                                      (if uu___18
+                                      (if uu___17
                                        then
                                          ((w FStar_Syntax_Util.t_true),
                                            false)
                                        else
                                          squashed_head_un_auto_squash_args
                                            tm1)
-                                  | uu___14 ->
+                                  | uu___13 ->
                                       squashed_head_un_auto_squash_args tm1
                                 else
-                                  (let uu___14 =
+                                  (let uu___13 =
                                      FStar_Syntax_Syntax.fv_eq_lid fv
                                        FStar_Parser_Const.iff_lid in
-                                   if uu___14
+                                   if uu___13
                                    then
-                                     let uu___15 =
-                                       FStar_Compiler_Effect.op_Bar_Greater
-                                         args
-                                         (FStar_Compiler_List.map simplify) in
-                                     match uu___15 with
+                                     let uu___14 =
+                                       FStar_Compiler_List.map simplify args in
+                                     match uu___14 with
                                      | (FStar_Pervasives_Native.Some (true),
-                                        uu___16)::(FStar_Pervasives_Native.Some
-                                                   (true), uu___17)::[]
+                                        uu___15)::(FStar_Pervasives_Native.Some
+                                                   (true), uu___16)::[]
                                          ->
                                          ((w FStar_Syntax_Util.t_true),
                                            false)
                                      | (FStar_Pervasives_Native.Some (false),
-                                        uu___16)::(FStar_Pervasives_Native.Some
-                                                   (false), uu___17)::[]
+                                        uu___15)::(FStar_Pervasives_Native.Some
+                                                   (false), uu___16)::[]
                                          ->
                                          ((w FStar_Syntax_Util.t_true),
                                            false)
                                      | (FStar_Pervasives_Native.Some (true),
-                                        uu___16)::(FStar_Pervasives_Native.Some
-                                                   (false), uu___17)::[]
+                                        uu___15)::(FStar_Pervasives_Native.Some
+                                                   (false), uu___16)::[]
                                          ->
                                          ((w FStar_Syntax_Util.t_false),
                                            false)
                                      | (FStar_Pervasives_Native.Some (false),
-                                        uu___16)::(FStar_Pervasives_Native.Some
-                                                   (true), uu___17)::[]
+                                        uu___15)::(FStar_Pervasives_Native.Some
+                                                   (true), uu___16)::[]
                                          ->
                                          ((w FStar_Syntax_Util.t_false),
                                            false)
-                                     | (uu___16, (arg, uu___17))::(FStar_Pervasives_Native.Some
+                                     | (uu___15, (arg, uu___16))::(FStar_Pervasives_Native.Some
                                                                    (true),
-                                                                   uu___18)::[]
+                                                                   uu___17)::[]
                                          ->
-                                         let uu___19 = maybe_auto_squash arg in
-                                         (uu___19, false)
+                                         let uu___18 = maybe_auto_squash arg in
+                                         (uu___18, false)
                                      | (FStar_Pervasives_Native.Some (true),
-                                        uu___16)::(uu___17, (arg, uu___18))::[]
+                                        uu___15)::(uu___16, (arg, uu___17))::[]
                                          ->
-                                         let uu___19 = maybe_auto_squash arg in
-                                         (uu___19, false)
-                                     | (uu___16, (arg, uu___17))::(FStar_Pervasives_Native.Some
+                                         let uu___18 = maybe_auto_squash arg in
+                                         (uu___18, false)
+                                     | (uu___15, (arg, uu___16))::(FStar_Pervasives_Native.Some
                                                                    (false),
-                                                                   uu___18)::[]
+                                                                   uu___17)::[]
                                          ->
-                                         let uu___19 =
-                                           let uu___20 =
+                                         let uu___18 =
+                                           let uu___19 =
                                              FStar_Syntax_Util.mk_neg arg in
-                                           maybe_auto_squash uu___20 in
-                                         (uu___19, false)
+                                           maybe_auto_squash uu___19 in
+                                         (uu___18, false)
                                      | (FStar_Pervasives_Native.Some (false),
-                                        uu___16)::(uu___17, (arg, uu___18))::[]
+                                        uu___15)::(uu___16, (arg, uu___17))::[]
+                                         ->
+                                         let uu___18 =
+                                           let uu___19 =
+                                             FStar_Syntax_Util.mk_neg arg in
+                                           maybe_auto_squash uu___19 in
+                                         (uu___18, false)
+                                     | (uu___15, (p, uu___16))::(uu___17,
+                                                                 (q, uu___18))::[]
                                          ->
                                          let uu___19 =
-                                           let uu___20 =
-                                             FStar_Syntax_Util.mk_neg arg in
-                                           maybe_auto_squash uu___20 in
-                                         (uu___19, false)
-                                     | (uu___16, (p, uu___17))::(uu___18,
-                                                                 (q, uu___19))::[]
-                                         ->
-                                         let uu___20 =
                                            FStar_Syntax_Util.term_eq p q in
-                                         (if uu___20
+                                         (if uu___19
                                           then
                                             ((w FStar_Syntax_Util.t_true),
                                               false)
                                           else
                                             squashed_head_un_auto_squash_args
                                               tm1)
-                                     | uu___16 ->
+                                     | uu___15 ->
                                          squashed_head_un_auto_squash_args
                                            tm1
                                    else
-                                     (let uu___16 =
+                                     (let uu___15 =
                                         FStar_Syntax_Syntax.fv_eq_lid fv
                                           FStar_Parser_Const.not_lid in
-                                      if uu___16
+                                      if uu___15
                                       then
-                                        let uu___17 =
-                                          FStar_Compiler_Effect.op_Bar_Greater
-                                            args
-                                            (FStar_Compiler_List.map simplify) in
-                                        match uu___17 with
+                                        let uu___16 =
+                                          FStar_Compiler_List.map simplify
+                                            args in
+                                        match uu___16 with
                                         | (FStar_Pervasives_Native.Some
-                                           (true), uu___18)::[] ->
+                                           (true), uu___17)::[] ->
                                             ((w FStar_Syntax_Util.t_false),
                                               false)
                                         | (FStar_Pervasives_Native.Some
-                                           (false), uu___18)::[] ->
+                                           (false), uu___17)::[] ->
                                             ((w FStar_Syntax_Util.t_true),
                                               false)
-                                        | uu___18 ->
+                                        | uu___17 ->
                                             squashed_head_un_auto_squash_args
                                               tm1
                                       else
-                                        (let uu___18 =
+                                        (let uu___17 =
                                            FStar_Syntax_Syntax.fv_eq_lid fv
                                              FStar_Parser_Const.forall_lid in
-                                         if uu___18
+                                         if uu___17
                                          then
                                            match args with
-                                           | (t, uu___19)::[] ->
+                                           | (t, uu___18)::[] ->
+                                               let uu___19 =
+                                                 let uu___20 =
+                                                   FStar_Syntax_Subst.compress
+                                                     t in
+                                                 uu___20.FStar_Syntax_Syntax.n in
+                                               (match uu___19 with
+                                                | FStar_Syntax_Syntax.Tm_abs
+                                                    {
+                                                      FStar_Syntax_Syntax.bs
+                                                        = uu___20::[];
+                                                      FStar_Syntax_Syntax.body
+                                                        = body;
+                                                      FStar_Syntax_Syntax.rc_opt
+                                                        = uu___21;_}
+                                                    ->
+                                                    let uu___22 = simp_t body in
+                                                    (match uu___22 with
+                                                     | FStar_Pervasives_Native.Some
+                                                         (true) ->
+                                                         ((w
+                                                             FStar_Syntax_Util.t_true),
+                                                           false)
+                                                     | uu___23 ->
+                                                         (tm1, false))
+                                                | uu___20 -> (tm1, false))
+                                           | (ty,
+                                              FStar_Pervasives_Native.Some
+                                              {
+                                                FStar_Syntax_Syntax.aqual_implicit
+                                                  = true;
+                                                FStar_Syntax_Syntax.aqual_attributes
+                                                  = uu___18;_})::(t, uu___19)::[]
+                                               ->
                                                let uu___20 =
                                                  let uu___21 =
                                                    FStar_Syntax_Subst.compress
@@ -7163,39 +7024,6 @@ and (maybe_simplify_aux :
                                                          ((w
                                                              FStar_Syntax_Util.t_true),
                                                            false)
-                                                     | uu___24 ->
-                                                         (tm1, false))
-                                                | uu___21 -> (tm1, false))
-                                           | (ty,
-                                              FStar_Pervasives_Native.Some
-                                              {
-                                                FStar_Syntax_Syntax.aqual_implicit
-                                                  = true;
-                                                FStar_Syntax_Syntax.aqual_attributes
-                                                  = uu___19;_})::(t, uu___20)::[]
-                                               ->
-                                               let uu___21 =
-                                                 let uu___22 =
-                                                   FStar_Syntax_Subst.compress
-                                                     t in
-                                                 uu___22.FStar_Syntax_Syntax.n in
-                                               (match uu___21 with
-                                                | FStar_Syntax_Syntax.Tm_abs
-                                                    {
-                                                      FStar_Syntax_Syntax.bs
-                                                        = uu___22::[];
-                                                      FStar_Syntax_Syntax.body
-                                                        = body;
-                                                      FStar_Syntax_Syntax.rc_opt
-                                                        = uu___23;_}
-                                                    ->
-                                                    let uu___24 = simp_t body in
-                                                    (match uu___24 with
-                                                     | FStar_Pervasives_Native.Some
-                                                         (true) ->
-                                                         ((w
-                                                             FStar_Syntax_Util.t_true),
-                                                           false)
                                                      | FStar_Pervasives_Native.Some
                                                          (false) when
                                                          clearly_inhabited ty
@@ -7203,19 +7031,54 @@ and (maybe_simplify_aux :
                                                          ((w
                                                              FStar_Syntax_Util.t_false),
                                                            false)
-                                                     | uu___25 ->
+                                                     | uu___24 ->
                                                          (tm1, false))
-                                                | uu___22 -> (tm1, false))
-                                           | uu___19 -> (tm1, false)
+                                                | uu___21 -> (tm1, false))
+                                           | uu___18 -> (tm1, false)
                                          else
-                                           (let uu___20 =
+                                           (let uu___19 =
                                               FStar_Syntax_Syntax.fv_eq_lid
                                                 fv
                                                 FStar_Parser_Const.exists_lid in
-                                            if uu___20
+                                            if uu___19
                                             then
                                               match args with
-                                              | (t, uu___21)::[] ->
+                                              | (t, uu___20)::[] ->
+                                                  let uu___21 =
+                                                    let uu___22 =
+                                                      FStar_Syntax_Subst.compress
+                                                        t in
+                                                    uu___22.FStar_Syntax_Syntax.n in
+                                                  (match uu___21 with
+                                                   | FStar_Syntax_Syntax.Tm_abs
+                                                       {
+                                                         FStar_Syntax_Syntax.bs
+                                                           = uu___22::[];
+                                                         FStar_Syntax_Syntax.body
+                                                           = body;
+                                                         FStar_Syntax_Syntax.rc_opt
+                                                           = uu___23;_}
+                                                       ->
+                                                       let uu___24 =
+                                                         simp_t body in
+                                                       (match uu___24 with
+                                                        | FStar_Pervasives_Native.Some
+                                                            (false) ->
+                                                            ((w
+                                                                FStar_Syntax_Util.t_false),
+                                                              false)
+                                                        | uu___25 ->
+                                                            (tm1, false))
+                                                   | uu___22 -> (tm1, false))
+                                              | (ty,
+                                                 FStar_Pervasives_Native.Some
+                                                 {
+                                                   FStar_Syntax_Syntax.aqual_implicit
+                                                     = true;
+                                                   FStar_Syntax_Syntax.aqual_attributes
+                                                     = uu___20;_})::(t,
+                                                                    uu___21)::[]
+                                                  ->
                                                   let uu___22 =
                                                     let uu___23 =
                                                       FStar_Syntax_Subst.compress
@@ -7239,41 +7102,6 @@ and (maybe_simplify_aux :
                                                             ((w
                                                                 FStar_Syntax_Util.t_false),
                                                               false)
-                                                        | uu___26 ->
-                                                            (tm1, false))
-                                                   | uu___23 -> (tm1, false))
-                                              | (ty,
-                                                 FStar_Pervasives_Native.Some
-                                                 {
-                                                   FStar_Syntax_Syntax.aqual_implicit
-                                                     = true;
-                                                   FStar_Syntax_Syntax.aqual_attributes
-                                                     = uu___21;_})::(t,
-                                                                    uu___22)::[]
-                                                  ->
-                                                  let uu___23 =
-                                                    let uu___24 =
-                                                      FStar_Syntax_Subst.compress
-                                                        t in
-                                                    uu___24.FStar_Syntax_Syntax.n in
-                                                  (match uu___23 with
-                                                   | FStar_Syntax_Syntax.Tm_abs
-                                                       {
-                                                         FStar_Syntax_Syntax.bs
-                                                           = uu___24::[];
-                                                         FStar_Syntax_Syntax.body
-                                                           = body;
-                                                         FStar_Syntax_Syntax.rc_opt
-                                                           = uu___25;_}
-                                                       ->
-                                                       let uu___26 =
-                                                         simp_t body in
-                                                       (match uu___26 with
-                                                        | FStar_Pervasives_Native.Some
-                                                            (false) ->
-                                                            ((w
-                                                                FStar_Syntax_Util.t_false),
-                                                              false)
                                                         | FStar_Pervasives_Native.Some
                                                             (true) when
                                                             clearly_inhabited
@@ -7282,16 +7110,16 @@ and (maybe_simplify_aux :
                                                             ((w
                                                                 FStar_Syntax_Util.t_true),
                                                               false)
-                                                        | uu___27 ->
+                                                        | uu___26 ->
                                                             (tm1, false))
-                                                   | uu___24 -> (tm1, false))
-                                              | uu___21 -> (tm1, false)
+                                                   | uu___23 -> (tm1, false))
+                                              | uu___20 -> (tm1, false)
                                             else
-                                              (let uu___22 =
+                                              (let uu___21 =
                                                  FStar_Syntax_Syntax.fv_eq_lid
                                                    fv
                                                    FStar_Parser_Const.b2t_lid in
-                                               if uu___22
+                                               if uu___21
                                                then
                                                  match args with
                                                  | ({
@@ -7300,12 +7128,12 @@ and (maybe_simplify_aux :
                                                         (FStar_Const.Const_bool
                                                         (true));
                                                       FStar_Syntax_Syntax.pos
-                                                        = uu___23;
+                                                        = uu___22;
                                                       FStar_Syntax_Syntax.vars
-                                                        = uu___24;
+                                                        = uu___23;
                                                       FStar_Syntax_Syntax.hash_code
-                                                        = uu___25;_},
-                                                    uu___26)::[] ->
+                                                        = uu___24;_},
+                                                    uu___25)::[] ->
                                                      ((w
                                                          FStar_Syntax_Util.t_true),
                                                        false)
@@ -7315,22 +7143,22 @@ and (maybe_simplify_aux :
                                                         (FStar_Const.Const_bool
                                                         (false));
                                                       FStar_Syntax_Syntax.pos
-                                                        = uu___23;
+                                                        = uu___22;
                                                       FStar_Syntax_Syntax.vars
-                                                        = uu___24;
+                                                        = uu___23;
                                                       FStar_Syntax_Syntax.hash_code
-                                                        = uu___25;_},
-                                                    uu___26)::[] ->
+                                                        = uu___24;_},
+                                                    uu___25)::[] ->
                                                      ((w
                                                          FStar_Syntax_Util.t_false),
                                                        false)
-                                                 | uu___23 -> (tm1, false)
+                                                 | uu___22 -> (tm1, false)
                                                else
-                                                 (let uu___24 =
+                                                 (let uu___23 =
                                                     FStar_Syntax_Syntax.fv_eq_lid
                                                       fv
                                                       FStar_Parser_Const.haseq_lid in
-                                                  if uu___24
+                                                  if uu___23
                                                   then
                                                     let t_has_eq_for_sure t =
                                                       let haseq_lids =
@@ -7338,61 +7166,55 @@ and (maybe_simplify_aux :
                                                         FStar_Parser_Const.bool_lid;
                                                         FStar_Parser_Const.unit_lid;
                                                         FStar_Parser_Const.string_lid] in
-                                                      let uu___25 =
-                                                        let uu___26 =
+                                                      let uu___24 =
+                                                        let uu___25 =
                                                           FStar_Syntax_Subst.compress
                                                             t in
-                                                        uu___26.FStar_Syntax_Syntax.n in
-                                                      match uu___25 with
+                                                        uu___25.FStar_Syntax_Syntax.n in
+                                                      match uu___24 with
                                                       | FStar_Syntax_Syntax.Tm_fvar
                                                           fv1 when
-                                                          FStar_Compiler_Effect.op_Bar_Greater
+                                                          FStar_Compiler_List.existsb
+                                                            (fun l ->
+                                                               FStar_Syntax_Syntax.fv_eq_lid
+                                                                 fv1 l)
                                                             haseq_lids
-                                                            (FStar_Compiler_List.existsb
-                                                               (fun l ->
-                                                                  FStar_Syntax_Syntax.fv_eq_lid
-                                                                    fv1 l))
                                                           -> true
-                                                      | uu___26 -> false in
+                                                      | uu___25 -> false in
                                                     (if
                                                        (FStar_Compiler_List.length
                                                           args)
                                                          = Prims.int_one
                                                      then
                                                        let t =
-                                                         let uu___25 =
-                                                           FStar_Compiler_Effect.op_Bar_Greater
-                                                             args
-                                                             FStar_Compiler_List.hd in
-                                                         FStar_Compiler_Effect.op_Bar_Greater
-                                                           uu___25
-                                                           FStar_Pervasives_Native.fst in
-                                                       let uu___25 =
-                                                         FStar_Compiler_Effect.op_Bar_Greater
-                                                           t
-                                                           t_has_eq_for_sure in
-                                                       (if uu___25
+                                                         let uu___24 =
+                                                           FStar_Compiler_List.hd
+                                                             args in
+                                                         FStar_Pervasives_Native.fst
+                                                           uu___24 in
+                                                       let uu___24 =
+                                                         t_has_eq_for_sure t in
+                                                       (if uu___24
                                                         then
                                                           ((w
                                                               FStar_Syntax_Util.t_true),
                                                             false)
                                                         else
-                                                          (let uu___27 =
-                                                             let uu___28 =
+                                                          (let uu___26 =
+                                                             let uu___27 =
                                                                FStar_Syntax_Subst.compress
                                                                  t in
-                                                             uu___28.FStar_Syntax_Syntax.n in
-                                                           match uu___27 with
+                                                             uu___27.FStar_Syntax_Syntax.n in
+                                                           match uu___26 with
                                                            | FStar_Syntax_Syntax.Tm_refine
-                                                               uu___28 ->
+                                                               uu___27 ->
                                                                let t1 =
                                                                  FStar_Syntax_Util.unrefine
                                                                    t in
-                                                               let uu___29 =
-                                                                 FStar_Compiler_Effect.op_Bar_Greater
-                                                                   t1
-                                                                   t_has_eq_for_sure in
-                                                               if uu___29
+                                                               let uu___28 =
+                                                                 t_has_eq_for_sure
+                                                                   t1 in
+                                                               if uu___28
                                                                then
                                                                  ((w
                                                                     FStar_Syntax_Util.t_true),
@@ -7400,14 +7222,14 @@ and (maybe_simplify_aux :
                                                                else
                                                                  (let haseq_tm
                                                                     =
-                                                                    let uu___31
+                                                                    let uu___30
                                                                     =
-                                                                    let uu___32
+                                                                    let uu___31
                                                                     =
                                                                     FStar_Syntax_Subst.compress
                                                                     tm1 in
-                                                                    uu___32.FStar_Syntax_Syntax.n in
-                                                                    match uu___31
+                                                                    uu___31.FStar_Syntax_Syntax.n in
+                                                                    match uu___30
                                                                     with
                                                                     | 
                                                                     FStar_Syntax_Syntax.Tm_app
@@ -7415,54 +7237,53 @@ and (maybe_simplify_aux :
                                                                     FStar_Syntax_Syntax.hd
                                                                     = hd;
                                                                     FStar_Syntax_Syntax.args
-                                                                    = uu___32;_}
+                                                                    = uu___31;_}
                                                                     -> hd
                                                                     | 
-                                                                    uu___32
+                                                                    uu___31
                                                                     ->
                                                                     FStar_Compiler_Effect.failwith
                                                                     "Impossible! We have already checked that this is a Tm_app" in
-                                                                  let uu___31
+                                                                  let uu___30
+                                                                    =
+                                                                    let uu___31
                                                                     =
                                                                     let uu___32
                                                                     =
-                                                                    let uu___33
-                                                                    =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    t1
-                                                                    FStar_Syntax_Syntax.as_arg in
-                                                                    [uu___33] in
+                                                                    FStar_Syntax_Syntax.as_arg
+                                                                    t1 in
+                                                                    [uu___32] in
                                                                     FStar_Syntax_Util.mk_app
                                                                     haseq_tm
-                                                                    uu___32 in
-                                                                  (uu___31,
+                                                                    uu___31 in
+                                                                  (uu___30,
                                                                     false))
-                                                           | uu___28 ->
+                                                           | uu___27 ->
                                                                (tm1, false)))
                                                      else (tm1, false))
                                                   else
-                                                    (let uu___26 =
+                                                    (let uu___25 =
                                                        FStar_Syntax_Syntax.fv_eq_lid
                                                          fv
                                                          FStar_Parser_Const.subtype_of_lid in
-                                                     if uu___26
+                                                     if uu___25
                                                      then
                                                        let is_unit ty =
-                                                         let uu___27 =
-                                                           let uu___28 =
+                                                         let uu___26 =
+                                                           let uu___27 =
                                                              FStar_Syntax_Subst.compress
                                                                ty in
-                                                           uu___28.FStar_Syntax_Syntax.n in
-                                                         match uu___27 with
+                                                           uu___27.FStar_Syntax_Syntax.n in
+                                                         match uu___26 with
                                                          | FStar_Syntax_Syntax.Tm_fvar
                                                              fv1 ->
                                                              FStar_Syntax_Syntax.fv_eq_lid
                                                                fv1
                                                                FStar_Parser_Const.unit_lid
-                                                         | uu___28 -> false in
+                                                         | uu___27 -> false in
                                                        match args with
-                                                       | (t, uu___27)::
-                                                           (ty, uu___28)::[]
+                                                       | (t, uu___26)::
+                                                           (ty, uu___27)::[]
                                                            when
                                                            (is_unit ty) &&
                                                              (FStar_Syntax_Util.is_sub_singleton
@@ -7471,13 +7292,13 @@ and (maybe_simplify_aux :
                                                            ((w
                                                                FStar_Syntax_Util.t_true),
                                                              false)
-                                                       | uu___27 ->
+                                                       | uu___26 ->
                                                            (tm1, false)
                                                      else
-                                                       (let uu___28 =
+                                                       (let uu___27 =
                                                           FStar_Syntax_Util.is_auto_squash
                                                             tm1 in
-                                                        match uu___28 with
+                                                        match uu___27 with
                                                         | FStar_Pervasives_Native.Some
                                                             (FStar_Syntax_Syntax.U_zero,
                                                              t)
@@ -7485,32 +7306,32 @@ and (maybe_simplify_aux :
                                                             FStar_Syntax_Util.is_sub_singleton
                                                               t
                                                             -> (t, false)
-                                                        | uu___29 ->
-                                                            let uu___30 =
+                                                        | uu___28 ->
+                                                            let uu___29 =
                                                               norm_cb cfg in
                                                             reduce_equality
-                                                              uu___30 cfg
+                                                              uu___29 cfg
                                                               env1 tm1))))))))))
                       | FStar_Syntax_Syntax.Tm_refine
                           { FStar_Syntax_Syntax.b = bv;
                             FStar_Syntax_Syntax.phi = t;_}
                           ->
-                          let uu___5 = simp_t t in
-                          (match uu___5 with
+                          let uu___4 = simp_t t in
+                          (match uu___4 with
                            | FStar_Pervasives_Native.Some (true) ->
                                ((bv.FStar_Syntax_Syntax.sort), false)
                            | FStar_Pervasives_Native.Some (false) ->
                                (tm1, false)
                            | FStar_Pervasives_Native.None -> (tm1, false))
-                      | FStar_Syntax_Syntax.Tm_match uu___5 ->
-                          let uu___6 = is_const_match tm1 in
-                          (match uu___6 with
+                      | FStar_Syntax_Syntax.Tm_match uu___4 ->
+                          let uu___5 = is_const_match tm1 in
+                          (match uu___5 with
                            | FStar_Pervasives_Native.Some (true) ->
                                ((w FStar_Syntax_Util.t_true), false)
                            | FStar_Pervasives_Native.Some (false) ->
                                ((w FStar_Syntax_Util.t_false), false)
                            | FStar_Pervasives_Native.None -> (tm1, false))
-                      | uu___5 -> (tm1, false)))
+                      | uu___4 -> (tm1, false)))
 and (rebuild :
   FStar_TypeChecker_Cfg.cfg ->
     env -> stack -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
@@ -7529,8 +7350,7 @@ and (rebuild :
                 let uu___6 =
                   let uu___7 =
                     let uu___8 = firstn (Prims.of_int (4)) stack1 in
-                    FStar_Compiler_Effect.op_Less_Bar
-                      FStar_Pervasives_Native.fst uu___8 in
+                    FStar_Pervasives_Native.fst uu___8 in
                   stack_to_string uu___7 in
                 FStar_Compiler_Util.print4
                   ">>> %s\nRebuild %s with %s env elements and top of the stack %s \n"
@@ -7548,34 +7368,26 @@ and (rebuild :
                         let uu___7 = FStar_Syntax_Print.term_to_string t in
                         let uu___8 =
                           let uu___9 =
-                            FStar_Compiler_Effect.op_Bar_Greater bvs
-                              (FStar_Compiler_List.map
-                                 FStar_Syntax_Print.bv_to_string) in
-                          FStar_Compiler_Effect.op_Bar_Greater uu___9
-                            (FStar_Compiler_String.concat ", ") in
+                            FStar_Compiler_List.map
+                              FStar_Syntax_Print.bv_to_string bvs in
+                          FStar_Compiler_String.concat ", " uu___9 in
                         FStar_Compiler_Util.print3
                           "!!! Rebuild (%s) %s, free vars=%s\n" uu___6 uu___7
                           uu___8);
                        FStar_Compiler_Effect.failwith "DIE!")
                 else ()));
           (let f_opt = is_fext_on_domain t in
-           let uu___1 =
-             (FStar_Compiler_Effect.op_Bar_Greater f_opt
-                FStar_Compiler_Util.is_some)
-               &&
+           if
+             (FStar_Compiler_Util.is_some f_opt) &&
                (match stack1 with
-                | (Arg uu___2)::uu___3 -> true
-                | uu___2 -> false) in
-           if uu___1
+                | (Arg uu___1)::uu___2 -> true
+                | uu___1 -> false)
            then
-             let uu___2 =
-               FStar_Compiler_Effect.op_Bar_Greater f_opt
-                 FStar_Compiler_Util.must in
-             FStar_Compiler_Effect.op_Bar_Greater uu___2
-               (norm cfg env1 stack1)
+             let uu___1 = FStar_Compiler_Util.must f_opt in
+             norm cfg env1 stack1 uu___1
            else
-             (let uu___3 = maybe_simplify cfg env1 stack1 t in
-              match uu___3 with
+             (let uu___2 = maybe_simplify cfg env1 stack1 t in
+              match uu___2 with
               | (t1, renorm) ->
                   if renorm
                   then norm cfg env1 stack1 t1
@@ -7730,16 +7542,14 @@ and (do_rebuild :
                  rebuild cfg env2 stack' t1) in
               let is_non_tac_layered_effect m =
                 let norm_m =
-                  FStar_Compiler_Effect.op_Bar_Greater m
-                    (FStar_TypeChecker_Env.norm_eff_name
-                       cfg.FStar_TypeChecker_Cfg.tcenv) in
+                  FStar_TypeChecker_Env.norm_eff_name
+                    cfg.FStar_TypeChecker_Cfg.tcenv m in
                 (let uu___ =
                    FStar_Ident.lid_equals norm_m
                      FStar_Parser_Const.effect_TAC_lid in
                  Prims.op_Negation uu___) &&
-                  (FStar_Compiler_Effect.op_Bar_Greater norm_m
-                     (FStar_TypeChecker_Env.is_layered_effect
-                        cfg.FStar_TypeChecker_Cfg.tcenv)) in
+                  (FStar_TypeChecker_Env.is_layered_effect
+                     cfg.FStar_TypeChecker_Cfg.tcenv norm_m) in
               let uu___ =
                 let uu___1 = FStar_Syntax_Subst.compress t in
                 uu___1.FStar_Syntax_Syntax.n in
@@ -7957,14 +7767,13 @@ and (do_rebuild :
                          FStar_Syntax_Print.term_to_string scrutinee in
                        let uu___5 =
                          let uu___6 =
-                           FStar_Compiler_Effect.op_Bar_Greater branches1
-                             (FStar_Compiler_List.map
-                                (fun uu___7 ->
-                                   match uu___7 with
-                                   | (p, uu___8, uu___9) ->
-                                       FStar_Syntax_Print.pat_to_string p)) in
-                         FStar_Compiler_Effect.op_Bar_Greater uu___6
-                           (FStar_Compiler_String.concat "\n\t") in
+                           FStar_Compiler_List.map
+                             (fun uu___7 ->
+                                match uu___7 with
+                                | (p, uu___8, uu___9) ->
+                                    FStar_Syntax_Print.pat_to_string p)
+                             branches1 in
+                         FStar_Compiler_String.concat "\n\t" uu___6 in
                        FStar_Compiler_Util.print2
                          "match is irreducible: scrutinee=%s\nbranches=%s\n"
                          uu___4 uu___5);
@@ -7978,16 +7787,14 @@ and (do_rebuild :
                      then cfg1
                      else
                        (let new_delta =
-                          FStar_Compiler_Effect.op_Bar_Greater
-                            cfg1.FStar_TypeChecker_Cfg.delta_level
-                            (FStar_Compiler_List.filter
-                               (fun uu___4 ->
-                                  match uu___4 with
-                                  | FStar_TypeChecker_Env.InliningDelta ->
-                                      true
-                                  | FStar_TypeChecker_Env.Eager_unfolding_only
-                                      -> true
-                                  | uu___5 -> false)) in
+                          FStar_Compiler_List.filter
+                            (fun uu___4 ->
+                               match uu___4 with
+                               | FStar_TypeChecker_Env.InliningDelta -> true
+                               | FStar_TypeChecker_Env.Eager_unfolding_only
+                                   -> true
+                               | uu___5 -> false)
+                            cfg1.FStar_TypeChecker_Cfg.delta_level in
                         let steps =
                           let uu___4 = cfg1.FStar_TypeChecker_Cfg.steps in
                           {
@@ -8092,17 +7899,16 @@ and (do_rebuild :
                                       (norm_universe cfg1 env3) us in
                                   FStar_Pervasives_Native.Some uu___4) in
                          let uu___3 =
-                           FStar_Compiler_Effect.op_Bar_Greater pats
-                             (FStar_Compiler_List.fold_left
-                                (fun uu___4 ->
-                                   fun uu___5 ->
-                                     match (uu___4, uu___5) with
-                                     | ((pats1, env4), (p1, b)) ->
-                                         let uu___6 = norm_pat env4 p1 in
-                                         (match uu___6 with
-                                          | (p2, env5) ->
-                                              (((p2, b) :: pats1), env5)))
-                                ([], env3)) in
+                           FStar_Compiler_List.fold_left
+                             (fun uu___4 ->
+                                fun uu___5 ->
+                                  match (uu___4, uu___5) with
+                                  | ((pats1, env4), (p1, b)) ->
+                                      let uu___6 = norm_pat env4 p1 in
+                                      (match uu___6 with
+                                       | (p2, env5) ->
+                                           (((p2, b) :: pats1), env5)))
+                             ([], env3) pats in
                          (match uu___3 with
                           | (pats1, env4) ->
                               ({
@@ -8142,29 +7948,26 @@ and (do_rebuild :
                      match env2 with
                      | [] when whnf -> branches1
                      | uu___4 ->
-                         FStar_Compiler_Effect.op_Bar_Greater branches1
-                           (FStar_Compiler_List.map
-                              (fun branch ->
-                                 let uu___5 =
-                                   FStar_Syntax_Subst.open_branch branch in
-                                 match uu___5 with
-                                 | (p, wopt, e) ->
-                                     let uu___6 = norm_pat env2 p in
-                                     (match uu___6 with
-                                      | (p1, env3) ->
-                                          let wopt1 =
-                                            match wopt with
-                                            | FStar_Pervasives_Native.None ->
-                                                FStar_Pervasives_Native.None
-                                            | FStar_Pervasives_Native.Some w
-                                                ->
-                                                let uu___7 =
-                                                  norm_or_whnf env3 w in
-                                                FStar_Pervasives_Native.Some
-                                                  uu___7 in
-                                          let e1 = norm_or_whnf env3 e in
-                                          FStar_Syntax_Util.branch
-                                            (p1, wopt1, e1)))) in
+                         FStar_Compiler_List.map
+                           (fun branch ->
+                              let uu___5 =
+                                FStar_Syntax_Subst.open_branch branch in
+                              match uu___5 with
+                              | (p, wopt, e) ->
+                                  let uu___6 = norm_pat env2 p in
+                                  (match uu___6 with
+                                   | (p1, env3) ->
+                                       let wopt1 =
+                                         match wopt with
+                                         | FStar_Pervasives_Native.None ->
+                                             FStar_Pervasives_Native.None
+                                         | FStar_Pervasives_Native.Some w ->
+                                             let uu___7 = norm_or_whnf env3 w in
+                                             FStar_Pervasives_Native.Some
+                                               uu___7 in
+                                       let e1 = norm_or_whnf env3 e in
+                                       FStar_Syntax_Util.branch
+                                         (p1, wopt1, e1))) branches1 in
                    let maybe_commute_matches uu___3 =
                      let can_commute =
                        match branches1 with
@@ -8448,9 +8251,7 @@ and (do_rebuild :
                                           | (uu___8, t1) ->
                                               FStar_Syntax_Print.term_to_string
                                                 t1) s in
-                                   FStar_Compiler_Effect.op_Bar_Greater
-                                     uu___6
-                                     (FStar_Compiler_String.concat "; ") in
+                                   FStar_Compiler_String.concat "; " uu___6 in
                                  FStar_Compiler_Util.print2
                                    "Matches pattern %s with subst = %s\n"
                                    uu___4 uu___5);
@@ -8907,17 +8708,11 @@ let (ghost_to_pure2 :
           (match uu___1 with
            | (c11, c21) ->
                let c1_eff =
-                 let uu___2 =
-                   FStar_Compiler_Effect.op_Bar_Greater c11
-                     FStar_Syntax_Util.comp_effect_name in
-                 FStar_Compiler_Effect.op_Bar_Greater uu___2
-                   (FStar_TypeChecker_Env.norm_eff_name env1) in
+                 FStar_TypeChecker_Env.norm_eff_name env1
+                   (FStar_Syntax_Util.comp_effect_name c11) in
                let c2_eff =
-                 let uu___2 =
-                   FStar_Compiler_Effect.op_Bar_Greater c21
-                     FStar_Syntax_Util.comp_effect_name in
-                 FStar_Compiler_Effect.op_Bar_Greater uu___2
-                   (FStar_TypeChecker_Env.norm_eff_name env1) in
+                 FStar_TypeChecker_Env.norm_eff_name env1
+                   (FStar_Syntax_Util.comp_effect_name c21) in
                let uu___2 = FStar_Ident.lid_equals c1_eff c2_eff in
                if uu___2
                then (c11, c21)
@@ -9155,8 +8950,7 @@ let (eta_expand_with_type :
                       then e
                       else
                         (let uu___6 =
-                           FStar_Compiler_Effect.op_Bar_Greater formals
-                             FStar_Syntax_Util.args_of_binders in
+                           FStar_Syntax_Util.args_of_binders formals in
                          match uu___6 with
                          | (binders, args) ->
                              let uu___7 =
@@ -9544,9 +9338,8 @@ let rec (elim_uvars :
         let uu___ =
           FStar_Compiler_List.map (elim_uvars_aux_t env1 [] [])
             s.FStar_Syntax_Syntax.sigattrs in
-        FStar_Compiler_Effect.op_Less_Bar
-          (FStar_Compiler_List.map
-             FStar_Pervasives_Native.__proj__Mktuple3__item___3) uu___ in
+        FStar_Compiler_List.map
+          FStar_Pervasives_Native.__proj__Mktuple3__item___3 uu___ in
       let s1 =
         {
           FStar_Syntax_Syntax.sigel = (s.FStar_Syntax_Syntax.sigel);
@@ -9683,34 +9476,33 @@ let rec (elim_uvars :
             FStar_Syntax_Syntax.lids1 = lids;_}
           ->
           let lbs1 =
-            FStar_Compiler_Effect.op_Bar_Greater lbs
-              (FStar_Compiler_List.map
-                 (fun lb ->
-                    let uu___ =
-                      FStar_Syntax_Subst.univ_var_opening
-                        lb.FStar_Syntax_Syntax.lbunivs in
-                    match uu___ with
-                    | (opening, lbunivs) ->
-                        let elim t =
-                          let uu___1 =
-                            let uu___2 = FStar_Syntax_Subst.subst opening t in
-                            remove_uvar_solutions env1 uu___2 in
-                          FStar_Syntax_Subst.close_univ_vars lbunivs uu___1 in
-                        let lbtyp = elim lb.FStar_Syntax_Syntax.lbtyp in
-                        let lbdef = elim lb.FStar_Syntax_Syntax.lbdef in
-                        {
-                          FStar_Syntax_Syntax.lbname =
-                            (lb.FStar_Syntax_Syntax.lbname);
-                          FStar_Syntax_Syntax.lbunivs = lbunivs;
-                          FStar_Syntax_Syntax.lbtyp = lbtyp;
-                          FStar_Syntax_Syntax.lbeff =
-                            (lb.FStar_Syntax_Syntax.lbeff);
-                          FStar_Syntax_Syntax.lbdef = lbdef;
-                          FStar_Syntax_Syntax.lbattrs =
-                            (lb.FStar_Syntax_Syntax.lbattrs);
-                          FStar_Syntax_Syntax.lbpos =
-                            (lb.FStar_Syntax_Syntax.lbpos)
-                        })) in
+            FStar_Compiler_List.map
+              (fun lb ->
+                 let uu___ =
+                   FStar_Syntax_Subst.univ_var_opening
+                     lb.FStar_Syntax_Syntax.lbunivs in
+                 match uu___ with
+                 | (opening, lbunivs) ->
+                     let elim t =
+                       let uu___1 =
+                         let uu___2 = FStar_Syntax_Subst.subst opening t in
+                         remove_uvar_solutions env1 uu___2 in
+                       FStar_Syntax_Subst.close_univ_vars lbunivs uu___1 in
+                     let lbtyp = elim lb.FStar_Syntax_Syntax.lbtyp in
+                     let lbdef = elim lb.FStar_Syntax_Syntax.lbdef in
+                     {
+                       FStar_Syntax_Syntax.lbname =
+                         (lb.FStar_Syntax_Syntax.lbname);
+                       FStar_Syntax_Syntax.lbunivs = lbunivs;
+                       FStar_Syntax_Syntax.lbtyp = lbtyp;
+                       FStar_Syntax_Syntax.lbeff =
+                         (lb.FStar_Syntax_Syntax.lbeff);
+                       FStar_Syntax_Syntax.lbdef = lbdef;
+                       FStar_Syntax_Syntax.lbattrs =
+                         (lb.FStar_Syntax_Syntax.lbattrs);
+                       FStar_Syntax_Syntax.lbpos =
+                         (lb.FStar_Syntax_Syntax.lbpos)
+                     }) lbs in
           {
             FStar_Syntax_Syntax.sigel =
               (FStar_Syntax_Syntax.Sig_let
@@ -9788,29 +9580,23 @@ let rec (elim_uvars :
                                 | (us1, t1) ->
                                     let uu___6 =
                                       let uu___7 =
-                                        FStar_Compiler_Effect.op_Bar_Greater
-                                          b_opening
-                                          (FStar_Syntax_Subst.shift_subst
-                                             n_us) in
+                                        FStar_Syntax_Subst.shift_subst n_us
+                                          b_opening in
                                       let uu___8 =
-                                        FStar_Compiler_Effect.op_Bar_Greater
-                                          b_closing
-                                          (FStar_Syntax_Subst.shift_subst
-                                             n_us) in
+                                        FStar_Syntax_Subst.shift_subst n_us
+                                          b_closing in
                                       (uu___7, uu___8) in
                                     (match uu___6 with
                                      | (b_opening1, b_closing1) ->
                                          let uu___7 =
                                            let uu___8 =
-                                             FStar_Compiler_Effect.op_Bar_Greater
-                                               univs_opening
-                                               (FStar_Syntax_Subst.shift_subst
-                                                  (n_us + n_binders)) in
+                                             FStar_Syntax_Subst.shift_subst
+                                               (n_us + n_binders)
+                                               univs_opening in
                                            let uu___9 =
-                                             FStar_Compiler_Effect.op_Bar_Greater
-                                               univs_closing
-                                               (FStar_Syntax_Subst.shift_subst
-                                                  (n_us + n_binders)) in
+                                             FStar_Syntax_Subst.shift_subst
+                                               (n_us + n_binders)
+                                               univs_closing in
                                            (uu___8, uu___9) in
                                          (match uu___7 with
                                           | (univs_opening1, univs_closing1)
@@ -10233,8 +10019,7 @@ let (maybe_unfold_head_fv :
            | FStar_Pervasives_Native.Some (us_formals, defn) ->
                let subst = FStar_TypeChecker_Env.mk_univ_subst us_formals us in
                let uu___1 = FStar_Syntax_Subst.subst subst defn in
-               FStar_Compiler_Effect.op_Bar_Greater uu___1
-                 (fun uu___2 -> FStar_Pervasives_Native.Some uu___2))
+               FStar_Pervasives_Native.Some uu___1)
 let rec (maybe_unfold_aux :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
@@ -10280,8 +10065,7 @@ let rec (maybe_unfold_aux :
                       let uu___5 =
                         FStar_Syntax_Syntax.mk_Tm_app head1 args
                           t.FStar_Syntax_Syntax.pos in
-                      FStar_Compiler_Effect.op_Bar_Greater uu___5
-                        (fun uu___6 -> FStar_Pervasives_Native.Some uu___6)))
+                      FStar_Pervasives_Native.Some uu___5))
 let (maybe_unfold_head :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_PatternUtils.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_PatternUtils.ml
@@ -48,49 +48,48 @@ let rec (elaborate_pat :
                             (FStar_Errors_Codes.Fatal_TooManyPatternArguments,
                               "Too many pattern arguments") uu___6
                       | (uu___4::uu___5, []) ->
-                          FStar_Compiler_Effect.op_Bar_Greater formals
-                            (FStar_Compiler_List.map
-                               (fun fml ->
-                                  let uu___6 =
-                                    ((fml.FStar_Syntax_Syntax.binder_bv),
-                                      (fml.FStar_Syntax_Syntax.binder_qual)) in
-                                  match uu___6 with
-                                  | (t1, imp) ->
-                                      (match imp with
-                                       | FStar_Pervasives_Native.Some
-                                           (FStar_Syntax_Syntax.Implicit
-                                           inaccessible) ->
-                                           let a =
-                                             let uu___7 =
-                                               let uu___8 =
-                                                 FStar_Syntax_Syntax.range_of_bv
-                                                   t1 in
-                                               FStar_Pervasives_Native.Some
-                                                 uu___8 in
-                                             FStar_Syntax_Syntax.new_bv
-                                               uu___7 FStar_Syntax_Syntax.tun in
-                                           let r =
-                                             FStar_Ident.range_of_lid
-                                               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                                           let uu___7 =
-                                             maybe_dot inaccessible a r in
-                                           (uu___7, true)
-                                       | uu___7 ->
-                                           let uu___8 =
-                                             let uu___9 =
-                                               let uu___10 =
-                                                 FStar_Syntax_Print.pat_to_string
-                                                   p in
-                                               FStar_Compiler_Util.format1
-                                                 "Insufficient pattern arguments (%s)"
-                                                 uu___10 in
-                                             (FStar_Errors_Codes.Fatal_InsufficientPatternArguments,
-                                               uu___9) in
-                                           let uu___9 =
-                                             FStar_Ident.range_of_lid
-                                               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                                           FStar_Errors.raise_error uu___8
-                                             uu___9)))
+                          FStar_Compiler_List.map
+                            (fun fml ->
+                               let uu___6 =
+                                 ((fml.FStar_Syntax_Syntax.binder_bv),
+                                   (fml.FStar_Syntax_Syntax.binder_qual)) in
+                               match uu___6 with
+                               | (t1, imp) ->
+                                   (match imp with
+                                    | FStar_Pervasives_Native.Some
+                                        (FStar_Syntax_Syntax.Implicit
+                                        inaccessible) ->
+                                        let a =
+                                          let uu___7 =
+                                            let uu___8 =
+                                              FStar_Syntax_Syntax.range_of_bv
+                                                t1 in
+                                            FStar_Pervasives_Native.Some
+                                              uu___8 in
+                                          FStar_Syntax_Syntax.new_bv uu___7
+                                            FStar_Syntax_Syntax.tun in
+                                        let r =
+                                          FStar_Ident.range_of_lid
+                                            (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
+                                        let uu___7 =
+                                          maybe_dot inaccessible a r in
+                                        (uu___7, true)
+                                    | uu___7 ->
+                                        let uu___8 =
+                                          let uu___9 =
+                                            let uu___10 =
+                                              FStar_Syntax_Print.pat_to_string
+                                                p in
+                                            FStar_Compiler_Util.format1
+                                              "Insufficient pattern arguments (%s)"
+                                              uu___10 in
+                                          (FStar_Errors_Codes.Fatal_InsufficientPatternArguments,
+                                            uu___9) in
+                                        let uu___9 =
+                                          FStar_Ident.range_of_lid
+                                            (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
+                                        FStar_Errors.raise_error uu___8
+                                          uu___9)) formals
                       | (f1::formals', (p1, p_imp)::pats') ->
                           (match ((f1.FStar_Syntax_Syntax.binder_bv),
                                    (f1.FStar_Syntax_Syntax.binder_qual))
@@ -303,8 +302,7 @@ let (pat_as_exp :
                 (match eopt with
                  | FStar_Pervasives_Native.None ->
                      ((let uu___1 =
-                         FStar_Compiler_Effect.op_Less_Bar
-                           (FStar_TypeChecker_Env.debug env1)
+                         FStar_TypeChecker_Env.debug env1
                            (FStar_Options.Other "Patterns") in
                        if uu___1
                        then
@@ -365,28 +363,27 @@ let (pat_as_exp :
                      ([x1], [x1], [], env2, e, g, p1))
             | FStar_Syntax_Syntax.Pat_cons (fv, us_opt, pats) ->
                 let uu___ =
-                  FStar_Compiler_Effect.op_Bar_Greater pats
-                    (FStar_Compiler_List.fold_left
-                       (fun uu___1 ->
-                          fun uu___2 ->
-                            match (uu___1, uu___2) with
-                            | ((b, a, w, env2, args, guard, pats1),
-                               (p2, imp)) ->
-                                let uu___3 = pat_as_arg_with_env env2 p2 in
-                                (match uu___3 with
-                                 | (b', a', w', env3, te, guard', pat) ->
-                                     let arg =
-                                       if imp
-                                       then FStar_Syntax_Syntax.iarg te
-                                       else FStar_Syntax_Syntax.as_arg te in
-                                     let uu___4 =
-                                       FStar_TypeChecker_Common.conj_guard
-                                         guard guard' in
-                                     ((b' :: b), (a' :: a), (w' :: w), env3,
-                                       (arg :: args), uu___4, ((pat, imp) ::
-                                       pats1))))
-                       ([], [], [], env1, [],
-                         FStar_TypeChecker_Common.trivial_guard, [])) in
+                  FStar_Compiler_List.fold_left
+                    (fun uu___1 ->
+                       fun uu___2 ->
+                         match (uu___1, uu___2) with
+                         | ((b, a, w, env2, args, guard, pats1), (p2, imp))
+                             ->
+                             let uu___3 = pat_as_arg_with_env env2 p2 in
+                             (match uu___3 with
+                              | (b', a', w', env3, te, guard', pat) ->
+                                  let arg =
+                                    if imp
+                                    then FStar_Syntax_Syntax.iarg te
+                                    else FStar_Syntax_Syntax.as_arg te in
+                                  let uu___4 =
+                                    FStar_TypeChecker_Common.conj_guard guard
+                                      guard' in
+                                  ((b' :: b), (a' :: a), (w' :: w), env3,
+                                    (arg :: args), uu___4, ((pat, imp) ::
+                                    pats1))))
+                    ([], [], [], env1, [],
+                      FStar_TypeChecker_Common.trivial_guard, []) pats in
                 (match uu___ with
                  | (b, a, w, env2, args, guard, pats1) ->
                      let inst_head hd us_opt1 =
@@ -418,24 +415,15 @@ let (pat_as_exp :
                      (match uu___1 with
                       | (hd, us_opt1) ->
                           let e =
-                            let uu___2 =
-                              FStar_Compiler_Effect.op_Bar_Greater args
-                                FStar_Compiler_List.rev in
-                            FStar_Syntax_Syntax.mk_Tm_app hd uu___2
+                            FStar_Syntax_Syntax.mk_Tm_app hd
+                              (FStar_Compiler_List.rev args)
                               p1.FStar_Syntax_Syntax.p in
-                          let uu___2 =
-                            FStar_Compiler_Effect.op_Bar_Greater
-                              (FStar_Compiler_List.rev b)
-                              FStar_Compiler_List.flatten in
-                          let uu___3 =
-                            FStar_Compiler_Effect.op_Bar_Greater
-                              (FStar_Compiler_List.rev a)
-                              FStar_Compiler_List.flatten in
-                          let uu___4 =
-                            FStar_Compiler_Effect.op_Bar_Greater
-                              (FStar_Compiler_List.rev w)
-                              FStar_Compiler_List.flatten in
-                          (uu___2, uu___3, uu___4, env2, e, guard,
+                          ((FStar_Compiler_List.flatten
+                              (FStar_Compiler_List.rev b)),
+                            (FStar_Compiler_List.flatten
+                               (FStar_Compiler_List.rev a)),
+                            (FStar_Compiler_List.flatten
+                               (FStar_Compiler_List.rev w)), env2, e, guard,
                             {
                               FStar_Syntax_Syntax.v =
                                 (FStar_Syntax_Syntax.Pat_cons
@@ -450,8 +438,7 @@ let (pat_as_exp :
             match uu___ with
             | (b, a, w, env2, arg, guard, p3) ->
                 let uu___1 =
-                  FStar_Compiler_Effect.op_Bar_Greater b
-                    (FStar_Compiler_Util.find_dup FStar_Syntax_Syntax.bv_eq) in
+                  FStar_Compiler_Util.find_dup FStar_Syntax_Syntax.bv_eq b in
                 (match uu___1 with
                  | FStar_Pervasives_Native.Some x ->
                      let m = FStar_Syntax_Print.bv_to_string x in

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Positivity.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Positivity.ml
@@ -2,15 +2,13 @@ open Prims
 let (string_of_lids : FStar_Ident.lident Prims.list -> Prims.string) =
   fun lids ->
     let uu___ = FStar_Compiler_List.map FStar_Ident.string_of_lid lids in
-    FStar_Compiler_Effect.op_Bar_Greater uu___
-      (FStar_Compiler_String.concat ", ")
+    FStar_Compiler_String.concat ", " uu___
 let (debug_positivity :
   FStar_TypeChecker_Env.env_t -> (unit -> Prims.string) -> unit) =
   fun env ->
     fun msg ->
       let uu___ =
-        FStar_Compiler_Effect.op_Less_Bar (FStar_TypeChecker_Env.debug env)
-          (FStar_Options.Other "Positivity") in
+        FStar_TypeChecker_Env.debug env (FStar_Options.Other "Positivity") in
       if uu___
       then
         let uu___1 =
@@ -210,8 +208,7 @@ let (max_uniformly_recursive_parameters :
           let params_to_string uu___ =
             let uu___1 =
               FStar_Compiler_List.map FStar_Syntax_Print.bv_to_string params in
-            FStar_Compiler_Effect.op_Bar_Greater uu___1
-              (FStar_Compiler_String.concat ", ") in
+            FStar_Compiler_String.concat ", " uu___1 in
           debug_positivity env
             (fun uu___1 ->
                let uu___2 = params_to_string () in
@@ -1066,16 +1063,12 @@ let rec (ty_strictly_positive_in_type :
                        (FStar_Syntax_Util.is_pure_or_ghost_comp c) ||
                          (let uu___7 =
                             let uu___8 =
-                              let uu___9 =
-                                FStar_Compiler_Effect.op_Bar_Greater c
-                                  FStar_Syntax_Util.comp_effect_name in
-                              FStar_Compiler_Effect.op_Bar_Greater uu___9
-                                (FStar_TypeChecker_Env.norm_eff_name env) in
-                            FStar_Compiler_Effect.op_Bar_Greater uu___8
-                              (FStar_TypeChecker_Env.lookup_effect_quals env) in
-                          FStar_Compiler_Effect.op_Bar_Greater uu___7
-                            (FStar_Compiler_List.contains
-                               FStar_Syntax_Syntax.TotalEffect)) in
+                              FStar_TypeChecker_Env.norm_eff_name env
+                                (FStar_Syntax_Util.comp_effect_name c) in
+                            FStar_TypeChecker_Env.lookup_effect_quals env
+                              uu___8 in
+                          FStar_Compiler_List.contains
+                            FStar_Syntax_Syntax.TotalEffect uu___7) in
                      if Prims.op_Negation check_comp
                      then
                        (debug_positivity env

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Primops.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Primops.ml
@@ -138,24 +138,24 @@ let try_unembed_simple :
 let (arg_as_int :
   FStar_Syntax_Syntax.arg -> FStar_BigInt.t FStar_Pervasives_Native.option) =
   fun a ->
-    FStar_Compiler_Effect.op_Bar_Greater (FStar_Pervasives_Native.fst a)
-      (try_unembed_simple FStar_Syntax_Embeddings.e_int)
+    try_unembed_simple FStar_Syntax_Embeddings.e_int
+      (FStar_Pervasives_Native.fst a)
 let (arg_as_bool :
   FStar_Syntax_Syntax.arg -> Prims.bool FStar_Pervasives_Native.option) =
   fun a ->
-    FStar_Compiler_Effect.op_Bar_Greater (FStar_Pervasives_Native.fst a)
-      (try_unembed_simple FStar_Syntax_Embeddings.e_bool)
+    try_unembed_simple FStar_Syntax_Embeddings.e_bool
+      (FStar_Pervasives_Native.fst a)
 let (arg_as_char :
   FStar_Syntax_Syntax.arg -> FStar_Char.char FStar_Pervasives_Native.option)
   =
   fun a ->
-    FStar_Compiler_Effect.op_Bar_Greater (FStar_Pervasives_Native.fst a)
-      (try_unembed_simple FStar_Syntax_Embeddings.e_char)
+    try_unembed_simple FStar_Syntax_Embeddings.e_char
+      (FStar_Pervasives_Native.fst a)
 let (arg_as_string :
   FStar_Syntax_Syntax.arg -> Prims.string FStar_Pervasives_Native.option) =
   fun a ->
-    FStar_Compiler_Effect.op_Bar_Greater (FStar_Pervasives_Native.fst a)
-      (try_unembed_simple FStar_Syntax_Embeddings.e_string)
+    try_unembed_simple FStar_Syntax_Embeddings.e_string
+      (FStar_Pervasives_Native.fst a)
 let arg_as_list :
   'a .
     'a FStar_Syntax_Embeddings_Base.embedding ->
@@ -163,18 +163,15 @@ let arg_as_list :
   =
   fun e ->
     fun a1 ->
-      let uu___ =
-        let uu___1 = FStar_Syntax_Embeddings.e_list e in
-        try_unembed_simple uu___1 in
-      FStar_Compiler_Effect.op_Bar_Greater (FStar_Pervasives_Native.fst a1)
-        uu___
+      let uu___ = FStar_Syntax_Embeddings.e_list e in
+      try_unembed_simple uu___ (FStar_Pervasives_Native.fst a1)
 let (arg_as_doc :
   FStar_Syntax_Syntax.arg ->
     FStar_Pprint.document FStar_Pervasives_Native.option)
   =
   fun a ->
-    FStar_Compiler_Effect.op_Bar_Greater (FStar_Pervasives_Native.fst a)
-      (try_unembed_simple FStar_Syntax_Embeddings.e_document)
+    try_unembed_simple FStar_Syntax_Embeddings.e_document
+      (FStar_Pervasives_Native.fst a)
 let (arg_as_bounded_int :
   FStar_Syntax_Syntax.arg ->
     (FStar_Syntax_Syntax.fv * FStar_BigInt.t *
@@ -516,8 +513,7 @@ let (built_in_primitive_steps_list : primitive_step Prims.list) =
         (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_char c)) rng in
     let uu___ =
       FStar_Compiler_List.map charterm (FStar_String.list_of_string s) in
-    FStar_Compiler_Effect.op_Less_Bar (FStar_Syntax_Util.mk_list char_t rng)
-      uu___ in
+    FStar_Syntax_Util.mk_list char_t rng uu___ in
   let string_of_list' rng l =
     let s = FStar_String.string_of_list l in FStar_Syntax_Util.exp_string s in
   let string_compare' rng s1 s2 =
@@ -926,25 +922,17 @@ let (built_in_primitive_steps_list : primitive_step Prims.list) =
                               let uu___24 =
                                 let u32_int_to_t =
                                   let uu___25 =
-                                    FStar_Compiler_Effect.op_Bar_Greater
-                                      ["FStar"; "UInt32"; "uint_to_t"]
-                                      FStar_Parser_Const.p2l in
-                                  FStar_Compiler_Effect.op_Bar_Greater
-                                    uu___25
-                                    (fun l ->
-                                       FStar_Syntax_Syntax.lid_as_fv l
-                                         FStar_Pervasives_Native.None) in
+                                    FStar_Parser_Const.p2l
+                                      ["FStar"; "UInt32"; "uint_to_t"] in
+                                  FStar_Syntax_Syntax.lid_as_fv uu___25
+                                    FStar_Pervasives_Native.None in
                                 let uu___25 =
                                   FStar_TypeChecker_NBETerm.unary_op
                                     FStar_TypeChecker_NBETerm.arg_as_char
                                     (fun c ->
                                        let uu___26 =
-                                         let uu___27 =
-                                           FStar_Compiler_Effect.op_Bar_Greater
-                                             c
-                                             FStar_Compiler_Util.int_of_char in
-                                         FStar_Compiler_Effect.op_Bar_Greater
-                                           uu___27 FStar_BigInt.of_int_fs in
+                                         FStar_BigInt.of_int_fs
+                                           (FStar_Compiler_Util.int_of_char c) in
                                        FStar_TypeChecker_NBETerm.int_as_bounded
                                          u32_int_to_t uu___26) in
                                 (FStar_Parser_Const.char_u32_of_char,
@@ -953,12 +941,9 @@ let (built_in_primitive_steps_list : primitive_step Prims.list) =
                                      (fun r ->
                                         fun c ->
                                           let uu___26 =
-                                            let uu___27 =
-                                              FStar_Compiler_Effect.op_Bar_Greater
-                                                c
-                                                FStar_Compiler_Util.int_of_char in
-                                            FStar_Compiler_Effect.op_Bar_Greater
-                                              uu___27 FStar_BigInt.of_int_fs in
+                                            FStar_BigInt.of_int_fs
+                                              (FStar_Compiler_Util.int_of_char
+                                                 c) in
                                           int_as_bounded r u32_int_to_t
                                             uu___26)), uu___25) in
                               let uu___25 =
@@ -1251,78 +1236,85 @@ let (built_in_primitive_steps_list : primitive_step Prims.list) =
       ("UInt128", (Prims.of_int (128)));
       ("SizeT", (Prims.of_int (64)))] in
     let add_sub_mul_v_comparisons =
-      FStar_Compiler_Effect.op_Bar_Greater
-        (FStar_Compiler_List.op_At bounded_signed_int_types
-           bounded_unsigned_int_types)
-        (FStar_Compiler_List.collect
-           (fun uu___ ->
-              match uu___ with
-              | (m, uu___1) ->
-                  let uu___2 =
-                    let uu___3 = FStar_Parser_Const.p2l ["FStar"; m; "add"] in
-                    let uu___4 =
-                      FStar_TypeChecker_NBETerm.binary_op
-                        FStar_TypeChecker_NBETerm.arg_as_bounded_int
-                        (fun uu___5 ->
+      FStar_Compiler_List.collect
+        (fun uu___ ->
+           match uu___ with
+           | (m, uu___1) ->
+               let uu___2 =
+                 let uu___3 = FStar_Parser_Const.p2l ["FStar"; m; "add"] in
+                 let uu___4 =
+                   FStar_TypeChecker_NBETerm.binary_op
+                     FStar_TypeChecker_NBETerm.arg_as_bounded_int
+                     (fun uu___5 ->
+                        fun uu___6 ->
+                          match (uu___5, uu___6) with
+                          | ((int_to_t, x, m1), (uu___7, y, uu___8)) ->
+                              let uu___9 =
+                                let uu___10 = FStar_BigInt.add_big_int x y in
+                                FStar_TypeChecker_NBETerm.int_as_bounded
+                                  int_to_t uu___10 in
+                              FStar_TypeChecker_NBETerm.with_meta_ds uu___9
+                                m1) in
+                 (uu___3, (Prims.of_int (2)), Prims.int_zero,
+                   (binary_op arg_as_bounded_int
+                      (fun r ->
+                         fun uu___5 ->
                            fun uu___6 ->
                              match (uu___5, uu___6) with
                              | ((int_to_t, x, m1), (uu___7, y, uu___8)) ->
                                  let uu___9 =
                                    let uu___10 = FStar_BigInt.add_big_int x y in
-                                   FStar_TypeChecker_NBETerm.int_as_bounded
-                                     int_to_t uu___10 in
-                                 FStar_TypeChecker_NBETerm.with_meta_ds
-                                   uu___9 m1) in
-                    (uu___3, (Prims.of_int (2)), Prims.int_zero,
-                      (binary_op arg_as_bounded_int
-                         (fun r ->
-                            fun uu___5 ->
-                              fun uu___6 ->
-                                match (uu___5, uu___6) with
-                                | ((int_to_t, x, m1), (uu___7, y, uu___8)) ->
-                                    let uu___9 =
-                                      let uu___10 =
-                                        FStar_BigInt.add_big_int x y in
-                                      int_as_bounded r int_to_t uu___10 in
-                                    with_meta_ds r uu___9 m1)), uu___4) in
-                  let uu___3 =
-                    let uu___4 =
-                      let uu___5 = FStar_Parser_Const.p2l ["FStar"; m; "sub"] in
-                      let uu___6 =
-                        FStar_TypeChecker_NBETerm.binary_op
-                          FStar_TypeChecker_NBETerm.arg_as_bounded_int
-                          (fun uu___7 ->
+                                   int_as_bounded r int_to_t uu___10 in
+                                 with_meta_ds r uu___9 m1)), uu___4) in
+               let uu___3 =
+                 let uu___4 =
+                   let uu___5 = FStar_Parser_Const.p2l ["FStar"; m; "sub"] in
+                   let uu___6 =
+                     FStar_TypeChecker_NBETerm.binary_op
+                       FStar_TypeChecker_NBETerm.arg_as_bounded_int
+                       (fun uu___7 ->
+                          fun uu___8 ->
+                            match (uu___7, uu___8) with
+                            | ((int_to_t, x, m1), (uu___9, y, uu___10)) ->
+                                let uu___11 =
+                                  let uu___12 = FStar_BigInt.sub_big_int x y in
+                                  FStar_TypeChecker_NBETerm.int_as_bounded
+                                    int_to_t uu___12 in
+                                FStar_TypeChecker_NBETerm.with_meta_ds
+                                  uu___11 m1) in
+                   (uu___5, (Prims.of_int (2)), Prims.int_zero,
+                     (binary_op arg_as_bounded_int
+                        (fun r ->
+                           fun uu___7 ->
                              fun uu___8 ->
                                match (uu___7, uu___8) with
                                | ((int_to_t, x, m1), (uu___9, y, uu___10)) ->
                                    let uu___11 =
                                      let uu___12 =
                                        FStar_BigInt.sub_big_int x y in
-                                     FStar_TypeChecker_NBETerm.int_as_bounded
-                                       int_to_t uu___12 in
-                                   FStar_TypeChecker_NBETerm.with_meta_ds
-                                     uu___11 m1) in
-                      (uu___5, (Prims.of_int (2)), Prims.int_zero,
-                        (binary_op arg_as_bounded_int
-                           (fun r ->
-                              fun uu___7 ->
-                                fun uu___8 ->
-                                  match (uu___7, uu___8) with
-                                  | ((int_to_t, x, m1), (uu___9, y, uu___10))
-                                      ->
-                                      let uu___11 =
-                                        let uu___12 =
-                                          FStar_BigInt.sub_big_int x y in
-                                        int_as_bounded r int_to_t uu___12 in
-                                      with_meta_ds r uu___11 m1)), uu___6) in
-                    let uu___5 =
-                      let uu___6 =
-                        let uu___7 =
-                          FStar_Parser_Const.p2l ["FStar"; m; "mul"] in
-                        let uu___8 =
-                          FStar_TypeChecker_NBETerm.binary_op
-                            FStar_TypeChecker_NBETerm.arg_as_bounded_int
-                            (fun uu___9 ->
+                                     int_as_bounded r int_to_t uu___12 in
+                                   with_meta_ds r uu___11 m1)), uu___6) in
+                 let uu___5 =
+                   let uu___6 =
+                     let uu___7 = FStar_Parser_Const.p2l ["FStar"; m; "mul"] in
+                     let uu___8 =
+                       FStar_TypeChecker_NBETerm.binary_op
+                         FStar_TypeChecker_NBETerm.arg_as_bounded_int
+                         (fun uu___9 ->
+                            fun uu___10 ->
+                              match (uu___9, uu___10) with
+                              | ((int_to_t, x, m1), (uu___11, y, uu___12)) ->
+                                  let uu___13 =
+                                    let uu___14 =
+                                      FStar_BigInt.mult_big_int x y in
+                                    FStar_TypeChecker_NBETerm.int_as_bounded
+                                      int_to_t uu___14 in
+                                  FStar_TypeChecker_NBETerm.with_meta_ds
+                                    uu___13 m1) in
+                     (uu___7, (Prims.of_int (2)), Prims.int_zero,
+                       (binary_op arg_as_bounded_int
+                          (fun r ->
+                             fun uu___9 ->
                                fun uu___10 ->
                                  match (uu___9, uu___10) with
                                  | ((int_to_t, x, m1), (uu___11, y, uu___12))
@@ -1330,57 +1322,57 @@ let (built_in_primitive_steps_list : primitive_step Prims.list) =
                                      let uu___13 =
                                        let uu___14 =
                                          FStar_BigInt.mult_big_int x y in
-                                       FStar_TypeChecker_NBETerm.int_as_bounded
-                                         int_to_t uu___14 in
-                                     FStar_TypeChecker_NBETerm.with_meta_ds
-                                       uu___13 m1) in
-                        (uu___7, (Prims.of_int (2)), Prims.int_zero,
-                          (binary_op arg_as_bounded_int
-                             (fun r ->
-                                fun uu___9 ->
-                                  fun uu___10 ->
-                                    match (uu___9, uu___10) with
-                                    | ((int_to_t, x, m1),
-                                       (uu___11, y, uu___12)) ->
-                                        let uu___13 =
-                                          let uu___14 =
-                                            FStar_BigInt.mult_big_int x y in
-                                          int_as_bounded r int_to_t uu___14 in
-                                        with_meta_ds r uu___13 m1)), uu___8) in
-                      let uu___7 =
-                        let uu___8 =
-                          let uu___9 =
-                            FStar_Parser_Const.p2l ["FStar"; m; "v"] in
-                          let uu___10 =
-                            FStar_TypeChecker_NBETerm.unary_op
-                              FStar_TypeChecker_NBETerm.arg_as_bounded_int
-                              (fun uu___11 ->
+                                       int_as_bounded r int_to_t uu___14 in
+                                     with_meta_ds r uu___13 m1)), uu___8) in
+                   let uu___7 =
+                     let uu___8 =
+                       let uu___9 = FStar_Parser_Const.p2l ["FStar"; m; "v"] in
+                       let uu___10 =
+                         FStar_TypeChecker_NBETerm.unary_op
+                           FStar_TypeChecker_NBETerm.arg_as_bounded_int
+                           (fun uu___11 ->
+                              match uu___11 with
+                              | (int_to_t, x, m1) ->
+                                  let uu___12 =
+                                    FStar_TypeChecker_NBETerm.embed
+                                      FStar_TypeChecker_NBETerm.e_int
+                                      bogus_cbs x in
+                                  FStar_TypeChecker_NBETerm.with_meta_ds
+                                    uu___12 m1) in
+                       (uu___9, Prims.int_one, Prims.int_zero,
+                         (unary_op arg_as_bounded_int
+                            (fun r ->
+                               fun uu___11 ->
                                  match uu___11 with
                                  | (int_to_t, x, m1) ->
                                      let uu___12 =
-                                       FStar_TypeChecker_NBETerm.embed
-                                         FStar_TypeChecker_NBETerm.e_int
-                                         bogus_cbs x in
-                                     FStar_TypeChecker_NBETerm.with_meta_ds
-                                       uu___12 m1) in
-                          (uu___9, Prims.int_one, Prims.int_zero,
-                            (unary_op arg_as_bounded_int
-                               (fun r ->
-                                  fun uu___11 ->
-                                    match uu___11 with
-                                    | (int_to_t, x, m1) ->
-                                        let uu___12 =
-                                          embed_simple
-                                            FStar_Syntax_Embeddings.e_int r x in
-                                        with_meta_ds r uu___12 m1)), uu___10) in
-                        let uu___9 =
-                          let uu___10 =
-                            let uu___11 =
-                              FStar_Parser_Const.p2l ["FStar"; m; "gt"] in
-                            let uu___12 =
-                              FStar_TypeChecker_NBETerm.binary_op
-                                FStar_TypeChecker_NBETerm.arg_as_bounded_int
-                                (fun uu___13 ->
+                                       embed_simple
+                                         FStar_Syntax_Embeddings.e_int r x in
+                                     with_meta_ds r uu___12 m1)), uu___10) in
+                     let uu___9 =
+                       let uu___10 =
+                         let uu___11 =
+                           FStar_Parser_Const.p2l ["FStar"; m; "gt"] in
+                         let uu___12 =
+                           FStar_TypeChecker_NBETerm.binary_op
+                             FStar_TypeChecker_NBETerm.arg_as_bounded_int
+                             (fun uu___13 ->
+                                fun uu___14 ->
+                                  match (uu___13, uu___14) with
+                                  | ((int_to_t, x, m1),
+                                     (uu___15, y, uu___16)) ->
+                                      let uu___17 =
+                                        let uu___18 =
+                                          FStar_BigInt.gt_big_int x y in
+                                        FStar_TypeChecker_NBETerm.embed
+                                          FStar_TypeChecker_NBETerm.e_bool
+                                          bogus_cbs uu___18 in
+                                      FStar_TypeChecker_NBETerm.with_meta_ds
+                                        uu___17 m1) in
+                         (uu___11, (Prims.of_int (2)), Prims.int_zero,
+                           (binary_op arg_as_bounded_int
+                              (fun r ->
+                                 fun uu___13 ->
                                    fun uu___14 ->
                                      match (uu___13, uu___14) with
                                      | ((int_to_t, x, m1),
@@ -1388,35 +1380,35 @@ let (built_in_primitive_steps_list : primitive_step Prims.list) =
                                          let uu___17 =
                                            let uu___18 =
                                              FStar_BigInt.gt_big_int x y in
-                                           FStar_TypeChecker_NBETerm.embed
-                                             FStar_TypeChecker_NBETerm.e_bool
-                                             bogus_cbs uu___18 in
-                                         FStar_TypeChecker_NBETerm.with_meta_ds
-                                           uu___17 m1) in
-                            (uu___11, (Prims.of_int (2)), Prims.int_zero,
-                              (binary_op arg_as_bounded_int
-                                 (fun r ->
-                                    fun uu___13 ->
-                                      fun uu___14 ->
-                                        match (uu___13, uu___14) with
-                                        | ((int_to_t, x, m1),
-                                           (uu___15, y, uu___16)) ->
-                                            let uu___17 =
-                                              let uu___18 =
-                                                FStar_BigInt.gt_big_int x y in
-                                              embed_simple
-                                                FStar_Syntax_Embeddings.e_bool
-                                                r uu___18 in
-                                            with_meta_ds r uu___17 m1)),
-                              uu___12) in
-                          let uu___11 =
-                            let uu___12 =
-                              let uu___13 =
-                                FStar_Parser_Const.p2l ["FStar"; m; "gte"] in
-                              let uu___14 =
-                                FStar_TypeChecker_NBETerm.binary_op
-                                  FStar_TypeChecker_NBETerm.arg_as_bounded_int
-                                  (fun uu___15 ->
+                                           embed_simple
+                                             FStar_Syntax_Embeddings.e_bool r
+                                             uu___18 in
+                                         with_meta_ds r uu___17 m1)),
+                           uu___12) in
+                       let uu___11 =
+                         let uu___12 =
+                           let uu___13 =
+                             FStar_Parser_Const.p2l ["FStar"; m; "gte"] in
+                           let uu___14 =
+                             FStar_TypeChecker_NBETerm.binary_op
+                               FStar_TypeChecker_NBETerm.arg_as_bounded_int
+                               (fun uu___15 ->
+                                  fun uu___16 ->
+                                    match (uu___15, uu___16) with
+                                    | ((int_to_t, x, m1),
+                                       (uu___17, y, uu___18)) ->
+                                        let uu___19 =
+                                          let uu___20 =
+                                            FStar_BigInt.ge_big_int x y in
+                                          FStar_TypeChecker_NBETerm.embed
+                                            FStar_TypeChecker_NBETerm.e_bool
+                                            bogus_cbs uu___20 in
+                                        FStar_TypeChecker_NBETerm.with_meta_ds
+                                          uu___19 m1) in
+                           (uu___13, (Prims.of_int (2)), Prims.int_zero,
+                             (binary_op arg_as_bounded_int
+                                (fun r ->
+                                   fun uu___15 ->
                                      fun uu___16 ->
                                        match (uu___15, uu___16) with
                                        | ((int_to_t, x, m1),
@@ -1424,35 +1416,35 @@ let (built_in_primitive_steps_list : primitive_step Prims.list) =
                                            let uu___19 =
                                              let uu___20 =
                                                FStar_BigInt.ge_big_int x y in
-                                             FStar_TypeChecker_NBETerm.embed
-                                               FStar_TypeChecker_NBETerm.e_bool
-                                               bogus_cbs uu___20 in
-                                           FStar_TypeChecker_NBETerm.with_meta_ds
-                                             uu___19 m1) in
-                              (uu___13, (Prims.of_int (2)), Prims.int_zero,
-                                (binary_op arg_as_bounded_int
-                                   (fun r ->
-                                      fun uu___15 ->
-                                        fun uu___16 ->
-                                          match (uu___15, uu___16) with
-                                          | ((int_to_t, x, m1),
-                                             (uu___17, y, uu___18)) ->
-                                              let uu___19 =
-                                                let uu___20 =
-                                                  FStar_BigInt.ge_big_int x y in
-                                                embed_simple
-                                                  FStar_Syntax_Embeddings.e_bool
-                                                  r uu___20 in
-                                              with_meta_ds r uu___19 m1)),
-                                uu___14) in
-                            let uu___13 =
-                              let uu___14 =
-                                let uu___15 =
-                                  FStar_Parser_Const.p2l ["FStar"; m; "lt"] in
-                                let uu___16 =
-                                  FStar_TypeChecker_NBETerm.binary_op
-                                    FStar_TypeChecker_NBETerm.arg_as_bounded_int
-                                    (fun uu___17 ->
+                                             embed_simple
+                                               FStar_Syntax_Embeddings.e_bool
+                                               r uu___20 in
+                                           with_meta_ds r uu___19 m1)),
+                             uu___14) in
+                         let uu___13 =
+                           let uu___14 =
+                             let uu___15 =
+                               FStar_Parser_Const.p2l ["FStar"; m; "lt"] in
+                             let uu___16 =
+                               FStar_TypeChecker_NBETerm.binary_op
+                                 FStar_TypeChecker_NBETerm.arg_as_bounded_int
+                                 (fun uu___17 ->
+                                    fun uu___18 ->
+                                      match (uu___17, uu___18) with
+                                      | ((int_to_t, x, m1),
+                                         (uu___19, y, uu___20)) ->
+                                          let uu___21 =
+                                            let uu___22 =
+                                              FStar_BigInt.lt_big_int x y in
+                                            FStar_TypeChecker_NBETerm.embed
+                                              FStar_TypeChecker_NBETerm.e_bool
+                                              bogus_cbs uu___22 in
+                                          FStar_TypeChecker_NBETerm.with_meta_ds
+                                            uu___21 m1) in
+                             (uu___15, (Prims.of_int (2)), Prims.int_zero,
+                               (binary_op arg_as_bounded_int
+                                  (fun r ->
+                                     fun uu___17 ->
                                        fun uu___18 ->
                                          match (uu___17, uu___18) with
                                          | ((int_to_t, x, m1),
@@ -1460,37 +1452,35 @@ let (built_in_primitive_steps_list : primitive_step Prims.list) =
                                              let uu___21 =
                                                let uu___22 =
                                                  FStar_BigInt.lt_big_int x y in
-                                               FStar_TypeChecker_NBETerm.embed
-                                                 FStar_TypeChecker_NBETerm.e_bool
-                                                 bogus_cbs uu___22 in
-                                             FStar_TypeChecker_NBETerm.with_meta_ds
-                                               uu___21 m1) in
-                                (uu___15, (Prims.of_int (2)), Prims.int_zero,
-                                  (binary_op arg_as_bounded_int
-                                     (fun r ->
-                                        fun uu___17 ->
-                                          fun uu___18 ->
-                                            match (uu___17, uu___18) with
-                                            | ((int_to_t, x, m1),
-                                               (uu___19, y, uu___20)) ->
-                                                let uu___21 =
-                                                  let uu___22 =
-                                                    FStar_BigInt.lt_big_int x
-                                                      y in
-                                                  embed_simple
-                                                    FStar_Syntax_Embeddings.e_bool
-                                                    r uu___22 in
-                                                with_meta_ds r uu___21 m1)),
-                                  uu___16) in
-                              let uu___15 =
-                                let uu___16 =
-                                  let uu___17 =
-                                    FStar_Parser_Const.p2l
-                                      ["FStar"; m; "lte"] in
-                                  let uu___18 =
-                                    FStar_TypeChecker_NBETerm.binary_op
-                                      FStar_TypeChecker_NBETerm.arg_as_bounded_int
-                                      (fun uu___19 ->
+                                               embed_simple
+                                                 FStar_Syntax_Embeddings.e_bool
+                                                 r uu___22 in
+                                             with_meta_ds r uu___21 m1)),
+                               uu___16) in
+                           let uu___15 =
+                             let uu___16 =
+                               let uu___17 =
+                                 FStar_Parser_Const.p2l ["FStar"; m; "lte"] in
+                               let uu___18 =
+                                 FStar_TypeChecker_NBETerm.binary_op
+                                   FStar_TypeChecker_NBETerm.arg_as_bounded_int
+                                   (fun uu___19 ->
+                                      fun uu___20 ->
+                                        match (uu___19, uu___20) with
+                                        | ((int_to_t, x, m1),
+                                           (uu___21, y, uu___22)) ->
+                                            let uu___23 =
+                                              let uu___24 =
+                                                FStar_BigInt.le_big_int x y in
+                                              FStar_TypeChecker_NBETerm.embed
+                                                FStar_TypeChecker_NBETerm.e_bool
+                                                bogus_cbs uu___24 in
+                                            FStar_TypeChecker_NBETerm.with_meta_ds
+                                              uu___23 m1) in
+                               (uu___17, (Prims.of_int (2)), Prims.int_zero,
+                                 (binary_op arg_as_bounded_int
+                                    (fun r ->
+                                       fun uu___19 ->
                                          fun uu___20 ->
                                            match (uu___19, uu___20) with
                                            | ((int_to_t, x, m1),
@@ -1499,91 +1489,37 @@ let (built_in_primitive_steps_list : primitive_step Prims.list) =
                                                  let uu___24 =
                                                    FStar_BigInt.le_big_int x
                                                      y in
-                                                 FStar_TypeChecker_NBETerm.embed
-                                                   FStar_TypeChecker_NBETerm.e_bool
-                                                   bogus_cbs uu___24 in
-                                               FStar_TypeChecker_NBETerm.with_meta_ds
-                                                 uu___23 m1) in
-                                  (uu___17, (Prims.of_int (2)),
-                                    Prims.int_zero,
-                                    (binary_op arg_as_bounded_int
-                                       (fun r ->
-                                          fun uu___19 ->
-                                            fun uu___20 ->
-                                              match (uu___19, uu___20) with
-                                              | ((int_to_t, x, m1),
-                                                 (uu___21, y, uu___22)) ->
-                                                  let uu___23 =
-                                                    let uu___24 =
-                                                      FStar_BigInt.le_big_int
-                                                        x y in
-                                                    embed_simple
-                                                      FStar_Syntax_Embeddings.e_bool
-                                                      r uu___24 in
-                                                  with_meta_ds r uu___23 m1)),
-                                    uu___18) in
-                                [uu___16] in
-                              uu___14 :: uu___15 in
-                            uu___12 :: uu___13 in
-                          uu___10 :: uu___11 in
-                        uu___8 :: uu___9 in
-                      uu___6 :: uu___7 in
-                    uu___4 :: uu___5 in
-                  uu___2 :: uu___3)) in
+                                                 embed_simple
+                                                   FStar_Syntax_Embeddings.e_bool
+                                                   r uu___24 in
+                                               with_meta_ds r uu___23 m1)),
+                                 uu___18) in
+                             [uu___16] in
+                           uu___14 :: uu___15 in
+                         uu___12 :: uu___13 in
+                       uu___10 :: uu___11 in
+                     uu___8 :: uu___9 in
+                   uu___6 :: uu___7 in
+                 uu___4 :: uu___5 in
+               uu___2 :: uu___3)
+        (FStar_Compiler_List.op_At bounded_signed_int_types
+           bounded_unsigned_int_types) in
     let unsigned_modulo_add_sub_mul_div_rem =
-      FStar_Compiler_Effect.op_Bar_Greater bounded_unsigned_int_types
-        (FStar_Compiler_List.collect
-           (fun uu___ ->
-              match uu___ with
-              | (m, sz) ->
-                  let modulus =
-                    let uu___1 = FStar_BigInt.of_int_fs sz in
-                    FStar_BigInt.shift_left_big_int FStar_BigInt.one uu___1 in
-                  let mod1 x = FStar_BigInt.mod_big_int x modulus in
-                  let uu___1 =
-                    if sz = (Prims.of_int (128))
-                    then []
-                    else
-                      (let uu___3 =
-                         let uu___4 =
-                           FStar_Parser_Const.p2l ["FStar"; m; "mul_mod"] in
-                         let uu___5 =
-                           FStar_TypeChecker_NBETerm.binary_op
-                             FStar_TypeChecker_NBETerm.arg_as_bounded_int
-                             (fun uu___6 ->
-                                fun uu___7 ->
-                                  match (uu___6, uu___7) with
-                                  | ((int_to_t, x, m1), (uu___8, y, uu___9))
-                                      ->
-                                      let uu___10 =
-                                        let uu___11 =
-                                          let uu___12 =
-                                            FStar_BigInt.mult_big_int x y in
-                                          mod1 uu___12 in
-                                        FStar_TypeChecker_NBETerm.int_as_bounded
-                                          int_to_t uu___11 in
-                                      FStar_TypeChecker_NBETerm.with_meta_ds
-                                        uu___10 m1) in
-                         (uu___4, (Prims.of_int (2)), Prims.int_zero,
-                           (binary_op arg_as_bounded_int
-                              (fun r ->
-                                 fun uu___6 ->
-                                   fun uu___7 ->
-                                     match (uu___6, uu___7) with
-                                     | ((int_to_t, x, m1),
-                                        (uu___8, y, uu___9)) ->
-                                         let uu___10 =
-                                           let uu___11 =
-                                             let uu___12 =
-                                               FStar_BigInt.mult_big_int x y in
-                                             mod1 uu___12 in
-                                           int_as_bounded r int_to_t uu___11 in
-                                         with_meta_ds r uu___10 m1)), uu___5) in
-                       [uu___3]) in
-                  let uu___2 =
-                    let uu___3 =
+      FStar_Compiler_List.collect
+        (fun uu___ ->
+           match uu___ with
+           | (m, sz) ->
+               let modulus =
+                 let uu___1 = FStar_BigInt.of_int_fs sz in
+                 FStar_BigInt.shift_left_big_int FStar_BigInt.one uu___1 in
+               let mod1 x = FStar_BigInt.mod_big_int x modulus in
+               let uu___1 =
+                 if sz = (Prims.of_int (128))
+                 then []
+                 else
+                   (let uu___3 =
                       let uu___4 =
-                        FStar_Parser_Const.p2l ["FStar"; m; "add_mod"] in
+                        FStar_Parser_Const.p2l ["FStar"; m; "mul_mod"] in
                       let uu___5 =
                         FStar_TypeChecker_NBETerm.binary_op
                           FStar_TypeChecker_NBETerm.arg_as_bounded_int
@@ -1594,7 +1530,7 @@ let (built_in_primitive_steps_list : primitive_step Prims.list) =
                                    let uu___10 =
                                      let uu___11 =
                                        let uu___12 =
-                                         FStar_BigInt.add_big_int x y in
+                                         FStar_BigInt.mult_big_int x y in
                                        mod1 uu___12 in
                                      FStar_TypeChecker_NBETerm.int_as_bounded
                                        int_to_t uu___11 in
@@ -1611,18 +1547,69 @@ let (built_in_primitive_steps_list : primitive_step Prims.list) =
                                       let uu___10 =
                                         let uu___11 =
                                           let uu___12 =
-                                            FStar_BigInt.add_big_int x y in
+                                            FStar_BigInt.mult_big_int x y in
                                           mod1 uu___12 in
                                         int_as_bounded r int_to_t uu___11 in
                                       with_meta_ds r uu___10 m1)), uu___5) in
-                    let uu___4 =
-                      let uu___5 =
-                        let uu___6 =
-                          FStar_Parser_Const.p2l ["FStar"; m; "sub_mod"] in
-                        let uu___7 =
-                          FStar_TypeChecker_NBETerm.binary_op
-                            FStar_TypeChecker_NBETerm.arg_as_bounded_int
-                            (fun uu___8 ->
+                    [uu___3]) in
+               let uu___2 =
+                 let uu___3 =
+                   let uu___4 =
+                     FStar_Parser_Const.p2l ["FStar"; m; "add_mod"] in
+                   let uu___5 =
+                     FStar_TypeChecker_NBETerm.binary_op
+                       FStar_TypeChecker_NBETerm.arg_as_bounded_int
+                       (fun uu___6 ->
+                          fun uu___7 ->
+                            match (uu___6, uu___7) with
+                            | ((int_to_t, x, m1), (uu___8, y, uu___9)) ->
+                                let uu___10 =
+                                  let uu___11 =
+                                    let uu___12 =
+                                      FStar_BigInt.add_big_int x y in
+                                    mod1 uu___12 in
+                                  FStar_TypeChecker_NBETerm.int_as_bounded
+                                    int_to_t uu___11 in
+                                FStar_TypeChecker_NBETerm.with_meta_ds
+                                  uu___10 m1) in
+                   (uu___4, (Prims.of_int (2)), Prims.int_zero,
+                     (binary_op arg_as_bounded_int
+                        (fun r ->
+                           fun uu___6 ->
+                             fun uu___7 ->
+                               match (uu___6, uu___7) with
+                               | ((int_to_t, x, m1), (uu___8, y, uu___9)) ->
+                                   let uu___10 =
+                                     let uu___11 =
+                                       let uu___12 =
+                                         FStar_BigInt.add_big_int x y in
+                                       mod1 uu___12 in
+                                     int_as_bounded r int_to_t uu___11 in
+                                   with_meta_ds r uu___10 m1)), uu___5) in
+                 let uu___4 =
+                   let uu___5 =
+                     let uu___6 =
+                       FStar_Parser_Const.p2l ["FStar"; m; "sub_mod"] in
+                     let uu___7 =
+                       FStar_TypeChecker_NBETerm.binary_op
+                         FStar_TypeChecker_NBETerm.arg_as_bounded_int
+                         (fun uu___8 ->
+                            fun uu___9 ->
+                              match (uu___8, uu___9) with
+                              | ((int_to_t, x, m1), (uu___10, y, uu___11)) ->
+                                  let uu___12 =
+                                    let uu___13 =
+                                      let uu___14 =
+                                        FStar_BigInt.sub_big_int x y in
+                                      mod1 uu___14 in
+                                    FStar_TypeChecker_NBETerm.int_as_bounded
+                                      int_to_t uu___13 in
+                                  FStar_TypeChecker_NBETerm.with_meta_ds
+                                    uu___12 m1) in
+                     (uu___6, (Prims.of_int (2)), Prims.int_zero,
+                       (binary_op arg_as_bounded_int
+                          (fun r ->
+                             fun uu___8 ->
                                fun uu___9 ->
                                  match (uu___8, uu___9) with
                                  | ((int_to_t, x, m1), (uu___10, y, uu___11))
@@ -1632,33 +1619,31 @@ let (built_in_primitive_steps_list : primitive_step Prims.list) =
                                          let uu___14 =
                                            FStar_BigInt.sub_big_int x y in
                                          mod1 uu___14 in
-                                       FStar_TypeChecker_NBETerm.int_as_bounded
-                                         int_to_t uu___13 in
-                                     FStar_TypeChecker_NBETerm.with_meta_ds
-                                       uu___12 m1) in
-                        (uu___6, (Prims.of_int (2)), Prims.int_zero,
-                          (binary_op arg_as_bounded_int
-                             (fun r ->
-                                fun uu___8 ->
-                                  fun uu___9 ->
-                                    match (uu___8, uu___9) with
-                                    | ((int_to_t, x, m1),
-                                       (uu___10, y, uu___11)) ->
-                                        let uu___12 =
-                                          let uu___13 =
-                                            let uu___14 =
-                                              FStar_BigInt.sub_big_int x y in
-                                            mod1 uu___14 in
-                                          int_as_bounded r int_to_t uu___13 in
-                                        with_meta_ds r uu___12 m1)), uu___7) in
-                      let uu___6 =
-                        let uu___7 =
-                          let uu___8 =
-                            FStar_Parser_Const.p2l ["FStar"; m; "div"] in
-                          let uu___9 =
-                            FStar_TypeChecker_NBETerm.binary_op
-                              FStar_TypeChecker_NBETerm.arg_as_bounded_int
-                              (fun uu___10 ->
+                                       int_as_bounded r int_to_t uu___13 in
+                                     with_meta_ds r uu___12 m1)), uu___7) in
+                   let uu___6 =
+                     let uu___7 =
+                       let uu___8 =
+                         FStar_Parser_Const.p2l ["FStar"; m; "div"] in
+                       let uu___9 =
+                         FStar_TypeChecker_NBETerm.binary_op
+                           FStar_TypeChecker_NBETerm.arg_as_bounded_int
+                           (fun uu___10 ->
+                              fun uu___11 ->
+                                match (uu___10, uu___11) with
+                                | ((int_to_t, x, m1), (uu___12, y, uu___13))
+                                    ->
+                                    let uu___14 =
+                                      let uu___15 =
+                                        FStar_BigInt.div_big_int x y in
+                                      FStar_TypeChecker_NBETerm.int_as_bounded
+                                        int_to_t uu___15 in
+                                    FStar_TypeChecker_NBETerm.with_meta_ds
+                                      uu___14 m1) in
+                       (uu___8, (Prims.of_int (2)), Prims.int_zero,
+                         (binary_op arg_as_bounded_int
+                            (fun r ->
+                               fun uu___10 ->
                                  fun uu___11 ->
                                    match (uu___10, uu___11) with
                                    | ((int_to_t, x, m1),
@@ -1666,32 +1651,31 @@ let (built_in_primitive_steps_list : primitive_step Prims.list) =
                                        let uu___14 =
                                          let uu___15 =
                                            FStar_BigInt.div_big_int x y in
-                                         FStar_TypeChecker_NBETerm.int_as_bounded
-                                           int_to_t uu___15 in
-                                       FStar_TypeChecker_NBETerm.with_meta_ds
-                                         uu___14 m1) in
-                          (uu___8, (Prims.of_int (2)), Prims.int_zero,
-                            (binary_op arg_as_bounded_int
-                               (fun r ->
-                                  fun uu___10 ->
-                                    fun uu___11 ->
-                                      match (uu___10, uu___11) with
-                                      | ((int_to_t, x, m1),
-                                         (uu___12, y, uu___13)) ->
-                                          let uu___14 =
-                                            let uu___15 =
-                                              FStar_BigInt.div_big_int x y in
-                                            int_as_bounded r int_to_t uu___15 in
-                                          with_meta_ds r uu___14 m1)),
-                            uu___9) in
-                        let uu___8 =
-                          let uu___9 =
-                            let uu___10 =
-                              FStar_Parser_Const.p2l ["FStar"; m; "rem"] in
-                            let uu___11 =
-                              FStar_TypeChecker_NBETerm.binary_op
-                                FStar_TypeChecker_NBETerm.arg_as_bounded_int
-                                (fun uu___12 ->
+                                         int_as_bounded r int_to_t uu___15 in
+                                       with_meta_ds r uu___14 m1)), uu___9) in
+                     let uu___8 =
+                       let uu___9 =
+                         let uu___10 =
+                           FStar_Parser_Const.p2l ["FStar"; m; "rem"] in
+                         let uu___11 =
+                           FStar_TypeChecker_NBETerm.binary_op
+                             FStar_TypeChecker_NBETerm.arg_as_bounded_int
+                             (fun uu___12 ->
+                                fun uu___13 ->
+                                  match (uu___12, uu___13) with
+                                  | ((int_to_t, x, m1),
+                                     (uu___14, y, uu___15)) ->
+                                      let uu___16 =
+                                        let uu___17 =
+                                          FStar_BigInt.mod_big_int x y in
+                                        FStar_TypeChecker_NBETerm.int_as_bounded
+                                          int_to_t uu___17 in
+                                      FStar_TypeChecker_NBETerm.with_meta_ds
+                                        uu___16 m1) in
+                         (uu___10, (Prims.of_int (2)), Prims.int_zero,
+                           (binary_op arg_as_bounded_int
+                              (fun r ->
+                                 fun uu___12 ->
                                    fun uu___13 ->
                                      match (uu___12, uu___13) with
                                      | ((int_to_t, x, m1),
@@ -1699,30 +1683,15 @@ let (built_in_primitive_steps_list : primitive_step Prims.list) =
                                          let uu___16 =
                                            let uu___17 =
                                              FStar_BigInt.mod_big_int x y in
-                                           FStar_TypeChecker_NBETerm.int_as_bounded
-                                             int_to_t uu___17 in
-                                         FStar_TypeChecker_NBETerm.with_meta_ds
-                                           uu___16 m1) in
-                            (uu___10, (Prims.of_int (2)), Prims.int_zero,
-                              (binary_op arg_as_bounded_int
-                                 (fun r ->
-                                    fun uu___12 ->
-                                      fun uu___13 ->
-                                        match (uu___12, uu___13) with
-                                        | ((int_to_t, x, m1),
-                                           (uu___14, y, uu___15)) ->
-                                            let uu___16 =
-                                              let uu___17 =
-                                                FStar_BigInt.mod_big_int x y in
-                                              int_as_bounded r int_to_t
-                                                uu___17 in
-                                            with_meta_ds r uu___16 m1)),
-                              uu___11) in
-                          [uu___9] in
-                        uu___7 :: uu___8 in
-                      uu___5 :: uu___6 in
-                    uu___3 :: uu___4 in
-                  FStar_Compiler_List.op_At uu___1 uu___2)) in
+                                           int_as_bounded r int_to_t uu___17 in
+                                         with_meta_ds r uu___16 m1)),
+                           uu___11) in
+                       [uu___9] in
+                     uu___7 :: uu___8 in
+                   uu___5 :: uu___6 in
+                 uu___3 :: uu___4 in
+               FStar_Compiler_List.op_At uu___1 uu___2)
+        bounded_unsigned_int_types in
     let mask m =
       match m with
       | "UInt8" -> FStar_BigInt.of_hex "ff"
@@ -1736,78 +1705,88 @@ let (built_in_primitive_steps_list : primitive_step Prims.list) =
               "Impossible: bad string on mask: %s\n" m in
           FStar_Compiler_Effect.failwith uu___1 in
     let bitwise =
-      FStar_Compiler_Effect.op_Bar_Greater bounded_unsigned_int_types
-        (FStar_Compiler_List.collect
-           (fun uu___ ->
-              match uu___ with
-              | (m, uu___1) ->
-                  let uu___2 =
-                    let uu___3 = FStar_Parser_Const.p2l ["FStar"; m; "logor"] in
-                    let uu___4 =
-                      FStar_TypeChecker_NBETerm.binary_op
-                        FStar_TypeChecker_NBETerm.arg_as_bounded_int
-                        (fun uu___5 ->
+      FStar_Compiler_List.collect
+        (fun uu___ ->
+           match uu___ with
+           | (m, uu___1) ->
+               let uu___2 =
+                 let uu___3 = FStar_Parser_Const.p2l ["FStar"; m; "logor"] in
+                 let uu___4 =
+                   FStar_TypeChecker_NBETerm.binary_op
+                     FStar_TypeChecker_NBETerm.arg_as_bounded_int
+                     (fun uu___5 ->
+                        fun uu___6 ->
+                          match (uu___5, uu___6) with
+                          | ((int_to_t, x, m1), (uu___7, y, uu___8)) ->
+                              let uu___9 =
+                                let uu___10 = FStar_BigInt.logor_big_int x y in
+                                FStar_TypeChecker_NBETerm.int_as_bounded
+                                  int_to_t uu___10 in
+                              FStar_TypeChecker_NBETerm.with_meta_ds uu___9
+                                m1) in
+                 (uu___3, (Prims.of_int (2)), Prims.int_zero,
+                   (binary_op arg_as_bounded_int
+                      (fun r ->
+                         fun uu___5 ->
                            fun uu___6 ->
                              match (uu___5, uu___6) with
                              | ((int_to_t, x, m1), (uu___7, y, uu___8)) ->
                                  let uu___9 =
                                    let uu___10 =
                                      FStar_BigInt.logor_big_int x y in
-                                   FStar_TypeChecker_NBETerm.int_as_bounded
-                                     int_to_t uu___10 in
-                                 FStar_TypeChecker_NBETerm.with_meta_ds
-                                   uu___9 m1) in
-                    (uu___3, (Prims.of_int (2)), Prims.int_zero,
-                      (binary_op arg_as_bounded_int
-                         (fun r ->
-                            fun uu___5 ->
-                              fun uu___6 ->
-                                match (uu___5, uu___6) with
-                                | ((int_to_t, x, m1), (uu___7, y, uu___8)) ->
-                                    let uu___9 =
-                                      let uu___10 =
-                                        FStar_BigInt.logor_big_int x y in
-                                      int_as_bounded r int_to_t uu___10 in
-                                    with_meta_ds r uu___9 m1)), uu___4) in
-                  let uu___3 =
-                    let uu___4 =
-                      let uu___5 =
-                        FStar_Parser_Const.p2l ["FStar"; m; "logand"] in
-                      let uu___6 =
-                        FStar_TypeChecker_NBETerm.binary_op
-                          FStar_TypeChecker_NBETerm.arg_as_bounded_int
-                          (fun uu___7 ->
+                                   int_as_bounded r int_to_t uu___10 in
+                                 with_meta_ds r uu___9 m1)), uu___4) in
+               let uu___3 =
+                 let uu___4 =
+                   let uu___5 = FStar_Parser_Const.p2l ["FStar"; m; "logand"] in
+                   let uu___6 =
+                     FStar_TypeChecker_NBETerm.binary_op
+                       FStar_TypeChecker_NBETerm.arg_as_bounded_int
+                       (fun uu___7 ->
+                          fun uu___8 ->
+                            match (uu___7, uu___8) with
+                            | ((int_to_t, x, m1), (uu___9, y, uu___10)) ->
+                                let uu___11 =
+                                  let uu___12 =
+                                    FStar_BigInt.logand_big_int x y in
+                                  FStar_TypeChecker_NBETerm.int_as_bounded
+                                    int_to_t uu___12 in
+                                FStar_TypeChecker_NBETerm.with_meta_ds
+                                  uu___11 m1) in
+                   (uu___5, (Prims.of_int (2)), Prims.int_zero,
+                     (binary_op arg_as_bounded_int
+                        (fun r ->
+                           fun uu___7 ->
                              fun uu___8 ->
                                match (uu___7, uu___8) with
                                | ((int_to_t, x, m1), (uu___9, y, uu___10)) ->
                                    let uu___11 =
                                      let uu___12 =
                                        FStar_BigInt.logand_big_int x y in
-                                     FStar_TypeChecker_NBETerm.int_as_bounded
-                                       int_to_t uu___12 in
-                                   FStar_TypeChecker_NBETerm.with_meta_ds
-                                     uu___11 m1) in
-                      (uu___5, (Prims.of_int (2)), Prims.int_zero,
-                        (binary_op arg_as_bounded_int
-                           (fun r ->
-                              fun uu___7 ->
-                                fun uu___8 ->
-                                  match (uu___7, uu___8) with
-                                  | ((int_to_t, x, m1), (uu___9, y, uu___10))
-                                      ->
-                                      let uu___11 =
-                                        let uu___12 =
-                                          FStar_BigInt.logand_big_int x y in
-                                        int_as_bounded r int_to_t uu___12 in
-                                      with_meta_ds r uu___11 m1)), uu___6) in
-                    let uu___5 =
-                      let uu___6 =
-                        let uu___7 =
-                          FStar_Parser_Const.p2l ["FStar"; m; "logxor"] in
-                        let uu___8 =
-                          FStar_TypeChecker_NBETerm.binary_op
-                            FStar_TypeChecker_NBETerm.arg_as_bounded_int
-                            (fun uu___9 ->
+                                     int_as_bounded r int_to_t uu___12 in
+                                   with_meta_ds r uu___11 m1)), uu___6) in
+                 let uu___5 =
+                   let uu___6 =
+                     let uu___7 =
+                       FStar_Parser_Const.p2l ["FStar"; m; "logxor"] in
+                     let uu___8 =
+                       FStar_TypeChecker_NBETerm.binary_op
+                         FStar_TypeChecker_NBETerm.arg_as_bounded_int
+                         (fun uu___9 ->
+                            fun uu___10 ->
+                              match (uu___9, uu___10) with
+                              | ((int_to_t, x, m1), (uu___11, y, uu___12)) ->
+                                  let uu___13 =
+                                    let uu___14 =
+                                      FStar_BigInt.logxor_big_int x y in
+                                    FStar_TypeChecker_NBETerm.int_as_bounded
+                                      int_to_t uu___14 in
+                                  FStar_TypeChecker_NBETerm.with_meta_ds
+                                    uu___13 m1) in
+                     (uu___7, (Prims.of_int (2)), Prims.int_zero,
+                       (binary_op arg_as_bounded_int
+                          (fun r ->
+                             fun uu___9 ->
                                fun uu___10 ->
                                  match (uu___9, uu___10) with
                                  | ((int_to_t, x, m1), (uu___11, y, uu___12))
@@ -1815,31 +1794,33 @@ let (built_in_primitive_steps_list : primitive_step Prims.list) =
                                      let uu___13 =
                                        let uu___14 =
                                          FStar_BigInt.logxor_big_int x y in
-                                       FStar_TypeChecker_NBETerm.int_as_bounded
-                                         int_to_t uu___14 in
-                                     FStar_TypeChecker_NBETerm.with_meta_ds
-                                       uu___13 m1) in
-                        (uu___7, (Prims.of_int (2)), Prims.int_zero,
-                          (binary_op arg_as_bounded_int
-                             (fun r ->
-                                fun uu___9 ->
-                                  fun uu___10 ->
-                                    match (uu___9, uu___10) with
-                                    | ((int_to_t, x, m1),
-                                       (uu___11, y, uu___12)) ->
-                                        let uu___13 =
-                                          let uu___14 =
-                                            FStar_BigInt.logxor_big_int x y in
-                                          int_as_bounded r int_to_t uu___14 in
-                                        with_meta_ds r uu___13 m1)), uu___8) in
-                      let uu___7 =
-                        let uu___8 =
-                          let uu___9 =
-                            FStar_Parser_Const.p2l ["FStar"; m; "lognot"] in
-                          let uu___10 =
-                            FStar_TypeChecker_NBETerm.unary_op
-                              FStar_TypeChecker_NBETerm.arg_as_bounded_int
-                              (fun uu___11 ->
+                                       int_as_bounded r int_to_t uu___14 in
+                                     with_meta_ds r uu___13 m1)), uu___8) in
+                   let uu___7 =
+                     let uu___8 =
+                       let uu___9 =
+                         FStar_Parser_Const.p2l ["FStar"; m; "lognot"] in
+                       let uu___10 =
+                         FStar_TypeChecker_NBETerm.unary_op
+                           FStar_TypeChecker_NBETerm.arg_as_bounded_int
+                           (fun uu___11 ->
+                              match uu___11 with
+                              | (int_to_t, x, d) ->
+                                  let uu___12 =
+                                    let uu___13 =
+                                      let uu___14 =
+                                        FStar_BigInt.lognot_big_int x in
+                                      let uu___15 = mask m in
+                                      FStar_BigInt.logand_big_int uu___14
+                                        uu___15 in
+                                    FStar_TypeChecker_NBETerm.int_as_bounded
+                                      int_to_t uu___13 in
+                                  FStar_TypeChecker_NBETerm.with_meta_ds
+                                    uu___12 d) in
+                       (uu___9, Prims.int_one, Prims.int_zero,
+                         (unary_op arg_as_bounded_int
+                            (fun r ->
+                               fun uu___11 ->
                                  match uu___11 with
                                  | (int_to_t, x, d) ->
                                      let uu___12 =
@@ -1849,34 +1830,36 @@ let (built_in_primitive_steps_list : primitive_step Prims.list) =
                                          let uu___15 = mask m in
                                          FStar_BigInt.logand_big_int uu___14
                                            uu___15 in
-                                       FStar_TypeChecker_NBETerm.int_as_bounded
-                                         int_to_t uu___13 in
-                                     FStar_TypeChecker_NBETerm.with_meta_ds
-                                       uu___12 d) in
-                          (uu___9, Prims.int_one, Prims.int_zero,
-                            (unary_op arg_as_bounded_int
-                               (fun r ->
-                                  fun uu___11 ->
-                                    match uu___11 with
-                                    | (int_to_t, x, d) ->
-                                        let uu___12 =
-                                          let uu___13 =
-                                            let uu___14 =
-                                              FStar_BigInt.lognot_big_int x in
-                                            let uu___15 = mask m in
-                                            FStar_BigInt.logand_big_int
-                                              uu___14 uu___15 in
-                                          int_as_bounded r int_to_t uu___13 in
-                                        with_meta_ds r uu___12 d)), uu___10) in
-                        let uu___9 =
-                          let uu___10 =
-                            let uu___11 =
-                              FStar_Parser_Const.p2l
-                                ["FStar"; m; "shift_left"] in
-                            let uu___12 =
-                              FStar_TypeChecker_NBETerm.binary_op
-                                FStar_TypeChecker_NBETerm.arg_as_bounded_int
-                                (fun uu___13 ->
+                                       int_as_bounded r int_to_t uu___13 in
+                                     with_meta_ds r uu___12 d)), uu___10) in
+                     let uu___9 =
+                       let uu___10 =
+                         let uu___11 =
+                           FStar_Parser_Const.p2l ["FStar"; m; "shift_left"] in
+                         let uu___12 =
+                           FStar_TypeChecker_NBETerm.binary_op
+                             FStar_TypeChecker_NBETerm.arg_as_bounded_int
+                             (fun uu___13 ->
+                                fun uu___14 ->
+                                  match (uu___13, uu___14) with
+                                  | ((int_to_t, x, d), (uu___15, y, uu___16))
+                                      ->
+                                      let uu___17 =
+                                        let uu___18 =
+                                          let uu___19 =
+                                            FStar_BigInt.shift_left_big_int x
+                                              y in
+                                          let uu___20 = mask m in
+                                          FStar_BigInt.logand_big_int uu___19
+                                            uu___20 in
+                                        FStar_TypeChecker_NBETerm.int_as_bounded
+                                          int_to_t uu___18 in
+                                      FStar_TypeChecker_NBETerm.with_meta_ds
+                                        uu___17 d) in
+                         (uu___11, (Prims.of_int (2)), Prims.int_zero,
+                           (binary_op arg_as_bounded_int
+                              (fun r ->
+                                 fun uu___13 ->
                                    fun uu___14 ->
                                      match (uu___13, uu___14) with
                                      | ((int_to_t, x, d),
@@ -1889,39 +1872,33 @@ let (built_in_primitive_steps_list : primitive_step Prims.list) =
                                              let uu___20 = mask m in
                                              FStar_BigInt.logand_big_int
                                                uu___19 uu___20 in
-                                           FStar_TypeChecker_NBETerm.int_as_bounded
-                                             int_to_t uu___18 in
-                                         FStar_TypeChecker_NBETerm.with_meta_ds
-                                           uu___17 d) in
-                            (uu___11, (Prims.of_int (2)), Prims.int_zero,
-                              (binary_op arg_as_bounded_int
-                                 (fun r ->
-                                    fun uu___13 ->
-                                      fun uu___14 ->
-                                        match (uu___13, uu___14) with
-                                        | ((int_to_t, x, d),
-                                           (uu___15, y, uu___16)) ->
-                                            let uu___17 =
-                                              let uu___18 =
-                                                let uu___19 =
-                                                  FStar_BigInt.shift_left_big_int
-                                                    x y in
-                                                let uu___20 = mask m in
-                                                FStar_BigInt.logand_big_int
-                                                  uu___19 uu___20 in
-                                              int_as_bounded r int_to_t
-                                                uu___18 in
-                                            with_meta_ds r uu___17 d)),
-                              uu___12) in
-                          let uu___11 =
-                            let uu___12 =
-                              let uu___13 =
-                                FStar_Parser_Const.p2l
-                                  ["FStar"; m; "shift_right"] in
-                              let uu___14 =
-                                FStar_TypeChecker_NBETerm.binary_op
-                                  FStar_TypeChecker_NBETerm.arg_as_bounded_int
-                                  (fun uu___15 ->
+                                           int_as_bounded r int_to_t uu___18 in
+                                         with_meta_ds r uu___17 d)), uu___12) in
+                       let uu___11 =
+                         let uu___12 =
+                           let uu___13 =
+                             FStar_Parser_Const.p2l
+                               ["FStar"; m; "shift_right"] in
+                           let uu___14 =
+                             FStar_TypeChecker_NBETerm.binary_op
+                               FStar_TypeChecker_NBETerm.arg_as_bounded_int
+                               (fun uu___15 ->
+                                  fun uu___16 ->
+                                    match (uu___15, uu___16) with
+                                    | ((int_to_t, x, d),
+                                       (uu___17, y, uu___18)) ->
+                                        let uu___19 =
+                                          let uu___20 =
+                                            FStar_BigInt.shift_right_big_int
+                                              x y in
+                                          FStar_TypeChecker_NBETerm.int_as_bounded
+                                            int_to_t uu___20 in
+                                        FStar_TypeChecker_NBETerm.with_meta_ds
+                                          uu___19 d) in
+                           (uu___13, (Prims.of_int (2)), Prims.int_zero,
+                             (binary_op arg_as_bounded_int
+                                (fun r ->
+                                   fun uu___15 ->
                                      fun uu___16 ->
                                        match (uu___15, uu___16) with
                                        | ((int_to_t, x, d),
@@ -1930,32 +1907,16 @@ let (built_in_primitive_steps_list : primitive_step Prims.list) =
                                              let uu___20 =
                                                FStar_BigInt.shift_right_big_int
                                                  x y in
-                                             FStar_TypeChecker_NBETerm.int_as_bounded
-                                               int_to_t uu___20 in
-                                           FStar_TypeChecker_NBETerm.with_meta_ds
-                                             uu___19 d) in
-                              (uu___13, (Prims.of_int (2)), Prims.int_zero,
-                                (binary_op arg_as_bounded_int
-                                   (fun r ->
-                                      fun uu___15 ->
-                                        fun uu___16 ->
-                                          match (uu___15, uu___16) with
-                                          | ((int_to_t, x, d),
-                                             (uu___17, y, uu___18)) ->
-                                              let uu___19 =
-                                                let uu___20 =
-                                                  FStar_BigInt.shift_right_big_int
-                                                    x y in
-                                                int_as_bounded r int_to_t
-                                                  uu___20 in
-                                              with_meta_ds r uu___19 d)),
-                                uu___14) in
-                            [uu___12] in
-                          uu___10 :: uu___11 in
-                        uu___8 :: uu___9 in
-                      uu___6 :: uu___7 in
-                    uu___4 :: uu___5 in
-                  uu___2 :: uu___3)) in
+                                             int_as_bounded r int_to_t
+                                               uu___20 in
+                                           with_meta_ds r uu___19 d)),
+                             uu___14) in
+                         [uu___12] in
+                       uu___10 :: uu___11 in
+                     uu___8 :: uu___9 in
+                   uu___6 :: uu___7 in
+                 uu___4 :: uu___5 in
+               uu___2 :: uu___3) bounded_unsigned_int_types in
     FStar_Compiler_List.op_At add_sub_mul_v_comparisons
       (FStar_Compiler_List.op_At unsigned_modulo_add_sub_mul_div_rem bitwise) in
   let reveal_hide =
@@ -1999,9 +1960,8 @@ let (built_in_primitive_steps_list : primitive_step Prims.list) =
       let emb_typ t =
         let uu___ =
           let uu___1 =
-            FStar_Compiler_Effect.op_Bar_Greater
-              FStar_Parser_Const.immutable_array_t_lid
-              FStar_Ident.string_of_lid in
+            FStar_Ident.string_of_lid
+              FStar_Parser_Const.immutable_array_t_lid in
           (uu___1, [t]) in
         FStar_Syntax_Syntax.ET_app uu___ in
       let un_lazy universes t l r =
@@ -2123,12 +2083,10 @@ let (built_in_primitive_steps_list : primitive_step Prims.list) =
                                    [uu___10] in
                                  (uu___8, universes, uu___9) in
                                FStar_TypeChecker_NBETerm.FV uu___7 in
-                             FStar_Compiler_Effect.op_Less_Bar
-                               FStar_TypeChecker_NBETerm.mk_t uu___6) in
+                             FStar_TypeChecker_NBETerm.mk_t uu___6) in
                       (uu___3, uu___4) in
                     FStar_TypeChecker_NBETerm.Lazy uu___2 in
-                  FStar_Compiler_Effect.op_Less_Bar
-                    FStar_TypeChecker_NBETerm.mk_t uu___1)
+                  FStar_TypeChecker_NBETerm.mk_t uu___1)
            (fun universes ->
               fun elt_t ->
                 fun uu___ ->

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Rel.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Rel.ml
@@ -555,11 +555,9 @@ let (maybe_invert_p :
   fun uu___ ->
     match uu___ with
     | FStar_TypeChecker_Common.TProb p ->
-        FStar_Compiler_Effect.op_Bar_Greater (maybe_invert p)
-          (fun uu___1 -> FStar_TypeChecker_Common.TProb uu___1)
+        FStar_TypeChecker_Common.TProb (maybe_invert p)
     | FStar_TypeChecker_Common.CProb p ->
-        FStar_Compiler_Effect.op_Bar_Greater (maybe_invert p)
-          (fun uu___1 -> FStar_TypeChecker_Common.CProb uu___1)
+        FStar_TypeChecker_Common.CProb (maybe_invert p)
 let (make_prob_eq :
   FStar_TypeChecker_Common.prob -> FStar_TypeChecker_Common.prob) =
   fun uu___ ->
@@ -806,9 +804,8 @@ let (hasBinders_prob :
       (fun prob ->
          let uu___ =
            let uu___1 = p_scope prob in
-           FStar_Compiler_Effect.op_Less_Bar
-             (FStar_Compiler_List.map
-                (fun b -> b.FStar_Syntax_Syntax.binder_bv)) uu___1 in
+           FStar_Compiler_List.map (fun b -> b.FStar_Syntax_Syntax.binder_bv)
+             uu___1 in
          FStar_Compiler_Set.from_list FStar_Syntax_Syntax.ord_bv uu___)
   }
 let (def_check_term_scoped_in_prob :
@@ -940,8 +937,7 @@ let (uvi_to_string : FStar_TypeChecker_Env.env -> uvi -> Prims.string) =
             then "?"
             else
               (let uu___3 = FStar_Syntax_Unionfind.univ_uvar_id u in
-               FStar_Compiler_Effect.op_Bar_Greater uu___3
-                 FStar_Compiler_Util.string_of_int) in
+               FStar_Compiler_Util.string_of_int uu___3) in
           let uu___1 =
             FStar_Class_Show.show FStar_Syntax_Print.showable_univ t in
           FStar_Compiler_Util.format2 "UNIV %s <- %s" x uu___1
@@ -954,8 +950,7 @@ let (uvi_to_string : FStar_TypeChecker_Env.env -> uvi -> Prims.string) =
               (let uu___3 =
                  FStar_Syntax_Unionfind.uvar_id
                    u.FStar_Syntax_Syntax.ctx_uvar_head in
-               FStar_Compiler_Effect.op_Bar_Greater uu___3
-                 FStar_Compiler_Util.string_of_int) in
+               FStar_Compiler_Util.string_of_int uu___3) in
           let uu___1 = FStar_TypeChecker_Normalize.term_to_string env t in
           FStar_Compiler_Util.format2 "TERM %s <- %s" x uu___1
 let (uvis_to_string :
@@ -983,9 +978,7 @@ let (giveup :
   fun wl ->
     fun reason ->
       fun prob ->
-        (let uu___1 =
-           FStar_Compiler_Effect.op_Less_Bar (debug wl)
-             (FStar_Options.Other "Rel") in
+        (let uu___1 = debug wl (FStar_Options.Other "Rel") in
          if uu___1
          then
            let uu___2 = FStar_Thunk.force reason in
@@ -1123,17 +1116,11 @@ let (p_invert :
   fun uu___ ->
     match uu___ with
     | FStar_TypeChecker_Common.TProb p ->
-        FStar_Compiler_Effect.op_Less_Bar
-          (fun uu___1 -> FStar_TypeChecker_Common.TProb uu___1) (invert p)
+        FStar_TypeChecker_Common.TProb (invert p)
     | FStar_TypeChecker_Common.CProb p ->
-        FStar_Compiler_Effect.op_Less_Bar
-          (fun uu___1 -> FStar_TypeChecker_Common.CProb uu___1) (invert p)
+        FStar_TypeChecker_Common.CProb (invert p)
 let (is_top_level_prob : FStar_TypeChecker_Common.prob -> Prims.bool) =
-  fun p ->
-    let uu___ =
-      FStar_Compiler_Effect.op_Bar_Greater (p_reason p)
-        FStar_Compiler_List.length in
-    uu___ = Prims.int_one
+  fun p -> (FStar_Compiler_List.length (p_reason p)) = Prims.int_one
 let (next_pid : unit -> Prims.int) =
   let ctr = FStar_Compiler_Util.mk_ref Prims.int_zero in
   fun uu___ ->
@@ -1319,8 +1306,7 @@ let new_problem :
                             let uu___1 =
                               let uu___2 =
                                 let uu___3 = FStar_Syntax_Syntax.bv_to_name x in
-                                FStar_Compiler_Effect.op_Less_Bar
-                                  FStar_Syntax_Syntax.as_arg uu___3 in
+                                FStar_Syntax_Syntax.as_arg uu___3 in
                               [uu___2] in
                             FStar_Syntax_Syntax.mk_Tm_app lg uu___1 loc in
                       let prob =
@@ -1406,24 +1392,17 @@ let (explain :
     fun d ->
       fun s ->
         let uu___ =
-          (FStar_Compiler_Effect.op_Less_Bar (debug wl)
-             (FStar_Options.Other "ExplainRel"))
-            ||
-            (FStar_Compiler_Effect.op_Less_Bar (debug wl)
-               (FStar_Options.Other "Rel")) in
+          (debug wl (FStar_Options.Other "ExplainRel")) ||
+            (debug wl (FStar_Options.Other "Rel")) in
         if uu___
         then
-          let uu___1 =
-            FStar_Compiler_Effect.op_Less_Bar
-              FStar_Compiler_Range_Ops.string_of_range (p_loc d) in
+          let uu___1 = FStar_Compiler_Range_Ops.string_of_range (p_loc d) in
           let uu___2 = prob_to_string' wl d in
-          let uu___3 =
-            FStar_Compiler_Effect.op_Bar_Greater (p_reason d)
-              (FStar_Compiler_String.concat "\n\t>") in
-          let uu___4 = FStar_Thunk.force s in
+          let uu___3 = FStar_Thunk.force s in
           FStar_Compiler_Util.format4
             "(%s) Failed to solve the sub-problem\n%s\nWhich arose because:\n\t%s\nFailed because:%s\n"
-            uu___1 uu___2 uu___3 uu___4
+            uu___1 uu___2 (FStar_Compiler_String.concat "\n\t>" (p_reason d))
+            uu___3
         else
           (let d1 = maybe_invert_p d in
            let rel =
@@ -1479,26 +1458,25 @@ let set_uvar :
 let (commit : FStar_TypeChecker_Env.env_t -> uvi Prims.list -> unit) =
   fun env ->
     fun uvis ->
-      FStar_Compiler_Effect.op_Bar_Greater uvis
-        (FStar_Compiler_List.iter
-           (fun uu___ ->
-              match uu___ with
-              | UNIV (u, t) ->
-                  (match t with
-                   | FStar_Syntax_Syntax.U_unif u' ->
-                       FStar_Syntax_Unionfind.univ_union u u'
-                   | uu___1 -> FStar_Syntax_Unionfind.univ_change u t)
-              | TERM (u, t) ->
-                  ((let uu___2 =
-                      FStar_Compiler_List.map
-                        (fun b -> b.FStar_Syntax_Syntax.binder_bv)
-                        u.FStar_Syntax_Syntax.ctx_uvar_binders in
-                    FStar_Defensive.def_check_scoped
-                      FStar_Class_Binders.hasBinders_list_bv
-                      FStar_Class_Binders.hasNames_term
-                      FStar_Syntax_Print.pretty_term
-                      t.FStar_Syntax_Syntax.pos "commit" uu___2 t);
-                   set_uvar env u FStar_Pervasives_Native.None t)))
+      FStar_Compiler_List.iter
+        (fun uu___ ->
+           match uu___ with
+           | UNIV (u, t) ->
+               (match t with
+                | FStar_Syntax_Syntax.U_unif u' ->
+                    FStar_Syntax_Unionfind.univ_union u u'
+                | uu___1 -> FStar_Syntax_Unionfind.univ_change u t)
+           | TERM (u, t) ->
+               ((let uu___2 =
+                   FStar_Compiler_List.map
+                     (fun b -> b.FStar_Syntax_Syntax.binder_bv)
+                     u.FStar_Syntax_Syntax.ctx_uvar_binders in
+                 FStar_Defensive.def_check_scoped
+                   FStar_Class_Binders.hasBinders_list_bv
+                   FStar_Class_Binders.hasNames_term
+                   FStar_Syntax_Print.pretty_term t.FStar_Syntax_Syntax.pos
+                   "commit" uu___2 t);
+                set_uvar env u FStar_Pervasives_Native.None t)) uvis
 let (find_term_uvar :
   FStar_Syntax_Syntax.uvar ->
     uvi Prims.list -> FStar_Syntax_Syntax.term FStar_Pervasives_Native.option)
@@ -1543,7 +1521,7 @@ let (sn' :
           FStar_TypeChecker_Normalize.normalize
             [FStar_TypeChecker_Env.Beta; FStar_TypeChecker_Env.Reify] env t in
         FStar_Syntax_Subst.compress uu___1 in
-      FStar_Compiler_Effect.op_Bar_Greater uu___ FStar_Syntax_Util.unlazy_emb
+      FStar_Syntax_Util.unlazy_emb uu___
 let (sn :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
@@ -1578,10 +1556,8 @@ let (norm_with_steps :
 let (should_strongly_reduce : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t ->
     let uu___ =
-      let uu___1 =
-        FStar_Compiler_Effect.op_Bar_Greater t FStar_Syntax_Util.unascribe in
-      FStar_Compiler_Effect.op_Bar_Greater uu___1
-        FStar_Syntax_Util.head_and_args in
+      let uu___1 = FStar_Syntax_Util.unascribe t in
+      FStar_Syntax_Util.head_and_args uu___1 in
     match uu___ with
     | (h, uu___1) ->
         let uu___2 =
@@ -1600,15 +1576,10 @@ let (whnf :
       let norm steps t1 =
         let uu___ =
           let uu___1 =
-            let uu___2 =
-              FStar_Compiler_Effect.op_Bar_Greater t1
-                FStar_Syntax_Util.unmeta in
-            FStar_Compiler_Effect.op_Bar_Greater uu___2
-              (FStar_TypeChecker_Normalize.normalize steps env) in
-          FStar_Compiler_Effect.op_Bar_Greater uu___1
-            FStar_Syntax_Subst.compress in
-        FStar_Compiler_Effect.op_Bar_Greater uu___
-          FStar_Syntax_Util.unlazy_emb in
+            let uu___2 = FStar_Syntax_Util.unmeta t1 in
+            FStar_TypeChecker_Normalize.normalize steps env uu___2 in
+          FStar_Syntax_Subst.compress uu___1 in
+        FStar_Syntax_Util.unlazy_emb uu___ in
       let uu___ =
         let uu___1 =
           let uu___2 = FStar_TypeChecker_Env.current_module env in
@@ -1646,30 +1617,28 @@ let (sn_binders :
   =
   fun env ->
     fun binders ->
-      FStar_Compiler_Effect.op_Bar_Greater binders
-        (FStar_Compiler_List.map
-           (fun b ->
-              let uu___ =
-                let uu___1 = b.FStar_Syntax_Syntax.binder_bv in
-                let uu___2 =
-                  sn env
-                    (b.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort in
-                {
-                  FStar_Syntax_Syntax.ppname =
-                    (uu___1.FStar_Syntax_Syntax.ppname);
-                  FStar_Syntax_Syntax.index =
-                    (uu___1.FStar_Syntax_Syntax.index);
-                  FStar_Syntax_Syntax.sort = uu___2
-                } in
-              {
-                FStar_Syntax_Syntax.binder_bv = uu___;
-                FStar_Syntax_Syntax.binder_qual =
-                  (b.FStar_Syntax_Syntax.binder_qual);
-                FStar_Syntax_Syntax.binder_positivity =
-                  (b.FStar_Syntax_Syntax.binder_positivity);
-                FStar_Syntax_Syntax.binder_attrs =
-                  (b.FStar_Syntax_Syntax.binder_attrs)
-              }))
+      FStar_Compiler_List.map
+        (fun b ->
+           let uu___ =
+             let uu___1 = b.FStar_Syntax_Syntax.binder_bv in
+             let uu___2 =
+               sn env
+                 (b.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort in
+             {
+               FStar_Syntax_Syntax.ppname =
+                 (uu___1.FStar_Syntax_Syntax.ppname);
+               FStar_Syntax_Syntax.index = (uu___1.FStar_Syntax_Syntax.index);
+               FStar_Syntax_Syntax.sort = uu___2
+             } in
+           {
+             FStar_Syntax_Syntax.binder_bv = uu___;
+             FStar_Syntax_Syntax.binder_qual =
+               (b.FStar_Syntax_Syntax.binder_qual);
+             FStar_Syntax_Syntax.binder_positivity =
+               (b.FStar_Syntax_Syntax.binder_positivity);
+             FStar_Syntax_Syntax.binder_attrs =
+               (b.FStar_Syntax_Syntax.binder_attrs)
+           }) binders
 let (norm_univ :
   worklist -> FStar_Syntax_Syntax.universe -> FStar_Syntax_Syntax.universe) =
   fun wl ->
@@ -1854,7 +1823,7 @@ let (unrefine :
   fun env ->
     fun t ->
       let uu___ = base_and_refinement env t in
-      FStar_Compiler_Effect.op_Bar_Greater uu___ FStar_Pervasives_Native.fst
+      FStar_Pervasives_Native.fst uu___
 let (trivial_refinement :
   FStar_Syntax_Syntax.term ->
     (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.term))
@@ -1899,8 +1868,7 @@ let (wl_to_string : worklist -> Prims.string) =
   fun wl ->
     let probs_to_string ps =
       let uu___ = FStar_Compiler_List.map (prob_to_string' wl) ps in
-      FStar_Compiler_Effect.op_Bar_Greater uu___
-        (FStar_Compiler_String.concat "\n\t") in
+      FStar_Compiler_String.concat "\n\t" uu___ in
     let uu___ = probs_to_string wl.attempting in
     let uu___1 =
       let uu___2 =
@@ -2036,8 +2004,7 @@ let (ensure_no_uvar_subst :
                                   FStar_Syntax_Syntax.mk_Tm_app t_v args_sol
                                     t0.FStar_Syntax_Syntax.pos in
                                 ((let uu___6 =
-                                    FStar_Compiler_Effect.op_Less_Bar
-                                      (FStar_TypeChecker_Env.debug env)
+                                    FStar_TypeChecker_Env.debug env
                                       (FStar_Options.Other "Rel") in
                                   if uu___6
                                   then
@@ -2211,9 +2178,7 @@ let (solve_prob' :
                | FStar_Pervasives_Native.None -> FStar_Syntax_Util.t_true
                | FStar_Pervasives_Native.Some phi1 -> phi1 in
              let assign_solution xs uv phi1 =
-               (let uu___2 =
-                  FStar_Compiler_Effect.op_Less_Bar (debug wl)
-                    (FStar_Options.Other "Rel") in
+               (let uu___2 = debug wl (FStar_Options.Other "Rel") in
                 if uu___2
                 then
                   let uu___3 = FStar_Compiler_Util.string_of_int (p_pid prob) in
@@ -2236,9 +2201,8 @@ let (solve_prob' :
                    Prims.strcat "solve_prob'.sol." uu___4 in
                  let uu___4 =
                    let uu___5 = p_scope prob in
-                   FStar_Compiler_Effect.op_Less_Bar
-                     (FStar_Compiler_List.map
-                        (fun b -> b.FStar_Syntax_Syntax.binder_bv)) uu___5 in
+                   FStar_Compiler_List.map
+                     (fun b -> b.FStar_Syntax_Syntax.binder_bv) uu___5 in
                  FStar_Defensive.def_check_scoped
                    FStar_Class_Binders.hasBinders_list_bv
                    FStar_Class_Binders.hasNames_term
@@ -2258,31 +2222,29 @@ let (solve_prob' :
                    uu___3 uu___4 in
                FStar_Compiler_Effect.failwith uu___2 in
              let args_as_binders args =
-               FStar_Compiler_Effect.op_Bar_Greater args
-                 (FStar_Compiler_List.collect
-                    (fun uu___1 ->
-                       match uu___1 with
-                       | (a, i) ->
-                           let uu___2 =
-                             let uu___3 = FStar_Syntax_Subst.compress a in
-                             uu___3.FStar_Syntax_Syntax.n in
-                           (match uu___2 with
-                            | FStar_Syntax_Syntax.Tm_name x ->
-                                let uu___3 =
-                                  FStar_Syntax_Util.bqual_and_attrs_of_aqual
-                                    i in
-                                (match uu___3 with
-                                 | (q, attrs) ->
-                                     let uu___4 =
-                                       FStar_Syntax_Util.parse_positivity_attributes
-                                         attrs in
-                                     (match uu___4 with
-                                      | (pq, attrs1) ->
-                                          let uu___5 =
-                                            FStar_Syntax_Syntax.mk_binder_with_attrs
-                                              x q pq attrs1 in
-                                          [uu___5]))
-                            | uu___3 -> (fail (); [])))) in
+               FStar_Compiler_List.collect
+                 (fun uu___1 ->
+                    match uu___1 with
+                    | (a, i) ->
+                        let uu___2 =
+                          let uu___3 = FStar_Syntax_Subst.compress a in
+                          uu___3.FStar_Syntax_Syntax.n in
+                        (match uu___2 with
+                         | FStar_Syntax_Syntax.Tm_name x ->
+                             let uu___3 =
+                               FStar_Syntax_Util.bqual_and_attrs_of_aqual i in
+                             (match uu___3 with
+                              | (q, attrs) ->
+                                  let uu___4 =
+                                    FStar_Syntax_Util.parse_positivity_attributes
+                                      attrs in
+                                  (match uu___4 with
+                                   | (pq, attrs1) ->
+                                       let uu___5 =
+                                         FStar_Syntax_Syntax.mk_binder_with_attrs
+                                           x q pq attrs1 in
+                                       [uu___5]))
+                         | uu___3 -> (fail (); []))) args in
              let wl1 =
                let g = whnf (p_env wl prob) (p_guard prob) in
                let uu___1 =
@@ -2315,9 +2277,7 @@ let (extend_universe_solution :
   fun pid ->
     fun sol ->
       fun wl ->
-        (let uu___1 =
-           FStar_Compiler_Effect.op_Less_Bar (debug wl)
-             (FStar_Options.Other "Rel") in
+        (let uu___1 = debug wl (FStar_Options.Other "Rel") in
          if uu___1
          then
            let uu___2 = FStar_Compiler_Util.string_of_int pid in
@@ -2350,14 +2310,10 @@ let (solve_prob :
           def_check_prob "solve_prob.prob" prob;
           FStar_Compiler_Util.iter_opt logical_guard
             (def_check_term_scoped_in_prob "solve_prob.guard" prob);
-          (let uu___3 =
-             FStar_Compiler_Effect.op_Less_Bar (debug wl)
-               (FStar_Options.Other "Rel") in
+          (let uu___3 = debug wl (FStar_Options.Other "Rel") in
            if uu___3
            then
-             let uu___4 =
-               FStar_Compiler_Effect.op_Less_Bar
-                 FStar_Compiler_Util.string_of_int (p_pid prob) in
+             let uu___4 = FStar_Compiler_Util.string_of_int (p_pid prob) in
              let uu___5 = uvis_to_string wl.tcenv uvis in
              FStar_Compiler_Util.print2 "Solving %s: with %s\n" uu___4 uu___5
            else ());
@@ -2371,15 +2327,13 @@ let (occurs :
     fun t ->
       let uvars =
         let uu___ = FStar_Syntax_Free.uvars t in
-        FStar_Compiler_Effect.op_Bar_Greater uu___
-          (FStar_Compiler_Set.elems FStar_Syntax_Free.ord_ctx_uvar) in
+        FStar_Compiler_Set.elems FStar_Syntax_Free.ord_ctx_uvar uu___ in
       let occurs1 =
-        FStar_Compiler_Effect.op_Bar_Greater uvars
-          (FStar_Compiler_Util.for_some
-             (fun uv ->
-                FStar_Syntax_Unionfind.equiv
-                  uv.FStar_Syntax_Syntax.ctx_uvar_head
-                  uk.FStar_Syntax_Syntax.ctx_uvar_head)) in
+        FStar_Compiler_Util.for_some
+          (fun uv ->
+             FStar_Syntax_Unionfind.equiv
+               uv.FStar_Syntax_Syntax.ctx_uvar_head
+               uk.FStar_Syntax_Syntax.ctx_uvar_head) uvars in
       (uvars, occurs1)
 let (occurs_check :
   FStar_Syntax_Syntax.ctx_uvar ->
@@ -2412,15 +2366,13 @@ let (occurs_full :
     fun t ->
       let uvars =
         let uu___ = FStar_Syntax_Free.uvars_full t in
-        FStar_Compiler_Effect.op_Bar_Greater uu___
-          (FStar_Compiler_Set.elems FStar_Syntax_Free.ord_ctx_uvar) in
+        FStar_Compiler_Set.elems FStar_Syntax_Free.ord_ctx_uvar uu___ in
       let occurs1 =
-        FStar_Compiler_Effect.op_Bar_Greater uvars
-          (FStar_Compiler_Util.for_some
-             (fun uv ->
-                FStar_Syntax_Unionfind.equiv
-                  uv.FStar_Syntax_Syntax.ctx_uvar_head
-                  uk.FStar_Syntax_Syntax.ctx_uvar_head)) in
+        FStar_Compiler_Util.for_some
+          (fun uv ->
+             FStar_Syntax_Unionfind.equiv
+               uv.FStar_Syntax_Syntax.ctx_uvar_head
+               uk.FStar_Syntax_Syntax.ctx_uvar_head) uvars in
       occurs1
 let rec (maximal_prefix :
   FStar_Syntax_Syntax.binders ->
@@ -2523,49 +2475,39 @@ let restrict_ctx :
                              FStar_Syntax_Syntax.Already_checked) uu___5);
                        wl1) in
                 let bs1 =
-                  FStar_Compiler_Effect.op_Bar_Greater bs
-                    (FStar_Compiler_List.filter
-                       (fun uu___2 ->
-                          match uu___2 with
-                          | { FStar_Syntax_Syntax.binder_bv = bv1;
-                              FStar_Syntax_Syntax.binder_qual = uu___3;
-                              FStar_Syntax_Syntax.binder_positivity = uu___4;
-                              FStar_Syntax_Syntax.binder_attrs = uu___5;_} ->
-                              (FStar_Compiler_Effect.op_Bar_Greater
-                                 src.FStar_Syntax_Syntax.ctx_uvar_binders
-                                 (FStar_Compiler_List.existsb
-                                    (fun uu___6 ->
-                                       match uu___6 with
-                                       | {
-                                           FStar_Syntax_Syntax.binder_bv =
-                                             bv2;
-                                           FStar_Syntax_Syntax.binder_qual =
-                                             uu___7;
-                                           FStar_Syntax_Syntax.binder_positivity
-                                             = uu___8;
-                                           FStar_Syntax_Syntax.binder_attrs =
-                                             uu___9;_}
-                                           ->
-                                           FStar_Syntax_Syntax.bv_eq bv1 bv2)))
-                                &&
-                                (let uu___6 =
-                                   FStar_Compiler_Effect.op_Bar_Greater pfx
-                                     (FStar_Compiler_List.existsb
-                                        (fun uu___7 ->
-                                           match uu___7 with
-                                           | {
-                                               FStar_Syntax_Syntax.binder_bv
-                                                 = bv2;
-                                               FStar_Syntax_Syntax.binder_qual
-                                                 = uu___8;
-                                               FStar_Syntax_Syntax.binder_positivity
-                                                 = uu___9;
-                                               FStar_Syntax_Syntax.binder_attrs
-                                                 = uu___10;_}
-                                               ->
-                                               FStar_Syntax_Syntax.bv_eq bv1
-                                                 bv2)) in
-                                 Prims.op_Negation uu___6))) in
+                  FStar_Compiler_List.filter
+                    (fun uu___2 ->
+                       match uu___2 with
+                       | { FStar_Syntax_Syntax.binder_bv = bv1;
+                           FStar_Syntax_Syntax.binder_qual = uu___3;
+                           FStar_Syntax_Syntax.binder_positivity = uu___4;
+                           FStar_Syntax_Syntax.binder_attrs = uu___5;_} ->
+                           (FStar_Compiler_List.existsb
+                              (fun uu___6 ->
+                                 match uu___6 with
+                                 | { FStar_Syntax_Syntax.binder_bv = bv2;
+                                     FStar_Syntax_Syntax.binder_qual = uu___7;
+                                     FStar_Syntax_Syntax.binder_positivity =
+                                       uu___8;
+                                     FStar_Syntax_Syntax.binder_attrs =
+                                       uu___9;_}
+                                     -> FStar_Syntax_Syntax.bv_eq bv1 bv2)
+                              src.FStar_Syntax_Syntax.ctx_uvar_binders)
+                             &&
+                             (let uu___6 =
+                                FStar_Compiler_List.existsb
+                                  (fun uu___7 ->
+                                     match uu___7 with
+                                     | { FStar_Syntax_Syntax.binder_bv = bv2;
+                                         FStar_Syntax_Syntax.binder_qual =
+                                           uu___8;
+                                         FStar_Syntax_Syntax.binder_positivity
+                                           = uu___9;
+                                         FStar_Syntax_Syntax.binder_attrs =
+                                           uu___10;_}
+                                         -> FStar_Syntax_Syntax.bv_eq bv1 bv2)
+                                  pfx in
+                              Prims.op_Negation uu___6)) bs in
                 if (FStar_Compiler_List.length bs1) = Prims.int_zero
                 then
                   let uu___2 = FStar_Syntax_Util.ctx_uvar_typ src in
@@ -2573,20 +2515,15 @@ let restrict_ctx :
                 else
                   (let uu___3 =
                      let t = FStar_Syntax_Util.ctx_uvar_typ src in
-                     let uu___4 =
-                       FStar_Compiler_Effect.op_Bar_Greater t
-                         FStar_Syntax_Syntax.mk_Total in
-                     FStar_Compiler_Effect.op_Bar_Greater uu___4
-                       (FStar_Syntax_Util.arrow bs1) in
+                     let uu___4 = FStar_Syntax_Syntax.mk_Total t in
+                     FStar_Syntax_Util.arrow bs1 uu___4 in
                    aux uu___3
                      (fun src' ->
                         let uu___4 =
                           let uu___5 =
-                            FStar_Compiler_Effect.op_Bar_Greater bs1
-                              FStar_Syntax_Syntax.binders_to_names in
-                          FStar_Compiler_Effect.op_Bar_Greater uu___5
-                            (FStar_Compiler_List.map
-                               FStar_Syntax_Syntax.as_arg) in
+                            FStar_Syntax_Syntax.binders_to_names bs1 in
+                          FStar_Compiler_List.map FStar_Syntax_Syntax.as_arg
+                            uu___5 in
                         FStar_Syntax_Syntax.mk_Tm_app src' uu___4
                           src.FStar_Syntax_Syntax.ctx_uvar_range))
 let restrict_all_uvars :
@@ -2628,13 +2565,12 @@ let (intersect_binders :
     fun v1 ->
       fun v2 ->
         let as_set v =
-          FStar_Compiler_Effect.op_Bar_Greater v
-            (FStar_Compiler_List.fold_left
-               (fun out ->
-                  fun x ->
-                    FStar_Compiler_Set.add FStar_Syntax_Syntax.ord_bv
-                      x.FStar_Syntax_Syntax.binder_bv out)
-               FStar_Syntax_Syntax.no_names) in
+          FStar_Compiler_List.fold_left
+            (fun out ->
+               fun x ->
+                 FStar_Compiler_Set.add FStar_Syntax_Syntax.ord_bv
+                   x.FStar_Syntax_Syntax.binder_bv out)
+            FStar_Syntax_Syntax.no_names v in
         let v1_set = as_set v1 in
         let ctx_binders =
           FStar_Compiler_List.fold_left
@@ -2645,39 +2581,37 @@ let (intersect_binders :
                      FStar_Compiler_Set.add FStar_Syntax_Syntax.ord_bv x out
                  | uu___ -> out) FStar_Syntax_Syntax.no_names g in
         let uu___ =
-          FStar_Compiler_Effect.op_Bar_Greater v2
-            (FStar_Compiler_List.fold_left
-               (fun uu___1 ->
-                  fun b ->
-                    match uu___1 with
-                    | (isect, isect_set) ->
-                        let uu___2 =
-                          ((b.FStar_Syntax_Syntax.binder_bv),
-                            (b.FStar_Syntax_Syntax.binder_qual)) in
-                        (match uu___2 with
-                         | (x, imp) ->
-                             let uu___3 =
-                               let uu___4 =
-                                 FStar_Compiler_Set.mem
-                                   FStar_Syntax_Syntax.ord_bv x v1_set in
-                               FStar_Compiler_Effect.op_Less_Bar
-                                 Prims.op_Negation uu___4 in
-                             if uu___3
-                             then (isect, isect_set)
-                             else
-                               (let fvs =
-                                  FStar_Syntax_Free.names
-                                    x.FStar_Syntax_Syntax.sort in
-                                let uu___5 =
-                                  FStar_Compiler_Set.subset
-                                    FStar_Syntax_Syntax.ord_bv fvs isect_set in
-                                if uu___5
-                                then
-                                  let uu___6 =
-                                    FStar_Compiler_Set.add
-                                      FStar_Syntax_Syntax.ord_bv x isect_set in
-                                  ((b :: isect), uu___6)
-                                else (isect, isect_set)))) ([], ctx_binders)) in
+          FStar_Compiler_List.fold_left
+            (fun uu___1 ->
+               fun b ->
+                 match uu___1 with
+                 | (isect, isect_set) ->
+                     let uu___2 =
+                       ((b.FStar_Syntax_Syntax.binder_bv),
+                         (b.FStar_Syntax_Syntax.binder_qual)) in
+                     (match uu___2 with
+                      | (x, imp) ->
+                          let uu___3 =
+                            let uu___4 =
+                              FStar_Compiler_Set.mem
+                                FStar_Syntax_Syntax.ord_bv x v1_set in
+                            Prims.op_Negation uu___4 in
+                          if uu___3
+                          then (isect, isect_set)
+                          else
+                            (let fvs =
+                               FStar_Syntax_Free.names
+                                 x.FStar_Syntax_Syntax.sort in
+                             let uu___5 =
+                               FStar_Compiler_Set.subset
+                                 FStar_Syntax_Syntax.ord_bv fvs isect_set in
+                             if uu___5
+                             then
+                               let uu___6 =
+                                 FStar_Compiler_Set.add
+                                   FStar_Syntax_Syntax.ord_bv x isect_set in
+                               ((b :: isect), uu___6)
+                             else (isect, isect_set)))) ([], ctx_binders) v2 in
         match uu___ with | (isect, uu___1) -> FStar_Compiler_List.rev isect
 let (binders_eq :
   FStar_Syntax_Syntax.binder Prims.list ->
@@ -2874,9 +2808,7 @@ let rec (head_matches :
         let t11 = FStar_Syntax_Util.unmeta t1 in
         let t21 = FStar_Syntax_Util.unmeta t2 in
         (let uu___1 =
-           FStar_Compiler_Effect.op_Less_Bar
-             (FStar_TypeChecker_Env.debug env)
-             (FStar_Options.Other "RelDelta") in
+           FStar_TypeChecker_Env.debug env (FStar_Options.Other "RelDelta") in
          if uu___1
          then
            ((let uu___3 =
@@ -2943,8 +2875,7 @@ let rec (head_matches :
                 MisMatch uu___3)
          | (FStar_Syntax_Syntax.Tm_uinst (f, uu___1),
             FStar_Syntax_Syntax.Tm_uinst (g, uu___2)) ->
-             let uu___3 = head_matches env f g in
-             FStar_Compiler_Effect.op_Bar_Greater uu___3 head_match
+             let uu___3 = head_matches env f g in head_match uu___3
          | (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reify uu___1),
             FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reify uu___2))
              -> FullMatch
@@ -2979,17 +2910,17 @@ let rec (head_matches :
              let uu___3 =
                head_matches env x.FStar_Syntax_Syntax.sort
                  y.FStar_Syntax_Syntax.sort in
-             FStar_Compiler_Effect.op_Bar_Greater uu___3 head_match
+             head_match uu___3
          | (FStar_Syntax_Syntax.Tm_refine
             { FStar_Syntax_Syntax.b = x; FStar_Syntax_Syntax.phi = uu___1;_},
             uu___2) ->
              let uu___3 = head_matches env x.FStar_Syntax_Syntax.sort t21 in
-             FStar_Compiler_Effect.op_Bar_Greater uu___3 head_match
+             head_match uu___3
          | (uu___1, FStar_Syntax_Syntax.Tm_refine
             { FStar_Syntax_Syntax.b = x; FStar_Syntax_Syntax.phi = uu___2;_})
              ->
              let uu___3 = head_matches env t11 x.FStar_Syntax_Syntax.sort in
-             FStar_Compiler_Effect.op_Bar_Greater uu___3 head_match
+             head_match uu___3
          | (FStar_Syntax_Syntax.Tm_type uu___1, FStar_Syntax_Syntax.Tm_type
             uu___2) -> HeadMatch false
          | (FStar_Syntax_Syntax.Tm_arrow uu___1, FStar_Syntax_Syntax.Tm_arrow
@@ -3000,21 +2931,16 @@ let rec (head_matches :
             FStar_Syntax_Syntax.Tm_app
             { FStar_Syntax_Syntax.hd = head';
               FStar_Syntax_Syntax.args = uu___2;_})
-             ->
-             let uu___3 = head_matches env head head' in
-             FStar_Compiler_Effect.op_Bar_Greater uu___3 head_match
+             -> let uu___3 = head_matches env head head' in head_match uu___3
          | (FStar_Syntax_Syntax.Tm_app
             { FStar_Syntax_Syntax.hd = head;
               FStar_Syntax_Syntax.args = uu___1;_},
             uu___2) ->
-             let uu___3 = head_matches env head t21 in
-             FStar_Compiler_Effect.op_Bar_Greater uu___3 head_match
+             let uu___3 = head_matches env head t21 in head_match uu___3
          | (uu___1, FStar_Syntax_Syntax.Tm_app
             { FStar_Syntax_Syntax.hd = head;
               FStar_Syntax_Syntax.args = uu___2;_})
-             ->
-             let uu___3 = head_matches env t11 head in
-             FStar_Compiler_Effect.op_Bar_Greater uu___3 head_match
+             -> let uu___3 = head_matches env t11 head in head_match uu___3
          | (FStar_Syntax_Syntax.Tm_let uu___1, FStar_Syntax_Syntax.Tm_let
             uu___2) -> HeadMatch true
          | (FStar_Syntax_Syntax.Tm_match uu___1, FStar_Syntax_Syntax.Tm_match
@@ -3044,8 +2970,7 @@ let (head_matches_delta :
             let head =
               let uu___ = unrefine env t in FStar_Syntax_Util.head_of uu___ in
             (let uu___1 =
-               FStar_Compiler_Effect.op_Less_Bar
-                 (FStar_TypeChecker_Env.debug env)
+               FStar_TypeChecker_Env.debug env
                  (FStar_Options.Other "RelDelta") in
              if uu___1
              then
@@ -3069,8 +2994,7 @@ let (head_matches_delta :
                  (match uu___2 with
                   | FStar_Pervasives_Native.None ->
                       ((let uu___4 =
-                          FStar_Compiler_Effect.op_Less_Bar
-                            (FStar_TypeChecker_Env.debug env)
+                          FStar_TypeChecker_Env.debug env
                             (FStar_Options.Other "RelDelta") in
                         if uu___4
                         then
@@ -3109,8 +3033,7 @@ let (head_matches_delta :
                       then FStar_Pervasives_Native.None
                       else
                         ((let uu___7 =
-                            FStar_Compiler_Effect.op_Less_Bar
-                              (FStar_TypeChecker_Env.debug env)
+                            FStar_TypeChecker_Env.debug env
                               (FStar_Options.Other "RelDelta") in
                           if uu___7
                           then
@@ -3139,12 +3062,10 @@ let (head_matches_delta :
             let uu___ =
               let uu___1 =
                 let uu___2 = FStar_Syntax_Util.head_and_args t in
-                FStar_Compiler_Effect.op_Bar_Greater uu___2
-                  FStar_Pervasives_Native.fst in
+                FStar_Pervasives_Native.fst uu___2 in
               let uu___2 =
                 let uu___3 = FStar_Syntax_Util.head_and_args t' in
-                FStar_Compiler_Effect.op_Bar_Greater uu___3
-                  FStar_Pervasives_Native.fst in
+                FStar_Pervasives_Native.fst uu___3 in
               (uu___1, uu___2) in
             match uu___ with
             | (head, head') ->
@@ -3155,8 +3076,7 @@ let (head_matches_delta :
           let rec aux retry n_delta t11 t21 =
             let r = head_matches env t11 t21 in
             (let uu___1 =
-               FStar_Compiler_Effect.op_Less_Bar
-                 (FStar_TypeChecker_Env.debug env)
+               FStar_TypeChecker_Env.debug env
                  (FStar_Options.Other "RelDelta") in
              if uu___1
              then
@@ -3287,9 +3207,7 @@ let (head_matches_delta :
              | uu___1 -> success n_delta r t11 t21) in
           let r = aux true Prims.int_zero t1 t2 in
           (let uu___1 =
-             FStar_Compiler_Effect.op_Less_Bar
-               (FStar_TypeChecker_Env.debug env)
-               (FStar_Options.Other "RelDelta") in
+             FStar_TypeChecker_Env.debug env (FStar_Options.Other "RelDelta") in
            if uu___1
            then
              let uu___2 =
@@ -3304,22 +3222,18 @@ let (head_matches_delta :
                then "None"
                else
                  (let uu___7 =
-                    FStar_Compiler_Effect.op_Bar_Greater
-                      (FStar_Pervasives_Native.snd r)
-                      FStar_Compiler_Util.must in
-                  FStar_Compiler_Effect.op_Bar_Greater uu___7
-                    (fun uu___8 ->
-                       match uu___8 with
-                       | (t11, t21) ->
-                           let uu___9 =
-                             FStar_Class_Show.show
-                               FStar_Syntax_Print.showable_term t11 in
-                           let uu___10 =
-                             let uu___11 =
-                               FStar_Class_Show.show
-                                 FStar_Syntax_Print.showable_term t21 in
-                             Prims.strcat "; " uu___11 in
-                           Prims.strcat uu___9 uu___10)) in
+                    FStar_Compiler_Util.must (FStar_Pervasives_Native.snd r) in
+                  match uu___7 with
+                  | (t11, t21) ->
+                      let uu___8 =
+                        FStar_Class_Show.show
+                          FStar_Syntax_Print.showable_term t11 in
+                      let uu___9 =
+                        let uu___10 =
+                          FStar_Class_Show.show
+                            FStar_Syntax_Print.showable_term t21 in
+                        Prims.strcat "; " uu___10 in
+                      Prims.strcat uu___8 uu___9) in
              FStar_Compiler_Util.print4
                "head_matches_delta (%s, %s) = %s (%s)\n" uu___2 uu___3 uu___4
                uu___5
@@ -3332,7 +3246,7 @@ let (kind_type :
   fun binders ->
     fun r ->
       let uu___ = FStar_Syntax_Util.type_u () in
-      FStar_Compiler_Effect.op_Bar_Greater uu___ FStar_Pervasives_Native.fst
+      FStar_Pervasives_Native.fst uu___
 let (rank_t_num : FStar_TypeChecker_Common.rank_t -> Prims.int) =
   fun uu___ ->
     match uu___ with
@@ -3384,8 +3298,7 @@ let (compress_prob :
       match p with
       | FStar_TypeChecker_Common.TProb p1 ->
           let uu___ = compress_tprob tcenv p1 in
-          FStar_Compiler_Effect.op_Bar_Greater uu___
-            (fun uu___1 -> FStar_TypeChecker_Common.TProb uu___1)
+          FStar_TypeChecker_Common.TProb uu___
       | FStar_TypeChecker_Common.CProb uu___ -> p
 let (rank :
   FStar_TypeChecker_Env.env ->
@@ -3394,9 +3307,7 @@ let (rank :
   =
   fun tcenv ->
     fun pr ->
-      let prob =
-        let uu___ = compress_prob tcenv pr in
-        FStar_Compiler_Effect.op_Bar_Greater uu___ maybe_invert_p in
+      let prob = let uu___ = compress_prob tcenv pr in maybe_invert_p uu___ in
       match prob with
       | FStar_TypeChecker_Common.TProb tp ->
           let uu___ =
@@ -3516,60 +3427,56 @@ let (rank :
                           (FStar_TypeChecker_Common.Rigid_rigid, tp) in
                     (match uu___2 with
                      | (rank1, tp1) ->
-                         let uu___3 =
-                           FStar_Compiler_Effect.op_Bar_Greater
-                             {
-                               FStar_TypeChecker_Common.pid =
-                                 (tp1.FStar_TypeChecker_Common.pid);
-                               FStar_TypeChecker_Common.lhs =
-                                 (tp1.FStar_TypeChecker_Common.lhs);
-                               FStar_TypeChecker_Common.relation =
-                                 (tp1.FStar_TypeChecker_Common.relation);
-                               FStar_TypeChecker_Common.rhs =
-                                 (tp1.FStar_TypeChecker_Common.rhs);
-                               FStar_TypeChecker_Common.element =
-                                 (tp1.FStar_TypeChecker_Common.element);
-                               FStar_TypeChecker_Common.logical_guard =
-                                 (tp1.FStar_TypeChecker_Common.logical_guard);
-                               FStar_TypeChecker_Common.logical_guard_uvar =
-                                 (tp1.FStar_TypeChecker_Common.logical_guard_uvar);
-                               FStar_TypeChecker_Common.reason =
-                                 (tp1.FStar_TypeChecker_Common.reason);
-                               FStar_TypeChecker_Common.loc =
-                                 (tp1.FStar_TypeChecker_Common.loc);
-                               FStar_TypeChecker_Common.rank =
-                                 (FStar_Pervasives_Native.Some rank1)
-                             }
-                             (fun uu___4 ->
-                                FStar_TypeChecker_Common.TProb uu___4) in
-                         (rank1, uu___3))))
+                         (rank1,
+                           (FStar_TypeChecker_Common.TProb
+                              {
+                                FStar_TypeChecker_Common.pid =
+                                  (tp1.FStar_TypeChecker_Common.pid);
+                                FStar_TypeChecker_Common.lhs =
+                                  (tp1.FStar_TypeChecker_Common.lhs);
+                                FStar_TypeChecker_Common.relation =
+                                  (tp1.FStar_TypeChecker_Common.relation);
+                                FStar_TypeChecker_Common.rhs =
+                                  (tp1.FStar_TypeChecker_Common.rhs);
+                                FStar_TypeChecker_Common.element =
+                                  (tp1.FStar_TypeChecker_Common.element);
+                                FStar_TypeChecker_Common.logical_guard =
+                                  (tp1.FStar_TypeChecker_Common.logical_guard);
+                                FStar_TypeChecker_Common.logical_guard_uvar =
+                                  (tp1.FStar_TypeChecker_Common.logical_guard_uvar);
+                                FStar_TypeChecker_Common.reason =
+                                  (tp1.FStar_TypeChecker_Common.reason);
+                                FStar_TypeChecker_Common.loc =
+                                  (tp1.FStar_TypeChecker_Common.loc);
+                                FStar_TypeChecker_Common.rank =
+                                  (FStar_Pervasives_Native.Some rank1)
+                              })))))
       | FStar_TypeChecker_Common.CProb cp ->
-          let uu___ =
-            FStar_Compiler_Effect.op_Bar_Greater
-              {
-                FStar_TypeChecker_Common.pid =
-                  (cp.FStar_TypeChecker_Common.pid);
-                FStar_TypeChecker_Common.lhs =
-                  (cp.FStar_TypeChecker_Common.lhs);
-                FStar_TypeChecker_Common.relation =
-                  (cp.FStar_TypeChecker_Common.relation);
-                FStar_TypeChecker_Common.rhs =
-                  (cp.FStar_TypeChecker_Common.rhs);
-                FStar_TypeChecker_Common.element =
-                  (cp.FStar_TypeChecker_Common.element);
-                FStar_TypeChecker_Common.logical_guard =
-                  (cp.FStar_TypeChecker_Common.logical_guard);
-                FStar_TypeChecker_Common.logical_guard_uvar =
-                  (cp.FStar_TypeChecker_Common.logical_guard_uvar);
-                FStar_TypeChecker_Common.reason =
-                  (cp.FStar_TypeChecker_Common.reason);
-                FStar_TypeChecker_Common.loc =
-                  (cp.FStar_TypeChecker_Common.loc);
-                FStar_TypeChecker_Common.rank =
-                  (FStar_Pervasives_Native.Some
-                     FStar_TypeChecker_Common.Rigid_rigid)
-              } (fun uu___1 -> FStar_TypeChecker_Common.CProb uu___1) in
-          (FStar_TypeChecker_Common.Rigid_rigid, uu___)
+          (FStar_TypeChecker_Common.Rigid_rigid,
+            (FStar_TypeChecker_Common.CProb
+               {
+                 FStar_TypeChecker_Common.pid =
+                   (cp.FStar_TypeChecker_Common.pid);
+                 FStar_TypeChecker_Common.lhs =
+                   (cp.FStar_TypeChecker_Common.lhs);
+                 FStar_TypeChecker_Common.relation =
+                   (cp.FStar_TypeChecker_Common.relation);
+                 FStar_TypeChecker_Common.rhs =
+                   (cp.FStar_TypeChecker_Common.rhs);
+                 FStar_TypeChecker_Common.element =
+                   (cp.FStar_TypeChecker_Common.element);
+                 FStar_TypeChecker_Common.logical_guard =
+                   (cp.FStar_TypeChecker_Common.logical_guard);
+                 FStar_TypeChecker_Common.logical_guard_uvar =
+                   (cp.FStar_TypeChecker_Common.logical_guard_uvar);
+                 FStar_TypeChecker_Common.reason =
+                   (cp.FStar_TypeChecker_Common.reason);
+                 FStar_TypeChecker_Common.loc =
+                   (cp.FStar_TypeChecker_Common.loc);
+                 FStar_TypeChecker_Common.rank =
+                   (FStar_Pervasives_Native.Some
+                      FStar_TypeChecker_Common.Rigid_rigid)
+               }))
 let (next_prob :
   worklist ->
     (FStar_TypeChecker_Common.prob * FStar_TypeChecker_Common.prob Prims.list
@@ -3637,28 +3544,24 @@ let (flex_prob_closing :
                 uu___3.FStar_Syntax_Syntax.n in
               (match uu___2 with
                | FStar_Syntax_Syntax.Tm_uvar (u, uu___3) ->
-                   FStar_Compiler_Effect.op_Bar_Greater
+                   FStar_Compiler_Util.for_some
+                     (fun uu___4 ->
+                        match uu___4 with
+                        | { FStar_Syntax_Syntax.binder_bv = y;
+                            FStar_Syntax_Syntax.binder_qual = uu___5;
+                            FStar_Syntax_Syntax.binder_positivity = uu___6;
+                            FStar_Syntax_Syntax.binder_attrs = uu___7;_} ->
+                            FStar_Compiler_Util.for_some
+                              (fun uu___8 ->
+                                 match uu___8 with
+                                 | { FStar_Syntax_Syntax.binder_bv = x;
+                                     FStar_Syntax_Syntax.binder_qual = uu___9;
+                                     FStar_Syntax_Syntax.binder_positivity =
+                                       uu___10;
+                                     FStar_Syntax_Syntax.binder_attrs =
+                                       uu___11;_}
+                                     -> FStar_Syntax_Syntax.bv_eq x y) bs)
                      u.FStar_Syntax_Syntax.ctx_uvar_binders
-                     (FStar_Compiler_Util.for_some
-                        (fun uu___4 ->
-                           match uu___4 with
-                           | { FStar_Syntax_Syntax.binder_bv = y;
-                               FStar_Syntax_Syntax.binder_qual = uu___5;
-                               FStar_Syntax_Syntax.binder_positivity = uu___6;
-                               FStar_Syntax_Syntax.binder_attrs = uu___7;_}
-                               ->
-                               FStar_Compiler_Effect.op_Bar_Greater bs
-                                 (FStar_Compiler_Util.for_some
-                                    (fun uu___8 ->
-                                       match uu___8 with
-                                       | { FStar_Syntax_Syntax.binder_bv = x;
-                                           FStar_Syntax_Syntax.binder_qual =
-                                             uu___9;
-                                           FStar_Syntax_Syntax.binder_positivity
-                                             = uu___10;
-                                           FStar_Syntax_Syntax.binder_attrs =
-                                             uu___11;_}
-                                           -> FStar_Syntax_Syntax.bv_eq x y))))
                | uu___3 -> false) in
         let uu___ = rank tcenv p in
         match uu___ with
@@ -3720,35 +3623,32 @@ let rec (really_solve_universe_eq :
           let rec occurs_univ v1 u =
             match u with
             | FStar_Syntax_Syntax.U_max us ->
-                FStar_Compiler_Effect.op_Bar_Greater us
-                  (FStar_Compiler_Util.for_some
-                     (fun u3 ->
-                        let uu___ = FStar_Syntax_Util.univ_kernel u3 in
-                        match uu___ with
-                        | (k, uu___1) ->
-                            (match k with
-                             | FStar_Syntax_Syntax.U_unif v2 ->
-                                 FStar_Syntax_Unionfind.univ_equiv v1 v2
-                             | uu___2 -> false)))
+                FStar_Compiler_Util.for_some
+                  (fun u3 ->
+                     let uu___ = FStar_Syntax_Util.univ_kernel u3 in
+                     match uu___ with
+                     | (k, uu___1) ->
+                         (match k with
+                          | FStar_Syntax_Syntax.U_unif v2 ->
+                              FStar_Syntax_Unionfind.univ_equiv v1 v2
+                          | uu___2 -> false)) us
             | uu___ -> occurs_univ v1 (FStar_Syntax_Syntax.U_max [u]) in
           let rec filter_out_common_univs u12 u22 =
             let common_elts =
-              FStar_Compiler_Effect.op_Bar_Greater u12
-                (FStar_Compiler_List.fold_left
-                   (fun uvs ->
-                      fun uv1 ->
-                        let uu___ =
-                          FStar_Compiler_Effect.op_Bar_Greater u22
-                            (FStar_Compiler_List.existsML
-                               (fun uv2 -> FStar_Syntax_Util.eq_univs uv1 uv2)) in
-                        if uu___ then uv1 :: uvs else uvs) []) in
+              FStar_Compiler_List.fold_left
+                (fun uvs ->
+                   fun uv1 ->
+                     let uu___ =
+                       FStar_Compiler_List.existsML
+                         (fun uv2 -> FStar_Syntax_Util.eq_univs uv1 uv2) u22 in
+                     if uu___ then uv1 :: uvs else uvs) [] u12 in
             let filter =
               FStar_Compiler_List.filter
                 (fun u ->
                    let uu___ =
-                     FStar_Compiler_Effect.op_Bar_Greater common_elts
-                       (FStar_Compiler_List.existsML
-                          (fun u' -> FStar_Syntax_Util.eq_univs u u')) in
+                     FStar_Compiler_List.existsML
+                       (fun u' -> FStar_Syntax_Util.eq_univs u u')
+                       common_elts in
                    Prims.op_Negation uu___) in
             let uu___ = filter u12 in
             let uu___1 = filter u22 in (uu___, uu___1) in
@@ -4043,8 +3943,7 @@ let (should_defer_flex_to_user_tac : worklist -> flex_t -> Prims.bool) =
             FStar_TypeChecker_DeferredImplicits.should_defer_uvar_to_user_tac
               wl.tcenv u in
           ((let uu___4 =
-              FStar_Compiler_Effect.op_Less_Bar (debug wl)
-                (FStar_Options.Other "ResolveImplicitsHook") in
+              debug wl (FStar_Options.Other "ResolveImplicitsHook") in
             if uu___4
             then
               let uu___5 = FStar_Syntax_Print.ctx_uvar_to_string_no_reason u in
@@ -4308,8 +4207,7 @@ let (simplify_vc :
     fun env ->
       fun t ->
         (let uu___1 =
-           FStar_Compiler_Effect.op_Less_Bar
-             (FStar_TypeChecker_Env.debug env)
+           FStar_TypeChecker_Env.debug env
              (FStar_Options.Other "Simplification") in
          if uu___1
          then
@@ -4330,8 +4228,7 @@ let (simplify_vc :
          let t' =
            norm_with_steps "FStar.TypeChecker.Rel.simplify_vc" steps1 env t in
          (let uu___2 =
-            FStar_Compiler_Effect.op_Less_Bar
-              (FStar_TypeChecker_Env.debug env)
+            FStar_TypeChecker_Env.debug env
               (FStar_Options.Other "Simplification") in
           if uu___2
           then
@@ -4442,8 +4339,7 @@ let (apply_substitutive_indexed_subcomp :
                     fun subcomp_name ->
                       fun r1 ->
                         let debug1 =
-                          FStar_Compiler_Effect.op_Less_Bar (debug wl)
-                            (FStar_Options.Other "LayeredEffectsApp") in
+                          debug wl (FStar_Options.Other "LayeredEffectsApp") in
                         let uu___ =
                           let uu___1 = bs in
                           match uu___1 with
@@ -4617,9 +4513,8 @@ let (apply_substitutive_indexed_subcomp :
                                                  ((FStar_Compiler_List.length
                                                      bs4)
                                                     - Prims.int_one) bs4 in
-                                             FStar_Compiler_Effect.op_Bar_Greater
-                                               uu___4
-                                               FStar_Pervasives_Native.fst in
+                                             FStar_Pervasives_Native.fst
+                                               uu___4 in
                                            let uu___4 =
                                              FStar_Compiler_List.fold_left
                                                (fun uu___5 ->
@@ -4690,14 +4585,10 @@ let (apply_substitutive_indexed_subcomp :
                                             | (subst4, wl3) ->
                                                 let subcomp_ct =
                                                   let uu___5 =
-                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                      subcomp_c
-                                                      (FStar_Syntax_Subst.subst_comp
-                                                         subst4) in
-                                                  FStar_Compiler_Effect.op_Bar_Greater
-                                                    uu___5
-                                                    (FStar_TypeChecker_Env.comp_to_comp_typ
-                                                       env) in
+                                                    FStar_Syntax_Subst.subst_comp
+                                                      subst4 subcomp_c in
+                                                  FStar_TypeChecker_Env.comp_to_comp_typ
+                                                    env uu___5 in
                                                 let fml =
                                                   let uu___5 =
                                                     let uu___6 =
@@ -4751,8 +4642,7 @@ let (apply_ad_hoc_indexed_subcomp :
                 fun subcomp_name ->
                   fun r1 ->
                     let dbg =
-                      FStar_Compiler_Effect.op_Less_Bar (debug wl)
-                        (FStar_Options.Other "LayeredEffectsApp") in
+                      debug wl (FStar_Options.Other "LayeredEffectsApp") in
                     let stronger_t_shape_error s =
                       let uu___ =
                         FStar_Ident.string_of_lid
@@ -4769,16 +4659,13 @@ let (apply_ad_hoc_indexed_subcomp :
                         | a_b::bs1 ->
                             let uu___2 =
                               let uu___3 =
-                                FStar_Compiler_Effect.op_Bar_Greater bs1
-                                  (FStar_Compiler_List.splitAt
-                                     ((FStar_Compiler_List.length bs1) -
-                                        Prims.int_one)) in
-                              FStar_Compiler_Effect.op_Bar_Greater uu___3
-                                (fun uu___4 ->
-                                   match uu___4 with
-                                   | (l1, l2) ->
-                                       let uu___5 = FStar_Compiler_List.hd l2 in
-                                       (l1, uu___5)) in
+                                FStar_Compiler_List.splitAt
+                                  ((FStar_Compiler_List.length bs1) -
+                                     Prims.int_one) bs1 in
+                              match uu___3 with
+                              | (l1, l2) ->
+                                  let uu___4 = FStar_Compiler_List.hd l2 in
+                                  (l1, uu___4) in
                             (match uu___2 with
                              | (rest_bs, f_b) -> (a_b, rest_bs, f_b))
                       else
@@ -4851,14 +4738,12 @@ let (apply_ad_hoc_indexed_subcomp :
                                    FStar_Syntax_Util.effect_indices_from_repr
                                      (f_b.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort
                                      uu___4 r1 uu___5 in
-                                 FStar_Compiler_Effect.op_Bar_Greater uu___3
-                                   (FStar_Compiler_List.map
-                                      (FStar_Syntax_Subst.subst substs)) in
+                                 FStar_Compiler_List.map
+                                   (FStar_Syntax_Subst.subst substs) uu___3 in
                                let uu___3 =
-                                 FStar_Compiler_Effect.op_Bar_Greater
-                                   ct1.FStar_Syntax_Syntax.effect_args
-                                   (FStar_Compiler_List.map
-                                      FStar_Pervasives_Native.fst) in
+                                 FStar_Compiler_List.map
+                                   FStar_Pervasives_Native.fst
+                                   ct1.FStar_Syntax_Syntax.effect_args in
                                FStar_Compiler_List.fold_left2
                                  (fun uu___4 ->
                                     fun f_sort_i ->
@@ -4866,8 +4751,7 @@ let (apply_ad_hoc_indexed_subcomp :
                                         match uu___4 with
                                         | (ps, wl2) ->
                                             ((let uu___6 =
-                                                FStar_Compiler_Effect.op_Less_Bar
-                                                  (debug wl2)
+                                                debug wl2
                                                   (FStar_Options.Other
                                                      "LayeredEffectsEqns") in
                                               if uu___6
@@ -4897,13 +4781,10 @@ let (apply_ad_hoc_indexed_subcomp :
                               | (f_sub_probs, wl2) ->
                                   let subcomp_ct =
                                     let uu___3 =
-                                      FStar_Compiler_Effect.op_Bar_Greater
-                                        subcomp_c
-                                        (FStar_Syntax_Subst.subst_comp substs) in
-                                    FStar_Compiler_Effect.op_Bar_Greater
-                                      uu___3
-                                      (FStar_TypeChecker_Env.comp_to_comp_typ
-                                         env) in
+                                      FStar_Syntax_Subst.subst_comp substs
+                                        subcomp_c in
+                                    FStar_TypeChecker_Env.comp_to_comp_typ
+                                      env uu___3 in
                                   let uu___3 =
                                     let g_sort_is =
                                       let uu___4 =
@@ -4917,10 +4798,9 @@ let (apply_ad_hoc_indexed_subcomp :
                                         subcomp_ct.FStar_Syntax_Syntax.result_typ
                                         uu___4 r1 uu___5 in
                                     let uu___4 =
-                                      FStar_Compiler_Effect.op_Bar_Greater
-                                        ct2.FStar_Syntax_Syntax.effect_args
-                                        (FStar_Compiler_List.map
-                                           FStar_Pervasives_Native.fst) in
+                                      FStar_Compiler_List.map
+                                        FStar_Pervasives_Native.fst
+                                        ct2.FStar_Syntax_Syntax.effect_args in
                                     FStar_Compiler_List.fold_left2
                                       (fun uu___5 ->
                                          fun g_sort_i ->
@@ -4928,8 +4808,7 @@ let (apply_ad_hoc_indexed_subcomp :
                                              match uu___5 with
                                              | (ps, wl3) ->
                                                  ((let uu___7 =
-                                                     FStar_Compiler_Effect.op_Less_Bar
-                                                       (debug wl3)
+                                                     debug wl3
                                                        (FStar_Options.Other
                                                           "LayeredEffectsEqns") in
                                                    if uu___7
@@ -4984,12 +4863,10 @@ let (has_typeclass_constraint :
   FStar_Syntax_Syntax.ctx_uvar -> worklist -> Prims.bool) =
   fun u ->
     fun wl ->
-      FStar_Compiler_Effect.op_Bar_Greater wl.typeclass_variables
-        (FStar_Compiler_Set.for_any FStar_Syntax_Free.ord_ctx_uvar
-           (fun v ->
-              FStar_Syntax_Unionfind.equiv
-                v.FStar_Syntax_Syntax.ctx_uvar_head
-                u.FStar_Syntax_Syntax.ctx_uvar_head))
+      FStar_Compiler_Set.for_any FStar_Syntax_Free.ord_ctx_uvar
+        (fun v ->
+           FStar_Syntax_Unionfind.equiv v.FStar_Syntax_Syntax.ctx_uvar_head
+             u.FStar_Syntax_Syntax.ctx_uvar_head) wl.typeclass_variables
 let (lazy_complete_repr : FStar_Syntax_Syntax.lazy_kind -> Prims.bool) =
   fun k ->
     match k with
@@ -5026,17 +4903,13 @@ let (gamma_has_free_uvars :
          | uu___1 -> false) g
 let rec (solve : worklist -> solution) =
   fun probs ->
-    (let uu___1 =
-       FStar_Compiler_Effect.op_Less_Bar (debug probs)
-         (FStar_Options.Other "Rel") in
+    (let uu___1 = debug probs (FStar_Options.Other "Rel") in
      if uu___1
      then
        let uu___2 = wl_to_string probs in
        FStar_Compiler_Util.print1 "solve:\n\t%s\n" uu___2
      else ());
-    (let uu___2 =
-       FStar_Compiler_Effect.op_Less_Bar (debug probs)
-         (FStar_Options.Other "ImplicitTrace") in
+    (let uu___2 = debug probs (FStar_Options.Other "ImplicitTrace") in
      if uu___2
      then
        let uu___3 =
@@ -5124,11 +4997,11 @@ let rec (solve : worklist -> solution) =
               Success uu___3
           | uu___3 ->
               let uu___4 =
-                FStar_Compiler_Effect.op_Bar_Greater probs.wl_deferred
-                  (FStar_Compiler_List.partition
-                     (fun uu___5 ->
-                        match uu___5 with
-                        | (c, uu___6, uu___7, uu___8) -> c < probs.ctr)) in
+                FStar_Compiler_List.partition
+                  (fun uu___5 ->
+                     match uu___5 with
+                     | (c, uu___6, uu___7, uu___8) -> c < probs.ctr)
+                  probs.wl_deferred in
               (match uu___4 with
                | (attempt1, rest) ->
                    (match attempt1 with
@@ -5141,11 +5014,11 @@ let rec (solve : worklist -> solution) =
                     | uu___5 ->
                         let uu___6 =
                           let uu___7 =
-                            FStar_Compiler_Effect.op_Bar_Greater attempt1
-                              (FStar_Compiler_List.map
-                                 (fun uu___8 ->
-                                    match uu___8 with
-                                    | (uu___9, uu___10, uu___11, y) -> y)) in
+                            FStar_Compiler_List.map
+                              (fun uu___8 ->
+                                 match uu___8 with
+                                 | (uu___9, uu___10, uu___11, y) -> y)
+                              attempt1 in
                           {
                             attempting = uu___7;
                             wl_deferred = rest;
@@ -5244,9 +5117,7 @@ and (giveup_or_defer :
         fun msg ->
           if wl.defer_ok = DeferAny
           then
-            ((let uu___1 =
-                FStar_Compiler_Effect.op_Less_Bar (debug wl)
-                  (FStar_Options.Other "Rel") in
+            ((let uu___1 = debug wl (FStar_Options.Other "Rel") in
               if uu___1
               then
                 let uu___2 = prob_to_string wl.tcenv orig in
@@ -5267,9 +5138,7 @@ and (giveup_or_defer_flex_flex :
         fun msg ->
           if wl.defer_ok <> NoDefer
           then
-            ((let uu___1 =
-                FStar_Compiler_Effect.op_Less_Bar (debug wl)
-                  (FStar_Options.Other "Rel") in
+            ((let uu___1 = debug wl (FStar_Options.Other "Rel") in
               if uu___1
               then
                 let uu___2 = prob_to_string wl.tcenv orig in
@@ -5284,9 +5153,7 @@ and (defer_to_user_tac :
   fun orig ->
     fun reason ->
       fun wl ->
-        (let uu___1 =
-           FStar_Compiler_Effect.op_Less_Bar (debug wl)
-             (FStar_Options.Other "Rel") in
+        (let uu___1 = debug wl (FStar_Options.Other "Rel") in
          if uu___1
          then
            let uu___2 = prob_to_string wl.tcenv orig in
@@ -5381,9 +5248,7 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                     (FStar_TypeChecker_Common.TProb p);
                   ((FStar_TypeChecker_Common.TProb p), wl3)) in
            let pairwise t1 t2 wl2 =
-             (let uu___2 =
-                FStar_Compiler_Effect.op_Less_Bar (debug wl2)
-                  (FStar_Options.Other "Rel") in
+             (let uu___2 = debug wl2 (FStar_Options.Other "Rel") in
               if uu___2
               then
                 let uu___3 =
@@ -5650,9 +5515,7 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                             (match uu___4 with
                              | (t12, ps, wl3) ->
                                  ((let uu___6 =
-                                     FStar_Compiler_Effect.op_Less_Bar
-                                       (debug wl3)
-                                       (FStar_Options.Other "Rel") in
+                                     debug wl3 (FStar_Options.Other "Rel") in
                                    if uu___6
                                    then
                                      let uu___7 =
@@ -5711,8 +5574,7 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                           | FStar_Pervasives_Native.Some (flex_bs, flex_t1)
                               ->
                               ((let uu___7 =
-                                  FStar_Compiler_Effect.op_Less_Bar
-                                    (debug wl1) (FStar_Options.Other "Rel") in
+                                  debug wl1 (FStar_Options.Other "Rel") in
                                 if uu___7
                                 then
                                   let uu___8 =
@@ -5755,9 +5617,7 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                             }] wl in
                      solve uu___5)
               | uu___3 ->
-                  ((let uu___5 =
-                      FStar_Compiler_Effect.op_Less_Bar (debug wl)
-                        (FStar_Options.Other "Rel") in
+                  ((let uu___5 = debug wl (FStar_Options.Other "Rel") in
                     if uu___5
                     then
                       let uu___6 =
@@ -5791,27 +5651,24 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                           ctx_uvar'.FStar_Syntax_Syntax.ctx_uvar_head
                                     | uu___10 -> false) in
                              let uu___7 =
-                               FStar_Compiler_Effect.op_Bar_Greater
-                                 wl.attempting
-                                 (FStar_Compiler_List.partition
-                                    (fun uu___8 ->
-                                       match uu___8 with
-                                       | FStar_TypeChecker_Common.TProb tp1
-                                           ->
-                                           let tp2 = maybe_invert tp1 in
-                                           (match tp2.FStar_TypeChecker_Common.rank
-                                            with
-                                            | FStar_Pervasives_Native.Some
-                                                rank' when rank1 = rank' ->
-                                                if flip
-                                                then
-                                                  equiv
-                                                    tp2.FStar_TypeChecker_Common.lhs
-                                                else
-                                                  equiv
-                                                    tp2.FStar_TypeChecker_Common.rhs
-                                            | uu___9 -> false)
-                                       | uu___9 -> false)) in
+                               FStar_Compiler_List.partition
+                                 (fun uu___8 ->
+                                    match uu___8 with
+                                    | FStar_TypeChecker_Common.TProb tp1 ->
+                                        let tp2 = maybe_invert tp1 in
+                                        (match tp2.FStar_TypeChecker_Common.rank
+                                         with
+                                         | FStar_Pervasives_Native.Some rank'
+                                             when rank1 = rank' ->
+                                             if flip
+                                             then
+                                               equiv
+                                                 tp2.FStar_TypeChecker_Common.lhs
+                                             else
+                                               equiv
+                                                 tp2.FStar_TypeChecker_Common.rhs
+                                         | uu___9 -> false)
+                                    | uu___9 -> false) wl.attempting in
                              (match uu___7 with
                               | (bounds_probs, rest) ->
                                   let bounds_typs =
@@ -5916,8 +5773,7 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                     (FStar_TypeChecker_Common.TProb
                                                        eq_prob);
                                                   (let uu___13 =
-                                                     FStar_Compiler_Effect.op_Less_Bar
-                                                       (debug wl1)
+                                                     debug wl1
                                                        (FStar_Options.Other
                                                           "Rel") in
                                                    if uu___13
@@ -6050,8 +5906,7 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                          solve wl4)
                                                     | Failed (p, msg) ->
                                                         ((let uu___16 =
-                                                            FStar_Compiler_Effect.op_Less_Bar
-                                                              (debug wl1)
+                                                            debug wl1
                                                               (FStar_Options.Other
                                                                  "Rel") in
                                                           if uu___16
@@ -6065,10 +5920,8 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                                     eq_prob)
                                                                   ::
                                                                   sub_probs) in
-                                                              FStar_Compiler_Effect.op_Bar_Greater
-                                                                uu___18
-                                                                (FStar_Compiler_String.concat
-                                                                   "\n") in
+                                                              FStar_Compiler_String.concat
+                                                                "\n" uu___18 in
                                                             FStar_Compiler_Util.print1
                                                               "meet/join attempted and failed to solve problems:\n%s\n"
                                                               uu___17
@@ -6298,9 +6151,7 @@ and (imitate_arrow :
                                          let uu___8 =
                                            let uu___9 =
                                              FStar_Syntax_Util.type_u () in
-                                           FStar_Compiler_Effect.op_Less_Bar
-                                             FStar_Pervasives_Native.fst
-                                             uu___9 in
+                                           FStar_Pervasives_Native.fst uu___9 in
                                          copy_uvar u_lhs [] uu___8 wl2 in
                                        (match uu___7 with
                                         | (uu___8, t_a, wl3) ->
@@ -6386,8 +6237,7 @@ and (imitate_arrow :
                                let uu___4 =
                                  let uu___5 =
                                    let uu___6 = FStar_Syntax_Util.type_u () in
-                                   FStar_Compiler_Effect.op_Bar_Greater
-                                     uu___6 FStar_Pervasives_Native.fst in
+                                   FStar_Pervasives_Native.fst uu___6 in
                                  copy_uvar u_lhs
                                    (FStar_Compiler_List.op_At bs_lhs bs)
                                    uu___5 wl1 in
@@ -6444,9 +6294,7 @@ and (solve_binders :
       fun orig ->
         fun wl ->
           fun rhs ->
-            (let uu___1 =
-               FStar_Compiler_Effect.op_Less_Bar (debug wl)
-                 (FStar_Options.Other "Rel") in
+            (let uu___1 = debug wl (FStar_Options.Other "Rel") in
              if uu___1
              then
                let uu___2 = FStar_Syntax_Print.binders_to_string ", " bs1 in
@@ -6475,9 +6323,7 @@ and (solve_binders :
                    let uu___1 = rhs wl1 scope subst in
                    (match uu___1 with
                     | (rhs_prob, wl2) ->
-                        ((let uu___3 =
-                            FStar_Compiler_Effect.op_Less_Bar (debug wl2)
-                              (FStar_Options.Other "Rel") in
+                        ((let uu___3 = debug wl2 (FStar_Options.Other "Rel") in
                           if uu___3
                           then
                             let uu___4 =
@@ -6529,11 +6375,9 @@ and (solve_binders :
                                  FStar_Syntax_Syntax.sort = uu___3
                                } in
                              let uu___3 =
-                               let uu___4 =
-                                 FStar_Compiler_Effect.op_Less_Bar invert_rel
-                                   (p_rel orig) in
                                mk_t_problem wl1 scope orig
-                                 hd11.FStar_Syntax_Syntax.sort uu___4
+                                 hd11.FStar_Syntax_Syntax.sort
+                                 (invert_rel (p_rel orig))
                                  hd21.FStar_Syntax_Syntax.sort
                                  FStar_Pervasives_Native.None
                                  "Formal parameter" in
@@ -6586,8 +6430,7 @@ and (solve_binders :
                                          FStar_Syntax_Util.mk_conj
                                            (p_guard prob) uu___5 in
                                        ((let uu___6 =
-                                           FStar_Compiler_Effect.op_Less_Bar
-                                             (debug wl3)
+                                           debug wl3
                                              (FStar_Options.Other "Rel") in
                                          if uu___6
                                          then
@@ -6721,9 +6564,7 @@ and (solve_t_flex_rigid_eq :
     fun wl ->
       fun lhs ->
         fun rhs ->
-          (let uu___1 =
-             FStar_Compiler_Effect.op_Less_Bar (debug wl)
-               (FStar_Options.Other "Rel") in
+          (let uu___1 = debug wl (FStar_Options.Other "Rel") in
            if uu___1
            then FStar_Compiler_Util.print_string "solve_t_flex_rigid_eq\n"
            else ());
@@ -6792,12 +6633,10 @@ and (solve_t_flex_rigid_eq :
                               remove_matching_prefix
                                 (FStar_Compiler_List.rev bs_orig)
                                 (FStar_Compiler_List.rev rhs_args) in
-                            FStar_Compiler_Effect.op_Bar_Greater uu___8
-                              (fun uu___9 ->
-                                 match uu___9 with
-                                 | (bs_rev, args_rev) ->
-                                     ((FStar_Compiler_List.rev bs_rev),
-                                       (FStar_Compiler_List.rev args_rev))) in
+                            match uu___8 with
+                            | (bs_rev, args_rev) ->
+                                ((FStar_Compiler_List.rev bs_rev),
+                                  (FStar_Compiler_List.rev args_rev)) in
                           (match uu___7 with
                            | (bs1, rhs_args1) ->
                                let uu___8 =
@@ -6816,9 +6655,7 @@ and (solve_t_flex_rigid_eq :
                                u_abs uu___7 uu___8 rhs2 in
                          [TERM (ctx_u, sol)]) in
               let try_quasi_pattern orig1 env wl1 lhs1 rhs1 =
-                (let uu___4 =
-                   FStar_Compiler_Effect.op_Less_Bar (debug wl1)
-                     (FStar_Options.Other "Rel") in
+                (let uu___4 = debug wl1 (FStar_Options.Other "Rel") in
                  if uu___4
                  then FStar_Compiler_Util.print_string "try_quasi_pattern\n"
                  else ());
@@ -7013,12 +6850,9 @@ and (solve_t_flex_rigid_eq :
                                           t_last_arg in
                                       let uu___10 =
                                         let uu___11 =
-                                          FStar_Compiler_Effect.op_Bar_Greater
-                                            t_res_lhs
-                                            FStar_Syntax_Syntax.mk_Total in
-                                        FStar_Compiler_Effect.op_Bar_Greater
-                                          uu___11
-                                          (FStar_Syntax_Util.arrow [b]) in
+                                          FStar_Syntax_Syntax.mk_Total
+                                            t_res_lhs in
+                                        FStar_Syntax_Util.arrow [b] uu___11 in
                                       copy_uvar u_lhs
                                         (FStar_Compiler_List.op_At bs_lhs [b])
                                         uu___10 wl1 in
@@ -7079,9 +6913,7 @@ and (solve_t_flex_rigid_eq :
                                           attempt sub_probs uu___9 in
                                         solve uu___8)))) in
               let imitate orig1 env wl1 lhs1 rhs1 =
-                (let uu___4 =
-                   FStar_Compiler_Effect.op_Less_Bar (debug wl1)
-                     (FStar_Options.Other "Rel") in
+                (let uu___4 = debug wl1 (FStar_Options.Other "Rel") in
                  if uu___4
                  then FStar_Compiler_Util.print_string "imitate\n"
                  else ());
@@ -7134,9 +6966,7 @@ and (solve_t_flex_rigid_eq :
                              msg))) in
               let try_first_order orig1 env wl1 lhs1 rhs1 =
                 let inapplicable msg lstring_opt =
-                  (let uu___4 =
-                     FStar_Compiler_Effect.op_Less_Bar (debug wl1)
-                       (FStar_Options.Other "Rel") in
+                  (let uu___4 = debug wl1 (FStar_Options.Other "Rel") in
                    if uu___4
                    then
                      let extra_msg =
@@ -7149,9 +6979,7 @@ and (solve_t_flex_rigid_eq :
                        extra_msg
                    else ());
                   FStar_Pervasives.Inl "first_order doesn't apply" in
-                (let uu___4 =
-                   FStar_Compiler_Effect.op_Less_Bar (debug wl1)
-                     (FStar_Options.Other "Rel") in
+                (let uu___4 = debug wl1 (FStar_Options.Other "Rel") in
                  if uu___4
                  then
                    let uu___5 = flex_t_to_string lhs1 in
@@ -7525,13 +7353,11 @@ and (solve_t_flex_rigid_eq :
                                                         wl2 ->
                                                         let uu___19 =
                                                           let uu___20 =
-                                                            FStar_Compiler_Effect.op_Bar_Greater
-                                                              head1
-                                                              FStar_Syntax_Free.uvars in
-                                                          FStar_Compiler_Effect.op_Bar_Greater
-                                                            uu___20
-                                                            (FStar_Compiler_Set.elems
-                                                               FStar_Syntax_Free.ord_ctx_uvar) in
+                                                            FStar_Syntax_Free.uvars
+                                                              head1 in
+                                                          FStar_Compiler_Set.elems
+                                                            FStar_Syntax_Free.ord_ctx_uvar
+                                                            uu___20 in
                                                         solve_sub_probs_if_head_types_equal
                                                           uu___19 wl2
                                                     | FStar_Pervasives.Inr
@@ -7569,8 +7395,7 @@ and (solve_t_flex_rigid_eq :
                        (match uu___4 with
                         | FStar_Pervasives_Native.Some lhs_binders ->
                             ((let uu___6 =
-                                FStar_Compiler_Effect.op_Less_Bar (debug wl)
-                                  (FStar_Options.Other "Rel") in
+                                debug wl (FStar_Options.Other "Rel") in
                               if uu___6
                               then
                                 FStar_Compiler_Util.print_string
@@ -7594,8 +7419,7 @@ and (solve_t_flex_rigid_eq :
                                           FStar_Compiler_Option.get msg in
                                         Prims.strcat "occurs-check failed: "
                                           uu___9 in
-                                      FStar_Compiler_Effect.op_Less_Bar
-                                        FStar_Thunk.mkv uu___8 in
+                                      FStar_Thunk.mkv uu___8 in
                                     giveup_or_defer orig wl
                                       FStar_TypeChecker_Common.Deferred_occur_check_failed
                                       uu___7
@@ -7693,9 +7517,7 @@ and (solve_t_flex_flex :
             let run_meta_arg_tac_and_try_again flex =
               let uv = flex_uvar flex in
               let t = run_meta_arg_tac env uv in
-              (let uu___1 =
-                 FStar_Compiler_Effect.op_Less_Bar (debug wl)
-                   (FStar_Options.Other "Rel") in
+              (let uu___1 = debug wl (FStar_Options.Other "Rel") in
                if uu___1
                then
                  let uu___2 =
@@ -7933,8 +7755,7 @@ and (solve_t_flex_flex :
                                                                 w uu___24
                                                                 w.FStar_Syntax_Syntax.pos in
                                                             ((let uu___25 =
-                                                                FStar_Compiler_Effect.op_Less_Bar
-                                                                  (debug wl1)
+                                                                debug wl1
                                                                   (FStar_Options.Other
                                                                     "Rel") in
                                                               if uu___25
@@ -8063,9 +7884,7 @@ and (solve_t' : tprob -> worklist -> solution) =
        let rigid_heads_match need_unif torig wl1 t1 t2 =
          let orig = FStar_TypeChecker_Common.TProb torig in
          let env = p_env wl1 orig in
-         (let uu___2 =
-            FStar_Compiler_Effect.op_Less_Bar (debug wl1)
-              (FStar_Options.Other "Rel") in
+         (let uu___2 = debug wl1 (FStar_Options.Other "Rel") in
           if uu___2
           then
             let uu___3 =
@@ -8230,8 +8049,7 @@ and (solve_t' : tprob -> worklist -> solution) =
                                          match uu___9 with
                                          | (subprobs, wl3) ->
                                              ((let uu___11 =
-                                                 FStar_Compiler_Effect.op_Less_Bar
-                                                   (debug wl3)
+                                                 debug wl3
                                                    (FStar_Options.Other "Rel") in
                                                if uu___11
                                                then
@@ -8308,8 +8126,7 @@ and (solve_t' : tprob -> worklist -> solution) =
                                          match uu___9 with
                                          | (prob, reason) ->
                                              ((let uu___11 =
-                                                 FStar_Compiler_Effect.op_Less_Bar
-                                                   (debug wl2)
+                                                 debug wl2
                                                    (FStar_Options.Other "Rel") in
                                                if uu___11
                                                then
@@ -8364,9 +8181,7 @@ and (solve_t' : tprob -> worklist -> solution) =
                                                                   ->
                                                                   ((let uu___18
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Less_Bar
-                                                                    (debug
-                                                                    wl2)
+                                                                    debug wl2
                                                                     (FStar_Options.Other
                                                                     "Rel") in
                                                                     if
@@ -8436,9 +8251,7 @@ and (solve_t' : tprob -> worklist -> solution) =
                                                                     } in
                                                                   ((let uu___19
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Less_Bar
-                                                                    (debug
-                                                                    wl2)
+                                                                    debug wl2
                                                                     (FStar_Options.Other
                                                                     "Rel") in
                                                                     if
@@ -8559,17 +8372,13 @@ and (solve_t' : tprob -> worklist -> solution) =
                                  let uu___8 =
                                    env.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
                                      env scrutinee must_tot in
-                                 FStar_Compiler_Effect.op_Bar_Greater uu___8
-                                   FStar_Pervasives_Native.fst in
-                               FStar_Compiler_Effect.op_Bar_Greater uu___7
-                                 (FStar_TypeChecker_Normalize.normalize_refinement
-                                    FStar_TypeChecker_Normalize.whnf_steps
-                                    env) in
-                             FStar_Compiler_Effect.op_Bar_Greater uu___6
-                               FStar_Syntax_Util.unrefine in
+                                 FStar_Pervasives_Native.fst uu___8 in
+                               FStar_TypeChecker_Normalize.normalize_refinement
+                                 FStar_TypeChecker_Normalize.whnf_steps env
+                                 uu___7 in
+                             FStar_Syntax_Util.unrefine uu___6 in
                            (let uu___7 =
-                              FStar_Compiler_Effect.op_Less_Bar (debug wl3)
-                                (FStar_Options.Other "Rel") in
+                              debug wl3 (FStar_Options.Other "Rel") in
                             if uu___7
                             then
                               let uu___8 =
@@ -8588,8 +8397,7 @@ and (solve_t' : tprob -> worklist -> solution) =
                             match uu___7 with
                             | (pat_term2, pat_term_t, g_pat_term) ->
                                 ((let uu___9 =
-                                    FStar_Compiler_Effect.op_Less_Bar
-                                      (debug wl3) (FStar_Options.Other "Rel") in
+                                    debug wl3 (FStar_Options.Other "Rel") in
                                   if uu___9
                                   then
                                     let uu___10 =
@@ -8608,11 +8416,9 @@ and (solve_t' : tprob -> worklist -> solution) =
                          (match uu___5 with
                           | (pat_term2, g_pat_term) ->
                               let uu___6 =
-                                let uu___7 =
-                                  FStar_Compiler_Effect.op_Bar_Greater
-                                    g_pat_term (simplify_guard env) in
-                                FStar_Compiler_Effect.op_Bar_Greater uu___7
-                                  FStar_TypeChecker_Env.is_trivial_guard_formula in
+                                let uu___7 = simplify_guard env g_pat_term in
+                                FStar_TypeChecker_Env.is_trivial_guard_formula
+                                  uu___7 in
                               if uu___6
                               then
                                 let uu___7 =
@@ -8707,9 +8513,7 @@ and (solve_t' : tprob -> worklist -> solution) =
          | FStar_Pervasives_Native.None ->
              FStar_Pervasives.Inr FStar_Pervasives_Native.None
          | FStar_Pervasives_Native.Some (t1, t2) ->
-             ((let uu___2 =
-                 FStar_Compiler_Effect.op_Less_Bar (debug wl1)
-                   (FStar_Options.Other "Rel") in
+             ((let uu___2 = debug wl1 (FStar_Options.Other "Rel") in
                if uu___2
                then
                  let uu___3 =
@@ -8742,9 +8546,7 @@ and (solve_t' : tprob -> worklist -> solution) =
                      Prims.op_Negation uu___10 in
                    if uu___9
                    then
-                     ((let uu___11 =
-                         FStar_Compiler_Effect.op_Less_Bar (debug wl1)
-                           (FStar_Options.Other "Rel") in
+                     ((let uu___11 = debug wl1 (FStar_Options.Other "Rel") in
                        if uu___11
                        then
                          let uu___12 =
@@ -8757,9 +8559,7 @@ and (solve_t' : tprob -> worklist -> solution) =
                    else
                      if wl1.defer_ok = DeferAny
                      then
-                       ((let uu___12 =
-                           FStar_Compiler_Effect.op_Less_Bar (debug wl1)
-                             (FStar_Options.Other "Rel") in
+                       ((let uu___12 = debug wl1 (FStar_Options.Other "Rel") in
                          if uu___12
                          then
                            FStar_Compiler_Util.print_string
@@ -8767,9 +8567,7 @@ and (solve_t' : tprob -> worklist -> solution) =
                          else ());
                         FStar_Pervasives.Inl "defer")
                      else
-                       ((let uu___13 =
-                           FStar_Compiler_Effect.op_Less_Bar (debug wl1)
-                             (FStar_Options.Other "Rel") in
+                       ((let uu___13 = debug wl1 (FStar_Options.Other "Rel") in
                          if uu___13
                          then
                            let uu___14 =
@@ -8796,29 +8594,26 @@ and (solve_t' : tprob -> worklist -> solution) =
                               FStar_Pervasives_Native.None, uu___16) -> true
                            | uu___14 -> false in
                          let head_matching_branch =
-                           FStar_Compiler_Effect.op_Bar_Greater branches
-                             (FStar_Compiler_Util.try_find
-                                (fun b ->
-                                   if pat_discriminates b
-                                   then
-                                     let uu___13 =
-                                       FStar_Syntax_Subst.open_branch b in
-                                     match uu___13 with
-                                     | (uu___14, uu___15, t') ->
-                                         let uu___16 =
-                                           head_matches_delta
-                                             (p_env wl1 orig) wl1.smt_ok s t' in
-                                         (match uu___16 with
-                                          | (FullMatch, uu___17) -> true
-                                          | (HeadMatch uu___17, uu___18) ->
-                                              true
-                                          | uu___17 -> false)
-                                   else false)) in
+                           FStar_Compiler_Util.try_find
+                             (fun b ->
+                                if pat_discriminates b
+                                then
+                                  let uu___13 =
+                                    FStar_Syntax_Subst.open_branch b in
+                                  match uu___13 with
+                                  | (uu___14, uu___15, t') ->
+                                      let uu___16 =
+                                        head_matches_delta (p_env wl1 orig)
+                                          wl1.smt_ok s t' in
+                                      (match uu___16 with
+                                       | (FullMatch, uu___17) -> true
+                                       | (HeadMatch uu___17, uu___18) -> true
+                                       | uu___17 -> false)
+                                else false) branches in
                          match head_matching_branch with
                          | FStar_Pervasives_Native.None ->
                              ((let uu___14 =
-                                 FStar_Compiler_Effect.op_Less_Bar
-                                   (debug wl1) (FStar_Options.Other "Rel") in
+                                 debug wl1 (FStar_Options.Other "Rel") in
                                if uu___14
                                then
                                  FStar_Compiler_Util.print_string
@@ -8843,17 +8638,13 @@ and (solve_t' : tprob -> worklist -> solution) =
                                       match uu___15 with
                                       | (p, uu___16, uu___17) ->
                                           try_solve_branch scrutinee p) in
-                               FStar_Compiler_Effect.op_Less_Bar
-                                 (fun uu___15 -> FStar_Pervasives.Inr uu___15)
-                                 uu___14))
+                               FStar_Pervasives.Inr uu___14))
                          | FStar_Pervasives_Native.Some b ->
                              let uu___13 = FStar_Syntax_Subst.open_branch b in
                              (match uu___13 with
                               | (p, uu___14, e) ->
                                   ((let uu___16 =
-                                      FStar_Compiler_Effect.op_Less_Bar
-                                        (debug wl1)
-                                        (FStar_Options.Other "Rel") in
+                                      debug wl1 (FStar_Options.Other "Rel") in
                                     if uu___16
                                     then
                                       let uu___17 =
@@ -8867,10 +8658,7 @@ and (solve_t' : tprob -> worklist -> solution) =
                                     else ());
                                    (let uu___16 =
                                       try_solve_branch scrutinee p in
-                                    FStar_Compiler_Effect.op_Less_Bar
-                                      (fun uu___17 ->
-                                         FStar_Pervasives.Inr uu___17)
-                                      uu___16)))))
+                                    FStar_Pervasives.Inr uu___16)))))
                | ((s, t),
                   (uu___3,
                    {
@@ -8888,9 +8676,7 @@ and (solve_t' : tprob -> worklist -> solution) =
                      Prims.op_Negation uu___10 in
                    if uu___9
                    then
-                     ((let uu___11 =
-                         FStar_Compiler_Effect.op_Less_Bar (debug wl1)
-                           (FStar_Options.Other "Rel") in
+                     ((let uu___11 = debug wl1 (FStar_Options.Other "Rel") in
                        if uu___11
                        then
                          let uu___12 =
@@ -8903,9 +8689,7 @@ and (solve_t' : tprob -> worklist -> solution) =
                    else
                      if wl1.defer_ok = DeferAny
                      then
-                       ((let uu___12 =
-                           FStar_Compiler_Effect.op_Less_Bar (debug wl1)
-                             (FStar_Options.Other "Rel") in
+                       ((let uu___12 = debug wl1 (FStar_Options.Other "Rel") in
                          if uu___12
                          then
                            FStar_Compiler_Util.print_string
@@ -8913,9 +8697,7 @@ and (solve_t' : tprob -> worklist -> solution) =
                          else ());
                         FStar_Pervasives.Inl "defer")
                      else
-                       ((let uu___13 =
-                           FStar_Compiler_Effect.op_Less_Bar (debug wl1)
-                             (FStar_Options.Other "Rel") in
+                       ((let uu___13 = debug wl1 (FStar_Options.Other "Rel") in
                          if uu___13
                          then
                            let uu___14 =
@@ -8942,29 +8724,26 @@ and (solve_t' : tprob -> worklist -> solution) =
                               FStar_Pervasives_Native.None, uu___16) -> true
                            | uu___14 -> false in
                          let head_matching_branch =
-                           FStar_Compiler_Effect.op_Bar_Greater branches
-                             (FStar_Compiler_Util.try_find
-                                (fun b ->
-                                   if pat_discriminates b
-                                   then
-                                     let uu___13 =
-                                       FStar_Syntax_Subst.open_branch b in
-                                     match uu___13 with
-                                     | (uu___14, uu___15, t') ->
-                                         let uu___16 =
-                                           head_matches_delta
-                                             (p_env wl1 orig) wl1.smt_ok s t' in
-                                         (match uu___16 with
-                                          | (FullMatch, uu___17) -> true
-                                          | (HeadMatch uu___17, uu___18) ->
-                                              true
-                                          | uu___17 -> false)
-                                   else false)) in
+                           FStar_Compiler_Util.try_find
+                             (fun b ->
+                                if pat_discriminates b
+                                then
+                                  let uu___13 =
+                                    FStar_Syntax_Subst.open_branch b in
+                                  match uu___13 with
+                                  | (uu___14, uu___15, t') ->
+                                      let uu___16 =
+                                        head_matches_delta (p_env wl1 orig)
+                                          wl1.smt_ok s t' in
+                                      (match uu___16 with
+                                       | (FullMatch, uu___17) -> true
+                                       | (HeadMatch uu___17, uu___18) -> true
+                                       | uu___17 -> false)
+                                else false) branches in
                          match head_matching_branch with
                          | FStar_Pervasives_Native.None ->
                              ((let uu___14 =
-                                 FStar_Compiler_Effect.op_Less_Bar
-                                   (debug wl1) (FStar_Options.Other "Rel") in
+                                 debug wl1 (FStar_Options.Other "Rel") in
                                if uu___14
                                then
                                  FStar_Compiler_Util.print_string
@@ -8989,17 +8768,13 @@ and (solve_t' : tprob -> worklist -> solution) =
                                       match uu___15 with
                                       | (p, uu___16, uu___17) ->
                                           try_solve_branch scrutinee p) in
-                               FStar_Compiler_Effect.op_Less_Bar
-                                 (fun uu___15 -> FStar_Pervasives.Inr uu___15)
-                                 uu___14))
+                               FStar_Pervasives.Inr uu___14))
                          | FStar_Pervasives_Native.Some b ->
                              let uu___13 = FStar_Syntax_Subst.open_branch b in
                              (match uu___13 with
                               | (p, uu___14, e) ->
                                   ((let uu___16 =
-                                      FStar_Compiler_Effect.op_Less_Bar
-                                        (debug wl1)
-                                        (FStar_Options.Other "Rel") in
+                                      debug wl1 (FStar_Options.Other "Rel") in
                                     if uu___16
                                     then
                                       let uu___17 =
@@ -9013,14 +8788,9 @@ and (solve_t' : tprob -> worklist -> solution) =
                                     else ());
                                    (let uu___16 =
                                       try_solve_branch scrutinee p in
-                                    FStar_Compiler_Effect.op_Less_Bar
-                                      (fun uu___17 ->
-                                         FStar_Pervasives.Inr uu___17)
-                                      uu___16)))))
+                                    FStar_Pervasives.Inr uu___16)))))
                | uu___3 ->
-                   ((let uu___5 =
-                       FStar_Compiler_Effect.op_Less_Bar (debug wl1)
-                         (FStar_Options.Other "Rel") in
+                   ((let uu___5 = debug wl1 (FStar_Options.Other "Rel") in
                      if uu___5
                      then
                        let uu___6 = FStar_Syntax_Print.tag_of_term t1 in
@@ -9032,9 +8802,7 @@ and (solve_t' : tprob -> worklist -> solution) =
                     FStar_Pervasives.Inr FStar_Pervasives_Native.None))) in
        let rigid_rigid_delta torig wl1 head1 head2 t1 t2 =
          let orig = FStar_TypeChecker_Common.TProb torig in
-         (let uu___2 =
-            FStar_Compiler_Effect.op_Less_Bar (debug wl1)
-              (FStar_Options.Other "RelDelta") in
+         (let uu___2 = debug wl1 (FStar_Options.Other "RelDelta") in
           if uu___2
           then
             let uu___3 = FStar_Syntax_Print.tag_of_term t1 in
@@ -9687,9 +9455,8 @@ and (solve_t' : tprob -> worklist -> solution) =
                                        FStar_Syntax_Subst.subst subst phi21 in
                                      let mk_imp imp phi13 phi23 =
                                        let uu___12 = imp phi13 phi23 in
-                                       FStar_Compiler_Effect.op_Bar_Greater
-                                         uu___12
-                                         (guard_on_element wl1 problem x13) in
+                                       guard_on_element wl1 problem x13
+                                         uu___12 in
                                      let fallback uu___12 =
                                        let impl =
                                          if
@@ -9814,10 +9581,9 @@ and (solve_t' : tprob -> worklist -> solution) =
                                                     tx;
                                                   (let guard =
                                                      let uu___16 =
-                                                       FStar_Compiler_Effect.op_Bar_Greater
-                                                         (p_guard ref_prob)
-                                                         (guard_on_element
-                                                            wl2 problem x13) in
+                                                       guard_on_element wl2
+                                                         problem x13
+                                                         (p_guard ref_prob) in
                                                      FStar_Syntax_Util.mk_conj
                                                        (p_guard base_prob)
                                                        uu___16 in
@@ -10351,7 +10117,7 @@ and (solve_t' : tprob -> worklist -> solution) =
             | (FStar_Syntax_Syntax.Tm_refine uu___7, uu___8) ->
                 let t21 =
                   let uu___9 = base_and_refinement (p_env wl orig) t2 in
-                  FStar_Compiler_Effect.op_Less_Bar force_refinement uu___9 in
+                  force_refinement uu___9 in
                 solve_t'
                   {
                     FStar_TypeChecker_Common.pid =
@@ -10377,7 +10143,7 @@ and (solve_t' : tprob -> worklist -> solution) =
             | (uu___7, FStar_Syntax_Syntax.Tm_refine uu___8) ->
                 let t11 =
                   let uu___9 = base_and_refinement (p_env wl orig) t1 in
-                  FStar_Compiler_Effect.op_Less_Bar force_refinement uu___9 in
+                  force_refinement uu___9 in
                 solve_t'
                   {
                     FStar_TypeChecker_Common.pid =
@@ -10451,9 +10217,8 @@ and (solve_t' : tprob -> worklist -> solution) =
                                               let uu___19 =
                                                 FStar_Syntax_Syntax.pat_bvs
                                                   p11 in
-                                              FStar_Compiler_Effect.op_Less_Bar
-                                                (FStar_Compiler_List.map
-                                                   FStar_Syntax_Syntax.mk_binder)
+                                              FStar_Compiler_List.map
+                                                FStar_Syntax_Syntax.mk_binder
                                                 uu___19 in
                                             let uu___19 =
                                               match (w11, w22) with
@@ -10501,8 +10266,7 @@ and (solve_t' : tprob -> worklist -> solution) =
                                                      (match uu___21 with
                                                       | (prob, wl3) ->
                                                           ((let uu___23 =
-                                                              FStar_Compiler_Effect.op_Less_Bar
-                                                                (debug wl3)
+                                                              debug wl3
                                                                 (FStar_Options.Other
                                                                    "Rel") in
                                                             if uu___23
@@ -10606,12 +10370,10 @@ and (solve_t' : tprob -> worklist -> solution) =
             | (FStar_Syntax_Syntax.Tm_match uu___7, uu___8) ->
                 let head1 =
                   let uu___9 = FStar_Syntax_Util.head_and_args t1 in
-                  FStar_Compiler_Effect.op_Bar_Greater uu___9
-                    FStar_Pervasives_Native.fst in
+                  FStar_Pervasives_Native.fst uu___9 in
                 let head2 =
                   let uu___9 = FStar_Syntax_Util.head_and_args t2 in
-                  FStar_Compiler_Effect.op_Bar_Greater uu___9
-                    FStar_Pervasives_Native.fst in
+                  FStar_Pervasives_Native.fst uu___9 in
                 ((let uu___10 = debug wl (FStar_Options.Other "Rel") in
                   if uu___10
                   then
@@ -10744,12 +10506,10 @@ and (solve_t' : tprob -> worklist -> solution) =
             | (FStar_Syntax_Syntax.Tm_uinst uu___7, uu___8) ->
                 let head1 =
                   let uu___9 = FStar_Syntax_Util.head_and_args t1 in
-                  FStar_Compiler_Effect.op_Bar_Greater uu___9
-                    FStar_Pervasives_Native.fst in
+                  FStar_Pervasives_Native.fst uu___9 in
                 let head2 =
                   let uu___9 = FStar_Syntax_Util.head_and_args t2 in
-                  FStar_Compiler_Effect.op_Bar_Greater uu___9
-                    FStar_Pervasives_Native.fst in
+                  FStar_Pervasives_Native.fst uu___9 in
                 ((let uu___10 = debug wl (FStar_Options.Other "Rel") in
                   if uu___10
                   then
@@ -10882,12 +10642,10 @@ and (solve_t' : tprob -> worklist -> solution) =
             | (FStar_Syntax_Syntax.Tm_name uu___7, uu___8) ->
                 let head1 =
                   let uu___9 = FStar_Syntax_Util.head_and_args t1 in
-                  FStar_Compiler_Effect.op_Bar_Greater uu___9
-                    FStar_Pervasives_Native.fst in
+                  FStar_Pervasives_Native.fst uu___9 in
                 let head2 =
                   let uu___9 = FStar_Syntax_Util.head_and_args t2 in
-                  FStar_Compiler_Effect.op_Bar_Greater uu___9
-                    FStar_Pervasives_Native.fst in
+                  FStar_Pervasives_Native.fst uu___9 in
                 ((let uu___10 = debug wl (FStar_Options.Other "Rel") in
                   if uu___10
                   then
@@ -11020,12 +10778,10 @@ and (solve_t' : tprob -> worklist -> solution) =
             | (FStar_Syntax_Syntax.Tm_constant uu___7, uu___8) ->
                 let head1 =
                   let uu___9 = FStar_Syntax_Util.head_and_args t1 in
-                  FStar_Compiler_Effect.op_Bar_Greater uu___9
-                    FStar_Pervasives_Native.fst in
+                  FStar_Pervasives_Native.fst uu___9 in
                 let head2 =
                   let uu___9 = FStar_Syntax_Util.head_and_args t2 in
-                  FStar_Compiler_Effect.op_Bar_Greater uu___9
-                    FStar_Pervasives_Native.fst in
+                  FStar_Pervasives_Native.fst uu___9 in
                 ((let uu___10 = debug wl (FStar_Options.Other "Rel") in
                   if uu___10
                   then
@@ -11158,12 +10914,10 @@ and (solve_t' : tprob -> worklist -> solution) =
             | (FStar_Syntax_Syntax.Tm_fvar uu___7, uu___8) ->
                 let head1 =
                   let uu___9 = FStar_Syntax_Util.head_and_args t1 in
-                  FStar_Compiler_Effect.op_Bar_Greater uu___9
-                    FStar_Pervasives_Native.fst in
+                  FStar_Pervasives_Native.fst uu___9 in
                 let head2 =
                   let uu___9 = FStar_Syntax_Util.head_and_args t2 in
-                  FStar_Compiler_Effect.op_Bar_Greater uu___9
-                    FStar_Pervasives_Native.fst in
+                  FStar_Pervasives_Native.fst uu___9 in
                 ((let uu___10 = debug wl (FStar_Options.Other "Rel") in
                   if uu___10
                   then
@@ -11296,12 +11050,10 @@ and (solve_t' : tprob -> worklist -> solution) =
             | (FStar_Syntax_Syntax.Tm_app uu___7, uu___8) ->
                 let head1 =
                   let uu___9 = FStar_Syntax_Util.head_and_args t1 in
-                  FStar_Compiler_Effect.op_Bar_Greater uu___9
-                    FStar_Pervasives_Native.fst in
+                  FStar_Pervasives_Native.fst uu___9 in
                 let head2 =
                   let uu___9 = FStar_Syntax_Util.head_and_args t2 in
-                  FStar_Compiler_Effect.op_Bar_Greater uu___9
-                    FStar_Pervasives_Native.fst in
+                  FStar_Pervasives_Native.fst uu___9 in
                 ((let uu___10 = debug wl (FStar_Options.Other "Rel") in
                   if uu___10
                   then
@@ -11434,12 +11186,10 @@ and (solve_t' : tprob -> worklist -> solution) =
             | (uu___7, FStar_Syntax_Syntax.Tm_match uu___8) ->
                 let head1 =
                   let uu___9 = FStar_Syntax_Util.head_and_args t1 in
-                  FStar_Compiler_Effect.op_Bar_Greater uu___9
-                    FStar_Pervasives_Native.fst in
+                  FStar_Pervasives_Native.fst uu___9 in
                 let head2 =
                   let uu___9 = FStar_Syntax_Util.head_and_args t2 in
-                  FStar_Compiler_Effect.op_Bar_Greater uu___9
-                    FStar_Pervasives_Native.fst in
+                  FStar_Pervasives_Native.fst uu___9 in
                 ((let uu___10 = debug wl (FStar_Options.Other "Rel") in
                   if uu___10
                   then
@@ -11572,12 +11322,10 @@ and (solve_t' : tprob -> worklist -> solution) =
             | (uu___7, FStar_Syntax_Syntax.Tm_uinst uu___8) ->
                 let head1 =
                   let uu___9 = FStar_Syntax_Util.head_and_args t1 in
-                  FStar_Compiler_Effect.op_Bar_Greater uu___9
-                    FStar_Pervasives_Native.fst in
+                  FStar_Pervasives_Native.fst uu___9 in
                 let head2 =
                   let uu___9 = FStar_Syntax_Util.head_and_args t2 in
-                  FStar_Compiler_Effect.op_Bar_Greater uu___9
-                    FStar_Pervasives_Native.fst in
+                  FStar_Pervasives_Native.fst uu___9 in
                 ((let uu___10 = debug wl (FStar_Options.Other "Rel") in
                   if uu___10
                   then
@@ -11710,12 +11458,10 @@ and (solve_t' : tprob -> worklist -> solution) =
             | (uu___7, FStar_Syntax_Syntax.Tm_name uu___8) ->
                 let head1 =
                   let uu___9 = FStar_Syntax_Util.head_and_args t1 in
-                  FStar_Compiler_Effect.op_Bar_Greater uu___9
-                    FStar_Pervasives_Native.fst in
+                  FStar_Pervasives_Native.fst uu___9 in
                 let head2 =
                   let uu___9 = FStar_Syntax_Util.head_and_args t2 in
-                  FStar_Compiler_Effect.op_Bar_Greater uu___9
-                    FStar_Pervasives_Native.fst in
+                  FStar_Pervasives_Native.fst uu___9 in
                 ((let uu___10 = debug wl (FStar_Options.Other "Rel") in
                   if uu___10
                   then
@@ -11848,12 +11594,10 @@ and (solve_t' : tprob -> worklist -> solution) =
             | (uu___7, FStar_Syntax_Syntax.Tm_constant uu___8) ->
                 let head1 =
                   let uu___9 = FStar_Syntax_Util.head_and_args t1 in
-                  FStar_Compiler_Effect.op_Bar_Greater uu___9
-                    FStar_Pervasives_Native.fst in
+                  FStar_Pervasives_Native.fst uu___9 in
                 let head2 =
                   let uu___9 = FStar_Syntax_Util.head_and_args t2 in
-                  FStar_Compiler_Effect.op_Bar_Greater uu___9
-                    FStar_Pervasives_Native.fst in
+                  FStar_Pervasives_Native.fst uu___9 in
                 ((let uu___10 = debug wl (FStar_Options.Other "Rel") in
                   if uu___10
                   then
@@ -11986,12 +11730,10 @@ and (solve_t' : tprob -> worklist -> solution) =
             | (uu___7, FStar_Syntax_Syntax.Tm_fvar uu___8) ->
                 let head1 =
                   let uu___9 = FStar_Syntax_Util.head_and_args t1 in
-                  FStar_Compiler_Effect.op_Bar_Greater uu___9
-                    FStar_Pervasives_Native.fst in
+                  FStar_Pervasives_Native.fst uu___9 in
                 let head2 =
                   let uu___9 = FStar_Syntax_Util.head_and_args t2 in
-                  FStar_Compiler_Effect.op_Bar_Greater uu___9
-                    FStar_Pervasives_Native.fst in
+                  FStar_Pervasives_Native.fst uu___9 in
                 ((let uu___10 = debug wl (FStar_Options.Other "Rel") in
                   if uu___10
                   then
@@ -12124,12 +11866,10 @@ and (solve_t' : tprob -> worklist -> solution) =
             | (uu___7, FStar_Syntax_Syntax.Tm_app uu___8) ->
                 let head1 =
                   let uu___9 = FStar_Syntax_Util.head_and_args t1 in
-                  FStar_Compiler_Effect.op_Bar_Greater uu___9
-                    FStar_Pervasives_Native.fst in
+                  FStar_Pervasives_Native.fst uu___9 in
                 let head2 =
                   let uu___9 = FStar_Syntax_Util.head_and_args t2 in
-                  FStar_Compiler_Effect.op_Bar_Greater uu___9
-                    FStar_Pervasives_Native.fst in
+                  FStar_Pervasives_Native.fst uu___9 in
                 ((let uu___10 = debug wl (FStar_Options.Other "Rel") in
                   if uu___10
                   then
@@ -12362,9 +12102,7 @@ and (solve_c :
         mk_t_problem wl1 [] orig t1 rel t2 FStar_Pervasives_Native.None
           reason in
       let solve_eq c1_comp c2_comp g_lift =
-        (let uu___1 =
-           FStar_Compiler_Effect.op_Less_Bar (debug wl)
-             (FStar_Options.Other "EQ") in
+        (let uu___1 = debug wl (FStar_Options.Other "EQ") in
          if uu___1
          then
            let uu___2 =
@@ -12475,12 +12213,11 @@ and (solve_c :
                               let uu___7 =
                                 let uu___8 =
                                   let uu___9 =
-                                    FStar_Compiler_Effect.op_Bar_Greater
-                                      g_lift.FStar_TypeChecker_Common.deferred
-                                      (FStar_Compiler_List.map
-                                         (fun uu___10 ->
-                                            match uu___10 with
-                                            | (uu___11, uu___12, p) -> p)) in
+                                    FStar_Compiler_List.map
+                                      (fun uu___10 ->
+                                         match uu___10 with
+                                         | (uu___11, uu___12, p) -> p)
+                                      g_lift.FStar_TypeChecker_Common.deferred in
                                   FStar_Compiler_List.op_At arg_sub_probs
                                     uu___9 in
                                 FStar_Compiler_List.op_At [ret_sub_prob]
@@ -12533,23 +12270,15 @@ and (solve_c :
                 Prims.op_Negation uu___1))
               && (FStar_TypeChecker_Env.is_reifiable_effect wl.tcenv c22) in
       let solve_layered_sub c11 c21 =
-        (let uu___1 =
-           FStar_Compiler_Effect.op_Less_Bar (debug wl)
-             (FStar_Options.Other "LayeredEffectsApp") in
+        (let uu___1 = debug wl (FStar_Options.Other "LayeredEffectsApp") in
          if uu___1
          then
            let uu___2 =
-             let uu___3 =
-               FStar_Compiler_Effect.op_Bar_Greater c11
-                 FStar_Syntax_Syntax.mk_Comp in
-             FStar_Compiler_Effect.op_Bar_Greater uu___3
-               (FStar_Class_Show.show FStar_Syntax_Print.showable_comp) in
+             let uu___3 = FStar_Syntax_Syntax.mk_Comp c11 in
+             FStar_Class_Show.show FStar_Syntax_Print.showable_comp uu___3 in
            let uu___3 =
-             let uu___4 =
-               FStar_Compiler_Effect.op_Bar_Greater c21
-                 FStar_Syntax_Syntax.mk_Comp in
-             FStar_Compiler_Effect.op_Bar_Greater uu___4
-               (FStar_Class_Show.show FStar_Syntax_Print.showable_comp) in
+             let uu___4 = FStar_Syntax_Syntax.mk_Comp c21 in
+             FStar_Class_Show.show FStar_Syntax_Print.showable_comp uu___4 in
            FStar_Compiler_Util.print2
              "solve_layered_sub c1: %s and c2: %s {\n" uu___2 uu___3
          else ());
@@ -12582,34 +12311,24 @@ and (solve_c :
              (let subcomp_name =
                 let uu___4 =
                   let uu___5 =
-                    FStar_Compiler_Effect.op_Bar_Greater
-                      c11.FStar_Syntax_Syntax.effect_name
-                      FStar_Ident.ident_of_lid in
-                  FStar_Compiler_Effect.op_Bar_Greater uu___5
-                    FStar_Ident.string_of_id in
+                    FStar_Ident.ident_of_lid
+                      c11.FStar_Syntax_Syntax.effect_name in
+                  FStar_Ident.string_of_id uu___5 in
                 let uu___5 =
                   let uu___6 =
-                    FStar_Compiler_Effect.op_Bar_Greater
-                      c21.FStar_Syntax_Syntax.effect_name
-                      FStar_Ident.ident_of_lid in
-                  FStar_Compiler_Effect.op_Bar_Greater uu___6
-                    FStar_Ident.string_of_id in
+                    FStar_Ident.ident_of_lid
+                      c21.FStar_Syntax_Syntax.effect_name in
+                  FStar_Ident.string_of_id uu___6 in
                 FStar_Compiler_Util.format2 "%s <: %s" uu___4 uu___5 in
               let lift_c1 edge =
                 let uu___4 =
-                  let uu___5 =
-                    FStar_Compiler_Effect.op_Bar_Greater c11
-                      FStar_Syntax_Syntax.mk_Comp in
-                  FStar_Compiler_Effect.op_Bar_Greater uu___5
-                    ((edge.FStar_TypeChecker_Env.mlift).FStar_TypeChecker_Env.mlift_wp
-                       env) in
-                FStar_Compiler_Effect.op_Bar_Greater uu___4
-                  (fun uu___5 ->
-                     match uu___5 with
-                     | (c, g) ->
-                         let uu___6 =
-                           FStar_TypeChecker_Env.comp_to_comp_typ env c in
-                         (uu___6, g)) in
+                  let uu___5 = FStar_Syntax_Syntax.mk_Comp c11 in
+                  (edge.FStar_TypeChecker_Env.mlift).FStar_TypeChecker_Env.mlift_wp
+                    env uu___5 in
+                match uu___4 with
+                | (c, g) ->
+                    let uu___5 = FStar_TypeChecker_Env.comp_to_comp_typ env c in
+                    (uu___5, g) in
               let uu___4 =
                 let uu___5 =
                   FStar_TypeChecker_Env.exists_polymonadic_subcomp env
@@ -12632,35 +12351,25 @@ and (solve_c :
                          (match uu___7 with
                           | (c12, g_lift) ->
                               let ed2 =
-                                FStar_Compiler_Effect.op_Bar_Greater
-                                  c21.FStar_Syntax_Syntax.effect_name
-                                  (FStar_TypeChecker_Env.get_effect_decl env) in
+                                FStar_TypeChecker_Env.get_effect_decl env
+                                  c21.FStar_Syntax_Syntax.effect_name in
                               let uu___8 =
                                 let uu___9 =
-                                  FStar_Compiler_Effect.op_Bar_Greater ed2
-                                    FStar_Syntax_Util.get_stronger_vc_combinator in
-                                FStar_Compiler_Effect.op_Bar_Greater uu___9
-                                  (fun uu___10 ->
-                                     match uu___10 with
-                                     | (ts, kopt) ->
-                                         let uu___11 =
-                                           let uu___12 =
-                                             let uu___13 =
-                                               FStar_TypeChecker_Env.inst_tscheme_with
-                                                 ts
-                                                 c21.FStar_Syntax_Syntax.comp_univs in
-                                             FStar_Compiler_Effect.op_Bar_Greater
-                                               uu___13
-                                               FStar_Pervasives_Native.snd in
-                                           FStar_Compiler_Effect.op_Bar_Greater
-                                             uu___12
-                                             (fun uu___13 ->
-                                                FStar_Pervasives_Native.Some
-                                                  uu___13) in
-                                         let uu___12 =
-                                           FStar_Compiler_Effect.op_Bar_Greater
-                                             kopt FStar_Compiler_Util.must in
-                                         (uu___11, uu___12)) in
+                                  FStar_Syntax_Util.get_stronger_vc_combinator
+                                    ed2 in
+                                match uu___9 with
+                                | (ts, kopt) ->
+                                    let uu___10 =
+                                      let uu___11 =
+                                        let uu___12 =
+                                          FStar_TypeChecker_Env.inst_tscheme_with
+                                            ts
+                                            c21.FStar_Syntax_Syntax.comp_univs in
+                                        FStar_Pervasives_Native.snd uu___12 in
+                                      FStar_Pervasives_Native.Some uu___11 in
+                                    let uu___11 =
+                                      FStar_Compiler_Util.must kopt in
+                                    (uu___10, uu___11) in
                               (match uu___8 with
                                | (tsopt, k) ->
                                    let num_eff_params =
@@ -12679,10 +12388,8 @@ and (solve_c :
                         let uu___8 =
                           FStar_TypeChecker_Env.inst_tscheme_with t
                             c21.FStar_Syntax_Syntax.comp_univs in
-                        FStar_Compiler_Effect.op_Bar_Greater uu___8
-                          FStar_Pervasives_Native.snd in
-                      FStar_Compiler_Effect.op_Bar_Greater uu___7
-                        (fun uu___8 -> FStar_Pervasives_Native.Some uu___8) in
+                        FStar_Pervasives_Native.snd uu___8 in
+                      FStar_Pervasives_Native.Some uu___7 in
                     (c11, FStar_TypeChecker_Env.trivial_guard, uu___6, kind,
                       Prims.int_zero, true) in
               match uu___4 with
@@ -12704,9 +12411,7 @@ and (solve_c :
                              uu___8) in
                     giveup wl uu___5 orig
                   else
-                    (let stronger_t =
-                       FStar_Compiler_Effect.op_Bar_Greater stronger_t_opt
-                         FStar_Compiler_Util.must in
+                    (let stronger_t = FStar_Compiler_Util.must stronger_t_opt in
                      let wl1 =
                        extend_wl wl g_lift.FStar_TypeChecker_Common.deferred
                          g_lift.FStar_TypeChecker_Common.deferred_to_tac
@@ -12777,8 +12482,7 @@ and (solve_c :
                                         if uu___14
                                         then
                                           ((let uu___16 =
-                                              FStar_Compiler_Effect.op_Less_Bar
-                                                (debug wl2)
+                                              debug wl2
                                                 (FStar_Options.Other
                                                    "LayeredEffectsEqns") in
                                             if uu___16
@@ -12860,8 +12564,7 @@ and (solve_c :
                                              (FStar_Pervasives_Native.Some
                                                 guard) [] wl4 in
                                          ((let uu___12 =
-                                             FStar_Compiler_Effect.op_Less_Bar
-                                               (debug wl5)
+                                             debug wl5
                                                (FStar_Options.Other
                                                   "LayeredEffectsApp") in
                                            if uu___12
@@ -12901,7 +12604,7 @@ and (solve_c :
              } in
            let uu___2 =
              let uu___3 =
-               FStar_Compiler_Effect.op_Bar_Greater
+               FStar_Syntax_Syntax.mk_Comp
                  {
                    FStar_Syntax_Syntax.comp_univs = univs;
                    FStar_Syntax_Syntax.effect_name =
@@ -12912,33 +12615,30 @@ and (solve_c :
                      (c12.FStar_Syntax_Syntax.effect_args);
                    FStar_Syntax_Syntax.flags =
                      (c12.FStar_Syntax_Syntax.flags)
-                 } FStar_Syntax_Syntax.mk_Comp in
-             FStar_Compiler_Effect.op_Bar_Greater uu___3
-               ((edge.FStar_TypeChecker_Env.mlift).FStar_TypeChecker_Env.mlift_wp
-                  env) in
-           FStar_Compiler_Effect.op_Bar_Greater uu___2
-             (fun uu___3 ->
-                match uu___3 with
-                | (c, g) ->
-                    let uu___4 =
-                      let uu___5 = FStar_TypeChecker_Env.is_trivial g in
-                      Prims.op_Negation uu___5 in
-                    if uu___4
-                    then
-                      let uu___5 =
-                        let uu___6 =
-                          let uu___7 =
-                            FStar_Ident.string_of_lid
-                              c12.FStar_Syntax_Syntax.effect_name in
-                          let uu___8 =
-                            FStar_Ident.string_of_lid
-                              c21.FStar_Syntax_Syntax.effect_name in
-                          FStar_Compiler_Util.format2
-                            "Lift between wp-effects (%s~>%s) should not have returned a non-trivial guard"
-                            uu___7 uu___8 in
-                        (FStar_Errors_Codes.Fatal_UnexpectedEffect, uu___6) in
-                      FStar_Errors.raise_error uu___5 r
-                    else FStar_TypeChecker_Env.comp_to_comp_typ env c) in
+                 } in
+             (edge.FStar_TypeChecker_Env.mlift).FStar_TypeChecker_Env.mlift_wp
+               env uu___3 in
+           match uu___2 with
+           | (c, g) ->
+               let uu___3 =
+                 let uu___4 = FStar_TypeChecker_Env.is_trivial g in
+                 Prims.op_Negation uu___4 in
+               if uu___3
+               then
+                 let uu___4 =
+                   let uu___5 =
+                     let uu___6 =
+                       FStar_Ident.string_of_lid
+                         c12.FStar_Syntax_Syntax.effect_name in
+                     let uu___7 =
+                       FStar_Ident.string_of_lid
+                         c21.FStar_Syntax_Syntax.effect_name in
+                     FStar_Compiler_Util.format2
+                       "Lift between wp-effects (%s~>%s) should not have returned a non-trivial guard"
+                       uu___6 uu___7 in
+                   (FStar_Errors_Codes.Fatal_UnexpectedEffect, uu___5) in
+                 FStar_Errors.raise_error uu___4 r
+               else FStar_TypeChecker_Env.comp_to_comp_typ env c in
          let uu___1 =
            should_fail_since_repr_subcomp_not_allowed wl.repr_subcomp_allowed
              c11.FStar_Syntax_Syntax.effect_name
@@ -12960,15 +12660,13 @@ and (solve_c :
            giveup wl uu___2 orig
          else
            (let is_null_wp_2 =
-              FStar_Compiler_Effect.op_Bar_Greater
-                c21.FStar_Syntax_Syntax.flags
-                (FStar_Compiler_Util.for_some
-                   (fun uu___3 ->
-                      match uu___3 with
-                      | FStar_Syntax_Syntax.TOTAL -> true
-                      | FStar_Syntax_Syntax.MLEFFECT -> true
-                      | FStar_Syntax_Syntax.SOMETRIVIAL -> true
-                      | uu___4 -> false)) in
+              FStar_Compiler_Util.for_some
+                (fun uu___3 ->
+                   match uu___3 with
+                   | FStar_Syntax_Syntax.TOTAL -> true
+                   | FStar_Syntax_Syntax.MLEFFECT -> true
+                   | FStar_Syntax_Syntax.SOMETRIVIAL -> true
+                   | uu___4 -> false) c21.FStar_Syntax_Syntax.flags in
             let uu___3 =
               match ((c11.FStar_Syntax_Syntax.effect_args),
                       (c21.FStar_Syntax_Syntax.effect_args))
@@ -13009,79 +12707,74 @@ and (solve_c :
                      FStar_Compiler_Util.must uu___7 in
                    match uu___6 with
                    | (c2_decl, qualifiers) ->
-                       let uu___7 =
-                         FStar_Compiler_Effect.op_Bar_Greater qualifiers
-                           (FStar_Compiler_List.contains
-                              FStar_Syntax_Syntax.Reifiable) in
-                       if uu___7
+                       if
+                         FStar_Compiler_List.contains
+                           FStar_Syntax_Syntax.Reifiable qualifiers
                        then
                          let c1_repr =
-                           let uu___8 =
+                           let uu___7 =
+                             let uu___8 =
+                               let uu___9 = lift_c1 () in
+                               FStar_Syntax_Syntax.mk_Comp uu___9 in
                              let uu___9 =
-                               let uu___10 = lift_c1 () in
-                               FStar_Syntax_Syntax.mk_Comp uu___10 in
-                             let uu___10 =
                                env.FStar_TypeChecker_Env.universe_of env
                                  c11.FStar_Syntax_Syntax.result_typ in
-                             FStar_TypeChecker_Env.reify_comp env uu___9
-                               uu___10 in
+                             FStar_TypeChecker_Env.reify_comp env uu___8
+                               uu___9 in
                            norm_with_steps
                              "FStar.TypeChecker.Rel.norm_with_steps.4"
                              [FStar_TypeChecker_Env.UnfoldUntil
                                 FStar_Syntax_Syntax.delta_constant;
                              FStar_TypeChecker_Env.Weak;
-                             FStar_TypeChecker_Env.HNF] env uu___8 in
+                             FStar_TypeChecker_Env.HNF] env uu___7 in
                          let c2_repr =
-                           let uu___8 =
-                             let uu___9 = FStar_Syntax_Syntax.mk_Comp c21 in
-                             let uu___10 =
+                           let uu___7 =
+                             let uu___8 = FStar_Syntax_Syntax.mk_Comp c21 in
+                             let uu___9 =
                                env.FStar_TypeChecker_Env.universe_of env
                                  c21.FStar_Syntax_Syntax.result_typ in
-                             FStar_TypeChecker_Env.reify_comp env uu___9
-                               uu___10 in
+                             FStar_TypeChecker_Env.reify_comp env uu___8
+                               uu___9 in
                            norm_with_steps
                              "FStar.TypeChecker.Rel.norm_with_steps.5"
                              [FStar_TypeChecker_Env.UnfoldUntil
                                 FStar_Syntax_Syntax.delta_constant;
                              FStar_TypeChecker_Env.Weak;
-                             FStar_TypeChecker_Env.HNF] env uu___8 in
-                         let uu___8 =
-                           let uu___9 =
-                             let uu___10 =
+                             FStar_TypeChecker_Env.HNF] env uu___7 in
+                         let uu___7 =
+                           let uu___8 =
+                             let uu___9 =
                                FStar_Class_Show.show
                                  FStar_Syntax_Print.showable_term c1_repr in
-                             let uu___11 =
+                             let uu___10 =
                                FStar_Class_Show.show
                                  FStar_Syntax_Print.showable_term c2_repr in
                              FStar_Compiler_Util.format2
-                               "sub effect repr: %s <: %s" uu___10 uu___11 in
+                               "sub effect repr: %s <: %s" uu___9 uu___10 in
                            sub_prob wl c1_repr
                              problem.FStar_TypeChecker_Common.relation
-                             c2_repr uu___9 in
-                         (match uu___8 with
+                             c2_repr uu___8 in
+                         (match uu___7 with
                           | (prob, wl1) ->
                               let wl2 =
                                 solve_prob orig
                                   (FStar_Pervasives_Native.Some
                                      (p_guard prob)) [] wl1 in
-                              let uu___9 = attempt [prob] wl2 in solve uu___9)
+                              let uu___8 = attempt [prob] wl2 in solve uu___8)
                        else
                          (let g =
                             if env.FStar_TypeChecker_Env.lax
                             then FStar_Syntax_Util.t_true
                             else
                               (let wpc1_2 =
-                                 let uu___10 = lift_c1 () in
-                                 FStar_Compiler_Effect.op_Bar_Greater uu___10
-                                   (fun ct ->
-                                      FStar_Compiler_List.hd
-                                        ct.FStar_Syntax_Syntax.effect_args) in
+                                 let uu___9 = lift_c1 () in
+                                 FStar_Compiler_List.hd
+                                   uu___9.FStar_Syntax_Syntax.effect_args in
                                if is_null_wp_2
                                then
-                                 ((let uu___11 =
-                                     FStar_Compiler_Effect.op_Less_Bar
-                                       (debug wl) (FStar_Options.Other "Rel") in
-                                   if uu___11
+                                 ((let uu___10 =
+                                     debug wl (FStar_Options.Other "Rel") in
+                                   if uu___10
                                    then
                                      FStar_Compiler_Util.print_string
                                        "Using trivial wp ... \n"
@@ -13090,107 +12783,97 @@ and (solve_c :
                                      env.FStar_TypeChecker_Env.universe_of
                                        env c11.FStar_Syntax_Syntax.result_typ in
                                    let trivial =
-                                     let uu___11 =
-                                       FStar_Compiler_Effect.op_Bar_Greater
-                                         c2_decl
-                                         FStar_Syntax_Util.get_wp_trivial_combinator in
-                                     match uu___11 with
+                                     let uu___10 =
+                                       FStar_Syntax_Util.get_wp_trivial_combinator
+                                         c2_decl in
+                                     match uu___10 with
                                      | FStar_Pervasives_Native.None ->
                                          FStar_Compiler_Effect.failwith
                                            "Rel doesn't yet handle undefined trivial combinator in an effect"
                                      | FStar_Pervasives_Native.Some t -> t in
-                                   let uu___11 =
-                                     let uu___12 =
-                                       let uu___13 =
+                                   let uu___10 =
+                                     let uu___11 =
+                                       let uu___12 =
                                          FStar_TypeChecker_Env.inst_effect_fun_with
                                            [c1_univ] env c2_decl trivial in
-                                       let uu___14 =
-                                         let uu___15 =
+                                       let uu___13 =
+                                         let uu___14 =
                                            FStar_Syntax_Syntax.as_arg
                                              c11.FStar_Syntax_Syntax.result_typ in
-                                         [uu___15; wpc1_2] in
+                                         [uu___14; wpc1_2] in
                                        {
-                                         FStar_Syntax_Syntax.hd = uu___13;
-                                         FStar_Syntax_Syntax.args = uu___14
+                                         FStar_Syntax_Syntax.hd = uu___12;
+                                         FStar_Syntax_Syntax.args = uu___13
                                        } in
-                                     FStar_Syntax_Syntax.Tm_app uu___12 in
-                                   FStar_Syntax_Syntax.mk uu___11 r))
+                                     FStar_Syntax_Syntax.Tm_app uu___11 in
+                                   FStar_Syntax_Syntax.mk uu___10 r))
                                else
                                  (let c2_univ =
                                     env.FStar_TypeChecker_Env.universe_of env
                                       c21.FStar_Syntax_Syntax.result_typ in
                                   let stronger =
+                                    let uu___10 =
+                                      FStar_Syntax_Util.get_stronger_vc_combinator
+                                        c2_decl in
+                                    FStar_Pervasives_Native.fst uu___10 in
+                                  let uu___10 =
                                     let uu___11 =
-                                      FStar_Compiler_Effect.op_Bar_Greater
-                                        c2_decl
-                                        FStar_Syntax_Util.get_stronger_vc_combinator in
-                                    FStar_Compiler_Effect.op_Bar_Greater
-                                      uu___11 FStar_Pervasives_Native.fst in
-                                  let uu___11 =
-                                    let uu___12 =
-                                      let uu___13 =
+                                      let uu___12 =
                                         FStar_TypeChecker_Env.inst_effect_fun_with
                                           [c2_univ] env c2_decl stronger in
-                                      let uu___14 =
-                                        let uu___15 =
+                                      let uu___13 =
+                                        let uu___14 =
                                           FStar_Syntax_Syntax.as_arg
                                             c21.FStar_Syntax_Syntax.result_typ in
-                                        let uu___16 =
-                                          let uu___17 =
+                                        let uu___15 =
+                                          let uu___16 =
                                             FStar_Syntax_Syntax.as_arg wpc2 in
-                                          [uu___17; wpc1_2] in
-                                        uu___15 :: uu___16 in
+                                          [uu___16; wpc1_2] in
+                                        uu___14 :: uu___15 in
                                       {
-                                        FStar_Syntax_Syntax.hd = uu___13;
-                                        FStar_Syntax_Syntax.args = uu___14
+                                        FStar_Syntax_Syntax.hd = uu___12;
+                                        FStar_Syntax_Syntax.args = uu___13
                                       } in
-                                    FStar_Syntax_Syntax.Tm_app uu___12 in
-                                  FStar_Syntax_Syntax.mk uu___11 r)) in
-                          (let uu___10 =
-                             FStar_Compiler_Effect.op_Less_Bar (debug wl)
-                               (FStar_Options.Other "Rel") in
-                           if uu___10
+                                    FStar_Syntax_Syntax.Tm_app uu___11 in
+                                  FStar_Syntax_Syntax.mk uu___10 r)) in
+                          (let uu___9 = debug wl (FStar_Options.Other "Rel") in
+                           if uu___9
                            then
-                             let uu___11 =
-                               let uu___12 =
+                             let uu___10 =
+                               let uu___11 =
                                  FStar_TypeChecker_Normalize.normalize
                                    [FStar_TypeChecker_Env.Iota;
                                    FStar_TypeChecker_Env.Eager_unfolding;
                                    FStar_TypeChecker_Env.Primops;
                                    FStar_TypeChecker_Env.Simplify] env g in
                                FStar_Class_Show.show
-                                 FStar_Syntax_Print.showable_term uu___12 in
+                                 FStar_Syntax_Print.showable_term uu___11 in
                              FStar_Compiler_Util.print1
-                               "WP guard (simplifed) is (%s)\n" uu___11
+                               "WP guard (simplifed) is (%s)\n" uu___10
                            else ());
-                          (let uu___10 =
+                          (let uu___9 =
                              sub_prob wl c11.FStar_Syntax_Syntax.result_typ
                                problem.FStar_TypeChecker_Common.relation
                                c21.FStar_Syntax_Syntax.result_typ
                                "result type" in
-                           match uu___10 with
+                           match uu___9 with
                            | (base_prob, wl1) ->
                                let wl2 =
-                                 let uu___11 =
-                                   let uu___12 =
+                                 let uu___10 =
+                                   let uu___11 =
                                      FStar_Syntax_Util.mk_conj
                                        (p_guard base_prob) g in
-                                   FStar_Compiler_Effect.op_Less_Bar
-                                     (fun uu___13 ->
-                                        FStar_Pervasives_Native.Some uu___13)
-                                     uu___12 in
-                                 solve_prob orig uu___11 [] wl1 in
-                               let uu___11 = attempt [base_prob] wl2 in
-                               solve uu___11))))) in
+                                   FStar_Pervasives_Native.Some uu___11 in
+                                 solve_prob orig uu___10 [] wl1 in
+                               let uu___10 = attempt [base_prob] wl2 in
+                               solve uu___10))))) in
       let uu___ = FStar_Compiler_Util.physical_equality c1 c2 in
       if uu___
       then
         let uu___1 = solve_prob orig FStar_Pervasives_Native.None [] wl in
         solve uu___1
       else
-        ((let uu___3 =
-            FStar_Compiler_Effect.op_Less_Bar (debug wl)
-              (FStar_Options.Other "Rel") in
+        ((let uu___3 = debug wl (FStar_Options.Other "Rel") in
           if uu___3
           then
             let uu___4 =
@@ -13204,17 +12887,11 @@ and (solve_c :
          (let uu___3 =
             let uu___4 =
               let uu___5 =
-                let uu___6 =
-                  FStar_Compiler_Effect.op_Bar_Greater c1
-                    FStar_Syntax_Util.comp_effect_name in
-                FStar_Compiler_Effect.op_Bar_Greater uu___6
-                  (FStar_TypeChecker_Env.norm_eff_name env) in
+                FStar_TypeChecker_Env.norm_eff_name env
+                  (FStar_Syntax_Util.comp_effect_name c1) in
               let uu___6 =
-                let uu___7 =
-                  FStar_Compiler_Effect.op_Bar_Greater c2
-                    FStar_Syntax_Util.comp_effect_name in
-                FStar_Compiler_Effect.op_Bar_Greater uu___7
-                  (FStar_TypeChecker_Env.norm_eff_name env) in
+                FStar_TypeChecker_Env.norm_eff_name env
+                  (FStar_Syntax_Util.comp_effect_name c2) in
               (uu___5, uu___6) in
             match uu___4 with
             | (eff1, eff2) ->
@@ -13274,8 +12951,7 @@ and (solve_c :
                      let uu___7 =
                        let uu___8 =
                          FStar_TypeChecker_Env.comp_to_comp_typ env c11 in
-                       FStar_Compiler_Effect.op_Less_Bar
-                         FStar_Syntax_Syntax.mk_Comp uu___8 in
+                       FStar_Syntax_Syntax.mk_Comp uu___8 in
                      {
                        FStar_TypeChecker_Common.pid =
                          (problem.FStar_TypeChecker_Common.pid);
@@ -13304,8 +12980,7 @@ and (solve_c :
                      let uu___7 =
                        let uu___8 =
                          FStar_TypeChecker_Env.comp_to_comp_typ env c11 in
-                       FStar_Compiler_Effect.op_Less_Bar
-                         FStar_Syntax_Syntax.mk_Comp uu___8 in
+                       FStar_Syntax_Syntax.mk_Comp uu___8 in
                      {
                        FStar_TypeChecker_Common.pid =
                          (problem.FStar_TypeChecker_Common.pid);
@@ -13334,8 +13009,7 @@ and (solve_c :
                      let uu___7 =
                        let uu___8 =
                          FStar_TypeChecker_Env.comp_to_comp_typ env c21 in
-                       FStar_Compiler_Effect.op_Less_Bar
-                         FStar_Syntax_Syntax.mk_Comp uu___8 in
+                       FStar_Syntax_Syntax.mk_Comp uu___8 in
                      {
                        FStar_TypeChecker_Common.pid =
                          (problem.FStar_TypeChecker_Common.pid);
@@ -13364,8 +13038,7 @@ and (solve_c :
                      let uu___7 =
                        let uu___8 =
                          FStar_TypeChecker_Env.comp_to_comp_typ env c21 in
-                       FStar_Compiler_Effect.op_Less_Bar
-                         FStar_Syntax_Syntax.mk_Comp uu___8 in
+                       FStar_Syntax_Syntax.mk_Comp uu___8 in
                      {
                        FStar_TypeChecker_Common.pid =
                          (problem.FStar_TypeChecker_Common.pid);
@@ -13444,9 +13117,7 @@ and (solve_c :
                            FStar_TypeChecker_Env.unfold_effect_abbrev env c11 in
                          let c22 =
                            FStar_TypeChecker_Env.unfold_effect_abbrev env c21 in
-                         (let uu___10 =
-                            FStar_Compiler_Effect.op_Less_Bar (debug wl)
-                              (FStar_Options.Other "Rel") in
+                         (let uu___10 = debug wl (FStar_Options.Other "Rel") in
                           if uu___10
                           then
                             let uu___11 =
@@ -13489,14 +13160,12 @@ let (print_pending_implicits :
   FStar_TypeChecker_Common.guard_t -> Prims.string) =
   fun g ->
     let uu___ =
-      FStar_Compiler_Effect.op_Bar_Greater
-        g.FStar_TypeChecker_Common.implicits
-        (FStar_Compiler_List.map
-           (fun i ->
-              FStar_Class_Show.show FStar_Syntax_Print.showable_ctxu
-                i.FStar_TypeChecker_Common.imp_uvar)) in
-    FStar_Compiler_Effect.op_Bar_Greater uu___
-      (FStar_Compiler_String.concat ", ")
+      FStar_Compiler_List.map
+        (fun i ->
+           FStar_Class_Show.show FStar_Syntax_Print.showable_ctxu
+             i.FStar_TypeChecker_Common.imp_uvar)
+        g.FStar_TypeChecker_Common.implicits in
+    FStar_Compiler_String.concat ", " uu___
 let (ineqs_to_string :
   (FStar_Syntax_Syntax.universe Prims.list * (FStar_Syntax_Syntax.universe *
     FStar_Syntax_Syntax.universe) Prims.list) -> Prims.string)
@@ -13504,29 +13173,23 @@ let (ineqs_to_string :
   fun ineqs ->
     let vars =
       let uu___ =
-        FStar_Compiler_Effect.op_Bar_Greater
-          (FStar_Pervasives_Native.fst ineqs)
-          (FStar_Compiler_List.map
-             (FStar_Class_Show.show FStar_Syntax_Print.showable_univ)) in
-      FStar_Compiler_Effect.op_Bar_Greater uu___
-        (FStar_Compiler_String.concat ", ") in
+        FStar_Compiler_List.map
+          (FStar_Class_Show.show FStar_Syntax_Print.showable_univ)
+          (FStar_Pervasives_Native.fst ineqs) in
+      FStar_Compiler_String.concat ", " uu___ in
     let ineqs1 =
       let uu___ =
-        FStar_Compiler_Effect.op_Bar_Greater
-          (FStar_Pervasives_Native.snd ineqs)
-          (FStar_Compiler_List.map
-             (fun uu___1 ->
-                match uu___1 with
-                | (u1, u2) ->
-                    let uu___2 =
-                      FStar_Class_Show.show FStar_Syntax_Print.showable_univ
-                        u1 in
-                    let uu___3 =
-                      FStar_Class_Show.show FStar_Syntax_Print.showable_univ
-                        u2 in
-                    FStar_Compiler_Util.format2 "%s < %s" uu___2 uu___3)) in
-      FStar_Compiler_Effect.op_Bar_Greater uu___
-        (FStar_Compiler_String.concat ", ") in
+        FStar_Compiler_List.map
+          (fun uu___1 ->
+             match uu___1 with
+             | (u1, u2) ->
+                 let uu___2 =
+                   FStar_Class_Show.show FStar_Syntax_Print.showable_univ u1 in
+                 let uu___3 =
+                   FStar_Class_Show.show FStar_Syntax_Print.showable_univ u2 in
+                 FStar_Compiler_Util.format2 "%s < %s" uu___2 uu___3)
+          (FStar_Pervasives_Native.snd ineqs) in
+      FStar_Compiler_String.concat ", " uu___ in
     FStar_Compiler_Util.format2 "Solving for {%s}; inequalities are {%s}"
       vars ineqs1
 let (guard_to_string :
@@ -13548,13 +13211,10 @@ let (guard_to_string :
             | FStar_TypeChecker_Common.Trivial -> "trivial"
             | FStar_TypeChecker_Common.NonTrivial f ->
                 let uu___1 =
-                  ((FStar_Compiler_Effect.op_Less_Bar
-                      (FStar_TypeChecker_Env.debug env)
+                  ((FStar_TypeChecker_Env.debug env
                       (FStar_Options.Other "Rel"))
                      ||
-                     (FStar_Compiler_Effect.op_Less_Bar
-                        (FStar_TypeChecker_Env.debug env)
-                        FStar_Options.Extreme))
+                     (FStar_TypeChecker_Env.debug env FStar_Options.Extreme))
                     || (FStar_Options.print_implicits ()) in
                 if uu___1
                 then FStar_TypeChecker_Normalize.term_to_string env f
@@ -13569,8 +13229,7 @@ let (guard_to_string :
                          let uu___5 = prob_to_string env x in
                          Prims.strcat ": " uu___5 in
                        Prims.strcat msg uu___4) defs in
-            FStar_Compiler_Effect.op_Bar_Greater uu___1
-              (FStar_Compiler_String.concat ",\n") in
+            FStar_Compiler_String.concat ",\n" uu___1 in
           let imps = print_pending_implicits g in
           let uu___1 = carry g.FStar_TypeChecker_Common.deferred in
           let uu___2 = carry g.FStar_TypeChecker_Common.deferred_to_tac in
@@ -13597,11 +13256,8 @@ let (new_t_problem :
               fun loc ->
                 let reason =
                   let uu___ =
-                    (FStar_Compiler_Effect.op_Less_Bar (debug wl)
-                       (FStar_Options.Other "ExplainRel"))
-                      ||
-                      (FStar_Compiler_Effect.op_Less_Bar (debug wl)
-                         (FStar_Options.Other "Rel")) in
+                    (debug wl (FStar_Options.Other "ExplainRel")) ||
+                      (debug wl (FStar_Options.Other "Rel")) in
                   if uu___
                   then
                     let uu___1 =
@@ -13634,8 +13290,7 @@ let (new_t_prob :
             let x =
               let uu___ =
                 let uu___1 = FStar_TypeChecker_Env.get_range env in
-                FStar_Compiler_Effect.op_Less_Bar
-                  (fun uu___2 -> FStar_Pervasives_Native.Some uu___2) uu___1 in
+                FStar_Pervasives_Native.Some uu___1 in
               FStar_Syntax_Syntax.new_bv uu___ t1 in
             let uu___ =
               let uu___1 = FStar_TypeChecker_Env.get_range env in
@@ -13654,9 +13309,7 @@ let (solve_and_commit :
   fun wl ->
     fun err ->
       let tx = FStar_Syntax_Unionfind.new_transaction () in
-      (let uu___1 =
-         FStar_Compiler_Effect.op_Less_Bar (debug wl)
-           (FStar_Options.Other "RelBench") in
+      (let uu___1 = debug wl (FStar_Options.Other "RelBench") in
        if uu___1
        then
          let uu___2 =
@@ -13668,9 +13321,7 @@ let (solve_and_commit :
       (let uu___1 = FStar_Compiler_Util.record_time (fun uu___2 -> solve wl) in
        match uu___1 with
        | (sol, ms) ->
-           ((let uu___3 =
-               FStar_Compiler_Effect.op_Less_Bar (debug wl)
-                 (FStar_Options.Other "RelBench") in
+           ((let uu___3 = debug wl (FStar_Options.Other "RelBench") in
              if uu___3
              then
                let uu___4 = FStar_Compiler_Util.string_of_int ms in
@@ -13684,8 +13335,7 @@ let (solve_and_commit :
                  (match uu___3 with
                   | ((), ms1) ->
                       ((let uu___5 =
-                          FStar_Compiler_Effect.op_Less_Bar (debug wl)
-                            (FStar_Options.Other "RelBench") in
+                          debug wl (FStar_Options.Other "RelBench") in
                         if uu___5
                         then
                           let uu___6 = FStar_Compiler_Util.string_of_int ms1 in
@@ -13696,16 +13346,12 @@ let (solve_and_commit :
                          (deferred, defer_to_tac, implicits)))
              | Failed (d, s) ->
                  ((let uu___4 =
-                     (FStar_Compiler_Effect.op_Less_Bar (debug wl)
-                        (FStar_Options.Other "ExplainRel"))
-                       ||
-                       (FStar_Compiler_Effect.op_Less_Bar (debug wl)
-                          (FStar_Options.Other "Rel")) in
+                     (debug wl (FStar_Options.Other "ExplainRel")) ||
+                       (debug wl (FStar_Options.Other "Rel")) in
                    if uu___4
                    then
                      let uu___5 = explain wl d s in
-                     FStar_Compiler_Effect.op_Less_Bar
-                       FStar_Compiler_Util.print_string uu___5
+                     FStar_Compiler_Util.print_string uu___5
                    else ());
                   (let result = err (d, s) in
                    FStar_Syntax_Unionfind.rollback tx; result)))))
@@ -13723,20 +13369,16 @@ let (with_guard :
         | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
         | FStar_Pervasives_Native.Some (deferred, defer_to_tac, implicits) ->
             let uu___ =
-              let uu___1 =
-                let uu___2 =
-                  FStar_Compiler_Effect.op_Bar_Greater (p_guard prob)
-                    (fun uu___3 -> FStar_TypeChecker_Common.NonTrivial uu___3) in
+              simplify_guard env
                 {
-                  FStar_TypeChecker_Common.guard_f = uu___2;
+                  FStar_TypeChecker_Common.guard_f =
+                    (FStar_TypeChecker_Common.NonTrivial (p_guard prob));
                   FStar_TypeChecker_Common.deferred_to_tac = defer_to_tac;
                   FStar_TypeChecker_Common.deferred = deferred;
                   FStar_TypeChecker_Common.univ_ineqs = ([], []);
                   FStar_TypeChecker_Common.implicits = implicits
                 } in
-              simplify_guard env uu___1 in
-            FStar_Compiler_Effect.op_Less_Bar
-              (fun uu___1 -> FStar_Pervasives_Native.Some uu___1) uu___
+            FStar_Pervasives_Native.Some uu___
 let (try_teq :
   Prims.bool ->
     FStar_TypeChecker_Env.env ->
@@ -13768,8 +13410,7 @@ let (try_teq :
            FStar_Profiling.profile
              (fun uu___3 ->
                 (let uu___5 =
-                   FStar_Compiler_Effect.op_Less_Bar
-                     (FStar_TypeChecker_Env.debug env)
+                   FStar_TypeChecker_Env.debug env
                      (FStar_Options.Other "Rel") in
                  if uu___5
                  then
@@ -13798,11 +13439,9 @@ let (try_teq :
                        let uu___6 =
                          solve_and_commit (singleton wl prob smt_ok1)
                            (fun uu___7 -> FStar_Pervasives_Native.None) in
-                       FStar_Compiler_Effect.op_Less_Bar
-                         (with_guard env prob) uu___6 in
+                       with_guard env prob uu___6 in
                      ((let uu___7 =
-                         FStar_Compiler_Effect.op_Less_Bar
-                           (FStar_TypeChecker_Env.debug env)
+                         FStar_TypeChecker_Env.debug env
                            (FStar_Options.Other "Rel") in
                        if uu___7
                        then
@@ -13831,9 +13470,7 @@ let (teq :
              FStar_TypeChecker_Common.trivial_guard)
         | FStar_Pervasives_Native.Some g ->
             ((let uu___2 =
-                FStar_Compiler_Effect.op_Less_Bar
-                  (FStar_TypeChecker_Env.debug env)
-                  (FStar_Options.Other "Rel") in
+                FStar_TypeChecker_Env.debug env (FStar_Options.Other "Rel") in
               if uu___2
               then
                 let uu___3 =
@@ -13856,8 +13493,7 @@ let (get_teq_predicate :
     fun t1 ->
       fun t2 ->
         (let uu___1 =
-           FStar_Compiler_Effect.op_Less_Bar
-             (FStar_TypeChecker_Env.debug env) (FStar_Options.Other "Rel") in
+           FStar_TypeChecker_Env.debug env (FStar_Options.Other "Rel") in
          if uu___1
          then
            let uu___2 =
@@ -13876,11 +13512,9 @@ let (get_teq_predicate :
                let uu___2 =
                  solve_and_commit (singleton wl prob true)
                    (fun uu___3 -> FStar_Pervasives_Native.None) in
-               FStar_Compiler_Effect.op_Less_Bar (with_guard env prob) uu___2 in
+               with_guard env prob uu___2 in
              ((let uu___3 =
-                 FStar_Compiler_Effect.op_Less_Bar
-                   (FStar_TypeChecker_Env.debug env)
-                   (FStar_Options.Other "Rel") in
+                 FStar_TypeChecker_Env.debug env (FStar_Options.Other "Rel") in
                if uu___3
                then
                  let uu___4 =
@@ -13932,9 +13566,7 @@ let (sub_or_eq_comp :
                  then FStar_TypeChecker_Common.EQ
                  else FStar_TypeChecker_Common.SUB in
                (let uu___3 =
-                  FStar_Compiler_Effect.op_Less_Bar
-                    (FStar_TypeChecker_Env.debug env)
-                    (FStar_Options.Other "Rel") in
+                  FStar_TypeChecker_Env.debug env (FStar_Options.Other "Rel") in
                 if uu___3
                 then
                   let uu___4 =
@@ -13976,13 +13608,11 @@ let (sub_or_eq_comp :
                              let uu___7 =
                                solve_and_commit (singleton wl1 prob1 true)
                                  (fun uu___8 -> FStar_Pervasives_Native.None) in
-                             FStar_Compiler_Effect.op_Less_Bar
-                               (with_guard env prob1) uu___7) in
+                             with_guard env prob1 uu___7) in
                       match uu___5 with
                       | (r, ms) ->
                           ((let uu___7 =
-                              FStar_Compiler_Effect.op_Less_Bar
-                                (FStar_TypeChecker_Env.debug env)
+                              FStar_TypeChecker_Env.debug env
                                 (FStar_Options.Other "RelBench") in
                             if uu___7
                             then
@@ -14083,34 +13713,29 @@ let (solve_universe_inequalities' :
                  v0') -> FStar_Syntax_Unionfind.univ_equiv v0 v0'
               | uu___2 -> false in
             let sols =
-              FStar_Compiler_Effect.op_Bar_Greater variables
-                (FStar_Compiler_List.collect
-                   (fun v ->
-                      let uu___1 = FStar_Syntax_Subst.compress_univ v in
-                      match uu___1 with
-                      | FStar_Syntax_Syntax.U_unif uu___2 ->
-                          let lower_bounds_of_v =
-                            FStar_Compiler_Effect.op_Bar_Greater ineqs
-                              (FStar_Compiler_List.collect
-                                 (fun uu___3 ->
-                                    match uu___3 with
-                                    | (u, v') ->
-                                        let uu___4 = equiv v v' in
-                                        if uu___4
-                                        then
-                                          let uu___5 =
-                                            FStar_Compiler_Effect.op_Bar_Greater
-                                              variables
-                                              (FStar_Compiler_Util.for_some
-                                                 (equiv u)) in
-                                          (if uu___5 then [] else [u])
-                                        else [])) in
-                          let lb =
-                            FStar_TypeChecker_Normalize.normalize_universe
-                              env
-                              (FStar_Syntax_Syntax.U_max lower_bounds_of_v) in
-                          [(lb, v)]
-                      | uu___2 -> [])) in
+              FStar_Compiler_List.collect
+                (fun v ->
+                   let uu___1 = FStar_Syntax_Subst.compress_univ v in
+                   match uu___1 with
+                   | FStar_Syntax_Syntax.U_unif uu___2 ->
+                       let lower_bounds_of_v =
+                         FStar_Compiler_List.collect
+                           (fun uu___3 ->
+                              match uu___3 with
+                              | (u, v') ->
+                                  let uu___4 = equiv v v' in
+                                  if uu___4
+                                  then
+                                    let uu___5 =
+                                      FStar_Compiler_Util.for_some (equiv u)
+                                        variables in
+                                    (if uu___5 then [] else [u])
+                                  else []) ineqs in
+                       let lb =
+                         FStar_TypeChecker_Normalize.normalize_universe env
+                           (FStar_Syntax_Syntax.U_max lower_bounds_of_v) in
+                       [(lb, v)]
+                   | uu___2 -> []) variables in
             let uu___1 =
               let wl =
                 let uu___2 = empty_worklist env in
@@ -14127,16 +13752,15 @@ let (solve_universe_inequalities' :
                   repr_subcomp_allowed = (uu___2.repr_subcomp_allowed);
                   typeclass_variables = (uu___2.typeclass_variables)
                 } in
-              FStar_Compiler_Effect.op_Bar_Greater sols
-                (FStar_Compiler_List.map
-                   (fun uu___2 ->
-                      match uu___2 with
-                      | (lb, v) ->
-                          let uu___3 =
-                            solve_universe_eq (Prims.of_int (-1)) wl lb v in
-                          (match uu___3 with
-                           | USolved wl1 -> ()
-                           | uu___4 -> fail lb v))) in
+              FStar_Compiler_List.map
+                (fun uu___2 ->
+                   match uu___2 with
+                   | (lb, v) ->
+                       let uu___3 =
+                         solve_universe_eq (Prims.of_int (-1)) wl lb v in
+                       (match uu___3 with
+                        | USolved wl1 -> ()
+                        | uu___4 -> fail lb v)) sols in
             let rec check_ineq uu___2 =
               match uu___2 with
               | (u, v) ->
@@ -14159,46 +13783,41 @@ let (solve_universe_inequalities' :
                    | (FStar_Syntax_Syntax.U_unif uu___3,
                       FStar_Syntax_Syntax.U_succ v0) -> check_ineq (u1, v0)
                    | (FStar_Syntax_Syntax.U_max us, uu___3) ->
-                       FStar_Compiler_Effect.op_Bar_Greater us
-                         (FStar_Compiler_Util.for_all
-                            (fun u2 -> check_ineq (u2, v1)))
+                       FStar_Compiler_Util.for_all
+                         (fun u2 -> check_ineq (u2, v1)) us
                    | (uu___3, FStar_Syntax_Syntax.U_max vs) ->
-                       FStar_Compiler_Effect.op_Bar_Greater vs
-                         (FStar_Compiler_Util.for_some
-                            (fun v2 -> check_ineq (u1, v2)))
+                       FStar_Compiler_Util.for_some
+                         (fun v2 -> check_ineq (u1, v2)) vs
                    | uu___3 -> false) in
             let uu___2 =
-              FStar_Compiler_Effect.op_Bar_Greater ineqs
-                (FStar_Compiler_Util.for_all
-                   (fun uu___3 ->
-                      match uu___3 with
-                      | (u, v) ->
-                          let uu___4 = check_ineq (u, v) in
-                          if uu___4
-                          then true
-                          else
-                            ((let uu___7 =
-                                FStar_Compiler_Effect.op_Less_Bar
-                                  (FStar_TypeChecker_Env.debug env)
-                                  (FStar_Options.Other "GenUniverses") in
-                              if uu___7
-                              then
-                                let uu___8 =
-                                  FStar_Class_Show.show
-                                    FStar_Syntax_Print.showable_univ u in
-                                let uu___9 =
-                                  FStar_Class_Show.show
-                                    FStar_Syntax_Print.showable_univ v in
-                                FStar_Compiler_Util.print2 "%s </= %s" uu___8
-                                  uu___9
-                              else ());
-                             false))) in
+              FStar_Compiler_Util.for_all
+                (fun uu___3 ->
+                   match uu___3 with
+                   | (u, v) ->
+                       let uu___4 = check_ineq (u, v) in
+                       if uu___4
+                       then true
+                       else
+                         ((let uu___7 =
+                             FStar_TypeChecker_Env.debug env
+                               (FStar_Options.Other "GenUniverses") in
+                           if uu___7
+                           then
+                             let uu___8 =
+                               FStar_Class_Show.show
+                                 FStar_Syntax_Print.showable_univ u in
+                             let uu___9 =
+                               FStar_Class_Show.show
+                                 FStar_Syntax_Print.showable_univ v in
+                             FStar_Compiler_Util.print2 "%s </= %s" uu___8
+                               uu___9
+                           else ());
+                          false)) ineqs in
             if uu___2
             then ()
             else
               ((let uu___5 =
-                  FStar_Compiler_Effect.op_Less_Bar
-                    (FStar_TypeChecker_Env.debug env)
+                  FStar_TypeChecker_Env.debug env
                     (FStar_Options.Other "GenUniverses") in
                 if uu___5
                 then
@@ -14255,40 +13874,36 @@ let (try_solve_deferred_constraints :
                    (fun uu___2 ->
                       let typeclass_variables =
                         let uu___3 =
-                          FStar_Compiler_Effect.op_Bar_Greater
-                            g.FStar_TypeChecker_Common.implicits
-                            (FStar_Compiler_List.collect
-                               (fun i ->
-                                  match (i.FStar_TypeChecker_Common.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_meta
-                                  with
-                                  | FStar_Pervasives_Native.Some
-                                      (FStar_Syntax_Syntax.Ctx_uvar_meta_tac
-                                      tac) ->
-                                      let uu___4 =
-                                        FStar_Syntax_Util.head_and_args_full
-                                          tac in
-                                      (match uu___4 with
-                                       | (head, uu___5) ->
-                                           let uu___6 =
-                                             FStar_Syntax_Util.is_fvar
-                                               FStar_Parser_Const.tcresolve_lid
-                                               head in
-                                           if uu___6
-                                           then
-                                             let goal_type =
-                                               FStar_Syntax_Util.ctx_uvar_typ
-                                                 i.FStar_TypeChecker_Common.imp_uvar in
-                                             let uvs =
-                                               FStar_Syntax_Free.uvars
-                                                 goal_type in
-                                             FStar_Compiler_Set.elems
-                                               FStar_Syntax_Free.ord_ctx_uvar
-                                               uvs
-                                           else [])
-                                  | uu___4 -> [])) in
-                        FStar_Compiler_Effect.op_Bar_Greater uu___3
-                          (FStar_Compiler_Set.from_list
-                             FStar_Syntax_Free.ord_ctx_uvar) in
+                          FStar_Compiler_List.collect
+                            (fun i ->
+                               match (i.FStar_TypeChecker_Common.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_meta
+                               with
+                               | FStar_Pervasives_Native.Some
+                                   (FStar_Syntax_Syntax.Ctx_uvar_meta_tac
+                                   tac) ->
+                                   let uu___4 =
+                                     FStar_Syntax_Util.head_and_args_full tac in
+                                   (match uu___4 with
+                                    | (head, uu___5) ->
+                                        let uu___6 =
+                                          FStar_Syntax_Util.is_fvar
+                                            FStar_Parser_Const.tcresolve_lid
+                                            head in
+                                        if uu___6
+                                        then
+                                          let goal_type =
+                                            FStar_Syntax_Util.ctx_uvar_typ
+                                              i.FStar_TypeChecker_Common.imp_uvar in
+                                          let uvs =
+                                            FStar_Syntax_Free.uvars goal_type in
+                                          FStar_Compiler_Set.elems
+                                            FStar_Syntax_Free.ord_ctx_uvar
+                                            uvs
+                                        else [])
+                               | uu___4 -> [])
+                            g.FStar_TypeChecker_Common.implicits in
+                        FStar_Compiler_Set.from_list
+                          FStar_Syntax_Free.ord_ctx_uvar uu___3 in
                       let wl =
                         let uu___3 =
                           wl_of_guard env g.FStar_TypeChecker_Common.deferred in
@@ -14314,8 +13929,7 @@ let (try_solve_deferred_constraints :
                               (FStar_Errors_Codes.Fatal_ErrorInSolveDeferredConstraints,
                                 msg) (p_loc d) in
                       (let uu___4 =
-                         FStar_Compiler_Effect.op_Less_Bar
-                           (FStar_TypeChecker_Env.debug env)
+                         FStar_TypeChecker_Env.debug env
                            (FStar_Options.Other "Rel") in
                        if uu___4
                        then
@@ -14379,8 +13993,7 @@ let (try_solve_deferred_constraints :
                               "FStar.TypeChecker.Rel.solve_deferred_to_tactic_goals"
                           else g1 in
                         (let uu___6 =
-                           FStar_Compiler_Effect.op_Less_Bar
-                             (FStar_TypeChecker_Env.debug env)
+                           FStar_TypeChecker_Env.debug env
                              (FStar_Options.Other "ResolveImplicitsHook") in
                          if uu___6
                          then
@@ -14448,15 +14061,11 @@ let (do_discharge_vc :
     fun env ->
       fun vc ->
         let debug1 =
-          ((FStar_Compiler_Effect.op_Less_Bar
-              (FStar_TypeChecker_Env.debug env) (FStar_Options.Other "Rel"))
-             ||
-             (FStar_Compiler_Effect.op_Less_Bar
-                (FStar_TypeChecker_Env.debug env)
+          ((FStar_TypeChecker_Env.debug env (FStar_Options.Other "Rel")) ||
+             (FStar_TypeChecker_Env.debug env
                 (FStar_Options.Other "SMTQuery")))
             ||
-            (FStar_Compiler_Effect.op_Less_Bar
-               (FStar_TypeChecker_Env.debug env)
+            (FStar_TypeChecker_Env.debug env
                (FStar_Options.Other "Discharge")) in
         let diag_doc =
           let uu___ = FStar_TypeChecker_Env.get_range env in
@@ -14479,8 +14088,7 @@ let (do_discharge_vc :
              FStar_Options.with_saved_options
                (fun uu___2 ->
                   (let uu___4 = FStar_Options.set_options "--no_tactics" in
-                   FStar_Compiler_Effect.op_Less_Bar (fun uu___5 -> ())
-                     uu___4);
+                   ());
                   (let vcs1 =
                      (env.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.preprocess
                        env vc in
@@ -14502,57 +14110,52 @@ let (do_discharge_vc :
                       diag_doc uu___5)
                    else ();
                    (let vcs2 =
-                      FStar_Compiler_Effect.op_Bar_Greater vcs1
-                        (FStar_Compiler_List.map
-                           (fun uu___5 ->
-                              match uu___5 with
-                              | (env1, goal, opts) ->
-                                  let uu___6 =
-                                    norm_with_steps
-                                      "FStar.TypeChecker.Rel.norm_with_steps.7"
-                                      [FStar_TypeChecker_Env.Simplify;
-                                      FStar_TypeChecker_Env.Primops;
-                                      FStar_TypeChecker_Env.Exclude
-                                        FStar_TypeChecker_Env.Zeta] env1 goal in
-                                  (env1, uu___6, opts))) in
+                      FStar_Compiler_List.map
+                        (fun uu___5 ->
+                           match uu___5 with
+                           | (env1, goal, opts) ->
+                               let uu___6 =
+                                 norm_with_steps
+                                   "FStar.TypeChecker.Rel.norm_with_steps.7"
+                                   [FStar_TypeChecker_Env.Simplify;
+                                   FStar_TypeChecker_Env.Primops;
+                                   FStar_TypeChecker_Env.Exclude
+                                     FStar_TypeChecker_Env.Zeta] env1 goal in
+                               (env1, uu___6, opts)) vcs1 in
                     let vcs3 =
-                      FStar_Compiler_Effect.op_Bar_Greater vcs2
-                        (FStar_Compiler_List.concatMap
-                           (fun uu___5 ->
-                              match uu___5 with
-                              | (env1, goal, opts) ->
-                                  let uu___6 =
-                                    (env1.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.handle_smt_goal
-                                      env1 goal in
-                                  FStar_Compiler_Effect.op_Bar_Greater uu___6
-                                    (FStar_Compiler_List.map
-                                       (fun uu___7 ->
-                                          match uu___7 with
-                                          | (env2, goal1) ->
-                                              (env2, goal1, opts))))) in
+                      FStar_Compiler_List.concatMap
+                        (fun uu___5 ->
+                           match uu___5 with
+                           | (env1, goal, opts) ->
+                               let uu___6 =
+                                 (env1.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.handle_smt_goal
+                                   env1 goal in
+                               FStar_Compiler_List.map
+                                 (fun uu___7 ->
+                                    match uu___7 with
+                                    | (env2, goal1) -> (env2, goal1, opts))
+                                 uu___6) vcs2 in
                     let vcs4 =
-                      FStar_Compiler_Effect.op_Bar_Greater vcs3
-                        (FStar_Compiler_List.concatMap
-                           (fun uu___5 ->
-                              match uu___5 with
-                              | (env1, goal, opts) ->
-                                  let uu___6 =
-                                    FStar_TypeChecker_Common.check_trivial
-                                      goal in
-                                  (match uu___6 with
-                                   | FStar_TypeChecker_Common.Trivial ->
-                                       (if debug1
-                                        then
-                                          (let uu___8 =
-                                             let uu___9 =
-                                               FStar_Errors_Msg.text
-                                                 "Goal completely solved by tactic\n" in
-                                             [uu___9] in
-                                           diag_doc uu___8)
-                                        else ();
-                                        [])
-                                   | FStar_TypeChecker_Common.NonTrivial
-                                       goal1 -> [(env1, goal1, opts)]))) in
+                      FStar_Compiler_List.concatMap
+                        (fun uu___5 ->
+                           match uu___5 with
+                           | (env1, goal, opts) ->
+                               let uu___6 =
+                                 FStar_TypeChecker_Common.check_trivial goal in
+                               (match uu___6 with
+                                | FStar_TypeChecker_Common.Trivial ->
+                                    (if debug1
+                                     then
+                                       (let uu___8 =
+                                          let uu___9 =
+                                            FStar_Errors_Msg.text
+                                              "Goal completely solved by tactic\n" in
+                                          [uu___9] in
+                                        diag_doc uu___8)
+                                     else ();
+                                     [])
+                                | FStar_TypeChecker_Common.NonTrivial goal1
+                                    -> [(env1, goal1, opts)])) vcs3 in
                     vcs4)))
            else
              (let uu___3 =
@@ -14564,47 +14167,44 @@ let (do_discharge_vc :
              uu___2 = FStar_Options.Always in
            if uu___1
            then
-             FStar_Compiler_Effect.op_Bar_Greater vcs
-               (FStar_Compiler_List.collect
-                  (fun uu___2 ->
-                     match uu___2 with
-                     | (env1, goal, opts) ->
-                         let uu___3 =
-                           FStar_TypeChecker_Env.split_smt_query env1 goal in
-                         (match uu___3 with
-                          | FStar_Pervasives_Native.None ->
-                              [(env1, goal, opts)]
-                          | FStar_Pervasives_Native.Some goals ->
-                              FStar_Compiler_Effect.op_Bar_Greater goals
-                                (FStar_Compiler_List.map
-                                   (fun uu___4 ->
-                                      match uu___4 with
-                                      | (env2, goal1) -> (env2, goal1, opts))))))
+             FStar_Compiler_List.collect
+               (fun uu___2 ->
+                  match uu___2 with
+                  | (env1, goal, opts) ->
+                      let uu___3 =
+                        FStar_TypeChecker_Env.split_smt_query env1 goal in
+                      (match uu___3 with
+                       | FStar_Pervasives_Native.None -> [(env1, goal, opts)]
+                       | FStar_Pervasives_Native.Some goals ->
+                           FStar_Compiler_List.map
+                             (fun uu___4 ->
+                                match uu___4 with
+                                | (env2, goal1) -> (env2, goal1, opts)) goals))
+               vcs
            else vcs in
-         FStar_Compiler_Effect.op_Bar_Greater vcs1
-           (FStar_Compiler_List.iter
-              (fun uu___1 ->
-                 match uu___1 with
-                 | (env1, goal, opts) ->
-                     FStar_Options.with_saved_options
-                       (fun uu___2 ->
-                          FStar_Options.set opts;
-                          if debug1
-                          then
-                            (let uu___5 =
-                               let uu___6 =
-                                 let uu___7 =
-                                   FStar_Errors_Msg.text
-                                     "Before calling solver, VC =" in
-                                 let uu___8 =
-                                   FStar_Class_PP.pp
-                                     FStar_Syntax_Print.pretty_term goal in
-                                 FStar_Pprint.op_Hat_Slash_Hat uu___7 uu___8 in
-                               [uu___6] in
-                             diag_doc uu___5)
-                          else ();
-                          (env1.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.solve
-                            use_env_range_msg env1 goal))))
+         FStar_Compiler_List.iter
+           (fun uu___1 ->
+              match uu___1 with
+              | (env1, goal, opts) ->
+                  FStar_Options.with_saved_options
+                    (fun uu___2 ->
+                       FStar_Options.set opts;
+                       if debug1
+                       then
+                         (let uu___5 =
+                            let uu___6 =
+                              let uu___7 =
+                                FStar_Errors_Msg.text
+                                  "Before calling solver, VC =" in
+                              let uu___8 =
+                                FStar_Class_PP.pp
+                                  FStar_Syntax_Print.pretty_term goal in
+                              FStar_Pprint.op_Hat_Slash_Hat uu___7 uu___8 in
+                            [uu___6] in
+                          diag_doc uu___5)
+                       else ();
+                       (env1.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.solve
+                         use_env_range_msg env1 goal)) vcs1)
 let (discharge_guard' :
   (unit -> Prims.string) FStar_Pervasives_Native.option ->
     FStar_TypeChecker_Env.env ->
@@ -14617,22 +14217,16 @@ let (discharge_guard' :
       fun g ->
         fun use_smt ->
           let debug1 =
-            ((FStar_Compiler_Effect.op_Less_Bar
-                (FStar_TypeChecker_Env.debug env) (FStar_Options.Other "Rel"))
-               ||
-               (FStar_Compiler_Effect.op_Less_Bar
-                  (FStar_TypeChecker_Env.debug env)
+            ((FStar_TypeChecker_Env.debug env (FStar_Options.Other "Rel")) ||
+               (FStar_TypeChecker_Env.debug env
                   (FStar_Options.Other "SMTQuery")))
               ||
-              (FStar_Compiler_Effect.op_Less_Bar
-                 (FStar_TypeChecker_Env.debug env)
-                 (FStar_Options.Other "Disch")) in
+              (FStar_TypeChecker_Env.debug env (FStar_Options.Other "Disch")) in
           let diag_doc =
             let uu___ = FStar_TypeChecker_Env.get_range env in
             FStar_Errors.diag_doc uu___ in
           (let uu___1 =
-             FStar_Compiler_Effect.op_Less_Bar
-               (FStar_TypeChecker_Env.debug env)
+             FStar_TypeChecker_Env.debug env
                (FStar_Options.Other "ResolveImplicitsHook") in
            if uu___1
            then
@@ -14752,8 +14346,7 @@ let (subtype_nosmt :
     fun t1 ->
       fun t2 ->
         (let uu___1 =
-           FStar_Compiler_Effect.op_Less_Bar
-             (FStar_TypeChecker_Env.debug env) (FStar_Options.Other "Rel") in
+           FStar_TypeChecker_Env.debug env (FStar_Options.Other "Rel") in
          if uu___1
          then
            let uu___2 = FStar_TypeChecker_Normalize.term_to_string env t1 in
@@ -14770,7 +14363,7 @@ let (subtype_nosmt :
                let uu___2 =
                  solve_and_commit (singleton wl prob false)
                    (fun uu___3 -> FStar_Pervasives_Native.None) in
-               FStar_Compiler_Effect.op_Less_Bar (with_guard env prob) uu___2 in
+               with_guard env prob uu___2 in
              (match g with
               | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
               | FStar_Pervasives_Native.Some g1 ->
@@ -14798,9 +14391,7 @@ let (check_subtyping :
         FStar_Profiling.profile
           (fun uu___1 ->
              (let uu___3 =
-                FStar_Compiler_Effect.op_Less_Bar
-                  (FStar_TypeChecker_Env.debug env)
-                  (FStar_Options.Other "Rel") in
+                FStar_TypeChecker_Env.debug env (FStar_Options.Other "Rel") in
               if uu___3
               then
                 let uu___4 =
@@ -14819,11 +14410,9 @@ let (check_subtyping :
                     let uu___4 =
                       solve_and_commit (singleton wl prob true)
                         (fun uu___5 -> FStar_Pervasives_Native.None) in
-                    FStar_Compiler_Effect.op_Less_Bar (with_guard env prob)
-                      uu___4 in
+                    with_guard env prob uu___4 in
                   ((let uu___5 =
-                      (FStar_Compiler_Effect.op_Less_Bar
-                         (FStar_TypeChecker_Env.debug env)
+                      (FStar_TypeChecker_Env.debug env
                          (FStar_Options.Other "Rel"))
                         && (FStar_Compiler_Util.is_some g) in
                     if uu___5
@@ -14936,20 +14525,16 @@ let (try_solve_single_valued_implicits :
                         FStar_Parser_Const.unit_lid
                       ->
                       let uu___3 =
-                        FStar_Compiler_Effect.op_Bar_Greater r
-                          FStar_Syntax_Syntax.unit_const_with_range in
-                      FStar_Compiler_Effect.op_Bar_Greater uu___3
-                        (fun uu___4 -> FStar_Pervasives_Native.Some uu___4)
+                        FStar_Syntax_Syntax.unit_const_with_range r in
+                      FStar_Pervasives_Native.Some uu___3
                   | FStar_Syntax_Syntax.Tm_refine
                       { FStar_Syntax_Syntax.b = b;
                         FStar_Syntax_Syntax.phi = uu___3;_}
                       when
                       FStar_Syntax_Util.is_unit b.FStar_Syntax_Syntax.sort ->
                       let uu___4 =
-                        FStar_Compiler_Effect.op_Bar_Greater r
-                          FStar_Syntax_Syntax.unit_const_with_range in
-                      FStar_Compiler_Effect.op_Bar_Greater uu___4
-                        (fun uu___5 -> FStar_Pervasives_Native.Some uu___5)
+                        FStar_Syntax_Syntax.unit_const_with_range r in
+                      FStar_Pervasives_Native.Some uu___4
                   | uu___3 -> FStar_Pervasives_Native.None) in
            let b =
              FStar_Compiler_List.fold_left
@@ -14959,9 +14544,7 @@ let (try_solve_single_valued_implicits :
                       (let uu___2 =
                          FStar_Syntax_Unionfind.find
                            (imp.FStar_TypeChecker_Common.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_head in
-                       FStar_Compiler_Effect.op_Bar_Greater uu___2
-                         FStar_Compiler_Util.is_none)
-                        &&
+                       FStar_Compiler_Util.is_none uu___2) &&
                         (let uu___2 =
                            FStar_Syntax_Util.ctx_uvar_should_check
                              imp.FStar_TypeChecker_Common.imp_uvar in
@@ -14999,9 +14582,7 @@ let (check_implicit_solution_and_discharge_guard :
               let uvar_should_check =
                 FStar_Syntax_Util.ctx_uvar_should_check imp_uvar in
               ((let uu___2 =
-                  FStar_Compiler_Effect.op_Less_Bar
-                    (FStar_TypeChecker_Env.debug env)
-                    (FStar_Options.Other "Rel") in
+                  FStar_TypeChecker_Env.debug env (FStar_Options.Other "Rel") in
                 if uu___2
                 then
                   let uu___3 =
@@ -15021,7 +14602,7 @@ let (check_implicit_solution_and_discharge_guard :
                 else ());
                (let env1 =
                   let uu___2 =
-                    FStar_Compiler_Effect.op_Bar_Greater
+                    FStar_TypeChecker_Env.clear_expected_typ
                       {
                         FStar_TypeChecker_Env.solver =
                           (env.FStar_TypeChecker_Env.solver);
@@ -15128,9 +14709,8 @@ let (check_implicit_solution_and_discharge_guard :
                           (env.FStar_TypeChecker_Env.erase_erasable_args);
                         FStar_TypeChecker_Env.core_check =
                           (env.FStar_TypeChecker_Env.core_check)
-                      } FStar_TypeChecker_Env.clear_expected_typ in
-                  FStar_Compiler_Effect.op_Bar_Greater uu___2
-                    FStar_Pervasives_Native.fst in
+                      } in
+                  FStar_Pervasives_Native.fst uu___2 in
                 let g =
                   FStar_Errors.with_ctx "While checking implicit solution"
                     (fun uu___2 ->
@@ -15308,9 +14888,8 @@ let (check_implicit_solution_and_discharge_guard :
                      | FStar_Pervasives_Native.None ->
                          FStar_Compiler_Effect.failwith
                            "Impossible, with use_smt = true, discharge_guard' must return Some" in
-                   FStar_Compiler_Effect.op_Bar_Greater
-                     g'.FStar_TypeChecker_Common.implicits
-                     (fun uu___4 -> FStar_Pervasives_Native.Some uu___4))))
+                   FStar_Pervasives_Native.Some
+                     (g'.FStar_TypeChecker_Common.implicits))))
 let rec (unresolved : FStar_Syntax_Syntax.ctx_uvar -> Prims.bool) =
   fun ctx_u ->
     let uu___ =
@@ -15345,27 +14924,19 @@ let (pick_a_univ_deffered_implicit :
         (match imps_with_deferred_univs with
          | [] -> (FStar_Pervasives_Native.None, out)
          | hd::tl ->
-             let uu___1 =
-               let uu___2 =
-                 FStar_Compiler_Effect.op_Bar_Greater hd
-                   FStar_Pervasives_Native.fst in
-               FStar_Compiler_Effect.op_Bar_Greater uu___2
-                 (fun uu___3 -> FStar_Pervasives_Native.Some uu___3) in
-             (uu___1, (FStar_Compiler_List.op_At tl rest)))
+             ((FStar_Pervasives_Native.Some (FStar_Pervasives_Native.fst hd)),
+               (FStar_Compiler_List.op_At tl rest)))
 let (is_tac_implicit_resolved :
   FStar_TypeChecker_Env.env ->
     FStar_TypeChecker_Common.implicit -> Prims.bool)
   =
   fun env ->
     fun i ->
-      let uu___ =
-        FStar_Compiler_Effect.op_Bar_Greater
-          i.FStar_TypeChecker_Common.imp_tm FStar_Syntax_Free.uvars in
-      FStar_Compiler_Effect.op_Bar_Greater uu___
-        (FStar_Compiler_Set.for_all FStar_Syntax_Free.ord_ctx_uvar
-           (fun uv ->
-              let uu___1 = FStar_Syntax_Util.ctx_uvar_should_check uv in
-              FStar_Syntax_Syntax.uu___is_Allow_unresolved uu___1))
+      let uu___ = FStar_Syntax_Free.uvars i.FStar_TypeChecker_Common.imp_tm in
+      FStar_Compiler_Set.for_all FStar_Syntax_Free.ord_ctx_uvar
+        (fun uv ->
+           let uu___1 = FStar_Syntax_Util.ctx_uvar_should_check uv in
+           FStar_Syntax_Syntax.uu___is_Allow_unresolved uu___1) uu___
 let (resolve_implicits' :
   FStar_TypeChecker_Env.env ->
     Prims.bool ->
@@ -15435,8 +15006,7 @@ let (resolve_implicits' :
                                             check_implicit_solution_and_discharge_guard
                                               env imp is_tac
                                               force_univ_constraints in
-                                          FStar_Compiler_Effect.op_Bar_Greater
-                                            uu___5 FStar_Compiler_Util.must in
+                                          FStar_Compiler_Util.must uu___5 in
                                         let uu___5 =
                                           let uu___6 =
                                             FStar_Compiler_List.map
@@ -15465,8 +15035,7 @@ let (resolve_implicits' :
                                  = uvar_decoration_should_check;_}
                                ->
                                ((let uu___5 =
-                                   FStar_Compiler_Effect.op_Less_Bar
-                                     (FStar_TypeChecker_Env.debug env)
+                                   FStar_TypeChecker_Env.debug env
                                      (FStar_Options.Other "Rel") in
                                  if uu___5
                                  then
@@ -15657,14 +15226,12 @@ let (resolve_implicits' :
                                          if uu___6
                                          then
                                            ((let uu___8 =
-                                               (FStar_Compiler_Effect.op_Less_Bar
-                                                  (FStar_TypeChecker_Env.debug
-                                                     env1)
+                                               (FStar_TypeChecker_Env.debug
+                                                  env1
                                                   (FStar_Options.Other "Rel"))
                                                  ||
-                                                 (FStar_Compiler_Effect.op_Less_Bar
-                                                    (FStar_TypeChecker_Env.debug
-                                                       env1)
+                                                 (FStar_TypeChecker_Env.debug
+                                                    env1
                                                     (FStar_Options.Other
                                                        "Imps")) in
                                              if uu___8
@@ -15931,12 +15498,11 @@ let (resolve_implicits' :
                                                 let uu___6 =
                                                   let uu___7 =
                                                     let uu___8 =
-                                                      FStar_Compiler_Effect.op_Bar_Greater
-                                                        imps
-                                                        (FStar_Compiler_List.map
-                                                           (fun i ->
-                                                              (i,
-                                                                Implicit_unresolved))) in
+                                                      FStar_Compiler_List.map
+                                                        (fun i ->
+                                                           (i,
+                                                             Implicit_unresolved))
+                                                        imps in
                                                     FStar_Compiler_List.op_At
                                                       uu___8 out in
                                                   (uu___7, true) in
@@ -15949,7 +15515,7 @@ let (resolve_implicits :
   fun env ->
     fun g ->
       (let uu___1 =
-         FStar_Compiler_Effect.op_Less_Bar (FStar_TypeChecker_Env.debug env)
+         FStar_TypeChecker_Env.debug env
            (FStar_Options.Other "ResolveImplicitsHook") in
        if uu___1
        then
@@ -15962,7 +15528,7 @@ let (resolve_implicits :
          resolve_implicits' env false false
            g.FStar_TypeChecker_Common.implicits in
        (let uu___2 =
-          FStar_Compiler_Effect.op_Less_Bar (FStar_TypeChecker_Env.debug env)
+          FStar_TypeChecker_Env.debug env
             (FStar_Options.Other "ResolveImplicitsHook") in
         if uu___2
         then
@@ -16017,7 +15583,7 @@ let (force_trivial_guard :
   fun env ->
     fun g ->
       (let uu___1 =
-         FStar_Compiler_Effect.op_Less_Bar (FStar_TypeChecker_Env.debug env)
+         FStar_TypeChecker_Env.debug env
            (FStar_Options.Other "ResolveImplicitsHook") in
        if uu___1
        then
@@ -16029,9 +15595,7 @@ let (force_trivial_guard :
       (let g1 = solve_deferred_constraints env g in
        let g2 = resolve_implicits env g1 in
        match g2.FStar_TypeChecker_Common.implicits with
-       | [] ->
-           let uu___1 = discharge_guard env g2 in
-           FStar_Compiler_Effect.op_Less_Bar (fun uu___2 -> ()) uu___1
+       | [] -> let uu___1 = discharge_guard env g2 in ()
        | imp::uu___1 ->
            let uu___2 =
              let uu___3 =
@@ -16111,20 +15675,14 @@ let (layered_effect_teq :
       fun t2 ->
         fun reason ->
           (let uu___1 =
-             FStar_Compiler_Effect.op_Less_Bar
-               (FStar_TypeChecker_Env.debug env)
+             FStar_TypeChecker_Env.debug env
                (FStar_Options.Other "LayeredEffectsEqns") in
            if uu___1
            then
              let uu___2 =
-               let uu___3 =
-                 FStar_Compiler_Effect.op_Bar_Greater reason
-                   FStar_Compiler_Util.is_none in
-               if uu___3
+               if FStar_Compiler_Util.is_none reason
                then "_"
-               else
-                 FStar_Compiler_Effect.op_Bar_Greater reason
-                   FStar_Compiler_Util.must in
+               else FStar_Compiler_Util.must reason in
              let uu___3 =
                FStar_Class_Show.show FStar_Syntax_Print.showable_term t1 in
              let uu___4 =

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Tc.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Tc.ml
@@ -34,16 +34,14 @@ let (set_hint_correlator :
   fun env ->
     fun se ->
       let tbl =
-        FStar_Compiler_Effect.op_Bar_Greater
-          env.FStar_TypeChecker_Env.qtbl_name_and_index
-          FStar_Pervasives_Native.snd in
+        FStar_Pervasives_Native.snd
+          env.FStar_TypeChecker_Env.qtbl_name_and_index in
       let get_n lid =
         let n_opt =
           let uu___ = FStar_Ident.string_of_lid lid in
           FStar_Compiler_Util.smap_try_find tbl uu___ in
         if FStar_Compiler_Util.is_some n_opt
-        then
-          FStar_Compiler_Effect.op_Bar_Greater n_opt FStar_Compiler_Util.must
+        then FStar_Compiler_Util.must n_opt
         else Prims.int_zero in
       let typ =
         let uu___ = sigelt_typ se in
@@ -164,8 +162,7 @@ let (set_hint_correlator :
                 let uu___1 = FStar_TypeChecker_Env.current_module env in
                 let uu___2 =
                   let uu___3 = FStar_GenSym.next_id () in
-                  FStar_Compiler_Effect.op_Bar_Greater uu___3
-                    FStar_Compiler_Util.string_of_int in
+                  FStar_Compiler_Util.string_of_int uu___3 in
                 FStar_Ident.lid_add_suffix uu___1 uu___2
             | l::uu___1 -> l in
           let uu___1 =
@@ -306,11 +303,9 @@ let (tc_type_common :
                    else
                      (let uu___3 =
                         let uu___4 =
-                          FStar_Compiler_Effect.op_Bar_Greater t2
-                            (FStar_TypeChecker_Normalize.remove_uvar_solutions
-                               env1) in
-                        FStar_Compiler_Effect.op_Bar_Greater uu___4
-                          (FStar_Syntax_Subst.close_univ_vars uvs1) in
+                          FStar_TypeChecker_Normalize.remove_uvar_solutions
+                            env1 t2 in
+                        FStar_Syntax_Subst.close_univ_vars uvs1 uu___4 in
                       (uvs1, uu___3)))
 let (tc_declare_typ :
   FStar_TypeChecker_Env.env ->
@@ -322,8 +317,7 @@ let (tc_declare_typ :
       fun r ->
         let uu___ =
           let uu___1 = FStar_Syntax_Util.type_u () in
-          FStar_Compiler_Effect.op_Bar_Greater uu___1
-            FStar_Pervasives_Native.fst in
+          FStar_Pervasives_Native.fst uu___1 in
         tc_type_common env ts uu___ r
 let (tc_assume :
   FStar_TypeChecker_Env.env ->
@@ -335,8 +329,7 @@ let (tc_assume :
       fun r ->
         let uu___ =
           let uu___1 = FStar_Syntax_Util.type_u () in
-          FStar_Compiler_Effect.op_Bar_Greater uu___1
-            FStar_Pervasives_Native.fst in
+          FStar_Pervasives_Native.fst uu___1 in
         tc_type_common env ts uu___ r
 let (tc_decl_attributes :
   FStar_TypeChecker_Env.env ->
@@ -415,8 +408,7 @@ let (tc_inductive' :
                      FStar_Compiler_List.map
                        (FStar_TypeChecker_TcInductive.mk_data_operations
                           quals attrs' env tcs) datas in
-                   FStar_Compiler_Effect.op_Bar_Greater uu___2
-                     FStar_Compiler_List.flatten in
+                   FStar_Compiler_List.flatten uu___2 in
                  ((let uu___3 =
                      (FStar_Options.no_positivity ()) ||
                        (let uu___4 = FStar_TypeChecker_Env.should_verify env in
@@ -587,8 +579,7 @@ let (tc_inductive :
                     match () with
                     | () ->
                         let uu___3 = tc_inductive' env1 ses quals attrs lids in
-                        FStar_Compiler_Effect.op_Bar_Greater uu___3
-                          (fun r -> pop (); r)) ()
+                        (pop (); uu___3)) ()
                with | uu___2 -> (pop (); FStar_Compiler_Effect.raise uu___2))
 let (check_must_erase_attribute :
   FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.sigelt -> unit) =
@@ -609,75 +600,68 @@ let (check_must_erase_attribute :
             (match uu___1 with
              | FStar_Pervasives_Native.None -> ()
              | FStar_Pervasives_Native.Some iface_decls ->
-                 FStar_Compiler_Effect.op_Bar_Greater
-                   (FStar_Pervasives_Native.snd lbs)
-                   (FStar_Compiler_List.iter
-                      (fun lb ->
-                         let lbname =
-                           FStar_Compiler_Util.right
-                             lb.FStar_Syntax_Syntax.lbname in
-                         let has_iface_val =
-                           let uu___2 =
-                             let uu___3 =
-                               let uu___4 =
-                                 FStar_Ident.ident_of_lid
-                                   (lbname.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                               FStar_Parser_AST.decl_is_val uu___4 in
-                             FStar_Compiler_Util.for_some uu___3 in
-                           FStar_Compiler_Effect.op_Bar_Greater iface_decls
-                             uu___2 in
-                         if has_iface_val
+                 FStar_Compiler_List.iter
+                   (fun lb ->
+                      let lbname =
+                        FStar_Compiler_Util.right
+                          lb.FStar_Syntax_Syntax.lbname in
+                      let has_iface_val =
+                        let uu___2 =
+                          let uu___3 =
+                            FStar_Ident.ident_of_lid
+                              (lbname.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
+                          FStar_Parser_AST.decl_is_val uu___3 in
+                        FStar_Compiler_Util.for_some uu___2 iface_decls in
+                      if has_iface_val
+                      then
+                        let must_erase =
+                          FStar_TypeChecker_Util.must_erase_for_extraction
+                            env lb.FStar_Syntax_Syntax.lbdef in
+                        let has_attr =
+                          FStar_TypeChecker_Env.fv_has_attr env lbname
+                            FStar_Parser_Const.must_erase_for_extraction_attr in
+                        (if must_erase && (Prims.op_Negation has_attr)
                          then
-                           let must_erase =
-                             FStar_TypeChecker_Util.must_erase_for_extraction
-                               env lb.FStar_Syntax_Syntax.lbdef in
-                           let has_attr =
-                             FStar_TypeChecker_Env.fv_has_attr env lbname
-                               FStar_Parser_Const.must_erase_for_extraction_attr in
-                           (if must_erase && (Prims.op_Negation has_attr)
-                            then
-                              let uu___2 =
+                           let uu___2 =
+                             FStar_Syntax_Syntax.range_of_fv lbname in
+                           let uu___3 =
+                             let uu___4 =
+                               let uu___5 =
+                                 let uu___6 =
+                                   let uu___7 =
+                                     FStar_Syntax_Print.fv_to_string lbname in
+                                   let uu___8 =
+                                     FStar_Syntax_Print.fv_to_string lbname in
+                                   FStar_Compiler_Util.format2
+                                     "Values of type `%s` will be erased during extraction, but its interface hides this fact. Add the `must_erase_for_extraction` attribute to the `val %s` declaration for this symbol in the interface"
+                                     uu___7 uu___8 in
+                                 FStar_Errors_Msg.text uu___6 in
+                               [uu___5] in
+                             (FStar_Errors_Codes.Error_MustEraseMissing,
+                               uu___4) in
+                           FStar_Errors.log_issue_doc uu___2 uu___3
+                         else
+                           if has_attr && (Prims.op_Negation must_erase)
+                           then
+                             (let uu___3 =
                                 FStar_Syntax_Syntax.range_of_fv lbname in
-                              let uu___3 =
-                                let uu___4 =
-                                  let uu___5 =
-                                    let uu___6 =
-                                      let uu___7 =
-                                        FStar_Syntax_Print.fv_to_string
-                                          lbname in
+                              let uu___4 =
+                                let uu___5 =
+                                  let uu___6 =
+                                    let uu___7 =
                                       let uu___8 =
                                         FStar_Syntax_Print.fv_to_string
                                           lbname in
-                                      FStar_Compiler_Util.format2
-                                        "Values of type `%s` will be erased during extraction, but its interface hides this fact. Add the `must_erase_for_extraction` attribute to the `val %s` declaration for this symbol in the interface"
-                                        uu___7 uu___8 in
-                                    FStar_Errors_Msg.text uu___6 in
-                                  [uu___5] in
+                                      FStar_Compiler_Util.format1
+                                        "Values of type `%s` cannot be erased during extraction, but the `must_erase_for_extraction` attribute claims that it can. Please remove the attribute."
+                                        uu___8 in
+                                    FStar_Errors_Msg.text uu___7 in
+                                  [uu___6] in
                                 (FStar_Errors_Codes.Error_MustEraseMissing,
-                                  uu___4) in
-                              FStar_Errors.log_issue_doc uu___2 uu___3
-                            else
-                              if has_attr && (Prims.op_Negation must_erase)
-                              then
-                                (let uu___3 =
-                                   FStar_Syntax_Syntax.range_of_fv lbname in
-                                 let uu___4 =
-                                   let uu___5 =
-                                     let uu___6 =
-                                       let uu___7 =
-                                         let uu___8 =
-                                           FStar_Syntax_Print.fv_to_string
-                                             lbname in
-                                         FStar_Compiler_Util.format1
-                                           "Values of type `%s` cannot be erased during extraction, but the `must_erase_for_extraction` attribute claims that it can. Please remove the attribute."
-                                           uu___8 in
-                                       FStar_Errors_Msg.text uu___7 in
-                                     [uu___6] in
-                                   (FStar_Errors_Codes.Error_MustEraseMissing,
-                                     uu___5) in
-                                 FStar_Errors.log_issue_doc uu___3 uu___4)
-                              else ())
-                         else ())))
+                                  uu___5) in
+                              FStar_Errors.log_issue_doc uu___3 uu___4)
+                           else ())
+                      else ()) (FStar_Pervasives_Native.snd lbs))
           else ()
       | uu___ -> ()
 let (check_typeclass_instance_attribute :
@@ -685,14 +669,13 @@ let (check_typeclass_instance_attribute :
   fun env ->
     fun se ->
       let is_tc_instance =
-        FStar_Compiler_Effect.op_Bar_Greater se.FStar_Syntax_Syntax.sigattrs
-          (FStar_Compiler_Util.for_some
-             (fun t ->
-                match t.FStar_Syntax_Syntax.n with
-                | FStar_Syntax_Syntax.Tm_fvar fv ->
-                    FStar_Syntax_Syntax.fv_eq_lid fv
-                      FStar_Parser_Const.tcinstance_lid
-                | uu___ -> false)) in
+        FStar_Compiler_Util.for_some
+          (fun t ->
+             match t.FStar_Syntax_Syntax.n with
+             | FStar_Syntax_Syntax.Tm_fvar fv ->
+                 FStar_Syntax_Syntax.fv_eq_lid fv
+                   FStar_Parser_Const.tcinstance_lid
+             | uu___ -> false) se.FStar_Syntax_Syntax.sigattrs in
       if Prims.op_Negation is_tc_instance
       then ()
       else
@@ -1018,79 +1001,76 @@ let (tc_sig_let :
                 FStar_Syntax_Syntax.lbpos = (lb.FStar_Syntax_Syntax.lbpos)
               } in
             let uu___ =
-              FStar_Compiler_Effect.op_Bar_Greater
-                (FStar_Pervasives_Native.snd lbs)
-                (FStar_Compiler_List.fold_left
-                   (fun uu___1 ->
-                      fun lb ->
-                        match uu___1 with
-                        | (gen, lbs1, quals_opt) ->
-                            let lbname =
-                              FStar_Compiler_Util.right
-                                lb.FStar_Syntax_Syntax.lbname in
-                            let uu___2 =
-                              let uu___3 =
-                                FStar_TypeChecker_Env.try_lookup_val_decl
-                                  env1
-                                  (lbname.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                              match uu___3 with
-                              | FStar_Pervasives_Native.None ->
-                                  (gen, lb, quals_opt)
-                              | FStar_Pervasives_Native.Some
-                                  ((uvs, tval), quals) ->
-                                  let quals_opt1 =
-                                    check_quals_eq
-                                      (lbname.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-                                      quals_opt quals in
-                                  let def =
-                                    match (lb.FStar_Syntax_Syntax.lbtyp).FStar_Syntax_Syntax.n
-                                    with
-                                    | FStar_Syntax_Syntax.Tm_unknown ->
-                                        lb.FStar_Syntax_Syntax.lbdef
-                                    | uu___4 ->
-                                        FStar_Syntax_Syntax.mk
-                                          (FStar_Syntax_Syntax.Tm_ascribed
-                                             {
-                                               FStar_Syntax_Syntax.tm =
-                                                 (lb.FStar_Syntax_Syntax.lbdef);
-                                               FStar_Syntax_Syntax.asc =
-                                                 ((FStar_Pervasives.Inl
-                                                     (lb.FStar_Syntax_Syntax.lbtyp)),
-                                                   FStar_Pervasives_Native.None,
-                                                   false);
-                                               FStar_Syntax_Syntax.eff_opt =
-                                                 FStar_Pervasives_Native.None
-                                             })
-                                          (lb.FStar_Syntax_Syntax.lbdef).FStar_Syntax_Syntax.pos in
-                                  (if
-                                     (lb.FStar_Syntax_Syntax.lbunivs <> [])
-                                       &&
-                                       ((FStar_Compiler_List.length
-                                           lb.FStar_Syntax_Syntax.lbunivs)
-                                          <> (FStar_Compiler_List.length uvs))
-                                   then
-                                     FStar_Errors.raise_error
-                                       (FStar_Errors_Codes.Fatal_IncoherentInlineUniverse,
-                                         "Inline universes are incoherent with annotation from val declaration")
-                                       r
-                                   else ();
-                                   (let uu___5 =
-                                      FStar_Syntax_Syntax.mk_lb
-                                        ((FStar_Pervasives.Inr lbname), uvs,
-                                          FStar_Parser_Const.effect_Tot_lid,
-                                          tval, def,
-                                          (lb.FStar_Syntax_Syntax.lbattrs),
-                                          (lb.FStar_Syntax_Syntax.lbpos)) in
-                                    (false, uu___5, quals_opt1))) in
-                            (match uu___2 with
-                             | (gen1, lb1, quals_opt1) ->
-                                 (gen1, (lb1 :: lbs1), quals_opt1)))
-                   (true, [],
-                     (if se.FStar_Syntax_Syntax.sigquals = []
-                      then FStar_Pervasives_Native.None
-                      else
-                        FStar_Pervasives_Native.Some
-                          (se.FStar_Syntax_Syntax.sigquals)))) in
+              FStar_Compiler_List.fold_left
+                (fun uu___1 ->
+                   fun lb ->
+                     match uu___1 with
+                     | (gen, lbs1, quals_opt) ->
+                         let lbname =
+                           FStar_Compiler_Util.right
+                             lb.FStar_Syntax_Syntax.lbname in
+                         let uu___2 =
+                           let uu___3 =
+                             FStar_TypeChecker_Env.try_lookup_val_decl env1
+                               (lbname.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
+                           match uu___3 with
+                           | FStar_Pervasives_Native.None ->
+                               (gen, lb, quals_opt)
+                           | FStar_Pervasives_Native.Some
+                               ((uvs, tval), quals) ->
+                               let quals_opt1 =
+                                 check_quals_eq
+                                   (lbname.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
+                                   quals_opt quals in
+                               let def =
+                                 match (lb.FStar_Syntax_Syntax.lbtyp).FStar_Syntax_Syntax.n
+                                 with
+                                 | FStar_Syntax_Syntax.Tm_unknown ->
+                                     lb.FStar_Syntax_Syntax.lbdef
+                                 | uu___4 ->
+                                     FStar_Syntax_Syntax.mk
+                                       (FStar_Syntax_Syntax.Tm_ascribed
+                                          {
+                                            FStar_Syntax_Syntax.tm =
+                                              (lb.FStar_Syntax_Syntax.lbdef);
+                                            FStar_Syntax_Syntax.asc =
+                                              ((FStar_Pervasives.Inl
+                                                  (lb.FStar_Syntax_Syntax.lbtyp)),
+                                                FStar_Pervasives_Native.None,
+                                                false);
+                                            FStar_Syntax_Syntax.eff_opt =
+                                              FStar_Pervasives_Native.None
+                                          })
+                                       (lb.FStar_Syntax_Syntax.lbdef).FStar_Syntax_Syntax.pos in
+                               (if
+                                  (lb.FStar_Syntax_Syntax.lbunivs <> []) &&
+                                    ((FStar_Compiler_List.length
+                                        lb.FStar_Syntax_Syntax.lbunivs)
+                                       <> (FStar_Compiler_List.length uvs))
+                                then
+                                  FStar_Errors.raise_error
+                                    (FStar_Errors_Codes.Fatal_IncoherentInlineUniverse,
+                                      "Inline universes are incoherent with annotation from val declaration")
+                                    r
+                                else ();
+                                (let uu___5 =
+                                   FStar_Syntax_Syntax.mk_lb
+                                     ((FStar_Pervasives.Inr lbname), uvs,
+                                       FStar_Parser_Const.effect_Tot_lid,
+                                       tval, def,
+                                       (lb.FStar_Syntax_Syntax.lbattrs),
+                                       (lb.FStar_Syntax_Syntax.lbpos)) in
+                                 (false, uu___5, quals_opt1))) in
+                         (match uu___2 with
+                          | (gen1, lb1, quals_opt1) ->
+                              (gen1, (lb1 :: lbs1), quals_opt1)))
+                (true, [],
+                  (if se.FStar_Syntax_Syntax.sigquals = []
+                   then FStar_Pervasives_Native.None
+                   else
+                     FStar_Pervasives_Native.Some
+                       (se.FStar_Syntax_Syntax.sigquals)))
+                (FStar_Pervasives_Native.snd lbs) in
             match uu___ with
             | (should_generalize, lbs', quals_opt) ->
                 (FStar_Syntax_Util.check_mutual_universes lbs';
@@ -1100,16 +1080,14 @@ let (tc_sig_let :
                         [FStar_Syntax_Syntax.Visible_default]
                     | FStar_Pervasives_Native.Some q ->
                         let uu___2 =
-                          FStar_Compiler_Effect.op_Bar_Greater q
-                            (FStar_Compiler_Util.for_some
-                               (fun uu___3 ->
-                                  match uu___3 with
-                                  | FStar_Syntax_Syntax.Irreducible -> true
-                                  | FStar_Syntax_Syntax.Visible_default ->
-                                      true
-                                  | FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen
-                                      -> true
-                                  | uu___4 -> false)) in
+                          FStar_Compiler_Util.for_some
+                            (fun uu___3 ->
+                               match uu___3 with
+                               | FStar_Syntax_Syntax.Irreducible -> true
+                               | FStar_Syntax_Syntax.Visible_default -> true
+                               | FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen
+                                   -> true
+                               | uu___4 -> false) q in
                         if uu___2
                         then q
                         else FStar_Syntax_Syntax.Visible_default :: q in
@@ -1155,8 +1133,7 @@ let (tc_sig_let :
                           FStar_TypeChecker_Env.preprocess env1 tau
                             lb.FStar_Syntax_Syntax.lbdef in
                         (let uu___4 =
-                           FStar_Compiler_Effect.op_Less_Bar
-                             (FStar_TypeChecker_Env.debug env1)
+                           FStar_TypeChecker_Env.debug env1
                              (FStar_Options.Other "TwoPhases") in
                          if uu___4
                          then
@@ -1547,8 +1524,7 @@ let (tc_sig_let :
                                       | (e3, uu___8, uu___9) -> e3) uu___5
                                    "FStar.TypeChecker.Tc.tc_sig_let-tc-phase1" in
                                (let uu___6 =
-                                  FStar_Compiler_Effect.op_Less_Bar
-                                    (FStar_TypeChecker_Env.debug env1)
+                                  FStar_TypeChecker_Env.debug env1
                                     (FStar_Options.Other "TwoPhases") in
                                 if uu___6
                                 then
@@ -1562,11 +1538,9 @@ let (tc_sig_let :
                                   let uu___6 =
                                     FStar_TypeChecker_Normalize.remove_uvar_solutions
                                       env' e2 in
-                                  FStar_Compiler_Effect.op_Bar_Greater uu___6
-                                    drop_lbtyp in
+                                  drop_lbtyp uu___6 in
                                 (let uu___7 =
-                                   FStar_Compiler_Effect.op_Less_Bar
-                                     (FStar_TypeChecker_Env.debug env1)
+                                   FStar_TypeChecker_Env.debug env1
                                      (FStar_Options.Other "TwoPhases") in
                                  if uu___7
                                  then
@@ -1816,10 +1790,9 @@ let (tc_sig_let :
                                     (FStar_Pervasives_Native.snd lbs1);
                                   (let lbs2 =
                                      let uu___10 =
-                                       FStar_Compiler_Effect.op_Bar_Greater
-                                         (FStar_Pervasives_Native.snd lbs1)
-                                         (FStar_Compiler_List.map
-                                            rename_parameters) in
+                                       FStar_Compiler_List.map
+                                         rename_parameters
+                                         (FStar_Pervasives_Native.snd lbs1) in
                                      ((FStar_Pervasives_Native.fst lbs1),
                                        uu___10) in
                                    let lbs3 =
@@ -2003,146 +1976,128 @@ let (tc_sig_let :
                                       FStar_Errors.raise_error
                                         (FStar_Errors_Codes.Fatal_InconsistentQualifierAnnotation,
                                           s) pos in
-                                    FStar_Compiler_Effect.op_Bar_Greater
-                                      (FStar_Pervasives_Native.snd lbs1)
-                                      (FStar_Compiler_List.iter
-                                         (fun lb ->
-                                            let uu___7 =
-                                              let uu___8 =
-                                                FStar_Syntax_Util.is_lemma
-                                                  lb.FStar_Syntax_Syntax.lbtyp in
-                                              Prims.op_Negation uu___8 in
-                                            if uu___7
+                                    FStar_Compiler_List.iter
+                                      (fun lb ->
+                                         let uu___7 =
+                                           let uu___8 =
+                                             FStar_Syntax_Util.is_lemma
+                                               lb.FStar_Syntax_Syntax.lbtyp in
+                                           Prims.op_Negation uu___8 in
+                                         if uu___7
+                                         then
+                                           err
+                                             "no_subtype annotation on a non-lemma"
+                                             lb.FStar_Syntax_Syntax.lbpos
+                                         else
+                                           (let lid_opt =
+                                              let uu___9 =
+                                                let uu___10 =
+                                                  FStar_Syntax_Free.fvars
+                                                    lb.FStar_Syntax_Syntax.lbtyp in
+                                                FStar_Compiler_Set.elems
+                                                  FStar_Syntax_Syntax.ord_fv
+                                                  uu___10 in
+                                              FStar_Compiler_List.tryFind
+                                                (fun lid ->
+                                                   let uu___10 =
+                                                     (let uu___11 =
+                                                        let uu___12 =
+                                                          FStar_Ident.path_of_lid
+                                                            lid in
+                                                        FStar_Compiler_List.hd
+                                                          uu___12 in
+                                                      uu___11 = "Prims") ||
+                                                       (FStar_Ident.lid_equals
+                                                          lid
+                                                          FStar_Parser_Const.pattern_lid) in
+                                                   Prims.op_Negation uu___10)
+                                                uu___9 in
+                                            if
+                                              FStar_Compiler_Util.is_some
+                                                lid_opt
                                             then
-                                              err
-                                                "no_subtype annotation on a non-lemma"
+                                              let uu___9 =
+                                                let uu___10 =
+                                                  let uu___11 =
+                                                    FStar_Compiler_Util.must
+                                                      lid_opt in
+                                                  FStar_Ident.string_of_lid
+                                                    uu___11 in
+                                                FStar_Compiler_Util.format1
+                                                  "%s is not allowed in no_subtyping lemmas (only prims symbols)"
+                                                  uu___10 in
+                                              err uu___9
                                                 lb.FStar_Syntax_Syntax.lbpos
                                             else
-                                              (let lid_opt =
-                                                 let uu___9 =
-                                                   let uu___10 =
-                                                     FStar_Syntax_Free.fvars
+                                              (let uu___10 =
+                                                 FStar_Syntax_Util.type_u () in
+                                               match uu___10 with
+                                               | (t, uu___11) ->
+                                                   let uu___12 =
+                                                     FStar_Syntax_Subst.open_univ_vars
+                                                       lb.FStar_Syntax_Syntax.lbunivs
                                                        lb.FStar_Syntax_Syntax.lbtyp in
-                                                   FStar_Compiler_Effect.op_Bar_Greater
-                                                     uu___10
-                                                     (FStar_Compiler_Set.elems
-                                                        FStar_Syntax_Syntax.ord_fv) in
-                                                 FStar_Compiler_Effect.op_Bar_Greater
-                                                   uu___9
-                                                   (FStar_Compiler_List.tryFind
-                                                      (fun lid ->
-                                                         let uu___10 =
-                                                           (let uu___11 =
-                                                              let uu___12 =
-                                                                FStar_Compiler_Effect.op_Bar_Greater
-                                                                  lid
-                                                                  FStar_Ident.path_of_lid in
-                                                              FStar_Compiler_Effect.op_Bar_Greater
-                                                                uu___12
-                                                                FStar_Compiler_List.hd in
-                                                            uu___11 = "Prims")
-                                                             ||
-                                                             (FStar_Ident.lid_equals
-                                                                lid
-                                                                FStar_Parser_Const.pattern_lid) in
-                                                         Prims.op_Negation
-                                                           uu___10)) in
-                                               let uu___9 =
-                                                 FStar_Compiler_Effect.op_Bar_Greater
-                                                   lid_opt
-                                                   FStar_Compiler_Util.is_some in
-                                               if uu___9
-                                               then
-                                                 let uu___10 =
-                                                   let uu___11 =
-                                                     let uu___12 =
-                                                       FStar_Compiler_Effect.op_Bar_Greater
-                                                         lid_opt
-                                                         FStar_Compiler_Util.must in
-                                                     FStar_Compiler_Effect.op_Bar_Greater
-                                                       uu___12
-                                                       FStar_Ident.string_of_lid in
-                                                   FStar_Compiler_Util.format1
-                                                     "%s is not allowed in no_subtyping lemmas (only prims symbols)"
-                                                     uu___11 in
-                                                 err uu___10
-                                                   lb.FStar_Syntax_Syntax.lbpos
-                                               else
-                                                 (let uu___11 =
-                                                    FStar_Syntax_Util.type_u
-                                                      () in
-                                                  match uu___11 with
-                                                  | (t, uu___12) ->
-                                                      let uu___13 =
-                                                        FStar_Syntax_Subst.open_univ_vars
-                                                          lb.FStar_Syntax_Syntax.lbunivs
-                                                          lb.FStar_Syntax_Syntax.lbtyp in
-                                                      (match uu___13 with
-                                                       | (uvs, lbtyp) ->
-                                                           let uu___14 =
-                                                             let uu___15 =
-                                                               FStar_TypeChecker_Env.push_univ_vars
-                                                                 env'2 uvs in
-                                                             FStar_TypeChecker_TcTerm.tc_check_tot_or_gtot_term
-                                                               uu___15 lbtyp
-                                                               t
-                                                               "checking no_subtype annotation" in
-                                                           (match uu___14
-                                                            with
-                                                            | (uu___15,
-                                                               uu___16, g) ->
-                                                                FStar_TypeChecker_Rel.force_trivial_guard
-                                                                  env'2 g))))))
+                                                   (match uu___12 with
+                                                    | (uvs, lbtyp) ->
+                                                        let uu___13 =
+                                                          let uu___14 =
+                                                            FStar_TypeChecker_Env.push_univ_vars
+                                                              env'2 uvs in
+                                                          FStar_TypeChecker_TcTerm.tc_check_tot_or_gtot_term
+                                                            uu___14 lbtyp t
+                                                            "checking no_subtype annotation" in
+                                                        (match uu___13 with
+                                                         | (uu___14, uu___15,
+                                                            g) ->
+                                                             FStar_TypeChecker_Rel.force_trivial_guard
+                                                               env'2 g)))))
+                                      (FStar_Pervasives_Native.snd lbs1)
                                   else ());
-                                 FStar_Compiler_Effect.op_Bar_Greater
-                                   (FStar_Pervasives_Native.snd lbs1)
-                                   (FStar_Compiler_List.iter
-                                      (fun lb ->
-                                         let fv =
-                                           FStar_Compiler_Util.right
-                                             lb.FStar_Syntax_Syntax.lbname in
-                                         FStar_TypeChecker_Env.insert_fv_info
-                                           env1 fv
-                                           lb.FStar_Syntax_Syntax.lbtyp));
+                                 FStar_Compiler_List.iter
+                                   (fun lb ->
+                                      let fv =
+                                        FStar_Compiler_Util.right
+                                          lb.FStar_Syntax_Syntax.lbname in
+                                      FStar_TypeChecker_Env.insert_fv_info
+                                        env1 fv lb.FStar_Syntax_Syntax.lbtyp)
+                                   (FStar_Pervasives_Native.snd lbs1);
                                  (let uu___8 = log env1 in
                                   if uu___8
                                   then
                                     let uu___9 =
                                       let uu___10 =
-                                        FStar_Compiler_Effect.op_Bar_Greater
-                                          (FStar_Pervasives_Native.snd lbs1)
-                                          (FStar_Compiler_List.map
-                                             (fun lb ->
-                                                let should_log =
-                                                  let uu___11 =
-                                                    let uu___12 =
-                                                      let uu___13 =
-                                                        let uu___14 =
-                                                          FStar_Compiler_Util.right
-                                                            lb.FStar_Syntax_Syntax.lbname in
-                                                        uu___14.FStar_Syntax_Syntax.fv_name in
-                                                      uu___13.FStar_Syntax_Syntax.v in
-                                                    FStar_TypeChecker_Env.try_lookup_val_decl
-                                                      env1 uu___12 in
-                                                  match uu___11 with
-                                                  | FStar_Pervasives_Native.None
-                                                      -> true
-                                                  | uu___12 -> false in
-                                                if should_log
-                                                then
-                                                  let uu___11 =
-                                                    FStar_Syntax_Print.lbname_to_string
-                                                      lb.FStar_Syntax_Syntax.lbname in
-                                                  let uu___12 =
-                                                    FStar_Syntax_Print.term_to_string
-                                                      lb.FStar_Syntax_Syntax.lbtyp in
-                                                  FStar_Compiler_Util.format2
-                                                    "let %s : %s" uu___11
-                                                    uu___12
-                                                else "")) in
-                                      FStar_Compiler_Effect.op_Bar_Greater
-                                        uu___10
-                                        (FStar_Compiler_String.concat "\n") in
+                                        FStar_Compiler_List.map
+                                          (fun lb ->
+                                             let should_log =
+                                               let uu___11 =
+                                                 let uu___12 =
+                                                   let uu___13 =
+                                                     let uu___14 =
+                                                       FStar_Compiler_Util.right
+                                                         lb.FStar_Syntax_Syntax.lbname in
+                                                     uu___14.FStar_Syntax_Syntax.fv_name in
+                                                   uu___13.FStar_Syntax_Syntax.v in
+                                                 FStar_TypeChecker_Env.try_lookup_val_decl
+                                                   env1 uu___12 in
+                                               match uu___11 with
+                                               | FStar_Pervasives_Native.None
+                                                   -> true
+                                               | uu___12 -> false in
+                                             if should_log
+                                             then
+                                               let uu___11 =
+                                                 FStar_Syntax_Print.lbname_to_string
+                                                   lb.FStar_Syntax_Syntax.lbname in
+                                               let uu___12 =
+                                                 FStar_Syntax_Print.term_to_string
+                                                   lb.FStar_Syntax_Syntax.lbtyp in
+                                               FStar_Compiler_Util.format2
+                                                 "let %s : %s" uu___11
+                                                 uu___12
+                                             else "")
+                                          (FStar_Pervasives_Native.snd lbs1) in
+                                      FStar_Compiler_String.concat "\n"
+                                        uu___10 in
                                     FStar_Compiler_Util.print1 "%s\n" uu___9
                                   else ());
                                  check_must_erase_attribute env0 se3;
@@ -2308,8 +2263,7 @@ let (tc_decl' :
                      let uu___5 =
                        FStar_Compiler_List.map
                          FStar_Compiler_Util.string_of_int expected_errors in
-                     FStar_Compiler_Effect.op_Less_Bar
-                       (FStar_Compiler_String.concat "; ") uu___5 in
+                     FStar_Compiler_String.concat "; " uu___5 in
                    FStar_Compiler_Util.print1 ">> Expecting errors: [%s]\n"
                      uu___4
                  else ());
@@ -2522,15 +2476,12 @@ let (tc_decl' :
                                       (env1.FStar_TypeChecker_Env.core_check)
                                   } ses se2.FStar_Syntax_Syntax.sigquals
                                   se2.FStar_Syntax_Syntax.sigattrs lids in
-                              FStar_Compiler_Effect.op_Bar_Greater uu___6
-                                FStar_Pervasives_Native.fst in
-                            FStar_Compiler_Effect.op_Bar_Greater uu___5
-                              (FStar_TypeChecker_Normalize.elim_uvars env1) in
-                          FStar_Compiler_Effect.op_Bar_Greater uu___4
-                            FStar_Syntax_Util.ses_of_sigbundle in
+                              FStar_Pervasives_Native.fst uu___6 in
+                            FStar_TypeChecker_Normalize.elim_uvars env1
+                              uu___5 in
+                          FStar_Syntax_Util.ses_of_sigbundle uu___4 in
                         (let uu___5 =
-                           FStar_Compiler_Effect.op_Less_Bar
-                             (FStar_TypeChecker_Env.debug env1)
+                           FStar_TypeChecker_Env.debug env1
                              (FStar_Options.Other "TwoPhases") in
                          if uu___5
                          then
@@ -2591,12 +2542,9 @@ let (tc_decl' :
                  match ne.FStar_Syntax_Syntax.combinators with
                  | FStar_Syntax_Syntax.DM4F_eff combs ->
                      let uu___2 =
-                       let uu___3 =
-                         FStar_Compiler_Effect.op_Bar_Greater
-                           combs.FStar_Syntax_Syntax.ret_wp
-                           FStar_Pervasives_Native.snd in
-                       FStar_Compiler_Effect.op_Bar_Greater uu___3
-                         FStar_Syntax_Subst.compress in
+                       FStar_Syntax_Subst.compress
+                         (FStar_Pervasives_Native.snd
+                            combs.FStar_Syntax_Syntax.ret_wp) in
                      (match uu___2 with
                       | {
                           FStar_Syntax_Syntax.n =
@@ -2651,42 +2599,38 @@ let (tc_decl' :
                                  (se2.FStar_Syntax_Syntax.sigopts)
                              }] in
                       let effect_and_lift_ses1 =
-                        FStar_Compiler_Effect.op_Bar_Greater
-                          effect_and_lift_ses
-                          (FStar_Compiler_List.map
-                             (fun sigelt ->
-                                {
-                                  FStar_Syntax_Syntax.sigel =
-                                    (sigelt.FStar_Syntax_Syntax.sigel);
-                                  FStar_Syntax_Syntax.sigrng =
-                                    (sigelt.FStar_Syntax_Syntax.sigrng);
-                                  FStar_Syntax_Syntax.sigquals =
-                                    (sigelt.FStar_Syntax_Syntax.sigquals);
-                                  FStar_Syntax_Syntax.sigmeta =
-                                    (let uu___3 =
-                                       sigelt.FStar_Syntax_Syntax.sigmeta in
-                                     {
-                                       FStar_Syntax_Syntax.sigmeta_active =
-                                         (uu___3.FStar_Syntax_Syntax.sigmeta_active);
-                                       FStar_Syntax_Syntax.sigmeta_fact_db_ids
-                                         =
-                                         (uu___3.FStar_Syntax_Syntax.sigmeta_fact_db_ids);
-                                       FStar_Syntax_Syntax.sigmeta_admit =
-                                         true;
-                                       FStar_Syntax_Syntax.sigmeta_already_checked
-                                         =
-                                         (uu___3.FStar_Syntax_Syntax.sigmeta_already_checked);
-                                       FStar_Syntax_Syntax.sigmeta_extension_data
-                                         =
-                                         (uu___3.FStar_Syntax_Syntax.sigmeta_extension_data)
-                                     });
-                                  FStar_Syntax_Syntax.sigattrs =
-                                    (sigelt.FStar_Syntax_Syntax.sigattrs);
-                                  FStar_Syntax_Syntax.sigopens_and_abbrevs =
-                                    (sigelt.FStar_Syntax_Syntax.sigopens_and_abbrevs);
-                                  FStar_Syntax_Syntax.sigopts =
-                                    (sigelt.FStar_Syntax_Syntax.sigopts)
-                                })) in
+                        FStar_Compiler_List.map
+                          (fun sigelt ->
+                             {
+                               FStar_Syntax_Syntax.sigel =
+                                 (sigelt.FStar_Syntax_Syntax.sigel);
+                               FStar_Syntax_Syntax.sigrng =
+                                 (sigelt.FStar_Syntax_Syntax.sigrng);
+                               FStar_Syntax_Syntax.sigquals =
+                                 (sigelt.FStar_Syntax_Syntax.sigquals);
+                               FStar_Syntax_Syntax.sigmeta =
+                                 (let uu___3 =
+                                    sigelt.FStar_Syntax_Syntax.sigmeta in
+                                  {
+                                    FStar_Syntax_Syntax.sigmeta_active =
+                                      (uu___3.FStar_Syntax_Syntax.sigmeta_active);
+                                    FStar_Syntax_Syntax.sigmeta_fact_db_ids =
+                                      (uu___3.FStar_Syntax_Syntax.sigmeta_fact_db_ids);
+                                    FStar_Syntax_Syntax.sigmeta_admit = true;
+                                    FStar_Syntax_Syntax.sigmeta_already_checked
+                                      =
+                                      (uu___3.FStar_Syntax_Syntax.sigmeta_already_checked);
+                                    FStar_Syntax_Syntax.sigmeta_extension_data
+                                      =
+                                      (uu___3.FStar_Syntax_Syntax.sigmeta_extension_data)
+                                  });
+                               FStar_Syntax_Syntax.sigattrs =
+                                 (sigelt.FStar_Syntax_Syntax.sigattrs);
+                               FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                                 (sigelt.FStar_Syntax_Syntax.sigopens_and_abbrevs);
+                               FStar_Syntax_Syntax.sigopts =
+                                 (sigelt.FStar_Syntax_Syntax.sigopts)
+                             }) effect_and_lift_ses in
                       ([],
                         (FStar_Compiler_List.op_At ses effect_and_lift_ses1),
                         env0))
@@ -2822,33 +2766,28 @@ let (tc_decl' :
                                          (env.FStar_TypeChecker_Env.core_check)
                                      } ne se2.FStar_Syntax_Syntax.sigquals
                                      se2.FStar_Syntax_Syntax.sigattrs in
-                                 FStar_Compiler_Effect.op_Bar_Greater uu___7
-                                   (fun ne3 ->
-                                      {
-                                        FStar_Syntax_Syntax.sigel =
-                                          (FStar_Syntax_Syntax.Sig_new_effect
-                                             ne3);
-                                        FStar_Syntax_Syntax.sigrng =
-                                          (se2.FStar_Syntax_Syntax.sigrng);
-                                        FStar_Syntax_Syntax.sigquals =
-                                          (se2.FStar_Syntax_Syntax.sigquals);
-                                        FStar_Syntax_Syntax.sigmeta =
-                                          (se2.FStar_Syntax_Syntax.sigmeta);
-                                        FStar_Syntax_Syntax.sigattrs =
-                                          (se2.FStar_Syntax_Syntax.sigattrs);
-                                        FStar_Syntax_Syntax.sigopens_and_abbrevs
-                                          =
-                                          (se2.FStar_Syntax_Syntax.sigopens_and_abbrevs);
-                                        FStar_Syntax_Syntax.sigopts =
-                                          (se2.FStar_Syntax_Syntax.sigopts)
-                                      }) in
-                               FStar_Compiler_Effect.op_Bar_Greater uu___6
-                                 (FStar_TypeChecker_Normalize.elim_uvars env) in
-                             FStar_Compiler_Effect.op_Bar_Greater uu___5
-                               FStar_Syntax_Util.eff_decl_of_new_effect in
+                                 {
+                                   FStar_Syntax_Syntax.sigel =
+                                     (FStar_Syntax_Syntax.Sig_new_effect
+                                        uu___7);
+                                   FStar_Syntax_Syntax.sigrng =
+                                     (se2.FStar_Syntax_Syntax.sigrng);
+                                   FStar_Syntax_Syntax.sigquals =
+                                     (se2.FStar_Syntax_Syntax.sigquals);
+                                   FStar_Syntax_Syntax.sigmeta =
+                                     (se2.FStar_Syntax_Syntax.sigmeta);
+                                   FStar_Syntax_Syntax.sigattrs =
+                                     (se2.FStar_Syntax_Syntax.sigattrs);
+                                   FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                                     (se2.FStar_Syntax_Syntax.sigopens_and_abbrevs);
+                                   FStar_Syntax_Syntax.sigopts =
+                                     (se2.FStar_Syntax_Syntax.sigopts)
+                                 } in
+                               FStar_TypeChecker_Normalize.elim_uvars env
+                                 uu___6 in
+                             FStar_Syntax_Util.eff_decl_of_new_effect uu___5 in
                            (let uu___6 =
-                              FStar_Compiler_Effect.op_Less_Bar
-                                (FStar_TypeChecker_Env.debug env)
+                              FStar_TypeChecker_Env.debug env
                                 (FStar_Options.Other "TwoPhases") in
                             if uu___6
                             then
@@ -3044,50 +2983,43 @@ let (tc_decl' :
                                   FStar_TypeChecker_Env.core_check =
                                     (env.FStar_TypeChecker_Env.core_check)
                                 } (lid, uvs, tps, c) r in
-                            FStar_Compiler_Effect.op_Bar_Greater uu___7
-                              (fun uu___8 ->
-                                 match uu___8 with
-                                 | (lid1, uvs1, tps1, c1) ->
-                                     {
-                                       FStar_Syntax_Syntax.sigel =
-                                         (FStar_Syntax_Syntax.Sig_effect_abbrev
-                                            {
-                                              FStar_Syntax_Syntax.lid4 = lid1;
-                                              FStar_Syntax_Syntax.us4 = uvs1;
-                                              FStar_Syntax_Syntax.bs2 = tps1;
-                                              FStar_Syntax_Syntax.comp1 = c1;
-                                              FStar_Syntax_Syntax.cflags =
-                                                flags
-                                            });
-                                       FStar_Syntax_Syntax.sigrng =
-                                         (se2.FStar_Syntax_Syntax.sigrng);
-                                       FStar_Syntax_Syntax.sigquals =
-                                         (se2.FStar_Syntax_Syntax.sigquals);
-                                       FStar_Syntax_Syntax.sigmeta =
-                                         (se2.FStar_Syntax_Syntax.sigmeta);
-                                       FStar_Syntax_Syntax.sigattrs =
-                                         (se2.FStar_Syntax_Syntax.sigattrs);
-                                       FStar_Syntax_Syntax.sigopens_and_abbrevs
-                                         =
-                                         (se2.FStar_Syntax_Syntax.sigopens_and_abbrevs);
-                                       FStar_Syntax_Syntax.sigopts =
-                                         (se2.FStar_Syntax_Syntax.sigopts)
-                                     }) in
-                          FStar_Compiler_Effect.op_Bar_Greater uu___6
-                            (FStar_TypeChecker_Normalize.elim_uvars env) in
-                        FStar_Compiler_Effect.op_Bar_Greater uu___5
-                          (fun se3 ->
-                             match se3.FStar_Syntax_Syntax.sigel with
-                             | FStar_Syntax_Syntax.Sig_effect_abbrev
-                                 { FStar_Syntax_Syntax.lid4 = lid1;
-                                   FStar_Syntax_Syntax.us4 = uvs1;
-                                   FStar_Syntax_Syntax.bs2 = tps1;
-                                   FStar_Syntax_Syntax.comp1 = c1;
-                                   FStar_Syntax_Syntax.cflags = uu___6;_}
-                                 -> (lid1, uvs1, tps1, c1)
-                             | uu___6 ->
-                                 FStar_Compiler_Effect.failwith
-                                   "Did not expect Sig_effect_abbrev to not be one after phase 1"))
+                            match uu___7 with
+                            | (lid1, uvs1, tps1, c1) ->
+                                {
+                                  FStar_Syntax_Syntax.sigel =
+                                    (FStar_Syntax_Syntax.Sig_effect_abbrev
+                                       {
+                                         FStar_Syntax_Syntax.lid4 = lid1;
+                                         FStar_Syntax_Syntax.us4 = uvs1;
+                                         FStar_Syntax_Syntax.bs2 = tps1;
+                                         FStar_Syntax_Syntax.comp1 = c1;
+                                         FStar_Syntax_Syntax.cflags = flags
+                                       });
+                                  FStar_Syntax_Syntax.sigrng =
+                                    (se2.FStar_Syntax_Syntax.sigrng);
+                                  FStar_Syntax_Syntax.sigquals =
+                                    (se2.FStar_Syntax_Syntax.sigquals);
+                                  FStar_Syntax_Syntax.sigmeta =
+                                    (se2.FStar_Syntax_Syntax.sigmeta);
+                                  FStar_Syntax_Syntax.sigattrs =
+                                    (se2.FStar_Syntax_Syntax.sigattrs);
+                                  FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                                    (se2.FStar_Syntax_Syntax.sigopens_and_abbrevs);
+                                  FStar_Syntax_Syntax.sigopts =
+                                    (se2.FStar_Syntax_Syntax.sigopts)
+                                } in
+                          FStar_TypeChecker_Normalize.elim_uvars env uu___6 in
+                        match uu___5.FStar_Syntax_Syntax.sigel with
+                        | FStar_Syntax_Syntax.Sig_effect_abbrev
+                            { FStar_Syntax_Syntax.lid4 = lid1;
+                              FStar_Syntax_Syntax.us4 = uvs1;
+                              FStar_Syntax_Syntax.bs2 = tps1;
+                              FStar_Syntax_Syntax.comp1 = c1;
+                              FStar_Syntax_Syntax.cflags = uu___6;_}
+                            -> (lid1, uvs1, tps1, c1)
+                        | uu___6 ->
+                            FStar_Compiler_Effect.failwith
+                              "Did not expect Sig_effect_abbrev to not be one after phase 1")
                  else (lid, uvs, tps, c) in
                (match uu___2 with
                 | (lid1, uvs1, tps1, c1) ->
@@ -3122,22 +3054,18 @@ let (tc_decl' :
                            } in
                          ([se3], [], env0)))
            | FStar_Syntax_Syntax.Sig_declare_typ uu___2 when
-               FStar_Compiler_Effect.op_Bar_Greater
-                 se2.FStar_Syntax_Syntax.sigquals
-                 (FStar_Compiler_Util.for_some
-                    (fun uu___3 ->
-                       match uu___3 with
-                       | FStar_Syntax_Syntax.OnlyName -> true
-                       | uu___4 -> false))
+               FStar_Compiler_Util.for_some
+                 (fun uu___3 ->
+                    match uu___3 with
+                    | FStar_Syntax_Syntax.OnlyName -> true
+                    | uu___4 -> false) se2.FStar_Syntax_Syntax.sigquals
                -> ([], [], env0)
            | FStar_Syntax_Syntax.Sig_let uu___2 when
-               FStar_Compiler_Effect.op_Bar_Greater
-                 se2.FStar_Syntax_Syntax.sigquals
-                 (FStar_Compiler_Util.for_some
-                    (fun uu___3 ->
-                       match uu___3 with
-                       | FStar_Syntax_Syntax.OnlyName -> true
-                       | uu___4 -> false))
+               FStar_Compiler_Util.for_some
+                 (fun uu___3 ->
+                    match uu___3 with
+                    | FStar_Syntax_Syntax.OnlyName -> true
+                    | uu___4 -> false) se2.FStar_Syntax_Syntax.sigquals
                -> ([], [], env0)
            | FStar_Syntax_Syntax.Sig_declare_typ
                { FStar_Syntax_Syntax.lid2 = lid;
@@ -3275,8 +3203,7 @@ let (tc_decl' :
                           match uu___6 with
                           | (uvs1, t1) ->
                               ((let uu___8 =
-                                  FStar_Compiler_Effect.op_Less_Bar
-                                    (FStar_TypeChecker_Env.debug env1)
+                                  FStar_TypeChecker_Env.debug env1
                                     (FStar_Options.Other "TwoPhases") in
                                 if uu___8
                                 then
@@ -3457,8 +3384,7 @@ let (tc_decl' :
                           match uu___6 with
                           | (uvs1, t1) ->
                               ((let uu___8 =
-                                  FStar_Compiler_Effect.op_Less_Bar
-                                    (FStar_TypeChecker_Env.debug env1)
+                                  FStar_TypeChecker_Env.debug env1
                                     (FStar_Options.Other "TwoPhases") in
                                 if uu___8
                                 then
@@ -3669,8 +3595,7 @@ let (tc_decl' :
                       let uu___6 =
                         FStar_Compiler_List.map
                           FStar_Syntax_Print.sigelt_to_string ses1 in
-                      FStar_Compiler_Effect.op_Less_Bar
-                        (FStar_Compiler_String.concat "\n") uu___6 in
+                      FStar_Compiler_String.concat "\n" uu___6 in
                     FStar_Compiler_Util.print1
                       "Splice returned sigelts {\n%s\n}\n" uu___5
                   else ());
@@ -3819,57 +3744,51 @@ let (tc_decl' :
                                     FStar_TypeChecker_Env.core_check =
                                       (env.FStar_TypeChecker_Env.core_check)
                                   } m n p t in
-                              FStar_Compiler_Effect.op_Bar_Greater uu___9
-                                (fun uu___10 ->
-                                   match uu___10 with
-                                   | (t2, ty, uu___11) ->
-                                       {
-                                         FStar_Syntax_Syntax.sigel =
-                                           (FStar_Syntax_Syntax.Sig_polymonadic_bind
-                                              {
-                                                FStar_Syntax_Syntax.m_lid = m;
-                                                FStar_Syntax_Syntax.n_lid = n;
-                                                FStar_Syntax_Syntax.p_lid = p;
-                                                FStar_Syntax_Syntax.tm3 = t2;
-                                                FStar_Syntax_Syntax.typ = ty;
-                                                FStar_Syntax_Syntax.kind1 =
-                                                  FStar_Pervasives_Native.None
-                                              });
-                                         FStar_Syntax_Syntax.sigrng =
-                                           (se2.FStar_Syntax_Syntax.sigrng);
-                                         FStar_Syntax_Syntax.sigquals =
-                                           (se2.FStar_Syntax_Syntax.sigquals);
-                                         FStar_Syntax_Syntax.sigmeta =
-                                           (se2.FStar_Syntax_Syntax.sigmeta);
-                                         FStar_Syntax_Syntax.sigattrs =
-                                           (se2.FStar_Syntax_Syntax.sigattrs);
-                                         FStar_Syntax_Syntax.sigopens_and_abbrevs
-                                           =
-                                           (se2.FStar_Syntax_Syntax.sigopens_and_abbrevs);
-                                         FStar_Syntax_Syntax.sigopts =
-                                           (se2.FStar_Syntax_Syntax.sigopts)
-                                       }) in
-                            FStar_Compiler_Effect.op_Bar_Greater uu___8
-                              (FStar_TypeChecker_Normalize.elim_uvars env) in
-                          FStar_Compiler_Effect.op_Bar_Greater uu___7
-                            (fun se3 ->
-                               match se3.FStar_Syntax_Syntax.sigel with
-                               | FStar_Syntax_Syntax.Sig_polymonadic_bind
-                                   { FStar_Syntax_Syntax.m_lid = uu___8;
-                                     FStar_Syntax_Syntax.n_lid = uu___9;
-                                     FStar_Syntax_Syntax.p_lid = uu___10;
-                                     FStar_Syntax_Syntax.tm3 = t2;
-                                     FStar_Syntax_Syntax.typ = ty;
-                                     FStar_Syntax_Syntax.kind1 = uu___11;_}
-                                   -> (t2, ty)
-                               | uu___8 ->
-                                   FStar_Compiler_Effect.failwith
-                                     "Impossible! tc for Sig_polymonadic_bind must be a Sig_polymonadic_bind") in
+                              match uu___9 with
+                              | (t2, ty, uu___10) ->
+                                  {
+                                    FStar_Syntax_Syntax.sigel =
+                                      (FStar_Syntax_Syntax.Sig_polymonadic_bind
+                                         {
+                                           FStar_Syntax_Syntax.m_lid = m;
+                                           FStar_Syntax_Syntax.n_lid = n;
+                                           FStar_Syntax_Syntax.p_lid = p;
+                                           FStar_Syntax_Syntax.tm3 = t2;
+                                           FStar_Syntax_Syntax.typ = ty;
+                                           FStar_Syntax_Syntax.kind1 =
+                                             FStar_Pervasives_Native.None
+                                         });
+                                    FStar_Syntax_Syntax.sigrng =
+                                      (se2.FStar_Syntax_Syntax.sigrng);
+                                    FStar_Syntax_Syntax.sigquals =
+                                      (se2.FStar_Syntax_Syntax.sigquals);
+                                    FStar_Syntax_Syntax.sigmeta =
+                                      (se2.FStar_Syntax_Syntax.sigmeta);
+                                    FStar_Syntax_Syntax.sigattrs =
+                                      (se2.FStar_Syntax_Syntax.sigattrs);
+                                    FStar_Syntax_Syntax.sigopens_and_abbrevs
+                                      =
+                                      (se2.FStar_Syntax_Syntax.sigopens_and_abbrevs);
+                                    FStar_Syntax_Syntax.sigopts =
+                                      (se2.FStar_Syntax_Syntax.sigopts)
+                                  } in
+                            FStar_TypeChecker_Normalize.elim_uvars env uu___8 in
+                          match uu___7.FStar_Syntax_Syntax.sigel with
+                          | FStar_Syntax_Syntax.Sig_polymonadic_bind
+                              { FStar_Syntax_Syntax.m_lid = uu___8;
+                                FStar_Syntax_Syntax.n_lid = uu___9;
+                                FStar_Syntax_Syntax.p_lid = uu___10;
+                                FStar_Syntax_Syntax.tm3 = t2;
+                                FStar_Syntax_Syntax.typ = ty;
+                                FStar_Syntax_Syntax.kind1 = uu___11;_}
+                              -> (t2, ty)
+                          | uu___8 ->
+                              FStar_Compiler_Effect.failwith
+                                "Impossible! tc for Sig_polymonadic_bind must be a Sig_polymonadic_bind" in
                         match uu___6 with
                         | (t2, ty) ->
                             ((let uu___8 =
-                                FStar_Compiler_Effect.op_Less_Bar
-                                  (FStar_TypeChecker_Env.debug env)
+                                FStar_TypeChecker_Env.debug env
                                   (FStar_Options.Other "TwoPhases") in
                               if uu___8
                               then
@@ -4069,57 +3988,49 @@ let (tc_decl' :
                                     FStar_TypeChecker_Env.core_check =
                                       (env.FStar_TypeChecker_Env.core_check)
                                   } m n t in
-                              FStar_Compiler_Effect.op_Bar_Greater uu___9
-                                (fun uu___10 ->
-                                   match uu___10 with
-                                   | (t2, ty, uu___11) ->
-                                       {
-                                         FStar_Syntax_Syntax.sigel =
-                                           (FStar_Syntax_Syntax.Sig_polymonadic_subcomp
-                                              {
-                                                FStar_Syntax_Syntax.m_lid1 =
-                                                  m;
-                                                FStar_Syntax_Syntax.n_lid1 =
-                                                  n;
-                                                FStar_Syntax_Syntax.tm4 = t2;
-                                                FStar_Syntax_Syntax.typ1 = ty;
-                                                FStar_Syntax_Syntax.kind2 =
-                                                  FStar_Pervasives_Native.None
-                                              });
-                                         FStar_Syntax_Syntax.sigrng =
-                                           (se2.FStar_Syntax_Syntax.sigrng);
-                                         FStar_Syntax_Syntax.sigquals =
-                                           (se2.FStar_Syntax_Syntax.sigquals);
-                                         FStar_Syntax_Syntax.sigmeta =
-                                           (se2.FStar_Syntax_Syntax.sigmeta);
-                                         FStar_Syntax_Syntax.sigattrs =
-                                           (se2.FStar_Syntax_Syntax.sigattrs);
-                                         FStar_Syntax_Syntax.sigopens_and_abbrevs
-                                           =
-                                           (se2.FStar_Syntax_Syntax.sigopens_and_abbrevs);
-                                         FStar_Syntax_Syntax.sigopts =
-                                           (se2.FStar_Syntax_Syntax.sigopts)
-                                       }) in
-                            FStar_Compiler_Effect.op_Bar_Greater uu___8
-                              (FStar_TypeChecker_Normalize.elim_uvars env) in
-                          FStar_Compiler_Effect.op_Bar_Greater uu___7
-                            (fun se3 ->
-                               match se3.FStar_Syntax_Syntax.sigel with
-                               | FStar_Syntax_Syntax.Sig_polymonadic_subcomp
-                                   { FStar_Syntax_Syntax.m_lid1 = uu___8;
-                                     FStar_Syntax_Syntax.n_lid1 = uu___9;
-                                     FStar_Syntax_Syntax.tm4 = t2;
-                                     FStar_Syntax_Syntax.typ1 = ty;
-                                     FStar_Syntax_Syntax.kind2 = uu___10;_}
-                                   -> (t2, ty)
-                               | uu___8 ->
-                                   FStar_Compiler_Effect.failwith
-                                     "Impossible! tc for Sig_polymonadic_subcomp must be a Sig_polymonadic_subcomp") in
+                              match uu___9 with
+                              | (t2, ty, uu___10) ->
+                                  {
+                                    FStar_Syntax_Syntax.sigel =
+                                      (FStar_Syntax_Syntax.Sig_polymonadic_subcomp
+                                         {
+                                           FStar_Syntax_Syntax.m_lid1 = m;
+                                           FStar_Syntax_Syntax.n_lid1 = n;
+                                           FStar_Syntax_Syntax.tm4 = t2;
+                                           FStar_Syntax_Syntax.typ1 = ty;
+                                           FStar_Syntax_Syntax.kind2 =
+                                             FStar_Pervasives_Native.None
+                                         });
+                                    FStar_Syntax_Syntax.sigrng =
+                                      (se2.FStar_Syntax_Syntax.sigrng);
+                                    FStar_Syntax_Syntax.sigquals =
+                                      (se2.FStar_Syntax_Syntax.sigquals);
+                                    FStar_Syntax_Syntax.sigmeta =
+                                      (se2.FStar_Syntax_Syntax.sigmeta);
+                                    FStar_Syntax_Syntax.sigattrs =
+                                      (se2.FStar_Syntax_Syntax.sigattrs);
+                                    FStar_Syntax_Syntax.sigopens_and_abbrevs
+                                      =
+                                      (se2.FStar_Syntax_Syntax.sigopens_and_abbrevs);
+                                    FStar_Syntax_Syntax.sigopts =
+                                      (se2.FStar_Syntax_Syntax.sigopts)
+                                  } in
+                            FStar_TypeChecker_Normalize.elim_uvars env uu___8 in
+                          match uu___7.FStar_Syntax_Syntax.sigel with
+                          | FStar_Syntax_Syntax.Sig_polymonadic_subcomp
+                              { FStar_Syntax_Syntax.m_lid1 = uu___8;
+                                FStar_Syntax_Syntax.n_lid1 = uu___9;
+                                FStar_Syntax_Syntax.tm4 = t2;
+                                FStar_Syntax_Syntax.typ1 = ty;
+                                FStar_Syntax_Syntax.kind2 = uu___10;_}
+                              -> (t2, ty)
+                          | uu___8 ->
+                              FStar_Compiler_Effect.failwith
+                                "Impossible! tc for Sig_polymonadic_subcomp must be a Sig_polymonadic_subcomp" in
                         match uu___6 with
                         | (t2, ty) ->
                             ((let uu___8 =
-                                FStar_Compiler_Effect.op_Less_Bar
-                                  (FStar_TypeChecker_Env.debug env)
+                                FStar_TypeChecker_Env.debug env
                                   (FStar_Options.Other "TwoPhases") in
                               if uu___8
                               then
@@ -4257,22 +4168,18 @@ let (add_sigelt_to_env :
                (FStar_Errors_Codes.Fatal_UnexpectedInductivetype, uu___3) in
              FStar_Errors.raise_error uu___2 se.FStar_Syntax_Syntax.sigrng
          | FStar_Syntax_Syntax.Sig_declare_typ uu___1 when
-             FStar_Compiler_Effect.op_Bar_Greater
-               se.FStar_Syntax_Syntax.sigquals
-               (FStar_Compiler_Util.for_some
-                  (fun uu___2 ->
-                     match uu___2 with
-                     | FStar_Syntax_Syntax.OnlyName -> true
-                     | uu___3 -> false))
+             FStar_Compiler_Util.for_some
+               (fun uu___2 ->
+                  match uu___2 with
+                  | FStar_Syntax_Syntax.OnlyName -> true
+                  | uu___3 -> false) se.FStar_Syntax_Syntax.sigquals
              -> env
          | FStar_Syntax_Syntax.Sig_let uu___1 when
-             FStar_Compiler_Effect.op_Bar_Greater
-               se.FStar_Syntax_Syntax.sigquals
-               (FStar_Compiler_Util.for_some
-                  (fun uu___2 ->
-                     match uu___2 with
-                     | FStar_Syntax_Syntax.OnlyName -> true
-                     | uu___3 -> false))
+             FStar_Compiler_Util.for_some
+               (fun uu___2 ->
+                  match uu___2 with
+                  | FStar_Syntax_Syntax.OnlyName -> true
+                  | uu___3 -> false) se.FStar_Syntax_Syntax.sigquals
              -> env
          | uu___1 ->
              let env1 = FStar_TypeChecker_Env.push_sigelt env se in
@@ -4743,17 +4650,15 @@ let (add_sigelt_to_env :
                   let env2 =
                     FStar_TypeChecker_Env.push_new_effect env1
                       (ne, (se.FStar_Syntax_Syntax.sigquals)) in
-                  FStar_Compiler_Effect.op_Bar_Greater
+                  FStar_Compiler_List.fold_left
+                    (fun env3 ->
+                       fun a ->
+                         let uu___2 =
+                           FStar_Syntax_Util.action_as_lb
+                             ne.FStar_Syntax_Syntax.mname a
+                             (a.FStar_Syntax_Syntax.action_defn).FStar_Syntax_Syntax.pos in
+                         FStar_TypeChecker_Env.push_sigelt env3 uu___2) env2
                     ne.FStar_Syntax_Syntax.actions
-                    (FStar_Compiler_List.fold_left
-                       (fun env3 ->
-                          fun a ->
-                            let uu___2 =
-                              FStar_Syntax_Util.action_as_lb
-                                ne.FStar_Syntax_Syntax.mname a
-                                (a.FStar_Syntax_Syntax.action_defn).FStar_Syntax_Syntax.pos in
-                            FStar_TypeChecker_Env.push_sigelt env3 uu___2)
-                       env2)
               | FStar_Syntax_Syntax.Sig_sub_effect sub ->
                   FStar_TypeChecker_Util.update_env_sub_eff env1 sub
                     se.FStar_Syntax_Syntax.sigrng
@@ -4765,9 +4670,7 @@ let (add_sigelt_to_env :
                     FStar_Syntax_Syntax.typ = ty;
                     FStar_Syntax_Syntax.kind1 = k;_}
                   ->
-                  let uu___3 =
-                    FStar_Compiler_Effect.op_Bar_Greater k
-                      FStar_Compiler_Util.must in
+                  let uu___3 = FStar_Compiler_Util.must k in
                   FStar_TypeChecker_Util.update_env_polymonadic_bind env1 m n
                     p ty uu___3
               | FStar_Syntax_Syntax.Sig_polymonadic_subcomp
@@ -4778,10 +4681,7 @@ let (add_sigelt_to_env :
                     FStar_Syntax_Syntax.kind2 = k;_}
                   ->
                   let uu___3 =
-                    let uu___4 =
-                      FStar_Compiler_Effect.op_Bar_Greater k
-                        FStar_Compiler_Util.must in
-                    (ty, uu___4) in
+                    let uu___4 = FStar_Compiler_Util.must k in (ty, uu___4) in
                   FStar_TypeChecker_Env.add_polymonadic_subcomp env1 m n
                     uu___3
               | uu___2 -> env1))
@@ -4858,56 +4758,51 @@ let (tc_decls :
                   match uu___7 with
                   | (ses', ses_elaborated, env2) ->
                       let ses'1 =
-                        FStar_Compiler_Effect.op_Bar_Greater ses'
-                          (FStar_Compiler_List.map
-                             (fun se1 ->
-                                (let uu___9 =
-                                   FStar_TypeChecker_Env.debug env2
-                                     (FStar_Options.Other "UF") in
-                                 if uu___9
-                                 then
-                                   let uu___10 =
-                                     FStar_Syntax_Print.sigelt_to_string se1 in
-                                   FStar_Compiler_Util.print1
-                                     "About to elim vars from %s\n" uu___10
-                                 else ());
-                                FStar_TypeChecker_Normalize.elim_uvars env2
-                                  se1)) in
+                        FStar_Compiler_List.map
+                          (fun se1 ->
+                             (let uu___9 =
+                                FStar_TypeChecker_Env.debug env2
+                                  (FStar_Options.Other "UF") in
+                              if uu___9
+                              then
+                                let uu___10 =
+                                  FStar_Syntax_Print.sigelt_to_string se1 in
+                                FStar_Compiler_Util.print1
+                                  "About to elim vars from %s\n" uu___10
+                              else ());
+                             FStar_TypeChecker_Normalize.elim_uvars env2 se1)
+                          ses' in
                       let ses_elaborated1 =
-                        FStar_Compiler_Effect.op_Bar_Greater ses_elaborated
-                          (FStar_Compiler_List.map
-                             (fun se1 ->
-                                (let uu___9 =
-                                   FStar_TypeChecker_Env.debug env2
-                                     (FStar_Options.Other "UF") in
-                                 if uu___9
-                                 then
-                                   let uu___10 =
-                                     FStar_Syntax_Print.sigelt_to_string se1 in
-                                   FStar_Compiler_Util.print1
-                                     "About to elim vars from (elaborated) %s\n"
-                                     uu___10
-                                 else ());
-                                FStar_TypeChecker_Normalize.elim_uvars env2
-                                  se1)) in
+                        FStar_Compiler_List.map
+                          (fun se1 ->
+                             (let uu___9 =
+                                FStar_TypeChecker_Env.debug env2
+                                  (FStar_Options.Other "UF") in
+                              if uu___9
+                              then
+                                let uu___10 =
+                                  FStar_Syntax_Print.sigelt_to_string se1 in
+                                FStar_Compiler_Util.print1
+                                  "About to elim vars from (elaborated) %s\n"
+                                  uu___10
+                              else ());
+                             FStar_TypeChecker_Normalize.elim_uvars env2 se1)
+                          ses_elaborated in
                       (FStar_TypeChecker_Env.promote_id_info env2
                          (compress_and_norm env2);
                        (let ses'2 =
-                          FStar_Compiler_Effect.op_Bar_Greater ses'1
-                            (FStar_Compiler_List.map
-                               (FStar_Syntax_Compress.deep_compress_se false
-                                  false)) in
+                          FStar_Compiler_List.map
+                            (FStar_Syntax_Compress.deep_compress_se false
+                               false) ses'1 in
                         let env3 =
-                          FStar_Compiler_Effect.op_Bar_Greater ses'2
-                            (FStar_Compiler_List.fold_left
-                               (fun env4 ->
-                                  fun se1 -> add_sigelt_to_env env4 se1 false)
-                               env2) in
+                          FStar_Compiler_List.fold_left
+                            (fun env4 ->
+                               fun se1 -> add_sigelt_to_env env4 se1 false)
+                            env2 ses'2 in
                         FStar_Syntax_Unionfind.reset ();
                         (let uu___11 =
                            (FStar_Options.log_types ()) ||
-                             (FStar_Compiler_Effect.op_Less_Bar
-                                (FStar_TypeChecker_Env.debug env3)
+                             (FStar_TypeChecker_Env.debug env3
                                 (FStar_Options.Other "LogTypes")) in
                          if uu___11
                          then
@@ -5200,19 +5095,16 @@ let (finish_partial_modul :
       fun en ->
         fun m ->
           let env = FStar_TypeChecker_Env.finish_module en m in
-          (let uu___1 =
-             FStar_Compiler_Effect.op_Bar_Greater
-               env.FStar_TypeChecker_Env.qtbl_name_and_index
-               FStar_Pervasives_Native.snd in
-           FStar_Compiler_Effect.op_Bar_Greater uu___1
-             FStar_Compiler_Util.smap_clear);
+          FStar_Compiler_Util.smap_clear
+            (FStar_Pervasives_Native.snd
+               env.FStar_TypeChecker_Env.qtbl_name_and_index);
           (let uu___2 =
              let uu___3 =
                let uu___4 =
                  FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name in
                Prims.strcat "Ending modul " uu___4 in
              pop_context env uu___3 in
-           FStar_Compiler_Effect.op_Bar_Greater uu___2 (fun uu___3 -> ()));
+           ());
           (m, env)
 let (deep_compress_modul :
   FStar_Syntax_Syntax.modul -> FStar_Syntax_Syntax.modul) =
@@ -5261,12 +5153,10 @@ let (load_checked_module_sigelts :
              fun se ->
                let env4 = add_sigelt_to_env env3 se true in
                let lids = FStar_Syntax_Util.lids_of_sigelt se in
-               FStar_Compiler_Effect.op_Bar_Greater lids
-                 (FStar_Compiler_List.iter
-                    (fun lid ->
-                       let uu___1 =
-                         FStar_TypeChecker_Env.lookup_sigelt env4 lid in
-                       ()));
+               FStar_Compiler_List.iter
+                 (fun lid ->
+                    let uu___1 = FStar_TypeChecker_Env.lookup_sigelt env4 lid in
+                    ()) lids;
                env4) env1 m.FStar_Syntax_Syntax.declarations in
       env2
 let (load_checked_module :

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_TcEffect.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_TcEffect.ml
@@ -66,13 +66,8 @@ let (check_and_gen :
                                            FStar_Compiler_Util.string_of_int
                                              n in
                                          let uu___7 =
-                                           let uu___8 =
-                                             FStar_Compiler_Effect.op_Bar_Greater
-                                               g_us
-                                               FStar_Compiler_List.length in
-                                           FStar_Compiler_Effect.op_Bar_Greater
-                                             uu___8
-                                             FStar_Compiler_Util.string_of_int in
+                                           FStar_Compiler_Util.string_of_int
+                                             (FStar_Compiler_List.length g_us) in
                                          let uu___8 =
                                            FStar_Syntax_Print.tscheme_to_string
                                              (g_us, t3) in
@@ -140,16 +135,12 @@ let (pure_wp_uvar :
                 FStar_TypeChecker_Env.lookup_definition
                   [FStar_TypeChecker_Env.NoDelta] env
                   FStar_Parser_Const.pure_wp_lid in
-              FStar_Compiler_Effect.op_Bar_Greater uu___
-                FStar_Compiler_Util.must in
+              FStar_Compiler_Util.must uu___ in
             let uu___ = FStar_TypeChecker_Env.inst_tscheme pure_wp_ts in
             match uu___ with
             | (uu___1, pure_wp_t1) ->
                 let uu___2 =
-                  let uu___3 =
-                    FStar_Compiler_Effect.op_Bar_Greater t
-                      FStar_Syntax_Syntax.as_arg in
-                  [uu___3] in
+                  let uu___3 = FStar_Syntax_Syntax.as_arg t in [uu___3] in
                 FStar_Syntax_Syntax.mk_Tm_app pure_wp_t1 uu___2 r in
           let uu___ =
             FStar_TypeChecker_Env.new_implicit_var_aux reason r env pure_wp_t
@@ -209,24 +200,20 @@ let (eq_binders :
                              let uu___6 =
                                let uu___7 =
                                  let uu___8 =
-                                   FStar_Compiler_Effect.op_Bar_Greater
-                                     b2.FStar_Syntax_Syntax.binder_bv
-                                     FStar_Syntax_Syntax.bv_to_name in
+                                   FStar_Syntax_Syntax.bv_to_name
+                                     b2.FStar_Syntax_Syntax.binder_bv in
                                  ((b1.FStar_Syntax_Syntax.binder_bv), uu___8) in
                                FStar_Syntax_Syntax.NT uu___7 in
                              [uu___6] in
                            FStar_Compiler_List.op_At ss uu___5 in
                          (uu___3, uu___4)) (true, []) bs1 bs2 in
-          FStar_Compiler_Effect.op_Bar_Greater uu___1
-            FStar_Pervasives_Native.fst in
+          FStar_Pervasives_Native.fst uu___1 in
         if uu___
         then
           let uu___1 =
-            FStar_Compiler_Effect.op_Bar_Greater bs1
-              (FStar_Compiler_List.map
-                 (fun uu___2 -> FStar_Syntax_Syntax.Substitutive_binder)) in
-          FStar_Compiler_Effect.op_Bar_Greater uu___1
-            (fun uu___2 -> FStar_Pervasives_Native.Some uu___2)
+            FStar_Compiler_List.map
+              (fun uu___2 -> FStar_Syntax_Syntax.Substitutive_binder) bs1 in
+          FStar_Pervasives_Native.Some uu___1
         else FStar_Pervasives_Native.None
 let (log_ad_hoc_combinator_warning :
   Prims.string -> FStar_Compiler_Range_Type.range -> unit) =
@@ -279,8 +266,7 @@ let (bind_combinator_kind :
                             fun has_range_binders ->
                               let debug s =
                                 let uu___ =
-                                  FStar_Compiler_Effect.op_Less_Bar
-                                    (FStar_TypeChecker_Env.debug env)
+                                  FStar_TypeChecker_Env.debug env
                                     (FStar_Options.Other "LayeredEffectsTc") in
                                 if uu___
                                 then FStar_Compiler_Util.print1 "%s\n" s
@@ -298,10 +284,8 @@ let (bind_combinator_kind :
                                | u_a::u_b::[] ->
                                    let uu___2 =
                                      let uu___3 =
-                                       FStar_Compiler_Effect.op_Bar_Greater k
-                                         FStar_Syntax_Util.arrow_formals in
-                                     FStar_Compiler_Effect.op_Bar_Greater
-                                       uu___3 FStar_Pervasives_Native.fst in
+                                       FStar_Syntax_Util.arrow_formals k in
+                                     FStar_Pervasives_Native.fst uu___3 in
                                    (match uu___2 with
                                     | a_b::b_b::rest_bs ->
                                         let uu___3 =
@@ -309,11 +293,8 @@ let (bind_combinator_kind :
                                             num_effect_params =
                                               Prims.int_zero
                                           then
-                                            FStar_Compiler_Effect.op_Bar_Greater
+                                            FStar_Pervasives_Native.Some
                                               ([], [], rest_bs)
-                                              (fun uu___4 ->
-                                                 FStar_Pervasives_Native.Some
-                                                   uu___4)
                                           else
                                             (let uu___5 =
                                                FStar_TypeChecker_Env.inst_tscheme_with
@@ -325,15 +306,12 @@ let (bind_combinator_kind :
                                                  let sig_bs =
                                                    let uu___7 =
                                                      let uu___8 =
-                                                       FStar_Compiler_Effect.op_Bar_Greater
-                                                         sig1
-                                                         FStar_Syntax_Util.arrow_formals in
-                                                     FStar_Compiler_Effect.op_Bar_Greater
-                                                       uu___8
-                                                       FStar_Pervasives_Native.fst in
-                                                   FStar_Compiler_Effect.op_Bar_Greater
-                                                     uu___7
-                                                     FStar_Compiler_List.tl in
+                                                       FStar_Syntax_Util.arrow_formals
+                                                         sig1 in
+                                                     FStar_Pervasives_Native.fst
+                                                       uu___8 in
+                                                   FStar_Compiler_List.tl
+                                                     uu___7 in
                                                  let uu___7 =
                                                    if
                                                      (FStar_Compiler_List.length
@@ -347,14 +325,10 @@ let (bind_combinator_kind :
                                                           FStar_Compiler_List.splitAt
                                                             num_effect_params
                                                             sig_bs in
-                                                        FStar_Compiler_Effect.op_Bar_Greater
-                                                          uu___10
-                                                          FStar_Pervasives_Native.fst in
-                                                      FStar_Compiler_Effect.op_Bar_Greater
-                                                        uu___9
-                                                        (fun uu___10 ->
-                                                           FStar_Pervasives_Native.Some
-                                                             uu___10)) in
+                                                        FStar_Pervasives_Native.fst
+                                                          uu___10 in
+                                                      FStar_Pervasives_Native.Some
+                                                        uu___9) in
                                                  op_let_Question uu___7
                                                    (fun sig_eff_params_bs ->
                                                       let uu___8 =
@@ -370,11 +344,8 @@ let (bind_combinator_kind :
                                                              FStar_Compiler_List.splitAt
                                                                num_effect_params
                                                                rest_bs in
-                                                           FStar_Compiler_Effect.op_Bar_Greater
-                                                             uu___10
-                                                             (fun uu___11 ->
-                                                                FStar_Pervasives_Native.Some
-                                                                  uu___11)) in
+                                                           FStar_Pervasives_Native.Some
+                                                             uu___10) in
                                                       op_let_Question uu___8
                                                         (fun uu___9 ->
                                                            match uu___9 with
@@ -390,15 +361,10 @@ let (bind_combinator_kind :
                                                                  (fun
                                                                     eff_params_bs_kinds
                                                                     ->
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
+                                                                    FStar_Pervasives_Native.Some
                                                                     (eff_params_bs,
                                                                     eff_params_bs_kinds,
-                                                                    rest_bs1)
-                                                                    (fun
-                                                                    uu___11
-                                                                    ->
-                                                                    FStar_Pervasives_Native.Some
-                                                                    uu___11))))) in
+                                                                    rest_bs1))))) in
                                         op_let_Question uu___3
                                           (fun uu___4 ->
                                              match uu___4 with
@@ -416,29 +382,42 @@ let (bind_combinator_kind :
                                                      | (uu___7, sig1) ->
                                                          let uu___8 =
                                                            let uu___9 =
-                                                             FStar_Compiler_Effect.op_Bar_Greater
-                                                               sig1
-                                                               FStar_Syntax_Util.arrow_formals in
-                                                           FStar_Compiler_Effect.op_Bar_Greater
-                                                             uu___9
-                                                             FStar_Pervasives_Native.fst in
-                                                         FStar_Compiler_Effect.op_Bar_Greater
-                                                           uu___8
-                                                           (fun uu___9 ->
-                                                              match uu___9
-                                                              with
-                                                              | a::bs ->
-                                                                  let uu___10
+                                                             FStar_Syntax_Util.arrow_formals
+                                                               sig1 in
+                                                           FStar_Pervasives_Native.fst
+                                                             uu___9 in
+                                                         (match uu___8 with
+                                                          | a::bs ->
+                                                              let uu___9 =
+                                                                FStar_Compiler_List.splitAt
+                                                                  num_effect_params
+                                                                  bs in
+                                                              (match uu___9
+                                                               with
+                                                               | (sig_bs,
+                                                                  bs1) ->
+                                                                   let ss =
+                                                                    let uu___10
                                                                     =
-                                                                    FStar_Compiler_List.splitAt
-                                                                    num_effect_params
-                                                                    bs in
-                                                                  (match uu___10
-                                                                   with
-                                                                   | 
-                                                                   (sig_bs,
-                                                                    bs1) ->
-                                                                    let ss =
+                                                                    let uu___11
+                                                                    =
+                                                                    let uu___12
+                                                                    =
+                                                                    let uu___13
+                                                                    =
+                                                                    FStar_Syntax_Syntax.bv_to_name
+                                                                    a_b.FStar_Syntax_Syntax.binder_bv in
+                                                                    ((a.FStar_Syntax_Syntax.binder_bv),
+                                                                    uu___13) in
+                                                                    FStar_Syntax_Syntax.NT
+                                                                    uu___12 in
+                                                                    [uu___11] in
+                                                                    FStar_Compiler_List.fold_left2
+                                                                    (fun ss1
+                                                                    ->
+                                                                    fun sig_b
+                                                                    ->
+                                                                    fun b ->
                                                                     let uu___11
                                                                     =
                                                                     let uu___12
@@ -447,46 +426,21 @@ let (bind_combinator_kind :
                                                                     =
                                                                     let uu___14
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    a_b.FStar_Syntax_Syntax.binder_bv
-                                                                    FStar_Syntax_Syntax.bv_to_name in
-                                                                    ((a.FStar_Syntax_Syntax.binder_bv),
+                                                                    FStar_Syntax_Syntax.bv_to_name
+                                                                    b.FStar_Syntax_Syntax.binder_bv in
+                                                                    ((sig_b.FStar_Syntax_Syntax.binder_bv),
                                                                     uu___14) in
                                                                     FStar_Syntax_Syntax.NT
                                                                     uu___13 in
                                                                     [uu___12] in
-                                                                    FStar_Compiler_List.fold_left2
-                                                                    (fun ss1
-                                                                    ->
-                                                                    fun sig_b
-                                                                    ->
-                                                                    fun b ->
-                                                                    let uu___12
-                                                                    =
-                                                                    let uu___13
-                                                                    =
-                                                                    let uu___14
-                                                                    =
-                                                                    let uu___15
-                                                                    =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    b.FStar_Syntax_Syntax.binder_bv
-                                                                    FStar_Syntax_Syntax.bv_to_name in
-                                                                    ((sig_b.FStar_Syntax_Syntax.binder_bv),
-                                                                    uu___15) in
-                                                                    FStar_Syntax_Syntax.NT
-                                                                    uu___14 in
-                                                                    [uu___13] in
                                                                     FStar_Compiler_List.op_At
                                                                     ss1
-                                                                    uu___12)
-                                                                    uu___11
+                                                                    uu___11)
+                                                                    uu___10
                                                                     sig_bs
                                                                     eff_params_bs in
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    bs1
-                                                                    (FStar_Syntax_Subst.subst_binders
-                                                                    ss))) in
+                                                                   FStar_Syntax_Subst.subst_binders
+                                                                    ss bs1)) in
                                                    let uu___6 =
                                                      if
                                                        (FStar_Compiler_List.length
@@ -502,11 +456,8 @@ let (bind_combinator_kind :
                                                             (FStar_Compiler_List.length
                                                                f_sig_bs)
                                                             rest_bs1 in
-                                                        FStar_Compiler_Effect.op_Bar_Greater
-                                                          uu___8
-                                                          (fun uu___9 ->
-                                                             FStar_Pervasives_Native.Some
-                                                               uu___9)) in
+                                                        FStar_Pervasives_Native.Some
+                                                          uu___8) in
                                                    op_let_Question uu___6
                                                      (fun uu___7 ->
                                                         match uu___7 with
@@ -518,14 +469,10 @@ let (bind_combinator_kind :
                                                               uu___8
                                                               (fun f_bs_kinds
                                                                  ->
-                                                                 FStar_Compiler_Effect.op_Bar_Greater
+                                                                 FStar_Pervasives_Native.Some
                                                                    (f_bs,
                                                                     f_bs_kinds,
-                                                                    rest_bs2)
-                                                                   (fun
-                                                                    uu___9 ->
-                                                                    FStar_Pervasives_Native.Some
-                                                                    uu___9))) in
+                                                                    rest_bs2))) in
                                                  op_let_Question uu___5
                                                    (fun uu___6 ->
                                                       match uu___6 with
@@ -546,33 +493,46 @@ let (bind_combinator_kind :
                                                                     =
                                                                     let uu___11
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    sig1
-                                                                    FStar_Syntax_Util.arrow_formals in
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___11
-                                                                    FStar_Pervasives_Native.fst in
-                                                                  FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___10
-                                                                    (
-                                                                    fun
-                                                                    uu___11
-                                                                    ->
-                                                                    match uu___11
-                                                                    with
-                                                                    | 
-                                                                    b::bs ->
-                                                                    let uu___12
+                                                                    FStar_Syntax_Util.arrow_formals
+                                                                    sig1 in
+                                                                    FStar_Pervasives_Native.fst
+                                                                    uu___11 in
+                                                                  (match uu___10
+                                                                   with
+                                                                   | 
+                                                                   b::bs ->
+                                                                    let uu___11
                                                                     =
                                                                     FStar_Compiler_List.splitAt
                                                                     num_effect_params
                                                                     bs in
-                                                                    (match uu___12
+                                                                    (match uu___11
                                                                     with
                                                                     | 
                                                                     (sig_bs,
                                                                     bs1) ->
                                                                     let ss =
+                                                                    let uu___12
+                                                                    =
+                                                                    let uu___13
+                                                                    =
+                                                                    let uu___14
+                                                                    =
+                                                                    let uu___15
+                                                                    =
+                                                                    FStar_Syntax_Syntax.bv_to_name
+                                                                    b_b.FStar_Syntax_Syntax.binder_bv in
+                                                                    ((b.FStar_Syntax_Syntax.binder_bv),
+                                                                    uu___15) in
+                                                                    FStar_Syntax_Syntax.NT
+                                                                    uu___14 in
+                                                                    [uu___13] in
+                                                                    FStar_Compiler_List.fold_left2
+                                                                    (fun ss1
+                                                                    ->
+                                                                    fun sig_b
+                                                                    ->
+                                                                    fun b1 ->
                                                                     let uu___13
                                                                     =
                                                                     let uu___14
@@ -581,46 +541,21 @@ let (bind_combinator_kind :
                                                                     =
                                                                     let uu___16
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    b_b.FStar_Syntax_Syntax.binder_bv
-                                                                    FStar_Syntax_Syntax.bv_to_name in
-                                                                    ((b.FStar_Syntax_Syntax.binder_bv),
+                                                                    FStar_Syntax_Syntax.bv_to_name
+                                                                    b1.FStar_Syntax_Syntax.binder_bv in
+                                                                    ((sig_b.FStar_Syntax_Syntax.binder_bv),
                                                                     uu___16) in
                                                                     FStar_Syntax_Syntax.NT
                                                                     uu___15 in
                                                                     [uu___14] in
-                                                                    FStar_Compiler_List.fold_left2
-                                                                    (fun ss1
-                                                                    ->
-                                                                    fun sig_b
-                                                                    ->
-                                                                    fun b1 ->
-                                                                    let uu___14
-                                                                    =
-                                                                    let uu___15
-                                                                    =
-                                                                    let uu___16
-                                                                    =
-                                                                    let uu___17
-                                                                    =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    b1.FStar_Syntax_Syntax.binder_bv
-                                                                    FStar_Syntax_Syntax.bv_to_name in
-                                                                    ((sig_b.FStar_Syntax_Syntax.binder_bv),
-                                                                    uu___17) in
-                                                                    FStar_Syntax_Syntax.NT
-                                                                    uu___16 in
-                                                                    [uu___15] in
                                                                     FStar_Compiler_List.op_At
                                                                     ss1
-                                                                    uu___14)
-                                                                    uu___13
+                                                                    uu___13)
+                                                                    uu___12
                                                                     sig_bs
                                                                     eff_params_bs in
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    bs1
-                                                                    (FStar_Syntax_Subst.subst_binders
-                                                                    ss))) in
+                                                                    FStar_Syntax_Subst.subst_binders
+                                                                    ss bs1)) in
                                                             let uu___8 =
                                                               if
                                                                 (FStar_Compiler_List.length
@@ -637,13 +572,8 @@ let (bind_combinator_kind :
                                                                     (FStar_Compiler_List.length
                                                                     g_sig_bs)
                                                                     rest_bs2 in
-                                                                 FStar_Compiler_Effect.op_Bar_Greater
-                                                                   uu___10
-                                                                   (fun
-                                                                    uu___11
-                                                                    ->
-                                                                    FStar_Pervasives_Native.Some
-                                                                    uu___11)) in
+                                                                 FStar_Pervasives_Native.Some
+                                                                   uu___10) in
                                                             op_let_Question
                                                               uu___8
                                                               (fun uu___9 ->
@@ -681,9 +611,8 @@ let (bind_combinator_kind :
                                                                     =
                                                                     let uu___13
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    a_b.FStar_Syntax_Syntax.binder_bv
-                                                                    FStar_Syntax_Syntax.bv_to_name in
+                                                                    FStar_Syntax_Syntax.bv_to_name
+                                                                    a_b.FStar_Syntax_Syntax.binder_bv in
                                                                     FStar_Syntax_Syntax.gen_bv
                                                                     "x"
                                                                     FStar_Pervasives_Native.None
@@ -720,12 +649,10 @@ let (bind_combinator_kind :
                                                                     =
                                                                     let uu___21
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    x_bv
-                                                                    FStar_Syntax_Syntax.bv_to_name in
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___21
-                                                                    FStar_Syntax_Syntax.as_arg in
+                                                                    FStar_Syntax_Syntax.bv_to_name
+                                                                    x_bv in
+                                                                    FStar_Syntax_Syntax.as_arg
+                                                                    uu___21 in
                                                                     [uu___20] in
                                                                     FStar_Syntax_Syntax.mk_Tm_app
                                                                     uu___18
@@ -738,9 +665,8 @@ let (bind_combinator_kind :
                                                                     [uu___15]
                                                                     else [])
                                                                     l in
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___13
-                                                                    FStar_Compiler_List.flatten in
+                                                                    FStar_Compiler_List.flatten
+                                                                    uu___13 in
                                                                     let g_sig_b_sort1
                                                                     =
                                                                     FStar_Syntax_Subst.subst
@@ -800,9 +726,8 @@ let (bind_combinator_kind :
                                                                     =
                                                                     let uu___16
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    g_b.FStar_Syntax_Syntax.binder_bv
-                                                                    FStar_Syntax_Syntax.bv_to_name in
+                                                                    FStar_Syntax_Syntax.bv_to_name
+                                                                    g_b.FStar_Syntax_Syntax.binder_bv in
                                                                     ((g_sig_b.FStar_Syntax_Syntax.binder_bv),
                                                                     uu___16) in
                                                                     FStar_Syntax_Syntax.NT
@@ -838,27 +763,17 @@ let (bind_combinator_kind :
                                                                     then
                                                                     FStar_Pervasives_Native.None
                                                                     else
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    g_bs_kinds1
-                                                                    (fun
-                                                                    uu___14
-                                                                    ->
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu___14) in
+                                                                    g_bs_kinds1 in
                                                                     op_let_Question
                                                                     uu___10
                                                                     (fun
                                                                     g_bs_kinds
                                                                     ->
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
+                                                                    FStar_Pervasives_Native.Some
                                                                     (g_bs,
                                                                     g_bs_kinds,
-                                                                    rest_bs3)
-                                                                    (fun
-                                                                    uu___11
-                                                                    ->
-                                                                    FStar_Pervasives_Native.Some
-                                                                    uu___11))) in
+                                                                    rest_bs3))) in
                                                           op_let_Question
                                                             uu___7
                                                             (fun uu___8 ->
@@ -909,14 +824,9 @@ let (bind_combinator_kind :
                                                                     (rest_bs5,
                                                                     f_b::g_b::[])
                                                                     ->
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
+                                                                    FStar_Pervasives_Native.Some
                                                                     (rest_bs5,
                                                                     f_b, g_b)
-                                                                    (fun
-                                                                    uu___13
-                                                                    ->
-                                                                    FStar_Pervasives_Native.Some
-                                                                    uu___13)
                                                                     else
                                                                     FStar_Pervasives_Native.None in
                                                                     op_let_Question
@@ -963,12 +873,10 @@ let (bind_combinator_kind :
                                                                     =
                                                                     let uu___18
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    a_b.FStar_Syntax_Syntax.binder_bv
-                                                                    FStar_Syntax_Syntax.bv_to_name in
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___18
-                                                                    FStar_Syntax_Syntax.as_arg in
+                                                                    FStar_Syntax_Syntax.bv_to_name
+                                                                    a_b.FStar_Syntax_Syntax.binder_bv in
+                                                                    FStar_Syntax_Syntax.as_arg
+                                                                    uu___18 in
                                                                     let uu___18
                                                                     =
                                                                     FStar_Compiler_List.map
@@ -990,12 +898,10 @@ let (bind_combinator_kind :
                                                                     ->
                                                                     let uu___23
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    b
-                                                                    FStar_Syntax_Syntax.bv_to_name in
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___23
-                                                                    FStar_Syntax_Syntax.as_arg)
+                                                                    FStar_Syntax_Syntax.bv_to_name
+                                                                    b in
+                                                                    FStar_Syntax_Syntax.as_arg
+                                                                    uu___23)
                                                                     repr_app_bs in
                                                                     uu___17
                                                                     ::
@@ -1019,23 +925,19 @@ let (bind_combinator_kind :
                                                                     =
                                                                     let uu___17
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    a_b.FStar_Syntax_Syntax.binder_bv
-                                                                    FStar_Syntax_Syntax.bv_to_name in
+                                                                    FStar_Syntax_Syntax.bv_to_name
+                                                                    a_b.FStar_Syntax_Syntax.binder_bv in
                                                                     let uu___18
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    repr_app_bs
-                                                                    (FStar_Compiler_List.map
+                                                                    FStar_Compiler_List.map
                                                                     (fun b ->
                                                                     let uu___19
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    b.FStar_Syntax_Syntax.binder_bv
-                                                                    FStar_Syntax_Syntax.bv_to_name in
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___19
-                                                                    FStar_Syntax_Syntax.as_arg)) in
+                                                                    FStar_Syntax_Syntax.bv_to_name
+                                                                    b.FStar_Syntax_Syntax.binder_bv in
+                                                                    FStar_Syntax_Syntax.as_arg
+                                                                    uu___19)
+                                                                    repr_app_bs in
                                                                     {
                                                                     FStar_Syntax_Syntax.comp_univs
                                                                     =
@@ -1086,9 +988,8 @@ let (bind_combinator_kind :
                                                                     =
                                                                     let uu___15
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    a_b.FStar_Syntax_Syntax.binder_bv
-                                                                    FStar_Syntax_Syntax.bv_to_name in
+                                                                    FStar_Syntax_Syntax.bv_to_name
+                                                                    a_b.FStar_Syntax_Syntax.binder_bv in
                                                                     FStar_Syntax_Syntax.gen_bv
                                                                     "x"
                                                                     FStar_Pervasives_Native.None
@@ -1114,12 +1015,10 @@ let (bind_combinator_kind :
                                                                     ->
                                                                     let uu___19
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    b
-                                                                    FStar_Syntax_Syntax.bv_to_name in
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___19
-                                                                    FStar_Syntax_Syntax.as_arg)
+                                                                    FStar_Syntax_Syntax.bv_to_name
+                                                                    b in
+                                                                    FStar_Syntax_Syntax.as_arg
+                                                                    uu___19)
                                                                     eff_params_bs in
                                                                     let g_bs_args
                                                                     =
@@ -1150,36 +1049,30 @@ let (bind_combinator_kind :
                                                                     then
                                                                     let uu___20
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    b
-                                                                    FStar_Syntax_Syntax.bv_to_name in
+                                                                    FStar_Syntax_Syntax.bv_to_name
+                                                                    b in
                                                                     let uu___21
                                                                     =
                                                                     let uu___22
                                                                     =
                                                                     let uu___23
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    x_bv
-                                                                    FStar_Syntax_Syntax.bv_to_name in
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___23
-                                                                    FStar_Syntax_Syntax.as_arg in
+                                                                    FStar_Syntax_Syntax.bv_to_name
+                                                                    x_bv in
+                                                                    FStar_Syntax_Syntax.as_arg
+                                                                    uu___23 in
                                                                     [uu___22] in
                                                                     FStar_Syntax_Syntax.mk_Tm_app
                                                                     uu___20
                                                                     uu___21
                                                                     FStar_Compiler_Range_Type.dummyRange
                                                                     else
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    b
-                                                                    FStar_Syntax_Syntax.bv_to_name)
-                                                                    g_bs
+                                                                    FStar_Syntax_Syntax.bv_to_name
+                                                                    b) g_bs
                                                                     g_bs_kinds in
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___15
-                                                                    (FStar_Compiler_List.map
-                                                                    FStar_Syntax_Syntax.as_arg) in
+                                                                    FStar_Compiler_List.map
+                                                                    FStar_Syntax_Syntax.as_arg
+                                                                    uu___15 in
                                                                     let repr_args
                                                                     =
                                                                     FStar_Compiler_List.op_At
@@ -1212,12 +1105,10 @@ let (bind_combinator_kind :
                                                                     =
                                                                     let uu___19
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    b_b.FStar_Syntax_Syntax.binder_bv
-                                                                    FStar_Syntax_Syntax.bv_to_name in
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___19
-                                                                    FStar_Syntax_Syntax.as_arg in
+                                                                    FStar_Syntax_Syntax.bv_to_name
+                                                                    b_b.FStar_Syntax_Syntax.binder_bv in
+                                                                    FStar_Syntax_Syntax.as_arg
+                                                                    uu___19 in
                                                                     uu___18
                                                                     ::
                                                                     repr_args in
@@ -1229,9 +1120,8 @@ let (bind_combinator_kind :
                                                                     =
                                                                     let uu___18
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    x_bv
-                                                                    FStar_Syntax_Syntax.mk_binder in
+                                                                    FStar_Syntax_Syntax.mk_binder
+                                                                    x_bv in
                                                                     [uu___18] in
                                                                     let uu___18
                                                                     =
@@ -1258,9 +1148,8 @@ let (bind_combinator_kind :
                                                                     =
                                                                     let uu___18
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    b_b.FStar_Syntax_Syntax.binder_bv
-                                                                    FStar_Syntax_Syntax.bv_to_name in
+                                                                    FStar_Syntax_Syntax.bv_to_name
+                                                                    b_b.FStar_Syntax_Syntax.binder_bv in
                                                                     {
                                                                     FStar_Syntax_Syntax.comp_univs
                                                                     =
@@ -1287,9 +1176,8 @@ let (bind_combinator_kind :
                                                                     =
                                                                     let uu___16
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    x_bv
-                                                                    FStar_Syntax_Syntax.mk_binder in
+                                                                    FStar_Syntax_Syntax.mk_binder
+                                                                    x_bv in
                                                                     [uu___16] in
                                                                     let uu___16
                                                                     =
@@ -1402,27 +1290,19 @@ let (validate_indexed_effect_bind_shape :
                                     let a_b =
                                       let uu___1 =
                                         let uu___2 =
-                                          FStar_Compiler_Effect.op_Bar_Greater
-                                            (FStar_Syntax_Syntax.U_name u_a)
-                                            FStar_Syntax_Util.type_with_u in
-                                        FStar_Compiler_Effect.op_Bar_Greater
-                                          uu___2
-                                          (FStar_Syntax_Syntax.gen_bv "a"
-                                             FStar_Pervasives_Native.None) in
-                                      FStar_Compiler_Effect.op_Bar_Greater
-                                        uu___1 FStar_Syntax_Syntax.mk_binder in
+                                          FStar_Syntax_Util.type_with_u
+                                            (FStar_Syntax_Syntax.U_name u_a) in
+                                        FStar_Syntax_Syntax.gen_bv "a"
+                                          FStar_Pervasives_Native.None uu___2 in
+                                      FStar_Syntax_Syntax.mk_binder uu___1 in
                                     let b_b =
                                       let uu___1 =
                                         let uu___2 =
-                                          FStar_Compiler_Effect.op_Bar_Greater
-                                            (FStar_Syntax_Syntax.U_name u_b)
-                                            FStar_Syntax_Util.type_with_u in
-                                        FStar_Compiler_Effect.op_Bar_Greater
-                                          uu___2
-                                          (FStar_Syntax_Syntax.gen_bv "b"
-                                             FStar_Pervasives_Native.None) in
-                                      FStar_Compiler_Effect.op_Bar_Greater
-                                        uu___1 FStar_Syntax_Syntax.mk_binder in
+                                          FStar_Syntax_Util.type_with_u
+                                            (FStar_Syntax_Syntax.U_name u_b) in
+                                        FStar_Syntax_Syntax.gen_bv "b"
+                                          FStar_Pervasives_Native.None uu___2 in
+                                      FStar_Syntax_Syntax.mk_binder uu___1 in
                                     let rest_bs =
                                       let uu___1 =
                                         let uu___2 =
@@ -1460,42 +1340,34 @@ let (validate_indexed_effect_bind_shape :
                                                ->
                                                let uu___10 =
                                                  let uu___11 =
-                                                   FStar_Compiler_Effect.op_Bar_Greater
-                                                     bs1
-                                                     (FStar_Compiler_List.splitAt
-                                                        ((FStar_Compiler_List.length
-                                                            bs1)
-                                                           -
-                                                           (Prims.of_int (2)))) in
-                                                 FStar_Compiler_Effect.op_Bar_Greater
-                                                   uu___11
-                                                   FStar_Pervasives_Native.fst in
-                                               let uu___11 =
+                                                   let uu___12 =
+                                                     let uu___13 =
+                                                       FStar_Syntax_Syntax.bv_to_name
+                                                         a_b.FStar_Syntax_Syntax.binder_bv in
+                                                     (a, uu___13) in
+                                                   FStar_Syntax_Syntax.NT
+                                                     uu___12 in
                                                  let uu___12 =
                                                    let uu___13 =
                                                      let uu___14 =
                                                        let uu___15 =
-                                                         FStar_Compiler_Effect.op_Bar_Greater
-                                                           a_b.FStar_Syntax_Syntax.binder_bv
-                                                           FStar_Syntax_Syntax.bv_to_name in
-                                                       (a, uu___15) in
+                                                         FStar_Syntax_Syntax.bv_to_name
+                                                           b_b.FStar_Syntax_Syntax.binder_bv in
+                                                       (b, uu___15) in
                                                      FStar_Syntax_Syntax.NT
                                                        uu___14 in
-                                                   let uu___14 =
-                                                     let uu___15 =
-                                                       let uu___16 =
-                                                         let uu___17 =
-                                                           FStar_Compiler_Effect.op_Bar_Greater
-                                                             b_b.FStar_Syntax_Syntax.binder_bv
-                                                             FStar_Syntax_Syntax.bv_to_name in
-                                                         (b, uu___17) in
-                                                       FStar_Syntax_Syntax.NT
-                                                         uu___16 in
-                                                     [uu___15] in
-                                                   uu___13 :: uu___14 in
-                                                 FStar_Syntax_Subst.subst_binders
+                                                   [uu___13] in
+                                                 uu___11 :: uu___12 in
+                                               let uu___11 =
+                                                 let uu___12 =
+                                                   FStar_Compiler_List.splitAt
+                                                     ((FStar_Compiler_List.length
+                                                         bs1)
+                                                        - (Prims.of_int (2)))
+                                                     bs1 in
+                                                 FStar_Pervasives_Native.fst
                                                    uu___12 in
-                                               FStar_Compiler_Effect.op_Bar_Greater
+                                               FStar_Syntax_Subst.subst_binders
                                                  uu___10 uu___11)
                                       | uu___2 ->
                                           let uu___3 =
@@ -1542,9 +1414,8 @@ let (validate_indexed_effect_bind_shape :
                                                FStar_TypeChecker_Env.push_binders
                                                  env (a_b :: b_b :: rest_bs1) in
                                              let uu___5 =
-                                               FStar_Compiler_Effect.op_Bar_Greater
-                                                 a_b.FStar_Syntax_Syntax.binder_bv
-                                                 FStar_Syntax_Syntax.bv_to_name in
+                                               FStar_Syntax_Syntax.bv_to_name
+                                                 a_b.FStar_Syntax_Syntax.binder_bv in
                                              FStar_TypeChecker_Util.fresh_effect_repr
                                                uu___4 r m_eff_name m_sig_ts
                                                m_repr_ts
@@ -1554,14 +1425,12 @@ let (validate_indexed_effect_bind_shape :
                                            | (repr, g) ->
                                                let uu___4 =
                                                  let uu___5 =
-                                                   FStar_Compiler_Effect.op_Bar_Greater
-                                                     repr
-                                                     (FStar_Syntax_Syntax.gen_bv
-                                                        "f"
-                                                        FStar_Pervasives_Native.None) in
-                                                 FStar_Compiler_Effect.op_Bar_Greater
-                                                   uu___5
-                                                   FStar_Syntax_Syntax.mk_binder in
+                                                   FStar_Syntax_Syntax.gen_bv
+                                                     "f"
+                                                     FStar_Pervasives_Native.None
+                                                     repr in
+                                                 FStar_Syntax_Syntax.mk_binder
+                                                   uu___5 in
                                                (uu___4, g) in
                                          (match uu___2 with
                                           | (f, guard_f) ->
@@ -1569,17 +1438,14 @@ let (validate_indexed_effect_bind_shape :
                                                 let x_a =
                                                   let uu___4 =
                                                     let uu___5 =
-                                                      FStar_Compiler_Effect.op_Bar_Greater
-                                                        a_b.FStar_Syntax_Syntax.binder_bv
-                                                        FStar_Syntax_Syntax.bv_to_name in
-                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                      uu___5
-                                                      (FStar_Syntax_Syntax.gen_bv
-                                                         "x"
-                                                         FStar_Pervasives_Native.None) in
-                                                  FStar_Compiler_Effect.op_Bar_Greater
-                                                    uu___4
-                                                    FStar_Syntax_Syntax.mk_binder in
+                                                      FStar_Syntax_Syntax.bv_to_name
+                                                        a_b.FStar_Syntax_Syntax.binder_bv in
+                                                    FStar_Syntax_Syntax.gen_bv
+                                                      "x"
+                                                      FStar_Pervasives_Native.None
+                                                      uu___5 in
+                                                  FStar_Syntax_Syntax.mk_binder
+                                                    uu___4 in
                                                 let uu___4 =
                                                   let uu___5 =
                                                     FStar_TypeChecker_Env.push_binders
@@ -1588,9 +1454,8 @@ let (validate_indexed_effect_bind_shape :
                                                          (a_b :: b_b ::
                                                          rest_bs1) [x_a]) in
                                                   let uu___6 =
-                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                      b_b.FStar_Syntax_Syntax.binder_bv
-                                                      FStar_Syntax_Syntax.bv_to_name in
+                                                    FStar_Syntax_Syntax.bv_to_name
+                                                      b_b.FStar_Syntax_Syntax.binder_bv in
                                                   FStar_TypeChecker_Util.fresh_effect_repr
                                                     uu___5 r n_eff_name
                                                     n_sig_ts n_repr_ts
@@ -1610,9 +1475,8 @@ let (validate_indexed_effect_bind_shape :
                                                           "g"
                                                           FStar_Pervasives_Native.None
                                                           uu___7 in
-                                                      FStar_Compiler_Effect.op_Bar_Greater
-                                                        uu___6
-                                                        FStar_Syntax_Syntax.mk_binder in
+                                                      FStar_Syntax_Syntax.mk_binder
+                                                        uu___6 in
                                                     (uu___5, g) in
                                               (match uu___3 with
                                                | (g, guard_g) ->
@@ -1622,9 +1486,8 @@ let (validate_indexed_effect_bind_shape :
                                                          env (a_b :: b_b ::
                                                          rest_bs1) in
                                                      let uu___6 =
-                                                       FStar_Compiler_Effect.op_Bar_Greater
-                                                         b_b.FStar_Syntax_Syntax.binder_bv
-                                                         FStar_Syntax_Syntax.bv_to_name in
+                                                       FStar_Syntax_Syntax.bv_to_name
+                                                         b_b.FStar_Syntax_Syntax.binder_bv in
                                                      FStar_TypeChecker_Util.fresh_effect_repr
                                                        uu___5 r p_eff_name
                                                        p_sig_ts p_repr_ts
@@ -1663,9 +1526,8 @@ let (validate_indexed_effect_bind_shape :
                                                                     =
                                                                     let uu___10
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    pure_wp_uvar1
-                                                                    FStar_Syntax_Syntax.as_arg in
+                                                                    FStar_Syntax_Syntax.as_arg
+                                                                    pure_wp_uvar1 in
                                                                     [uu___10] in
                                                                    {
                                                                     FStar_Syntax_Syntax.comp_univs
@@ -1731,13 +1593,10 @@ let (validate_indexed_effect_bind_shape :
                                                                  env uu___7);
                                                               (let k1 =
                                                                  let uu___7 =
-                                                                   FStar_Compiler_Effect.op_Bar_Greater
-                                                                    k
-                                                                    (FStar_TypeChecker_Normalize.remove_uvar_solutions
-                                                                    env) in
-                                                                 FStar_Compiler_Effect.op_Bar_Greater
-                                                                   uu___7
-                                                                   FStar_Syntax_Subst.compress in
+                                                                   FStar_TypeChecker_Normalize.remove_uvar_solutions
+                                                                    env k in
+                                                                 FStar_Syntax_Subst.compress
+                                                                   uu___7 in
                                                                let lopt =
                                                                  bind_combinator_kind
                                                                    env
@@ -1767,10 +1626,8 @@ let (validate_indexed_effect_bind_shape :
                                                                     FStar_Syntax_Syntax.Substitutive_combinator
                                                                     l in
                                                                (let uu___8 =
-                                                                  FStar_Compiler_Effect.op_Less_Bar
-                                                                    (
-                                                                    FStar_TypeChecker_Env.debug
-                                                                    env)
+                                                                  FStar_TypeChecker_Env.debug
+                                                                    env
                                                                     (
                                                                     FStar_Options.Other
                                                                     "LayeredEffectsTc") in
@@ -1810,18 +1667,13 @@ let (subcomp_combinator_kind :
                 fun u ->
                   fun k ->
                     fun num_effect_params ->
-                      let uu___ =
-                        FStar_Compiler_Effect.op_Bar_Greater k
-                          FStar_Syntax_Util.arrow_formals_comp in
+                      let uu___ = FStar_Syntax_Util.arrow_formals_comp k in
                       match uu___ with
                       | (a_b::rest_bs, k_c) ->
                           let uu___1 =
                             if num_effect_params = Prims.int_zero
                             then
-                              FStar_Compiler_Effect.op_Bar_Greater
-                                ([], [], rest_bs)
-                                (fun uu___2 ->
-                                   FStar_Pervasives_Native.Some uu___2)
+                              FStar_Pervasives_Native.Some ([], [], rest_bs)
                             else
                               (let uu___3 =
                                  FStar_TypeChecker_Env.inst_tscheme_with
@@ -1829,17 +1681,14 @@ let (subcomp_combinator_kind :
                                match uu___3 with
                                | (uu___4, sig1) ->
                                    let uu___5 =
-                                     FStar_Compiler_Effect.op_Bar_Greater
-                                       sig1 FStar_Syntax_Util.arrow_formals in
+                                     FStar_Syntax_Util.arrow_formals sig1 in
                                    (match uu___5 with
                                     | (uu___6::sig_bs, uu___7) ->
                                         let sig_effect_params_bs =
                                           let uu___8 =
                                             FStar_Compiler_List.splitAt
                                               num_effect_params sig_bs in
-                                          FStar_Compiler_Effect.op_Bar_Greater
-                                            uu___8
-                                            FStar_Pervasives_Native.fst in
+                                          FStar_Pervasives_Native.fst uu___8 in
                                         let uu___8 =
                                           FStar_Compiler_List.splitAt
                                             num_effect_params rest_bs in
@@ -1851,13 +1700,10 @@ let (subcomp_combinator_kind :
                                                  eff_params_bs in
                                              op_let_Question uu___9
                                                (fun eff_params_bs_kinds ->
-                                                  FStar_Compiler_Effect.op_Bar_Greater
+                                                  FStar_Pervasives_Native.Some
                                                     (eff_params_bs,
                                                       eff_params_bs_kinds,
-                                                      rest_bs1)
-                                                    (fun uu___10 ->
-                                                       FStar_Pervasives_Native.Some
-                                                         uu___10))))) in
+                                                      rest_bs1))))) in
                           op_let_Question uu___1
                             (fun uu___2 ->
                                match uu___2 with
@@ -1873,65 +1719,53 @@ let (subcomp_combinator_kind :
                                        | (uu___5, sig1) ->
                                            let uu___6 =
                                              let uu___7 =
-                                               FStar_Compiler_Effect.op_Bar_Greater
-                                                 sig1
-                                                 FStar_Syntax_Util.arrow_formals in
-                                             FStar_Compiler_Effect.op_Bar_Greater
-                                               uu___7
-                                               FStar_Pervasives_Native.fst in
-                                           FStar_Compiler_Effect.op_Bar_Greater
-                                             uu___6
-                                             (fun uu___7 ->
-                                                match uu___7 with
-                                                | a::bs ->
-                                                    let uu___8 =
-                                                      FStar_Compiler_List.splitAt
-                                                        num_effect_params bs in
-                                                    (match uu___8 with
-                                                     | (sig_bs, bs1) ->
-                                                         let ss =
-                                                           let uu___9 =
-                                                             let uu___10 =
-                                                               let uu___11 =
-                                                                 let uu___12
-                                                                   =
-                                                                   FStar_Compiler_Effect.op_Bar_Greater
-                                                                    a_b.FStar_Syntax_Syntax.binder_bv
-                                                                    FStar_Syntax_Syntax.bv_to_name in
-                                                                 ((a.FStar_Syntax_Syntax.binder_bv),
-                                                                   uu___12) in
-                                                               FStar_Syntax_Syntax.NT
-                                                                 uu___11 in
-                                                             [uu___10] in
-                                                           FStar_Compiler_List.fold_left2
-                                                             (fun ss1 ->
-                                                                fun sig_b ->
-                                                                  fun b ->
-                                                                    let uu___10
+                                               FStar_Syntax_Util.arrow_formals
+                                                 sig1 in
+                                             FStar_Pervasives_Native.fst
+                                               uu___7 in
+                                           (match uu___6 with
+                                            | a::bs ->
+                                                let uu___7 =
+                                                  FStar_Compiler_List.splitAt
+                                                    num_effect_params bs in
+                                                (match uu___7 with
+                                                 | (sig_bs, bs1) ->
+                                                     let ss =
+                                                       let uu___8 =
+                                                         let uu___9 =
+                                                           let uu___10 =
+                                                             let uu___11 =
+                                                               FStar_Syntax_Syntax.bv_to_name
+                                                                 a_b.FStar_Syntax_Syntax.binder_bv in
+                                                             ((a.FStar_Syntax_Syntax.binder_bv),
+                                                               uu___11) in
+                                                           FStar_Syntax_Syntax.NT
+                                                             uu___10 in
+                                                         [uu___9] in
+                                                       FStar_Compiler_List.fold_left2
+                                                         (fun ss1 ->
+                                                            fun sig_b ->
+                                                              fun b ->
+                                                                let uu___9 =
+                                                                  let uu___10
                                                                     =
                                                                     let uu___11
                                                                     =
                                                                     let uu___12
                                                                     =
-                                                                    let uu___13
-                                                                    =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    b.FStar_Syntax_Syntax.binder_bv
-                                                                    FStar_Syntax_Syntax.bv_to_name in
+                                                                    FStar_Syntax_Syntax.bv_to_name
+                                                                    b.FStar_Syntax_Syntax.binder_bv in
                                                                     ((sig_b.FStar_Syntax_Syntax.binder_bv),
-                                                                    uu___13) in
+                                                                    uu___12) in
                                                                     FStar_Syntax_Syntax.NT
-                                                                    uu___12 in
-                                                                    [uu___11] in
-                                                                    FStar_Compiler_List.op_At
-                                                                    ss1
-                                                                    uu___10)
-                                                             uu___9 sig_bs
-                                                             eff_params_bs in
-                                                         FStar_Compiler_Effect.op_Bar_Greater
-                                                           bs1
-                                                           (FStar_Syntax_Subst.subst_binders
-                                                              ss))) in
+                                                                    uu___11 in
+                                                                  [uu___10] in
+                                                                FStar_Compiler_List.op_At
+                                                                  ss1 uu___9)
+                                                         uu___8 sig_bs
+                                                         eff_params_bs in
+                                                     FStar_Syntax_Subst.subst_binders
+                                                       ss bs1)) in
                                      let uu___4 =
                                        if
                                          (FStar_Compiler_List.length rest_bs1)
@@ -1944,11 +1778,7 @@ let (subcomp_combinator_kind :
                                             FStar_Compiler_List.splitAt
                                               (FStar_Compiler_List.length
                                                  f_sig_bs) rest_bs1 in
-                                          FStar_Compiler_Effect.op_Bar_Greater
-                                            uu___6
-                                            (fun uu___7 ->
-                                               FStar_Pervasives_Native.Some
-                                                 uu___7)) in
+                                          FStar_Pervasives_Native.Some uu___6) in
                                      op_let_Question uu___4
                                        (fun uu___5 ->
                                           match uu___5 with
@@ -1957,12 +1787,9 @@ let (subcomp_combinator_kind :
                                                 eq_binders env f_sig_bs f_bs in
                                               op_let_Question uu___6
                                                 (fun f_bs_kinds ->
-                                                   FStar_Compiler_Effect.op_Bar_Greater
+                                                   FStar_Pervasives_Native.Some
                                                      (f_bs, f_bs_kinds,
-                                                       rest_bs2)
-                                                     (fun uu___7 ->
-                                                        FStar_Pervasives_Native.Some
-                                                          uu___7))) in
+                                                       rest_bs2))) in
                                    op_let_Question uu___3
                                      (fun uu___4 ->
                                         match uu___4 with
@@ -1981,11 +1808,8 @@ let (subcomp_combinator_kind :
                                                     rest_bs2 in
                                                 match uu___6 with
                                                 | (rest_bs3, f_b::[]) ->
-                                                    FStar_Compiler_Effect.op_Bar_Greater
+                                                    FStar_Pervasives_Native.Some
                                                       (rest_bs3, f_b)
-                                                      (fun uu___7 ->
-                                                         FStar_Pervasives_Native.Some
-                                                           uu___7)
                                               else
                                                 FStar_Pervasives_Native.None in
                                             op_let_Question uu___5
@@ -2013,12 +1837,10 @@ let (subcomp_combinator_kind :
                                                                     =
                                                                     let uu___12
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    a_b.FStar_Syntax_Syntax.binder_bv
-                                                                    FStar_Syntax_Syntax.bv_to_name in
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___12
-                                                                    FStar_Syntax_Syntax.as_arg in
+                                                                    FStar_Syntax_Syntax.bv_to_name
+                                                                    a_b.FStar_Syntax_Syntax.binder_bv in
+                                                                    FStar_Syntax_Syntax.as_arg
+                                                                    uu___12 in
                                                                     let uu___12
                                                                     =
                                                                     FStar_Compiler_List.map
@@ -2040,12 +1862,10 @@ let (subcomp_combinator_kind :
                                                                     ->
                                                                     let uu___17
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    b
-                                                                    FStar_Syntax_Syntax.bv_to_name in
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___17
-                                                                    FStar_Syntax_Syntax.as_arg)
+                                                                    FStar_Syntax_Syntax.bv_to_name
+                                                                    b in
+                                                                    FStar_Syntax_Syntax.as_arg
+                                                                    uu___17)
                                                                     (FStar_Compiler_List.op_At
                                                                     eff_params_bs
                                                                     f_bs) in
@@ -2066,25 +1886,21 @@ let (subcomp_combinator_kind :
                                                                let uu___10 =
                                                                  let uu___11
                                                                    =
-                                                                   FStar_Compiler_Effect.op_Bar_Greater
-                                                                    a_b.FStar_Syntax_Syntax.binder_bv
-                                                                    FStar_Syntax_Syntax.bv_to_name in
+                                                                   FStar_Syntax_Syntax.bv_to_name
+                                                                    a_b.FStar_Syntax_Syntax.binder_bv in
                                                                  let uu___12
                                                                    =
-                                                                   FStar_Compiler_Effect.op_Bar_Greater
-                                                                    (FStar_Compiler_List.op_At
-                                                                    eff_params_bs
-                                                                    f_bs)
-                                                                    (FStar_Compiler_List.map
+                                                                   FStar_Compiler_List.map
                                                                     (fun b ->
                                                                     let uu___13
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    b.FStar_Syntax_Syntax.binder_bv
-                                                                    FStar_Syntax_Syntax.bv_to_name in
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___13
-                                                                    FStar_Syntax_Syntax.as_arg)) in
+                                                                    FStar_Syntax_Syntax.bv_to_name
+                                                                    b.FStar_Syntax_Syntax.binder_bv in
+                                                                    FStar_Syntax_Syntax.as_arg
+                                                                    uu___13)
+                                                                    (FStar_Compiler_List.op_At
+                                                                    eff_params_bs
+                                                                    f_bs) in
                                                                  {
                                                                    FStar_Syntax_Syntax.comp_univs
                                                                     =
@@ -2145,12 +1961,10 @@ let (subcomp_combinator_kind :
                                                                     =
                                                                     let uu___12
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    a_b.FStar_Syntax_Syntax.binder_bv
-                                                                    FStar_Syntax_Syntax.bv_to_name in
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___12
-                                                                    FStar_Syntax_Syntax.as_arg in
+                                                                    FStar_Syntax_Syntax.bv_to_name
+                                                                    a_b.FStar_Syntax_Syntax.binder_bv in
+                                                                    FStar_Syntax_Syntax.as_arg
+                                                                    uu___12 in
                                                                     let uu___12
                                                                     =
                                                                     FStar_Compiler_List.map
@@ -2172,12 +1986,10 @@ let (subcomp_combinator_kind :
                                                                     ->
                                                                     let uu___17
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    b
-                                                                    FStar_Syntax_Syntax.bv_to_name in
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___17
-                                                                    FStar_Syntax_Syntax.as_arg)
+                                                                    FStar_Syntax_Syntax.bv_to_name
+                                                                    b in
+                                                                    FStar_Syntax_Syntax.as_arg
+                                                                    uu___17)
                                                                     (FStar_Compiler_List.op_At
                                                                     eff_params_bs
                                                                     f_or_g_bs) in
@@ -2202,25 +2014,21 @@ let (subcomp_combinator_kind :
                                                                     =
                                                                     let uu___11
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    a_b.FStar_Syntax_Syntax.binder_bv
-                                                                    FStar_Syntax_Syntax.bv_to_name in
+                                                                    FStar_Syntax_Syntax.bv_to_name
+                                                                    a_b.FStar_Syntax_Syntax.binder_bv in
                                                                     let uu___12
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    (FStar_Compiler_List.op_At
-                                                                    eff_params_bs
-                                                                    f_or_g_bs)
-                                                                    (FStar_Compiler_List.map
+                                                                    FStar_Compiler_List.map
                                                                     (fun b ->
                                                                     let uu___13
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    b.FStar_Syntax_Syntax.binder_bv
-                                                                    FStar_Syntax_Syntax.bv_to_name in
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___13
-                                                                    FStar_Syntax_Syntax.as_arg)) in
+                                                                    FStar_Syntax_Syntax.bv_to_name
+                                                                    b.FStar_Syntax_Syntax.binder_bv in
+                                                                    FStar_Syntax_Syntax.as_arg
+                                                                    uu___13)
+                                                                    (FStar_Compiler_List.op_At
+                                                                    eff_params_bs
+                                                                    f_or_g_bs) in
                                                                     {
                                                                     FStar_Syntax_Syntax.comp_univs
                                                                     =
@@ -2284,32 +2092,46 @@ let (subcomp_combinator_kind :
                                                                     =
                                                                     let uu___14
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    sig1
-                                                                    FStar_Syntax_Util.arrow_formals in
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___14
-                                                                    FStar_Pervasives_Native.fst in
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___13
-                                                                    (fun
-                                                                    uu___14
-                                                                    ->
-                                                                    match uu___14
+                                                                    FStar_Syntax_Util.arrow_formals
+                                                                    sig1 in
+                                                                    FStar_Pervasives_Native.fst
+                                                                    uu___14 in
+                                                                    (match uu___13
                                                                     with
                                                                     | 
                                                                     a::bs ->
-                                                                    let uu___15
+                                                                    let uu___14
                                                                     =
                                                                     FStar_Compiler_List.splitAt
                                                                     num_effect_params
                                                                     bs in
-                                                                    (match uu___15
+                                                                    (match uu___14
                                                                     with
                                                                     | 
                                                                     (sig_bs,
                                                                     bs1) ->
                                                                     let ss =
+                                                                    let uu___15
+                                                                    =
+                                                                    let uu___16
+                                                                    =
+                                                                    let uu___17
+                                                                    =
+                                                                    let uu___18
+                                                                    =
+                                                                    FStar_Syntax_Syntax.bv_to_name
+                                                                    a_b.FStar_Syntax_Syntax.binder_bv in
+                                                                    ((a.FStar_Syntax_Syntax.binder_bv),
+                                                                    uu___18) in
+                                                                    FStar_Syntax_Syntax.NT
+                                                                    uu___17 in
+                                                                    [uu___16] in
+                                                                    FStar_Compiler_List.fold_left2
+                                                                    (fun ss1
+                                                                    ->
+                                                                    fun sig_b
+                                                                    ->
+                                                                    fun b ->
                                                                     let uu___16
                                                                     =
                                                                     let uu___17
@@ -2318,46 +2140,21 @@ let (subcomp_combinator_kind :
                                                                     =
                                                                     let uu___19
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    a_b.FStar_Syntax_Syntax.binder_bv
-                                                                    FStar_Syntax_Syntax.bv_to_name in
-                                                                    ((a.FStar_Syntax_Syntax.binder_bv),
+                                                                    FStar_Syntax_Syntax.bv_to_name
+                                                                    b.FStar_Syntax_Syntax.binder_bv in
+                                                                    ((sig_b.FStar_Syntax_Syntax.binder_bv),
                                                                     uu___19) in
                                                                     FStar_Syntax_Syntax.NT
                                                                     uu___18 in
                                                                     [uu___17] in
-                                                                    FStar_Compiler_List.fold_left2
-                                                                    (fun ss1
-                                                                    ->
-                                                                    fun sig_b
-                                                                    ->
-                                                                    fun b ->
-                                                                    let uu___17
-                                                                    =
-                                                                    let uu___18
-                                                                    =
-                                                                    let uu___19
-                                                                    =
-                                                                    let uu___20
-                                                                    =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    b.FStar_Syntax_Syntax.binder_bv
-                                                                    FStar_Syntax_Syntax.bv_to_name in
-                                                                    ((sig_b.FStar_Syntax_Syntax.binder_bv),
-                                                                    uu___20) in
-                                                                    FStar_Syntax_Syntax.NT
-                                                                    uu___19 in
-                                                                    [uu___18] in
                                                                     FStar_Compiler_List.op_At
                                                                     ss1
-                                                                    uu___17)
-                                                                    uu___16
+                                                                    uu___16)
+                                                                    uu___15
                                                                     sig_bs
                                                                     eff_params_bs in
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    bs1
-                                                                    (FStar_Syntax_Subst.subst_binders
-                                                                    ss))) in
+                                                                    FStar_Syntax_Subst.subst_binders
+                                                                    ss bs1)) in
                                                                let uu___11 =
                                                                  if
                                                                    (FStar_Compiler_List.length
@@ -2374,13 +2171,8 @@ let (subcomp_combinator_kind :
                                                                     (FStar_Compiler_List.length
                                                                     g_sig_bs)
                                                                     rest_bs3 in
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___13
-                                                                    (fun
-                                                                    uu___14
-                                                                    ->
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu___14)) in
+                                                                    uu___13) in
                                                                op_let_Question
                                                                  uu___11
                                                                  (fun uu___12
@@ -2402,15 +2194,10 @@ let (subcomp_combinator_kind :
                                                                     (fun
                                                                     g_bs_kinds
                                                                     ->
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
+                                                                    FStar_Pervasives_Native.Some
                                                                     (g_bs,
                                                                     g_bs_kinds,
-                                                                    rest_bs4)
-                                                                    (fun
-                                                                    uu___14
-                                                                    ->
-                                                                    FStar_Pervasives_Native.Some
-                                                                    uu___14))) in
+                                                                    rest_bs4))) in
                                                              op_let_Question
                                                                uu___10
                                                                (fun uu___11
@@ -2438,9 +2225,8 @@ let (subcomp_combinator_kind :
                                                                     ->
                                                                     FStar_Syntax_Syntax.Ad_hoc_binder)
                                                                     rest_bs4 in
-                                                                    let uu___13
-                                                                    =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
+                                                                    FStar_Pervasives_Native.Some
+                                                                    (FStar_Syntax_Syntax.Substitutive_combinator
                                                                     (FStar_Compiler_List.op_At
                                                                     [FStar_Syntax_Syntax.Type_binder]
                                                                     (FStar_Compiler_List.op_At
@@ -2451,14 +2237,7 @@ let (subcomp_combinator_kind :
                                                                     g_bs_kinds
                                                                     (FStar_Compiler_List.op_At
                                                                     rest_kinds
-                                                                    [FStar_Syntax_Syntax.Repr_binder])))))
-                                                                    (fun
-                                                                    uu___14
-                                                                    ->
-                                                                    FStar_Syntax_Syntax.Substitutive_combinator
-                                                                    uu___14) in
-                                                                    FStar_Pervasives_Native.Some
-                                                                    uu___13)))))))
+                                                                    [FStar_Syntax_Syntax.Repr_binder])))))))))))))
 let (validate_indexed_effect_subcomp_shape :
   FStar_TypeChecker_Env.env ->
     FStar_Ident.lident ->
@@ -2492,14 +2271,11 @@ let (validate_indexed_effect_subcomp_shape :
                         let a_b =
                           let uu___ =
                             let uu___1 =
-                              FStar_Compiler_Effect.op_Bar_Greater
-                                (FStar_Syntax_Syntax.U_name u)
-                                FStar_Syntax_Util.type_with_u in
-                            FStar_Compiler_Effect.op_Bar_Greater uu___1
-                              (FStar_Syntax_Syntax.gen_bv "a"
-                                 FStar_Pervasives_Native.None) in
-                          FStar_Compiler_Effect.op_Bar_Greater uu___
-                            FStar_Syntax_Syntax.mk_binder in
+                              FStar_Syntax_Util.type_with_u
+                                (FStar_Syntax_Syntax.U_name u) in
+                            FStar_Syntax_Syntax.gen_bv "a"
+                              FStar_Pervasives_Native.None uu___1 in
+                          FStar_Syntax_Syntax.mk_binder uu___ in
                         let rest_bs =
                           let uu___ =
                             let uu___1 =
@@ -2523,26 +2299,21 @@ let (validate_indexed_effect_subcomp_shape :
                                    ->
                                    let uu___6 =
                                      let uu___7 =
-                                       FStar_Compiler_Effect.op_Bar_Greater
-                                         bs1
-                                         (FStar_Compiler_List.splitAt
-                                            ((FStar_Compiler_List.length bs1)
-                                               - Prims.int_one)) in
-                                     FStar_Compiler_Effect.op_Bar_Greater
-                                       uu___7 FStar_Pervasives_Native.fst in
+                                       let uu___8 =
+                                         let uu___9 =
+                                           FStar_Syntax_Syntax.bv_to_name
+                                             a_b.FStar_Syntax_Syntax.binder_bv in
+                                         (a, uu___9) in
+                                       FStar_Syntax_Syntax.NT uu___8 in
+                                     [uu___7] in
                                    let uu___7 =
                                      let uu___8 =
-                                       let uu___9 =
-                                         let uu___10 =
-                                           let uu___11 =
-                                             FStar_Syntax_Syntax.bv_to_name
-                                               a_b.FStar_Syntax_Syntax.binder_bv in
-                                           (a, uu___11) in
-                                         FStar_Syntax_Syntax.NT uu___10 in
-                                       [uu___9] in
-                                     FStar_Syntax_Subst.subst_binders uu___8 in
-                                   FStar_Compiler_Effect.op_Bar_Greater
-                                     uu___6 uu___7)
+                                       FStar_Compiler_List.splitAt
+                                         ((FStar_Compiler_List.length bs1) -
+                                            Prims.int_one) bs1 in
+                                     FStar_Pervasives_Native.fst uu___8 in
+                                   FStar_Syntax_Subst.subst_binders uu___6
+                                     uu___7)
                           | uu___1 ->
                               let uu___2 =
                                 let uu___3 =
@@ -2561,9 +2332,8 @@ let (validate_indexed_effect_subcomp_shape :
                               FStar_TypeChecker_Env.push_binders env (a_b ::
                                 rest_bs) in
                             let uu___3 =
-                              FStar_Compiler_Effect.op_Bar_Greater
-                                a_b.FStar_Syntax_Syntax.binder_bv
-                                FStar_Syntax_Syntax.bv_to_name in
+                              FStar_Syntax_Syntax.bv_to_name
+                                a_b.FStar_Syntax_Syntax.binder_bv in
                             FStar_TypeChecker_Util.fresh_effect_repr uu___2 r
                               m_eff_name m_sig_ts m_repr_ts
                               (FStar_Syntax_Syntax.U_name u) uu___3 in
@@ -2571,11 +2341,9 @@ let (validate_indexed_effect_subcomp_shape :
                           | (repr, g) ->
                               let uu___2 =
                                 let uu___3 =
-                                  FStar_Compiler_Effect.op_Bar_Greater repr
-                                    (FStar_Syntax_Syntax.gen_bv "f"
-                                       FStar_Pervasives_Native.None) in
-                                FStar_Compiler_Effect.op_Bar_Greater uu___3
-                                  FStar_Syntax_Syntax.mk_binder in
+                                  FStar_Syntax_Syntax.gen_bv "f"
+                                    FStar_Pervasives_Native.None repr in
+                                FStar_Syntax_Syntax.mk_binder uu___3 in
                               (uu___2, g) in
                         match uu___ with
                         | (f, guard_f) ->
@@ -2584,9 +2352,8 @@ let (validate_indexed_effect_subcomp_shape :
                                 FStar_TypeChecker_Env.push_binders env (a_b
                                   :: rest_bs) in
                               let uu___3 =
-                                FStar_Compiler_Effect.op_Bar_Greater
-                                  a_b.FStar_Syntax_Syntax.binder_bv
-                                  FStar_Syntax_Syntax.bv_to_name in
+                                FStar_Syntax_Syntax.bv_to_name
+                                  a_b.FStar_Syntax_Syntax.binder_bv in
                               FStar_TypeChecker_Util.fresh_effect_repr uu___2
                                 r n_eff_name n_sig_ts n_repr_ts
                                 (FStar_Syntax_Syntax.U_name u) uu___3 in
@@ -2612,9 +2379,8 @@ let (validate_indexed_effect_subcomp_shape :
                                             [uu___5] in
                                           let uu___5 =
                                             let uu___6 =
-                                              FStar_Compiler_Effect.op_Bar_Greater
-                                                pure_wp_uvar1
-                                                FStar_Syntax_Syntax.as_arg in
+                                              FStar_Syntax_Syntax.as_arg
+                                                pure_wp_uvar1 in
                                             [uu___6] in
                                           {
                                             FStar_Syntax_Syntax.comp_univs =
@@ -2633,8 +2399,7 @@ let (validate_indexed_effect_subcomp_shape :
                                           (FStar_Compiler_List.op_At (a_b ::
                                              rest_bs) [f]) c in
                                       ((let uu___4 =
-                                          FStar_Compiler_Effect.op_Less_Bar
-                                            (FStar_TypeChecker_Env.debug env)
+                                          FStar_TypeChecker_Env.debug env
                                             (FStar_Options.Other
                                                "LayeredEffectsTc") in
                                         if uu___4
@@ -2676,13 +2441,9 @@ let (validate_indexed_effect_subcomp_shape :
                                            env uu___5);
                                         (let k1 =
                                            let uu___5 =
-                                             FStar_Compiler_Effect.op_Bar_Greater
-                                               k
-                                               (FStar_TypeChecker_Normalize.remove_uvar_solutions
-                                                  env) in
-                                           FStar_Compiler_Effect.op_Bar_Greater
-                                             uu___5
-                                             FStar_Syntax_Subst.compress in
+                                             FStar_TypeChecker_Normalize.remove_uvar_solutions
+                                               env k in
+                                           FStar_Syntax_Subst.compress uu___5 in
                                          let kopt =
                                            subcomp_combinator_kind env
                                              m_eff_name n_eff_name m_sig_ts
@@ -2697,9 +2458,7 @@ let (validate_indexed_effect_subcomp_shape :
                                            | FStar_Pervasives_Native.Some k2
                                                -> k2 in
                                          (let uu___6 =
-                                            FStar_Compiler_Effect.op_Less_Bar
-                                              (FStar_TypeChecker_Env.debug
-                                                 env)
+                                            FStar_TypeChecker_Env.debug env
                                               (FStar_Options.Other
                                                  "LayeredEffectsTc") in
                                           if uu___6
@@ -2735,10 +2494,7 @@ let (ite_combinator_kind :
                 | (a_b::rest_bs, uu___1, uu___2) ->
                     let uu___3 =
                       if num_effect_params = Prims.int_zero
-                      then
-                        FStar_Compiler_Effect.op_Bar_Greater
-                          ([], [], rest_bs)
-                          (fun uu___4 -> FStar_Pervasives_Native.Some uu___4)
+                      then FStar_Pervasives_Native.Some ([], [], rest_bs)
                       else
                         (let uu___5 =
                            FStar_TypeChecker_Env.inst_tscheme_with sig_ts
@@ -2746,16 +2502,14 @@ let (ite_combinator_kind :
                          match uu___5 with
                          | (uu___6, sig1) ->
                              let uu___7 =
-                               FStar_Compiler_Effect.op_Bar_Greater sig1
-                                 FStar_Syntax_Util.arrow_formals in
+                               FStar_Syntax_Util.arrow_formals sig1 in
                              (match uu___7 with
                               | (uu___8::sig_bs, uu___9) ->
                                   let sig_effect_params_bs =
                                     let uu___10 =
                                       FStar_Compiler_List.splitAt
                                         num_effect_params sig_bs in
-                                    FStar_Compiler_Effect.op_Bar_Greater
-                                      uu___10 FStar_Pervasives_Native.fst in
+                                    FStar_Pervasives_Native.fst uu___10 in
                                   let uu___10 =
                                     FStar_Compiler_List.splitAt
                                       num_effect_params rest_bs in
@@ -2766,13 +2520,10 @@ let (ite_combinator_kind :
                                            eff_params_bs in
                                        op_let_Question uu___11
                                          (fun eff_params_bs_kinds ->
-                                            FStar_Compiler_Effect.op_Bar_Greater
+                                            FStar_Pervasives_Native.Some
                                               (eff_params_bs,
                                                 eff_params_bs_kinds,
-                                                rest_bs1)
-                                              (fun uu___12 ->
-                                                 FStar_Pervasives_Native.Some
-                                                   uu___12))))) in
+                                                rest_bs1))))) in
                     op_let_Question uu___3
                       (fun uu___4 ->
                          match uu___4 with
@@ -2786,60 +2537,48 @@ let (ite_combinator_kind :
                                  | (uu___7, sig1) ->
                                      let uu___8 =
                                        let uu___9 =
-                                         FStar_Compiler_Effect.op_Bar_Greater
-                                           sig1
-                                           FStar_Syntax_Util.arrow_formals in
-                                       FStar_Compiler_Effect.op_Bar_Greater
-                                         uu___9 FStar_Pervasives_Native.fst in
-                                     FStar_Compiler_Effect.op_Bar_Greater
-                                       uu___8
-                                       (fun uu___9 ->
-                                          match uu___9 with
-                                          | a::bs ->
-                                              let uu___10 =
-                                                FStar_Compiler_List.splitAt
-                                                  num_effect_params bs in
-                                              (match uu___10 with
-                                               | (sig_bs, bs1) ->
-                                                   let ss =
-                                                     let uu___11 =
-                                                       let uu___12 =
-                                                         let uu___13 =
-                                                           let uu___14 =
-                                                             FStar_Compiler_Effect.op_Bar_Greater
-                                                               a_b.FStar_Syntax_Syntax.binder_bv
-                                                               FStar_Syntax_Syntax.bv_to_name in
-                                                           ((a.FStar_Syntax_Syntax.binder_bv),
-                                                             uu___14) in
-                                                         FStar_Syntax_Syntax.NT
-                                                           uu___13 in
-                                                       [uu___12] in
-                                                     FStar_Compiler_List.fold_left2
-                                                       (fun ss1 ->
-                                                          fun sig_b ->
-                                                            fun b ->
-                                                              let uu___12 =
-                                                                let uu___13 =
-                                                                  let uu___14
-                                                                    =
-                                                                    let uu___15
-                                                                    =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    b.FStar_Syntax_Syntax.binder_bv
-                                                                    FStar_Syntax_Syntax.bv_to_name in
-                                                                    ((sig_b.FStar_Syntax_Syntax.binder_bv),
-                                                                    uu___15) in
-                                                                  FStar_Syntax_Syntax.NT
-                                                                    uu___14 in
-                                                                [uu___13] in
-                                                              FStar_Compiler_List.op_At
-                                                                ss1 uu___12)
-                                                       uu___11 sig_bs
-                                                       eff_params_bs in
-                                                   FStar_Compiler_Effect.op_Bar_Greater
-                                                     bs1
-                                                     (FStar_Syntax_Subst.subst_binders
-                                                        ss))) in
+                                         FStar_Syntax_Util.arrow_formals sig1 in
+                                       FStar_Pervasives_Native.fst uu___9 in
+                                     (match uu___8 with
+                                      | a::bs ->
+                                          let uu___9 =
+                                            FStar_Compiler_List.splitAt
+                                              num_effect_params bs in
+                                          (match uu___9 with
+                                           | (sig_bs, bs1) ->
+                                               let ss =
+                                                 let uu___10 =
+                                                   let uu___11 =
+                                                     let uu___12 =
+                                                       let uu___13 =
+                                                         FStar_Syntax_Syntax.bv_to_name
+                                                           a_b.FStar_Syntax_Syntax.binder_bv in
+                                                       ((a.FStar_Syntax_Syntax.binder_bv),
+                                                         uu___13) in
+                                                     FStar_Syntax_Syntax.NT
+                                                       uu___12 in
+                                                   [uu___11] in
+                                                 FStar_Compiler_List.fold_left2
+                                                   (fun ss1 ->
+                                                      fun sig_b ->
+                                                        fun b ->
+                                                          let uu___11 =
+                                                            let uu___12 =
+                                                              let uu___13 =
+                                                                let uu___14 =
+                                                                  FStar_Syntax_Syntax.bv_to_name
+                                                                    b.FStar_Syntax_Syntax.binder_bv in
+                                                                ((sig_b.FStar_Syntax_Syntax.binder_bv),
+                                                                  uu___14) in
+                                                              FStar_Syntax_Syntax.NT
+                                                                uu___13 in
+                                                            [uu___12] in
+                                                          FStar_Compiler_List.op_At
+                                                            ss1 uu___11)
+                                                   uu___10 sig_bs
+                                                   eff_params_bs in
+                                               FStar_Syntax_Subst.subst_binders
+                                                 ss bs1)) in
                                let uu___6 =
                                  if
                                    (FStar_Compiler_List.length rest_bs1) <
@@ -2850,10 +2589,7 @@ let (ite_combinator_kind :
                                       FStar_Compiler_List.splitAt
                                         (FStar_Compiler_List.length f_sig_bs)
                                         rest_bs1 in
-                                    FStar_Compiler_Effect.op_Bar_Greater
-                                      uu___8
-                                      (fun uu___9 ->
-                                         FStar_Pervasives_Native.Some uu___9)) in
+                                    FStar_Pervasives_Native.Some uu___8) in
                                op_let_Question uu___6
                                  (fun uu___7 ->
                                     match uu___7 with
@@ -2862,11 +2598,8 @@ let (ite_combinator_kind :
                                           eq_binders env f_sig_bs f_bs in
                                         op_let_Question uu___8
                                           (fun f_bs_kinds ->
-                                             FStar_Compiler_Effect.op_Bar_Greater
-                                               (f_bs, f_bs_kinds, rest_bs2)
-                                               (fun uu___9 ->
-                                                  FStar_Pervasives_Native.Some
-                                                    uu___9))) in
+                                             FStar_Pervasives_Native.Some
+                                               (f_bs, f_bs_kinds, rest_bs2))) in
                              op_let_Question uu___5
                                (fun uu___6 ->
                                   match uu___6 with
@@ -2883,11 +2616,7 @@ let (ite_combinator_kind :
                                                   rest_bs2)
                                                  - (Prims.of_int (3)))
                                               rest_bs2 in
-                                          FStar_Compiler_Effect.op_Bar_Greater
-                                            uu___8
-                                            (fun uu___9 ->
-                                               FStar_Pervasives_Native.Some
-                                                 uu___9)
+                                          FStar_Pervasives_Native.Some uu___8
                                         else FStar_Pervasives_Native.None in
                                       op_let_Question uu___7
                                         (fun uu___8 ->
@@ -2905,12 +2634,10 @@ let (ite_combinator_kind :
                                                        let uu___12 =
                                                          let uu___13 =
                                                            let uu___14 =
-                                                             FStar_Compiler_Effect.op_Bar_Greater
-                                                               a_b.FStar_Syntax_Syntax.binder_bv
-                                                               FStar_Syntax_Syntax.bv_to_name in
-                                                           FStar_Compiler_Effect.op_Bar_Greater
-                                                             uu___14
-                                                             FStar_Syntax_Syntax.as_arg in
+                                                             FStar_Syntax_Syntax.bv_to_name
+                                                               a_b.FStar_Syntax_Syntax.binder_bv in
+                                                           FStar_Syntax_Syntax.as_arg
+                                                             uu___14 in
                                                          let uu___14 =
                                                            FStar_Compiler_List.map
                                                              (fun uu___15 ->
@@ -2928,12 +2655,10 @@ let (ite_combinator_kind :
                                                                     ->
                                                                     let uu___19
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    b
-                                                                    FStar_Syntax_Syntax.bv_to_name in
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___19
-                                                                    FStar_Syntax_Syntax.as_arg)
+                                                                    FStar_Syntax_Syntax.bv_to_name
+                                                                    b in
+                                                                    FStar_Syntax_Syntax.as_arg
+                                                                    uu___19)
                                                              (FStar_Compiler_List.op_At
                                                                 eff_params_bs
                                                                 f_bs) in
@@ -2968,12 +2693,10 @@ let (ite_combinator_kind :
                                                             let uu___12 =
                                                               let uu___13 =
                                                                 let uu___14 =
-                                                                  FStar_Compiler_Effect.op_Bar_Greater
-                                                                    a_b.FStar_Syntax_Syntax.binder_bv
-                                                                    FStar_Syntax_Syntax.bv_to_name in
-                                                                FStar_Compiler_Effect.op_Bar_Greater
-                                                                  uu___14
-                                                                  FStar_Syntax_Syntax.as_arg in
+                                                                  FStar_Syntax_Syntax.bv_to_name
+                                                                    a_b.FStar_Syntax_Syntax.binder_bv in
+                                                                FStar_Syntax_Syntax.as_arg
+                                                                  uu___14 in
                                                               let uu___14 =
                                                                 FStar_Compiler_List.map
                                                                   (fun
@@ -2994,12 +2717,10 @@ let (ite_combinator_kind :
                                                                     ->
                                                                     let uu___19
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    b
-                                                                    FStar_Syntax_Syntax.bv_to_name in
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___19
-                                                                    FStar_Syntax_Syntax.as_arg)
+                                                                    FStar_Syntax_Syntax.bv_to_name
+                                                                    b in
+                                                                    FStar_Syntax_Syntax.as_arg
+                                                                    uu___19)
                                                                   (FStar_Compiler_List.op_At
                                                                     eff_params_bs
                                                                     f_or_g_bs) in
@@ -3044,31 +2765,45 @@ let (ite_combinator_kind :
                                                                let uu___15 =
                                                                  let uu___16
                                                                    =
-                                                                   FStar_Compiler_Effect.op_Bar_Greater
-                                                                    sig1
-                                                                    FStar_Syntax_Util.arrow_formals in
-                                                                 FStar_Compiler_Effect.op_Bar_Greater
-                                                                   uu___16
-                                                                   FStar_Pervasives_Native.fst in
-                                                               FStar_Compiler_Effect.op_Bar_Greater
-                                                                 uu___15
-                                                                 (fun uu___16
-                                                                    ->
-                                                                    match uu___16
-                                                                    with
-                                                                    | 
-                                                                    a::bs ->
-                                                                    let uu___17
+                                                                   FStar_Syntax_Util.arrow_formals
+                                                                    sig1 in
+                                                                 FStar_Pervasives_Native.fst
+                                                                   uu___16 in
+                                                               (match uu___15
+                                                                with
+                                                                | a::bs ->
+                                                                    let uu___16
                                                                     =
                                                                     FStar_Compiler_List.splitAt
                                                                     num_effect_params
                                                                     bs in
-                                                                    (match uu___17
+                                                                    (match uu___16
                                                                     with
                                                                     | 
                                                                     (sig_bs,
                                                                     bs1) ->
                                                                     let ss =
+                                                                    let uu___17
+                                                                    =
+                                                                    let uu___18
+                                                                    =
+                                                                    let uu___19
+                                                                    =
+                                                                    let uu___20
+                                                                    =
+                                                                    FStar_Syntax_Syntax.bv_to_name
+                                                                    a_b.FStar_Syntax_Syntax.binder_bv in
+                                                                    ((a.FStar_Syntax_Syntax.binder_bv),
+                                                                    uu___20) in
+                                                                    FStar_Syntax_Syntax.NT
+                                                                    uu___19 in
+                                                                    [uu___18] in
+                                                                    FStar_Compiler_List.fold_left2
+                                                                    (fun ss1
+                                                                    ->
+                                                                    fun sig_b
+                                                                    ->
+                                                                    fun b ->
                                                                     let uu___18
                                                                     =
                                                                     let uu___19
@@ -3077,46 +2812,21 @@ let (ite_combinator_kind :
                                                                     =
                                                                     let uu___21
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    a_b.FStar_Syntax_Syntax.binder_bv
-                                                                    FStar_Syntax_Syntax.bv_to_name in
-                                                                    ((a.FStar_Syntax_Syntax.binder_bv),
+                                                                    FStar_Syntax_Syntax.bv_to_name
+                                                                    b.FStar_Syntax_Syntax.binder_bv in
+                                                                    ((sig_b.FStar_Syntax_Syntax.binder_bv),
                                                                     uu___21) in
                                                                     FStar_Syntax_Syntax.NT
                                                                     uu___20 in
                                                                     [uu___19] in
-                                                                    FStar_Compiler_List.fold_left2
-                                                                    (fun ss1
-                                                                    ->
-                                                                    fun sig_b
-                                                                    ->
-                                                                    fun b ->
-                                                                    let uu___19
-                                                                    =
-                                                                    let uu___20
-                                                                    =
-                                                                    let uu___21
-                                                                    =
-                                                                    let uu___22
-                                                                    =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    b.FStar_Syntax_Syntax.binder_bv
-                                                                    FStar_Syntax_Syntax.bv_to_name in
-                                                                    ((sig_b.FStar_Syntax_Syntax.binder_bv),
-                                                                    uu___22) in
-                                                                    FStar_Syntax_Syntax.NT
-                                                                    uu___21 in
-                                                                    [uu___20] in
                                                                     FStar_Compiler_List.op_At
                                                                     ss1
-                                                                    uu___19)
-                                                                    uu___18
+                                                                    uu___18)
+                                                                    uu___17
                                                                     sig_bs
                                                                     eff_params_bs in
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    bs1
-                                                                    (FStar_Syntax_Subst.subst_binders
-                                                                    ss))) in
+                                                                    FStar_Syntax_Subst.subst_binders
+                                                                    ss bs1)) in
                                                          let uu___13 =
                                                            if
                                                              (FStar_Compiler_List.length
@@ -3132,12 +2842,8 @@ let (ite_combinator_kind :
                                                                   (FStar_Compiler_List.length
                                                                     g_sig_bs)
                                                                   rest_bs3 in
-                                                              FStar_Compiler_Effect.op_Bar_Greater
-                                                                uu___15
-                                                                (fun uu___16
-                                                                   ->
-                                                                   FStar_Pervasives_Native.Some
-                                                                    uu___16)) in
+                                                              FStar_Pervasives_Native.Some
+                                                                uu___15) in
                                                          op_let_Question
                                                            uu___13
                                                            (fun uu___14 ->
@@ -3157,15 +2863,10 @@ let (ite_combinator_kind :
                                                                     fun
                                                                     g_bs_kinds
                                                                     ->
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
+                                                                    FStar_Pervasives_Native.Some
                                                                     (g_bs,
                                                                     g_bs_kinds,
-                                                                    rest_bs4)
-                                                                    (fun
-                                                                    uu___16
-                                                                    ->
-                                                                    FStar_Pervasives_Native.Some
-                                                                    uu___16))) in
+                                                                    rest_bs4))) in
                                                        op_let_Question
                                                          uu___12
                                                          (fun uu___13 ->
@@ -3190,9 +2891,8 @@ let (ite_combinator_kind :
                                                                     ->
                                                                     FStar_Syntax_Syntax.Ad_hoc_binder)
                                                                     rest_bs4 in
-                                                                    let uu___15
-                                                                    =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
+                                                                    FStar_Pervasives_Native.Some
+                                                                    (FStar_Syntax_Syntax.Substitutive_combinator
                                                                     (FStar_Compiler_List.op_At
                                                                     [FStar_Syntax_Syntax.Type_binder]
                                                                     (FStar_Compiler_List.op_At
@@ -3205,14 +2905,7 @@ let (ite_combinator_kind :
                                                                     rest_kinds
                                                                     [FStar_Syntax_Syntax.Repr_binder;
                                                                     FStar_Syntax_Syntax.Repr_binder;
-                                                                    FStar_Syntax_Syntax.Substitutive_binder])))))
-                                                                    (fun
-                                                                    uu___16
-                                                                    ->
-                                                                    FStar_Syntax_Syntax.Substitutive_combinator
-                                                                    uu___16) in
-                                                                    FStar_Pervasives_Native.Some
-                                                                    uu___15)))))))
+                                                                    FStar_Syntax_Syntax.Substitutive_binder])))))))))))))
 let (validate_indexed_effect_ite_shape :
   FStar_TypeChecker_Env.env ->
     FStar_Ident.lident ->
@@ -3241,17 +2934,11 @@ let (validate_indexed_effect_ite_shape :
                     let a_b =
                       let uu___ =
                         let uu___1 =
-                          let uu___2 =
-                            FStar_Compiler_Effect.op_Bar_Greater u
-                              (fun uu___3 ->
-                                 FStar_Syntax_Syntax.U_name uu___3) in
-                          FStar_Compiler_Effect.op_Bar_Greater uu___2
-                            FStar_Syntax_Util.type_with_u in
-                        FStar_Compiler_Effect.op_Bar_Greater uu___1
-                          (FStar_Syntax_Syntax.gen_bv "a"
-                             FStar_Pervasives_Native.None) in
-                      FStar_Compiler_Effect.op_Bar_Greater uu___
-                        FStar_Syntax_Syntax.mk_binder in
+                          FStar_Syntax_Util.type_with_u
+                            (FStar_Syntax_Syntax.U_name u) in
+                        FStar_Syntax_Syntax.gen_bv "a"
+                          FStar_Pervasives_Native.None uu___1 in
+                      FStar_Syntax_Syntax.mk_binder uu___ in
                     let rest_bs =
                       let uu___ =
                         let uu___1 = FStar_Syntax_Subst.compress ite_ty in
@@ -3273,26 +2960,20 @@ let (validate_indexed_effect_ite_shape :
                                ->
                                let uu___6 =
                                  let uu___7 =
-                                   FStar_Compiler_Effect.op_Bar_Greater bs1
-                                     (FStar_Compiler_List.splitAt
-                                        ((FStar_Compiler_List.length bs1) -
-                                           (Prims.of_int (3)))) in
-                                 FStar_Compiler_Effect.op_Bar_Greater uu___7
-                                   FStar_Pervasives_Native.fst in
+                                   let uu___8 =
+                                     let uu___9 =
+                                       FStar_Syntax_Syntax.bv_to_name
+                                         a_b.FStar_Syntax_Syntax.binder_bv in
+                                     (a, uu___9) in
+                                   FStar_Syntax_Syntax.NT uu___8 in
+                                 [uu___7] in
                                let uu___7 =
                                  let uu___8 =
-                                   let uu___9 =
-                                     let uu___10 =
-                                       let uu___11 =
-                                         FStar_Compiler_Effect.op_Bar_Greater
-                                           a_b.FStar_Syntax_Syntax.binder_bv
-                                           FStar_Syntax_Syntax.bv_to_name in
-                                       (a, uu___11) in
-                                     FStar_Syntax_Syntax.NT uu___10 in
-                                   [uu___9] in
-                                 FStar_Syntax_Subst.subst_binders uu___8 in
-                               FStar_Compiler_Effect.op_Bar_Greater uu___6
-                                 uu___7)
+                                   FStar_Compiler_List.splitAt
+                                     ((FStar_Compiler_List.length bs1) -
+                                        (Prims.of_int (3))) bs1 in
+                                 FStar_Pervasives_Native.fst uu___8 in
+                               FStar_Syntax_Subst.subst_binders uu___6 uu___7)
                       | uu___1 ->
                           let uu___2 =
                             let uu___3 =
@@ -3310,9 +2991,8 @@ let (validate_indexed_effect_ite_shape :
                           FStar_TypeChecker_Env.push_binders env (a_b ::
                             rest_bs) in
                         let uu___3 =
-                          FStar_Compiler_Effect.op_Bar_Greater
-                            a_b.FStar_Syntax_Syntax.binder_bv
-                            FStar_Syntax_Syntax.bv_to_name in
+                          FStar_Syntax_Syntax.bv_to_name
+                            a_b.FStar_Syntax_Syntax.binder_bv in
                         FStar_TypeChecker_Util.fresh_effect_repr uu___2 r
                           eff_name sig_ts
                           (FStar_Pervasives_Native.Some repr_ts)
@@ -3321,11 +3001,9 @@ let (validate_indexed_effect_ite_shape :
                       | (repr, g) ->
                           let uu___2 =
                             let uu___3 =
-                              FStar_Compiler_Effect.op_Bar_Greater repr
-                                (FStar_Syntax_Syntax.gen_bv "f"
-                                   FStar_Pervasives_Native.None) in
-                            FStar_Compiler_Effect.op_Bar_Greater uu___3
-                              FStar_Syntax_Syntax.mk_binder in
+                              FStar_Syntax_Syntax.gen_bv "f"
+                                FStar_Pervasives_Native.None repr in
+                            FStar_Syntax_Syntax.mk_binder uu___3 in
                           (uu___2, g) in
                     match uu___ with
                     | (f, guard_f) ->
@@ -3335,9 +3013,8 @@ let (validate_indexed_effect_ite_shape :
                               FStar_TypeChecker_Env.push_binders env (a_b ::
                                 rest_bs) in
                             let uu___4 =
-                              FStar_Compiler_Effect.op_Bar_Greater
-                                a_b.FStar_Syntax_Syntax.binder_bv
-                                FStar_Syntax_Syntax.bv_to_name in
+                              FStar_Syntax_Syntax.bv_to_name
+                                a_b.FStar_Syntax_Syntax.binder_bv in
                             FStar_TypeChecker_Util.fresh_effect_repr uu___3 r
                               eff_name sig_ts
                               (FStar_Pervasives_Native.Some repr_ts)
@@ -3346,11 +3023,9 @@ let (validate_indexed_effect_ite_shape :
                           | (repr, g) ->
                               let uu___3 =
                                 let uu___4 =
-                                  FStar_Compiler_Effect.op_Bar_Greater repr
-                                    (FStar_Syntax_Syntax.gen_bv "g"
-                                       FStar_Pervasives_Native.None) in
-                                FStar_Compiler_Effect.op_Bar_Greater uu___4
-                                  FStar_Syntax_Syntax.mk_binder in
+                                  FStar_Syntax_Syntax.gen_bv "g"
+                                    FStar_Pervasives_Native.None repr in
+                                FStar_Syntax_Syntax.mk_binder uu___4 in
                               (uu___3, g) in
                         (match uu___1 with
                          | (g, guard_g) ->
@@ -3359,17 +3034,15 @@ let (validate_indexed_effect_ite_shape :
                                  FStar_Syntax_Syntax.gen_bv "p"
                                    FStar_Pervasives_Native.None
                                    FStar_Syntax_Util.t_bool in
-                               FStar_Compiler_Effect.op_Bar_Greater uu___2
-                                 FStar_Syntax_Syntax.mk_binder in
+                               FStar_Syntax_Syntax.mk_binder uu___2 in
                              let uu___2 =
                                let uu___3 =
                                  FStar_TypeChecker_Env.push_binders env
                                    (FStar_Compiler_List.op_At (a_b ::
                                       rest_bs) [p]) in
                                let uu___4 =
-                                 FStar_Compiler_Effect.op_Bar_Greater
-                                   a_b.FStar_Syntax_Syntax.binder_bv
-                                   FStar_Syntax_Syntax.bv_to_name in
+                                 FStar_Syntax_Syntax.bv_to_name
+                                   a_b.FStar_Syntax_Syntax.binder_bv in
                                FStar_TypeChecker_Util.fresh_effect_repr
                                  uu___3 r eff_name sig_ts
                                  (FStar_Pervasives_Native.Some repr_ts)
@@ -3409,12 +3082,9 @@ let (validate_indexed_effect_ite_shape :
                                       env uu___4);
                                    (let k1 =
                                       let uu___4 =
-                                        FStar_Compiler_Effect.op_Bar_Greater
-                                          k
-                                          (FStar_TypeChecker_Normalize.remove_uvar_solutions
-                                             env) in
-                                      FStar_Compiler_Effect.op_Bar_Greater
-                                        uu___4 FStar_Syntax_Subst.compress in
+                                        FStar_TypeChecker_Normalize.remove_uvar_solutions
+                                          env k in
+                                      FStar_Syntax_Subst.compress uu___4 in
                                     let kopt =
                                       ite_combinator_kind env eff_name sig_ts
                                         repr_ts u k1 num_effect_params in
@@ -3426,8 +3096,7 @@ let (validate_indexed_effect_ite_shape :
                                            FStar_Syntax_Syntax.Ad_hoc_combinator)
                                       | FStar_Pervasives_Native.Some k2 -> k2 in
                                     (let uu___5 =
-                                       FStar_Compiler_Effect.op_Less_Bar
-                                         (FStar_TypeChecker_Env.debug env)
+                                       FStar_TypeChecker_Env.debug env
                                          (FStar_Options.Other
                                             "LayeredEffectsTc") in
                                      if uu___5
@@ -3466,29 +3135,20 @@ let (validate_indexed_effect_close_shape :
                     let b_b =
                       let uu___ =
                         let uu___1 =
-                          let uu___2 =
-                            FStar_Compiler_Effect.op_Bar_Greater u_b
-                              (fun uu___3 ->
-                                 FStar_Syntax_Syntax.U_name uu___3) in
-                          FStar_Compiler_Effect.op_Bar_Greater uu___2
-                            FStar_Syntax_Util.type_with_u in
-                        FStar_Compiler_Effect.op_Bar_Greater uu___1
-                          (FStar_Syntax_Syntax.gen_bv "b"
-                             FStar_Pervasives_Native.None) in
-                      FStar_Compiler_Effect.op_Bar_Greater uu___
-                        FStar_Syntax_Syntax.mk_binder in
+                          FStar_Syntax_Util.type_with_u
+                            (FStar_Syntax_Syntax.U_name u_b) in
+                        FStar_Syntax_Syntax.gen_bv "b"
+                          FStar_Pervasives_Native.None uu___1 in
+                      FStar_Syntax_Syntax.mk_binder uu___ in
                     let uu___ =
                       let uu___1 =
                         let uu___2 =
                           let uu___3 =
                             FStar_TypeChecker_Env.inst_tscheme_with sig_ts
                               [FStar_Syntax_Syntax.U_name u_a] in
-                          FStar_Compiler_Effect.op_Bar_Greater uu___3
-                            FStar_Pervasives_Native.snd in
-                        FStar_Compiler_Effect.op_Bar_Greater uu___2
-                          FStar_Syntax_Util.arrow_formals in
-                      FStar_Compiler_Effect.op_Bar_Greater uu___1
-                        FStar_Pervasives_Native.fst in
+                          FStar_Pervasives_Native.snd uu___3 in
+                        FStar_Syntax_Util.arrow_formals uu___2 in
+                      FStar_Pervasives_Native.fst uu___1 in
                     match uu___ with
                     | a_b::sig_bs ->
                         let uu___1 =
@@ -3506,8 +3166,7 @@ let (validate_indexed_effect_close_shape :
                                             b_b.FStar_Syntax_Syntax.binder_bv in
                                         FStar_Syntax_Syntax.gen_bv "x"
                                           FStar_Pervasives_Native.None uu___3 in
-                                      FStar_Compiler_Effect.op_Bar_Greater
-                                        uu___2 FStar_Syntax_Syntax.mk_binder in
+                                      FStar_Syntax_Syntax.mk_binder uu___2 in
                                     let uu___2 =
                                       let uu___3 =
                                         b.FStar_Syntax_Syntax.binder_bv in
@@ -3545,8 +3204,7 @@ let (validate_indexed_effect_close_shape :
                                            b_b.FStar_Syntax_Syntax.binder_bv in
                                        FStar_Syntax_Syntax.gen_bv "x"
                                          FStar_Pervasives_Native.None uu___5 in
-                                     FStar_Compiler_Effect.op_Bar_Greater
-                                       uu___4 FStar_Syntax_Syntax.mk_binder in
+                                     FStar_Syntax_Syntax.mk_binder uu___4 in
                                    let is_args =
                                      FStar_Compiler_List.map
                                        (fun uu___4 ->
@@ -3568,29 +3226,23 @@ let (validate_indexed_effect_close_shape :
                                                 let uu___10 =
                                                   let uu___11 =
                                                     let uu___12 =
-                                                      FStar_Compiler_Effect.op_Bar_Greater
-                                                        x_b.FStar_Syntax_Syntax.binder_bv
-                                                        FStar_Syntax_Syntax.bv_to_name in
-                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                      uu___12
-                                                      FStar_Syntax_Syntax.as_arg in
+                                                      FStar_Syntax_Syntax.bv_to_name
+                                                        x_b.FStar_Syntax_Syntax.binder_bv in
+                                                    FStar_Syntax_Syntax.as_arg
+                                                      uu___12 in
                                                   [uu___11] in
                                                 FStar_Syntax_Syntax.mk_Tm_app
                                                   uu___9 uu___10
                                                   FStar_Compiler_Range_Type.dummyRange in
-                                              FStar_Compiler_Effect.op_Bar_Greater
-                                                uu___8
-                                                FStar_Syntax_Syntax.as_arg)
-                                       bs in
+                                              FStar_Syntax_Syntax.as_arg
+                                                uu___8) bs in
                                    let repr_app =
                                      let uu___4 =
                                        let uu___5 =
                                          let uu___6 =
-                                           FStar_Compiler_Effect.op_Bar_Greater
-                                             a_b.FStar_Syntax_Syntax.binder_bv
-                                             FStar_Syntax_Syntax.bv_to_name in
-                                         FStar_Compiler_Effect.op_Bar_Greater
-                                           uu___6 FStar_Syntax_Syntax.as_arg in
+                                           FStar_Syntax_Syntax.bv_to_name
+                                             a_b.FStar_Syntax_Syntax.binder_bv in
+                                         FStar_Syntax_Syntax.as_arg uu___6 in
                                        uu___5 :: is_args in
                                      FStar_Syntax_Syntax.mk_Tm_app repr_t
                                        uu___4
@@ -3602,17 +3254,15 @@ let (validate_indexed_effect_close_shape :
                                    let uu___4 =
                                      FStar_Syntax_Syntax.gen_bv "f"
                                        FStar_Pervasives_Native.None f_sort in
-                                   FStar_Compiler_Effect.op_Bar_Greater
-                                     uu___4 FStar_Syntax_Syntax.mk_binder in
+                                   FStar_Syntax_Syntax.mk_binder uu___4 in
                              let env1 =
                                FStar_TypeChecker_Env.push_binders env (a_b ::
                                  b_b ::
                                  (FStar_Compiler_List.op_At eff_params_bs bs)) in
                              let uu___2 =
                                let uu___3 =
-                                 FStar_Compiler_Effect.op_Bar_Greater
-                                   a_b.FStar_Syntax_Syntax.binder_bv
-                                   FStar_Syntax_Syntax.bv_to_name in
+                                 FStar_Syntax_Syntax.bv_to_name
+                                   a_b.FStar_Syntax_Syntax.binder_bv in
                                FStar_TypeChecker_Util.fresh_effect_repr env1
                                  r eff_name sig_ts
                                  (FStar_Pervasives_Native.Some repr_ts)
@@ -3649,11 +3299,9 @@ let (validate_indexed_effect_close_shape :
                                     FStar_TypeChecker_Rel.force_trivial_guard
                                       env1 uu___4);
                                    (let uu___4 =
-                                      FStar_Compiler_Effect.op_Bar_Greater k
-                                        (FStar_TypeChecker_Normalize.remove_uvar_solutions
-                                           env1) in
-                                    FStar_Compiler_Effect.op_Bar_Greater
-                                      uu___4 FStar_Syntax_Subst.compress))))
+                                      FStar_TypeChecker_Normalize.remove_uvar_solutions
+                                        env1 k in
+                                    FStar_Syntax_Subst.compress uu___4))))
 let (lift_combinator_kind :
   FStar_TypeChecker_Env.env ->
     FStar_Ident.lident ->
@@ -3681,27 +3329,21 @@ let (lift_combinator_kind :
                       match uu___3 with
                       | (uu___4, sig1) ->
                           let uu___5 =
-                            let uu___6 =
-                              FStar_Compiler_Effect.op_Bar_Greater sig1
-                                FStar_Syntax_Util.arrow_formals in
-                            FStar_Compiler_Effect.op_Bar_Greater uu___6
-                              FStar_Pervasives_Native.fst in
-                          FStar_Compiler_Effect.op_Bar_Greater uu___5
-                            (fun uu___6 ->
-                               match uu___6 with
-                               | a::bs ->
-                                   let uu___7 =
-                                     let uu___8 =
-                                       let uu___9 =
-                                         let uu___10 =
-                                           FStar_Compiler_Effect.op_Bar_Greater
-                                             a_b.FStar_Syntax_Syntax.binder_bv
-                                             FStar_Syntax_Syntax.bv_to_name in
-                                         ((a.FStar_Syntax_Syntax.binder_bv),
-                                           uu___10) in
-                                       FStar_Syntax_Syntax.NT uu___9 in
-                                     [uu___8] in
-                                   FStar_Syntax_Subst.subst_binders uu___7 bs) in
+                            let uu___6 = FStar_Syntax_Util.arrow_formals sig1 in
+                            FStar_Pervasives_Native.fst uu___6 in
+                          (match uu___5 with
+                           | a::bs ->
+                               let uu___6 =
+                                 let uu___7 =
+                                   let uu___8 =
+                                     let uu___9 =
+                                       FStar_Syntax_Syntax.bv_to_name
+                                         a_b.FStar_Syntax_Syntax.binder_bv in
+                                     ((a.FStar_Syntax_Syntax.binder_bv),
+                                       uu___9) in
+                                   FStar_Syntax_Syntax.NT uu___8 in
+                                 [uu___7] in
+                               FStar_Syntax_Subst.subst_binders uu___6 bs) in
                     let uu___3 =
                       if
                         (FStar_Compiler_List.length rest_bs) <
@@ -3711,8 +3353,7 @@ let (lift_combinator_kind :
                         (let uu___5 =
                            FStar_Compiler_List.splitAt
                              (FStar_Compiler_List.length f_sig_bs) rest_bs in
-                         FStar_Compiler_Effect.op_Bar_Greater uu___5
-                           (fun uu___6 -> FStar_Pervasives_Native.Some uu___6)) in
+                         FStar_Pervasives_Native.Some uu___5) in
                     op_let_Question uu___3
                       (fun uu___4 ->
                          match uu___4 with
@@ -3720,10 +3361,8 @@ let (lift_combinator_kind :
                              let uu___5 = eq_binders env f_sig_bs f_bs in
                              op_let_Question uu___5
                                (fun f_bs_kinds ->
-                                  FStar_Compiler_Effect.op_Bar_Greater
-                                    (f_bs, f_bs_kinds, rest_bs1)
-                                    (fun uu___6 ->
-                                       FStar_Pervasives_Native.Some uu___6))) in
+                                  FStar_Pervasives_Native.Some
+                                    (f_bs, f_bs_kinds, rest_bs1))) in
                   op_let_Question uu___2
                     (fun uu___3 ->
                        match uu___3 with
@@ -3739,10 +3378,8 @@ let (lift_combinator_kind :
                                       Prims.int_one) rest_bs1 in
                                match uu___5 with
                                | (rest_bs2, f_b::[]) ->
-                                   FStar_Compiler_Effect.op_Bar_Greater
+                                   FStar_Pervasives_Native.Some
                                      (rest_bs2, f_b)
-                                     (fun uu___6 ->
-                                        FStar_Pervasives_Native.Some uu___6)
                              else FStar_Pervasives_Native.None in
                            op_let_Question uu___4
                              (fun uu___5 ->
@@ -3762,12 +3399,10 @@ let (lift_combinator_kind :
                                                  let uu___9 =
                                                    let uu___10 =
                                                      let uu___11 =
-                                                       FStar_Compiler_Effect.op_Bar_Greater
-                                                         a_b.FStar_Syntax_Syntax.binder_bv
-                                                         FStar_Syntax_Syntax.bv_to_name in
-                                                     FStar_Compiler_Effect.op_Bar_Greater
-                                                       uu___11
-                                                       FStar_Syntax_Syntax.as_arg in
+                                                       FStar_Syntax_Syntax.bv_to_name
+                                                         a_b.FStar_Syntax_Syntax.binder_bv in
+                                                     FStar_Syntax_Syntax.as_arg
+                                                       uu___11 in
                                                    let uu___11 =
                                                      FStar_Compiler_List.map
                                                        (fun uu___12 ->
@@ -3783,13 +3418,10 @@ let (lift_combinator_kind :
                                                                 = uu___15;_}
                                                               ->
                                                               let uu___16 =
-                                                                FStar_Compiler_Effect.op_Bar_Greater
-                                                                  b
-                                                                  FStar_Syntax_Syntax.bv_to_name in
-                                                              FStar_Compiler_Effect.op_Bar_Greater
-                                                                uu___16
-                                                                FStar_Syntax_Syntax.as_arg)
-                                                       f_bs in
+                                                                FStar_Syntax_Syntax.bv_to_name
+                                                                  b in
+                                                              FStar_Syntax_Syntax.as_arg
+                                                                uu___16) f_bs in
                                                    uu___10 :: uu___11 in
                                                  FStar_Syntax_Syntax.mk_Tm_app
                                                    t uu___9
@@ -3803,21 +3435,16 @@ let (lift_combinator_kind :
                                             let uu___8 =
                                               let uu___9 =
                                                 let uu___10 =
-                                                  FStar_Compiler_Effect.op_Bar_Greater
-                                                    a_b.FStar_Syntax_Syntax.binder_bv
-                                                    FStar_Syntax_Syntax.bv_to_name in
+                                                  FStar_Syntax_Syntax.bv_to_name
+                                                    a_b.FStar_Syntax_Syntax.binder_bv in
                                                 let uu___11 =
-                                                  FStar_Compiler_Effect.op_Bar_Greater
-                                                    f_bs
-                                                    (FStar_Compiler_List.map
-                                                       (fun b ->
-                                                          let uu___12 =
-                                                            FStar_Compiler_Effect.op_Bar_Greater
-                                                              b.FStar_Syntax_Syntax.binder_bv
-                                                              FStar_Syntax_Syntax.bv_to_name in
-                                                          FStar_Compiler_Effect.op_Bar_Greater
-                                                            uu___12
-                                                            FStar_Syntax_Syntax.as_arg)) in
+                                                  FStar_Compiler_List.map
+                                                    (fun b ->
+                                                       let uu___12 =
+                                                         FStar_Syntax_Syntax.bv_to_name
+                                                           b.FStar_Syntax_Syntax.binder_bv in
+                                                       FStar_Syntax_Syntax.as_arg
+                                                         uu___12) f_bs in
                                                 {
                                                   FStar_Syntax_Syntax.comp_univs
                                                     =
@@ -3894,14 +3521,11 @@ let (validate_indexed_effect_lift_shape :
                   let a_b =
                     let uu___1 =
                       let uu___2 =
-                        FStar_Compiler_Effect.op_Bar_Greater
-                          (FStar_Syntax_Syntax.U_name u)
-                          FStar_Syntax_Util.type_with_u in
-                      FStar_Compiler_Effect.op_Bar_Greater uu___2
-                        (FStar_Syntax_Syntax.gen_bv "a"
-                           FStar_Pervasives_Native.None) in
-                    FStar_Compiler_Effect.op_Bar_Greater uu___1
-                      FStar_Syntax_Syntax.mk_binder in
+                        FStar_Syntax_Util.type_with_u
+                          (FStar_Syntax_Syntax.U_name u) in
+                      FStar_Syntax_Syntax.gen_bv "a"
+                        FStar_Pervasives_Native.None uu___2 in
+                    FStar_Syntax_Syntax.mk_binder uu___1 in
                   let uu___1 =
                     let uu___2 =
                       let uu___3 = FStar_Syntax_Subst.compress lift_t in
@@ -3923,29 +3547,23 @@ let (validate_indexed_effect_lift_shape :
                              let uu___7 =
                                let uu___8 =
                                  let uu___9 =
-                                   FStar_Compiler_Effect.op_Bar_Greater bs1
-                                     (FStar_Compiler_List.splitAt
-                                        ((FStar_Compiler_List.length bs1) -
-                                           Prims.int_one)) in
-                                 FStar_Compiler_Effect.op_Bar_Greater uu___9
-                                   FStar_Pervasives_Native.fst in
+                                   let uu___10 =
+                                     let uu___11 =
+                                       FStar_Syntax_Syntax.bv_to_name
+                                         a_b.FStar_Syntax_Syntax.binder_bv in
+                                     (a, uu___11) in
+                                   FStar_Syntax_Syntax.NT uu___10 in
+                                 [uu___9] in
                                let uu___9 =
                                  let uu___10 =
-                                   let uu___11 =
-                                     let uu___12 =
-                                       let uu___13 =
-                                         FStar_Syntax_Syntax.bv_to_name
-                                           a_b.FStar_Syntax_Syntax.binder_bv in
-                                       (a, uu___13) in
-                                     FStar_Syntax_Syntax.NT uu___12 in
-                                   [uu___11] in
-                                 FStar_Syntax_Subst.subst_binders uu___10 in
-                               FStar_Compiler_Effect.op_Bar_Greater uu___8
-                                 uu___9 in
+                                   FStar_Compiler_List.splitAt
+                                     ((FStar_Compiler_List.length bs1) -
+                                        Prims.int_one) bs1 in
+                                 FStar_Pervasives_Native.fst uu___10 in
+                               FStar_Syntax_Subst.subst_binders uu___8 uu___9 in
                              let uu___8 =
-                               FStar_Compiler_Effect.op_Bar_Greater
-                                 (FStar_Syntax_Util.comp_effect_name c)
-                                 (FStar_TypeChecker_Env.norm_eff_name env) in
+                               FStar_TypeChecker_Env.norm_eff_name env
+                                 (FStar_Syntax_Util.comp_effect_name c) in
                              (uu___7, uu___8))
                     | uu___3 ->
                         let uu___4 =
@@ -3988,9 +3606,8 @@ let (validate_indexed_effect_lift_shape :
                                  m_ed.FStar_Syntax_Syntax.signature in
                              let uu___7 = FStar_Syntax_Util.get_eff_repr m_ed in
                              let uu___8 =
-                               FStar_Compiler_Effect.op_Bar_Greater
-                                 a_b.FStar_Syntax_Syntax.binder_bv
-                                 FStar_Syntax_Syntax.bv_to_name in
+                               FStar_Syntax_Syntax.bv_to_name
+                                 a_b.FStar_Syntax_Syntax.binder_bv in
                              FStar_TypeChecker_Util.fresh_effect_repr uu___5
                                r m_eff_name uu___6 uu___7
                                (FStar_Syntax_Syntax.U_name u) uu___8 in
@@ -3998,11 +3615,9 @@ let (validate_indexed_effect_lift_shape :
                            | (repr, g) ->
                                let uu___5 =
                                  let uu___6 =
-                                   FStar_Compiler_Effect.op_Bar_Greater repr
-                                     (FStar_Syntax_Syntax.gen_bv "f"
-                                        FStar_Pervasives_Native.None) in
-                                 FStar_Compiler_Effect.op_Bar_Greater uu___6
-                                   FStar_Syntax_Syntax.mk_binder in
+                                   FStar_Syntax_Syntax.gen_bv "f"
+                                     FStar_Pervasives_Native.None repr in
+                                 FStar_Syntax_Syntax.mk_binder uu___6 in
                                (uu___5, g) in
                          match uu___3 with
                          | (f, guard_f) ->
@@ -4016,9 +3631,8 @@ let (validate_indexed_effect_lift_shape :
                                let uu___7 =
                                  FStar_Syntax_Util.get_eff_repr n_ed in
                                let uu___8 =
-                                 FStar_Compiler_Effect.op_Bar_Greater
-                                   a_b.FStar_Syntax_Syntax.binder_bv
-                                   FStar_Syntax_Syntax.bv_to_name in
+                                 FStar_Syntax_Syntax.bv_to_name
+                                   a_b.FStar_Syntax_Syntax.binder_bv in
                                FStar_TypeChecker_Util.fresh_effect_repr
                                  uu___5 r n_eff_name uu___6 uu___7
                                  (FStar_Syntax_Syntax.U_name u) uu___8 in
@@ -4044,9 +3658,8 @@ let (validate_indexed_effect_lift_shape :
                                              [uu___8] in
                                            let uu___8 =
                                              let uu___9 =
-                                               FStar_Compiler_Effect.op_Bar_Greater
-                                                 pure_wp_uvar1
-                                                 FStar_Syntax_Syntax.as_arg in
+                                               FStar_Syntax_Syntax.as_arg
+                                                 pure_wp_uvar1 in
                                              [uu___9] in
                                            {
                                              FStar_Syntax_Syntax.comp_univs =
@@ -4094,13 +3707,9 @@ let (validate_indexed_effect_lift_shape :
                                            env uu___7);
                                         (let k1 =
                                            let uu___7 =
-                                             FStar_Compiler_Effect.op_Bar_Greater
-                                               k
-                                               (FStar_TypeChecker_Normalize.remove_uvar_solutions
-                                                  env) in
-                                           FStar_Compiler_Effect.op_Bar_Greater
-                                             uu___7
-                                             FStar_Syntax_Subst.compress in
+                                             FStar_TypeChecker_Normalize.remove_uvar_solutions
+                                               env k in
+                                           FStar_Syntax_Subst.compress uu___7 in
                                          let lopt =
                                            let uu___7 =
                                              FStar_Syntax_Util.effect_sig_ts
@@ -4121,9 +3730,7 @@ let (validate_indexed_effect_lift_shape :
                                                FStar_Syntax_Syntax.Substitutive_combinator
                                                  l in
                                          (let uu___8 =
-                                            FStar_Compiler_Effect.op_Less_Bar
-                                              (FStar_TypeChecker_Env.debug
-                                                 env)
+                                            FStar_TypeChecker_Env.debug env
                                               (FStar_Options.Other
                                                  "LayeredEffectsTc") in
                                           if uu___8
@@ -4155,8 +3762,7 @@ let (tc_layered_eff_decl :
           FStar_Errors.with_ctx uu___
             (fun uu___1 ->
                (let uu___3 =
-                  FStar_Compiler_Effect.op_Less_Bar
-                    (FStar_TypeChecker_Env.debug env0)
+                  FStar_TypeChecker_Env.debug env0
                     (FStar_Options.Other "LayeredEffectsTc") in
                 if uu___3
                 then
@@ -4191,8 +3797,7 @@ let (tc_layered_eff_decl :
                   match uu___4 with
                   | (us, t, ty) ->
                       let uu___5 =
-                        FStar_Compiler_Effect.op_Less_Bar
-                          (FStar_TypeChecker_Env.debug env0)
+                        FStar_TypeChecker_Env.debug env0
                           (FStar_Options.Other "LayeredEffectsTc") in
                       if uu___5
                       then
@@ -4209,17 +3814,14 @@ let (tc_layered_eff_decl :
                       else () in
                 let fresh_a_and_u_a a =
                   let uu___4 = FStar_Syntax_Util.type_u () in
-                  FStar_Compiler_Effect.op_Bar_Greater uu___4
-                    (fun uu___5 ->
-                       match uu___5 with
-                       | (t, u) ->
-                           let uu___6 =
-                             let uu___7 =
-                               FStar_Syntax_Syntax.gen_bv a
-                                 FStar_Pervasives_Native.None t in
-                             FStar_Compiler_Effect.op_Bar_Greater uu___7
-                               FStar_Syntax_Syntax.mk_binder in
-                           (uu___6, u)) in
+                  match uu___4 with
+                  | (t, u) ->
+                      let uu___5 =
+                        let uu___6 =
+                          FStar_Syntax_Syntax.gen_bv a
+                            FStar_Pervasives_Native.None t in
+                        FStar_Syntax_Syntax.mk_binder uu___6 in
+                      (uu___5, u) in
                 let fresh_x_a x a =
                   let uu___4 =
                     let uu___5 =
@@ -4227,8 +3829,7 @@ let (tc_layered_eff_decl :
                         a.FStar_Syntax_Syntax.binder_bv in
                     FStar_Syntax_Syntax.gen_bv x FStar_Pervasives_Native.None
                       uu___5 in
-                  FStar_Compiler_Effect.op_Bar_Greater uu___4
-                    FStar_Syntax_Syntax.mk_binder in
+                  FStar_Syntax_Syntax.mk_binder uu___4 in
                 let check_and_gen1 =
                   let uu___4 =
                     FStar_Ident.string_of_lid ed.FStar_Syntax_Syntax.mname in
@@ -4260,9 +3861,8 @@ let (tc_layered_eff_decl :
                                  | (a, u) ->
                                      let rest_bs =
                                        let uu___9 =
-                                         FStar_Compiler_Effect.op_Bar_Greater
-                                           a.FStar_Syntax_Syntax.binder_bv
-                                           FStar_Syntax_Syntax.bv_to_name in
+                                         FStar_Syntax_Syntax.bv_to_name
+                                           a.FStar_Syntax_Syntax.binder_bv in
                                        FStar_TypeChecker_Util.layered_effect_indices_as_binders
                                          env r ed.FStar_Syntax_Syntax.mname
                                          (sig_us, sig_t) u uu___9 in
@@ -4279,10 +3879,8 @@ let (tc_layered_eff_decl :
                                       (let uu___10 =
                                          let uu___11 =
                                            let uu___12 =
-                                             FStar_Compiler_Effect.op_Bar_Greater
-                                               k
-                                               (FStar_TypeChecker_Normalize.remove_uvar_solutions
-                                                  env) in
+                                             FStar_TypeChecker_Normalize.remove_uvar_solutions
+                                               env k in
                                            FStar_Syntax_Subst.close_univ_vars
                                              us uu___12 in
                                          (sig_us, uu___11, sig_ty) in
@@ -4292,11 +3890,8 @@ let (tc_layered_eff_decl :
                     (log_combinator "signature" signature;
                      (let repr =
                         let repr_ts =
-                          let uu___6 =
-                            FStar_Compiler_Effect.op_Bar_Greater ed
-                              FStar_Syntax_Util.get_eff_repr in
-                          FStar_Compiler_Effect.op_Bar_Greater uu___6
-                            FStar_Compiler_Util.must in
+                          let uu___6 = FStar_Syntax_Util.get_eff_repr ed in
+                          FStar_Compiler_Util.must uu___6 in
                         let r =
                           (FStar_Pervasives_Native.snd repr_ts).FStar_Syntax_Syntax.pos in
                         let uu___6 =
@@ -4320,9 +3915,8 @@ let (tc_layered_eff_decl :
                                           match uu___9 with
                                           | (us1, t, uu___10) -> (us1, t) in
                                         let uu___9 =
-                                          FStar_Compiler_Effect.op_Bar_Greater
-                                            a.FStar_Syntax_Syntax.binder_bv
-                                            FStar_Syntax_Syntax.bv_to_name in
+                                          FStar_Syntax_Syntax.bv_to_name
+                                            a.FStar_Syntax_Syntax.binder_bv in
                                         FStar_TypeChecker_Util.layered_effect_indices_as_binders
                                           env r ed.FStar_Syntax_Syntax.mname
                                           signature_ts u uu___9 in
@@ -4331,13 +3925,9 @@ let (tc_layered_eff_decl :
                                         let uu___9 =
                                           let uu___10 =
                                             FStar_Syntax_Util.type_u () in
-                                          FStar_Compiler_Effect.op_Bar_Greater
-                                            uu___10
-                                            (fun uu___11 ->
-                                               match uu___11 with
-                                               | (t, u1) ->
-                                                   FStar_Syntax_Syntax.mk_Total
-                                                     t) in
+                                          match uu___10 with
+                                          | (t, u1) ->
+                                              FStar_Syntax_Syntax.mk_Total t in
                                         FStar_Syntax_Util.arrow bs uu___9 in
                                       let g =
                                         FStar_TypeChecker_Rel.teq env ty k in
@@ -4345,10 +3935,8 @@ let (tc_layered_eff_decl :
                                          env g;
                                        (let uu___10 =
                                           let uu___11 =
-                                            FStar_Compiler_Effect.op_Bar_Greater
-                                              k
-                                              (FStar_TypeChecker_Normalize.remove_uvar_solutions
-                                                 env) in
+                                            FStar_TypeChecker_Normalize.remove_uvar_solutions
+                                              env k in
                                           FStar_Syntax_Subst.close_univ_vars
                                             us uu___11 in
                                         (repr_us, repr_t, uu___10))))) in
@@ -4382,11 +3970,8 @@ let (tc_layered_eff_decl :
                          FStar_Errors.raise_error uu___7 r in
                        let return_repr =
                          let return_repr_ts =
-                           let uu___7 =
-                             FStar_Compiler_Effect.op_Bar_Greater ed
-                               FStar_Syntax_Util.get_return_repr in
-                           FStar_Compiler_Effect.op_Bar_Greater uu___7
-                             FStar_Compiler_Util.must in
+                           let uu___7 = FStar_Syntax_Util.get_return_repr ed in
+                           FStar_Compiler_Util.must uu___7 in
                          let r =
                            (FStar_Pervasives_Native.snd return_repr_ts).FStar_Syntax_Syntax.pos in
                          let uu___7 =
@@ -4446,32 +4031,26 @@ let (tc_layered_eff_decl :
                                                     let uu___20 =
                                                       let uu___21 =
                                                         let uu___22 =
-                                                          let uu___23 =
-                                                            let uu___24 =
-                                                              FStar_Syntax_Syntax.bv_to_name
-                                                                a.FStar_Syntax_Syntax.binder_bv in
-                                                            (a', uu___24) in
-                                                          FStar_Syntax_Syntax.NT
-                                                            uu___23 in
-                                                        [uu___22] in
-                                                      FStar_Syntax_Subst.subst_binders
+                                                          FStar_Syntax_Syntax.bv_to_name
+                                                            x_a.FStar_Syntax_Syntax.binder_bv in
+                                                        (x', uu___22) in
+                                                      FStar_Syntax_Syntax.NT
                                                         uu___21 in
-                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                      bs1 uu___20 in
+                                                    [uu___20] in
                                                   let uu___20 =
                                                     let uu___21 =
                                                       let uu___22 =
                                                         let uu___23 =
                                                           let uu___24 =
                                                             FStar_Syntax_Syntax.bv_to_name
-                                                              x_a.FStar_Syntax_Syntax.binder_bv in
-                                                          (x', uu___24) in
+                                                              a.FStar_Syntax_Syntax.binder_bv in
+                                                          (a', uu___24) in
                                                         FStar_Syntax_Syntax.NT
                                                           uu___23 in
                                                       [uu___22] in
                                                     FStar_Syntax_Subst.subst_binders
-                                                      uu___21 in
-                                                  FStar_Compiler_Effect.op_Bar_Greater
+                                                      uu___21 bs1 in
+                                                  FStar_Syntax_Subst.subst_binders
                                                     uu___19 uu___20)
                                          | uu___11 ->
                                              not_an_arrow_error "return"
@@ -4482,9 +4061,8 @@ let (tc_layered_eff_decl :
                                            FStar_TypeChecker_Env.push_binders
                                              env bs in
                                          let uu___12 =
-                                           FStar_Compiler_Effect.op_Bar_Greater
-                                             a.FStar_Syntax_Syntax.binder_bv
-                                             FStar_Syntax_Syntax.bv_to_name in
+                                           FStar_Syntax_Syntax.bv_to_name
+                                             a.FStar_Syntax_Syntax.binder_bv in
                                          fresh_repr r uu___11 u_a uu___12 in
                                        (match uu___10 with
                                         | (repr1, g) ->
@@ -4503,24 +4081,17 @@ let (tc_layered_eff_decl :
                                               FStar_TypeChecker_Rel.force_trivial_guard
                                                 env uu___12);
                                              (let k1 =
-                                                FStar_Compiler_Effect.op_Bar_Greater
-                                                  k
-                                                  (FStar_TypeChecker_Normalize.remove_uvar_solutions
-                                                     env) in
+                                                FStar_TypeChecker_Normalize.remove_uvar_solutions
+                                                  env k in
                                               let uu___12 =
-                                                FStar_Compiler_Effect.op_Bar_Greater
-                                                  k1
-                                                  (FStar_Syntax_Subst.close_univ_vars
-                                                     us) in
+                                                FStar_Syntax_Subst.close_univ_vars
+                                                  us k1 in
                                               (ret_us, ret_t, uu___12)))))) in
                        log_combinator "return_repr" return_repr;
                        (let uu___8 =
                           let bind_repr_ts =
-                            let uu___9 =
-                              FStar_Compiler_Effect.op_Bar_Greater ed
-                                FStar_Syntax_Util.get_bind_repr in
-                            FStar_Compiler_Effect.op_Bar_Greater uu___9
-                              FStar_Compiler_Util.must in
+                            let uu___9 = FStar_Syntax_Util.get_bind_repr ed in
+                            FStar_Compiler_Util.must uu___9 in
                           let r =
                             (FStar_Pervasives_Native.snd bind_repr_ts).FStar_Syntax_Syntax.pos in
                           let uu___9 =
@@ -4562,10 +4133,8 @@ let (tc_layered_eff_decl :
                                     | (k, kind) ->
                                         let uu___12 =
                                           let uu___13 =
-                                            FStar_Compiler_Effect.op_Bar_Greater
-                                              k
-                                              (FStar_Syntax_Subst.close_univ_vars
-                                                 bind_us) in
+                                            FStar_Syntax_Subst.close_univ_vars
+                                              bind_us k in
                                           (bind_us, bind_t, uu___13) in
                                         (uu___12, kind))) in
                         match uu___8 with
@@ -4575,17 +4144,12 @@ let (tc_layered_eff_decl :
                                 let stronger_repr =
                                   let ts =
                                     let uu___11 =
-                                      FStar_Compiler_Effect.op_Bar_Greater ed
-                                        FStar_Syntax_Util.get_stronger_repr in
-                                    FStar_Compiler_Effect.op_Bar_Greater
-                                      uu___11 FStar_Compiler_Util.must in
+                                      FStar_Syntax_Util.get_stronger_repr ed in
+                                    FStar_Compiler_Util.must uu___11 in
                                   let uu___11 =
                                     let uu___12 =
-                                      let uu___13 =
-                                        FStar_Compiler_Effect.op_Bar_Greater
-                                          ts FStar_Pervasives_Native.snd in
-                                      FStar_Compiler_Effect.op_Bar_Greater
-                                        uu___13 FStar_Syntax_Subst.compress in
+                                      FStar_Syntax_Subst.compress
+                                        (FStar_Pervasives_Native.snd ts) in
                                     uu___12.FStar_Syntax_Syntax.n in
                                   match uu___11 with
                                   | FStar_Syntax_Syntax.Tm_unknown ->
@@ -4625,28 +4189,24 @@ let (tc_layered_eff_decl :
                                                     FStar_TypeChecker_Env.inst_tscheme_with
                                                       repr_ts
                                                       [FStar_Syntax_Syntax.U_unknown] in
-                                                  FStar_Compiler_Effect.op_Bar_Greater
-                                                    uu___16
-                                                    FStar_Pervasives_Native.snd in
+                                                  FStar_Pervasives_Native.snd
+                                                    uu___16 in
                                                 let repr_t_applied =
                                                   let uu___16 =
                                                     let uu___17 =
                                                       let uu___18 =
                                                         let uu___19 =
                                                           let uu___20 =
-                                                            FStar_Compiler_Effect.op_Bar_Greater
-                                                              bs1
-                                                              (FStar_Compiler_List.map
-                                                                 (fun b ->
-                                                                    b.FStar_Syntax_Syntax.binder_bv)) in
-                                                          FStar_Compiler_Effect.op_Bar_Greater
-                                                            uu___20
-                                                            (FStar_Compiler_List.map
-                                                               FStar_Syntax_Syntax.bv_to_name) in
-                                                        FStar_Compiler_Effect.op_Bar_Greater
-                                                          uu___19
-                                                          (FStar_Compiler_List.map
-                                                             FStar_Syntax_Syntax.as_arg) in
+                                                            FStar_Compiler_List.map
+                                                              (fun b ->
+                                                                 b.FStar_Syntax_Syntax.binder_bv)
+                                                              bs1 in
+                                                          FStar_Compiler_List.map
+                                                            FStar_Syntax_Syntax.bv_to_name
+                                                            uu___20 in
+                                                        FStar_Compiler_List.map
+                                                          FStar_Syntax_Syntax.as_arg
+                                                          uu___19 in
                                                       {
                                                         FStar_Syntax_Syntax.hd
                                                           = repr_t;
@@ -4666,9 +4226,8 @@ let (tc_layered_eff_decl :
                                                 let uu___16 =
                                                   let uu___17 =
                                                     let uu___18 =
-                                                      FStar_Compiler_Effect.op_Bar_Greater
-                                                        f_b.FStar_Syntax_Syntax.binder_bv
-                                                        FStar_Syntax_Syntax.bv_to_name in
+                                                      FStar_Syntax_Syntax.bv_to_name
+                                                        f_b.FStar_Syntax_Syntax.binder_bv in
                                                     FStar_Syntax_Util.abs
                                                       (FStar_Compiler_List.op_At
                                                          bs1 [f_b]) uu___18
@@ -4701,8 +4260,7 @@ let (tc_layered_eff_decl :
                                 match uu___11 with
                                 | (stronger_us, stronger_t, stronger_ty) ->
                                     ((let uu___13 =
-                                        FStar_Compiler_Effect.op_Less_Bar
-                                          (FStar_TypeChecker_Env.debug env0)
+                                        FStar_TypeChecker_Env.debug env0
                                           (FStar_Options.Other
                                              "LayeredEffectsTc") in
                                       if uu___13
@@ -4750,10 +4308,8 @@ let (tc_layered_eff_decl :
                                            | (k, kind) ->
                                                let uu___15 =
                                                  let uu___16 =
-                                                   FStar_Compiler_Effect.op_Bar_Greater
-                                                     k
-                                                     (FStar_Syntax_Subst.close_univ_vars
-                                                        stronger_us) in
+                                                   FStar_Syntax_Subst.close_univ_vars
+                                                     stronger_us k in
                                                  (stronger_us, stronger_t,
                                                    uu___16) in
                                                (uu___15, kind)))) in
@@ -4766,24 +4322,14 @@ let (tc_layered_eff_decl :
                                         let ts =
                                           let uu___13 =
                                             let uu___14 =
-                                              FStar_Compiler_Effect.op_Bar_Greater
-                                                ed
-                                                FStar_Syntax_Util.get_layered_if_then_else_combinator in
-                                            FStar_Compiler_Effect.op_Bar_Greater
-                                              uu___14
-                                              FStar_Compiler_Util.must in
-                                          FStar_Compiler_Effect.op_Bar_Greater
-                                            uu___13
-                                            FStar_Pervasives_Native.fst in
+                                              FStar_Syntax_Util.get_layered_if_then_else_combinator
+                                                ed in
+                                            FStar_Compiler_Util.must uu___14 in
+                                          FStar_Pervasives_Native.fst uu___13 in
                                         let uu___13 =
                                           let uu___14 =
-                                            let uu___15 =
-                                              FStar_Compiler_Effect.op_Bar_Greater
-                                                ts
-                                                FStar_Pervasives_Native.snd in
-                                            FStar_Compiler_Effect.op_Bar_Greater
-                                              uu___15
-                                              FStar_Syntax_Subst.compress in
+                                            FStar_Syntax_Subst.compress
+                                              (FStar_Pervasives_Native.snd ts) in
                                           uu___14.FStar_Syntax_Syntax.n in
                                         match uu___13 with
                                         | FStar_Syntax_Syntax.Tm_unknown ->
@@ -4823,29 +4369,25 @@ let (tc_layered_eff_decl :
                                                           FStar_TypeChecker_Env.inst_tscheme_with
                                                             repr_ts
                                                             [FStar_Syntax_Syntax.U_unknown] in
-                                                        FStar_Compiler_Effect.op_Bar_Greater
-                                                          uu___18
-                                                          FStar_Pervasives_Native.snd in
+                                                        FStar_Pervasives_Native.snd
+                                                          uu___18 in
                                                       let repr_t_applied =
                                                         let uu___18 =
                                                           let uu___19 =
                                                             let uu___20 =
                                                               let uu___21 =
                                                                 let uu___22 =
-                                                                  FStar_Compiler_Effect.op_Bar_Greater
-                                                                    bs1
+                                                                  FStar_Compiler_List.map
                                                                     (
-                                                                    FStar_Compiler_List.map
-                                                                    (fun b ->
-                                                                    b.FStar_Syntax_Syntax.binder_bv)) in
-                                                                FStar_Compiler_Effect.op_Bar_Greater
-                                                                  uu___22
-                                                                  (FStar_Compiler_List.map
-                                                                    FStar_Syntax_Syntax.bv_to_name) in
-                                                              FStar_Compiler_Effect.op_Bar_Greater
-                                                                uu___21
-                                                                (FStar_Compiler_List.map
-                                                                   FStar_Syntax_Syntax.as_arg) in
+                                                                    fun b ->
+                                                                    b.FStar_Syntax_Syntax.binder_bv)
+                                                                    bs1 in
+                                                                FStar_Compiler_List.map
+                                                                  FStar_Syntax_Syntax.bv_to_name
+                                                                  uu___22 in
+                                                              FStar_Compiler_List.map
+                                                                FStar_Syntax_Syntax.as_arg
+                                                                uu___21 in
                                                             {
                                                               FStar_Syntax_Syntax.hd
                                                                 = repr_t;
@@ -4947,10 +4489,9 @@ let (tc_layered_eff_decl :
                                                      | (k, kind) ->
                                                          let uu___18 =
                                                            let uu___19 =
-                                                             FStar_Compiler_Effect.op_Bar_Greater
-                                                               k
-                                                               (FStar_Syntax_Subst.close_univ_vars
-                                                                  if_then_else_us) in
+                                                             FStar_Syntax_Subst.close_univ_vars
+                                                               if_then_else_us
+                                                               k in
                                                            (if_then_else_us,
                                                              uu___19,
                                                              if_then_else_ty) in
@@ -4967,18 +4508,14 @@ let (tc_layered_eff_decl :
                                                   let uu___16 =
                                                     let uu___17 =
                                                       let uu___18 =
-                                                        FStar_Compiler_Effect.op_Bar_Greater
-                                                          ed
-                                                          FStar_Syntax_Util.get_layered_if_then_else_combinator in
-                                                      FStar_Compiler_Effect.op_Bar_Greater
-                                                        uu___18
-                                                        FStar_Compiler_Util.must in
-                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                      uu___17
-                                                      FStar_Pervasives_Native.fst in
-                                                  FStar_Compiler_Effect.op_Bar_Greater
-                                                    uu___16
-                                                    FStar_Pervasives_Native.snd in
+                                                        FStar_Syntax_Util.get_layered_if_then_else_combinator
+                                                          ed in
+                                                      FStar_Compiler_Util.must
+                                                        uu___18 in
+                                                    FStar_Pervasives_Native.fst
+                                                      uu___17 in
+                                                  FStar_Pervasives_Native.snd
+                                                    uu___16 in
                                                 uu___15.FStar_Syntax_Syntax.pos in
                                               let uu___15 = if_then_else in
                                               match uu___15 with
@@ -5011,26 +4548,20 @@ let (tc_layered_eff_decl :
                                                                let uu___23 =
                                                                  let uu___24
                                                                    =
-                                                                   FStar_Compiler_Effect.op_Bar_Greater
-                                                                    bs1
-                                                                    (FStar_Compiler_List.splitAt
+                                                                   FStar_Compiler_List.splitAt
                                                                     ((FStar_Compiler_List.length
                                                                     bs1) -
-                                                                    (Prims.of_int (3)))) in
-                                                                 FStar_Compiler_Effect.op_Bar_Greater
-                                                                   uu___24
-                                                                   FStar_Pervasives_Native.snd in
-                                                               FStar_Compiler_Effect.op_Bar_Greater
-                                                                 uu___23
-                                                                 (fun l ->
-                                                                    let uu___24
-                                                                    = l in
-                                                                    match uu___24
-                                                                    with
-                                                                    | 
-                                                                    f::g::p::[]
-                                                                    ->
-                                                                    (f, g, p)) in
+                                                                    (Prims.of_int (3)))
+                                                                    bs1 in
+                                                                 FStar_Pervasives_Native.snd
+                                                                   uu___24 in
+                                                               let uu___24 =
+                                                                 uu___23 in
+                                                               match uu___24
+                                                               with
+                                                               | f::g::p::[]
+                                                                   ->
+                                                                   (f, g, p) in
                                                              (match uu___22
                                                               with
                                                               | (f_b, g_b,
@@ -5049,9 +4580,7 @@ let (tc_layered_eff_decl :
                                                                     =
                                                                     let uu___25
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    bs1
-                                                                    (FStar_Compiler_List.map
+                                                                    FStar_Compiler_List.map
                                                                     (fun b ->
                                                                     let uu___26
                                                                     =
@@ -5062,20 +4591,19 @@ let (tc_layered_eff_decl :
                                                                     FStar_Syntax_Util.aqual_of_binder
                                                                     b in
                                                                     (uu___26,
-                                                                    uu___27))) in
+                                                                    uu___27))
+                                                                    bs1 in
                                                                     FStar_Syntax_Syntax.mk_Tm_app
                                                                     ite_t1
                                                                     uu___25 r in
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___24
-                                                                    (FStar_TypeChecker_Normalize.normalize
+                                                                    FStar_TypeChecker_Normalize.normalize
                                                                     [FStar_TypeChecker_Env.Beta]
-                                                                    env) in
+                                                                    env
+                                                                    uu___24 in
                                                                   let uu___24
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    bs1
-                                                                    FStar_Compiler_List.hd in
+                                                                    FStar_Compiler_List.hd
+                                                                    bs1 in
                                                                   let uu___25
                                                                     =
                                                                     FStar_Syntax_Syntax.bv_to_name
@@ -5160,29 +4688,23 @@ let (tc_layered_eff_decl :
                                                                     =
                                                                     let uu___29
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    rest_bs
-                                                                    (FStar_Compiler_List.splitAt
+                                                                    FStar_Compiler_List.splitAt
                                                                     ((FStar_Compiler_List.length
                                                                     rest_bs)
                                                                     -
-                                                                    Prims.int_one)) in
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___29
-                                                                    (fun
-                                                                    uu___30
-                                                                    ->
-                                                                    match uu___30
+                                                                    Prims.int_one)
+                                                                    rest_bs in
+                                                                    match uu___29
                                                                     with
                                                                     | 
                                                                     (l1, l2)
                                                                     ->
-                                                                    let uu___31
+                                                                    let uu___30
                                                                     =
                                                                     FStar_Compiler_List.hd
                                                                     l2 in
                                                                     (l1,
-                                                                    uu___31)) in
+                                                                    uu___30) in
                                                                     (match uu___28
                                                                     with
                                                                     | 
@@ -5218,24 +4740,22 @@ let (tc_layered_eff_decl :
                                                                     =
                                                                     let uu___25
                                                                     =
-                                                                    let uu___26
-                                                                    =
                                                                     FStar_Syntax_Syntax.bv_to_name
                                                                     a_b.FStar_Syntax_Syntax.binder_bv in
                                                                     ((subcomp_a_b.FStar_Syntax_Syntax.binder_bv),
-                                                                    uu___26) in
+                                                                    uu___25) in
                                                                     FStar_Syntax_Syntax.NT
-                                                                    uu___25 in
-                                                                    [uu___24] in
-                                                                    (uu___23,
+                                                                    uu___24 in
+                                                                    [uu___23] in
+                                                                    (uu___22,
                                                                     [],
                                                                     FStar_TypeChecker_Env.trivial_guard) in
                                                                     FStar_Compiler_List.fold_left
                                                                     (fun
-                                                                    uu___23
+                                                                    uu___22
                                                                     ->
                                                                     fun b ->
-                                                                    match uu___23
+                                                                    match uu___22
                                                                     with
                                                                     | 
                                                                     (subst,
@@ -5246,38 +4766,38 @@ let (tc_layered_eff_decl :
                                                                     FStar_Syntax_Subst.subst
                                                                     subst
                                                                     (b.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort in
-                                                                    let uu___24
+                                                                    let uu___23
                                                                     =
                                                                     let ctx_uvar_meta
                                                                     =
                                                                     FStar_Compiler_Util.map_option
                                                                     (fun
-                                                                    uu___25
+                                                                    uu___24
                                                                     ->
                                                                     FStar_Syntax_Syntax.Ctx_uvar_meta_attr
-                                                                    uu___25)
+                                                                    uu___24)
                                                                     attr_opt in
-                                                                    let uu___25
+                                                                    let uu___24
                                                                     =
-                                                                    let uu___26
+                                                                    let uu___25
                                                                     =
                                                                     FStar_Syntax_Print.binder_to_string
                                                                     b in
                                                                     FStar_Compiler_Util.format1
                                                                     "uvar for subcomp %s binder when checking ite soundness"
-                                                                    uu___26 in
+                                                                    uu___25 in
                                                                     FStar_TypeChecker_Env.new_implicit_var_aux
-                                                                    uu___25 r
+                                                                    uu___24 r
                                                                     env1 sort
                                                                     FStar_Syntax_Syntax.Strict
                                                                     ctx_uvar_meta in
-                                                                    (match uu___24
+                                                                    (match uu___23
                                                                     with
                                                                     | 
                                                                     (t,
-                                                                    uu___25,
+                                                                    uu___24,
                                                                     g_t) ->
-                                                                    let uu___26
+                                                                    let uu___25
                                                                     =
                                                                     FStar_TypeChecker_Common.conj_guard
                                                                     g g_t in
@@ -5290,11 +4810,9 @@ let (tc_layered_eff_decl :
                                                                     (FStar_Compiler_List.op_At
                                                                     uvars 
                                                                     [t]),
-                                                                    uu___26)))
-                                                                    uu___22 in
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    subcomp_bs
-                                                                    uu___21 in
+                                                                    uu___25)))
+                                                                    uu___21
+                                                                    subcomp_bs in
                                                                    match uu___20
                                                                    with
                                                                    | 
@@ -5313,10 +4831,9 @@ let (tc_layered_eff_decl :
                                                                     FStar_Syntax_Subst.subst_comp
                                                                     subst
                                                                     subcomp_c in
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___21
-                                                                    (FStar_TypeChecker_Env.unfold_effect_abbrev
-                                                                    env1) in
+                                                                    FStar_TypeChecker_Env.unfold_effect_abbrev
+                                                                    env1
+                                                                    uu___21 in
                                                                     let g_f_or_g
                                                                     =
                                                                     FStar_TypeChecker_Rel.layered_effect_teq
@@ -5339,12 +4856,10 @@ let (tc_layered_eff_decl :
                                                                     =
                                                                     let uu___23
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    c.FStar_Syntax_Syntax.effect_args
-                                                                    FStar_Compiler_List.hd in
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___23
-                                                                    FStar_Pervasives_Native.fst in
+                                                                    FStar_Compiler_List.hd
+                                                                    c.FStar_Syntax_Syntax.effect_args in
+                                                                    FStar_Pervasives_Native.fst
+                                                                    uu___23 in
                                                                     FStar_TypeChecker_Env.pure_precondition_for_trivial_post
                                                                     env1
                                                                     uu___21
@@ -5357,18 +4872,9 @@ let (tc_layered_eff_decl :
                                                                     | 
                                                                     FStar_Pervasives_Native.None
                                                                     ->
-                                                                    let uu___21
-                                                                    =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    fml
-                                                                    (fun
-                                                                    uu___22
-                                                                    ->
-                                                                    FStar_TypeChecker_Common.NonTrivial
-                                                                    uu___22) in
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___21
                                                                     FStar_TypeChecker_Env.guard_of_guard_formula
+                                                                    (FStar_TypeChecker_Common.NonTrivial
+                                                                    fml)
                                                                     | 
                                                                     FStar_Pervasives_Native.Some
                                                                     attr ->
@@ -5379,22 +4885,14 @@ let (tc_layered_eff_decl :
                                                                     FStar_Syntax_Util.mk_squash
                                                                     FStar_Syntax_Syntax.U_zero
                                                                     fml in
-                                                                    let uu___23
-                                                                    =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    (FStar_Syntax_Syntax.Ctx_uvar_meta_attr
-                                                                    attr)
-                                                                    (fun
-                                                                    uu___24
-                                                                    ->
-                                                                    FStar_Pervasives_Native.Some
-                                                                    uu___24) in
                                                                     FStar_TypeChecker_Env.new_implicit_var_aux
                                                                     "tc_layered_effect_decl.g_precondition"
                                                                     r env1
                                                                     uu___22
                                                                     FStar_Syntax_Syntax.Strict
-                                                                    uu___23 in
+                                                                    (FStar_Pervasives_Native.Some
+                                                                    (FStar_Syntax_Syntax.Ctx_uvar_meta_attr
+                                                                    attr)) in
                                                                     (match uu___21
                                                                     with
                                                                     | 
@@ -5437,9 +4935,8 @@ let (tc_layered_eff_decl :
                                                                     =
                                                                     let uu___22
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    p_t
-                                                                    FStar_Syntax_Util.b2t in
+                                                                    FStar_Syntax_Util.b2t
+                                                                    p_t in
                                                                     FStar_Syntax_Util.mk_squash
                                                                     FStar_Syntax_Syntax.U_zero
                                                                     uu___22 in
@@ -5462,21 +4959,18 @@ let (tc_layered_eff_decl :
                                                                     FStar_Syntax_Syntax.lid_as_fv
                                                                     FStar_Parser_Const.not_lid
                                                                     FStar_Pervasives_Native.None in
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___21
-                                                                    FStar_Syntax_Syntax.fv_to_tm in
+                                                                    FStar_Syntax_Syntax.fv_to_tm
+                                                                    uu___21 in
                                                                     let uu___21
                                                                     =
                                                                     let uu___22
                                                                     =
                                                                     let uu___23
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    p_t
-                                                                    FStar_Syntax_Util.b2t in
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___23
-                                                                    FStar_Syntax_Syntax.as_arg in
+                                                                    FStar_Syntax_Util.b2t
+                                                                    p_t in
+                                                                    FStar_Syntax_Syntax.as_arg
+                                                                    uu___23 in
                                                                     [uu___22] in
                                                                     FStar_Syntax_Syntax.mk_Tm_app
                                                                     uu___20
@@ -5496,9 +4990,8 @@ let (tc_layered_eff_decl :
                                                                     ite_soundness_tac_attr))))));
                                          (let close_ =
                                             let ts_opt =
-                                              FStar_Compiler_Effect.op_Bar_Greater
-                                                ed
-                                                FStar_Syntax_Util.get_layered_close_combinator in
+                                              FStar_Syntax_Util.get_layered_close_combinator
+                                                ed in
                                             match ts_opt with
                                             | FStar_Pervasives_Native.None ->
                                                 FStar_Pervasives_Native.None
@@ -5553,10 +5046,8 @@ let (tc_layered_eff_decl :
                                                                   r in
                                                           let uu___16 =
                                                             let uu___17 =
-                                                              FStar_Compiler_Effect.op_Bar_Greater
-                                                                k
-                                                                (FStar_Syntax_Subst.close_univ_vars
-                                                                   close_us) in
+                                                              FStar_Syntax_Subst.close_univ_vars
+                                                                close_us k in
                                                             (close_us,
                                                               uu___17,
                                                               close_ty) in
@@ -5676,10 +5167,9 @@ let (tc_layered_eff_decl :
                                                                     FStar_Syntax_Syntax.args
                                                                     = a::args;_}
                                                                     ->
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
+                                                                    FStar_Compiler_List.map
+                                                                    FStar_Pervasives_Native.fst
                                                                     args
-                                                                    (FStar_Compiler_List.map
-                                                                    FStar_Pervasives_Native.fst)
                                                                     | 
                                                                     uu___24
                                                                     ->
@@ -5694,9 +5184,8 @@ let (tc_layered_eff_decl :
                                                                     =
                                                                     let uu___25
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    x_bv
-                                                                    FStar_Syntax_Syntax.mk_binder in
+                                                                    FStar_Syntax_Syntax.mk_binder
+                                                                    x_bv in
                                                                     [uu___25] in
                                                                     FStar_Compiler_List.op_At
                                                                     (a_b ::
@@ -5728,13 +5217,8 @@ let (tc_layered_eff_decl :
                                                                     =
                                                                     FStar_Compiler_List.hd
                                                                     us1 in
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___26
-                                                                    (fun
-                                                                    uu___27
-                                                                    ->
                                                                     FStar_Syntax_Syntax.U_name
-                                                                    uu___27) in
+                                                                    uu___26 in
                                                                     [uu___25] in
                                                                     FStar_TypeChecker_Env.inst_tscheme_with
                                                                     subcomp_ts
@@ -5763,9 +5247,8 @@ let (tc_layered_eff_decl :
                                                                     =
                                                                     let uu___28
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    a_b.FStar_Syntax_Syntax.binder_bv
-                                                                    FStar_Syntax_Syntax.bv_to_name in
+                                                                    FStar_Syntax_Syntax.bv_to_name
+                                                                    a_b.FStar_Syntax_Syntax.binder_bv in
                                                                     ((a_b_subcomp.FStar_Syntax_Syntax.binder_bv),
                                                                     uu___28) in
                                                                     FStar_Syntax_Syntax.NT
@@ -5834,10 +5317,9 @@ let (tc_layered_eff_decl :
                                                                     FStar_Syntax_Subst.subst_comp
                                                                     subcomp_substs2
                                                                     subcomp_c in
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___29
-                                                                    (FStar_TypeChecker_Env.unfold_effect_abbrev
-                                                                    env) in
+                                                                    FStar_TypeChecker_Env.unfold_effect_abbrev
+                                                                    env
+                                                                    uu___29 in
                                                                     let fml =
                                                                     let uu___29
                                                                     =
@@ -5847,12 +5329,10 @@ let (tc_layered_eff_decl :
                                                                     =
                                                                     let uu___31
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    subcomp_c1.FStar_Syntax_Syntax.effect_args
-                                                                    FStar_Compiler_List.hd in
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___31
-                                                                    FStar_Pervasives_Native.fst in
+                                                                    FStar_Compiler_List.hd
+                                                                    subcomp_c1.FStar_Syntax_Syntax.effect_args in
+                                                                    FStar_Pervasives_Native.fst
+                                                                    uu___31 in
                                                                     FStar_TypeChecker_Env.pure_precondition_for_trivial_post
                                                                     env
                                                                     uu___29
@@ -5860,18 +5340,9 @@ let (tc_layered_eff_decl :
                                                                     uu___30 r in
                                                                     let uu___29
                                                                     =
-                                                                    let uu___30
-                                                                    =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    fml
-                                                                    (fun
-                                                                    uu___31
-                                                                    ->
-                                                                    FStar_TypeChecker_Common.NonTrivial
-                                                                    uu___31) in
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___30
-                                                                    FStar_TypeChecker_Env.guard_of_guard_formula in
+                                                                    FStar_TypeChecker_Env.guard_of_guard_formula
+                                                                    (FStar_TypeChecker_Common.NonTrivial
+                                                                    fml) in
                                                                     FStar_TypeChecker_Rel.force_trivial_guard
                                                                     env
                                                                     uu___29)))))))))));
@@ -5978,9 +5449,8 @@ let (tc_layered_eff_decl :
                                                               FStar_TypeChecker_Env.inst_tscheme_with
                                                                 repr_ts
                                                                 ct.FStar_Syntax_Syntax.comp_univs in
-                                                            FStar_Compiler_Effect.op_Bar_Greater
-                                                              uu___18
-                                                              FStar_Pervasives_Native.snd in
+                                                            FStar_Pervasives_Native.snd
+                                                              uu___18 in
                                                           let repr2 =
                                                             let uu___18 =
                                                               let uu___19 =
@@ -6174,9 +5644,8 @@ let (tc_layered_eff_decl :
                                                         | (act_defn, uu___19,
                                                            g_d) ->
                                                             ((let uu___21 =
-                                                                FStar_Compiler_Effect.op_Less_Bar
-                                                                  (FStar_TypeChecker_Env.debug
-                                                                    env1)
+                                                                FStar_TypeChecker_Env.debug
+                                                                  env1
                                                                   (FStar_Options.Other
                                                                     "LayeredEffectsTc") in
                                                               if uu___21
@@ -6310,9 +5779,8 @@ let (tc_layered_eff_decl :
                                                               | (k, g_k) ->
                                                                   ((let uu___23
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Less_Bar
-                                                                    (FStar_TypeChecker_Env.debug
-                                                                    env1)
+                                                                    FStar_TypeChecker_Env.debug
+                                                                    env1
                                                                     (FStar_Options.Other
                                                                     "LayeredEffectsTc") in
                                                                     if
@@ -6341,9 +5809,8 @@ let (tc_layered_eff_decl :
                                                                     (
                                                                     let uu___25
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Less_Bar
-                                                                    (FStar_TypeChecker_Env.debug
-                                                                    env1)
+                                                                    FStar_TypeChecker_Env.debug
+                                                                    env1
                                                                     (FStar_Options.Other
                                                                     "LayeredEffectsTc") in
                                                                     if
@@ -6514,9 +5981,8 @@ let (tc_layered_eff_decl :
                                                                     (
                                                                     let uu___26
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Less_Bar
-                                                                    (FStar_TypeChecker_Env.debug
-                                                                    env1)
+                                                                    FStar_TypeChecker_Env.debug
+                                                                    env1
                                                                     (FStar_Options.Other
                                                                     "LayeredEffectsTc") in
                                                                     if
@@ -6779,9 +6245,8 @@ let (tc_layered_eff_decl :
                                                               FStar_Syntax_Syntax.Extract_none
                                                                 m))) in
                                            (let uu___15 =
-                                              FStar_Compiler_Effect.op_Less_Bar
-                                                (FStar_TypeChecker_Env.debug
-                                                   env0)
+                                              FStar_TypeChecker_Env.debug
+                                                env0
                                                 (FStar_Options.Other
                                                    "LayeredEffectsTc") in
                                             if uu___15
@@ -6889,9 +6354,7 @@ let (tc_non_layered_eff_decl :
           FStar_Errors.with_ctx uu___
             (fun uu___1 ->
                (let uu___3 =
-                  FStar_Compiler_Effect.op_Less_Bar
-                    (FStar_TypeChecker_Env.debug env0)
-                    (FStar_Options.Other "ED") in
+                  FStar_TypeChecker_Env.debug env0 (FStar_Options.Other "ED") in
                 if uu___3
                 then
                   let uu___4 = FStar_Syntax_Print.eff_decl_to_string false ed in
@@ -6929,13 +6392,9 @@ let (tc_non_layered_eff_decl :
                                  let uu___10 =
                                    let uu___11 =
                                      let uu___12 =
-                                       FStar_Compiler_Effect.op_Bar_Greater
-                                         tmp_t1
-                                         FStar_Syntax_Util.arrow_formals in
-                                     FStar_Compiler_Effect.op_Bar_Greater
-                                       uu___12 FStar_Pervasives_Native.fst in
-                                   FStar_Compiler_Effect.op_Bar_Greater
-                                     uu___11 FStar_Syntax_Subst.close_binders in
+                                       FStar_Syntax_Util.arrow_formals tmp_t1 in
+                                     FStar_Pervasives_Native.fst uu___12 in
+                                   FStar_Syntax_Subst.close_binders uu___11 in
                                  (us, uu___10) in
                            (match uu___8 with
                             | (us, bs2) ->
@@ -7085,8 +6544,7 @@ let (tc_non_layered_eff_decl :
                                     (ed1.FStar_Syntax_Syntax.extraction_mode)
                                 } in
                               ((let uu___7 =
-                                  FStar_Compiler_Effect.op_Less_Bar
-                                    (FStar_TypeChecker_Env.debug env0)
+                                  FStar_TypeChecker_Env.debug env0
                                     (FStar_Options.Other "ED") in
                                 if uu___7
                                 then
@@ -7109,9 +6567,7 @@ let (tc_non_layered_eff_decl :
                                       let env1 =
                                         if
                                           FStar_Compiler_Util.is_some env_opt
-                                        then
-                                          FStar_Compiler_Effect.op_Bar_Greater
-                                            env_opt FStar_Compiler_Util.must
+                                        then FStar_Compiler_Util.must env_opt
                                         else env in
                                       let uu___8 =
                                         FStar_Syntax_Subst.open_univ_vars us1
@@ -7158,13 +6614,9 @@ let (tc_non_layered_eff_decl :
                                                         FStar_Compiler_Util.string_of_int
                                                           n in
                                                       let uu___13 =
-                                                        let uu___14 =
-                                                          FStar_Compiler_Effect.op_Bar_Greater
-                                                            g_us
-                                                            FStar_Compiler_List.length in
-                                                        FStar_Compiler_Effect.op_Bar_Greater
-                                                          uu___14
-                                                          FStar_Compiler_Util.string_of_int in
+                                                        FStar_Compiler_Util.string_of_int
+                                                          (FStar_Compiler_List.length
+                                                             g_us) in
                                                       FStar_Compiler_Util.format4
                                                         "Expected %s:%s to be universe-polymorphic in %s universes, found %s"
                                                         uu___11 comb uu___12
@@ -7228,8 +6680,7 @@ let (tc_non_layered_eff_decl :
                                     FStar_Pervasives_Native.None uu___7
                                     FStar_Pervasives_Native.None in
                                 (let uu___8 =
-                                   FStar_Compiler_Effect.op_Less_Bar
-                                     (FStar_TypeChecker_Env.debug env0)
+                                   FStar_TypeChecker_Env.debug env0
                                      (FStar_Options.Other "ED") in
                                  if uu___8
                                  then
@@ -7247,12 +6698,9 @@ let (tc_non_layered_eff_decl :
                                      let uu___10 =
                                        let uu___11 =
                                          let uu___12 =
-                                           FStar_Compiler_Effect.op_Bar_Greater
-                                             ed2.FStar_Syntax_Syntax.signature
-                                             FStar_Syntax_Util.effect_sig_ts in
-                                         FStar_Compiler_Effect.op_Bar_Greater
-                                           uu___12
-                                           FStar_Pervasives_Native.snd in
+                                           FStar_Syntax_Util.effect_sig_ts
+                                             ed2.FStar_Syntax_Syntax.signature in
+                                         FStar_Pervasives_Native.snd uu___12 in
                                        uu___11.FStar_Syntax_Syntax.pos in
                                      FStar_Errors.raise_error uu___9 uu___10 in
                                    let uu___9 =
@@ -7299,8 +6747,7 @@ let (tc_non_layered_eff_decl :
                                         | uu___12 -> fail signature1) in
                                  let log_combinator s ts =
                                    let uu___8 =
-                                     FStar_Compiler_Effect.op_Less_Bar
-                                       (FStar_TypeChecker_Env.debug env)
+                                     FStar_TypeChecker_Env.debug env
                                        (FStar_Options.Other "ED") in
                                    if uu___8
                                    then
@@ -7337,9 +6784,8 @@ let (tc_non_layered_eff_decl :
                                          FStar_Syntax_Util.arrow uu___9
                                            uu___10 in
                                        let uu___9 =
-                                         FStar_Compiler_Effect.op_Bar_Greater
-                                           ed2
-                                           FStar_Syntax_Util.get_return_vc_combinator in
+                                         FStar_Syntax_Util.get_return_vc_combinator
+                                           ed2 in
                                        check_and_gen' "ret_wp" Prims.int_one
                                          FStar_Pervasives_Native.None uu___9
                                          (FStar_Pervasives_Native.Some k) in
@@ -7393,12 +6839,10 @@ let (tc_non_layered_eff_decl :
                                                  uu___11 uu___12 in
                                              let uu___11 =
                                                let uu___12 =
-                                                 FStar_Compiler_Effect.op_Bar_Greater
-                                                   ed2
-                                                   FStar_Syntax_Util.get_bind_vc_combinator in
-                                               FStar_Compiler_Effect.op_Bar_Greater
-                                                 uu___12
-                                                 FStar_Pervasives_Native.fst in
+                                                 FStar_Syntax_Util.get_bind_vc_combinator
+                                                   ed2 in
+                                               FStar_Pervasives_Native.fst
+                                                 uu___12 in
                                              check_and_gen' "bind_wp"
                                                (Prims.of_int (2))
                                                FStar_Pervasives_Native.None
@@ -7437,12 +6881,10 @@ let (tc_non_layered_eff_decl :
                                                   uu___13 uu___14 in
                                               let uu___13 =
                                                 let uu___14 =
-                                                  FStar_Compiler_Effect.op_Bar_Greater
-                                                    ed2
-                                                    FStar_Syntax_Util.get_stronger_vc_combinator in
-                                                FStar_Compiler_Effect.op_Bar_Greater
-                                                  uu___14
-                                                  FStar_Pervasives_Native.fst in
+                                                  FStar_Syntax_Util.get_stronger_vc_combinator
+                                                    ed2 in
+                                                FStar_Pervasives_Native.fst
+                                                  uu___14 in
                                               check_and_gen' "stronger"
                                                 Prims.int_one
                                                 FStar_Pervasives_Native.None
@@ -7464,9 +6906,8 @@ let (tc_non_layered_eff_decl :
                                             let uu___13 =
                                               let uu___14 =
                                                 FStar_Syntax_Util.type_u () in
-                                              FStar_Compiler_Effect.op_Bar_Greater
-                                                uu___14
-                                                FStar_Pervasives_Native.fst in
+                                              FStar_Pervasives_Native.fst
+                                                uu___14 in
                                             FStar_Syntax_Syntax.new_bv
                                               uu___12 uu___13 in
                                           let k =
@@ -7497,12 +6938,9 @@ let (tc_non_layered_eff_decl :
                                               uu___13 in
                                           let uu___12 =
                                             let uu___13 =
-                                              FStar_Compiler_Effect.op_Bar_Greater
-                                                ed2
-                                                FStar_Syntax_Util.get_wp_if_then_else_combinator in
-                                            FStar_Compiler_Effect.op_Bar_Greater
-                                              uu___13
-                                              FStar_Compiler_Util.must in
+                                              FStar_Syntax_Util.get_wp_if_then_else_combinator
+                                                ed2 in
+                                            FStar_Compiler_Util.must uu___13 in
                                           check_and_gen' "if_then_else"
                                             Prims.int_one
                                             FStar_Pervasives_Native.None
@@ -7532,12 +6970,9 @@ let (tc_non_layered_eff_decl :
                                                uu___14 in
                                            let uu___13 =
                                              let uu___14 =
-                                               FStar_Compiler_Effect.op_Bar_Greater
-                                                 ed2
-                                                 FStar_Syntax_Util.get_wp_ite_combinator in
-                                             FStar_Compiler_Effect.op_Bar_Greater
-                                               uu___14
-                                               FStar_Compiler_Util.must in
+                                               FStar_Syntax_Util.get_wp_ite_combinator
+                                                 ed2 in
+                                             FStar_Compiler_Util.must uu___14 in
                                            check_and_gen' "ite_wp"
                                              Prims.int_one
                                              FStar_Pervasives_Native.None
@@ -7558,9 +6993,8 @@ let (tc_non_layered_eff_decl :
                                               let uu___15 =
                                                 let uu___16 =
                                                   FStar_Syntax_Util.type_u () in
-                                                FStar_Compiler_Effect.op_Bar_Greater
-                                                  uu___16
-                                                  FStar_Pervasives_Native.fst in
+                                                FStar_Pervasives_Native.fst
+                                                  uu___16 in
                                               FStar_Syntax_Syntax.new_bv
                                                 uu___14 uu___15 in
                                             let wp_sort_b_a =
@@ -7600,12 +7034,10 @@ let (tc_non_layered_eff_decl :
                                                 uu___15 in
                                             let uu___14 =
                                               let uu___15 =
-                                                FStar_Compiler_Effect.op_Bar_Greater
-                                                  ed2
-                                                  FStar_Syntax_Util.get_wp_close_combinator in
-                                              FStar_Compiler_Effect.op_Bar_Greater
-                                                uu___15
-                                                FStar_Compiler_Util.must in
+                                                FStar_Syntax_Util.get_wp_close_combinator
+                                                  ed2 in
+                                              FStar_Compiler_Util.must
+                                                uu___15 in
                                             check_and_gen' "close_wp"
                                               (Prims.of_int (2))
                                               FStar_Pervasives_Native.None
@@ -7639,12 +7071,10 @@ let (tc_non_layered_eff_decl :
                                                   let trivial1 =
                                                     let uu___17 =
                                                       let uu___18 =
-                                                        FStar_Compiler_Effect.op_Bar_Greater
-                                                          ed2
-                                                          FStar_Syntax_Util.get_wp_trivial_combinator in
-                                                      FStar_Compiler_Effect.op_Bar_Greater
-                                                        uu___18
-                                                        FStar_Compiler_Util.must in
+                                                        FStar_Syntax_Util.get_wp_trivial_combinator
+                                                          ed2 in
+                                                      FStar_Compiler_Util.must
+                                                        uu___18 in
                                                     check_and_gen' "trivial"
                                                       Prims.int_one
                                                       FStar_Pervasives_Native.None
@@ -7656,9 +7086,7 @@ let (tc_non_layered_eff_decl :
                                                    trivial1)) in
                                        let uu___14 =
                                          let uu___15 =
-                                           FStar_Compiler_Effect.op_Bar_Greater
-                                             ed2
-                                             FStar_Syntax_Util.get_eff_repr in
+                                           FStar_Syntax_Util.get_eff_repr ed2 in
                                          match uu___15 with
                                          | FStar_Pervasives_Native.None ->
                                              (FStar_Pervasives_Native.None,
@@ -7695,12 +7123,10 @@ let (tc_non_layered_eff_decl :
                                                             uu___20 uu___21 in
                                                         let uu___20 =
                                                           let uu___21 =
-                                                            FStar_Compiler_Effect.op_Bar_Greater
-                                                              ed2
-                                                              FStar_Syntax_Util.get_eff_repr in
-                                                          FStar_Compiler_Effect.op_Bar_Greater
-                                                            uu___21
-                                                            FStar_Compiler_Util.must in
+                                                            FStar_Syntax_Util.get_eff_repr
+                                                              ed2 in
+                                                          FStar_Compiler_Util.must
+                                                            uu___21 in
                                                         check_and_gen' "repr"
                                                           Prims.int_one
                                                           FStar_Pervasives_Native.None
@@ -7723,14 +7149,12 @@ let (tc_non_layered_eff_decl :
                                                        let uu___21 =
                                                          let uu___22 =
                                                            let uu___23 =
-                                                             FStar_Compiler_Effect.op_Bar_Greater
-                                                               t
-                                                               FStar_Syntax_Syntax.as_arg in
+                                                             FStar_Syntax_Syntax.as_arg
+                                                               t in
                                                            let uu___24 =
                                                              let uu___25 =
-                                                               FStar_Compiler_Effect.op_Bar_Greater
-                                                                 wp
-                                                                 FStar_Syntax_Syntax.as_arg in
+                                                               FStar_Syntax_Syntax.as_arg
+                                                                 wp in
                                                              [uu___25] in
                                                            uu___23 :: uu___24 in
                                                          {
@@ -7771,12 +7195,10 @@ let (tc_non_layered_eff_decl :
                                                let return_repr =
                                                  let return_repr_ts =
                                                    let uu___18 =
-                                                     FStar_Compiler_Effect.op_Bar_Greater
-                                                       ed2
-                                                       FStar_Syntax_Util.get_return_repr in
-                                                   FStar_Compiler_Effect.op_Bar_Greater
-                                                     uu___18
-                                                     FStar_Compiler_Util.must in
+                                                     FStar_Syntax_Util.get_return_repr
+                                                       ed2 in
+                                                   FStar_Compiler_Util.must
+                                                     uu___18 in
                                                  let uu___18 =
                                                    fresh_a_and_wp () in
                                                  match uu___18 with
@@ -7795,25 +7217,22 @@ let (tc_non_layered_eff_decl :
                                                            let uu___21 =
                                                              FStar_TypeChecker_Env.inst_tscheme
                                                                ret_wp in
-                                                           FStar_Compiler_Effect.op_Bar_Greater
-                                                             uu___21
-                                                             FStar_Pervasives_Native.snd in
+                                                           FStar_Pervasives_Native.snd
+                                                             uu___21 in
                                                          let uu___21 =
                                                            let uu___22 =
                                                              let uu___23 =
                                                                FStar_Syntax_Syntax.bv_to_name
                                                                  a in
-                                                             FStar_Compiler_Effect.op_Bar_Greater
-                                                               uu___23
-                                                               FStar_Syntax_Syntax.as_arg in
+                                                             FStar_Syntax_Syntax.as_arg
+                                                               uu___23 in
                                                            let uu___23 =
                                                              let uu___24 =
                                                                let uu___25 =
                                                                  FStar_Syntax_Syntax.bv_to_name
                                                                    x_a in
-                                                               FStar_Compiler_Effect.op_Bar_Greater
-                                                                 uu___25
-                                                                 FStar_Syntax_Syntax.as_arg in
+                                                               FStar_Syntax_Syntax.as_arg
+                                                                 uu___25 in
                                                              [uu___24] in
                                                            uu___22 :: uu___23 in
                                                          FStar_Syntax_Syntax.mk_Tm_app
@@ -7862,12 +7281,10 @@ let (tc_non_layered_eff_decl :
                                                (let bind_repr =
                                                   let bind_repr_ts =
                                                     let uu___19 =
-                                                      FStar_Compiler_Effect.op_Bar_Greater
-                                                        ed2
-                                                        FStar_Syntax_Util.get_bind_repr in
-                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                      uu___19
-                                                      FStar_Compiler_Util.must in
+                                                      FStar_Syntax_Util.get_bind_repr
+                                                        ed2 in
+                                                    FStar_Compiler_Util.must
+                                                      uu___19 in
                                                   let uu___19 =
                                                     fresh_a_and_wp () in
                                                   match uu___19 with
@@ -7920,9 +7337,8 @@ let (tc_non_layered_eff_decl :
                                                                    =
                                                                    FStar_Syntax_Syntax.bv_to_name
                                                                     x_a in
-                                                                 FStar_Compiler_Effect.op_Bar_Greater
-                                                                   uu___24
-                                                                   FStar_Syntax_Syntax.as_arg in
+                                                                 FStar_Syntax_Syntax.as_arg
+                                                                   uu___24 in
                                                                [uu___23] in
                                                              FStar_Syntax_Syntax.mk_Tm_app
                                                                uu___21
@@ -7935,9 +7351,8 @@ let (tc_non_layered_eff_decl :
                                                                    =
                                                                    FStar_TypeChecker_Env.inst_tscheme
                                                                     bind_wp in
-                                                                 FStar_Compiler_Effect.op_Bar_Greater
-                                                                   uu___22
-                                                                   FStar_Pervasives_Native.snd in
+                                                                 FStar_Pervasives_Native.snd
+                                                                   uu___22 in
                                                                let uu___22 =
                                                                  let uu___23
                                                                    =
@@ -8063,7 +7478,6 @@ let (tc_non_layered_eff_decl :
                                                                     =
                                                                     mk_repr b
                                                                     wp_g_x in
-                                                                    FStar_Compiler_Effect.op_Less_Bar
                                                                     FStar_Syntax_Syntax.mk_Total
                                                                     uu___35 in
                                                                     FStar_Syntax_Util.arrow
@@ -8105,7 +7519,7 @@ let (tc_non_layered_eff_decl :
                                                                     (FStar_Pervasives_Native.snd
                                                                     bind_repr_ts).FStar_Syntax_Syntax.pos in
                                                                 let env2 =
-                                                                  FStar_Compiler_Effect.op_Bar_Greater
+                                                                  FStar_Pervasives_Native.Some
                                                                     {
                                                                     FStar_TypeChecker_Env.solver
                                                                     =
@@ -8262,13 +7676,7 @@ let (tc_non_layered_eff_decl :
                                                                     FStar_TypeChecker_Env.core_check
                                                                     =
                                                                     (env1.FStar_TypeChecker_Env.core_check)
-                                                                    }
-                                                                    (
-                                                                    fun
-                                                                    uu___24
-                                                                    ->
-                                                                    FStar_Pervasives_Native.Some
-                                                                    uu___24) in
+                                                                    } in
                                                                 check_and_gen'
                                                                   "bind_repr"
                                                                   (Prims.of_int (2))
@@ -9024,10 +8432,9 @@ let (tc_non_layered_eff_decl :
                                                                     =
                                                                     act_typ5
                                                                     })))))))) in
-                                                   FStar_Compiler_Effect.op_Bar_Greater
-                                                     ed2.FStar_Syntax_Syntax.actions
-                                                     (FStar_Compiler_List.map
-                                                        check_action) in
+                                                   FStar_Compiler_List.map
+                                                     check_action
+                                                     ed2.FStar_Syntax_Syntax.actions in
                                                  ((FStar_Pervasives_Native.Some
                                                      repr),
                                                    (FStar_Pervasives_Native.Some
@@ -9103,17 +8510,15 @@ let (tc_non_layered_eff_decl :
                                                         cl
                                                           ((a.FStar_Syntax_Syntax.action_univs),
                                                             (a.FStar_Syntax_Syntax.action_defn)) in
-                                                      FStar_Compiler_Effect.op_Bar_Greater
-                                                        uu___18
-                                                        FStar_Pervasives_Native.snd in
+                                                      FStar_Pervasives_Native.snd
+                                                        uu___18 in
                                                     let uu___18 =
                                                       let uu___19 =
                                                         cl
                                                           ((a.FStar_Syntax_Syntax.action_univs),
                                                             (a.FStar_Syntax_Syntax.action_typ)) in
-                                                      FStar_Compiler_Effect.op_Bar_Greater
-                                                        uu___19
-                                                        FStar_Pervasives_Native.snd in
+                                                      FStar_Pervasives_Native.snd
+                                                        uu___19 in
                                                     {
                                                       FStar_Syntax_Syntax.action_name
                                                         =
@@ -9156,9 +8561,8 @@ let (tc_non_layered_eff_decl :
                                                  (ed2.FStar_Syntax_Syntax.extraction_mode)
                                              } in
                                            ((let uu___16 =
-                                               FStar_Compiler_Effect.op_Less_Bar
-                                                 (FStar_TypeChecker_Env.debug
-                                                    env)
+                                               FStar_TypeChecker_Env.debug
+                                                 env
                                                  (FStar_Options.Other "ED") in
                                              if uu___16
                                              then
@@ -9181,9 +8585,7 @@ let (tc_eff_decl :
     fun ed ->
       fun quals ->
         fun attrs ->
-          let uu___ =
-            FStar_Compiler_Effect.op_Bar_Greater ed
-              FStar_Syntax_Util.is_layered in
+          let uu___ = FStar_Syntax_Util.is_layered ed in
           if uu___
           then tc_layered_eff_decl env ed quals attrs
           else tc_non_layered_eff_decl env ed quals attrs
@@ -9231,27 +8633,20 @@ let (tc_layered_lift :
   fun env0 ->
     fun sub ->
       (let uu___1 =
-         FStar_Compiler_Effect.op_Less_Bar (FStar_TypeChecker_Env.debug env0)
+         FStar_TypeChecker_Env.debug env0
            (FStar_Options.Other "LayeredEffectsTc") in
        if uu___1
        then
          let uu___2 = FStar_Syntax_Print.sub_eff_to_string sub in
          FStar_Compiler_Util.print1 "Typechecking sub_effect: %s\n" uu___2
        else ());
-      (let lift_ts =
-         FStar_Compiler_Effect.op_Bar_Greater sub.FStar_Syntax_Syntax.lift
-           FStar_Compiler_Util.must in
-       let r =
-         let uu___1 =
-           FStar_Compiler_Effect.op_Bar_Greater lift_ts
-             FStar_Pervasives_Native.snd in
-         uu___1.FStar_Syntax_Syntax.pos in
+      (let lift_ts = FStar_Compiler_Util.must sub.FStar_Syntax_Syntax.lift in
+       let r = (FStar_Pervasives_Native.snd lift_ts).FStar_Syntax_Syntax.pos in
        let uu___1 = check_and_gen env0 "" "lift" Prims.int_one lift_ts in
        match uu___1 with
        | (us, lift, lift_ty) ->
            ((let uu___3 =
-               FStar_Compiler_Effect.op_Less_Bar
-                 (FStar_TypeChecker_Env.debug env0)
+               FStar_TypeChecker_Env.debug env0
                  (FStar_Options.Other "LayeredEffectsTc") in
              if uu___3
              then
@@ -9276,8 +8671,7 @@ let (tc_layered_lift :
                         let uu___5 =
                           let uu___6 =
                             let uu___7 =
-                              FStar_Compiler_Effect.op_Bar_Greater k
-                                (FStar_Syntax_Subst.close_univ_vars us1) in
+                              FStar_Syntax_Subst.close_univ_vars us1 k in
                             (us1, uu___7) in
                           FStar_Pervasives_Native.Some uu___6 in
                         {
@@ -9292,8 +8686,7 @@ let (tc_layered_lift :
                             (FStar_Pervasives_Native.Some kind)
                         } in
                       ((let uu___6 =
-                          FStar_Compiler_Effect.op_Less_Bar
-                            (FStar_TypeChecker_Env.debug env0)
+                          FStar_TypeChecker_Env.debug env0
                             (FStar_Options.Other "LayeredEffectsTc") in
                         if uu___6
                         then
@@ -9379,11 +8772,8 @@ let (tc_lift :
             FStar_TypeChecker_Env.get_effect_decl env
               sub.FStar_Syntax_Syntax.target in
           let uu___2 =
-            (FStar_Compiler_Effect.op_Bar_Greater ed_src
-               FStar_Syntax_Util.is_layered)
-              ||
-              (FStar_Compiler_Effect.op_Bar_Greater ed_tgt
-                 FStar_Syntax_Util.is_layered) in
+            (FStar_Syntax_Util.is_layered ed_src) ||
+              (FStar_Syntax_Util.is_layered ed_tgt) in
           if uu___2
           then
             let uu___3 = FStar_TypeChecker_Env.set_range env r in
@@ -9451,10 +8841,8 @@ let (tc_lift :
                              let repr =
                                let uu___8 =
                                  let uu___9 =
-                                   FStar_Compiler_Effect.op_Bar_Greater ed
-                                     FStar_Syntax_Util.get_eff_repr in
-                                 FStar_Compiler_Effect.op_Bar_Greater uu___9
-                                   FStar_Compiler_Util.must in
+                                   FStar_Syntax_Util.get_eff_repr ed in
+                                 FStar_Compiler_Util.must uu___9 in
                                FStar_TypeChecker_Env.inst_effect_fun_with
                                  [FStar_Syntax_Syntax.U_unknown] env ed
                                  uu___8 in
@@ -9836,53 +9224,39 @@ let (tc_lift :
                                                      (uvs, uu___13)) in
                                                 FStar_Pervasives_Native.Some
                                                   lift4))) in
-                           ((let uu___8 =
-                               let uu___9 =
-                                 let uu___10 =
-                                   FStar_Compiler_Effect.op_Bar_Greater
-                                     lift_wp FStar_Pervasives_Native.fst in
-                                 FStar_Compiler_Effect.op_Bar_Greater uu___10
-                                   FStar_Compiler_List.length in
-                               uu___9 <> Prims.int_one in
-                             if uu___8
-                             then
-                               let uu___9 =
-                                 let uu___10 =
-                                   let uu___11 =
+                           (if
+                              (FStar_Compiler_List.length
+                                 (FStar_Pervasives_Native.fst lift_wp))
+                                <> Prims.int_one
+                            then
+                              (let uu___8 =
+                                 let uu___9 =
+                                   let uu___10 =
                                      FStar_Syntax_Print.lid_to_string
                                        sub.FStar_Syntax_Syntax.source in
-                                   let uu___12 =
+                                   let uu___11 =
                                      FStar_Syntax_Print.lid_to_string
                                        sub.FStar_Syntax_Syntax.target in
-                                   let uu___13 =
-                                     let uu___14 =
-                                       let uu___15 =
-                                         FStar_Compiler_Effect.op_Bar_Greater
-                                           lift_wp
-                                           FStar_Pervasives_Native.fst in
-                                       FStar_Compiler_Effect.op_Bar_Greater
-                                         uu___15 FStar_Compiler_List.length in
-                                     FStar_Compiler_Effect.op_Bar_Greater
-                                       uu___14
-                                       FStar_Compiler_Util.string_of_int in
+                                   let uu___12 =
+                                     FStar_Compiler_Util.string_of_int
+                                       (FStar_Compiler_List.length
+                                          (FStar_Pervasives_Native.fst
+                                             lift_wp)) in
                                    FStar_Compiler_Util.format3
                                      "Sub effect wp must be polymorphic in exactly 1 universe; %s ~> %s has %s universes"
-                                     uu___11 uu___12 uu___13 in
+                                     uu___10 uu___11 uu___12 in
                                  (FStar_Errors_Codes.Fatal_TooManyUniverse,
-                                   uu___10) in
-                               FStar_Errors.raise_error uu___9 r
-                             else ());
+                                   uu___9) in
+                               FStar_Errors.raise_error uu___8 r)
+                            else ();
                             (let uu___9 =
                                (FStar_Compiler_Util.is_some lift1) &&
                                  (let uu___10 =
                                     let uu___11 =
                                       let uu___12 =
-                                        FStar_Compiler_Effect.op_Bar_Greater
-                                          lift1 FStar_Compiler_Util.must in
-                                      FStar_Compiler_Effect.op_Bar_Greater
-                                        uu___12 FStar_Pervasives_Native.fst in
-                                    FStar_Compiler_Effect.op_Bar_Greater
-                                      uu___11 FStar_Compiler_List.length in
+                                        FStar_Compiler_Util.must lift1 in
+                                      FStar_Pervasives_Native.fst uu___12 in
+                                    FStar_Compiler_List.length uu___11 in
                                   uu___10 <> Prims.int_one) in
                              if uu___9
                              then
@@ -9898,16 +9272,11 @@ let (tc_lift :
                                      let uu___15 =
                                        let uu___16 =
                                          let uu___17 =
-                                           FStar_Compiler_Effect.op_Bar_Greater
-                                             lift1 FStar_Compiler_Util.must in
-                                         FStar_Compiler_Effect.op_Bar_Greater
-                                           uu___17
-                                           FStar_Pervasives_Native.fst in
-                                       FStar_Compiler_Effect.op_Bar_Greater
-                                         uu___16 FStar_Compiler_List.length in
-                                     FStar_Compiler_Effect.op_Bar_Greater
-                                       uu___15
-                                       FStar_Compiler_Util.string_of_int in
+                                           FStar_Compiler_Util.must lift1 in
+                                         FStar_Pervasives_Native.fst uu___17 in
+                                       FStar_Compiler_List.length uu___16 in
+                                     FStar_Compiler_Util.string_of_int
+                                       uu___15 in
                                    FStar_Compiler_Util.format3
                                      "Sub effect lift must be polymorphic in exactly 1 universe; %s ~> %s has %s universes"
                                      uu___12 uu___13 uu___14 in
@@ -9972,13 +9341,9 @@ let (tc_effect_abbrev :
                             | (c3, u, g) ->
                                 let is_default_effect =
                                   let uu___5 =
-                                    let uu___6 =
-                                      FStar_Compiler_Effect.op_Bar_Greater c3
-                                        FStar_Syntax_Util.comp_effect_name in
-                                    FStar_Compiler_Effect.op_Bar_Greater
-                                      uu___6
-                                      (FStar_TypeChecker_Env.get_default_effect
-                                         env3) in
+                                    FStar_TypeChecker_Env.get_default_effect
+                                      env3
+                                      (FStar_Syntax_Util.comp_effect_name c3) in
                                   match uu___5 with
                                   | FStar_Pervasives_Native.None -> false
                                   | FStar_Pervasives_Native.Some l ->
@@ -10005,13 +9370,9 @@ let (tc_effect_abbrev :
                                                   FStar_Ident.string_of_lid
                                                     lid in
                                                 let uu___14 =
-                                                  let uu___15 =
-                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                      c3
-                                                      FStar_Syntax_Util.comp_effect_name in
-                                                  FStar_Compiler_Effect.op_Bar_Greater
-                                                    uu___15
-                                                    FStar_Ident.string_of_lid in
+                                                  FStar_Ident.string_of_lid
+                                                    (FStar_Syntax_Util.comp_effect_name
+                                                       c3) in
                                                 FStar_Compiler_Util.format2
                                                   "Effect %s is marked as a default effect for %s, but it has more than one arguments"
                                                   uu___13 uu___14 in
@@ -10107,10 +9468,9 @@ let (tc_effect_abbrev :
                                                          FStar_Syntax_Print.lid_to_string
                                                            lid in
                                                        let uu___15 =
-                                                         FStar_Compiler_Effect.op_Bar_Greater
+                                                         FStar_Compiler_Util.string_of_int
                                                            (FStar_Compiler_List.length
-                                                              uvs2)
-                                                           FStar_Compiler_Util.string_of_int in
+                                                              uvs2) in
                                                        let uu___16 =
                                                          FStar_Syntax_Print.term_to_string
                                                            t1 in
@@ -10213,23 +9573,14 @@ let (tc_polymonadic_bind :
           fun ts ->
             let eff_name =
               let uu___ =
-                let uu___1 =
-                  FStar_Compiler_Effect.op_Bar_Greater m
-                    FStar_Ident.ident_of_lid in
-                FStar_Compiler_Effect.op_Bar_Greater uu___1
-                  FStar_Ident.string_of_id in
+                let uu___1 = FStar_Ident.ident_of_lid m in
+                FStar_Ident.string_of_id uu___1 in
               let uu___1 =
-                let uu___2 =
-                  FStar_Compiler_Effect.op_Bar_Greater n
-                    FStar_Ident.ident_of_lid in
-                FStar_Compiler_Effect.op_Bar_Greater uu___2
-                  FStar_Ident.string_of_id in
+                let uu___2 = FStar_Ident.ident_of_lid n in
+                FStar_Ident.string_of_id uu___2 in
               let uu___2 =
-                let uu___3 =
-                  FStar_Compiler_Effect.op_Bar_Greater p
-                    FStar_Ident.ident_of_lid in
-                FStar_Compiler_Effect.op_Bar_Greater uu___3
-                  FStar_Ident.string_of_id in
+                let uu___3 = FStar_Ident.ident_of_lid p in
+                FStar_Ident.string_of_id uu___3 in
               FStar_Compiler_Util.format3 "(%s, %s) |> %s)" uu___ uu___1
                 uu___2 in
             let r = (FStar_Pervasives_Native.snd ts).FStar_Syntax_Syntax.pos in
@@ -10275,8 +9626,7 @@ let (tc_polymonadic_bind :
                            (match uu___4 with
                             | (k, kind) ->
                                 ((let uu___6 =
-                                    FStar_Compiler_Effect.op_Less_Bar
-                                      (FStar_TypeChecker_Env.debug env1)
+                                    FStar_TypeChecker_Env.debug env1
                                       FStar_Options.Extreme in
                                   if uu___6
                                   then
@@ -10297,17 +9647,15 @@ let (tc_polymonadic_bind :
                                           FStar_Compiler_Util.format1
                                             "Polymonadic binds (%s in this case) is an experimental feature;it is subject to some redesign in the future. Please keep us informed (on github etc.) about how you are using it"
                                             eff_name in
-                                        FStar_Compiler_Effect.op_Less_Bar
-                                          FStar_Errors_Msg.text uu___10 in
+                                        FStar_Errors_Msg.text uu___10 in
                                       [uu___9] in
                                     (FStar_Errors_Codes.Warning_BleedingEdge_Feature,
                                       uu___8) in
                                   FStar_Errors.log_issue_doc r uu___7);
                                  (let uu___7 =
                                     let uu___8 =
-                                      FStar_Compiler_Effect.op_Bar_Greater k
-                                        (FStar_Syntax_Subst.close_univ_vars
-                                           us1) in
+                                      FStar_Syntax_Subst.close_univ_vars us1
+                                        k in
                                     (us1, uu___8) in
                                   ((us1, t), uu___7, kind)))))))
 let (tc_polymonadic_subcomp :
@@ -10326,18 +9674,12 @@ let (tc_polymonadic_subcomp :
           check_lift_for_erasable_effects env0 m n r;
           (let combinator_name =
              let uu___1 =
-               let uu___2 =
-                 FStar_Compiler_Effect.op_Bar_Greater m
-                   FStar_Ident.ident_of_lid in
-               FStar_Compiler_Effect.op_Bar_Greater uu___2
-                 FStar_Ident.string_of_id in
+               let uu___2 = FStar_Ident.ident_of_lid m in
+               FStar_Ident.string_of_id uu___2 in
              let uu___2 =
                let uu___3 =
-                 let uu___4 =
-                   FStar_Compiler_Effect.op_Bar_Greater n
-                     FStar_Ident.ident_of_lid in
-                 FStar_Compiler_Effect.op_Bar_Greater uu___4
-                   FStar_Ident.string_of_id in
+                 let uu___4 = FStar_Ident.ident_of_lid n in
+                 FStar_Ident.string_of_id uu___4 in
                Prims.strcat " <: " uu___3 in
              Prims.strcat uu___1 uu___2 in
            let uu___1 =
@@ -10374,8 +9716,7 @@ let (tc_polymonadic_subcomp :
                          (match uu___4 with
                           | (k, kind) ->
                               ((let uu___6 =
-                                  FStar_Compiler_Effect.op_Less_Bar
-                                    (FStar_TypeChecker_Env.debug env)
+                                  FStar_TypeChecker_Env.debug env
                                     FStar_Options.Extreme in
                                 if uu___6
                                 then
@@ -10396,15 +9737,13 @@ let (tc_polymonadic_subcomp :
                                         FStar_Compiler_Util.format1
                                           "Polymonadic subcomp (%s in this case) is an experimental feature;it is subject to some redesign in the future. Please keep us informed (on github etc.) about how you are using it"
                                           combinator_name in
-                                      FStar_Compiler_Effect.op_Less_Bar
-                                        FStar_Errors_Msg.text uu___10 in
+                                      FStar_Errors_Msg.text uu___10 in
                                     [uu___9] in
                                   (FStar_Errors_Codes.Warning_BleedingEdge_Feature,
                                     uu___8) in
                                 FStar_Errors.log_issue_doc r uu___7);
                                (let uu___7 =
                                   let uu___8 =
-                                    FStar_Compiler_Effect.op_Bar_Greater k
-                                      (FStar_Syntax_Subst.close_univ_vars us1) in
+                                    FStar_Syntax_Subst.close_univ_vars us1 k in
                                   (us1, uu___8) in
                                 ((us1, t), uu___7, kind)))))))

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_TcInductive.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_TcInductive.ml
@@ -82,19 +82,15 @@ let (tc_tycon :
                                           (((FStar_Syntax_Util.is_eqtype_no_unrefine
                                                t)
                                               &&
-                                              (let uu___6 =
-                                                 FStar_Compiler_Effect.op_Bar_Greater
-                                                   s.FStar_Syntax_Syntax.sigquals
-                                                   (FStar_Compiler_List.contains
-                                                      FStar_Syntax_Syntax.Noeq) in
-                                               Prims.op_Negation uu___6))
+                                              (Prims.op_Negation
+                                                 (FStar_Compiler_List.contains
+                                                    FStar_Syntax_Syntax.Noeq
+                                                    s.FStar_Syntax_Syntax.sigquals)))
                                              &&
-                                             (let uu___6 =
-                                                FStar_Compiler_Effect.op_Bar_Greater
-                                                  s.FStar_Syntax_Syntax.sigquals
-                                                  (FStar_Compiler_List.contains
-                                                     FStar_Syntax_Syntax.Unopteq) in
-                                              Prims.op_Negation uu___6))
+                                             (Prims.op_Negation
+                                                (FStar_Compiler_List.contains
+                                                   FStar_Syntax_Syntax.Unopteq
+                                                   s.FStar_Syntax_Syntax.sigquals)))
                                             ||
                                             (FStar_TypeChecker_Rel.teq_nosmt_force
                                                env1 t t_type) in
@@ -126,36 +122,28 @@ let (tc_tycon :
                                           let t_tc =
                                             let uu___7 =
                                               let uu___8 =
-                                                FStar_Compiler_Effect.op_Bar_Greater
-                                                  tps3
-                                                  (FStar_Syntax_Subst.subst_binders
-                                                     usubst1) in
+                                                FStar_Syntax_Subst.subst_binders
+                                                  usubst1 tps3 in
                                               let uu___9 =
                                                 let uu___10 =
-                                                  let uu___11 =
-                                                    FStar_Syntax_Subst.shift_subst
-                                                      (FStar_Compiler_List.length
-                                                         tps3) usubst1 in
-                                                  FStar_Syntax_Subst.subst_binders
-                                                    uu___11 in
-                                                FStar_Compiler_Effect.op_Bar_Greater
-                                                  indices uu___10 in
+                                                  FStar_Syntax_Subst.shift_subst
+                                                    (FStar_Compiler_List.length
+                                                       tps3) usubst1 in
+                                                FStar_Syntax_Subst.subst_binders
+                                                  uu___10 indices in
                                               FStar_Compiler_List.op_At
                                                 uu___8 uu___9 in
                                             let uu___8 =
                                               let uu___9 =
                                                 let uu___10 =
-                                                  let uu___11 =
-                                                    FStar_Syntax_Subst.shift_subst
-                                                      ((FStar_Compiler_List.length
-                                                          tps3)
-                                                         +
-                                                         (FStar_Compiler_List.length
-                                                            indices)) usubst1 in
-                                                  FStar_Syntax_Subst.subst
-                                                    uu___11 in
-                                                FStar_Compiler_Effect.op_Bar_Greater
-                                                  t uu___10 in
+                                                  FStar_Syntax_Subst.shift_subst
+                                                    ((FStar_Compiler_List.length
+                                                        tps3)
+                                                       +
+                                                       (FStar_Compiler_List.length
+                                                          indices)) usubst1 in
+                                                FStar_Syntax_Subst.subst
+                                                  uu___10 t in
                                               FStar_Syntax_Syntax.mk_Total
                                                 uu___9 in
                                             FStar_Syntax_Util.arrow uu___7
@@ -298,29 +286,25 @@ let (tc_data :
                                           ->
                                           let tps1 =
                                             let uu___11 =
-                                              FStar_Compiler_Effect.op_Bar_Greater
-                                                tps
-                                                (FStar_Syntax_Subst.subst_binders
-                                                   usubst) in
-                                            FStar_Compiler_Effect.op_Bar_Greater
-                                              uu___11
-                                              (FStar_Compiler_List.map
-                                                 (fun x ->
-                                                    {
-                                                      FStar_Syntax_Syntax.binder_bv
-                                                        =
-                                                        (x.FStar_Syntax_Syntax.binder_bv);
-                                                      FStar_Syntax_Syntax.binder_qual
-                                                        =
-                                                        (FStar_Pervasives_Native.Some
-                                                           FStar_Syntax_Syntax.imp_tag);
-                                                      FStar_Syntax_Syntax.binder_positivity
-                                                        =
-                                                        (x.FStar_Syntax_Syntax.binder_positivity);
-                                                      FStar_Syntax_Syntax.binder_attrs
-                                                        =
-                                                        (x.FStar_Syntax_Syntax.binder_attrs)
-                                                    })) in
+                                              FStar_Syntax_Subst.subst_binders
+                                                usubst tps in
+                                            FStar_Compiler_List.map
+                                              (fun x ->
+                                                 {
+                                                   FStar_Syntax_Syntax.binder_bv
+                                                     =
+                                                     (x.FStar_Syntax_Syntax.binder_bv);
+                                                   FStar_Syntax_Syntax.binder_qual
+                                                     =
+                                                     (FStar_Pervasives_Native.Some
+                                                        FStar_Syntax_Syntax.imp_tag);
+                                                   FStar_Syntax_Syntax.binder_positivity
+                                                     =
+                                                     (x.FStar_Syntax_Syntax.binder_positivity);
+                                                   FStar_Syntax_Syntax.binder_attrs
+                                                     =
+                                                     (x.FStar_Syntax_Syntax.binder_attrs)
+                                                 }) uu___11 in
                                           let tps2 =
                                             FStar_Syntax_Subst.open_binders
                                               tps1 in
@@ -378,26 +362,24 @@ let (tc_data :
                                                FStar_Syntax_Syntax.comp = res
                                              }) t3.FStar_Syntax_Syntax.pos in
                                       let subst =
-                                        FStar_Compiler_Effect.op_Bar_Greater
-                                          tps
-                                          (FStar_Compiler_List.mapi
-                                             (fun i ->
-                                                fun uu___7 ->
-                                                  match uu___7 with
-                                                  | {
-                                                      FStar_Syntax_Syntax.binder_bv
-                                                        = x;
-                                                      FStar_Syntax_Syntax.binder_qual
-                                                        = uu___8;
-                                                      FStar_Syntax_Syntax.binder_positivity
-                                                        = uu___9;
-                                                      FStar_Syntax_Syntax.binder_attrs
-                                                        = uu___10;_}
-                                                      ->
-                                                      FStar_Syntax_Syntax.DB
-                                                        ((ntps -
-                                                            (Prims.int_one +
-                                                               i)), x))) in
+                                        FStar_Compiler_List.mapi
+                                          (fun i ->
+                                             fun uu___7 ->
+                                               match uu___7 with
+                                               | {
+                                                   FStar_Syntax_Syntax.binder_bv
+                                                     = x;
+                                                   FStar_Syntax_Syntax.binder_qual
+                                                     = uu___8;
+                                                   FStar_Syntax_Syntax.binder_positivity
+                                                     = uu___9;
+                                                   FStar_Syntax_Syntax.binder_attrs
+                                                     = uu___10;_}
+                                                   ->
+                                                   FStar_Syntax_Syntax.DB
+                                                     ((ntps -
+                                                         (Prims.int_one + i)),
+                                                       x)) tps in
                                       let uu___7 =
                                         let uu___8 =
                                           FStar_Syntax_Subst.subst subst t4 in
@@ -636,9 +618,8 @@ let (tc_data :
                                                      let uu___10 =
                                                        unfold_whnf env2
                                                          res_lcomp.FStar_TypeChecker_Common.res_typ in
-                                                     FStar_Compiler_Effect.op_Bar_Greater
-                                                       uu___10
-                                                       FStar_Syntax_Util.unrefine in
+                                                     FStar_Syntax_Util.unrefine
+                                                       uu___10 in
                                                    (let uu___11 =
                                                       let uu___12 =
                                                         FStar_Syntax_Subst.compress
@@ -667,26 +648,24 @@ let (tc_data :
                                                    (let t2 =
                                                       let uu___11 =
                                                         let uu___12 =
-                                                          FStar_Compiler_Effect.op_Bar_Greater
-                                                            tps
-                                                            (FStar_Compiler_List.map
-                                                               (fun b ->
-                                                                  {
-                                                                    FStar_Syntax_Syntax.binder_bv
-                                                                    =
-                                                                    (b.FStar_Syntax_Syntax.binder_bv);
-                                                                    FStar_Syntax_Syntax.binder_qual
-                                                                    =
-                                                                    (FStar_Pervasives_Native.Some
+                                                          FStar_Compiler_List.map
+                                                            (fun b ->
+                                                               {
+                                                                 FStar_Syntax_Syntax.binder_bv
+                                                                   =
+                                                                   (b.FStar_Syntax_Syntax.binder_bv);
+                                                                 FStar_Syntax_Syntax.binder_qual
+                                                                   =
+                                                                   (FStar_Pervasives_Native.Some
                                                                     (FStar_Syntax_Syntax.Implicit
                                                                     true));
-                                                                    FStar_Syntax_Syntax.binder_positivity
-                                                                    =
-                                                                    (b.FStar_Syntax_Syntax.binder_positivity);
-                                                                    FStar_Syntax_Syntax.binder_attrs
-                                                                    =
-                                                                    (b.FStar_Syntax_Syntax.binder_attrs)
-                                                                  })) in
+                                                                 FStar_Syntax_Syntax.binder_positivity
+                                                                   =
+                                                                   (b.FStar_Syntax_Syntax.binder_positivity);
+                                                                 FStar_Syntax_Syntax.binder_attrs
+                                                                   =
+                                                                   (b.FStar_Syntax_Syntax.binder_attrs)
+                                                               }) tps in
                                                         FStar_Compiler_List.op_At
                                                           uu___12 arguments1 in
                                                       let uu___12 =
@@ -746,49 +725,45 @@ let (generalize_and_inst_within :
     fun tcs ->
       fun datas ->
         let binders =
-          FStar_Compiler_Effect.op_Bar_Greater tcs
-            (FStar_Compiler_List.map
-               (fun uu___ ->
-                  match uu___ with
-                  | (se, uu___1) ->
-                      (match se.FStar_Syntax_Syntax.sigel with
-                       | FStar_Syntax_Syntax.Sig_inductive_typ
-                           { FStar_Syntax_Syntax.lid = uu___2;
-                             FStar_Syntax_Syntax.us = uu___3;
-                             FStar_Syntax_Syntax.params = tps;
-                             FStar_Syntax_Syntax.num_uniform_params = uu___4;
-                             FStar_Syntax_Syntax.t = k;
-                             FStar_Syntax_Syntax.mutuals = uu___5;
-                             FStar_Syntax_Syntax.ds = uu___6;_}
-                           ->
-                           let uu___7 =
-                             let uu___8 = FStar_Syntax_Syntax.mk_Total k in
-                             FStar_Compiler_Effect.op_Less_Bar
-                               (FStar_Syntax_Util.arrow tps) uu___8 in
-                           FStar_Syntax_Syntax.null_binder uu___7
-                       | uu___2 ->
-                           FStar_Compiler_Effect.failwith "Impossible"))) in
+          FStar_Compiler_List.map
+            (fun uu___ ->
+               match uu___ with
+               | (se, uu___1) ->
+                   (match se.FStar_Syntax_Syntax.sigel with
+                    | FStar_Syntax_Syntax.Sig_inductive_typ
+                        { FStar_Syntax_Syntax.lid = uu___2;
+                          FStar_Syntax_Syntax.us = uu___3;
+                          FStar_Syntax_Syntax.params = tps;
+                          FStar_Syntax_Syntax.num_uniform_params = uu___4;
+                          FStar_Syntax_Syntax.t = k;
+                          FStar_Syntax_Syntax.mutuals = uu___5;
+                          FStar_Syntax_Syntax.ds = uu___6;_}
+                        ->
+                        let uu___7 =
+                          let uu___8 = FStar_Syntax_Syntax.mk_Total k in
+                          FStar_Syntax_Util.arrow tps uu___8 in
+                        FStar_Syntax_Syntax.null_binder uu___7
+                    | uu___2 -> FStar_Compiler_Effect.failwith "Impossible"))
+            tcs in
         let binders' =
-          FStar_Compiler_Effect.op_Bar_Greater datas
-            (FStar_Compiler_List.map
-               (fun se ->
-                  match se.FStar_Syntax_Syntax.sigel with
-                  | FStar_Syntax_Syntax.Sig_datacon
-                      { FStar_Syntax_Syntax.lid1 = uu___;
-                        FStar_Syntax_Syntax.us1 = uu___1;
-                        FStar_Syntax_Syntax.t1 = t;
-                        FStar_Syntax_Syntax.ty_lid = uu___2;
-                        FStar_Syntax_Syntax.num_ty_params = uu___3;
-                        FStar_Syntax_Syntax.mutuals1 = uu___4;_}
-                      -> FStar_Syntax_Syntax.null_binder t
-                  | uu___ -> FStar_Compiler_Effect.failwith "Impossible")) in
+          FStar_Compiler_List.map
+            (fun se ->
+               match se.FStar_Syntax_Syntax.sigel with
+               | FStar_Syntax_Syntax.Sig_datacon
+                   { FStar_Syntax_Syntax.lid1 = uu___;
+                     FStar_Syntax_Syntax.us1 = uu___1;
+                     FStar_Syntax_Syntax.t1 = t;
+                     FStar_Syntax_Syntax.ty_lid = uu___2;
+                     FStar_Syntax_Syntax.num_ty_params = uu___3;
+                     FStar_Syntax_Syntax.mutuals1 = uu___4;_}
+                   -> FStar_Syntax_Syntax.null_binder t
+               | uu___ -> FStar_Compiler_Effect.failwith "Impossible") datas in
         let t =
           let uu___ = FStar_Syntax_Syntax.mk_Total FStar_Syntax_Syntax.t_unit in
           FStar_Syntax_Util.arrow
             (FStar_Compiler_List.op_At binders binders') uu___ in
         (let uu___1 =
-           FStar_Compiler_Effect.op_Less_Bar
-             (FStar_TypeChecker_Env.debug env)
+           FStar_TypeChecker_Env.debug env
              (FStar_Options.Other "GenUniverses") in
          if uu___1
          then
@@ -800,18 +775,15 @@ let (generalize_and_inst_within :
          match uu___1 with
          | (uvs, t1) ->
              ((let uu___3 =
-                 FStar_Compiler_Effect.op_Less_Bar
-                   (FStar_TypeChecker_Env.debug env)
+                 FStar_TypeChecker_Env.debug env
                    (FStar_Options.Other "GenUniverses") in
                if uu___3
                then
                  let uu___4 =
                    let uu___5 =
-                     FStar_Compiler_Effect.op_Bar_Greater uvs
-                       (FStar_Compiler_List.map
-                          (fun u -> FStar_Ident.string_of_id u)) in
-                   FStar_Compiler_Effect.op_Bar_Greater uu___5
-                     (FStar_Compiler_String.concat ", ") in
+                     FStar_Compiler_List.map
+                       (fun u -> FStar_Ident.string_of_id u) uvs in
+                   FStar_Compiler_String.concat ", " uu___5 in
                  let uu___5 = FStar_Syntax_Print.term_to_string t1 in
                  FStar_Compiler_Util.print2 "@@@@@@Generalized to (%s, %s)\n"
                    uu___4 uu___5
@@ -948,52 +920,48 @@ let (generalize_and_inst_within :
                                | [] -> datas
                                | uu___7 ->
                                    let uvs_universes =
-                                     FStar_Compiler_Effect.op_Bar_Greater
-                                       uvs1
-                                       (FStar_Compiler_List.map
-                                          (fun uu___8 ->
-                                             FStar_Syntax_Syntax.U_name
-                                               uu___8)) in
+                                     FStar_Compiler_List.map
+                                       (fun uu___8 ->
+                                          FStar_Syntax_Syntax.U_name uu___8)
+                                       uvs1 in
                                    let tc_insts =
-                                     FStar_Compiler_Effect.op_Bar_Greater
-                                       tcs1
-                                       (FStar_Compiler_List.map
-                                          (fun uu___8 ->
-                                             match uu___8 with
-                                             | {
-                                                 FStar_Syntax_Syntax.sigel =
-                                                   FStar_Syntax_Syntax.Sig_inductive_typ
-                                                   {
-                                                     FStar_Syntax_Syntax.lid
-                                                       = tc;
-                                                     FStar_Syntax_Syntax.us =
-                                                       uu___9;
-                                                     FStar_Syntax_Syntax.params
-                                                       = uu___10;
-                                                     FStar_Syntax_Syntax.num_uniform_params
-                                                       = uu___11;
-                                                     FStar_Syntax_Syntax.t =
-                                                       uu___12;
-                                                     FStar_Syntax_Syntax.mutuals
-                                                       = uu___13;
-                                                     FStar_Syntax_Syntax.ds =
-                                                       uu___14;_};
-                                                 FStar_Syntax_Syntax.sigrng =
-                                                   uu___15;
-                                                 FStar_Syntax_Syntax.sigquals
-                                                   = uu___16;
-                                                 FStar_Syntax_Syntax.sigmeta
-                                                   = uu___17;
-                                                 FStar_Syntax_Syntax.sigattrs
-                                                   = uu___18;
-                                                 FStar_Syntax_Syntax.sigopens_and_abbrevs
-                                                   = uu___19;
-                                                 FStar_Syntax_Syntax.sigopts
-                                                   = uu___20;_}
-                                                 -> (tc, uvs_universes)
-                                             | uu___9 ->
-                                                 FStar_Compiler_Effect.failwith
-                                                   "Impossible")) in
+                                     FStar_Compiler_List.map
+                                       (fun uu___8 ->
+                                          match uu___8 with
+                                          | {
+                                              FStar_Syntax_Syntax.sigel =
+                                                FStar_Syntax_Syntax.Sig_inductive_typ
+                                                {
+                                                  FStar_Syntax_Syntax.lid =
+                                                    tc;
+                                                  FStar_Syntax_Syntax.us =
+                                                    uu___9;
+                                                  FStar_Syntax_Syntax.params
+                                                    = uu___10;
+                                                  FStar_Syntax_Syntax.num_uniform_params
+                                                    = uu___11;
+                                                  FStar_Syntax_Syntax.t =
+                                                    uu___12;
+                                                  FStar_Syntax_Syntax.mutuals
+                                                    = uu___13;
+                                                  FStar_Syntax_Syntax.ds =
+                                                    uu___14;_};
+                                              FStar_Syntax_Syntax.sigrng =
+                                                uu___15;
+                                              FStar_Syntax_Syntax.sigquals =
+                                                uu___16;
+                                              FStar_Syntax_Syntax.sigmeta =
+                                                uu___17;
+                                              FStar_Syntax_Syntax.sigattrs =
+                                                uu___18;
+                                              FStar_Syntax_Syntax.sigopens_and_abbrevs
+                                                = uu___19;
+                                              FStar_Syntax_Syntax.sigopts =
+                                                uu___20;_}
+                                              -> (tc, uvs_universes)
+                                          | uu___9 ->
+                                              FStar_Compiler_Effect.failwith
+                                                "Impossible") tcs1 in
                                    FStar_Compiler_List.map2
                                      (fun uu___8 ->
                                         fun d ->
@@ -1030,10 +998,8 @@ let (generalize_and_inst_within :
                                                        FStar_Syntax_InstFV.instantiate
                                                          tc_insts
                                                          t3.FStar_Syntax_Syntax.sort in
-                                                     FStar_Compiler_Effect.op_Bar_Greater
-                                                       uu___14
-                                                       (FStar_Syntax_Subst.close_univ_vars
-                                                          uvs1) in
+                                                     FStar_Syntax_Subst.close_univ_vars
+                                                       uvs1 uu___14 in
                                                    {
                                                      FStar_Syntax_Syntax.sigel
                                                        =
@@ -1915,39 +1881,35 @@ let (check_inductive_well_typedness :
       fun quals ->
         fun lids ->
           let uu___ =
-            FStar_Compiler_Effect.op_Bar_Greater ses
-              (FStar_Compiler_List.partition
-                 (fun uu___1 ->
-                    match uu___1 with
-                    | {
-                        FStar_Syntax_Syntax.sigel =
-                          FStar_Syntax_Syntax.Sig_inductive_typ uu___2;
-                        FStar_Syntax_Syntax.sigrng = uu___3;
-                        FStar_Syntax_Syntax.sigquals = uu___4;
-                        FStar_Syntax_Syntax.sigmeta = uu___5;
-                        FStar_Syntax_Syntax.sigattrs = uu___6;
-                        FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___7;
-                        FStar_Syntax_Syntax.sigopts = uu___8;_} -> true
-                    | uu___2 -> false)) in
+            FStar_Compiler_List.partition
+              (fun uu___1 ->
+                 match uu___1 with
+                 | {
+                     FStar_Syntax_Syntax.sigel =
+                       FStar_Syntax_Syntax.Sig_inductive_typ uu___2;
+                     FStar_Syntax_Syntax.sigrng = uu___3;
+                     FStar_Syntax_Syntax.sigquals = uu___4;
+                     FStar_Syntax_Syntax.sigmeta = uu___5;
+                     FStar_Syntax_Syntax.sigattrs = uu___6;
+                     FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___7;
+                     FStar_Syntax_Syntax.sigopts = uu___8;_} -> true
+                 | uu___2 -> false) ses in
           match uu___ with
           | (tys, datas) ->
               ((let uu___2 =
-                  FStar_Compiler_Effect.op_Bar_Greater datas
-                    (FStar_Compiler_Util.for_some
-                       (fun uu___3 ->
-                          match uu___3 with
-                          | {
-                              FStar_Syntax_Syntax.sigel =
-                                FStar_Syntax_Syntax.Sig_datacon uu___4;
-                              FStar_Syntax_Syntax.sigrng = uu___5;
-                              FStar_Syntax_Syntax.sigquals = uu___6;
-                              FStar_Syntax_Syntax.sigmeta = uu___7;
-                              FStar_Syntax_Syntax.sigattrs = uu___8;
-                              FStar_Syntax_Syntax.sigopens_and_abbrevs =
-                                uu___9;
-                              FStar_Syntax_Syntax.sigopts = uu___10;_} ->
-                              false
-                          | uu___4 -> true)) in
+                  FStar_Compiler_Util.for_some
+                    (fun uu___3 ->
+                       match uu___3 with
+                       | {
+                           FStar_Syntax_Syntax.sigel =
+                             FStar_Syntax_Syntax.Sig_datacon uu___4;
+                           FStar_Syntax_Syntax.sigrng = uu___5;
+                           FStar_Syntax_Syntax.sigquals = uu___6;
+                           FStar_Syntax_Syntax.sigmeta = uu___7;
+                           FStar_Syntax_Syntax.sigattrs = uu___8;
+                           FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___9;
+                           FStar_Syntax_Syntax.sigopts = uu___10;_} -> false
+                       | uu___4 -> true) datas in
                 if uu___2
                 then
                   let uu___3 = FStar_TypeChecker_Env.get_range env in
@@ -2048,8 +2010,7 @@ let (check_inductive_well_typedness :
                                  (g2.FStar_TypeChecker_Common.implicits)
                              } in
                            (let uu___6 =
-                              FStar_Compiler_Effect.op_Less_Bar
-                                (FStar_TypeChecker_Env.debug env0)
+                              FStar_TypeChecker_Env.debug env0
                                 (FStar_Options.Other "GenUniverses") in
                             if uu___6
                             then
@@ -2072,205 +2033,194 @@ let (check_inductive_well_typedness :
                          (match uu___4 with
                           | (tcs1, datas2) ->
                               let tcs2 =
-                                FStar_Compiler_Effect.op_Bar_Greater tcs1
-                                  (FStar_Compiler_List.map
-                                     (fun se ->
-                                        match se.FStar_Syntax_Syntax.sigel
-                                        with
-                                        | FStar_Syntax_Syntax.Sig_inductive_typ
-                                            { FStar_Syntax_Syntax.lid = l;
-                                              FStar_Syntax_Syntax.us = univs1;
-                                              FStar_Syntax_Syntax.params =
-                                                binders;
-                                              FStar_Syntax_Syntax.num_uniform_params
-                                                = num_uniform;
-                                              FStar_Syntax_Syntax.t = typ;
-                                              FStar_Syntax_Syntax.mutuals =
-                                                ts;
-                                              FStar_Syntax_Syntax.ds = ds;_}
-                                            ->
-                                            let fail expected inferred =
-                                              let uu___5 =
-                                                let uu___6 =
-                                                  let uu___7 =
-                                                    FStar_Syntax_Print.tscheme_to_string
-                                                      expected in
-                                                  let uu___8 =
-                                                    FStar_Syntax_Print.tscheme_to_string
-                                                      inferred in
-                                                  FStar_Compiler_Util.format2
-                                                    "Expected an inductive with type %s; got %s"
-                                                    uu___7 uu___8 in
-                                                (FStar_Errors_Codes.Fatal_UnexpectedInductivetype,
-                                                  uu___6) in
-                                              FStar_Errors.raise_error uu___5
-                                                se.FStar_Syntax_Syntax.sigrng in
-                                            let copy_binder_attrs_from_val
-                                              binders1 expected =
-                                              let expected_attrs =
-                                                let uu___5 =
-                                                  let uu___6 =
-                                                    FStar_TypeChecker_Normalize.get_n_binders
-                                                      env1
-                                                      (FStar_Compiler_List.length
-                                                         binders1) expected in
-                                                  FStar_Compiler_Effect.op_Bar_Greater
-                                                    uu___6
-                                                    FStar_Pervasives_Native.fst in
-                                                FStar_Compiler_Effect.op_Bar_Greater
-                                                  uu___5
-                                                  (FStar_Compiler_List.map
-                                                     (fun uu___6 ->
-                                                        match uu___6 with
-                                                        | {
-                                                            FStar_Syntax_Syntax.binder_bv
-                                                              = uu___7;
-                                                            FStar_Syntax_Syntax.binder_qual
-                                                              = uu___8;
-                                                            FStar_Syntax_Syntax.binder_positivity
-                                                              = pqual;
-                                                            FStar_Syntax_Syntax.binder_attrs
-                                                              = attrs;_}
-                                                            -> (attrs, pqual))) in
+                                FStar_Compiler_List.map
+                                  (fun se ->
+                                     match se.FStar_Syntax_Syntax.sigel with
+                                     | FStar_Syntax_Syntax.Sig_inductive_typ
+                                         { FStar_Syntax_Syntax.lid = l;
+                                           FStar_Syntax_Syntax.us = univs1;
+                                           FStar_Syntax_Syntax.params =
+                                             binders;
+                                           FStar_Syntax_Syntax.num_uniform_params
+                                             = num_uniform;
+                                           FStar_Syntax_Syntax.t = typ;
+                                           FStar_Syntax_Syntax.mutuals = ts;
+                                           FStar_Syntax_Syntax.ds = ds;_}
+                                         ->
+                                         let fail expected inferred =
+                                           let uu___5 =
+                                             let uu___6 =
+                                               let uu___7 =
+                                                 FStar_Syntax_Print.tscheme_to_string
+                                                   expected in
+                                               let uu___8 =
+                                                 FStar_Syntax_Print.tscheme_to_string
+                                                   inferred in
+                                               FStar_Compiler_Util.format2
+                                                 "Expected an inductive with type %s; got %s"
+                                                 uu___7 uu___8 in
+                                             (FStar_Errors_Codes.Fatal_UnexpectedInductivetype,
+                                               uu___6) in
+                                           FStar_Errors.raise_error uu___5
+                                             se.FStar_Syntax_Syntax.sigrng in
+                                         let copy_binder_attrs_from_val
+                                           binders1 expected =
+                                           let expected_attrs =
+                                             let uu___5 =
+                                               let uu___6 =
+                                                 FStar_TypeChecker_Normalize.get_n_binders
+                                                   env1
+                                                   (FStar_Compiler_List.length
+                                                      binders1) expected in
+                                               FStar_Pervasives_Native.fst
+                                                 uu___6 in
+                                             FStar_Compiler_List.map
+                                               (fun uu___6 ->
+                                                  match uu___6 with
+                                                  | {
+                                                      FStar_Syntax_Syntax.binder_bv
+                                                        = uu___7;
+                                                      FStar_Syntax_Syntax.binder_qual
+                                                        = uu___8;
+                                                      FStar_Syntax_Syntax.binder_positivity
+                                                        = pqual;
+                                                      FStar_Syntax_Syntax.binder_attrs
+                                                        = attrs;_}
+                                                      -> (attrs, pqual))
+                                               uu___5 in
+                                           if
+                                             (FStar_Compiler_List.length
+                                                expected_attrs)
+                                               <>
+                                               (FStar_Compiler_List.length
+                                                  binders1)
+                                           then
+                                             let uu___5 =
+                                               let uu___6 =
+                                                 let uu___7 =
+                                                   FStar_Compiler_Util.string_of_int
+                                                     (FStar_Compiler_List.length
+                                                        binders1) in
+                                                 let uu___8 =
+                                                   FStar_Syntax_Print.term_to_string
+                                                     expected in
+                                                 FStar_Compiler_Util.format2
+                                                   "Could not get %s type parameters from val type %s"
+                                                   uu___7 uu___8 in
+                                               (FStar_Errors_Codes.Fatal_UnexpectedInductivetype,
+                                                 uu___6) in
+                                             FStar_Errors.raise_error uu___5
+                                               se.FStar_Syntax_Syntax.sigrng
+                                           else
+                                             FStar_Compiler_List.map2
+                                               (fun uu___6 ->
+                                                  fun b ->
+                                                    match uu___6 with
+                                                    | (ex_attrs, pqual) ->
+                                                        ((let uu___8 =
+                                                            let uu___9 =
+                                                              FStar_TypeChecker_Common.check_positivity_qual
+                                                                true pqual
+                                                                b.FStar_Syntax_Syntax.binder_positivity in
+                                                            Prims.op_Negation
+                                                              uu___9 in
+                                                          if uu___8
+                                                          then
+                                                            let uu___9 =
+                                                              FStar_Syntax_Syntax.range_of_bv
+                                                                b.FStar_Syntax_Syntax.binder_bv in
+                                                            FStar_Errors.raise_error
+                                                              (FStar_Errors_Codes.Fatal_UnexpectedInductivetype,
+                                                                "Incompatible positivity annotation")
+                                                              uu___9
+                                                          else ());
+                                                         {
+                                                           FStar_Syntax_Syntax.binder_bv
+                                                             =
+                                                             (b.FStar_Syntax_Syntax.binder_bv);
+                                                           FStar_Syntax_Syntax.binder_qual
+                                                             =
+                                                             (b.FStar_Syntax_Syntax.binder_qual);
+                                                           FStar_Syntax_Syntax.binder_positivity
+                                                             = pqual;
+                                                           FStar_Syntax_Syntax.binder_attrs
+                                                             =
+                                                             (FStar_Compiler_List.op_At
+                                                                b.FStar_Syntax_Syntax.binder_attrs
+                                                                ex_attrs)
+                                                         })) expected_attrs
+                                               binders1 in
+                                         let inferred_typ_with_binders
+                                           binders1 =
+                                           let body =
+                                             match binders1 with
+                                             | [] -> typ
+                                             | uu___5 ->
+                                                 let uu___6 =
+                                                   let uu___7 =
+                                                     let uu___8 =
+                                                       FStar_Syntax_Syntax.mk_Total
+                                                         typ in
+                                                     {
+                                                       FStar_Syntax_Syntax.bs1
+                                                         = binders1;
+                                                       FStar_Syntax_Syntax.comp
+                                                         = uu___8
+                                                     } in
+                                                   FStar_Syntax_Syntax.Tm_arrow
+                                                     uu___7 in
+                                                 FStar_Syntax_Syntax.mk
+                                                   uu___6
+                                                   se.FStar_Syntax_Syntax.sigrng in
+                                           (univs1, body) in
+                                         let uu___5 =
+                                           FStar_TypeChecker_Env.try_lookup_val_decl
+                                             env0 l in
+                                         (match uu___5 with
+                                          | FStar_Pervasives_Native.None ->
+                                              se
+                                          | FStar_Pervasives_Native.Some
+                                              (expected_typ, uu___6) ->
                                               if
                                                 (FStar_Compiler_List.length
-                                                   expected_attrs)
-                                                  <>
+                                                   univs1)
+                                                  =
                                                   (FStar_Compiler_List.length
-                                                     binders1)
+                                                     (FStar_Pervasives_Native.fst
+                                                        expected_typ))
                                               then
-                                                let uu___5 =
-                                                  let uu___6 =
-                                                    let uu___7 =
-                                                      let uu___8 =
-                                                        FStar_Compiler_Effect.op_Bar_Greater
-                                                          binders1
-                                                          FStar_Compiler_List.length in
-                                                      FStar_Compiler_Effect.op_Bar_Greater
-                                                        uu___8
-                                                        FStar_Compiler_Util.string_of_int in
-                                                    let uu___8 =
-                                                      FStar_Syntax_Print.term_to_string
-                                                        expected in
-                                                    FStar_Compiler_Util.format2
-                                                      "Could not get %s type parameters from val type %s"
-                                                      uu___7 uu___8 in
-                                                  (FStar_Errors_Codes.Fatal_UnexpectedInductivetype,
-                                                    uu___6) in
-                                                FStar_Errors.raise_error
-                                                  uu___5
-                                                  se.FStar_Syntax_Syntax.sigrng
-                                              else
-                                                FStar_Compiler_List.map2
-                                                  (fun uu___6 ->
-                                                     fun b ->
-                                                       match uu___6 with
-                                                       | (ex_attrs, pqual) ->
-                                                           ((let uu___8 =
-                                                               let uu___9 =
-                                                                 FStar_TypeChecker_Common.check_positivity_qual
-                                                                   true pqual
-                                                                   b.FStar_Syntax_Syntax.binder_positivity in
-                                                               Prims.op_Negation
-                                                                 uu___9 in
-                                                             if uu___8
-                                                             then
-                                                               let uu___9 =
-                                                                 FStar_Syntax_Syntax.range_of_bv
-                                                                   b.FStar_Syntax_Syntax.binder_bv in
-                                                               FStar_Errors.raise_error
-                                                                 (FStar_Errors_Codes.Fatal_UnexpectedInductivetype,
-                                                                   "Incompatible positivity annotation")
-                                                                 uu___9
-                                                             else ());
+                                                let uu___7 =
+                                                  FStar_Syntax_Subst.open_univ_vars
+                                                    univs1
+                                                    (FStar_Pervasives_Native.snd
+                                                       expected_typ) in
+                                                (match uu___7 with
+                                                 | (uu___8, expected) ->
+                                                     let binders1 =
+                                                       copy_binder_attrs_from_val
+                                                         binders expected in
+                                                     let inferred_typ =
+                                                       inferred_typ_with_binders
+                                                         binders1 in
+                                                     let uu___9 =
+                                                       FStar_Syntax_Subst.open_univ_vars
+                                                         univs1
+                                                         (FStar_Pervasives_Native.snd
+                                                            inferred_typ) in
+                                                     (match uu___9 with
+                                                      | (uu___10, inferred)
+                                                          ->
+                                                          let uu___11 =
+                                                            FStar_TypeChecker_Rel.teq_nosmt_force
+                                                              env0 inferred
+                                                              expected in
+                                                          if uu___11
+                                                          then
                                                             {
-                                                              FStar_Syntax_Syntax.binder_bv
+                                                              FStar_Syntax_Syntax.sigel
                                                                 =
-                                                                (b.FStar_Syntax_Syntax.binder_bv);
-                                                              FStar_Syntax_Syntax.binder_qual
-                                                                =
-                                                                (b.FStar_Syntax_Syntax.binder_qual);
-                                                              FStar_Syntax_Syntax.binder_positivity
-                                                                = pqual;
-                                                              FStar_Syntax_Syntax.binder_attrs
-                                                                =
-                                                                (FStar_Compiler_List.op_At
-                                                                   b.FStar_Syntax_Syntax.binder_attrs
-                                                                   ex_attrs)
-                                                            }))
-                                                  expected_attrs binders1 in
-                                            let inferred_typ_with_binders
-                                              binders1 =
-                                              let body =
-                                                match binders1 with
-                                                | [] -> typ
-                                                | uu___5 ->
-                                                    let uu___6 =
-                                                      let uu___7 =
-                                                        let uu___8 =
-                                                          FStar_Syntax_Syntax.mk_Total
-                                                            typ in
-                                                        {
-                                                          FStar_Syntax_Syntax.bs1
-                                                            = binders1;
-                                                          FStar_Syntax_Syntax.comp
-                                                            = uu___8
-                                                        } in
-                                                      FStar_Syntax_Syntax.Tm_arrow
-                                                        uu___7 in
-                                                    FStar_Syntax_Syntax.mk
-                                                      uu___6
-                                                      se.FStar_Syntax_Syntax.sigrng in
-                                              (univs1, body) in
-                                            let uu___5 =
-                                              FStar_TypeChecker_Env.try_lookup_val_decl
-                                                env0 l in
-                                            (match uu___5 with
-                                             | FStar_Pervasives_Native.None
-                                                 -> se
-                                             | FStar_Pervasives_Native.Some
-                                                 (expected_typ, uu___6) ->
-                                                 if
-                                                   (FStar_Compiler_List.length
-                                                      univs1)
-                                                     =
-                                                     (FStar_Compiler_List.length
-                                                        (FStar_Pervasives_Native.fst
-                                                           expected_typ))
-                                                 then
-                                                   let uu___7 =
-                                                     FStar_Syntax_Subst.open_univ_vars
-                                                       univs1
-                                                       (FStar_Pervasives_Native.snd
-                                                          expected_typ) in
-                                                   (match uu___7 with
-                                                    | (uu___8, expected) ->
-                                                        let binders1 =
-                                                          copy_binder_attrs_from_val
-                                                            binders expected in
-                                                        let inferred_typ =
-                                                          inferred_typ_with_binders
-                                                            binders1 in
-                                                        let uu___9 =
-                                                          FStar_Syntax_Subst.open_univ_vars
-                                                            univs1
-                                                            (FStar_Pervasives_Native.snd
-                                                               inferred_typ) in
-                                                        (match uu___9 with
-                                                         | (uu___10,
-                                                            inferred) ->
-                                                             let uu___11 =
-                                                               FStar_TypeChecker_Rel.teq_nosmt_force
-                                                                 env0
-                                                                 inferred
-                                                                 expected in
-                                                             if uu___11
-                                                             then
-                                                               {
-                                                                 FStar_Syntax_Syntax.sigel
-                                                                   =
-                                                                   (FStar_Syntax_Syntax.Sig_inductive_typ
-                                                                    {
+                                                                (FStar_Syntax_Syntax.Sig_inductive_typ
+                                                                   {
                                                                     FStar_Syntax_Syntax.lid
                                                                     = l;
                                                                     FStar_Syntax_Syntax.us
@@ -2287,36 +2237,35 @@ let (check_inductive_well_typedness :
                                                                     = ts;
                                                                     FStar_Syntax_Syntax.ds
                                                                     = ds
-                                                                    });
-                                                                 FStar_Syntax_Syntax.sigrng
-                                                                   =
-                                                                   (se.FStar_Syntax_Syntax.sigrng);
-                                                                 FStar_Syntax_Syntax.sigquals
-                                                                   =
-                                                                   (se.FStar_Syntax_Syntax.sigquals);
-                                                                 FStar_Syntax_Syntax.sigmeta
-                                                                   =
-                                                                   (se.FStar_Syntax_Syntax.sigmeta);
-                                                                 FStar_Syntax_Syntax.sigattrs
-                                                                   =
-                                                                   (se.FStar_Syntax_Syntax.sigattrs);
-                                                                 FStar_Syntax_Syntax.sigopens_and_abbrevs
-                                                                   =
-                                                                   (se.FStar_Syntax_Syntax.sigopens_and_abbrevs);
-                                                                 FStar_Syntax_Syntax.sigopts
-                                                                   =
-                                                                   (se.FStar_Syntax_Syntax.sigopts)
-                                                               }
-                                                             else
-                                                               fail
-                                                                 expected_typ
-                                                                 inferred_typ))
-                                                 else
-                                                   (let uu___8 =
-                                                      inferred_typ_with_binders
-                                                        binders in
-                                                    fail expected_typ uu___8))
-                                        | uu___5 -> se)) in
+                                                                   });
+                                                              FStar_Syntax_Syntax.sigrng
+                                                                =
+                                                                (se.FStar_Syntax_Syntax.sigrng);
+                                                              FStar_Syntax_Syntax.sigquals
+                                                                =
+                                                                (se.FStar_Syntax_Syntax.sigquals);
+                                                              FStar_Syntax_Syntax.sigmeta
+                                                                =
+                                                                (se.FStar_Syntax_Syntax.sigmeta);
+                                                              FStar_Syntax_Syntax.sigattrs
+                                                                =
+                                                                (se.FStar_Syntax_Syntax.sigattrs);
+                                                              FStar_Syntax_Syntax.sigopens_and_abbrevs
+                                                                =
+                                                                (se.FStar_Syntax_Syntax.sigopens_and_abbrevs);
+                                                              FStar_Syntax_Syntax.sigopts
+                                                                =
+                                                                (se.FStar_Syntax_Syntax.sigopts)
+                                                            }
+                                                          else
+                                                            fail expected_typ
+                                                              inferred_typ))
+                                              else
+                                                (let uu___8 =
+                                                   inferred_typ_with_binders
+                                                     binders in
+                                                 fail expected_typ uu___8))
+                                     | uu___5 -> se) tcs1 in
                               let sig_bndle =
                                 let uu___5 =
                                   FStar_TypeChecker_Env.get_range env0 in
@@ -2394,10 +2343,9 @@ let (mk_discriminator_and_indexed_projectors :
                                 FStar_Syntax_Syntax.Tm_uinst uu___1 in
                               FStar_Syntax_Syntax.mk uu___ p in
                             let args =
-                              FStar_Compiler_Effect.op_Bar_Greater
-                                (FStar_Compiler_List.op_At tps indices)
-                                (FStar_Compiler_List.map
-                                   FStar_Syntax_Util.arg_of_non_null_binder) in
+                              FStar_Compiler_List.map
+                                FStar_Syntax_Util.arg_of_non_null_binder
+                                (FStar_Compiler_List.op_At tps indices) in
                             FStar_Syntax_Syntax.mk_Tm_app inst_tc args p in
                           let unrefined_arg_binder =
                             let uu___ = projectee arg_typ in
@@ -2428,8 +2376,7 @@ let (mk_discriminator_and_indexed_projectors :
                                        let uu___5 =
                                          let uu___6 =
                                            FStar_Syntax_Syntax.bv_to_name x in
-                                         FStar_Compiler_Effect.op_Less_Bar
-                                           FStar_Syntax_Syntax.as_arg uu___6 in
+                                         FStar_Syntax_Syntax.as_arg uu___6 in
                                        [uu___5] in
                                      FStar_Syntax_Syntax.mk_Tm_app uu___3
                                        uu___4 p in
@@ -2463,22 +2410,20 @@ let (mk_discriminator_and_indexed_projectors :
                                    }) tps in
                             FStar_Compiler_List.op_At uu___ fields in
                           let imp_binders =
-                            FStar_Compiler_Effect.op_Bar_Greater
-                              (FStar_Compiler_List.op_At tps indices)
-                              (FStar_Compiler_List.map
-                                 (fun b ->
-                                    let uu___ =
-                                      mk_implicit
-                                        b.FStar_Syntax_Syntax.binder_qual in
-                                    {
-                                      FStar_Syntax_Syntax.binder_bv =
-                                        (b.FStar_Syntax_Syntax.binder_bv);
-                                      FStar_Syntax_Syntax.binder_qual = uu___;
-                                      FStar_Syntax_Syntax.binder_positivity =
-                                        (b.FStar_Syntax_Syntax.binder_positivity);
-                                      FStar_Syntax_Syntax.binder_attrs =
-                                        (b.FStar_Syntax_Syntax.binder_attrs)
-                                    })) in
+                            FStar_Compiler_List.map
+                              (fun b ->
+                                 let uu___ =
+                                   mk_implicit
+                                     b.FStar_Syntax_Syntax.binder_qual in
+                                 {
+                                   FStar_Syntax_Syntax.binder_bv =
+                                     (b.FStar_Syntax_Syntax.binder_bv);
+                                   FStar_Syntax_Syntax.binder_qual = uu___;
+                                   FStar_Syntax_Syntax.binder_positivity =
+                                     (b.FStar_Syntax_Syntax.binder_positivity);
+                                   FStar_Syntax_Syntax.binder_attrs =
+                                     (b.FStar_Syntax_Syntax.binder_attrs)
+                                 }) (FStar_Compiler_List.op_At tps indices) in
                           let early_prims_inductive =
                             (let uu___ =
                                FStar_TypeChecker_Env.current_module env in
@@ -2536,8 +2481,7 @@ let (mk_discriminator_and_indexed_projectors :
                                        FStar_Syntax_Util.t_bool in
                                  let uu___1 =
                                    FStar_Syntax_Util.arrow binders bool_typ in
-                                 FStar_Compiler_Effect.op_Less_Bar
-                                   (FStar_Syntax_Subst.close_univ_vars uvs)
+                                 FStar_Syntax_Subst.close_univ_vars uvs
                                    uu___1 in
                                let decl =
                                  let uu___1 =
@@ -2581,47 +2525,46 @@ let (mk_discriminator_and_indexed_projectors :
                                     then FStar_Syntax_Util.exp_true_bool
                                     else
                                       (let arg_pats =
-                                         FStar_Compiler_Effect.op_Bar_Greater
-                                           all_params
-                                           (FStar_Compiler_List.mapi
-                                              (fun j ->
-                                                 fun uu___4 ->
-                                                   match uu___4 with
-                                                   | {
-                                                       FStar_Syntax_Syntax.binder_bv
-                                                         = x;
-                                                       FStar_Syntax_Syntax.binder_qual
-                                                         = imp;
-                                                       FStar_Syntax_Syntax.binder_positivity
-                                                         = uu___5;
-                                                       FStar_Syntax_Syntax.binder_attrs
-                                                         = uu___6;_}
-                                                       ->
-                                                       let b =
-                                                         FStar_Syntax_Syntax.is_bqual_implicit
-                                                           imp in
-                                                       if b && (j < ntps)
-                                                       then
-                                                         let uu___7 =
-                                                           pos
-                                                             (FStar_Syntax_Syntax.Pat_dot_term
-                                                                FStar_Pervasives_Native.None) in
-                                                         (uu___7, b)
-                                                       else
-                                                         (let uu___8 =
-                                                            let uu___9 =
-                                                              let uu___10 =
-                                                                let uu___11 =
-                                                                  FStar_Ident.string_of_id
-                                                                    x.FStar_Syntax_Syntax.ppname in
-                                                                FStar_Syntax_Syntax.gen_bv
-                                                                  uu___11
-                                                                  FStar_Pervasives_Native.None
-                                                                  FStar_Syntax_Syntax.tun in
-                                                              FStar_Syntax_Syntax.Pat_var
-                                                                uu___10 in
-                                                            pos uu___9 in
-                                                          (uu___8, b)))) in
+                                         FStar_Compiler_List.mapi
+                                           (fun j ->
+                                              fun uu___4 ->
+                                                match uu___4 with
+                                                | {
+                                                    FStar_Syntax_Syntax.binder_bv
+                                                      = x;
+                                                    FStar_Syntax_Syntax.binder_qual
+                                                      = imp;
+                                                    FStar_Syntax_Syntax.binder_positivity
+                                                      = uu___5;
+                                                    FStar_Syntax_Syntax.binder_attrs
+                                                      = uu___6;_}
+                                                    ->
+                                                    let b =
+                                                      FStar_Syntax_Syntax.is_bqual_implicit
+                                                        imp in
+                                                    if b && (j < ntps)
+                                                    then
+                                                      let uu___7 =
+                                                        pos
+                                                          (FStar_Syntax_Syntax.Pat_dot_term
+                                                             FStar_Pervasives_Native.None) in
+                                                      (uu___7, b)
+                                                    else
+                                                      (let uu___8 =
+                                                         let uu___9 =
+                                                           let uu___10 =
+                                                             let uu___11 =
+                                                               FStar_Ident.string_of_id
+                                                                 x.FStar_Syntax_Syntax.ppname in
+                                                             FStar_Syntax_Syntax.gen_bv
+                                                               uu___11
+                                                               FStar_Pervasives_Native.None
+                                                               FStar_Syntax_Syntax.tun in
+                                                           FStar_Syntax_Syntax.Pat_var
+                                                             uu___10 in
+                                                         pos uu___9 in
+                                                       (uu___8, b)))
+                                           all_params in
                                        let pat_true =
                                          let uu___4 =
                                            let uu___5 =
@@ -2710,13 +2653,9 @@ let (mk_discriminator_and_indexed_projectors :
                                         let uu___5 =
                                           let uu___6 =
                                             let uu___7 =
-                                              FStar_Compiler_Effect.op_Bar_Greater
-                                                lb.FStar_Syntax_Syntax.lbname
-                                                FStar_Compiler_Util.right in
-                                            FStar_Compiler_Effect.op_Bar_Greater
-                                              uu___7
-                                              (fun fv ->
-                                                 (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v) in
+                                              FStar_Compiler_Util.right
+                                                lb.FStar_Syntax_Syntax.lbname in
+                                            (uu___7.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
                                           [uu___6] in
                                         {
                                           FStar_Syntax_Syntax.lbs1 =
@@ -2759,219 +2698,197 @@ let (mk_discriminator_and_indexed_projectors :
                             FStar_Syntax_Util.arg_of_non_null_binder
                               arg_binder in
                           let subst =
-                            FStar_Compiler_Effect.op_Bar_Greater fields
-                              (FStar_Compiler_List.mapi
-                                 (fun i ->
-                                    fun uu___ ->
-                                      match uu___ with
-                                      | { FStar_Syntax_Syntax.binder_bv = a;
-                                          FStar_Syntax_Syntax.binder_qual =
-                                            uu___1;
-                                          FStar_Syntax_Syntax.binder_positivity
-                                            = uu___2;
-                                          FStar_Syntax_Syntax.binder_attrs =
-                                            uu___3;_}
-                                          ->
-                                          let field_name =
-                                            FStar_Syntax_Util.mk_field_projector_name
-                                              lid a i in
-                                          let field_proj_tm =
-                                            let uu___4 =
-                                              let uu___5 =
-                                                FStar_Syntax_Syntax.lid_as_fv
-                                                  field_name
-                                                  FStar_Pervasives_Native.None in
-                                              FStar_Syntax_Syntax.fv_to_tm
-                                                uu___5 in
-                                            FStar_Syntax_Syntax.mk_Tm_uinst
-                                              uu___4 inst_univs in
-                                          let proj =
-                                            FStar_Syntax_Syntax.mk_Tm_app
-                                              field_proj_tm [arg] p in
-                                          FStar_Syntax_Syntax.NT (a, proj))) in
+                            FStar_Compiler_List.mapi
+                              (fun i ->
+                                 fun uu___ ->
+                                   match uu___ with
+                                   | { FStar_Syntax_Syntax.binder_bv = a;
+                                       FStar_Syntax_Syntax.binder_qual =
+                                         uu___1;
+                                       FStar_Syntax_Syntax.binder_positivity
+                                         = uu___2;
+                                       FStar_Syntax_Syntax.binder_attrs =
+                                         uu___3;_}
+                                       ->
+                                       let field_name =
+                                         FStar_Syntax_Util.mk_field_projector_name
+                                           lid a i in
+                                       let field_proj_tm =
+                                         let uu___4 =
+                                           let uu___5 =
+                                             FStar_Syntax_Syntax.lid_as_fv
+                                               field_name
+                                               FStar_Pervasives_Native.None in
+                                           FStar_Syntax_Syntax.fv_to_tm
+                                             uu___5 in
+                                         FStar_Syntax_Syntax.mk_Tm_uinst
+                                           uu___4 inst_univs in
+                                       let proj =
+                                         FStar_Syntax_Syntax.mk_Tm_app
+                                           field_proj_tm [arg] p in
+                                       FStar_Syntax_Syntax.NT (a, proj))
+                              fields in
                           let projectors_ses =
                             let uu___ =
-                              FStar_Compiler_Effect.op_Bar_Greater fields
-                                (FStar_Compiler_List.mapi
-                                   (fun i ->
-                                      fun uu___1 ->
-                                        match uu___1 with
-                                        | {
-                                            FStar_Syntax_Syntax.binder_bv = x;
-                                            FStar_Syntax_Syntax.binder_qual =
-                                              uu___2;
-                                            FStar_Syntax_Syntax.binder_positivity
-                                              = uu___3;
-                                            FStar_Syntax_Syntax.binder_attrs
-                                              = uu___4;_}
-                                            ->
-                                            let p1 =
-                                              FStar_Syntax_Syntax.range_of_bv
-                                                x in
-                                            let field_name =
-                                              FStar_Syntax_Util.mk_field_projector_name
-                                                lid x i in
-                                            let result_comp =
-                                              let t =
-                                                FStar_Syntax_Subst.subst
-                                                  subst
-                                                  x.FStar_Syntax_Syntax.sort in
-                                              if erasable
-                                              then
-                                                FStar_Syntax_Syntax.mk_GTotal
-                                                  t
+                              FStar_Compiler_List.mapi
+                                (fun i ->
+                                   fun uu___1 ->
+                                     match uu___1 with
+                                     | { FStar_Syntax_Syntax.binder_bv = x;
+                                         FStar_Syntax_Syntax.binder_qual =
+                                           uu___2;
+                                         FStar_Syntax_Syntax.binder_positivity
+                                           = uu___3;
+                                         FStar_Syntax_Syntax.binder_attrs =
+                                           uu___4;_}
+                                         ->
+                                         let p1 =
+                                           FStar_Syntax_Syntax.range_of_bv x in
+                                         let field_name =
+                                           FStar_Syntax_Util.mk_field_projector_name
+                                             lid x i in
+                                         let result_comp =
+                                           let t =
+                                             FStar_Syntax_Subst.subst subst
+                                               x.FStar_Syntax_Syntax.sort in
+                                           if erasable
+                                           then
+                                             FStar_Syntax_Syntax.mk_GTotal t
+                                           else
+                                             FStar_Syntax_Syntax.mk_Total t in
+                                         let t =
+                                           let uu___5 =
+                                             FStar_Syntax_Util.arrow binders
+                                               result_comp in
+                                           FStar_Syntax_Subst.close_univ_vars
+                                             uvs uu___5 in
+                                         let only_decl =
+                                           early_prims_inductive ||
+                                             (FStar_Syntax_Util.has_attribute
+                                                attrs
+                                                FStar_Parser_Const.no_auto_projectors_attr) in
+                                         let no_decl = false in
+                                         let quals q =
+                                           if only_decl
+                                           then
+                                             FStar_Syntax_Syntax.Assumption
+                                             :: q
+                                           else q in
+                                         let quals1 =
+                                           let iquals1 =
+                                             FStar_Compiler_List.filter
+                                               (fun uu___5 ->
+                                                  match uu___5 with
+                                                  | FStar_Syntax_Syntax.Inline_for_extraction
+                                                      -> true
+                                                  | FStar_Syntax_Syntax.NoExtract
+                                                      -> true
+                                                  | FStar_Syntax_Syntax.Private
+                                                      -> true
+                                                  | uu___6 -> false) iquals in
+                                           quals
+                                             ((FStar_Syntax_Syntax.Projector
+                                                 (lid,
+                                                   (x.FStar_Syntax_Syntax.ppname)))
+                                             :: iquals1) in
+                                         let attrs1 =
+                                           FStar_Compiler_List.op_At
+                                             (if only_decl
+                                              then []
                                               else
-                                                FStar_Syntax_Syntax.mk_Total
-                                                  t in
-                                            let t =
-                                              let uu___5 =
-                                                FStar_Syntax_Util.arrow
-                                                  binders result_comp in
-                                              FStar_Compiler_Effect.op_Less_Bar
-                                                (FStar_Syntax_Subst.close_univ_vars
-                                                   uvs) uu___5 in
-                                            let only_decl =
-                                              early_prims_inductive ||
-                                                (FStar_Syntax_Util.has_attribute
-                                                   attrs
-                                                   FStar_Parser_Const.no_auto_projectors_attr) in
-                                            let no_decl = false in
-                                            let quals q =
-                                              if only_decl
-                                              then
-                                                FStar_Syntax_Syntax.Assumption
-                                                :: q
-                                              else q in
-                                            let quals1 =
-                                              let iquals1 =
-                                                FStar_Compiler_Effect.op_Bar_Greater
-                                                  iquals
-                                                  (FStar_Compiler_List.filter
-                                                     (fun uu___5 ->
-                                                        match uu___5 with
-                                                        | FStar_Syntax_Syntax.Inline_for_extraction
-                                                            -> true
-                                                        | FStar_Syntax_Syntax.NoExtract
-                                                            -> true
-                                                        | FStar_Syntax_Syntax.Private
-                                                            -> true
-                                                        | uu___6 -> false)) in
-                                              quals
-                                                ((FStar_Syntax_Syntax.Projector
-                                                    (lid,
-                                                      (x.FStar_Syntax_Syntax.ppname)))
-                                                :: iquals1) in
-                                            let attrs1 =
-                                              FStar_Compiler_List.op_At
-                                                (if only_decl
-                                                 then []
-                                                 else
-                                                   [FStar_Syntax_Util.attr_substitute])
-                                                attrs in
-                                            let decl =
-                                              let uu___5 =
-                                                FStar_Ident.range_of_lid
-                                                  field_name in
-                                              {
-                                                FStar_Syntax_Syntax.sigel =
-                                                  (FStar_Syntax_Syntax.Sig_declare_typ
-                                                     {
-                                                       FStar_Syntax_Syntax.lid2
-                                                         = field_name;
-                                                       FStar_Syntax_Syntax.us2
-                                                         = uvs;
-                                                       FStar_Syntax_Syntax.t2
-                                                         = t
-                                                     });
-                                                FStar_Syntax_Syntax.sigrng =
-                                                  uu___5;
-                                                FStar_Syntax_Syntax.sigquals
-                                                  = quals1;
-                                                FStar_Syntax_Syntax.sigmeta =
-                                                  FStar_Syntax_Syntax.default_sigmeta;
-                                                FStar_Syntax_Syntax.sigattrs
-                                                  = attrs1;
-                                                FStar_Syntax_Syntax.sigopens_and_abbrevs
-                                                  = [];
-                                                FStar_Syntax_Syntax.sigopts =
-                                                  FStar_Pervasives_Native.None
-                                              } in
-                                            ((let uu___6 =
-                                                FStar_TypeChecker_Env.debug
-                                                  env
-                                                  (FStar_Options.Other
-                                                     "LogTypes") in
-                                              if uu___6
-                                              then
-                                                let uu___7 =
-                                                  FStar_Syntax_Print.sigelt_to_string
-                                                    decl in
-                                                FStar_Compiler_Util.print1
-                                                  "Declaration of a projector %s\n"
-                                                  uu___7
-                                              else ());
-                                             if only_decl
-                                             then [decl]
-                                             else
-                                               (let projection =
-                                                  let uu___7 =
-                                                    FStar_Ident.string_of_id
-                                                      x.FStar_Syntax_Syntax.ppname in
-                                                  FStar_Syntax_Syntax.gen_bv
-                                                    uu___7
-                                                    FStar_Pervasives_Native.None
-                                                    FStar_Syntax_Syntax.tun in
-                                                let arg_pats =
-                                                  FStar_Compiler_Effect.op_Bar_Greater
-                                                    all_params
-                                                    (FStar_Compiler_List.mapi
-                                                       (fun j ->
-                                                          fun uu___7 ->
-                                                            match uu___7 with
-                                                            | {
-                                                                FStar_Syntax_Syntax.binder_bv
-                                                                  = x1;
-                                                                FStar_Syntax_Syntax.binder_qual
-                                                                  = imp;
-                                                                FStar_Syntax_Syntax.binder_positivity
-                                                                  = uu___8;
-                                                                FStar_Syntax_Syntax.binder_attrs
-                                                                  = uu___9;_}
-                                                                ->
-                                                                let b =
-                                                                  FStar_Syntax_Syntax.is_bqual_implicit
-                                                                    imp in
-                                                                if
-                                                                  (i + ntps)
-                                                                    = j
-                                                                then
-                                                                  let uu___10
-                                                                    =
-                                                                    pos
-                                                                    (FStar_Syntax_Syntax.Pat_var
-                                                                    projection) in
-                                                                  (uu___10,
-                                                                    b)
-                                                                else
-                                                                  if
-                                                                    b &&
-                                                                    (j < ntps)
-                                                                  then
-                                                                    (
-                                                                    let uu___11
-                                                                    =
-                                                                    pos
-                                                                    (FStar_Syntax_Syntax.Pat_dot_term
+                                                [FStar_Syntax_Util.attr_substitute])
+                                             attrs in
+                                         let decl =
+                                           let uu___5 =
+                                             FStar_Ident.range_of_lid
+                                               field_name in
+                                           {
+                                             FStar_Syntax_Syntax.sigel =
+                                               (FStar_Syntax_Syntax.Sig_declare_typ
+                                                  {
+                                                    FStar_Syntax_Syntax.lid2
+                                                      = field_name;
+                                                    FStar_Syntax_Syntax.us2 =
+                                                      uvs;
+                                                    FStar_Syntax_Syntax.t2 =
+                                                      t
+                                                  });
+                                             FStar_Syntax_Syntax.sigrng =
+                                               uu___5;
+                                             FStar_Syntax_Syntax.sigquals =
+                                               quals1;
+                                             FStar_Syntax_Syntax.sigmeta =
+                                               FStar_Syntax_Syntax.default_sigmeta;
+                                             FStar_Syntax_Syntax.sigattrs =
+                                               attrs1;
+                                             FStar_Syntax_Syntax.sigopens_and_abbrevs
+                                               = [];
+                                             FStar_Syntax_Syntax.sigopts =
+                                               FStar_Pervasives_Native.None
+                                           } in
+                                         ((let uu___6 =
+                                             FStar_TypeChecker_Env.debug env
+                                               (FStar_Options.Other
+                                                  "LogTypes") in
+                                           if uu___6
+                                           then
+                                             let uu___7 =
+                                               FStar_Syntax_Print.sigelt_to_string
+                                                 decl in
+                                             FStar_Compiler_Util.print1
+                                               "Declaration of a projector %s\n"
+                                               uu___7
+                                           else ());
+                                          if only_decl
+                                          then [decl]
+                                          else
+                                            (let projection =
+                                               let uu___7 =
+                                                 FStar_Ident.string_of_id
+                                                   x.FStar_Syntax_Syntax.ppname in
+                                               FStar_Syntax_Syntax.gen_bv
+                                                 uu___7
+                                                 FStar_Pervasives_Native.None
+                                                 FStar_Syntax_Syntax.tun in
+                                             let arg_pats =
+                                               FStar_Compiler_List.mapi
+                                                 (fun j ->
+                                                    fun uu___7 ->
+                                                      match uu___7 with
+                                                      | {
+                                                          FStar_Syntax_Syntax.binder_bv
+                                                            = x1;
+                                                          FStar_Syntax_Syntax.binder_qual
+                                                            = imp;
+                                                          FStar_Syntax_Syntax.binder_positivity
+                                                            = uu___8;
+                                                          FStar_Syntax_Syntax.binder_attrs
+                                                            = uu___9;_}
+                                                          ->
+                                                          let b =
+                                                            FStar_Syntax_Syntax.is_bqual_implicit
+                                                              imp in
+                                                          if (i + ntps) = j
+                                                          then
+                                                            let uu___10 =
+                                                              pos
+                                                                (FStar_Syntax_Syntax.Pat_var
+                                                                   projection) in
+                                                            (uu___10, b)
+                                                          else
+                                                            if
+                                                              b && (j < ntps)
+                                                            then
+                                                              (let uu___11 =
+                                                                 pos
+                                                                   (FStar_Syntax_Syntax.Pat_dot_term
                                                                     FStar_Pervasives_Native.None) in
-                                                                    (uu___11,
-                                                                    b))
-                                                                  else
-                                                                    (
-                                                                    let uu___12
-                                                                    =
-                                                                    let uu___13
-                                                                    =
-                                                                    let uu___14
+                                                               (uu___11, b))
+                                                            else
+                                                              (let uu___12 =
+                                                                 let uu___13
+                                                                   =
+                                                                   let uu___14
                                                                     =
                                                                     let uu___15
                                                                     =
@@ -2981,214 +2898,195 @@ let (mk_discriminator_and_indexed_projectors :
                                                                     uu___15
                                                                     FStar_Pervasives_Native.None
                                                                     FStar_Syntax_Syntax.tun in
-                                                                    FStar_Syntax_Syntax.Pat_var
+                                                                   FStar_Syntax_Syntax.Pat_var
                                                                     uu___14 in
-                                                                    pos
-                                                                    uu___13 in
-                                                                    (uu___12,
-                                                                    b)))) in
-                                                let pat =
-                                                  let uu___7 =
-                                                    let uu___8 =
-                                                      let uu___9 =
-                                                        let uu___10 =
-                                                          FStar_Syntax_Syntax.lid_as_fv
-                                                            lid
-                                                            (FStar_Pervasives_Native.Some
-                                                               fvq) in
-                                                        (uu___10,
-                                                          FStar_Pervasives_Native.None,
-                                                          arg_pats) in
-                                                      FStar_Syntax_Syntax.Pat_cons
-                                                        uu___9 in
-                                                    pos uu___8 in
-                                                  let uu___8 =
-                                                    FStar_Syntax_Syntax.bv_to_name
-                                                      projection in
-                                                  (uu___7,
-                                                    FStar_Pervasives_Native.None,
-                                                    uu___8) in
-                                                let body =
-                                                  let return_bv =
-                                                    FStar_Syntax_Syntax.gen_bv
-                                                      "proj_ret"
-                                                      (FStar_Pervasives_Native.Some
-                                                         p1)
-                                                      FStar_Syntax_Syntax.tun in
-                                                  let result_typ =
-                                                    let uu___7 =
-                                                      let uu___8 =
-                                                        FStar_Compiler_Effect.op_Bar_Greater
-                                                          result_comp
-                                                          FStar_Syntax_Util.comp_result in
-                                                      let uu___9 =
-                                                        let uu___10 =
-                                                          let uu___11 =
-                                                            let uu___12 =
-                                                              let uu___13 =
-                                                                FStar_Syntax_Syntax.bv_to_name
-                                                                  return_bv in
-                                                              ((arg_binder.FStar_Syntax_Syntax.binder_bv),
-                                                                uu___13) in
-                                                            FStar_Syntax_Syntax.NT
-                                                              uu___12 in
-                                                          [uu___11] in
-                                                        FStar_Syntax_Subst.subst
-                                                          uu___10 in
-                                                      FStar_Compiler_Effect.op_Bar_Greater
-                                                        uu___8 uu___9 in
-                                                    let uu___8 =
-                                                      let uu___9 =
-                                                        let uu___10 =
-                                                          FStar_Syntax_Syntax.mk_binder
-                                                            return_bv in
-                                                        [uu___10] in
-                                                      FStar_Syntax_Subst.close
-                                                        uu___9 in
-                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                      uu___7 uu___8 in
-                                                  let return_binder =
-                                                    let uu___7 =
-                                                      let uu___8 =
-                                                        let uu___9 =
-                                                          FStar_Syntax_Syntax.mk_binder
-                                                            return_bv in
-                                                        [uu___9] in
-                                                      FStar_Syntax_Subst.close_binders
-                                                        uu___8 in
-                                                    FStar_Compiler_List.hd
-                                                      uu___7 in
-                                                  let returns_annotation =
-                                                    let use_eq = true in
-                                                    FStar_Pervasives_Native.Some
-                                                      (return_binder,
-                                                        ((FStar_Pervasives.Inl
-                                                            result_typ),
-                                                          FStar_Pervasives_Native.None,
-                                                          use_eq)) in
-                                                  let uu___7 =
-                                                    let uu___8 =
-                                                      let uu___9 =
-                                                        let uu___10 =
-                                                          FStar_Syntax_Util.branch
-                                                            pat in
-                                                        [uu___10] in
-                                                      {
-                                                        FStar_Syntax_Syntax.scrutinee
-                                                          = arg_exp;
-                                                        FStar_Syntax_Syntax.ret_opt
-                                                          =
-                                                          returns_annotation;
-                                                        FStar_Syntax_Syntax.brs
-                                                          = uu___9;
-                                                        FStar_Syntax_Syntax.rc_opt1
-                                                          =
-                                                          FStar_Pervasives_Native.None
-                                                      } in
-                                                    FStar_Syntax_Syntax.Tm_match
-                                                      uu___8 in
-                                                  FStar_Syntax_Syntax.mk
-                                                    uu___7 p1 in
-                                                let imp =
-                                                  FStar_Syntax_Util.abs
-                                                    binders body
-                                                    FStar_Pervasives_Native.None in
-                                                let dd =
-                                                  FStar_Syntax_Syntax.Delta_equational_at_level
-                                                    Prims.int_one in
-                                                let lbtyp =
-                                                  if no_decl
-                                                  then t
-                                                  else
-                                                    FStar_Syntax_Syntax.tun in
-                                                let lb =
-                                                  let uu___7 =
-                                                    let uu___8 =
-                                                      FStar_Syntax_Syntax.lid_and_dd_as_fv
-                                                        field_name dd
-                                                        FStar_Pervasives_Native.None in
-                                                    FStar_Pervasives.Inr
-                                                      uu___8 in
-                                                  let uu___8 =
-                                                    FStar_Syntax_Subst.close_univ_vars
-                                                      uvs imp in
-                                                  {
-                                                    FStar_Syntax_Syntax.lbname
-                                                      = uu___7;
-                                                    FStar_Syntax_Syntax.lbunivs
-                                                      = uvs;
-                                                    FStar_Syntax_Syntax.lbtyp
-                                                      = lbtyp;
-                                                    FStar_Syntax_Syntax.lbeff
-                                                      =
-                                                      FStar_Parser_Const.effect_Tot_lid;
-                                                    FStar_Syntax_Syntax.lbdef
-                                                      = uu___8;
-                                                    FStar_Syntax_Syntax.lbattrs
-                                                      = [];
-                                                    FStar_Syntax_Syntax.lbpos
-                                                      =
-                                                      FStar_Compiler_Range_Type.dummyRange
-                                                  } in
-                                                let impl =
-                                                  let uu___7 =
-                                                    let uu___8 =
-                                                      let uu___9 =
-                                                        let uu___10 =
-                                                          let uu___11 =
-                                                            FStar_Compiler_Effect.op_Bar_Greater
-                                                              lb.FStar_Syntax_Syntax.lbname
-                                                              FStar_Compiler_Util.right in
-                                                          FStar_Compiler_Effect.op_Bar_Greater
-                                                            uu___11
-                                                            (fun fv ->
-                                                               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v) in
-                                                        [uu___10] in
-                                                      {
-                                                        FStar_Syntax_Syntax.lbs1
-                                                          = (false, [lb]);
-                                                        FStar_Syntax_Syntax.lids1
-                                                          = uu___9
-                                                      } in
-                                                    FStar_Syntax_Syntax.Sig_let
-                                                      uu___8 in
-                                                  {
-                                                    FStar_Syntax_Syntax.sigel
-                                                      = uu___7;
-                                                    FStar_Syntax_Syntax.sigrng
-                                                      = p1;
-                                                    FStar_Syntax_Syntax.sigquals
-                                                      = quals1;
-                                                    FStar_Syntax_Syntax.sigmeta
-                                                      =
-                                                      FStar_Syntax_Syntax.default_sigmeta;
-                                                    FStar_Syntax_Syntax.sigattrs
-                                                      = attrs1;
-                                                    FStar_Syntax_Syntax.sigopens_and_abbrevs
-                                                      = [];
-                                                    FStar_Syntax_Syntax.sigopts
-                                                      =
-                                                      FStar_Pervasives_Native.None
-                                                  } in
-                                                (let uu___8 =
-                                                   FStar_TypeChecker_Env.debug
-                                                     env
-                                                     (FStar_Options.Other
-                                                        "LogTypes") in
-                                                 if uu___8
-                                                 then
+                                                                 pos uu___13 in
+                                                               (uu___12, b)))
+                                                 all_params in
+                                             let pat =
+                                               let uu___7 =
+                                                 let uu___8 =
                                                    let uu___9 =
-                                                     FStar_Syntax_Print.sigelt_to_string
-                                                       impl in
-                                                   FStar_Compiler_Util.print1
-                                                     "Implementation of a projector %s\n"
+                                                     let uu___10 =
+                                                       FStar_Syntax_Syntax.lid_as_fv
+                                                         lid
+                                                         (FStar_Pervasives_Native.Some
+                                                            fvq) in
+                                                     (uu___10,
+                                                       FStar_Pervasives_Native.None,
+                                                       arg_pats) in
+                                                   FStar_Syntax_Syntax.Pat_cons
+                                                     uu___9 in
+                                                 pos uu___8 in
+                                               let uu___8 =
+                                                 FStar_Syntax_Syntax.bv_to_name
+                                                   projection in
+                                               (uu___7,
+                                                 FStar_Pervasives_Native.None,
+                                                 uu___8) in
+                                             let body =
+                                               let return_bv =
+                                                 FStar_Syntax_Syntax.gen_bv
+                                                   "proj_ret"
+                                                   (FStar_Pervasives_Native.Some
+                                                      p1)
+                                                   FStar_Syntax_Syntax.tun in
+                                               let result_typ =
+                                                 let uu___7 =
+                                                   let uu___8 =
+                                                     FStar_Syntax_Syntax.mk_binder
+                                                       return_bv in
+                                                   [uu___8] in
+                                                 let uu___8 =
+                                                   let uu___9 =
+                                                     let uu___10 =
+                                                       let uu___11 =
+                                                         let uu___12 =
+                                                           FStar_Syntax_Syntax.bv_to_name
+                                                             return_bv in
+                                                         ((arg_binder.FStar_Syntax_Syntax.binder_bv),
+                                                           uu___12) in
+                                                       FStar_Syntax_Syntax.NT
+                                                         uu___11 in
+                                                     [uu___10] in
+                                                   FStar_Syntax_Subst.subst
                                                      uu___9
-                                                 else ());
-                                                if no_decl
-                                                then [impl]
-                                                else [decl; impl])))) in
-                            FStar_Compiler_Effect.op_Bar_Greater uu___
-                              FStar_Compiler_List.flatten in
+                                                     (FStar_Syntax_Util.comp_result
+                                                        result_comp) in
+                                                 FStar_Syntax_Subst.close
+                                                   uu___7 uu___8 in
+                                               let return_binder =
+                                                 let uu___7 =
+                                                   let uu___8 =
+                                                     let uu___9 =
+                                                       FStar_Syntax_Syntax.mk_binder
+                                                         return_bv in
+                                                     [uu___9] in
+                                                   FStar_Syntax_Subst.close_binders
+                                                     uu___8 in
+                                                 FStar_Compiler_List.hd
+                                                   uu___7 in
+                                               let returns_annotation =
+                                                 let use_eq = true in
+                                                 FStar_Pervasives_Native.Some
+                                                   (return_binder,
+                                                     ((FStar_Pervasives.Inl
+                                                         result_typ),
+                                                       FStar_Pervasives_Native.None,
+                                                       use_eq)) in
+                                               let uu___7 =
+                                                 let uu___8 =
+                                                   let uu___9 =
+                                                     let uu___10 =
+                                                       FStar_Syntax_Util.branch
+                                                         pat in
+                                                     [uu___10] in
+                                                   {
+                                                     FStar_Syntax_Syntax.scrutinee
+                                                       = arg_exp;
+                                                     FStar_Syntax_Syntax.ret_opt
+                                                       = returns_annotation;
+                                                     FStar_Syntax_Syntax.brs
+                                                       = uu___9;
+                                                     FStar_Syntax_Syntax.rc_opt1
+                                                       =
+                                                       FStar_Pervasives_Native.None
+                                                   } in
+                                                 FStar_Syntax_Syntax.Tm_match
+                                                   uu___8 in
+                                               FStar_Syntax_Syntax.mk uu___7
+                                                 p1 in
+                                             let imp =
+                                               FStar_Syntax_Util.abs binders
+                                                 body
+                                                 FStar_Pervasives_Native.None in
+                                             let dd =
+                                               FStar_Syntax_Syntax.Delta_equational_at_level
+                                                 Prims.int_one in
+                                             let lbtyp =
+                                               if no_decl
+                                               then t
+                                               else FStar_Syntax_Syntax.tun in
+                                             let lb =
+                                               let uu___7 =
+                                                 let uu___8 =
+                                                   FStar_Syntax_Syntax.lid_and_dd_as_fv
+                                                     field_name dd
+                                                     FStar_Pervasives_Native.None in
+                                                 FStar_Pervasives.Inr uu___8 in
+                                               let uu___8 =
+                                                 FStar_Syntax_Subst.close_univ_vars
+                                                   uvs imp in
+                                               {
+                                                 FStar_Syntax_Syntax.lbname =
+                                                   uu___7;
+                                                 FStar_Syntax_Syntax.lbunivs
+                                                   = uvs;
+                                                 FStar_Syntax_Syntax.lbtyp =
+                                                   lbtyp;
+                                                 FStar_Syntax_Syntax.lbeff =
+                                                   FStar_Parser_Const.effect_Tot_lid;
+                                                 FStar_Syntax_Syntax.lbdef =
+                                                   uu___8;
+                                                 FStar_Syntax_Syntax.lbattrs
+                                                   = [];
+                                                 FStar_Syntax_Syntax.lbpos =
+                                                   FStar_Compiler_Range_Type.dummyRange
+                                               } in
+                                             let impl =
+                                               let uu___7 =
+                                                 let uu___8 =
+                                                   let uu___9 =
+                                                     let uu___10 =
+                                                       let uu___11 =
+                                                         FStar_Compiler_Util.right
+                                                           lb.FStar_Syntax_Syntax.lbname in
+                                                       (uu___11.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
+                                                     [uu___10] in
+                                                   {
+                                                     FStar_Syntax_Syntax.lbs1
+                                                       = (false, [lb]);
+                                                     FStar_Syntax_Syntax.lids1
+                                                       = uu___9
+                                                   } in
+                                                 FStar_Syntax_Syntax.Sig_let
+                                                   uu___8 in
+                                               {
+                                                 FStar_Syntax_Syntax.sigel =
+                                                   uu___7;
+                                                 FStar_Syntax_Syntax.sigrng =
+                                                   p1;
+                                                 FStar_Syntax_Syntax.sigquals
+                                                   = quals1;
+                                                 FStar_Syntax_Syntax.sigmeta
+                                                   =
+                                                   FStar_Syntax_Syntax.default_sigmeta;
+                                                 FStar_Syntax_Syntax.sigattrs
+                                                   = attrs1;
+                                                 FStar_Syntax_Syntax.sigopens_and_abbrevs
+                                                   = [];
+                                                 FStar_Syntax_Syntax.sigopts
+                                                   =
+                                                   FStar_Pervasives_Native.None
+                                               } in
+                                             (let uu___8 =
+                                                FStar_TypeChecker_Env.debug
+                                                  env
+                                                  (FStar_Options.Other
+                                                     "LogTypes") in
+                                              if uu___8
+                                              then
+                                                let uu___9 =
+                                                  FStar_Syntax_Print.sigelt_to_string
+                                                    impl in
+                                                FStar_Compiler_Util.print1
+                                                  "Implementation of a projector %s\n"
+                                                  uu___9
+                                              else ());
+                                             if no_decl
+                                             then [impl]
+                                             else [decl; impl]))) fields in
+                            FStar_Compiler_List.flatten uu___ in
                           let no_plugin se =
                             let not_plugin_attr t =
                               let h = FStar_Syntax_Util.head_of t in
@@ -3307,14 +3205,13 @@ let (mk_data_operations :
                                 | (indices, uu___6) ->
                                     let refine_domain =
                                       let uu___7 =
-                                        FStar_Compiler_Effect.op_Bar_Greater
-                                          se.FStar_Syntax_Syntax.sigquals
-                                          (FStar_Compiler_Util.for_some
-                                             (fun uu___8 ->
-                                                match uu___8 with
-                                                | FStar_Syntax_Syntax.RecordConstructor
-                                                    uu___9 -> true
-                                                | uu___9 -> false)) in
+                                        FStar_Compiler_Util.for_some
+                                          (fun uu___8 ->
+                                             match uu___8 with
+                                             | FStar_Syntax_Syntax.RecordConstructor
+                                                 uu___9 -> true
+                                             | uu___9 -> false)
+                                          se.FStar_Syntax_Syntax.sigquals in
                                       if uu___7 then false else should_refine in
                                     let fv_qual =
                                       let filter_records uu___7 =

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_TcTerm.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_TcTerm.ml
@@ -285,8 +285,7 @@ let (check_no_escape :
                                        let uu___7 =
                                          let uu___8 =
                                            FStar_Syntax_Util.type_u () in
-                                         FStar_Compiler_Effect.op_Less_Bar
-                                           FStar_Pervasives_Native.fst uu___8 in
+                                         FStar_Pervasives_Native.fst uu___8 in
                                        FStar_TypeChecker_Util.new_implicit_var
                                          "no escape" uu___6 env uu___7 in
                                      (match uu___5 with
@@ -419,72 +418,68 @@ let (maybe_warn_on_use :
       match uu___ with
       | FStar_Pervasives_Native.None -> ()
       | FStar_Pervasives_Native.Some attrs ->
-          FStar_Compiler_Effect.op_Bar_Greater attrs
-            (FStar_Compiler_List.iter
-               (fun a ->
-                  let uu___1 = FStar_Syntax_Util.head_and_args a in
-                  match uu___1 with
-                  | (head, args) ->
-                      let msg_arg m =
-                        match args with
-                        | ({
-                             FStar_Syntax_Syntax.n =
-                               FStar_Syntax_Syntax.Tm_constant
-                               (FStar_Const.Const_string (s, uu___2));
-                             FStar_Syntax_Syntax.pos = uu___3;
-                             FStar_Syntax_Syntax.vars = uu___4;
-                             FStar_Syntax_Syntax.hash_code = uu___5;_},
-                           uu___6)::[] ->
-                            let uu___7 =
-                              let uu___8 = FStar_Errors_Msg.text s in
-                              [uu___8] in
-                            FStar_Compiler_List.op_At m uu___7
-                        | uu___2 -> m in
-                      (match head.FStar_Syntax_Syntax.n with
-                       | FStar_Syntax_Syntax.Tm_fvar attr_fv when
-                           FStar_Ident.lid_equals
-                             (attr_fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-                             FStar_Parser_Const.warn_on_use_attr
-                           ->
-                           let m =
-                             let uu___2 =
-                               let uu___3 =
-                                 FStar_Ident.string_of_lid
-                                   (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                               FStar_Compiler_Util.format1
-                                 "Every use of %s triggers a warning" uu___3 in
-                             FStar_Compiler_Effect.op_Less_Bar
-                               FStar_Errors_Msg.text uu___2 in
-                           let uu___2 =
-                             FStar_Ident.range_of_lid
-                               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                           let uu___3 =
-                             let uu___4 = msg_arg [m] in
-                             (FStar_Errors_Codes.Warning_WarnOnUse, uu___4) in
-                           FStar_Errors.log_issue_doc uu___2 uu___3
-                       | FStar_Syntax_Syntax.Tm_fvar attr_fv when
-                           FStar_Ident.lid_equals
-                             (attr_fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-                             FStar_Parser_Const.deprecated_attr
-                           ->
-                           let m =
-                             let uu___2 =
-                               let uu___3 =
-                                 FStar_Ident.string_of_lid
-                                   (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                               FStar_Compiler_Util.format1 "%s is deprecated"
-                                 uu___3 in
-                             FStar_Compiler_Effect.op_Less_Bar
-                               FStar_Errors_Msg.text uu___2 in
-                           let uu___2 =
-                             FStar_Ident.range_of_lid
-                               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                           let uu___3 =
-                             let uu___4 = msg_arg [m] in
-                             (FStar_Errors_Codes.Warning_DeprecatedDefinition,
-                               uu___4) in
-                           FStar_Errors.log_issue_doc uu___2 uu___3
-                       | uu___2 -> ())))
+          FStar_Compiler_List.iter
+            (fun a ->
+               let uu___1 = FStar_Syntax_Util.head_and_args a in
+               match uu___1 with
+               | (head, args) ->
+                   let msg_arg m =
+                     match args with
+                     | ({
+                          FStar_Syntax_Syntax.n =
+                            FStar_Syntax_Syntax.Tm_constant
+                            (FStar_Const.Const_string (s, uu___2));
+                          FStar_Syntax_Syntax.pos = uu___3;
+                          FStar_Syntax_Syntax.vars = uu___4;
+                          FStar_Syntax_Syntax.hash_code = uu___5;_},
+                        uu___6)::[] ->
+                         let uu___7 =
+                           let uu___8 = FStar_Errors_Msg.text s in [uu___8] in
+                         FStar_Compiler_List.op_At m uu___7
+                     | uu___2 -> m in
+                   (match head.FStar_Syntax_Syntax.n with
+                    | FStar_Syntax_Syntax.Tm_fvar attr_fv when
+                        FStar_Ident.lid_equals
+                          (attr_fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
+                          FStar_Parser_Const.warn_on_use_attr
+                        ->
+                        let m =
+                          let uu___2 =
+                            let uu___3 =
+                              FStar_Ident.string_of_lid
+                                (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
+                            FStar_Compiler_Util.format1
+                              "Every use of %s triggers a warning" uu___3 in
+                          FStar_Errors_Msg.text uu___2 in
+                        let uu___2 =
+                          FStar_Ident.range_of_lid
+                            (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
+                        let uu___3 =
+                          let uu___4 = msg_arg [m] in
+                          (FStar_Errors_Codes.Warning_WarnOnUse, uu___4) in
+                        FStar_Errors.log_issue_doc uu___2 uu___3
+                    | FStar_Syntax_Syntax.Tm_fvar attr_fv when
+                        FStar_Ident.lid_equals
+                          (attr_fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
+                          FStar_Parser_Const.deprecated_attr
+                        ->
+                        let m =
+                          let uu___2 =
+                            let uu___3 =
+                              FStar_Ident.string_of_lid
+                                (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
+                            FStar_Compiler_Util.format1 "%s is deprecated"
+                              uu___3 in
+                          FStar_Errors_Msg.text uu___2 in
+                        let uu___2 =
+                          FStar_Ident.range_of_lid
+                            (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
+                        let uu___3 =
+                          let uu___4 = msg_arg [m] in
+                          (FStar_Errors_Codes.Warning_DeprecatedDefinition,
+                            uu___4) in
+                        FStar_Errors.log_issue_doc uu___2 uu___3
+                    | uu___2 -> ())) attrs
 let (value_check_expected_typ :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
@@ -507,8 +502,7 @@ let (value_check_expected_typ :
              match tlc with
              | FStar_Pervasives.Inl t ->
                  let uu___1 = FStar_Syntax_Syntax.mk_Total t in
-                 FStar_Compiler_Effect.op_Less_Bar
-                   FStar_TypeChecker_Common.lcomp_of_comp uu___1
+                 FStar_TypeChecker_Common.lcomp_of_comp uu___1
              | FStar_Pervasives.Inr lc1 -> lc1 in
            let t = lc.FStar_TypeChecker_Common.res_typ in
            let uu___1 =
@@ -545,9 +539,7 @@ let (value_check_expected_typ :
                           if uu___5
                           then FStar_Pervasives_Native.None
                           else
-                            FStar_Compiler_Effect.op_Less_Bar
-                              (fun uu___7 ->
-                                 FStar_Pervasives_Native.Some uu___7)
+                            FStar_Pervasives_Native.Some
                               (FStar_TypeChecker_Err.subtyping_failed env t1
                                  t') in
                         let uu___5 =
@@ -657,13 +649,11 @@ let (check_expected_effect :
                             (uu___7, c, FStar_Pervasives_Native.None)
                           else
                             (let norm_eff_name =
-                               FStar_Compiler_Effect.op_Bar_Greater
-                                 (FStar_Syntax_Util.comp_effect_name c)
-                                 (FStar_TypeChecker_Env.norm_eff_name env) in
+                               FStar_TypeChecker_Env.norm_eff_name env
+                                 (FStar_Syntax_Util.comp_effect_name c) in
                              let uu___8 =
-                               FStar_Compiler_Effect.op_Bar_Greater
-                                 norm_eff_name
-                                 (FStar_TypeChecker_Env.is_layered_effect env) in
+                               FStar_TypeChecker_Env.is_layered_effect env
+                                 norm_eff_name in
                              if uu___8
                              then
                                let def_eff_opt =
@@ -674,12 +664,9 @@ let (check_expected_effect :
                                    let uu___9 =
                                      let uu___10 =
                                        let uu___11 =
-                                         let uu___12 =
-                                           FStar_Compiler_Effect.op_Bar_Greater
-                                             c
-                                             FStar_Syntax_Util.comp_effect_name in
-                                         FStar_Compiler_Effect.op_Bar_Greater
-                                           uu___12 FStar_Ident.string_of_lid in
+                                         FStar_Ident.string_of_lid
+                                           (FStar_Syntax_Util.comp_effect_name
+                                              c) in
                                        let uu___12 =
                                          FStar_Compiler_Range_Ops.string_of_range
                                            e.FStar_Syntax_Syntax.pos in
@@ -793,8 +780,7 @@ let (check_expected_effect :
                                    "check_expected_effect.c.after_assume" env
                                    c4;
                                  (let uu___8 =
-                                    FStar_Compiler_Effect.op_Less_Bar
-                                      (FStar_TypeChecker_Env.debug env)
+                                    FStar_TypeChecker_Env.debug env
                                       FStar_Options.Medium in
                                   if uu___8
                                   then
@@ -965,18 +951,17 @@ let (check_pat_fvs :
                 [FStar_TypeChecker_Env.Beta] env pats in
             get_pat_vars uu___ uu___1 in
           let uu___ =
-            FStar_Compiler_Effect.op_Bar_Greater bs
-              (FStar_Compiler_Util.find_opt
-                 (fun uu___1 ->
-                    match uu___1 with
-                    | { FStar_Syntax_Syntax.binder_bv = b;
-                        FStar_Syntax_Syntax.binder_qual = uu___2;
-                        FStar_Syntax_Syntax.binder_positivity = uu___3;
-                        FStar_Syntax_Syntax.binder_attrs = uu___4;_} ->
-                        let uu___5 =
-                          FStar_Compiler_Set.mem FStar_Syntax_Syntax.ord_bv b
-                            pat_vars in
-                        Prims.op_Negation uu___5)) in
+            FStar_Compiler_Util.find_opt
+              (fun uu___1 ->
+                 match uu___1 with
+                 | { FStar_Syntax_Syntax.binder_bv = b;
+                     FStar_Syntax_Syntax.binder_qual = uu___2;
+                     FStar_Syntax_Syntax.binder_positivity = uu___3;
+                     FStar_Syntax_Syntax.binder_attrs = uu___4;_} ->
+                     let uu___5 =
+                       FStar_Compiler_Set.mem FStar_Syntax_Syntax.ord_bv b
+                         pat_vars in
+                     Prims.op_Negation uu___5) bs in
           match uu___ with
           | FStar_Pervasives_Native.None -> ()
           | FStar_Pervasives_Native.Some
@@ -1073,9 +1058,7 @@ let (check_no_smt_theory_symbols :
               FStar_Syntax_Syntax.meta = uu___1;_}
             -> aux t2 in
       let tlist =
-        let uu___ = FStar_Compiler_Effect.op_Bar_Greater t pat_terms in
-        FStar_Compiler_Effect.op_Bar_Greater uu___
-          (FStar_Compiler_List.collect aux) in
+        let uu___ = pat_terms t in FStar_Compiler_List.collect aux uu___ in
       if (FStar_Compiler_List.length tlist) = Prims.int_zero
       then ()
       else
@@ -1289,21 +1272,17 @@ let (guard_letrecs :
                  | (out_rev, env2) -> FStar_Compiler_List.rev out_rev in
                let cflags = FStar_Syntax_Util.comp_flags c in
                let uu___1 =
-                 FStar_Compiler_Effect.op_Bar_Greater cflags
-                   (FStar_Compiler_List.tryFind
-                      (fun uu___2 ->
-                         match uu___2 with
-                         | FStar_Syntax_Syntax.DECREASES uu___3 -> true
-                         | uu___3 -> false)) in
+                 FStar_Compiler_List.tryFind
+                   (fun uu___2 ->
+                      match uu___2 with
+                      | FStar_Syntax_Syntax.DECREASES uu___3 -> true
+                      | uu___3 -> false) cflags in
                match uu___1 with
                | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.DECREASES
                    d) -> d
                | uu___2 ->
-                   let uu___3 =
-                     FStar_Compiler_Effect.op_Bar_Greater bs
-                       filter_types_and_functions in
-                   FStar_Compiler_Effect.op_Bar_Greater uu___3
-                     (fun uu___4 -> FStar_Syntax_Syntax.Decreases_lex uu___4)) in
+                   let uu___3 = filter_types_and_functions bs in
+                   FStar_Syntax_Syntax.Decreases_lex uu___3) in
             let precedes_t =
               FStar_TypeChecker_Util.fvar_env env1
                 FStar_Parser_Const.precedes_lid in
@@ -1315,19 +1294,15 @@ let (guard_letrecs :
                       let uu___1 =
                         env2.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
                           env2 e1 false in
-                      FStar_Compiler_Effect.op_Bar_Greater uu___1
-                        FStar_Pervasives_Native.fst in
-                    FStar_Compiler_Effect.op_Bar_Greater uu___
-                      FStar_Syntax_Util.unrefine in
+                      FStar_Pervasives_Native.fst uu___1 in
+                    FStar_Syntax_Util.unrefine uu___ in
                   let t2 =
                     let uu___ =
                       let uu___1 =
                         env2.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
                           env2 e2 false in
-                      FStar_Compiler_Effect.op_Bar_Greater uu___1
-                        FStar_Pervasives_Native.fst in
-                    FStar_Compiler_Effect.op_Bar_Greater uu___
-                      FStar_Syntax_Util.unrefine in
+                      FStar_Pervasives_Native.fst uu___1 in
+                    FStar_Syntax_Util.unrefine uu___ in
                   let rec warn t11 t21 =
                     let uu___ =
                       let uu___1 = FStar_Syntax_Util.eq_tm t11 t21 in
@@ -1362,12 +1337,11 @@ let (guard_letrecs :
                              ||
                              (let uu___3 =
                                 FStar_Compiler_List.zip args1 args2 in
-                              FStar_Compiler_Effect.op_Bar_Greater uu___3
-                                (FStar_Compiler_List.existsML
-                                   (fun uu___4 ->
-                                      match uu___4 with
-                                      | ((a1, uu___5), (a2, uu___6)) ->
-                                          warn a1 a2)))
+                              FStar_Compiler_List.existsML
+                                (fun uu___4 ->
+                                   match uu___4 with
+                                   | ((a1, uu___5), (a2, uu___6)) ->
+                                       warn a1 a2) uu___3)
                        | (FStar_Syntax_Syntax.Tm_refine
                           { FStar_Syntax_Syntax.b = t12;
                             FStar_Syntax_Syntax.phi = phi1;_},
@@ -1420,8 +1394,7 @@ let (guard_letrecs :
                                    "SMT may not be able to prove the types of %s at %s (%s) and %s at %s (%s) to be equal, if the proof fails, try annotating these with the same type"
                                    uu___9 uu___10 uu___11 uu___12 uu___13
                                    uu___14 in
-                               FStar_Compiler_Effect.op_Less_Bar
-                                 FStar_Errors_Msg.text uu___8 in
+                               FStar_Errors_Msg.text uu___8 in
                              [uu___7] in
                            (FStar_Errors_Codes.Warning_Defensive, uu___6) in
                          FStar_Errors.log_issue_doc
@@ -1497,19 +1470,13 @@ let (guard_letrecs :
                       if n < n_prev
                       then
                         (let uu___3 =
-                           let uu___4 =
-                             FStar_Compiler_Effect.op_Bar_Greater l_prev
-                               (FStar_Compiler_List.splitAt n) in
-                           FStar_Compiler_Effect.op_Bar_Greater uu___4
-                             FStar_Pervasives_Native.fst in
+                           let uu___4 = FStar_Compiler_List.splitAt n l_prev in
+                           FStar_Pervasives_Native.fst uu___4 in
                          (l, uu___3))
                       else
                         (let uu___4 =
-                           let uu___5 =
-                             FStar_Compiler_Effect.op_Bar_Greater l
-                               (FStar_Compiler_List.splitAt n_prev) in
-                           FStar_Compiler_Effect.op_Bar_Greater uu___5
-                             FStar_Pervasives_Native.fst in
+                           let uu___5 = FStar_Compiler_List.splitAt n_prev l in
+                           FStar_Pervasives_Native.fst uu___5 in
                          (uu___4, l_prev)) in
               match uu___ with | (l1, l_prev1) -> aux l1 l_prev1 in
             let mk_precedes env2 d d_prev =
@@ -1572,33 +1539,31 @@ let (guard_letrecs :
                             "impossible: bad formals arity, guard_one_letrec"
                         else ();
                         (let formals1 =
-                           FStar_Compiler_Effect.op_Bar_Greater formals
-                             (FStar_Compiler_List.map
-                                (fun b ->
-                                   let uu___3 =
-                                     FStar_Syntax_Syntax.is_null_bv
-                                       b.FStar_Syntax_Syntax.binder_bv in
-                                   if uu___3
-                                   then
-                                     let uu___4 =
-                                       let uu___5 =
-                                         let uu___6 =
-                                           FStar_Syntax_Syntax.range_of_bv
-                                             b.FStar_Syntax_Syntax.binder_bv in
-                                         FStar_Pervasives_Native.Some uu___6 in
-                                       FStar_Syntax_Syntax.new_bv uu___5
-                                         (b.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort in
-                                     {
-                                       FStar_Syntax_Syntax.binder_bv = uu___4;
-                                       FStar_Syntax_Syntax.binder_qual =
-                                         (b.FStar_Syntax_Syntax.binder_qual);
-                                       FStar_Syntax_Syntax.binder_positivity
-                                         =
-                                         (b.FStar_Syntax_Syntax.binder_positivity);
-                                       FStar_Syntax_Syntax.binder_attrs =
-                                         (b.FStar_Syntax_Syntax.binder_attrs)
-                                     }
-                                   else b)) in
+                           FStar_Compiler_List.map
+                             (fun b ->
+                                let uu___3 =
+                                  FStar_Syntax_Syntax.is_null_bv
+                                    b.FStar_Syntax_Syntax.binder_bv in
+                                if uu___3
+                                then
+                                  let uu___4 =
+                                    let uu___5 =
+                                      let uu___6 =
+                                        FStar_Syntax_Syntax.range_of_bv
+                                          b.FStar_Syntax_Syntax.binder_bv in
+                                      FStar_Pervasives_Native.Some uu___6 in
+                                    FStar_Syntax_Syntax.new_bv uu___5
+                                      (b.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort in
+                                  {
+                                    FStar_Syntax_Syntax.binder_bv = uu___4;
+                                    FStar_Syntax_Syntax.binder_qual =
+                                      (b.FStar_Syntax_Syntax.binder_qual);
+                                    FStar_Syntax_Syntax.binder_positivity =
+                                      (b.FStar_Syntax_Syntax.binder_positivity);
+                                    FStar_Syntax_Syntax.binder_attrs =
+                                      (b.FStar_Syntax_Syntax.binder_attrs)
+                                  }
+                                else b) formals in
                          let dec = decreases_clause formals1 c in
                          let precedes =
                            let env2 =
@@ -1651,8 +1616,7 @@ let (guard_letrecs :
                                    uu___6 uu___7 uu___8
                                else ());
                               (l, t', u_names))))) in
-            FStar_Compiler_Effect.op_Bar_Greater letrecs
-              (FStar_Compiler_List.map guard_one_letrec)
+            FStar_Compiler_List.map guard_one_letrec letrecs
 let (wrap_guard_with_tactic_opt :
   FStar_Syntax_Syntax.term FStar_Pervasives_Native.option ->
     FStar_TypeChecker_Env.guard_t -> FStar_TypeChecker_Env.guard_t)
@@ -1698,14 +1662,9 @@ let (is_comp_ascribed_reflect :
               | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reflect l)
                   ->
                   let uu___7 =
-                    let uu___8 =
-                      FStar_Compiler_Effect.op_Bar_Greater args
-                        FStar_Compiler_List.hd in
-                    FStar_Compiler_Effect.op_Bar_Greater uu___8
-                      (fun uu___9 ->
-                         match uu___9 with | (e2, aqual) -> (l, e2, aqual)) in
-                  FStar_Compiler_Effect.op_Bar_Greater uu___7
-                    (fun uu___8 -> FStar_Pervasives_Native.Some uu___8)
+                    let uu___8 = FStar_Compiler_List.hd args in
+                    match uu___8 with | (e2, aqual) -> (l, e2, aqual) in
+                  FStar_Pervasives_Native.Some uu___7
               | uu___7 -> FStar_Pervasives_Native.None)
          | uu___6 -> FStar_Pervasives_Native.None)
     | uu___1 -> FStar_Pervasives_Native.None
@@ -1725,8 +1684,7 @@ let rec (tc_term :
        then
          let uu___3 =
            let uu___4 = FStar_TypeChecker_Env.get_range env in
-           FStar_Compiler_Effect.op_Less_Bar
-             FStar_Compiler_Range_Ops.string_of_range uu___4 in
+           FStar_Compiler_Range_Ops.string_of_range uu___4 in
          let uu___4 =
            FStar_Compiler_Util.string_of_bool
              env.FStar_TypeChecker_Env.phase1 in
@@ -1854,8 +1812,7 @@ let rec (tc_term :
              then
                ((let uu___6 =
                    let uu___7 = FStar_TypeChecker_Env.get_range env in
-                   FStar_Compiler_Effect.op_Less_Bar
-                     FStar_Compiler_Range_Ops.string_of_range uu___7 in
+                   FStar_Compiler_Range_Ops.string_of_range uu___7 in
                  let uu___7 = FStar_Syntax_Print.term_to_string e in
                  let uu___8 =
                    let uu___9 = FStar_Syntax_Subst.compress e in
@@ -1869,8 +1826,7 @@ let rec (tc_term :
                  | (e1, lc, uu___7) ->
                      let uu___8 =
                        let uu___9 = FStar_TypeChecker_Env.get_range env in
-                       FStar_Compiler_Effect.op_Less_Bar
-                         FStar_Compiler_Range_Ops.string_of_range uu___9 in
+                       FStar_Compiler_Range_Ops.string_of_range uu___9 in
                      let uu___9 = FStar_Syntax_Print.term_to_string e1 in
                      let uu___10 =
                        FStar_TypeChecker_Common.lcomp_to_string lc in
@@ -1903,9 +1859,7 @@ and (tc_maybe_toplevel_term :
         then
           let uu___3 =
             let uu___4 = FStar_TypeChecker_Env.get_range env1 in
-            FStar_Compiler_Effect.op_Less_Bar
-              (FStar_Class_Show.show FStar_Compiler_Range_Ops.show_range)
-              uu___4 in
+            FStar_Class_Show.show FStar_Compiler_Range_Ops.show_range uu___4 in
           let uu___4 = FStar_Syntax_Print.tag_of_term top in
           let uu___5 =
             FStar_Class_Show.show FStar_Syntax_Print.showable_term top in
@@ -2401,18 +2355,11 @@ and (tc_maybe_toplevel_term :
                  FStar_Pervasives_Native.None, use_eq);
               FStar_Syntax_Syntax.eff_opt = uu___3;_}
             when
+            let uu___4 = is_comp_ascribed_reflect top in
+            FStar_Compiler_Util.is_some uu___4 ->
             let uu___4 =
-              FStar_Compiler_Effect.op_Bar_Greater top
-                is_comp_ascribed_reflect in
-            FStar_Compiler_Effect.op_Bar_Greater uu___4
-              FStar_Compiler_Util.is_some
-            ->
-            let uu___4 =
-              let uu___5 =
-                FStar_Compiler_Effect.op_Bar_Greater top
-                  is_comp_ascribed_reflect in
-              FStar_Compiler_Effect.op_Bar_Greater uu___5
-                FStar_Compiler_Util.must in
+              let uu___5 = is_comp_ascribed_reflect top in
+              FStar_Compiler_Util.must uu___5 in
             (match uu___4 with
              | (effect_lid, e1, aqual) ->
                  let uu___5 = FStar_TypeChecker_Env.clear_expected_typ env1 in
@@ -2465,18 +2412,15 @@ and (tc_maybe_toplevel_term :
                                  top.FStar_Syntax_Syntax.pos
                              else ());
                             (let u_c =
-                               FStar_Compiler_Effect.op_Bar_Greater
-                                 expected_ct.FStar_Syntax_Syntax.comp_univs
-                                 FStar_Compiler_List.hd in
+                               FStar_Compiler_List.hd
+                                 expected_ct.FStar_Syntax_Syntax.comp_univs in
                              let repr =
                                let uu___11 =
                                  let uu___12 =
-                                   FStar_Compiler_Effect.op_Bar_Greater
-                                     expected_ct FStar_Syntax_Syntax.mk_Comp in
+                                   FStar_Syntax_Syntax.mk_Comp expected_ct in
                                  FStar_TypeChecker_Env.effect_repr env0
                                    uu___12 u_c in
-                               FStar_Compiler_Effect.op_Bar_Greater uu___11
-                                 FStar_Compiler_Util.must in
+                               FStar_Compiler_Util.must uu___11 in
                              let e2 =
                                let uu___11 =
                                  let uu___12 =
@@ -2497,8 +2441,7 @@ and (tc_maybe_toplevel_term :
                                FStar_Syntax_Syntax.mk uu___11
                                  e1.FStar_Syntax_Syntax.pos in
                              (let uu___12 =
-                                FStar_Compiler_Effect.op_Less_Bar
-                                  (FStar_TypeChecker_Env.debug env0)
+                                FStar_TypeChecker_Env.debug env0
                                   FStar_Options.Extreme in
                               if uu___12
                               then
@@ -2513,8 +2456,7 @@ and (tc_maybe_toplevel_term :
                               | (e3, uu___13, g_e) ->
                                   let e4 = FStar_Syntax_Util.unascribe e3 in
                                   ((let uu___15 =
-                                      FStar_Compiler_Effect.op_Less_Bar
-                                        (FStar_TypeChecker_Env.debug env0)
+                                      FStar_TypeChecker_Env.debug env0
                                         FStar_Options.Extreme in
                                     if uu___15
                                     then
@@ -2542,36 +2484,24 @@ and (tc_maybe_toplevel_term :
                                                FStar_Syntax_Syntax.args =
                                                  [(e4, aqual)]
                                              }) r in
-                                      let uu___15 =
-                                        let uu___16 =
-                                          let uu___17 =
-                                            let uu___18 =
-                                              FStar_Compiler_Effect.op_Bar_Greater
-                                                expected_c1
-                                                FStar_Syntax_Util.comp_effect_name in
-                                            FStar_Compiler_Effect.op_Bar_Greater
-                                              uu___18
-                                              (fun uu___19 ->
-                                                 FStar_Pervasives_Native.Some
-                                                   uu___19) in
-                                          {
-                                            FStar_Syntax_Syntax.tm = tm1;
-                                            FStar_Syntax_Syntax.asc =
-                                              ((FStar_Pervasives.Inr
-                                                  expected_c1),
-                                                FStar_Pervasives_Native.None,
-                                                use_eq);
-                                            FStar_Syntax_Syntax.eff_opt =
-                                              uu___17
-                                          } in
-                                        FStar_Syntax_Syntax.Tm_ascribed
-                                          uu___16 in
-                                      FStar_Syntax_Syntax.mk uu___15 r in
+                                      FStar_Syntax_Syntax.mk
+                                        (FStar_Syntax_Syntax.Tm_ascribed
+                                           {
+                                             FStar_Syntax_Syntax.tm = tm1;
+                                             FStar_Syntax_Syntax.asc =
+                                               ((FStar_Pervasives.Inr
+                                                   expected_c1),
+                                                 FStar_Pervasives_Native.None,
+                                                 use_eq);
+                                             FStar_Syntax_Syntax.eff_opt =
+                                               (FStar_Pervasives_Native.Some
+                                                  (FStar_Syntax_Util.comp_effect_name
+                                                     expected_c1))
+                                           }) r in
                                     let uu___15 =
                                       let uu___16 =
-                                        FStar_Compiler_Effect.op_Bar_Greater
-                                          expected_c1
-                                          FStar_TypeChecker_Common.lcomp_of_comp in
+                                        FStar_TypeChecker_Common.lcomp_of_comp
+                                          expected_c1 in
                                       comp_check_expected_typ env1 top1
                                         uu___16 in
                                     match uu___15 with
@@ -2595,11 +2525,9 @@ and (tc_maybe_toplevel_term :
                   | (expected_c1, uu___6, g) ->
                       let uu___7 =
                         let uu___8 =
-                          FStar_Compiler_Effect.op_Bar_Greater
-                            (FStar_Syntax_Util.comp_result expected_c1)
-                            (fun t ->
-                               FStar_TypeChecker_Env.set_expected_typ_maybe_eq
-                                 env0 t use_eq) in
+                          FStar_TypeChecker_Env.set_expected_typ_maybe_eq
+                            env0 (FStar_Syntax_Util.comp_result expected_c1)
+                            use_eq in
                         tc_term uu___8 e1 in
                       (match uu___7 with
                        | (e2, c', g') ->
@@ -2855,8 +2783,7 @@ and (tc_maybe_toplevel_term :
             let uu___5 =
               let uu___6 =
                 let uu___7 = FStar_TypeChecker_Env.clear_expected_typ env1 in
-                FStar_Compiler_Effect.op_Less_Bar FStar_Pervasives_Native.fst
-                  uu___7 in
+                FStar_Pervasives_Native.fst uu___7 in
               tc_term uu___6 e1 in
             (match uu___5 with
              | (e2, c, g) ->
@@ -2877,8 +2804,7 @@ and (tc_maybe_toplevel_term :
                             FStar_Syntax_Syntax.tabbrev
                               FStar_Parser_Const.range_lid in
                           FStar_Syntax_Syntax.mk_Total uu___11 in
-                        FStar_Compiler_Effect.op_Less_Bar
-                          FStar_TypeChecker_Common.lcomp_of_comp uu___10 in
+                        FStar_TypeChecker_Common.lcomp_of_comp uu___10 in
                       (uu___8, uu___9, g)))
         | FStar_Syntax_Syntax.Tm_app
             {
@@ -3022,9 +2948,8 @@ and (tc_maybe_toplevel_term :
                                 then
                                   let uu___13 =
                                     FStar_Syntax_Syntax.mk_Total repr in
-                                  FStar_Compiler_Effect.op_Bar_Greater
+                                  FStar_TypeChecker_Common.lcomp_of_comp
                                     uu___13
-                                    FStar_TypeChecker_Common.lcomp_of_comp
                                 else
                                   (let ct =
                                      {
@@ -3037,9 +2962,8 @@ and (tc_maybe_toplevel_term :
                                      } in
                                    let uu___14 =
                                      FStar_Syntax_Syntax.mk_Comp ct in
-                                   FStar_Compiler_Effect.op_Bar_Greater
-                                     uu___14
-                                     FStar_TypeChecker_Common.lcomp_of_comp) in
+                                   FStar_TypeChecker_Common.lcomp_of_comp
+                                     uu___14) in
                               let uu___12 =
                                 comp_check_expected_typ env1 e3 c2 in
                               match uu___12 with
@@ -3108,8 +3032,7 @@ and (tc_maybe_toplevel_term :
                                       let uu___16 =
                                         FStar_TypeChecker_Common.is_total_lcomp
                                           c in
-                                      FStar_Compiler_Effect.op_Less_Bar
-                                        Prims.op_Negation uu___16 in
+                                      Prims.op_Negation uu___16 in
                                     if uu___15
                                     then
                                       FStar_Errors.log_issue
@@ -3191,9 +3114,8 @@ and (tc_maybe_toplevel_term :
                                                 = eff_args;
                                               FStar_Syntax_Syntax.flags = []
                                             } in
-                                        FStar_Compiler_Effect.op_Bar_Greater
-                                          uu___14
-                                          FStar_TypeChecker_Common.lcomp_of_comp in
+                                        FStar_TypeChecker_Common.lcomp_of_comp
+                                          uu___14 in
                                       let e3 =
                                         FStar_Syntax_Syntax.mk
                                           (FStar_Syntax_Syntax.Tm_app
@@ -3385,8 +3307,7 @@ and (tc_maybe_toplevel_term :
                  (match uu___10 with
                   | (thead, uu___11) ->
                       ((let uu___13 =
-                          FStar_Compiler_Effect.op_Less_Bar
-                            (FStar_TypeChecker_Env.debug env1)
+                          FStar_TypeChecker_Env.debug env1
                             (FStar_Options.Other "RFD") in
                         if uu___13
                         then
@@ -3519,9 +3440,8 @@ and (tc_maybe_toplevel_term :
             let env2 =
               let uu___2 =
                 let uu___3 = FStar_TypeChecker_Env.clear_expected_typ env1 in
-                FStar_Compiler_Effect.op_Bar_Greater uu___3
-                  FStar_Pervasives_Native.fst in
-              FStar_Compiler_Effect.op_Bar_Greater uu___2 instantiate_both in
+                FStar_Pervasives_Native.fst uu___3 in
+              instantiate_both uu___2 in
             ((let uu___3 =
                 FStar_TypeChecker_Env.debug env2 FStar_Options.High in
               if uu___3
@@ -3539,13 +3459,11 @@ and (tc_maybe_toplevel_term :
               | (head1, chead, g_head) ->
                   let uu___4 =
                     let uu___5 = FStar_TypeChecker_Common.lcomp_comp chead in
-                    FStar_Compiler_Effect.op_Bar_Greater uu___5
-                      (fun uu___6 ->
-                         match uu___6 with
-                         | (c, g) ->
-                             let uu___7 =
-                               FStar_TypeChecker_Env.conj_guard g_head g in
-                             (c, uu___7)) in
+                    match uu___5 with
+                    | (c, g) ->
+                        let uu___6 =
+                          FStar_TypeChecker_Env.conj_guard g_head g in
+                        (c, uu___6) in
                   (match uu___4 with
                    | (chead1, g_head1) ->
                        let uu___5 =
@@ -3689,12 +3607,9 @@ and (tc_match :
           let uu___2 =
             let uu___3 =
               let uu___4 =
-                let uu___5 =
-                  FStar_Compiler_Effect.op_Bar_Greater env
-                    FStar_TypeChecker_Env.clear_expected_typ in
-                FStar_Compiler_Effect.op_Bar_Greater uu___5
-                  FStar_Pervasives_Native.fst in
-              FStar_Compiler_Effect.op_Bar_Greater uu___4 instantiate_both in
+                let uu___5 = FStar_TypeChecker_Env.clear_expected_typ env in
+                FStar_Pervasives_Native.fst uu___5 in
+              instantiate_both uu___4 in
             tc_term uu___3 e1 in
           (match uu___2 with
            | (e11, c1, g1) ->
@@ -3872,9 +3787,8 @@ and (tc_match :
                                 (e12.FStar_Syntax_Syntax.pos))
                              c11.FStar_TypeChecker_Common.res_typ in
                          let t_eqns =
-                           FStar_Compiler_Effect.op_Bar_Greater eqns
-                             (FStar_Compiler_List.map
-                                (tc_eqn guard_x env_branches ret_opt1)) in
+                           FStar_Compiler_List.map
+                             (tc_eqn guard_x env_branches ret_opt1) eqns in
                          let uu___5 =
                            match ret_opt1 with
                            | FStar_Pervasives_Native.Some
@@ -3887,15 +3801,13 @@ and (tc_match :
                                         e12)] c in
                                let uu___8 =
                                  let uu___9 =
-                                   FStar_Compiler_Effect.op_Bar_Greater
-                                     t_eqns
-                                     (FStar_Compiler_List.map
-                                        (fun uu___10 ->
-                                           match uu___10 with
-                                           | (uu___11, f, uu___12, uu___13,
-                                              uu___14, g, b1) -> (f, g, b1))) in
-                                 FStar_Compiler_Effect.op_Bar_Greater uu___9
-                                   FStar_Compiler_List.unzip3 in
+                                   FStar_Compiler_List.map
+                                     (fun uu___10 ->
+                                        match uu___10 with
+                                        | (uu___11, f, uu___12, uu___13,
+                                           uu___14, g, b1) -> (f, g, b1))
+                                     t_eqns in
+                                 FStar_Compiler_List.unzip3 uu___9 in
                                (match uu___8 with
                                 | (fmls, gs, erasables) ->
                                     let uu___9 =
@@ -3908,33 +3820,25 @@ and (tc_match :
                                              FStar_Compiler_List.map2
                                                FStar_TypeChecker_Common.weaken_guard_formula
                                                gs neg_conds in
-                                           FStar_Compiler_Effect.op_Bar_Greater
-                                             uu___10
-                                             FStar_TypeChecker_Env.conj_guards in
+                                           FStar_TypeChecker_Env.conj_guards
+                                             uu___10 in
                                          let g_exhaustiveness =
                                            let uu___10 =
                                              let uu___11 =
                                                let uu___12 =
+                                                 FStar_TypeChecker_Env.get_range
+                                                   env in
+                                               let uu___13 =
                                                  FStar_Syntax_Util.mk_imp
                                                    exhaustiveness_cond
                                                    FStar_Syntax_Util.t_false in
-                                               let uu___13 =
-                                                 let uu___14 =
-                                                   FStar_TypeChecker_Env.get_range
-                                                     env in
-                                                 FStar_TypeChecker_Util.label
-                                                   FStar_TypeChecker_Err.exhaustiveness_check
-                                                   uu___14 in
-                                               FStar_Compiler_Effect.op_Bar_Greater
+                                               FStar_TypeChecker_Util.label
+                                                 FStar_TypeChecker_Err.exhaustiveness_check
                                                  uu___12 uu___13 in
-                                             FStar_Compiler_Effect.op_Bar_Greater
-                                               uu___11
-                                               (fun uu___12 ->
-                                                  FStar_TypeChecker_Common.NonTrivial
-                                                    uu___12) in
-                                           FStar_Compiler_Effect.op_Bar_Greater
-                                             uu___10
-                                             FStar_TypeChecker_Env.guard_of_guard_formula in
+                                             FStar_TypeChecker_Common.NonTrivial
+                                               uu___11 in
+                                           FStar_TypeChecker_Env.guard_of_guard_formula
+                                             uu___10 in
                                          let g2 =
                                            FStar_TypeChecker_Env.conj_guard g
                                              g_exhaustiveness in
@@ -3964,11 +3868,9 @@ and (tc_match :
                                            FStar_TypeChecker_Common.lcomp_of_comp
                                              c2 in
                                          let uu___11 =
-                                           FStar_Compiler_Effect.op_Bar_Greater
-                                             erasables
-                                             (FStar_Compiler_List.fold_left
-                                                (fun acc ->
-                                                   fun b1 -> acc || b1) false) in
+                                           FStar_Compiler_List.fold_left
+                                             (fun acc -> fun b1 -> acc || b1)
+                                             false erasables in
                                          (uu___10, g4, uu___11)))
                            | uu___6 ->
                                let uu___7 =
@@ -3982,13 +3884,10 @@ and (tc_match :
                                             let uu___10 =
                                               let uu___11 =
                                                 let uu___12 =
-                                                  FStar_Compiler_Effect.op_Bar_Greater
-                                                    cflags
-                                                    FStar_Compiler_Util.must in
+                                                  FStar_Compiler_Util.must
+                                                    cflags in
                                                 let uu___13 =
-                                                  FStar_Compiler_Effect.op_Bar_Greater
-                                                    c
-                                                    FStar_Compiler_Util.must in
+                                                  FStar_Compiler_Util.must c in
                                                 (f, eff_label, uu___12,
                                                   uu___13) in
                                               uu___11 :: caccum in
@@ -4009,12 +3908,8 @@ and (tc_match :
                                              let uu___9 =
                                                FStar_TypeChecker_Env.expected_typ
                                                  env_branches in
-                                             FStar_Compiler_Effect.op_Bar_Greater
-                                               uu___9
-                                               FStar_Compiler_Util.must in
-                                           FStar_Compiler_Effect.op_Bar_Greater
-                                             uu___8
-                                             FStar_Pervasives_Native.fst in
+                                             FStar_Compiler_Util.must uu___9 in
+                                           FStar_Pervasives_Native.fst uu___8 in
                                          let uu___8 =
                                            FStar_TypeChecker_Util.bind_cases
                                              env res_t cases guard_x in
@@ -4105,20 +4000,18 @@ and (tc_match :
                                       FStar_Pervasives_Native.Some (b2, asc1) in
                                 let mk_match scrutinee =
                                   let branches =
-                                    FStar_Compiler_Effect.op_Bar_Greater
-                                      t_eqns
-                                      (FStar_Compiler_List.map
-                                         (fun uu___6 ->
-                                            match uu___6 with
-                                            | ((pat, wopt, br), uu___7,
-                                               eff_label, uu___8, uu___9,
-                                               uu___10, uu___11) ->
-                                                let uu___12 =
-                                                  FStar_TypeChecker_Util.maybe_lift
-                                                    env br eff_label
-                                                    cres1.FStar_TypeChecker_Common.eff_name
-                                                    cres1.FStar_TypeChecker_Common.res_typ in
-                                                (pat, wopt, uu___12))) in
+                                    FStar_Compiler_List.map
+                                      (fun uu___6 ->
+                                         match uu___6 with
+                                         | ((pat, wopt, br), uu___7,
+                                            eff_label, uu___8, uu___9,
+                                            uu___10, uu___11) ->
+                                             let uu___12 =
+                                               FStar_TypeChecker_Util.maybe_lift
+                                                 env br eff_label
+                                                 cres1.FStar_TypeChecker_Common.eff_name
+                                                 cres1.FStar_TypeChecker_Common.res_typ in
+                                             (pat, wopt, uu___12)) t_eqns in
                                   let e2 =
                                     let rc =
                                       {
@@ -4303,8 +4196,7 @@ and (tc_synth :
                 let uu___2 =
                   let uu___3 =
                     let uu___4 = FStar_Syntax_Util.type_u () in
-                    FStar_Compiler_Effect.op_Less_Bar
-                      FStar_Pervasives_Native.fst uu___4 in
+                    FStar_Pervasives_Native.fst uu___4 in
                   FStar_TypeChecker_Env.set_expected_typ env uu___3 in
                 tc_term uu___2 typ in
               (match uu___1 with
@@ -4328,8 +4220,7 @@ and (tc_synth :
                                    (tau1.FStar_Syntax_Syntax.hash_code)
                                } in
                            (let uu___8 =
-                              FStar_Compiler_Effect.op_Less_Bar
-                                (FStar_TypeChecker_Env.debug env)
+                              FStar_TypeChecker_Env.debug env
                                 (FStar_Options.Other "Tac") in
                             if uu___8
                             then
@@ -4341,9 +4232,7 @@ and (tc_synth :
                              tau1.FStar_Syntax_Syntax.pos t;
                            (let uu___9 =
                               let uu___10 = FStar_Syntax_Syntax.mk_Total typ1 in
-                              FStar_Compiler_Effect.op_Less_Bar
-                                FStar_TypeChecker_Common.lcomp_of_comp
-                                uu___10 in
+                              FStar_TypeChecker_Common.lcomp_of_comp uu___10 in
                             (t, uu___9, FStar_TypeChecker_Env.trivial_guard)))))))
 and (tc_tactic :
   FStar_Syntax_Syntax.typ ->
@@ -4509,8 +4398,7 @@ and (check_instantiated_fvar :
                    else
                      (let uu___4 =
                         let uu___5 = FStar_Syntax_Syntax.mk_Total t1 in
-                        FStar_Compiler_Effect.op_Less_Bar
-                          FStar_TypeChecker_Common.lcomp_of_comp uu___5 in
+                        FStar_TypeChecker_Common.lcomp_of_comp uu___5 in
                       FStar_Pervasives.Inr uu___4) in
                  value_check_expected_typ env e1 tc implicits)
 and (tc_value :
@@ -4576,8 +4464,7 @@ and (tc_value :
                 | (e1, uu___3, g1) ->
                     let uu___4 =
                       let uu___5 = FStar_Syntax_Syntax.mk_Total t in
-                      FStar_Compiler_Effect.op_Bar_Greater uu___5
-                        FStar_TypeChecker_Common.lcomp_of_comp in
+                      FStar_TypeChecker_Common.lcomp_of_comp uu___5 in
                     let uu___5 = FStar_TypeChecker_Env.conj_guard g0 g1 in
                     (e1, uu___4, uu___5)))
       | FStar_Syntax_Syntax.Tm_name x ->
@@ -4606,8 +4493,7 @@ and (tc_value :
                        else
                          (let uu___5 =
                             let uu___6 = FStar_Syntax_Syntax.mk_Total t1 in
-                            FStar_Compiler_Effect.op_Less_Bar
-                              FStar_TypeChecker_Common.lcomp_of_comp uu___6 in
+                            FStar_TypeChecker_Common.lcomp_of_comp uu___6 in
                           FStar_Pervasives.Inr uu___5) in
                      value_check_expected_typ env1 e2 tc implicits)))
       | FStar_Syntax_Syntax.Tm_uinst
@@ -4716,8 +4602,7 @@ and (tc_value :
                let fv1 = FStar_Syntax_Syntax.set_range_of_fv fv range in
                (maybe_warn_on_use env1 fv1;
                 (let uu___3 =
-                   FStar_Compiler_Effect.op_Less_Bar
-                     (FStar_TypeChecker_Env.debug env1)
+                   FStar_TypeChecker_Env.debug env1
                      (FStar_Options.Other "Range") in
                  if uu___3
                  then
@@ -4957,8 +4842,7 @@ and (tc_constant :
               let uu___1 =
                 FStar_Syntax_DsEnv.try_lookup_lid
                   env.FStar_TypeChecker_Env.dsenv FStar_Parser_Const.char_lid in
-              FStar_Compiler_Effect.op_Bar_Greater uu___1
-                FStar_Compiler_Util.must
+              FStar_Compiler_Util.must uu___1
           | FStar_Const.Const_effect -> FStar_Syntax_Util.ktype0
           | FStar_Const.Const_range uu___ -> FStar_Syntax_Syntax.t_range
           | FStar_Const.Const_range_of ->
@@ -5176,121 +5060,106 @@ and (tc_comp :
                           | (res, args2) ->
                               let uu___6 =
                                 let uu___7 =
-                                  FStar_Compiler_Effect.op_Bar_Greater
-                                    c1.FStar_Syntax_Syntax.flags
-                                    (FStar_Compiler_List.map
-                                       (fun uu___8 ->
-                                          match uu___8 with
-                                          | FStar_Syntax_Syntax.DECREASES
-                                              (FStar_Syntax_Syntax.Decreases_lex
-                                              l) ->
-                                              let uu___9 =
-                                                FStar_TypeChecker_Env.clear_expected_typ
-                                                  env in
-                                              (match uu___9 with
-                                               | (env1, uu___10) ->
-                                                   let uu___11 =
-                                                     FStar_Compiler_Effect.op_Bar_Greater
-                                                       l
-                                                       (FStar_Compiler_List.fold_left
-                                                          (fun uu___12 ->
-                                                             fun e ->
-                                                               match uu___12
-                                                               with
-                                                               | (l1, g) ->
-                                                                   let uu___13
-                                                                    =
-                                                                    tc_tot_or_gtot_term
-                                                                    env1 e in
-                                                                   (match uu___13
-                                                                    with
-                                                                    | 
-                                                                    (e1,
-                                                                    uu___14,
-                                                                    g_e) ->
-                                                                    let uu___15
+                                  FStar_Compiler_List.map
+                                    (fun uu___8 ->
+                                       match uu___8 with
+                                       | FStar_Syntax_Syntax.DECREASES
+                                           (FStar_Syntax_Syntax.Decreases_lex
+                                           l) ->
+                                           let uu___9 =
+                                             FStar_TypeChecker_Env.clear_expected_typ
+                                               env in
+                                           (match uu___9 with
+                                            | (env1, uu___10) ->
+                                                let uu___11 =
+                                                  FStar_Compiler_List.fold_left
+                                                    (fun uu___12 ->
+                                                       fun e ->
+                                                         match uu___12 with
+                                                         | (l1, g) ->
+                                                             let uu___13 =
+                                                               tc_tot_or_gtot_term
+                                                                 env1 e in
+                                                             (match uu___13
+                                                              with
+                                                              | (e1, uu___14,
+                                                                 g_e) ->
+                                                                  let uu___15
                                                                     =
                                                                     FStar_TypeChecker_Env.conj_guard
                                                                     g g_e in
-                                                                    ((FStar_Compiler_List.op_At
-                                                                    l1 [e1]),
+                                                                  ((FStar_Compiler_List.op_At
+                                                                    l1 
+                                                                    [e1]),
                                                                     uu___15)))
-                                                          ([],
-                                                            FStar_TypeChecker_Env.trivial_guard)) in
-                                                   (match uu___11 with
-                                                    | (l1, g) ->
-                                                        ((FStar_Syntax_Syntax.DECREASES
-                                                            (FStar_Syntax_Syntax.Decreases_lex
-                                                               l1)), g)))
-                                          | FStar_Syntax_Syntax.DECREASES
-                                              (FStar_Syntax_Syntax.Decreases_wf
-                                              (rel, e)) ->
-                                              let uu___9 =
-                                                FStar_TypeChecker_Env.clear_expected_typ
-                                                  env in
-                                              (match uu___9 with
-                                               | (env1, uu___10) ->
-                                                   let uu___11 =
-                                                     FStar_Syntax_Util.type_u
-                                                       () in
-                                                   (match uu___11 with
-                                                    | (t, u_t) ->
-                                                        let u_r =
-                                                          FStar_TypeChecker_Env.new_u_univ
-                                                            () in
-                                                        let uu___12 =
-                                                          FStar_TypeChecker_Util.new_implicit_var
-                                                            "implicit for type of the well-founded relation in decreases clause"
-                                                            rel.FStar_Syntax_Syntax.pos
-                                                            env1 t in
-                                                        (match uu___12 with
-                                                         | (a, uu___13, g_a)
-                                                             ->
-                                                             let wf_t =
-                                                               let uu___14 =
-                                                                 let uu___15
+                                                    ([],
+                                                      FStar_TypeChecker_Env.trivial_guard)
+                                                    l in
+                                                (match uu___11 with
+                                                 | (l1, g) ->
+                                                     ((FStar_Syntax_Syntax.DECREASES
+                                                         (FStar_Syntax_Syntax.Decreases_lex
+                                                            l1)), g)))
+                                       | FStar_Syntax_Syntax.DECREASES
+                                           (FStar_Syntax_Syntax.Decreases_wf
+                                           (rel, e)) ->
+                                           let uu___9 =
+                                             FStar_TypeChecker_Env.clear_expected_typ
+                                               env in
+                                           (match uu___9 with
+                                            | (env1, uu___10) ->
+                                                let uu___11 =
+                                                  FStar_Syntax_Util.type_u () in
+                                                (match uu___11 with
+                                                 | (t, u_t) ->
+                                                     let u_r =
+                                                       FStar_TypeChecker_Env.new_u_univ
+                                                         () in
+                                                     let uu___12 =
+                                                       FStar_TypeChecker_Util.new_implicit_var
+                                                         "implicit for type of the well-founded relation in decreases clause"
+                                                         rel.FStar_Syntax_Syntax.pos
+                                                         env1 t in
+                                                     (match uu___12 with
+                                                      | (a, uu___13, g_a) ->
+                                                          let wf_t =
+                                                            let uu___14 =
+                                                              let uu___15 =
+                                                                FStar_TypeChecker_Env.fvar_of_nonqual_lid
+                                                                  env1
+                                                                  FStar_Parser_Const.well_founded_relation_lid in
+                                                              FStar_Syntax_Syntax.mk_Tm_uinst
+                                                                uu___15
+                                                                [u_t; u_r] in
+                                                            let uu___15 =
+                                                              let uu___16 =
+                                                                FStar_Syntax_Syntax.as_arg
+                                                                  a in
+                                                              [uu___16] in
+                                                            FStar_Syntax_Syntax.mk_Tm_app
+                                                              uu___14 uu___15
+                                                              rel.FStar_Syntax_Syntax.pos in
+                                                          let uu___14 =
+                                                            let uu___15 =
+                                                              FStar_TypeChecker_Env.set_expected_typ
+                                                                env1 wf_t in
+                                                            tc_tot_or_gtot_term
+                                                              uu___15 rel in
+                                                          (match uu___14 with
+                                                           | (rel1, uu___15,
+                                                              g_rel) ->
+                                                               let uu___16 =
+                                                                 let uu___17
                                                                    =
-                                                                   FStar_TypeChecker_Env.fvar_of_nonqual_lid
-                                                                    env1
-                                                                    FStar_Parser_Const.well_founded_relation_lid in
-                                                                 FStar_Syntax_Syntax.mk_Tm_uinst
-                                                                   uu___15
-                                                                   [u_t; u_r] in
-                                                               let uu___15 =
-                                                                 let uu___16
-                                                                   =
-                                                                   FStar_Syntax_Syntax.as_arg
-                                                                    a in
-                                                                 [uu___16] in
-                                                               FStar_Syntax_Syntax.mk_Tm_app
-                                                                 uu___14
-                                                                 uu___15
-                                                                 rel.FStar_Syntax_Syntax.pos in
-                                                             let uu___14 =
-                                                               let uu___15 =
-                                                                 FStar_TypeChecker_Env.set_expected_typ
-                                                                   env1 wf_t in
-                                                               tc_tot_or_gtot_term
-                                                                 uu___15 rel in
-                                                             (match uu___14
-                                                              with
-                                                              | (rel1,
-                                                                 uu___15,
-                                                                 g_rel) ->
-                                                                  let uu___16
-                                                                    =
-                                                                    let uu___17
-                                                                    =
-                                                                    FStar_TypeChecker_Env.set_expected_typ
+                                                                   FStar_TypeChecker_Env.set_expected_typ
                                                                     env1 a in
-                                                                    tc_tot_or_gtot_term
-                                                                    uu___17 e in
-                                                                  (match uu___16
-                                                                   with
-                                                                   | 
-                                                                   (e1,
-                                                                    uu___17,
-                                                                    g_e) ->
+                                                                 tc_tot_or_gtot_term
+                                                                   uu___17 e in
+                                                               (match uu___16
+                                                                with
+                                                                | (e1,
+                                                                   uu___17,
+                                                                   g_e) ->
                                                                     let uu___18
                                                                     =
                                                                     FStar_TypeChecker_Env.conj_guards
@@ -5302,11 +5171,11 @@ and (tc_comp :
                                                                     (rel1,
                                                                     e1))),
                                                                     uu___18))))))
-                                          | f1 ->
-                                              (f1,
-                                                FStar_TypeChecker_Env.trivial_guard))) in
-                                FStar_Compiler_Effect.op_Bar_Greater uu___7
-                                  FStar_Compiler_List.unzip in
+                                       | f1 ->
+                                           (f1,
+                                             FStar_TypeChecker_Env.trivial_guard))
+                                    c1.FStar_Syntax_Syntax.flags in
+                                FStar_Compiler_List.unzip uu___7 in
                               (match uu___6 with
                                | (flags, guards) ->
                                    let u =
@@ -5326,9 +5195,8 @@ and (tc_comp :
                                          FStar_Syntax_Syntax.flags = flags
                                        } in
                                    let u_c =
-                                     FStar_Compiler_Effect.op_Bar_Greater c2
-                                       (FStar_TypeChecker_Util.universe_of_comp
-                                          env u) in
+                                     FStar_TypeChecker_Util.universe_of_comp
+                                       env u c2 in
                                    let uu___7 =
                                      FStar_Compiler_List.fold_left
                                        FStar_TypeChecker_Env.conj_guard f
@@ -5371,8 +5239,7 @@ and (tc_universe :
         (match u with
          | FStar_Syntax_Syntax.U_unknown ->
              let uu___1 = FStar_Syntax_Util.type_u () in
-             FStar_Compiler_Effect.op_Bar_Greater uu___1
-               FStar_Pervasives_Native.snd
+             FStar_Pervasives_Native.snd uu___1
          | uu___1 -> aux u)
 and (tc_abs_expected_function_typ :
   FStar_TypeChecker_Env.env ->
@@ -5672,51 +5539,48 @@ and (tc_abs_expected_function_typ :
                                  (envbody.FStar_TypeChecker_Env.core_check)
                              } in
                            let uu___2 =
-                             FStar_Compiler_Effect.op_Bar_Greater letrecs
-                               (FStar_Compiler_List.fold_left
-                                  (fun uu___3 ->
-                                     fun uu___4 ->
-                                       match (uu___3, uu___4) with
-                                       | ((env1, letrec_binders, g),
-                                          (l, t3, u_names)) ->
-                                           let uu___5 =
-                                             let uu___6 =
-                                               let uu___7 =
-                                                 FStar_TypeChecker_Env.clear_expected_typ
-                                                   env1 in
-                                               FStar_Compiler_Effect.op_Bar_Greater
-                                                 uu___7
-                                                 FStar_Pervasives_Native.fst in
-                                             tc_term uu___6 t3 in
-                                           (match uu___5 with
-                                            | (t4, uu___6, g') ->
-                                                let env2 =
-                                                  FStar_TypeChecker_Env.push_let_binding
-                                                    env1 l (u_names, t4) in
-                                                let lb =
-                                                  match l with
-                                                  | FStar_Pervasives.Inl x ->
-                                                      let uu___7 =
-                                                        FStar_Syntax_Syntax.mk_binder
-                                                          {
-                                                            FStar_Syntax_Syntax.ppname
-                                                              =
-                                                              (x.FStar_Syntax_Syntax.ppname);
-                                                            FStar_Syntax_Syntax.index
-                                                              =
-                                                              (x.FStar_Syntax_Syntax.index);
-                                                            FStar_Syntax_Syntax.sort
-                                                              = t4
-                                                          } in
-                                                      uu___7 ::
-                                                        letrec_binders
-                                                  | uu___7 -> letrec_binders in
-                                                let uu___7 =
-                                                  FStar_TypeChecker_Env.conj_guard
-                                                    g g' in
-                                                (env2, lb, uu___7)))
-                                  (envbody1, [],
-                                    FStar_TypeChecker_Env.trivial_guard)) in
+                             FStar_Compiler_List.fold_left
+                               (fun uu___3 ->
+                                  fun uu___4 ->
+                                    match (uu___3, uu___4) with
+                                    | ((env1, letrec_binders, g),
+                                       (l, t3, u_names)) ->
+                                        let uu___5 =
+                                          let uu___6 =
+                                            let uu___7 =
+                                              FStar_TypeChecker_Env.clear_expected_typ
+                                                env1 in
+                                            FStar_Pervasives_Native.fst
+                                              uu___7 in
+                                          tc_term uu___6 t3 in
+                                        (match uu___5 with
+                                         | (t4, uu___6, g') ->
+                                             let env2 =
+                                               FStar_TypeChecker_Env.push_let_binding
+                                                 env1 l (u_names, t4) in
+                                             let lb =
+                                               match l with
+                                               | FStar_Pervasives.Inl x ->
+                                                   let uu___7 =
+                                                     FStar_Syntax_Syntax.mk_binder
+                                                       {
+                                                         FStar_Syntax_Syntax.ppname
+                                                           =
+                                                           (x.FStar_Syntax_Syntax.ppname);
+                                                         FStar_Syntax_Syntax.index
+                                                           =
+                                                           (x.FStar_Syntax_Syntax.index);
+                                                         FStar_Syntax_Syntax.sort
+                                                           = t4
+                                                       } in
+                                                   uu___7 :: letrec_binders
+                                               | uu___7 -> letrec_binders in
+                                             let uu___7 =
+                                               FStar_TypeChecker_Env.conj_guard
+                                                 g g' in
+                                             (env2, lb, uu___7)))
+                               (envbody1, [],
+                                 FStar_TypeChecker_Env.trivial_guard) letrecs in
                            match uu___2 with
                            | (envbody2, letrec_binders, g) ->
                                let uu___3 =
@@ -5967,10 +5831,8 @@ and (tc_abs_expected_function_typ :
                     then
                       let uu___2 =
                         let uu___3 =
-                          FStar_Compiler_Effect.op_Bar_Greater t2
-                            (FStar_TypeChecker_Normalize.unfold_whnf env) in
-                        FStar_Compiler_Effect.op_Bar_Greater uu___3
-                          FStar_Syntax_Util.unascribe in
+                          FStar_TypeChecker_Normalize.unfold_whnf env t2 in
+                        FStar_Syntax_Util.unascribe uu___3 in
                       as_function_typ true uu___2
                     else
                       (let uu___3 =
@@ -6137,18 +5999,15 @@ and (tc_abs_check_binders :
                                           t expected_t in
                                       match uu___9 with
                                       | FStar_Pervasives_Native.Some g ->
-                                          FStar_Compiler_Effect.op_Bar_Greater
-                                            g
-                                            (FStar_TypeChecker_Rel.resolve_implicits
-                                               env1)
+                                          FStar_TypeChecker_Rel.resolve_implicits
+                                            env1 g
                                       | FStar_Pervasives_Native.None ->
                                           if use_eq
                                           then
                                             let uu___10 =
                                               FStar_TypeChecker_Rel.teq env1
                                                 t expected_t in
-                                            FStar_Compiler_Effect.op_Bar_Greater
-                                              uu___10 label_guard
+                                            label_guard uu___10
                                           else
                                             (let uu___11 =
                                                FStar_TypeChecker_Rel.get_subtyping_prop
@@ -6323,8 +6182,7 @@ and (tc_abs :
                           uu___5 uu___6 uu___7
                       else ());
                      (let uu___5 =
-                        FStar_Compiler_Effect.op_Less_Bar
-                          (FStar_TypeChecker_Env.debug env1)
+                        FStar_TypeChecker_Env.debug env1
                           (FStar_Options.Other "NYC") in
                       if uu___5
                       then
@@ -6344,15 +6202,10 @@ and (tc_abs :
                           let use_eq_opt =
                             match topt with
                             | FStar_Pervasives_Native.Some (uu___7, use_eq)
-                                ->
-                                FStar_Compiler_Effect.op_Bar_Greater use_eq
-                                  (fun uu___8 ->
-                                     FStar_Pervasives_Native.Some uu___8)
+                                -> FStar_Pervasives_Native.Some use_eq
                             | uu___7 -> FStar_Pervasives_Native.None in
                           let uu___7 =
-                            (FStar_Compiler_Effect.op_Bar_Greater c_opt
-                               FStar_Compiler_Util.is_some)
-                              &&
+                            (FStar_Compiler_Util.is_some c_opt) &&
                               (let uu___8 =
                                  let uu___9 =
                                    FStar_Syntax_Subst.compress body1 in
@@ -6381,20 +6234,17 @@ and (tc_abs :
                               let uu___9 =
                                 FStar_TypeChecker_Env.clear_expected_typ
                                   envbody1 in
-                              FStar_Compiler_Effect.op_Bar_Greater uu___9
-                                FStar_Pervasives_Native.fst in
+                              FStar_Pervasives_Native.fst uu___9 in
                             let uu___9 =
                               let uu___10 =
                                 let uu___11 =
                                   let uu___12 =
                                     let uu___13 =
                                       let uu___14 =
-                                        FStar_Compiler_Effect.op_Bar_Greater
-                                          c_opt FStar_Compiler_Util.must in
+                                        FStar_Compiler_Util.must c_opt in
                                       FStar_Pervasives.Inr uu___14 in
                                     let uu___14 =
-                                      FStar_Compiler_Effect.op_Bar_Greater
-                                        use_eq_opt FStar_Compiler_Util.must in
+                                      FStar_Compiler_Util.must use_eq_opt in
                                     (uu___13, FStar_Pervasives_Native.None,
                                       uu___14) in
                                   {
@@ -6580,8 +6430,7 @@ and (tc_abs :
                       match uu___5 with
                       | (body2, cbody, guard_body) ->
                           ((let uu___7 =
-                              FStar_Compiler_Effect.op_Less_Bar
-                                (FStar_TypeChecker_Env.debug env1)
+                              FStar_TypeChecker_Env.debug env1
                                 FStar_Options.Extreme in
                             if uu___7
                             then
@@ -6595,8 +6444,7 @@ and (tc_abs :
                               if env1.FStar_TypeChecker_Env.top_level
                               then
                                 ((let uu___8 =
-                                    FStar_Compiler_Effect.op_Less_Bar
-                                      (FStar_TypeChecker_Env.debug env1)
+                                    FStar_TypeChecker_Env.debug env1
                                       FStar_Options.Medium in
                                   if uu___8
                                   then
@@ -6711,9 +6559,8 @@ and (tc_abs :
                                                let uu___11 =
                                                  FStar_Syntax_Syntax.mk_Total
                                                    tfun_computed in
-                                               FStar_Compiler_Effect.op_Bar_Greater
-                                                 uu___11
-                                                 FStar_TypeChecker_Common.lcomp_of_comp in
+                                               FStar_TypeChecker_Common.lcomp_of_comp
+                                                 uu___11 in
                                              let uu___11 =
                                                FStar_TypeChecker_Util.check_has_type_maybe_coerce
                                                  env1 e lc t1 use_eq in
@@ -6791,9 +6638,8 @@ and (check_application_args :
                            let g =
                              let uu___4 =
                                FStar_TypeChecker_Env.conj_guard ghead1 guard in
-                             FStar_Compiler_Effect.op_Bar_Greater uu___4
-                               (FStar_TypeChecker_Rel.solve_deferred_constraints
-                                  env) in
+                             FStar_TypeChecker_Rel.solve_deferred_constraints
+                               env uu___4 in
                            let uu___4 =
                              let uu___5 = FStar_Syntax_Util.arrow bs cres in
                              FStar_Syntax_Syntax.mk_Total uu___5 in
@@ -6831,16 +6677,14 @@ and (check_application_args :
                                           let uu___8 =
                                             FStar_Syntax_Subst.subst_comp
                                               subst chead1 in
-                                          FStar_Compiler_Effect.op_Bar_Greater
-                                            uu___8
-                                            FStar_TypeChecker_Common.lcomp_of_comp in
+                                          FStar_TypeChecker_Common.lcomp_of_comp
+                                            uu___8 in
                                         let uu___8 =
                                           let uu___9 =
                                             FStar_Syntax_Subst.subst_comp
                                               subst cres2 in
-                                          FStar_Compiler_Effect.op_Bar_Greater
-                                            uu___9
-                                            FStar_TypeChecker_Common.lcomp_of_comp in
+                                          FStar_TypeChecker_Common.lcomp_of_comp
+                                            uu___9 in
                                         (uu___7, uu___8) in
                                       match uu___6 with
                                       | (chead2, cres3) ->
@@ -6912,50 +6756,37 @@ and (check_application_args :
                                                ->
                                                let comp =
                                                  let arg_rets_names_opt =
-                                                   let uu___8 =
-                                                     FStar_Compiler_Effect.op_Bar_Greater
-                                                       arg_rets_rev
-                                                       FStar_Compiler_List.rev in
-                                                   FStar_Compiler_Effect.op_Bar_Greater
-                                                     uu___8
-                                                     (FStar_Compiler_List.map
-                                                        (fun uu___9 ->
-                                                           match uu___9 with
-                                                           | (t, uu___10) ->
-                                                               let uu___11 =
-                                                                 let uu___12
-                                                                   =
-                                                                   FStar_Syntax_Subst.compress
-                                                                    t in
-                                                                 uu___12.FStar_Syntax_Syntax.n in
-                                                               (match uu___11
-                                                                with
-                                                                | FStar_Syntax_Syntax.Tm_name
-                                                                    bv ->
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    bv
-                                                                    (fun
-                                                                    uu___12
-                                                                    ->
-                                                                    FStar_Pervasives_Native.Some
-                                                                    uu___12)
-                                                                | uu___12 ->
-                                                                    FStar_Pervasives_Native.None))) in
+                                                   FStar_Compiler_List.map
+                                                     (fun uu___8 ->
+                                                        match uu___8 with
+                                                        | (t, uu___9) ->
+                                                            let uu___10 =
+                                                              let uu___11 =
+                                                                FStar_Syntax_Subst.compress
+                                                                  t in
+                                                              uu___11.FStar_Syntax_Syntax.n in
+                                                            (match uu___10
+                                                             with
+                                                             | FStar_Syntax_Syntax.Tm_name
+                                                                 bv ->
+                                                                 FStar_Pervasives_Native.Some
+                                                                   bv
+                                                             | uu___11 ->
+                                                                 FStar_Pervasives_Native.None))
+                                                     (FStar_Compiler_List.rev
+                                                        arg_rets_rev) in
                                                  let push_option_names_to_env
                                                    =
                                                    FStar_Compiler_List.fold_left
                                                      (fun env1 ->
                                                         fun name_opt ->
                                                           let uu___8 =
-                                                            FStar_Compiler_Effect.op_Bar_Greater
-                                                              name_opt
-                                                              (FStar_Compiler_Util.map_option
-                                                                 (FStar_TypeChecker_Env.push_bv
-                                                                    env1)) in
-                                                          FStar_Compiler_Effect.op_Bar_Greater
-                                                            uu___8
-                                                            (FStar_Compiler_Util.dflt
-                                                               env1)) in
+                                                            FStar_Compiler_Util.map_option
+                                                              (FStar_TypeChecker_Env.push_bv
+                                                                 env1)
+                                                              name_opt in
+                                                          FStar_Compiler_Util.dflt
+                                                            env1 uu___8) in
                                                  let uu___8 =
                                                    FStar_Compiler_List.fold_left
                                                      (fun uu___9 ->
@@ -7011,9 +6842,8 @@ and (check_application_args :
                                                                     arg_rets_names_opt)
                                                                     - i)
                                                                     arg_rets_names_opt in
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___13
-                                                                    FStar_Pervasives_Native.fst in
+                                                                    FStar_Pervasives_Native.fst
+                                                                    uu___13 in
                                                                     push_option_names_to_env
                                                                     env
                                                                     uu___12
@@ -7287,8 +7117,7 @@ and (check_application_args :
                                                               arg_comps_rev in
                                                           FStar_Compiler_List.map
                                                             map_fun uu___12 in
-                                                        FStar_Compiler_Effect.op_Less_Bar
-                                                          FStar_Compiler_List.split
+                                                        FStar_Compiler_List.split
                                                           uu___11 in
                                                       match uu___10 with
                                                       | (lifted_args,
@@ -7467,9 +7296,8 @@ and (check_application_args :
                                           let uu___12 =
                                             let uu___13 =
                                               FStar_Syntax_Syntax.mk_Total t1 in
-                                            FStar_Compiler_Effect.op_Bar_Greater
-                                              uu___13
-                                              FStar_TypeChecker_Common.lcomp_of_comp in
+                                            FStar_TypeChecker_Common.lcomp_of_comp
+                                              uu___13 in
                                           (arg, FStar_Pervasives_Native.None,
                                             uu___12) in
                                         uu___11 :: outargs in
@@ -7581,9 +7409,8 @@ and (check_application_args :
                                                  let uu___13 =
                                                    FStar_Syntax_Syntax.mk_Total
                                                      t1 in
-                                                 FStar_Compiler_Effect.op_Bar_Greater
-                                                   uu___13
-                                                   FStar_TypeChecker_Common.lcomp_of_comp in
+                                                 FStar_TypeChecker_Common.lcomp_of_comp
+                                                   uu___13 in
                                                (arg,
                                                  FStar_Pervasives_Native.None,
                                                  uu___12) in
@@ -7653,12 +7480,8 @@ and (check_application_args :
                                     let uu___9 =
                                       FStar_Syntax_Print.term_to_string targ1 in
                                     let uu___10 =
-                                      let uu___11 =
-                                        FStar_Compiler_Effect.op_Bar_Greater
-                                          bqual1 is_eq in
-                                      FStar_Compiler_Effect.op_Bar_Greater
-                                        uu___11
-                                        FStar_Compiler_Util.string_of_bool in
+                                      FStar_Compiler_Util.string_of_bool
+                                        (is_eq bqual1) in
                                     FStar_Compiler_Util.print4
                                       "Checking arg (%s) %s at type %s with use_eq:%s\n"
                                       uu___7 uu___8 uu___9 uu___10
@@ -7670,9 +7493,8 @@ and (check_application_args :
                                         let uu___7 =
                                           FStar_TypeChecker_Env.conj_guard g
                                             g_e in
-                                        FStar_Compiler_Effect.op_Less_Bar
-                                          (FStar_TypeChecker_Env.conj_guard
-                                             g_ex) uu___7 in
+                                        FStar_TypeChecker_Env.conj_guard g_ex
+                                          uu___7 in
                                       let arg = (e1, aq1) in
                                       let xterm =
                                         let uu___7 =
@@ -7717,14 +7539,12 @@ and (check_application_args :
                                let uu___4 =
                                  let uu___5 =
                                    FStar_TypeChecker_Common.lcomp_comp chead1 in
-                                 FStar_Compiler_Effect.op_Bar_Greater uu___5
-                                   (fun uu___6 ->
-                                      match uu___6 with
-                                      | (c, g1) ->
-                                          let uu___7 =
-                                            FStar_TypeChecker_Env.conj_guard
-                                              ghead1 g1 in
-                                          (c, uu___7)) in
+                                 match uu___5 with
+                                 | (c, g1) ->
+                                     let uu___6 =
+                                       FStar_TypeChecker_Env.conj_guard
+                                         ghead1 g1 in
+                                     (c, uu___6) in
                                (match uu___4 with
                                 | (chead2, ghead2) ->
                                     let rec aux norm1 solve ghead3 tres =
@@ -7732,11 +7552,8 @@ and (check_application_args :
                                         let uu___5 =
                                           let uu___6 =
                                             FStar_Syntax_Subst.compress tres in
-                                          FStar_Compiler_Effect.op_Bar_Greater
-                                            uu___6 FStar_Syntax_Util.unrefine in
-                                        FStar_Compiler_Effect.op_Bar_Greater
-                                          uu___5
-                                          FStar_Syntax_Util.unmeta_safe in
+                                          FStar_Syntax_Util.unrefine uu___6 in
+                                        FStar_Syntax_Util.unmeta_safe uu___5 in
                                       match tres1.FStar_Syntax_Syntax.n with
                                       | FStar_Syntax_Syntax.Tm_arrow
                                           { FStar_Syntax_Syntax.bs1 = bs1;
@@ -7769,13 +7586,10 @@ and (check_application_args :
                                           let rec norm_tres tres2 =
                                             let tres3 =
                                               let uu___6 =
-                                                FStar_Compiler_Effect.op_Bar_Greater
-                                                  tres2
-                                                  (FStar_TypeChecker_Normalize.unfold_whnf
-                                                     env) in
-                                              FStar_Compiler_Effect.op_Bar_Greater
-                                                uu___6
-                                                FStar_Syntax_Util.unascribe in
+                                                FStar_TypeChecker_Normalize.unfold_whnf
+                                                  env tres2 in
+                                              FStar_Syntax_Util.unascribe
+                                                uu___6 in
                                             let uu___6 =
                                               let uu___7 =
                                                 FStar_Syntax_Subst.compress
@@ -7877,8 +7691,7 @@ and (check_application_args :
                                     let uu___7 =
                                       let uu___8 =
                                         FStar_Syntax_Util.type_u () in
-                                      FStar_Compiler_Effect.op_Bar_Greater
-                                        uu___8 FStar_Pervasives_Native.fst in
+                                      FStar_Pervasives_Native.fst uu___8 in
                                     FStar_TypeChecker_Util.new_implicit_var
                                       "formal parameter"
                                       tf.FStar_Syntax_Syntax.pos env uu___7 in
@@ -7898,8 +7711,7 @@ and (check_application_args :
                             let uu___5 =
                               let uu___6 =
                                 let uu___7 = FStar_Syntax_Util.type_u () in
-                                FStar_Compiler_Effect.op_Bar_Greater uu___7
-                                  FStar_Pervasives_Native.fst in
+                                FStar_Pervasives_Native.fst uu___7 in
                               FStar_TypeChecker_Util.new_implicit_var
                                 "result type" tf.FStar_Syntax_Syntax.pos env
                                 uu___6 in
@@ -7923,8 +7735,7 @@ and (check_application_args :
                            | (cres, guard2) ->
                                let bs_cres = FStar_Syntax_Util.arrow bs cres in
                                ((let uu___6 =
-                                   FStar_Compiler_Effect.op_Less_Bar
-                                     (FStar_TypeChecker_Env.debug env)
+                                   FStar_TypeChecker_Env.debug env
                                      FStar_Options.Extreme in
                                  if uu___6
                                  then
@@ -7968,8 +7779,7 @@ and (check_application_args :
                                     let uu___11 =
                                       let uu___12 =
                                         FStar_Syntax_Util.type_u () in
-                                      FStar_Compiler_Effect.op_Bar_Greater
-                                        uu___12 FStar_Pervasives_Native.fst in
+                                      FStar_Pervasives_Native.fst uu___12 in
                                     FStar_TypeChecker_Util.new_implicit_var
                                       "formal parameter"
                                       tf.FStar_Syntax_Syntax.pos env uu___11 in
@@ -7989,8 +7799,7 @@ and (check_application_args :
                             let uu___9 =
                               let uu___10 =
                                 let uu___11 = FStar_Syntax_Util.type_u () in
-                                FStar_Compiler_Effect.op_Bar_Greater uu___11
-                                  FStar_Pervasives_Native.fst in
+                                FStar_Pervasives_Native.fst uu___11 in
                               FStar_TypeChecker_Util.new_implicit_var
                                 "result type" tf.FStar_Syntax_Syntax.pos env
                                 uu___10 in
@@ -8014,8 +7823,7 @@ and (check_application_args :
                            | (cres, guard2) ->
                                let bs_cres = FStar_Syntax_Util.arrow bs cres in
                                ((let uu___10 =
-                                   FStar_Compiler_Effect.op_Less_Bar
-                                     (FStar_TypeChecker_Env.debug env)
+                                   FStar_TypeChecker_Env.debug env
                                      FStar_Options.Extreme in
                                  if uu___10
                                  then
@@ -8161,8 +7969,7 @@ and (check_short_circuit_args :
                          if ghost
                          then
                            let uu___1 = FStar_Syntax_Syntax.mk_GTotal res_t in
-                           FStar_Compiler_Effect.op_Bar_Greater uu___1
-                             FStar_TypeChecker_Common.lcomp_of_comp
+                           FStar_TypeChecker_Common.lcomp_of_comp uu___1
                          else FStar_TypeChecker_Common.lcomp_of_comp c in
                        let uu___1 =
                          FStar_TypeChecker_Util.strengthen_precondition
@@ -8252,8 +8059,7 @@ and (tc_pat :
           aux false uu___ in
         let pat_typ_ok env1 pat_t1 scrutinee_t =
           (let uu___1 =
-             FStar_Compiler_Effect.op_Less_Bar
-               (FStar_TypeChecker_Env.debug env1)
+             FStar_TypeChecker_Env.debug env1
                (FStar_Options.Other "Patterns") in
            if uu___1
            then
@@ -8313,8 +8119,7 @@ and (tc_pat :
                                         FStar_Syntax_Syntax.lid_of_fv f in
                                       FStar_TypeChecker_Env.is_type_constructor
                                         env1 uu___13 in
-                                    FStar_Compiler_Effect.op_Less_Bar
-                                      Prims.op_Negation uu___12 in
+                                    Prims.op_Negation uu___12 in
                                   if uu___11
                                   then
                                     fail1
@@ -8724,8 +8529,7 @@ and (tc_pat :
                | uu___1 -> fail "Not a simple pattern") in
         let rec check_nested_pattern env1 p t =
           (let uu___1 =
-             FStar_Compiler_Effect.op_Less_Bar
-               (FStar_TypeChecker_Env.debug env1)
+             FStar_TypeChecker_Env.debug env1
                (FStar_Options.Other "Patterns") in
            if uu___1
            then
@@ -8747,75 +8551,54 @@ and (tc_pat :
                let uu___1 =
                  FStar_Syntax_Syntax.gen_bv "x" FStar_Pervasives_Native.None
                    t in
-               FStar_Compiler_Effect.op_Bar_Greater uu___1
-                 FStar_Syntax_Syntax.mk_binder in
+               FStar_Syntax_Syntax.mk_binder uu___1 in
              let ty_args =
                let uu___1 = FStar_Syntax_Util.head_and_args t in
                match uu___1 with
                | (hd, args) ->
                    let uu___2 =
                      let uu___3 =
-                       let uu___4 =
-                         FStar_Compiler_Effect.op_Bar_Greater hd
-                           FStar_Syntax_Subst.compress in
-                       FStar_Compiler_Effect.op_Bar_Greater uu___4
-                         FStar_Syntax_Util.un_uinst in
+                       let uu___4 = FStar_Syntax_Subst.compress hd in
+                       FStar_Syntax_Util.un_uinst uu___4 in
                      uu___3.FStar_Syntax_Syntax.n in
                    (match uu___2 with
                     | FStar_Syntax_Syntax.Tm_fvar fv ->
                         let uu___3 =
                           let uu___4 =
-                            let uu___5 =
-                              FStar_Compiler_Effect.op_Bar_Greater fv
-                                FStar_Syntax_Syntax.lid_of_fv in
-                            FStar_Compiler_Effect.op_Bar_Greater uu___5
-                              (FStar_TypeChecker_Env.num_inductive_ty_params
-                                 env1) in
-                          FStar_Compiler_Effect.op_Bar_Greater uu___4
-                            (fun nopt ->
-                               let uu___5 =
-                                 FStar_Compiler_Effect.op_Bar_Greater nopt
-                                   (FStar_Compiler_Util.map_option
-                                      (fun n ->
-                                         if
-                                           (FStar_Compiler_List.length args)
-                                             >= n
-                                         then
-                                           let uu___6 =
-                                             FStar_Compiler_Effect.op_Bar_Greater
-                                               args
-                                               (FStar_Compiler_List.splitAt n) in
-                                           FStar_Compiler_Effect.op_Bar_Greater
-                                             uu___6
-                                             FStar_Pervasives_Native.fst
-                                         else [])) in
-                               FStar_Compiler_Util.dflt [] uu___5) in
-                        FStar_Compiler_Effect.op_Bar_Greater uu___3
-                          (FStar_Compiler_List.map
-                             (fun uu___4 ->
-                                match uu___4 with
-                                | (t1, uu___5) -> FStar_Syntax_Syntax.iarg t1))
+                            let uu___5 = FStar_Syntax_Syntax.lid_of_fv fv in
+                            FStar_TypeChecker_Env.num_inductive_ty_params
+                              env1 uu___5 in
+                          let uu___5 =
+                            FStar_Compiler_Util.map_option
+                              (fun n ->
+                                 if (FStar_Compiler_List.length args) >= n
+                                 then
+                                   let uu___6 =
+                                     FStar_Compiler_List.splitAt n args in
+                                   FStar_Pervasives_Native.fst uu___6
+                                 else []) uu___4 in
+                          FStar_Compiler_Util.dflt [] uu___5 in
+                        FStar_Compiler_List.map
+                          (fun uu___4 ->
+                             match uu___4 with
+                             | (t1, uu___5) -> FStar_Syntax_Syntax.iarg t1)
+                          uu___3
                     | uu___3 -> []) in
              let tm =
                let uu___1 =
                  let uu___2 =
                    let uu___3 =
                      let uu___4 =
-                       FStar_Compiler_Effect.op_Bar_Greater
-                         x_b.FStar_Syntax_Syntax.binder_bv
-                         FStar_Syntax_Syntax.bv_to_name in
-                     FStar_Compiler_Effect.op_Bar_Greater uu___4
-                       FStar_Syntax_Syntax.as_arg in
+                       FStar_Syntax_Syntax.bv_to_name
+                         x_b.FStar_Syntax_Syntax.binder_bv in
+                     FStar_Syntax_Syntax.as_arg uu___4 in
                    [uu___3] in
                  FStar_Compiler_List.op_At ty_args uu___2 in
                FStar_Syntax_Syntax.mk_Tm_app disc uu___1
                  FStar_Compiler_Range_Type.dummyRange in
              let tm1 =
                let uu___1 =
-                 let uu___2 =
-                   FStar_Compiler_Effect.op_Bar_Greater tm
-                     FStar_Syntax_Syntax.as_arg in
-                 [uu___2] in
+                 let uu___2 = FStar_Syntax_Syntax.as_arg tm in [uu___2] in
                FStar_Syntax_Syntax.mk_Tm_app inner_t uu___1
                  FStar_Compiler_Range_Type.dummyRange in
              FStar_Syntax_Util.abs [x_b] tm1 FStar_Pervasives_Native.None in
@@ -8963,15 +8746,13 @@ and (tc_pat :
                    FStar_Syntax_Syntax.p = (p.FStar_Syntax_Syntax.p)
                  } in
                let sub_pats1 =
-                 FStar_Compiler_Effect.op_Bar_Greater sub_pats
-                   (FStar_Compiler_List.filter
-                      (fun uu___1 ->
-                         match uu___1 with
-                         | (x, uu___2) ->
-                             (match x.FStar_Syntax_Syntax.v with
-                              | FStar_Syntax_Syntax.Pat_dot_term uu___3 ->
-                                  false
-                              | uu___3 -> true))) in
+                 FStar_Compiler_List.filter
+                   (fun uu___1 ->
+                      match uu___1 with
+                      | (x, uu___2) ->
+                          (match x.FStar_Syntax_Syntax.v with
+                           | FStar_Syntax_Syntax.Pat_dot_term uu___3 -> false
+                           | uu___3 -> true)) sub_pats in
                let uu___1 =
                  FStar_TypeChecker_PatternUtils.pat_as_exp false false env1
                    simple_pat in
@@ -9005,15 +8786,11 @@ and (tc_pat :
                            erasable) ->
                             let simple_bvs1 =
                               let uu___5 =
-                                FStar_Compiler_Effect.op_Bar_Greater
-                                  simple_bvs
-                                  (FStar_Compiler_Util.first_N
-                                     ((FStar_Compiler_List.length simple_bvs)
-                                        -
-                                        (FStar_Compiler_List.length
-                                           simple_bvs_pat))) in
-                              FStar_Compiler_Effect.op_Bar_Greater uu___5
-                                FStar_Pervasives_Native.snd in
+                                FStar_Compiler_Util.first_N
+                                  ((FStar_Compiler_List.length simple_bvs) -
+                                     (FStar_Compiler_List.length
+                                        simple_bvs_pat)) simple_bvs in
+                              FStar_Pervasives_Native.snd uu___5 in
                             let g' =
                               let uu___5 =
                                 expected_pat_typ env1
@@ -9052,8 +8829,7 @@ and (tc_pat :
                             let guard2 =
                               FStar_TypeChecker_Env.conj_guard guard1 g' in
                             ((let uu___6 =
-                                FStar_Compiler_Effect.op_Less_Bar
-                                  (FStar_TypeChecker_Env.debug env1)
+                                FStar_TypeChecker_Env.debug env1
                                   (FStar_Options.Other "Patterns") in
                               if uu___6
                               then
@@ -9081,9 +8857,7 @@ and (tc_pat :
                                            Prims.strcat uu___12 uu___13 in
                                          Prims.strcat "(" uu___11)
                                       simple_bvs1 in
-                                  FStar_Compiler_Effect.op_Bar_Greater
-                                    uu___10
-                                    (FStar_Compiler_String.concat " ") in
+                                  FStar_Compiler_String.concat " " uu___10 in
                                 FStar_Compiler_Util.print3
                                   "$$$$$$$$$$$$Checked simple pattern %s at type %s with bvs=%s\n"
                                   uu___7 uu___8 uu___9
@@ -9119,10 +8893,9 @@ and (tc_pat :
                                              erasable_p) ->
                                               let g'1 =
                                                 let uu___9 =
-                                                  FStar_Compiler_Effect.op_Bar_Greater
-                                                    bvs
-                                                    (FStar_Compiler_List.map
-                                                       FStar_Syntax_Syntax.mk_binder) in
+                                                  FStar_Compiler_List.map
+                                                    FStar_Syntax_Syntax.mk_binder
+                                                    bvs in
                                                 FStar_TypeChecker_Env.close_guard
                                                   env2 uu___9 g' in
                                               let tms_p1 =
@@ -9134,15 +8907,12 @@ and (tc_pat :
                                                     env2 uu___9 i in
                                                 let uu___9 =
                                                   let uu___10 =
-                                                    let uu___11 =
-                                                      FStar_Syntax_Syntax.fvar
-                                                        disc_tm
-                                                        FStar_Pervasives_Native.None in
-                                                    mk_disc_t uu___11 in
-                                                  FStar_Compiler_List.map
-                                                    uu___10 in
-                                                FStar_Compiler_Effect.op_Bar_Greater
-                                                  tms_p uu___9 in
+                                                    FStar_Syntax_Syntax.fvar
+                                                      disc_tm
+                                                      FStar_Pervasives_Native.None in
+                                                  mk_disc_t uu___10 in
+                                                FStar_Compiler_List.map
+                                                  uu___9 tms_p in
                                               let uu___9 =
                                                 FStar_TypeChecker_Env.conj_guard
                                                   g g'1 in
@@ -9244,9 +9014,7 @@ and (tc_pat :
                                  reconstruct_nested_pat simple_pat_elab in
                                (bvs, tms, pat_e, uu___6, g, erasable1)))))) in
         (let uu___1 =
-           FStar_Compiler_Effect.op_Less_Bar
-             (FStar_TypeChecker_Env.debug env)
-             (FStar_Options.Other "Patterns") in
+           FStar_TypeChecker_Env.debug env (FStar_Options.Other "Patterns") in
          if uu___1
          then
            let uu___2 = FStar_Syntax_Print.pat_to_string p0 in
@@ -9255,16 +9023,14 @@ and (tc_pat :
         (let uu___1 =
            let uu___2 =
              let uu___3 = FStar_TypeChecker_Env.clear_expected_typ env in
-             FStar_Compiler_Effect.op_Bar_Greater uu___3
-               FStar_Pervasives_Native.fst in
+             FStar_Pervasives_Native.fst uu___3 in
            let uu___3 = FStar_TypeChecker_PatternUtils.elaborate_pat env p0 in
            let uu___4 = expected_pat_typ env p0.FStar_Syntax_Syntax.p pat_t in
            check_nested_pattern uu___2 uu___3 uu___4 in
          match uu___1 with
          | (bvs, tms, pat_e, pat, g, erasable) ->
              ((let uu___3 =
-                 FStar_Compiler_Effect.op_Less_Bar
-                   (FStar_TypeChecker_Env.debug env)
+                 FStar_TypeChecker_Env.debug env
                    (FStar_Options.Other "Patterns") in
                if uu___3
                then
@@ -9309,8 +9075,7 @@ and (tc_eqn :
                      FStar_Syntax_Syntax.bv_to_name scrutinee in
                    let uu___3 =
                      let uu___4 = FStar_TypeChecker_Env.push_bv env scrutinee in
-                     FStar_Compiler_Effect.op_Bar_Greater uu___4
-                       FStar_TypeChecker_Env.clear_expected_typ in
+                     FStar_TypeChecker_Env.clear_expected_typ uu___4 in
                    (match uu___3 with
                     | (scrutinee_env, uu___4) ->
                         let uu___5 =
@@ -9321,8 +9086,7 @@ and (tc_eqn :
                          | (pattern1, pat_bvs, pat_bv_tms, pat_env, pat_exp,
                             norm_pat_exp, guard_pat, erasable) ->
                              ((let uu___7 =
-                                 FStar_Compiler_Effect.op_Less_Bar
-                                   (FStar_TypeChecker_Env.debug env)
+                                 FStar_TypeChecker_Env.debug env
                                    FStar_Options.Extreme in
                                if uu___7
                                then
@@ -9382,16 +9146,12 @@ and (tc_eqn :
                                        | FStar_Pervasives_Native.Some
                                            (b, asc) ->
                                            let uu___9 =
-                                             FStar_Compiler_Effect.op_Bar_Greater
-                                               asc
-                                               (FStar_Syntax_Subst.subst_ascription
-                                                  [FStar_Syntax_Syntax.NT
-                                                     ((b.FStar_Syntax_Syntax.binder_bv),
-                                                       norm_pat_exp)]) in
-                                           FStar_Compiler_Effect.op_Bar_Greater
-                                             uu___9
-                                             (FStar_Syntax_Util.ascribe
-                                                branch_exp) in
+                                             FStar_Syntax_Subst.subst_ascription
+                                               [FStar_Syntax_Syntax.NT
+                                                  ((b.FStar_Syntax_Syntax.binder_bv),
+                                                    norm_pat_exp)] asc in
+                                           FStar_Syntax_Util.ascribe
+                                             branch_exp uu___9 in
                                      let uu___9 = tc_term pat_env branch_exp1 in
                                      match uu___9 with
                                      | (branch_exp2, c, g_branch) ->
@@ -9439,10 +9199,8 @@ and (tc_eqn :
                                                     FStar_Syntax_Util.t_bool
                                                     w
                                                     FStar_Syntax_Util.exp_true_bool in
-                                                FStar_Compiler_Effect.op_Less_Bar
-                                                  (fun uu___11 ->
-                                                     FStar_Pervasives_Native.Some
-                                                       uu___11) uu___10 in
+                                                FStar_Pervasives_Native.Some
+                                                  uu___10 in
                                           let branch_guard =
                                             let uu___10 =
                                               let uu___11 =
@@ -9553,9 +9311,8 @@ and (tc_eqn :
                                                    let uu___12 =
                                                      FStar_Syntax_Subst.compress
                                                        pat_exp1 in
-                                                   FStar_Compiler_Effect.op_Bar_Greater
-                                                     uu___12
-                                                     FStar_Syntax_Util.unmeta in
+                                                   FStar_Syntax_Util.unmeta
+                                                     uu___12 in
                                                  match ((pattern2.FStar_Syntax_Syntax.v),
                                                          (pat_exp2.FStar_Syntax_Syntax.n))
                                                  with
@@ -9694,17 +9451,14 @@ and (tc_eqn :
                                                             let uu___17 =
                                                               FStar_Compiler_List.zip
                                                                 pat_args args in
-                                                            FStar_Compiler_Effect.op_Bar_Greater
-                                                              uu___17
-                                                              (FStar_Compiler_List.mapi
-                                                                 (fun i ->
-                                                                    fun
-                                                                    uu___18
-                                                                    ->
-                                                                    match uu___18
-                                                                    with
-                                                                    | 
-                                                                    ((pi,
+                                                            FStar_Compiler_List.mapi
+                                                              (fun i ->
+                                                                 fun uu___18
+                                                                   ->
+                                                                   match uu___18
+                                                                   with
+                                                                   | 
+                                                                   ((pi,
                                                                     uu___19),
                                                                     (ei,
                                                                     uu___20))
@@ -9762,10 +9516,10 @@ and (tc_eqn :
                                                                     uu___23 in
                                                                     build_branch_guard
                                                                     scrutinee_tm2
-                                                                    pi ei)) in
-                                                          FStar_Compiler_Effect.op_Bar_Greater
-                                                            uu___16
-                                                            FStar_Compiler_List.flatten in
+                                                                    pi ei)
+                                                              uu___17 in
+                                                          FStar_Compiler_List.flatten
+                                                            uu___16 in
                                                         let uu___16 =
                                                           let uu___17 =
                                                             force_scrutinee
@@ -9806,8 +9560,7 @@ and (tc_eqn :
                                                         build_branch_guard
                                                           scrutinee_tm1
                                                           pattern2 pat in
-                                                      FStar_Compiler_Effect.op_Less_Bar
-                                                        FStar_Syntax_Util.mk_and_l
+                                                      FStar_Syntax_Util.mk_and_l
                                                         uu___14 in
                                                     let uu___14 =
                                                       tc_check_tot_or_gtot_term
@@ -9832,9 +9585,8 @@ and (tc_eqn :
                                                        branch_guard1 w in
                                                branch_guard2) in
                                           (let uu___11 =
-                                             FStar_Compiler_Effect.op_Less_Bar
-                                               (FStar_TypeChecker_Env.debug
-                                                  env) FStar_Options.Extreme in
+                                             FStar_TypeChecker_Env.debug env
+                                               FStar_Options.Extreme in
                                            if uu___11
                                            then
                                              let uu___12 =
@@ -9881,27 +9633,20 @@ and (tc_eqn :
                                                  let g_branch1 =
                                                    let uu___15 =
                                                      let uu___16 =
-                                                       let uu___17 =
-                                                         FStar_Compiler_Effect.op_Bar_Greater
+                                                       if
+                                                         FStar_Compiler_Util.is_some
                                                            eqs
-                                                           FStar_Compiler_Util.is_some in
-                                                       if uu___17
                                                        then
-                                                         let uu___18 =
-                                                           FStar_Compiler_Effect.op_Bar_Greater
-                                                             eqs
-                                                             FStar_Compiler_Util.must in
+                                                         let uu___17 =
+                                                           FStar_Compiler_Util.must
+                                                             eqs in
                                                          FStar_TypeChecker_Common.weaken_guard_formula
-                                                           g_branch uu___18
+                                                           g_branch uu___17
                                                        else g_branch in
-                                                     FStar_Compiler_Effect.op_Bar_Greater
-                                                       uu___16
-                                                       (FStar_TypeChecker_Env.close_guard
-                                                          env pat_bs) in
-                                                   FStar_Compiler_Effect.op_Bar_Greater
-                                                     uu___15
-                                                     (FStar_TypeChecker_Util.close_guard_implicits
-                                                        env true pat_bs) in
+                                                     FStar_TypeChecker_Env.close_guard
+                                                       env pat_bs uu___16 in
+                                                   FStar_TypeChecker_Util.close_guard_implicits
+                                                     env true pat_bs uu___15 in
                                                  ((FStar_Syntax_Util.comp_effect_name
                                                      c1),
                                                    FStar_Pervasives_Native.None,
@@ -9918,22 +9663,18 @@ and (tc_eqn :
                                                       let close_branch_with_substitutions
                                                         =
                                                         let m =
-                                                          FStar_Compiler_Effect.op_Bar_Greater
-                                                            c1.FStar_TypeChecker_Common.eff_name
-                                                            (FStar_TypeChecker_Env.norm_eff_name
-                                                               env) in
+                                                          FStar_TypeChecker_Env.norm_eff_name
+                                                            env
+                                                            c1.FStar_TypeChecker_Common.eff_name in
                                                         (FStar_TypeChecker_Env.is_layered_effect
                                                            env m)
                                                           &&
                                                           (let uu___14 =
                                                              let uu___15 =
-                                                               FStar_Compiler_Effect.op_Bar_Greater
-                                                                 m
-                                                                 (FStar_TypeChecker_Env.get_effect_decl
-                                                                    env) in
-                                                             FStar_Compiler_Effect.op_Bar_Greater
-                                                               uu___15
-                                                               FStar_Syntax_Util.get_layered_close_combinator in
+                                                               FStar_TypeChecker_Env.get_effect_decl
+                                                                 env m in
+                                                             FStar_Syntax_Util.get_layered_close_combinator
+                                                               uu___15 in
                                                            FStar_Pervasives_Native.uu___is_None
                                                              uu___14) in
                                                       let uu___14 =
@@ -10062,9 +9803,8 @@ and (tc_eqn :
                                                              then
                                                                ((let uu___16
                                                                    =
-                                                                   FStar_Compiler_Effect.op_Less_Bar
-                                                                    (FStar_TypeChecker_Env.debug
-                                                                    env)
+                                                                   FStar_TypeChecker_Env.debug
+                                                                    env
                                                                     (FStar_Options.Other
                                                                     "LayeredEffects") in
                                                                  if uu___16
@@ -10074,9 +9814,7 @@ and (tc_eqn :
                                                                  else ());
                                                                 (let pat_bv_tms1
                                                                    =
-                                                                   FStar_Compiler_Effect.op_Bar_Greater
-                                                                    pat_bv_tms
-                                                                    (FStar_Compiler_List.map
+                                                                   FStar_Compiler_List.map
                                                                     (fun
                                                                     pat_bv_tm
                                                                     ->
@@ -10084,14 +9822,14 @@ and (tc_eqn :
                                                                     =
                                                                     let uu___17
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    scrutinee_tm
-                                                                    FStar_Syntax_Syntax.as_arg in
+                                                                    FStar_Syntax_Syntax.as_arg
+                                                                    scrutinee_tm in
                                                                     [uu___17] in
                                                                     FStar_Syntax_Syntax.mk_Tm_app
                                                                     pat_bv_tm
                                                                     uu___16
-                                                                    FStar_Compiler_Range_Type.dummyRange)) in
+                                                                    FStar_Compiler_Range_Type.dummyRange)
+                                                                    pat_bv_tms in
                                                                  let pat_bv_tms2
                                                                    =
                                                                    let env1 =
@@ -10285,25 +10023,19 @@ and (tc_eqn :
                                                                     =
                                                                     let uu___20
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    pat_bv_tm
-                                                                    (FStar_Syntax_Subst.subst
-                                                                    substs) in
-                                                                    let uu___21
-                                                                    =
-                                                                    let uu___22
-                                                                    =
                                                                     FStar_TypeChecker_Env.set_expected_typ
                                                                     env1
                                                                     expected_t in
+                                                                    let uu___21
+                                                                    =
+                                                                    FStar_Syntax_Subst.subst
+                                                                    substs
+                                                                    pat_bv_tm in
                                                                     tc_trivial_guard
-                                                                    uu___22 in
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
                                                                     uu___20
                                                                     uu___21 in
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___19
-                                                                    FStar_Pervasives_Native.fst in
+                                                                    FStar_Pervasives_Native.fst
+                                                                    uu___19 in
                                                                     ((FStar_Compiler_List.op_At
                                                                     substs
                                                                     [
@@ -10316,20 +10048,17 @@ and (tc_eqn :
                                                                     ([], [])
                                                                     pat_bv_tms1
                                                                     pat_bvs in
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___17
-                                                                    FStar_Pervasives_Native.snd in
-                                                                   FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___16
-                                                                    (FStar_Compiler_List.map
+                                                                    FStar_Pervasives_Native.snd
+                                                                    uu___17 in
+                                                                   FStar_Compiler_List.map
                                                                     (FStar_TypeChecker_Normalize.normalize
                                                                     [FStar_TypeChecker_Env.Beta]
-                                                                    env1)) in
+                                                                    env1)
+                                                                    uu___16 in
                                                                  (let uu___17
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Less_Bar
-                                                                    (FStar_TypeChecker_Env.debug
-                                                                    env)
+                                                                    FStar_TypeChecker_Env.debug
+                                                                    env
                                                                     (FStar_Options.Other
                                                                     "LayeredEffects") in
                                                                   if uu___17
@@ -10377,9 +10106,12 @@ and (tc_eqn :
                                                                   else ());
                                                                  (let uu___17
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    c_weak1
-                                                                    (FStar_TypeChecker_Common.apply_lcomp
+                                                                    FStar_TypeChecker_Env.push_bv
+                                                                    env
+                                                                    scrutinee in
+                                                                  let uu___18
+                                                                    =
+                                                                    FStar_TypeChecker_Common.apply_lcomp
                                                                     (fun c2
                                                                     -> c2)
                                                                     (fun g ->
@@ -10392,34 +10124,23 @@ and (tc_eqn :
                                                                     FStar_Pervasives_Native.Some
                                                                     eqs1 ->
                                                                     FStar_TypeChecker_Common.weaken_guard_formula
-                                                                    g eqs1)) in
-                                                                  let uu___18
-                                                                    =
-                                                                    let uu___19
-                                                                    =
-                                                                    FStar_TypeChecker_Env.push_bv
-                                                                    env
-                                                                    scrutinee in
-                                                                    FStar_TypeChecker_Util.close_layered_lcomp_with_substitutions
-                                                                    uu___19
-                                                                    pat_bvs
-                                                                    pat_bv_tms2 in
-                                                                  FStar_Compiler_Effect.op_Bar_Greater
+                                                                    g eqs1)
+                                                                    c_weak1 in
+                                                                  FStar_TypeChecker_Util.close_layered_lcomp_with_substitutions
                                                                     uu___17
+                                                                    pat_bvs
+                                                                    pat_bv_tms2
                                                                     uu___18)))
                                                              else
                                                                (let uu___16 =
                                                                   let uu___17
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    c_weak1.FStar_TypeChecker_Common.eff_name
-                                                                    (FStar_TypeChecker_Env.norm_eff_name
-                                                                    env) in
-                                                                  FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___17
-                                                                    (
-                                                                    FStar_TypeChecker_Env.is_layered_effect
-                                                                    env) in
+                                                                    FStar_TypeChecker_Env.norm_eff_name
+                                                                    env
+                                                                    c_weak1.FStar_TypeChecker_Common.eff_name in
+                                                                  FStar_TypeChecker_Env.is_layered_effect
+                                                                    env
+                                                                    uu___17 in
                                                                 if uu___16
                                                                 then
                                                                   let uu___17
@@ -10471,9 +10192,8 @@ and (tc_eqn :
                                                    let uu___14 =
                                                      FStar_TypeChecker_Rel.guard_to_string
                                                        env guard in
-                                                   FStar_Compiler_Effect.op_Less_Bar
-                                                     (FStar_Compiler_Util.print1
-                                                        "Carrying guard from match: %s\n")
+                                                   FStar_Compiler_Util.print1
+                                                     "Carrying guard from match: %s\n"
                                                      uu___14
                                                  else ());
                                                 (let uu___13 =
@@ -10522,8 +10242,7 @@ and (check_top_level_let :
                       let uu___3 =
                         FStar_TypeChecker_Rel.solve_deferred_constraints env1
                           g1 in
-                      FStar_Compiler_Effect.op_Bar_Greater uu___3
-                        (FStar_TypeChecker_Rel.resolve_implicits env1) in
+                      FStar_TypeChecker_Rel.resolve_implicits env1 uu___3 in
                     let uu___3 = FStar_TypeChecker_Common.lcomp_comp c1 in
                     match uu___3 with
                     | (comp1, g_comp1) ->
@@ -10541,8 +10260,7 @@ and (check_top_level_let :
                                FStar_TypeChecker_Rel.resolve_generalization_implicits
                                  env1 g12 in
                              let g14 =
-                               FStar_Compiler_Effect.op_Less_Bar
-                                 (FStar_TypeChecker_Env.map_guard g13)
+                               FStar_TypeChecker_Env.map_guard g13
                                  (FStar_TypeChecker_Normalize.normalize
                                     [FStar_TypeChecker_Env.Beta;
                                     FStar_TypeChecker_Env.DoNotUnfoldPureLets;
@@ -10792,8 +10510,7 @@ and (check_inner_let :
           let uu___ =
             let uu___1 =
               let uu___2 = FStar_TypeChecker_Env.clear_expected_typ env2 in
-              FStar_Compiler_Effect.op_Bar_Greater uu___2
-                FStar_Pervasives_Native.fst in
+              FStar_Pervasives_Native.fst uu___2 in
             check_let_bound_def false uu___1 lb in
           (match uu___ with
            | (e1, uu___1, c1, g1, annotated) ->
@@ -10848,21 +10565,15 @@ and (check_inner_let :
                      let env_x = FStar_TypeChecker_Env.push_bv env2 x1 in
                      let uu___4 =
                        let uu___5 = tc_term env_x e21 in
-                       FStar_Compiler_Effect.op_Bar_Greater uu___5
-                         (fun uu___6 ->
-                            match uu___6 with
-                            | (e22, c2, g2) ->
-                                let uu___7 =
-                                  let uu___8 =
-                                    FStar_Compiler_Effect.op_Bar_Greater
-                                      (fun uu___9 ->
-                                         "folding guard g2 of e2 in the lcomp")
-                                      (fun uu___9 ->
-                                         FStar_Pervasives_Native.Some uu___9) in
-                                  FStar_TypeChecker_Util.strengthen_precondition
-                                    uu___8 env_x e22 c2 g2 in
-                                (match uu___7 with
-                                 | (c21, g21) -> (e22, c21, g21))) in
+                       match uu___5 with
+                       | (e22, c2, g2) ->
+                           let uu___6 =
+                             FStar_TypeChecker_Util.strengthen_precondition
+                               (FStar_Pervasives_Native.Some
+                                  (fun uu___7 ->
+                                     "folding guard g2 of e2 in the lcomp"))
+                               env_x e22 c2 g2 in
+                           (match uu___6 with | (c21, g21) -> (e22, c21, g21)) in
                      (match uu___4 with
                       | (e22, c2, g2) ->
                           let c21 =
@@ -10927,11 +10638,10 @@ and (check_inner_let :
                           let g21 =
                             let uu___5 =
                               let uu___6 =
-                                FStar_Compiler_Effect.op_Bar_Greater
-                                  cres.FStar_TypeChecker_Common.eff_name
-                                  (FStar_TypeChecker_Env.norm_eff_name env2) in
-                              FStar_Compiler_Effect.op_Bar_Greater uu___6
-                                (FStar_TypeChecker_Env.is_layered_effect env2) in
+                                FStar_TypeChecker_Env.norm_eff_name env2
+                                  cres.FStar_TypeChecker_Common.eff_name in
+                              FStar_TypeChecker_Env.is_layered_effect env2
+                                uu___6 in
                             FStar_TypeChecker_Util.close_guard_implicits env2
                               uu___5 xb g2 in
                           let guard = FStar_TypeChecker_Env.conj_guard g1 g21 in
@@ -10945,13 +10655,10 @@ and (check_inner_let :
                               let uu___6 =
                                 let uu___7 =
                                   FStar_TypeChecker_Env.expected_typ env2 in
-                                FStar_Compiler_Effect.op_Bar_Greater uu___7
-                                  FStar_Compiler_Option.get in
-                              FStar_Compiler_Effect.op_Bar_Greater uu___6
-                                FStar_Pervasives_Native.fst in
+                                FStar_Compiler_Option.get uu___7 in
+                              FStar_Pervasives_Native.fst uu___6 in
                             ((let uu___7 =
-                                FStar_Compiler_Effect.op_Less_Bar
-                                  (FStar_TypeChecker_Env.debug env2)
+                                FStar_TypeChecker_Env.debug env2
                                   (FStar_Options.Other "Exports") in
                               if uu___7
                               then
@@ -10973,8 +10680,7 @@ and (check_inner_let :
                              match uu___7 with
                              | (t, g_ex) ->
                                  ((let uu___9 =
-                                     FStar_Compiler_Effect.op_Less_Bar
-                                       (FStar_TypeChecker_Env.debug env2)
+                                     FStar_TypeChecker_Env.debug env2
                                        (FStar_Options.Other "Exports") in
                                    if uu___9
                                    then
@@ -11034,63 +10740,56 @@ and (check_top_level_let_rec :
                                   let uu___5 =
                                     FStar_TypeChecker_Env.conj_guard g_t
                                       g_lbs in
-                                  FStar_Compiler_Effect.op_Bar_Greater uu___5
-                                    (FStar_TypeChecker_Rel.solve_deferred_constraints
-                                       env1) in
-                                FStar_Compiler_Effect.op_Bar_Greater uu___4
-                                  (FStar_TypeChecker_Rel.resolve_implicits
-                                     env1) in
+                                  FStar_TypeChecker_Rel.solve_deferred_constraints
+                                    env1 uu___5 in
+                                FStar_TypeChecker_Rel.resolve_implicits env1
+                                  uu___4 in
                               let all_lb_names =
                                 let uu___4 =
-                                  FStar_Compiler_Effect.op_Bar_Greater lbs3
-                                    (FStar_Compiler_List.map
-                                       (fun lb ->
-                                          FStar_Compiler_Util.right
-                                            lb.FStar_Syntax_Syntax.lbname)) in
-                                FStar_Compiler_Effect.op_Bar_Greater uu___4
-                                  (fun uu___5 ->
-                                     FStar_Pervasives_Native.Some uu___5) in
+                                  FStar_Compiler_List.map
+                                    (fun lb ->
+                                       FStar_Compiler_Util.right
+                                         lb.FStar_Syntax_Syntax.lbname) lbs3 in
+                                FStar_Pervasives_Native.Some uu___4 in
                               let uu___4 =
                                 if
                                   Prims.op_Negation
                                     env1.FStar_TypeChecker_Env.generalize
                                 then
                                   let lbs4 =
-                                    FStar_Compiler_Effect.op_Bar_Greater lbs3
-                                      (FStar_Compiler_List.map
-                                         (fun lb ->
-                                            let lbdef =
-                                              FStar_TypeChecker_Normalize.reduce_uvar_solutions
-                                                env1
-                                                lb.FStar_Syntax_Syntax.lbdef in
-                                            if
-                                              lb.FStar_Syntax_Syntax.lbunivs
-                                                = []
-                                            then lb
-                                            else
-                                              FStar_Syntax_Util.close_univs_and_mk_letbinding
-                                                all_lb_names
-                                                lb.FStar_Syntax_Syntax.lbname
-                                                lb.FStar_Syntax_Syntax.lbunivs
-                                                lb.FStar_Syntax_Syntax.lbtyp
-                                                lb.FStar_Syntax_Syntax.lbeff
-                                                lbdef
-                                                lb.FStar_Syntax_Syntax.lbattrs
-                                                lb.FStar_Syntax_Syntax.lbpos)) in
+                                    FStar_Compiler_List.map
+                                      (fun lb ->
+                                         let lbdef =
+                                           FStar_TypeChecker_Normalize.reduce_uvar_solutions
+                                             env1
+                                             lb.FStar_Syntax_Syntax.lbdef in
+                                         if
+                                           lb.FStar_Syntax_Syntax.lbunivs =
+                                             []
+                                         then lb
+                                         else
+                                           FStar_Syntax_Util.close_univs_and_mk_letbinding
+                                             all_lb_names
+                                             lb.FStar_Syntax_Syntax.lbname
+                                             lb.FStar_Syntax_Syntax.lbunivs
+                                             lb.FStar_Syntax_Syntax.lbtyp
+                                             lb.FStar_Syntax_Syntax.lbeff
+                                             lbdef
+                                             lb.FStar_Syntax_Syntax.lbattrs
+                                             lb.FStar_Syntax_Syntax.lbpos)
+                                      lbs3 in
                                   (lbs4, g_lbs1)
                                 else
                                   (let ecs =
                                      let uu___6 =
-                                       FStar_Compiler_Effect.op_Bar_Greater
-                                         lbs3
-                                         (FStar_Compiler_List.map
-                                            (fun lb ->
-                                               let uu___7 =
-                                                 FStar_Syntax_Syntax.mk_Total
-                                                   lb.FStar_Syntax_Syntax.lbtyp in
-                                               ((lb.FStar_Syntax_Syntax.lbname),
-                                                 (lb.FStar_Syntax_Syntax.lbdef),
-                                                 uu___7))) in
+                                       FStar_Compiler_List.map
+                                         (fun lb ->
+                                            let uu___7 =
+                                              FStar_Syntax_Syntax.mk_Total
+                                                lb.FStar_Syntax_Syntax.lbtyp in
+                                            ((lb.FStar_Syntax_Syntax.lbname),
+                                              (lb.FStar_Syntax_Syntax.lbdef),
+                                              uu___7)) lbs3 in
                                      FStar_TypeChecker_Generalize.generalize
                                        env1 true uu___6 in
                                    let lbs4 =
@@ -11118,8 +10817,7 @@ and (check_top_level_let_rec :
                                      let uu___5 =
                                        FStar_Syntax_Syntax.mk_Total
                                          FStar_Syntax_Syntax.t_unit in
-                                     FStar_Compiler_Effect.op_Less_Bar
-                                       FStar_TypeChecker_Common.lcomp_of_comp
+                                     FStar_TypeChecker_Common.lcomp_of_comp
                                        uu___5 in
                                    let uu___5 =
                                      FStar_Syntax_Subst.close_let_rec lbs4
@@ -11129,10 +10827,8 @@ and (check_top_level_let_rec :
                                         ((let uu___7 =
                                             FStar_TypeChecker_Rel.discharge_guard
                                               env1 g_lbs2 in
-                                          FStar_Compiler_Effect.op_Bar_Greater
-                                            uu___7
-                                            (FStar_TypeChecker_Rel.force_trivial_guard
-                                               env1));
+                                          FStar_TypeChecker_Rel.force_trivial_guard
+                                            env1 uu___7);
                                          (let uu___7 =
                                             FStar_Syntax_Syntax.mk
                                               (FStar_Syntax_Syntax.Tm_let
@@ -11173,65 +10869,61 @@ and (check_inner_let_rec :
                      | (lbs2, rec_env, g_t) ->
                          let uu___3 =
                            let uu___4 = check_let_recs rec_env lbs2 in
-                           FStar_Compiler_Effect.op_Bar_Greater uu___4
-                             (fun uu___5 ->
-                                match uu___5 with
-                                | (lbs3, g) ->
-                                    let uu___6 =
-                                      FStar_TypeChecker_Env.conj_guard g_t g in
-                                    (lbs3, uu___6)) in
+                           match uu___4 with
+                           | (lbs3, g) ->
+                               let uu___5 =
+                                 FStar_TypeChecker_Env.conj_guard g_t g in
+                               (lbs3, uu___5) in
                          (match uu___3 with
                           | (lbs3, g_lbs) ->
                               let uu___4 =
-                                FStar_Compiler_Effect.op_Bar_Greater lbs3
-                                  (FStar_Compiler_Util.fold_map
-                                     (fun env2 ->
-                                        fun lb ->
-                                          let x =
-                                            let uu___5 =
-                                              FStar_Compiler_Util.left
-                                                lb.FStar_Syntax_Syntax.lbname in
-                                            {
-                                              FStar_Syntax_Syntax.ppname =
-                                                (uu___5.FStar_Syntax_Syntax.ppname);
-                                              FStar_Syntax_Syntax.index =
-                                                (uu___5.FStar_Syntax_Syntax.index);
-                                              FStar_Syntax_Syntax.sort =
-                                                (lb.FStar_Syntax_Syntax.lbtyp)
-                                            } in
-                                          let lb1 =
-                                            {
-                                              FStar_Syntax_Syntax.lbname =
-                                                (FStar_Pervasives.Inl x);
-                                              FStar_Syntax_Syntax.lbunivs =
-                                                (lb.FStar_Syntax_Syntax.lbunivs);
-                                              FStar_Syntax_Syntax.lbtyp =
-                                                (lb.FStar_Syntax_Syntax.lbtyp);
-                                              FStar_Syntax_Syntax.lbeff =
-                                                (lb.FStar_Syntax_Syntax.lbeff);
-                                              FStar_Syntax_Syntax.lbdef =
-                                                (lb.FStar_Syntax_Syntax.lbdef);
-                                              FStar_Syntax_Syntax.lbattrs =
-                                                (lb.FStar_Syntax_Syntax.lbattrs);
-                                              FStar_Syntax_Syntax.lbpos =
-                                                (lb.FStar_Syntax_Syntax.lbpos)
-                                            } in
-                                          let env3 =
-                                            FStar_TypeChecker_Env.push_let_binding
-                                              env2
-                                              lb1.FStar_Syntax_Syntax.lbname
-                                              ([],
-                                                (lb1.FStar_Syntax_Syntax.lbtyp)) in
-                                          (env3, lb1)) env1) in
+                                FStar_Compiler_Util.fold_map
+                                  (fun env2 ->
+                                     fun lb ->
+                                       let x =
+                                         let uu___5 =
+                                           FStar_Compiler_Util.left
+                                             lb.FStar_Syntax_Syntax.lbname in
+                                         {
+                                           FStar_Syntax_Syntax.ppname =
+                                             (uu___5.FStar_Syntax_Syntax.ppname);
+                                           FStar_Syntax_Syntax.index =
+                                             (uu___5.FStar_Syntax_Syntax.index);
+                                           FStar_Syntax_Syntax.sort =
+                                             (lb.FStar_Syntax_Syntax.lbtyp)
+                                         } in
+                                       let lb1 =
+                                         {
+                                           FStar_Syntax_Syntax.lbname =
+                                             (FStar_Pervasives.Inl x);
+                                           FStar_Syntax_Syntax.lbunivs =
+                                             (lb.FStar_Syntax_Syntax.lbunivs);
+                                           FStar_Syntax_Syntax.lbtyp =
+                                             (lb.FStar_Syntax_Syntax.lbtyp);
+                                           FStar_Syntax_Syntax.lbeff =
+                                             (lb.FStar_Syntax_Syntax.lbeff);
+                                           FStar_Syntax_Syntax.lbdef =
+                                             (lb.FStar_Syntax_Syntax.lbdef);
+                                           FStar_Syntax_Syntax.lbattrs =
+                                             (lb.FStar_Syntax_Syntax.lbattrs);
+                                           FStar_Syntax_Syntax.lbpos =
+                                             (lb.FStar_Syntax_Syntax.lbpos)
+                                         } in
+                                       let env3 =
+                                         FStar_TypeChecker_Env.push_let_binding
+                                           env2
+                                           lb1.FStar_Syntax_Syntax.lbname
+                                           ([],
+                                             (lb1.FStar_Syntax_Syntax.lbtyp)) in
+                                       (env3, lb1)) env1 lbs3 in
                               (match uu___4 with
                                | (env2, lbs4) ->
                                    let bvs =
-                                     FStar_Compiler_Effect.op_Bar_Greater
-                                       lbs4
-                                       (FStar_Compiler_List.map
-                                          (fun lb ->
-                                             FStar_Compiler_Util.left
-                                               lb.FStar_Syntax_Syntax.lbname)) in
+                                     FStar_Compiler_List.map
+                                       (fun lb ->
+                                          FStar_Compiler_Util.left
+                                            lb.FStar_Syntax_Syntax.lbname)
+                                       lbs4 in
                                    let uu___5 = tc_term env2 e21 in
                                    (match uu___5 with
                                     | (e22, cres, g2) ->
@@ -11262,14 +10954,11 @@ and (check_inner_let_rec :
                                         let cres4 =
                                           let uu___6 =
                                             let uu___7 =
-                                              FStar_Compiler_Effect.op_Bar_Greater
-                                                cres3.FStar_TypeChecker_Common.eff_name
-                                                (FStar_TypeChecker_Env.norm_eff_name
-                                                   env2) in
-                                            FStar_Compiler_Effect.op_Bar_Greater
-                                              uu___7
-                                              (FStar_TypeChecker_Env.is_layered_effect
-                                                 env2) in
+                                              FStar_TypeChecker_Env.norm_eff_name
+                                                env2
+                                                cres3.FStar_TypeChecker_Common.eff_name in
+                                            FStar_TypeChecker_Env.is_layered_effect
+                                              env2 uu___7 in
                                           if uu___6
                                           then
                                             let bvss =
@@ -11280,35 +10969,26 @@ and (check_inner_let_rec :
                                               (fun c ->
                                                  let uu___7 =
                                                    let uu___8 =
-                                                     FStar_Compiler_Effect.op_Bar_Greater
-                                                       c
-                                                       FStar_Syntax_Util.comp_effect_args in
-                                                   FStar_Compiler_Effect.op_Bar_Greater
-                                                     uu___8
-                                                     (FStar_Compiler_List.existsb
-                                                        (fun uu___9 ->
-                                                           match uu___9 with
-                                                           | (t, uu___10) ->
-                                                               let uu___11 =
-                                                                 let uu___12
-                                                                   =
-                                                                   let uu___13
-                                                                    =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    t
-                                                                    FStar_Syntax_Free.names in
-                                                                   FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___13
-                                                                    (FStar_Compiler_Set.inter
-                                                                    FStar_Syntax_Syntax.ord_bv
-                                                                    bvss) in
-                                                                 FStar_Compiler_Effect.op_Bar_Greater
-                                                                   uu___12
-                                                                   (FStar_Compiler_Set.is_empty
-                                                                    FStar_Syntax_Syntax.ord_bv) in
-                                                               FStar_Compiler_Effect.op_Bar_Greater
-                                                                 uu___11
-                                                                 Prims.op_Negation)) in
+                                                     FStar_Syntax_Util.comp_effect_args
+                                                       c in
+                                                   FStar_Compiler_List.existsb
+                                                     (fun uu___9 ->
+                                                        match uu___9 with
+                                                        | (t, uu___10) ->
+                                                            let uu___11 =
+                                                              let uu___12 =
+                                                                let uu___13 =
+                                                                  FStar_Syntax_Free.names
+                                                                    t in
+                                                                FStar_Compiler_Set.inter
+                                                                  FStar_Syntax_Syntax.ord_bv
+                                                                  bvss
+                                                                  uu___13 in
+                                                              FStar_Compiler_Set.is_empty
+                                                                FStar_Syntax_Syntax.ord_bv
+                                                                uu___12 in
+                                                            Prims.op_Negation
+                                                              uu___11) uu___8 in
                                                  if uu___7
                                                  then
                                                    FStar_Errors.raise_error
@@ -11337,15 +11017,13 @@ and (check_inner_let_rec :
                                           } in
                                         let guard1 =
                                           let bs =
-                                            FStar_Compiler_Effect.op_Bar_Greater
-                                              lbs4
-                                              (FStar_Compiler_List.map
-                                                 (fun lb ->
-                                                    let uu___6 =
-                                                      FStar_Compiler_Util.left
-                                                        lb.FStar_Syntax_Syntax.lbname in
-                                                    FStar_Syntax_Syntax.mk_binder
-                                                      uu___6)) in
+                                            FStar_Compiler_List.map
+                                              (fun lb ->
+                                                 let uu___6 =
+                                                   FStar_Compiler_Util.left
+                                                     lb.FStar_Syntax_Syntax.lbname in
+                                                 FStar_Syntax_Syntax.mk_binder
+                                                   uu___6) lbs4 in
                                           FStar_TypeChecker_Util.close_guard_implicits
                                             env2 false bs guard in
                                         let uu___6 =
@@ -11466,13 +11144,10 @@ and (build_let_rec_env :
                         else
                           (let uu___7 =
                              let uu___8 =
-                               FStar_Compiler_Effect.op_Bar_Greater
-                                 (FStar_Syntax_Util.comp_effect_name c)
-                                 (FStar_TypeChecker_Env.lookup_effect_quals
-                                    env) in
-                             FStar_Compiler_Effect.op_Bar_Greater uu___8
-                               (FStar_Compiler_List.contains
-                                  FStar_Syntax_Syntax.TotalEffect) in
+                               FStar_TypeChecker_Env.lookup_effect_quals env
+                                 (FStar_Syntax_Util.comp_effect_name c) in
+                             FStar_Compiler_List.contains
+                               FStar_Syntax_Syntax.TotalEffect uu___8 in
                            if uu___7
                            then
                              let uu___8 =
@@ -11486,8 +11161,7 @@ and (build_let_rec_env :
           let uu___ =
             let uu___1 =
               let uu___2 = FStar_Syntax_Util.type_u () in
-              FStar_Compiler_Effect.op_Less_Bar FStar_Pervasives_Native.fst
-                uu___2 in
+              FStar_Pervasives_Native.fst uu___2 in
             tc_check_tot_or_gtot_term
               {
                 FStar_TypeChecker_Env.solver =
@@ -11595,11 +11269,8 @@ and (build_let_rec_env :
           match uu___ with
           | (t1, uu___1, g) ->
               let uu___2 =
-                let uu___3 =
-                  FStar_Compiler_Effect.op_Bar_Greater g
-                    (FStar_TypeChecker_Rel.resolve_implicits env) in
-                FStar_Compiler_Effect.op_Bar_Greater uu___3
-                  (FStar_TypeChecker_Rel.discharge_guard env01) in
+                let uu___3 = FStar_TypeChecker_Rel.resolve_implicits env g in
+                FStar_TypeChecker_Rel.discharge_guard env01 uu___3 in
               (env01, uu___2, t1) in
         let uu___ =
           FStar_Compiler_List.fold_left
@@ -11637,8 +11308,7 @@ and (build_let_rec_env :
                                  | FStar_Pervasives_Native.Some
                                      (arity, lbdef1) ->
                                      ((let uu___7 =
-                                         FStar_Compiler_Effect.op_Less_Bar
-                                           (FStar_TypeChecker_Env.debug env2)
+                                         FStar_TypeChecker_Env.debug env2
                                            FStar_Options.Extreme in
                                        if uu___7
                                        then
@@ -11837,109 +11507,107 @@ and (check_let_recs :
     fun lbts ->
       let uu___ =
         let uu___1 =
-          FStar_Compiler_Effect.op_Bar_Greater lbts
-            (FStar_Compiler_List.map
-               (fun lb ->
-                  let uu___2 =
-                    FStar_Syntax_Util.abs_formals
-                      lb.FStar_Syntax_Syntax.lbdef in
-                  match uu___2 with
-                  | (bs, t, lcomp) ->
-                      (match bs with
-                       | [] ->
-                           let uu___3 =
-                             let uu___4 =
-                               let uu___5 =
-                                 FStar_Syntax_Print.lbname_to_string
-                                   lb.FStar_Syntax_Syntax.lbname in
+          FStar_Compiler_List.map
+            (fun lb ->
+               let uu___2 =
+                 FStar_Syntax_Util.abs_formals lb.FStar_Syntax_Syntax.lbdef in
+               match uu___2 with
+               | (bs, t, lcomp) ->
+                   (match bs with
+                    | [] ->
+                        let uu___3 =
+                          let uu___4 =
+                            let uu___5 =
+                              FStar_Syntax_Print.lbname_to_string
+                                lb.FStar_Syntax_Syntax.lbname in
+                            let uu___6 =
+                              FStar_Syntax_Print.term_to_string
+                                lb.FStar_Syntax_Syntax.lbdef in
+                            FStar_Compiler_Util.format2
+                              "Only function literals may be defined recursively; %s is defined to be %s"
+                              uu___5 uu___6 in
+                          (FStar_Errors_Codes.Fatal_RecursiveFunctionLiteral,
+                            uu___4) in
+                        let uu___4 =
+                          FStar_Syntax_Syntax.range_of_lbname
+                            lb.FStar_Syntax_Syntax.lbname in
+                        FStar_Errors.raise_error uu___3 uu___4
+                    | uu___3 ->
+                        let arity =
+                          let uu___4 =
+                            FStar_TypeChecker_Env.get_letrec_arity env
+                              lb.FStar_Syntax_Syntax.lbname in
+                          match uu___4 with
+                          | FStar_Pervasives_Native.Some n -> n
+                          | FStar_Pervasives_Native.None ->
+                              FStar_Compiler_List.length bs in
+                        let uu___4 = FStar_Compiler_List.splitAt arity bs in
+                        (match uu___4 with
+                         | (bs0, bs1) ->
+                             let def =
+                               if FStar_Compiler_List.isEmpty bs1
+                               then FStar_Syntax_Util.abs bs0 t lcomp
+                               else
+                                 (let inner =
+                                    FStar_Syntax_Util.abs bs1 t lcomp in
+                                  let inner1 =
+                                    FStar_Syntax_Subst.close bs0 inner in
+                                  let bs01 =
+                                    FStar_Syntax_Subst.close_binders bs0 in
+                                  FStar_Syntax_Syntax.mk
+                                    (FStar_Syntax_Syntax.Tm_abs
+                                       {
+                                         FStar_Syntax_Syntax.bs = bs01;
+                                         FStar_Syntax_Syntax.body = inner1;
+                                         FStar_Syntax_Syntax.rc_opt =
+                                           FStar_Pervasives_Native.None
+                                       }) inner1.FStar_Syntax_Syntax.pos) in
+                             let lb1 =
+                               {
+                                 FStar_Syntax_Syntax.lbname =
+                                   (lb.FStar_Syntax_Syntax.lbname);
+                                 FStar_Syntax_Syntax.lbunivs =
+                                   (lb.FStar_Syntax_Syntax.lbunivs);
+                                 FStar_Syntax_Syntax.lbtyp =
+                                   (lb.FStar_Syntax_Syntax.lbtyp);
+                                 FStar_Syntax_Syntax.lbeff =
+                                   (lb.FStar_Syntax_Syntax.lbeff);
+                                 FStar_Syntax_Syntax.lbdef = def;
+                                 FStar_Syntax_Syntax.lbattrs =
+                                   (lb.FStar_Syntax_Syntax.lbattrs);
+                                 FStar_Syntax_Syntax.lbpos =
+                                   (lb.FStar_Syntax_Syntax.lbpos)
+                               } in
+                             let uu___5 =
                                let uu___6 =
-                                 FStar_Syntax_Print.term_to_string
-                                   lb.FStar_Syntax_Syntax.lbdef in
-                               FStar_Compiler_Util.format2
-                                 "Only function literals may be defined recursively; %s is defined to be %s"
-                                 uu___5 uu___6 in
-                             (FStar_Errors_Codes.Fatal_RecursiveFunctionLiteral,
-                               uu___4) in
-                           let uu___4 =
-                             FStar_Syntax_Syntax.range_of_lbname
-                               lb.FStar_Syntax_Syntax.lbname in
-                           FStar_Errors.raise_error uu___3 uu___4
-                       | uu___3 ->
-                           let arity =
-                             let uu___4 =
-                               FStar_TypeChecker_Env.get_letrec_arity env
-                                 lb.FStar_Syntax_Syntax.lbname in
-                             match uu___4 with
-                             | FStar_Pervasives_Native.Some n -> n
-                             | FStar_Pervasives_Native.None ->
-                                 FStar_Compiler_List.length bs in
-                           let uu___4 = FStar_Compiler_List.splitAt arity bs in
-                           (match uu___4 with
-                            | (bs0, bs1) ->
-                                let def =
-                                  if FStar_Compiler_List.isEmpty bs1
-                                  then FStar_Syntax_Util.abs bs0 t lcomp
-                                  else
-                                    (let inner =
-                                       FStar_Syntax_Util.abs bs1 t lcomp in
-                                     let inner1 =
-                                       FStar_Syntax_Subst.close bs0 inner in
-                                     let bs01 =
-                                       FStar_Syntax_Subst.close_binders bs0 in
-                                     FStar_Syntax_Syntax.mk
-                                       (FStar_Syntax_Syntax.Tm_abs
-                                          {
-                                            FStar_Syntax_Syntax.bs = bs01;
-                                            FStar_Syntax_Syntax.body = inner1;
-                                            FStar_Syntax_Syntax.rc_opt =
-                                              FStar_Pervasives_Native.None
-                                          }) inner1.FStar_Syntax_Syntax.pos) in
-                                let lb1 =
-                                  {
-                                    FStar_Syntax_Syntax.lbname =
-                                      (lb.FStar_Syntax_Syntax.lbname);
-                                    FStar_Syntax_Syntax.lbunivs =
-                                      (lb.FStar_Syntax_Syntax.lbunivs);
-                                    FStar_Syntax_Syntax.lbtyp =
-                                      (lb.FStar_Syntax_Syntax.lbtyp);
-                                    FStar_Syntax_Syntax.lbeff =
-                                      (lb.FStar_Syntax_Syntax.lbeff);
-                                    FStar_Syntax_Syntax.lbdef = def;
-                                    FStar_Syntax_Syntax.lbattrs =
-                                      (lb.FStar_Syntax_Syntax.lbattrs);
-                                    FStar_Syntax_Syntax.lbpos =
-                                      (lb.FStar_Syntax_Syntax.lbpos)
-                                  } in
-                                let uu___5 =
-                                  let uu___6 =
-                                    FStar_TypeChecker_Env.set_expected_typ
-                                      env lb1.FStar_Syntax_Syntax.lbtyp in
-                                  tc_tot_or_gtot_term uu___6
-                                    lb1.FStar_Syntax_Syntax.lbdef in
-                                (match uu___5 with
-                                 | (e, c, g) ->
-                                     ((let uu___7 =
-                                         let uu___8 =
-                                           FStar_TypeChecker_Common.is_total_lcomp
-                                             c in
-                                         Prims.op_Negation uu___8 in
-                                       if uu___7
-                                       then
-                                         FStar_Errors.raise_error
-                                           (FStar_Errors_Codes.Fatal_UnexpectedGTotForLetRec,
-                                             "Expected let rec to be a Tot term; got effect GTot")
-                                           e.FStar_Syntax_Syntax.pos
-                                       else ());
-                                      (let lb2 =
-                                         FStar_Syntax_Util.mk_letbinding
-                                           lb1.FStar_Syntax_Syntax.lbname
-                                           lb1.FStar_Syntax_Syntax.lbunivs
-                                           lb1.FStar_Syntax_Syntax.lbtyp
-                                           FStar_Parser_Const.effect_Tot_lid
-                                           e lb1.FStar_Syntax_Syntax.lbattrs
-                                           lb1.FStar_Syntax_Syntax.lbpos in
-                                       (lb2, g)))))))) in
-        FStar_Compiler_Effect.op_Bar_Greater uu___1 FStar_Compiler_List.unzip in
+                                 FStar_TypeChecker_Env.set_expected_typ env
+                                   lb1.FStar_Syntax_Syntax.lbtyp in
+                               tc_tot_or_gtot_term uu___6
+                                 lb1.FStar_Syntax_Syntax.lbdef in
+                             (match uu___5 with
+                              | (e, c, g) ->
+                                  ((let uu___7 =
+                                      let uu___8 =
+                                        FStar_TypeChecker_Common.is_total_lcomp
+                                          c in
+                                      Prims.op_Negation uu___8 in
+                                    if uu___7
+                                    then
+                                      FStar_Errors.raise_error
+                                        (FStar_Errors_Codes.Fatal_UnexpectedGTotForLetRec,
+                                          "Expected let rec to be a Tot term; got effect GTot")
+                                        e.FStar_Syntax_Syntax.pos
+                                    else ());
+                                   (let lb2 =
+                                      FStar_Syntax_Util.mk_letbinding
+                                        lb1.FStar_Syntax_Syntax.lbname
+                                        lb1.FStar_Syntax_Syntax.lbunivs
+                                        lb1.FStar_Syntax_Syntax.lbtyp
+                                        FStar_Parser_Const.effect_Tot_lid e
+                                        lb1.FStar_Syntax_Syntax.lbattrs
+                                        lb1.FStar_Syntax_Syntax.lbpos in
+                                    (lb2, g))))))) lbts in
+        FStar_Compiler_List.unzip uu___1 in
       match uu___ with
       | (lbs, gs) ->
           let g_lbs =
@@ -12316,8 +11984,7 @@ and (tc_smt_pats :
              fun uu___1 ->
                match (uu___, uu___1) with
                | ((t, imp), (args1, g)) ->
-                   (FStar_Compiler_Effect.op_Bar_Greater t
-                      (check_no_smt_theory_symbols en1);
+                   (check_no_smt_theory_symbols en1 t;
                     (let uu___3 = tc_term en1 t in
                      match uu___3 with
                      | (t1, uu___4, g') ->
@@ -12489,9 +12156,7 @@ let (typeof_tot_or_gtot_term :
     fun e ->
       fun must_tot ->
         (let uu___1 =
-           FStar_Compiler_Effect.op_Less_Bar
-             (FStar_TypeChecker_Env.debug env)
-             (FStar_Options.Other "RelCheck") in
+           FStar_TypeChecker_Env.debug env (FStar_Options.Other "RelCheck") in
          if uu___1
          then
            let uu___2 = FStar_Syntax_Print.term_to_string e in
@@ -13012,8 +12677,7 @@ let rec (universe_of_aux :
                  let uu___2 = universe_of_aux env1 res in
                  level_of_type env1 res uu___2 in
                let u_c =
-                 FStar_Compiler_Effect.op_Bar_Greater c1
-                   (FStar_TypeChecker_Util.universe_of_comp env1 u_res) in
+                 FStar_TypeChecker_Util.universe_of_comp env1 u_res c1 in
                let u =
                  FStar_TypeChecker_Normalize.normalize_universe env1
                    (FStar_Syntax_Syntax.U_max (u_c :: us)) in
@@ -13190,8 +12854,7 @@ let rec (universe_of_aux :
                            (env2.FStar_TypeChecker_Env.core_check)
                        } in
                      ((let uu___5 =
-                         FStar_Compiler_Effect.op_Less_Bar
-                           (FStar_TypeChecker_Env.debug env3)
+                         FStar_TypeChecker_Env.debug env3
                            (FStar_Options.Other "UniverseOf") in
                        if uu___5
                        then
@@ -13213,8 +12876,7 @@ let rec (universe_of_aux :
                            ((let uu___11 =
                                FStar_TypeChecker_Rel.solve_deferred_constraints
                                  env3 g in
-                             FStar_Compiler_Effect.op_Bar_Greater uu___11
-                               (fun uu___12 -> ()));
+                             ());
                             (t, args1))))) in
           let uu___1 = type_of_head true env hd args in
           (match uu___1 with
@@ -13315,28 +12977,22 @@ let rec (__typeof_tot_or_gtot_term_fastpath :
             -> FStar_Pervasives_Native.None
         | FStar_Syntax_Syntax.Tm_name uu___ ->
             let uu___1 = universe_of_aux env t1 in
-            FStar_Compiler_Effect.op_Bar_Greater uu___1
-              (fun uu___2 -> FStar_Pervasives_Native.Some uu___2)
+            FStar_Pervasives_Native.Some uu___1
         | FStar_Syntax_Syntax.Tm_fvar uu___ ->
             let uu___1 = universe_of_aux env t1 in
-            FStar_Compiler_Effect.op_Bar_Greater uu___1
-              (fun uu___2 -> FStar_Pervasives_Native.Some uu___2)
+            FStar_Pervasives_Native.Some uu___1
         | FStar_Syntax_Syntax.Tm_uinst uu___ ->
             let uu___1 = universe_of_aux env t1 in
-            FStar_Compiler_Effect.op_Bar_Greater uu___1
-              (fun uu___2 -> FStar_Pervasives_Native.Some uu___2)
+            FStar_Pervasives_Native.Some uu___1
         | FStar_Syntax_Syntax.Tm_constant uu___ ->
             let uu___1 = universe_of_aux env t1 in
-            FStar_Compiler_Effect.op_Bar_Greater uu___1
-              (fun uu___2 -> FStar_Pervasives_Native.Some uu___2)
+            FStar_Pervasives_Native.Some uu___1
         | FStar_Syntax_Syntax.Tm_type uu___ ->
             let uu___1 = universe_of_aux env t1 in
-            FStar_Compiler_Effect.op_Bar_Greater uu___1
-              (fun uu___2 -> FStar_Pervasives_Native.Some uu___2)
+            FStar_Pervasives_Native.Some uu___1
         | FStar_Syntax_Syntax.Tm_arrow uu___ ->
             let uu___1 = universe_of_aux env t1 in
-            FStar_Compiler_Effect.op_Bar_Greater uu___1
-              (fun uu___2 -> FStar_Pervasives_Native.Some uu___2)
+            FStar_Pervasives_Native.Some uu___1
         | FStar_Syntax_Syntax.Tm_lazy i ->
             let uu___ = FStar_Syntax_Util.unfold_lazy i in
             __typeof_tot_or_gtot_term_fastpath env uu___ must_tot
@@ -13503,9 +13159,7 @@ let rec (__typeof_tot_or_gtot_term_fastpath :
                                     let uu___4 =
                                       __typeof_tot_or_gtot_term_fastpath env
                                         a must_tot in
-                                    FStar_Compiler_Effect.op_Bar_Greater
-                                      uu___4 FStar_Compiler_Util.is_some)
-                             args) in
+                                    FStar_Compiler_Util.is_some uu___4) args) in
                       if uu___1
                       then FStar_Pervasives_Native.Some t2
                       else FStar_Pervasives_Native.None))
@@ -13529,14 +13183,10 @@ let rec (__typeof_tot_or_gtot_term_fastpath :
             let uu___4 =
               ((Prims.op_Negation must_tot) ||
                  (let uu___5 =
-                    let uu___6 =
-                      FStar_Compiler_Effect.op_Bar_Greater c
-                        FStar_Syntax_Util.comp_effect_name in
-                    FStar_Compiler_Effect.op_Bar_Greater uu___6
-                      (FStar_TypeChecker_Env.norm_eff_name env) in
-                  FStar_Compiler_Effect.op_Bar_Greater uu___5
-                    (FStar_Ident.lid_equals
-                       FStar_Parser_Const.effect_PURE_lid)))
+                    FStar_TypeChecker_Env.norm_eff_name env
+                      (FStar_Syntax_Util.comp_effect_name c) in
+                  FStar_Ident.lid_equals FStar_Parser_Const.effect_PURE_lid
+                    uu___5))
                 || (FStar_TypeChecker_Normalize.non_info_norm env k) in
             if uu___4
             then FStar_Pervasives_Native.Some k
@@ -13629,41 +13279,23 @@ let rec (effectof_tot_or_gtot_term_fastpath :
       | FStar_Syntax_Syntax.Tm_bvar uu___1 ->
           FStar_Compiler_Effect.failwith "Impossible!"
       | FStar_Syntax_Syntax.Tm_name uu___1 ->
-          FStar_Compiler_Effect.op_Bar_Greater
-            FStar_Parser_Const.effect_PURE_lid
-            (fun uu___2 -> FStar_Pervasives_Native.Some uu___2)
+          FStar_Pervasives_Native.Some FStar_Parser_Const.effect_PURE_lid
       | FStar_Syntax_Syntax.Tm_lazy uu___1 ->
-          FStar_Compiler_Effect.op_Bar_Greater
-            FStar_Parser_Const.effect_PURE_lid
-            (fun uu___2 -> FStar_Pervasives_Native.Some uu___2)
+          FStar_Pervasives_Native.Some FStar_Parser_Const.effect_PURE_lid
       | FStar_Syntax_Syntax.Tm_fvar uu___1 ->
-          FStar_Compiler_Effect.op_Bar_Greater
-            FStar_Parser_Const.effect_PURE_lid
-            (fun uu___2 -> FStar_Pervasives_Native.Some uu___2)
+          FStar_Pervasives_Native.Some FStar_Parser_Const.effect_PURE_lid
       | FStar_Syntax_Syntax.Tm_uinst uu___1 ->
-          FStar_Compiler_Effect.op_Bar_Greater
-            FStar_Parser_Const.effect_PURE_lid
-            (fun uu___2 -> FStar_Pervasives_Native.Some uu___2)
+          FStar_Pervasives_Native.Some FStar_Parser_Const.effect_PURE_lid
       | FStar_Syntax_Syntax.Tm_constant uu___1 ->
-          FStar_Compiler_Effect.op_Bar_Greater
-            FStar_Parser_Const.effect_PURE_lid
-            (fun uu___2 -> FStar_Pervasives_Native.Some uu___2)
+          FStar_Pervasives_Native.Some FStar_Parser_Const.effect_PURE_lid
       | FStar_Syntax_Syntax.Tm_type uu___1 ->
-          FStar_Compiler_Effect.op_Bar_Greater
-            FStar_Parser_Const.effect_PURE_lid
-            (fun uu___2 -> FStar_Pervasives_Native.Some uu___2)
+          FStar_Pervasives_Native.Some FStar_Parser_Const.effect_PURE_lid
       | FStar_Syntax_Syntax.Tm_abs uu___1 ->
-          FStar_Compiler_Effect.op_Bar_Greater
-            FStar_Parser_Const.effect_PURE_lid
-            (fun uu___2 -> FStar_Pervasives_Native.Some uu___2)
+          FStar_Pervasives_Native.Some FStar_Parser_Const.effect_PURE_lid
       | FStar_Syntax_Syntax.Tm_arrow uu___1 ->
-          FStar_Compiler_Effect.op_Bar_Greater
-            FStar_Parser_Const.effect_PURE_lid
-            (fun uu___2 -> FStar_Pervasives_Native.Some uu___2)
+          FStar_Pervasives_Native.Some FStar_Parser_Const.effect_PURE_lid
       | FStar_Syntax_Syntax.Tm_refine uu___1 ->
-          FStar_Compiler_Effect.op_Bar_Greater
-            FStar_Parser_Const.effect_PURE_lid
-            (fun uu___2 -> FStar_Pervasives_Native.Some uu___2)
+          FStar_Pervasives_Native.Some FStar_Parser_Const.effect_PURE_lid
       | FStar_Syntax_Syntax.Tm_app
           { FStar_Syntax_Syntax.hd = hd; FStar_Syntax_Syntax.args = args;_}
           ->
@@ -13758,11 +13390,8 @@ let rec (effectof_tot_or_gtot_term_fastpath :
             FStar_Syntax_Syntax.eff_opt = uu___4;_}
           ->
           let c_eff =
-            let uu___5 =
-              FStar_Compiler_Effect.op_Bar_Greater c
-                FStar_Syntax_Util.comp_effect_name in
-            FStar_Compiler_Effect.op_Bar_Greater uu___5
-              (FStar_TypeChecker_Env.norm_eff_name env) in
+            FStar_TypeChecker_Env.norm_eff_name env
+              (FStar_Syntax_Util.comp_effect_name c) in
           let uu___5 =
             (FStar_Ident.lid_equals c_eff FStar_Parser_Const.effect_PURE_lid)
               ||

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Util.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Util.ml
@@ -37,18 +37,16 @@ let (close_guard_implicits :
           if uu___
           then
             let uu___1 =
-              FStar_Compiler_Effect.op_Bar_Greater
-                g.FStar_TypeChecker_Common.deferred
-                (FStar_Compiler_List.partition
-                   (fun uu___2 ->
-                      match uu___2 with
-                      | (uu___3, uu___4, p) ->
-                          FStar_TypeChecker_Rel.flex_prob_closing env xs p)) in
+              FStar_Compiler_List.partition
+                (fun uu___2 ->
+                   match uu___2 with
+                   | (uu___3, uu___4, p) ->
+                       FStar_TypeChecker_Rel.flex_prob_closing env xs p)
+                g.FStar_TypeChecker_Common.deferred in
             match uu___1 with
             | (solve_now, defer) ->
                 ((let uu___3 =
-                    FStar_Compiler_Effect.op_Less_Bar
-                      (FStar_TypeChecker_Env.debug env)
+                    FStar_TypeChecker_Env.debug env
                       (FStar_Options.Other "Rel") in
                   if uu___3
                   then
@@ -155,8 +153,7 @@ let (extract_let_rec_annotation :
                let e1 = FStar_Syntax_Subst.subst u_subst e in
                let t2 = FStar_Syntax_Subst.subst u_subst t1 in
                ((let uu___6 =
-                   FStar_Compiler_Effect.op_Less_Bar
-                     (FStar_TypeChecker_Env.debug env)
+                   FStar_TypeChecker_Env.debug env
                      (FStar_Options.Other "Dec") in
                  if uu___6
                  then
@@ -185,13 +182,11 @@ let (extract_let_rec_annotation :
                  let reconcile_let_rec_ascription_and_body_type tarr
                    lbtyp_opt =
                    let get_decreases c =
-                     FStar_Compiler_Effect.op_Bar_Greater
-                       (FStar_Syntax_Util.comp_flags c)
-                       (FStar_Compiler_Util.prefix_until
-                          (fun uu___6 ->
-                             match uu___6 with
-                             | FStar_Syntax_Syntax.DECREASES uu___7 -> true
-                             | uu___7 -> false)) in
+                     FStar_Compiler_Util.prefix_until
+                       (fun uu___6 ->
+                          match uu___6 with
+                          | FStar_Syntax_Syntax.DECREASES uu___7 -> true
+                          | uu___7 -> false) (FStar_Syntax_Util.comp_flags c) in
                    let fallback uu___6 =
                      let uu___7 = FStar_Syntax_Util.arrow_formals_comp tarr in
                      match uu___7 with
@@ -562,13 +557,10 @@ let (extract_let_rec_annotation :
                           let uu___9 =
                             let uu___10 =
                               let uu___11 =
-                                FStar_Compiler_Effect.op_Bar_Greater
-                                  (FStar_Syntax_Util.comp_effect_name c)
-                                  (FStar_TypeChecker_Env.lookup_effect_quals
-                                     env1) in
-                              FStar_Compiler_Effect.op_Bar_Greater uu___11
-                                (FStar_Compiler_List.contains
-                                   FStar_Syntax_Syntax.TotalEffect) in
+                                FStar_TypeChecker_Env.lookup_effect_quals
+                                  env1 (FStar_Syntax_Util.comp_effect_name c) in
+                              FStar_Compiler_List.contains
+                                FStar_Syntax_Syntax.TotalEffect uu___11 in
                             Prims.op_Negation uu___10 in
                           if uu___9
                           then (univ_vars1, t2, e1, false)
@@ -602,11 +594,8 @@ let rec (decorated_pattern_as_term :
         let uu___ = mk (FStar_Syntax_Syntax.Tm_name x) in ([x], uu___)
     | FStar_Syntax_Syntax.Pat_cons (fv, us_opt, pats) ->
         let uu___ =
-          let uu___1 =
-            FStar_Compiler_Effect.op_Bar_Greater pats
-              (FStar_Compiler_List.map pat_as_arg) in
-          FStar_Compiler_Effect.op_Bar_Greater uu___1
-            FStar_Compiler_List.unzip in
+          let uu___1 = FStar_Compiler_List.map pat_as_arg pats in
+          FStar_Compiler_List.unzip uu___1 in
         (match uu___ with
          | (vars, args) ->
              let vars1 = FStar_Compiler_List.flatten vars in
@@ -648,11 +637,8 @@ let (lcomp_univ_opt :
       FStar_TypeChecker_Env.guard_t))
   =
   fun lc ->
-    let uu___ =
-      FStar_Compiler_Effect.op_Bar_Greater lc
-        FStar_TypeChecker_Common.lcomp_comp in
-    FStar_Compiler_Effect.op_Bar_Greater uu___
-      (fun uu___1 -> match uu___1 with | (c, g) -> ((comp_univ_opt c), g))
+    let uu___ = FStar_TypeChecker_Common.lcomp_comp lc in
+    match uu___ with | (c, g) -> ((comp_univ_opt c), g)
 let (destruct_wp_comp :
   FStar_Syntax_Syntax.comp_typ ->
     (FStar_Syntax_Syntax.universe * FStar_Syntax_Syntax.typ *
@@ -713,9 +699,7 @@ let (effect_args_from_repr :
           | FStar_Syntax_Syntax.Tm_app
               { FStar_Syntax_Syntax.hd = uu___;
                 FStar_Syntax_Syntax.args = uu___1::is;_}
-              ->
-              FStar_Compiler_Effect.op_Bar_Greater is
-                (FStar_Compiler_List.map FStar_Pervasives_Native.fst)
+              -> FStar_Compiler_List.map FStar_Pervasives_Native.fst is
           | uu___ -> err ()
         else
           (match repr1.FStar_Syntax_Syntax.n with
@@ -723,16 +707,10 @@ let (effect_args_from_repr :
                { FStar_Syntax_Syntax.bs1 = uu___1;
                  FStar_Syntax_Syntax.comp = c;_}
                ->
-               let uu___2 =
-                 FStar_Compiler_Effect.op_Bar_Greater c
-                   FStar_Syntax_Util.comp_eff_name_res_and_args in
-               FStar_Compiler_Effect.op_Bar_Greater uu___2
-                 (fun uu___3 ->
-                    match uu___3 with
-                    | (uu___4, uu___5, args) ->
-                        FStar_Compiler_Effect.op_Bar_Greater args
-                          (FStar_Compiler_List.map
-                             FStar_Pervasives_Native.fst))
+               let uu___2 = FStar_Syntax_Util.comp_eff_name_res_and_args c in
+               (match uu___2 with
+                | (uu___3, uu___4, args) ->
+                    FStar_Compiler_List.map FStar_Pervasives_Native.fst args)
            | uu___1 -> err ())
 let (mk_wp_return :
   FStar_TypeChecker_Env.env ->
@@ -753,7 +731,7 @@ let (mk_wp_return :
                   let uu___1 =
                     FStar_TypeChecker_Env.lid_exists env
                       FStar_Parser_Const.effect_GTot_lid in
-                  FStar_Compiler_Effect.op_Less_Bar Prims.op_Negation uu___1 in
+                  Prims.op_Negation uu___1 in
                 if uu___
                 then FStar_Syntax_Syntax.mk_Total a
                 else
@@ -769,8 +747,7 @@ let (mk_wp_return :
                         then FStar_Syntax_Syntax.tun
                         else
                           (let ret_wp =
-                             FStar_Compiler_Effect.op_Bar_Greater ed
-                               FStar_Syntax_Util.get_return_vc_combinator in
+                             FStar_Syntax_Util.get_return_vc_combinator ed in
                            let uu___6 =
                              FStar_TypeChecker_Env.inst_effect_fun_with 
                                [u_a] env ed ret_wp in
@@ -784,8 +761,7 @@ let (mk_wp_return :
                              e.FStar_Syntax_Syntax.pos) in
                       mk_comp ed u_a a wp [FStar_Syntax_Syntax.RETURN])) in
               (let uu___1 =
-                 FStar_Compiler_Effect.op_Less_Bar
-                   (FStar_TypeChecker_Env.debug env)
+                 FStar_TypeChecker_Env.debug env
                    (FStar_Options.Other "Return") in
                if uu___1
                then
@@ -829,7 +805,7 @@ let (label_opt :
           | FStar_Pervasives_Native.Some reason1 ->
               let uu___ =
                 let uu___1 = FStar_TypeChecker_Env.should_verify env in
-                FStar_Compiler_Effect.op_Less_Bar Prims.op_Negation uu___1 in
+                Prims.op_Negation uu___1 in
               if uu___
               then f
               else (let uu___2 = reason1 () in label uu___2 r f)
@@ -868,7 +844,7 @@ let (lift_comp :
     fun c ->
       fun lift ->
         let uu___ =
-          FStar_Compiler_Effect.op_Bar_Greater
+          FStar_Syntax_Syntax.mk_Comp
             {
               FStar_Syntax_Syntax.comp_univs =
                 (c.FStar_Syntax_Syntax.comp_univs);
@@ -879,9 +855,8 @@ let (lift_comp :
               FStar_Syntax_Syntax.effect_args =
                 (c.FStar_Syntax_Syntax.effect_args);
               FStar_Syntax_Syntax.flags = []
-            } FStar_Syntax_Syntax.mk_Comp in
-        FStar_Compiler_Effect.op_Bar_Greater uu___
-          (lift.FStar_TypeChecker_Env.mlift_wp env)
+            } in
+        lift.FStar_TypeChecker_Env.mlift_wp env uu___
 let (join_effects :
   FStar_TypeChecker_Env.env ->
     FStar_Ident.lident -> FStar_Ident.lident -> FStar_Ident.lident)
@@ -1090,11 +1065,8 @@ let (close_wp_comp :
               (let env_bvs = FStar_TypeChecker_Env.push_bvs env bvs in
                let close_wp u_res md res_t bvs1 wp0 =
                  let close =
-                   let uu___5 =
-                     FStar_Compiler_Effect.op_Bar_Greater md
-                       FStar_Syntax_Util.get_wp_close_combinator in
-                   FStar_Compiler_Effect.op_Bar_Greater uu___5
-                     FStar_Compiler_Util.must in
+                   let uu___5 = FStar_Syntax_Util.get_wp_close_combinator md in
+                   FStar_Compiler_Util.must uu___5 in
                  FStar_Compiler_List.fold_right
                    (fun x ->
                       fun wp ->
@@ -1140,14 +1112,12 @@ let (close_wp_comp :
                        c1.FStar_Syntax_Syntax.effect_name in
                    let wp1 = close_wp u_res_t md res_t bvs wp in
                    let uu___6 =
-                     FStar_Compiler_Effect.op_Bar_Greater
-                       c1.FStar_Syntax_Syntax.flags
-                       (FStar_Compiler_List.filter
-                          (fun uu___7 ->
-                             match uu___7 with
-                             | FStar_Syntax_Syntax.MLEFFECT -> true
-                             | FStar_Syntax_Syntax.SHOULD_NOT_INLINE -> true
-                             | uu___8 -> false)) in
+                     FStar_Compiler_List.filter
+                       (fun uu___7 ->
+                          match uu___7 with
+                          | FStar_Syntax_Syntax.MLEFFECT -> true
+                          | FStar_Syntax_Syntax.SHOULD_NOT_INLINE -> true
+                          | uu___8 -> false) c1.FStar_Syntax_Syntax.flags in
                    mk_comp md u_res_t c1.FStar_Syntax_Syntax.result_typ wp1
                      uu___6)))
 let (close_wp_lcomp :
@@ -1158,17 +1128,11 @@ let (close_wp_lcomp :
   fun env ->
     fun bvs ->
       fun lc ->
-        let bs =
-          FStar_Compiler_Effect.op_Bar_Greater bvs
-            (FStar_Compiler_List.map FStar_Syntax_Syntax.mk_binder) in
-        FStar_Compiler_Effect.op_Bar_Greater lc
-          (FStar_TypeChecker_Common.apply_lcomp (close_wp_comp env bvs)
-             (fun g ->
-                let uu___ =
-                  FStar_Compiler_Effect.op_Bar_Greater g
-                    (FStar_TypeChecker_Env.close_guard env bs) in
-                FStar_Compiler_Effect.op_Bar_Greater uu___
-                  (close_guard_implicits env false bs)))
+        let bs = FStar_Compiler_List.map FStar_Syntax_Syntax.mk_binder bvs in
+        FStar_TypeChecker_Common.apply_lcomp (close_wp_comp env bvs)
+          (fun g ->
+             let uu___ = FStar_TypeChecker_Env.close_guard env bs g in
+             close_guard_implicits env false bs uu___) lc
 let (substitutive_indexed_close_substs :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.binders ->
@@ -1187,8 +1151,7 @@ let (substitutive_indexed_close_substs :
             fun num_effect_params ->
               fun r ->
                 let debug =
-                  FStar_Compiler_Effect.op_Less_Bar
-                    (FStar_TypeChecker_Env.debug env)
+                  FStar_TypeChecker_Env.debug env
                     (FStar_Options.Other "LayeredEffectsApp") in
                 let uu___ =
                   let uu___1 = close_bs in
@@ -1246,9 +1209,8 @@ let (substitutive_indexed_close_substs :
                                                  let uu___9 =
                                                    let uu___10 =
                                                      let uu___11 =
-                                                       FStar_Compiler_Effect.op_Bar_Greater
-                                                         b_bv
-                                                         FStar_Syntax_Syntax.mk_binder in
+                                                       FStar_Syntax_Syntax.mk_binder
+                                                         b_bv in
                                                      [uu___11] in
                                                    FStar_Syntax_Util.abs
                                                      uu___10 ct_arg
@@ -1283,7 +1245,7 @@ let (close_layered_comp_with_combinator :
                   "mk_indexed_close called with a non-indexed effect") r in
         let close_ts =
           let uu___ = FStar_Syntax_Util.get_layered_close_combinator ed in
-          FStar_Compiler_Effect.op_Bar_Greater uu___ FStar_Compiler_Util.must in
+          FStar_Compiler_Util.must uu___ in
         let effect_args =
           FStar_Compiler_List.fold_right
             (fun x ->
@@ -1340,18 +1302,12 @@ let (close_layered_lcomp_with_combinator :
   fun env ->
     fun bvs ->
       fun lc ->
-        let bs =
-          FStar_Compiler_Effect.op_Bar_Greater bvs
-            (FStar_Compiler_List.map FStar_Syntax_Syntax.mk_binder) in
-        FStar_Compiler_Effect.op_Bar_Greater lc
-          (FStar_TypeChecker_Common.apply_lcomp
-             (close_layered_comp_with_combinator env bvs)
-             (fun g ->
-                let uu___ =
-                  FStar_Compiler_Effect.op_Bar_Greater g
-                    (FStar_TypeChecker_Env.close_guard env bs) in
-                FStar_Compiler_Effect.op_Bar_Greater uu___
-                  (close_guard_implicits env false bs)))
+        let bs = FStar_Compiler_List.map FStar_Syntax_Syntax.mk_binder bvs in
+        FStar_TypeChecker_Common.apply_lcomp
+          (close_layered_comp_with_combinator env bvs)
+          (fun g ->
+             let uu___ = FStar_TypeChecker_Env.close_guard env bs g in
+             close_guard_implicits env false bs uu___) lc
 let (close_layered_lcomp_with_substitutions :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.bv Prims.list ->
@@ -1362,29 +1318,22 @@ let (close_layered_lcomp_with_substitutions :
     fun bvs ->
       fun tms ->
         fun lc ->
-          let bs =
-            FStar_Compiler_Effect.op_Bar_Greater bvs
-              (FStar_Compiler_List.map FStar_Syntax_Syntax.mk_binder) in
+          let bs = FStar_Compiler_List.map FStar_Syntax_Syntax.mk_binder bvs in
           let substs =
             FStar_Compiler_List.map2
               (fun bv -> fun tm -> FStar_Syntax_Syntax.NT (bv, tm)) bvs tms in
-          FStar_Compiler_Effect.op_Bar_Greater lc
-            (FStar_TypeChecker_Common.apply_lcomp
-               (FStar_Syntax_Subst.subst_comp substs)
-               (fun g ->
-                  let uu___ =
-                    FStar_Compiler_Effect.op_Bar_Greater g
-                      (FStar_TypeChecker_Env.close_guard env bs) in
-                  FStar_Compiler_Effect.op_Bar_Greater uu___
-                    (close_guard_implicits env false bs)))
+          FStar_TypeChecker_Common.apply_lcomp
+            (FStar_Syntax_Subst.subst_comp substs)
+            (fun g ->
+               let uu___ = FStar_TypeChecker_Env.close_guard env bs g in
+               close_guard_implicits env false bs uu___) lc
 let (should_not_inline_lc : FStar_TypeChecker_Common.lcomp -> Prims.bool) =
   fun lc ->
-    FStar_Compiler_Effect.op_Bar_Greater lc.FStar_TypeChecker_Common.cflags
-      (FStar_Compiler_Util.for_some
-         (fun uu___ ->
-            match uu___ with
-            | FStar_Syntax_Syntax.SHOULD_NOT_INLINE -> true
-            | uu___1 -> false))
+    FStar_Compiler_Util.for_some
+      (fun uu___ ->
+         match uu___ with
+         | FStar_Syntax_Syntax.SHOULD_NOT_INLINE -> true
+         | uu___1 -> false) lc.FStar_TypeChecker_Common.cflags
 let (should_return :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term FStar_Pervasives_Native.option ->
@@ -1396,41 +1345,30 @@ let (should_return :
         let lc_is_unit_or_effectful =
           let c =
             let uu___ =
-              FStar_Compiler_Effect.op_Bar_Greater
-                lc.FStar_TypeChecker_Common.res_typ
-                FStar_Syntax_Util.arrow_formals_comp in
-            FStar_Compiler_Effect.op_Bar_Greater uu___
-              FStar_Pervasives_Native.snd in
+              FStar_Syntax_Util.arrow_formals_comp
+                lc.FStar_TypeChecker_Common.res_typ in
+            FStar_Pervasives_Native.snd uu___ in
           let uu___ = FStar_TypeChecker_Env.is_reifiable_comp env c in
           if uu___
           then
             let c_eff_name =
-              let uu___1 =
-                FStar_Compiler_Effect.op_Bar_Greater c
-                  FStar_Syntax_Util.comp_effect_name in
-              FStar_Compiler_Effect.op_Bar_Greater uu___1
-                (FStar_TypeChecker_Env.norm_eff_name env) in
+              FStar_TypeChecker_Env.norm_eff_name env
+                (FStar_Syntax_Util.comp_effect_name c) in
             let uu___1 =
               (FStar_TypeChecker_Common.is_pure_or_ghost_lcomp lc) &&
                 (FStar_Ident.lid_equals c_eff_name
                    FStar_Parser_Const.effect_TAC_lid) in
             (if uu___1
              then false
-             else
-               FStar_Compiler_Effect.op_Bar_Greater c_eff_name
-                 (FStar_TypeChecker_Env.is_layered_effect env))
+             else FStar_TypeChecker_Env.is_layered_effect env c_eff_name)
           else
             (let uu___2 = FStar_Syntax_Util.is_pure_or_ghost_comp c in
              if uu___2
              then
                let uu___3 =
-                 let uu___4 =
-                   FStar_Compiler_Effect.op_Bar_Greater c
-                     FStar_Syntax_Util.comp_result in
-                 FStar_Compiler_Effect.op_Bar_Greater uu___4
-                   (FStar_TypeChecker_Normalize.unfold_whnf env) in
-               FStar_Compiler_Effect.op_Bar_Greater uu___3
-                 FStar_Syntax_Util.is_unit
+                 FStar_TypeChecker_Normalize.unfold_whnf env
+                   (FStar_Syntax_Util.comp_result c) in
+               FStar_Syntax_Util.is_unit uu___3
              else true) in
         match eopt with
         | FStar_Pervasives_Native.None -> false
@@ -1482,33 +1420,26 @@ let (substitutive_indexed_bind_substs :
                       fun num_effect_params ->
                         fun has_range_binders ->
                           let debug =
-                            FStar_Compiler_Effect.op_Less_Bar
-                              (FStar_TypeChecker_Env.debug env)
+                            FStar_TypeChecker_Env.debug env
                               (FStar_Options.Other "LayeredEffectsApp") in
                           let bind_name uu___ =
                             if debug
                             then
                               let uu___1 =
                                 let uu___2 =
-                                  FStar_Compiler_Effect.op_Bar_Greater
-                                    m_ed.FStar_Syntax_Syntax.mname
-                                    FStar_Ident.ident_of_lid in
-                                FStar_Compiler_Effect.op_Bar_Greater uu___2
-                                  FStar_Ident.string_of_id in
+                                  FStar_Ident.ident_of_lid
+                                    m_ed.FStar_Syntax_Syntax.mname in
+                                FStar_Ident.string_of_id uu___2 in
                               let uu___2 =
                                 let uu___3 =
-                                  FStar_Compiler_Effect.op_Bar_Greater
-                                    n_ed.FStar_Syntax_Syntax.mname
-                                    FStar_Ident.ident_of_lid in
-                                FStar_Compiler_Effect.op_Bar_Greater uu___3
-                                  FStar_Ident.string_of_id in
+                                  FStar_Ident.ident_of_lid
+                                    n_ed.FStar_Syntax_Syntax.mname in
+                                FStar_Ident.string_of_id uu___3 in
                               let uu___3 =
                                 let uu___4 =
-                                  FStar_Compiler_Effect.op_Bar_Greater
-                                    p_ed.FStar_Syntax_Syntax.mname
-                                    FStar_Ident.ident_of_lid in
-                                FStar_Compiler_Effect.op_Bar_Greater uu___4
-                                  FStar_Ident.string_of_id in
+                                  FStar_Ident.ident_of_lid
+                                    p_ed.FStar_Syntax_Syntax.mname in
+                                FStar_Ident.string_of_id uu___4 in
                               FStar_Compiler_Util.format3 "(%s, %s) |> %s"
                                 uu___1 uu___2 uu___3
                             else "" in
@@ -1520,8 +1451,7 @@ let (substitutive_indexed_bind_substs :
                                   let uu___3 =
                                     FStar_Compiler_List.splitAt
                                       (Prims.of_int (2)) binder_kinds in
-                                  FStar_Compiler_Effect.op_Bar_Greater uu___3
-                                    FStar_Pervasives_Native.snd in
+                                  FStar_Pervasives_Native.snd uu___3 in
                                 (bs1, uu___2,
                                   [FStar_Syntax_Syntax.NT
                                      ((a_b.FStar_Syntax_Syntax.binder_bv),
@@ -1626,9 +1556,7 @@ let (substitutive_indexed_bind_substs :
                                              FStar_Compiler_List.splitAt
                                                m_num_effect_args
                                                binder_kinds2 in
-                                           FStar_Compiler_Effect.op_Bar_Greater
-                                             uu___5
-                                             FStar_Pervasives_Native.snd in
+                                           FStar_Pervasives_Native.snd uu___5 in
                                          (bs3, uu___4,
                                            (FStar_Compiler_List.op_At subst1
                                               f_subst)) in
@@ -1647,9 +1575,8 @@ let (substitutive_indexed_bind_substs :
                                                   FStar_Compiler_List.splitAt
                                                     n_num_effect_args
                                                     binder_kinds3 in
-                                                FStar_Compiler_Effect.op_Bar_Greater
-                                                  uu___5
-                                                  FStar_Pervasives_Native.fst in
+                                                FStar_Pervasives_Native.fst
+                                                  uu___5 in
                                               let x_bv =
                                                 match b with
                                                 | FStar_Pervasives_Native.None
@@ -1680,9 +1607,8 @@ let (substitutive_indexed_bind_substs :
                                                                  let uu___9 =
                                                                    let uu___10
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    x_bv
-                                                                    FStar_Syntax_Syntax.mk_binder in
+                                                                    FStar_Syntax_Syntax.mk_binder
+                                                                    x_bv in
                                                                    [uu___10] in
                                                                  FStar_Syntax_Util.abs
                                                                    uu___9
@@ -1741,22 +1667,17 @@ let (substitutive_indexed_bind_substs :
                                                                     =
                                                                     let uu___13
                                                                     =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    x_bv
-                                                                    FStar_Syntax_Syntax.mk_binder in
+                                                                    FStar_Syntax_Syntax.mk_binder
+                                                                    x_bv in
                                                                     [uu___13] in
                                                                     FStar_TypeChecker_Env.push_binders
                                                                     env
                                                                     uu___12 in
-                                                                    let uu___12
-                                                                    =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    arg
-                                                                    FStar_Pervasives_Native.fst in
                                                                     FStar_TypeChecker_Rel.layered_effect_teq
                                                                     uu___11
                                                                     uv_t
-                                                                    uu___12
+                                                                    (FStar_Pervasives_Native.fst
+                                                                    arg)
                                                                     (FStar_Pervasives_Native.Some
                                                                     "") in
                                                                     let uu___11
@@ -1788,9 +1709,8 @@ let (substitutive_indexed_bind_substs :
                                                  let uu___4 =
                                                    FStar_Compiler_List.splitAt
                                                      (Prims.of_int (2)) bs4 in
-                                                 FStar_Compiler_Effect.op_Bar_Greater
+                                                 FStar_Pervasives_Native.snd
                                                    uu___4
-                                                   FStar_Pervasives_Native.snd
                                                else bs4 in
                                              let bs6 =
                                                let uu___4 =
@@ -1799,9 +1719,8 @@ let (substitutive_indexed_bind_substs :
                                                        bs5)
                                                       - (Prims.of_int (2)))
                                                    bs5 in
-                                               FStar_Compiler_Effect.op_Bar_Greater
-                                                 uu___4
-                                                 FStar_Pervasives_Native.fst in
+                                               FStar_Pervasives_Native.fst
+                                                 uu___4 in
                                              FStar_Compiler_List.fold_left
                                                (fun uu___4 ->
                                                   fun b1 ->
@@ -1868,33 +1787,26 @@ let (ad_hoc_indexed_bind_substs :
                   fun r1 ->
                     fun has_range_binders ->
                       let debug =
-                        FStar_Compiler_Effect.op_Less_Bar
-                          (FStar_TypeChecker_Env.debug env)
+                        FStar_TypeChecker_Env.debug env
                           (FStar_Options.Other "LayeredEffectsApp") in
                       let bind_name uu___ =
                         if debug
                         then
                           let uu___1 =
                             let uu___2 =
-                              FStar_Compiler_Effect.op_Bar_Greater
-                                m_ed.FStar_Syntax_Syntax.mname
-                                FStar_Ident.ident_of_lid in
-                            FStar_Compiler_Effect.op_Bar_Greater uu___2
-                              FStar_Ident.string_of_id in
+                              FStar_Ident.ident_of_lid
+                                m_ed.FStar_Syntax_Syntax.mname in
+                            FStar_Ident.string_of_id uu___2 in
                           let uu___2 =
                             let uu___3 =
-                              FStar_Compiler_Effect.op_Bar_Greater
-                                n_ed.FStar_Syntax_Syntax.mname
-                                FStar_Ident.ident_of_lid in
-                            FStar_Compiler_Effect.op_Bar_Greater uu___3
-                              FStar_Ident.string_of_id in
+                              FStar_Ident.ident_of_lid
+                                n_ed.FStar_Syntax_Syntax.mname in
+                            FStar_Ident.string_of_id uu___3 in
                           let uu___3 =
                             let uu___4 =
-                              FStar_Compiler_Effect.op_Bar_Greater
-                                p_ed.FStar_Syntax_Syntax.mname
-                                FStar_Ident.ident_of_lid in
-                            FStar_Compiler_Effect.op_Bar_Greater uu___4
-                              FStar_Ident.string_of_id in
+                              FStar_Ident.ident_of_lid
+                                p_ed.FStar_Syntax_Syntax.mname in
+                            FStar_Ident.string_of_id uu___4 in
                           FStar_Compiler_Util.format3 "(%s, %s) |> %s" uu___1
                             uu___2 uu___3
                         else "" in
@@ -1923,22 +1835,20 @@ let (ad_hoc_indexed_bind_substs :
                                     (((FStar_Compiler_List.length bs1) -
                                         (Prims.of_int (2)))
                                        - num_range_binders) bs1 in
-                                FStar_Compiler_Effect.op_Bar_Greater uu___3
-                                  (fun uu___4 ->
-                                     match uu___4 with
-                                     | (l1, l2) ->
-                                         let uu___5 =
-                                           FStar_Compiler_List.splitAt
-                                             num_range_binders l2 in
-                                         (match uu___5 with
-                                          | (uu___6, l21) ->
-                                              let uu___7 =
-                                                FStar_Compiler_List.hd l21 in
-                                              let uu___8 =
-                                                let uu___9 =
-                                                  FStar_Compiler_List.tl l21 in
-                                                FStar_Compiler_List.hd uu___9 in
-                                              (l1, uu___7, uu___8))) in
+                                match uu___3 with
+                                | (l1, l2) ->
+                                    let uu___4 =
+                                      FStar_Compiler_List.splitAt
+                                        num_range_binders l2 in
+                                    (match uu___4 with
+                                     | (uu___5, l21) ->
+                                         let uu___6 =
+                                           FStar_Compiler_List.hd l21 in
+                                         let uu___7 =
+                                           let uu___8 =
+                                             FStar_Compiler_List.tl l21 in
+                                           FStar_Compiler_List.hd uu___8 in
+                                         (l1, uu___6, uu___7)) in
                               (match uu___2 with
                                | (rest_bs, f_b, g_b) ->
                                    (a_b, b_b, rest_bs, f_b, g_b))
@@ -1974,48 +1884,45 @@ let (ad_hoc_indexed_bind_substs :
                           (match uu___1 with
                            | (rest_bs_uvars, g_uvars) ->
                                ((let uu___3 =
-                                   FStar_Compiler_Effect.op_Less_Bar
-                                     (FStar_TypeChecker_Env.debug env)
+                                   FStar_TypeChecker_Env.debug env
                                      (FStar_Options.Other
                                         "ResolveImplicitsHook") in
                                  if uu___3
                                  then
-                                   FStar_Compiler_Effect.op_Bar_Greater
-                                     rest_bs_uvars
-                                     (FStar_Compiler_List.iter
-                                        (fun t ->
-                                           let uu___4 =
-                                             let uu___5 =
-                                               FStar_Syntax_Subst.compress t in
-                                             uu___5.FStar_Syntax_Syntax.n in
-                                           match uu___4 with
-                                           | FStar_Syntax_Syntax.Tm_uvar
-                                               (u, uu___5) ->
-                                               let uu___6 =
-                                                 FStar_Syntax_Print.term_to_string
-                                                   t in
-                                               let uu___7 =
-                                                 match u.FStar_Syntax_Syntax.ctx_uvar_meta
-                                                 with
-                                                 | FStar_Pervasives_Native.Some
-                                                     (FStar_Syntax_Syntax.Ctx_uvar_meta_attr
-                                                     a) ->
-                                                     FStar_Syntax_Print.term_to_string
-                                                       a
-                                                 | uu___8 -> "<no attr>" in
-                                               FStar_Compiler_Util.print2
-                                                 "Generated uvar %s with attribute %s\n"
-                                                 uu___6 uu___7
-                                           | uu___5 ->
-                                               let uu___6 =
-                                                 let uu___7 =
-                                                   FStar_Syntax_Print.term_to_string
-                                                     t in
-                                                 Prims.strcat
-                                                   "Impossible, expected a uvar, got : "
-                                                   uu___7 in
-                                               FStar_Compiler_Effect.failwith
-                                                 uu___6))
+                                   FStar_Compiler_List.iter
+                                     (fun t ->
+                                        let uu___4 =
+                                          let uu___5 =
+                                            FStar_Syntax_Subst.compress t in
+                                          uu___5.FStar_Syntax_Syntax.n in
+                                        match uu___4 with
+                                        | FStar_Syntax_Syntax.Tm_uvar
+                                            (u, uu___5) ->
+                                            let uu___6 =
+                                              FStar_Syntax_Print.term_to_string
+                                                t in
+                                            let uu___7 =
+                                              match u.FStar_Syntax_Syntax.ctx_uvar_meta
+                                              with
+                                              | FStar_Pervasives_Native.Some
+                                                  (FStar_Syntax_Syntax.Ctx_uvar_meta_attr
+                                                  a) ->
+                                                  FStar_Syntax_Print.term_to_string
+                                                    a
+                                              | uu___8 -> "<no attr>" in
+                                            FStar_Compiler_Util.print2
+                                              "Generated uvar %s with attribute %s\n"
+                                              uu___6 uu___7
+                                        | uu___5 ->
+                                            let uu___6 =
+                                              let uu___7 =
+                                                FStar_Syntax_Print.term_to_string
+                                                  t in
+                                              Prims.strcat
+                                                "Impossible, expected a uvar, got : "
+                                                uu___7 in
+                                            FStar_Compiler_Effect.failwith
+                                              uu___6) rest_bs_uvars
                                  else ());
                                 (let subst =
                                    FStar_Compiler_List.map2
@@ -2036,10 +1943,9 @@ let (ad_hoc_indexed_bind_substs :
                                        let uu___5 =
                                          FStar_Syntax_Util.is_layered m_ed in
                                        effect_args_from_repr uu___4 uu___5 r1 in
-                                     FStar_Compiler_Effect.op_Bar_Greater
-                                       uu___3
-                                       (FStar_Compiler_List.map
-                                          (FStar_Syntax_Subst.subst subst)) in
+                                     FStar_Compiler_List.map
+                                       (FStar_Syntax_Subst.subst subst)
+                                       uu___3 in
                                    let uu___3 =
                                      FStar_Compiler_List.map
                                        FStar_Pervasives_Native.fst
@@ -2049,9 +1955,8 @@ let (ad_hoc_indexed_bind_substs :
                                         fun i1 ->
                                           fun f_i1 ->
                                             (let uu___5 =
-                                               FStar_Compiler_Effect.op_Less_Bar
-                                                 (FStar_TypeChecker_Env.debug
-                                                    env)
+                                               FStar_TypeChecker_Env.debug
+                                                 env
                                                  (FStar_Options.Other
                                                     "ResolveImplicitsHook") in
                                              if uu___5
@@ -2116,9 +2021,8 @@ let (ad_hoc_indexed_bind_substs :
                                                         bs2 in
                                                     uu___7.FStar_Syntax_Syntax.binder_bv in
                                                   let uu___7 =
-                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                      x_a.FStar_Syntax_Syntax.binder_bv
-                                                      FStar_Syntax_Syntax.bv_to_name in
+                                                    FStar_Syntax_Syntax.bv_to_name
+                                                      x_a.FStar_Syntax_Syntax.binder_bv in
                                                   (uu___6, uu___7) in
                                                 FStar_Syntax_Syntax.NT uu___5 in
                                               let c2 =
@@ -2134,11 +2038,9 @@ let (ad_hoc_indexed_bind_substs :
                                                     n_ed in
                                                 effect_args_from_repr uu___6
                                                   uu___7 r1 in
-                                              FStar_Compiler_Effect.op_Bar_Greater
-                                                uu___5
-                                                (FStar_Compiler_List.map
-                                                   (FStar_Syntax_Subst.subst
-                                                      subst)))
+                                              FStar_Compiler_List.map
+                                                (FStar_Syntax_Subst.subst
+                                                   subst) uu___5)
                                      | uu___4 ->
                                          FStar_Compiler_Effect.failwith
                                            "impossible: mk_indexed_bind" in
@@ -2155,9 +2057,8 @@ let (ad_hoc_indexed_bind_substs :
                                           fun i1 ->
                                             fun g_i1 ->
                                               (let uu___6 =
-                                                 FStar_Compiler_Effect.op_Less_Bar
-                                                   (FStar_TypeChecker_Env.debug
-                                                      env)
+                                                 FStar_TypeChecker_Env.debug
+                                                   env
                                                    (FStar_Options.Other
                                                       "ResolveImplicitsHook") in
                                                if uu___6
@@ -2183,10 +2084,8 @@ let (ad_hoc_indexed_bind_substs :
                                                  g uu___6))
                                        FStar_TypeChecker_Env.trivial_guard
                                        uu___4 g_sort_is in
-                                   FStar_Compiler_Effect.op_Bar_Greater
-                                     uu___3
-                                     (FStar_TypeChecker_Env.close_guard env
-                                        [x_a]) in
+                                   FStar_TypeChecker_Env.close_guard env
+                                     [x_a] uu___3 in
                                  let uu___3 =
                                    FStar_TypeChecker_Env.conj_guards
                                      [g_uvars; f_guard; g_guard] in
@@ -2207,8 +2106,7 @@ let (mk_indexed_return :
           fun e ->
             fun r ->
               let debug =
-                FStar_Compiler_Effect.op_Less_Bar
-                  (FStar_TypeChecker_Env.debug env)
+                FStar_TypeChecker_Env.debug env
                   (FStar_Options.Other "LayeredEffectsApp") in
               if debug
               then
@@ -2222,9 +2120,7 @@ let (mk_indexed_return :
                    uu___2 uu___3 uu___4)
               else ();
               (let uu___1 =
-                 let uu___2 =
-                   FStar_Compiler_Effect.op_Bar_Greater ed
-                     FStar_Syntax_Util.get_return_vc_combinator in
+                 let uu___2 = FStar_Syntax_Util.get_return_vc_combinator ed in
                  FStar_TypeChecker_Env.inst_tscheme_with uu___2 [u_a] in
                match uu___1 with
                | (uu___2, return_t) ->
@@ -2302,15 +2198,13 @@ let (mk_indexed_return :
                                    FStar_Syntax_Subst.compress return_typ in
                                  let uu___7 = FStar_Syntax_Util.is_layered ed in
                                  effect_args_from_repr uu___6 uu___7 r in
-                               FStar_Compiler_Effect.op_Bar_Greater uu___5
-                                 (FStar_Compiler_List.map
-                                    (FStar_Syntax_Subst.subst subst)) in
+                               FStar_Compiler_List.map
+                                 (FStar_Syntax_Subst.subst subst) uu___5 in
                              let c =
                                let uu___5 =
                                  let uu___6 =
-                                   FStar_Compiler_Effect.op_Bar_Greater is
-                                     (FStar_Compiler_List.map
-                                        FStar_Syntax_Syntax.as_arg) in
+                                   FStar_Compiler_List.map
+                                     FStar_Syntax_Syntax.as_arg is in
                                  {
                                    FStar_Syntax_Syntax.comp_univs = [u_a];
                                    FStar_Syntax_Syntax.effect_name =
@@ -2359,8 +2253,7 @@ let (mk_indexed_bind :
                         fun num_effect_params ->
                           fun has_range_binders ->
                             let debug =
-                              FStar_Compiler_Effect.op_Less_Bar
-                                (FStar_TypeChecker_Env.debug env)
+                              FStar_TypeChecker_Env.debug env
                                 (FStar_Options.Other "LayeredEffectsApp") in
                             if debug
                             then
@@ -2375,8 +2268,7 @@ let (mk_indexed_bind :
                                  uu___1 uu___2)
                             else ();
                             (let uu___2 =
-                               FStar_Compiler_Effect.op_Less_Bar
-                                 (FStar_TypeChecker_Env.debug env)
+                               FStar_TypeChecker_Env.debug env
                                  (FStar_Options.Other "ResolveImplicitsHook") in
                              if uu___2
                              then
@@ -2404,25 +2296,19 @@ let (mk_indexed_bind :
                                  let bind_name uu___3 =
                                    let uu___4 =
                                      let uu___5 =
-                                       FStar_Compiler_Effect.op_Bar_Greater
-                                         m_ed.FStar_Syntax_Syntax.mname
-                                         FStar_Ident.ident_of_lid in
-                                     FStar_Compiler_Effect.op_Bar_Greater
-                                       uu___5 FStar_Ident.string_of_id in
+                                       FStar_Ident.ident_of_lid
+                                         m_ed.FStar_Syntax_Syntax.mname in
+                                     FStar_Ident.string_of_id uu___5 in
                                    let uu___5 =
                                      let uu___6 =
-                                       FStar_Compiler_Effect.op_Bar_Greater
-                                         n_ed.FStar_Syntax_Syntax.mname
-                                         FStar_Ident.ident_of_lid in
-                                     FStar_Compiler_Effect.op_Bar_Greater
-                                       uu___6 FStar_Ident.string_of_id in
+                                       FStar_Ident.ident_of_lid
+                                         n_ed.FStar_Syntax_Syntax.mname in
+                                     FStar_Ident.string_of_id uu___6 in
                                    let uu___6 =
                                      let uu___7 =
-                                       FStar_Compiler_Effect.op_Bar_Greater
-                                         p_ed.FStar_Syntax_Syntax.mname
-                                         FStar_Ident.ident_of_lid in
-                                     FStar_Compiler_Effect.op_Bar_Greater
-                                       uu___7 FStar_Ident.string_of_id in
+                                       FStar_Ident.ident_of_lid
+                                         p_ed.FStar_Syntax_Syntax.mname in
+                                     FStar_Ident.string_of_id uu___7 in
                                    FStar_Compiler_Util.format3
                                      "(%s, %s) |> %s" uu___4 uu___5 uu___6 in
                                  ((let uu___4 =
@@ -2512,14 +2398,10 @@ let (mk_indexed_bind :
                                              | (subst, g) ->
                                                  let bind_ct =
                                                    let uu___8 =
-                                                     FStar_Compiler_Effect.op_Bar_Greater
-                                                       bind_c
-                                                       (FStar_Syntax_Subst.subst_comp
-                                                          subst) in
-                                                   FStar_Compiler_Effect.op_Bar_Greater
-                                                     uu___8
-                                                     (FStar_TypeChecker_Env.comp_to_comp_typ
-                                                        env) in
+                                                     FStar_Syntax_Subst.subst_comp
+                                                       subst bind_c in
+                                                   FStar_TypeChecker_Env.comp_to_comp_typ
+                                                     env uu___8 in
                                                  let fml =
                                                    let uu___8 =
                                                      let uu___9 =
@@ -2592,9 +2474,8 @@ let (mk_indexed_bind :
                                                      FStar_TypeChecker_Env.conj_guards
                                                        uu___9 in
                                                    (let uu___10 =
-                                                      FStar_Compiler_Effect.op_Less_Bar
-                                                        (FStar_TypeChecker_Env.debug
-                                                           env)
+                                                      FStar_TypeChecker_Env.debug
+                                                        env
                                                         (FStar_Options.Other
                                                            "ResolveImplicitsHook") in
                                                     if uu___10
@@ -2668,9 +2549,7 @@ let (mk_wp_bind :
                           uu___5 :: uu___6 in
                         uu___3 :: uu___4 in
                       uu___1 :: uu___2 in
-                    let uu___1 =
-                      FStar_Compiler_Effect.op_Bar_Greater md
-                        FStar_Syntax_Util.get_bind_vc_combinator in
+                    let uu___1 = FStar_Syntax_Util.get_bind_vc_combinator md in
                     (match uu___1 with
                      | (bind_wp, uu___2) ->
                          let wp =
@@ -2732,9 +2611,8 @@ let (mk_bind :
                                    if uu___5
                                    then
                                      let m_ed =
-                                       FStar_Compiler_Effect.op_Bar_Greater m
-                                         (FStar_TypeChecker_Env.get_effect_decl
-                                            env) in
+                                       FStar_TypeChecker_Env.get_effect_decl
+                                         env m in
                                      let num_effect_params =
                                        match m_ed.FStar_Syntax_Syntax.signature
                                        with
@@ -2744,9 +2622,8 @@ let (mk_bind :
                                            FStar_Compiler_Effect.failwith
                                              "Impossible (mk_bind expected an indexed effect)" in
                                      let uu___6 =
-                                       FStar_Compiler_Effect.op_Bar_Greater
-                                         m_ed
-                                         FStar_Syntax_Util.get_bind_vc_combinator in
+                                       FStar_Syntax_Util.get_bind_vc_combinator
+                                         m_ed in
                                      match uu___6 with
                                      | (bind_t, bind_kind) ->
                                          let has_range_args =
@@ -2754,9 +2631,7 @@ let (mk_bind :
                                              m_ed.FStar_Syntax_Syntax.eff_attrs
                                              FStar_Parser_Const.bind_has_range_args_attr in
                                          let uu___7 =
-                                           FStar_Compiler_Effect.op_Bar_Greater
-                                             bind_kind
-                                             FStar_Compiler_Util.must in
+                                           FStar_Compiler_Util.must bind_kind in
                                          mk_indexed_bind env m m m bind_t
                                            uu___7 ct11 b ct21 flags r1
                                            num_effect_params has_range_args
@@ -2801,17 +2676,14 @@ let (strengthen_comp :
                  let uu___2 =
                    let uu___3 =
                      let uu___4 = label_opt env reason r f in
-                     FStar_Compiler_Effect.op_Less_Bar
-                       FStar_Syntax_Syntax.as_arg uu___4 in
+                     FStar_Syntax_Syntax.as_arg uu___4 in
                    [uu___3] in
                  FStar_Syntax_Syntax.mk_Tm_app pure_assert_wp uu___2 r in
                let r1 = FStar_TypeChecker_Env.get_range env in
                let pure_c =
                  let uu___2 =
                    let uu___3 =
-                     let uu___4 =
-                       FStar_Compiler_Effect.op_Bar_Greater pure_assert_wp1
-                         FStar_Syntax_Syntax.as_arg in
+                     let uu___4 = FStar_Syntax_Syntax.as_arg pure_assert_wp1 in
                      [uu___4] in
                    {
                      FStar_Syntax_Syntax.comp_univs =
@@ -2840,9 +2712,7 @@ let (mk_return :
         fun a ->
           fun e ->
             fun r ->
-              let uu___ =
-                FStar_Compiler_Effect.op_Bar_Greater ed
-                  FStar_Syntax_Util.is_layered in
+              let uu___ = FStar_Syntax_Util.is_layered ed in
               if uu___
               then mk_indexed_return env ed u_a a e r
               else
@@ -2874,25 +2744,23 @@ let (weaken_flags :
   =
   fun flags ->
     let uu___ =
-      FStar_Compiler_Effect.op_Bar_Greater flags
-        (FStar_Compiler_Util.for_some
-           (fun uu___1 ->
-              match uu___1 with
-              | FStar_Syntax_Syntax.SHOULD_NOT_INLINE -> true
-              | uu___2 -> false)) in
+      FStar_Compiler_Util.for_some
+        (fun uu___1 ->
+           match uu___1 with
+           | FStar_Syntax_Syntax.SHOULD_NOT_INLINE -> true
+           | uu___2 -> false) flags in
     if uu___
     then [FStar_Syntax_Syntax.SHOULD_NOT_INLINE]
     else
-      FStar_Compiler_Effect.op_Bar_Greater flags
-        (FStar_Compiler_List.collect
-           (fun uu___2 ->
-              match uu___2 with
-              | FStar_Syntax_Syntax.TOTAL ->
-                  [FStar_Syntax_Syntax.TRIVIAL_POSTCONDITION]
-              | FStar_Syntax_Syntax.RETURN ->
-                  [FStar_Syntax_Syntax.PARTIAL_RETURN;
-                  FStar_Syntax_Syntax.TRIVIAL_POSTCONDITION]
-              | f -> [f]))
+      FStar_Compiler_List.collect
+        (fun uu___2 ->
+           match uu___2 with
+           | FStar_Syntax_Syntax.TOTAL ->
+               [FStar_Syntax_Syntax.TRIVIAL_POSTCONDITION]
+           | FStar_Syntax_Syntax.RETURN ->
+               [FStar_Syntax_Syntax.PARTIAL_RETURN;
+               FStar_Syntax_Syntax.TRIVIAL_POSTCONDITION]
+           | f -> [f]) flags
 let (weaken_comp :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.comp ->
@@ -2915,19 +2783,14 @@ let (weaken_comp :
              FStar_Syntax_Syntax.fv_to_tm uu___2 in
            let pure_assume_wp1 =
              let uu___2 =
-               let uu___3 =
-                 FStar_Compiler_Effect.op_Less_Bar FStar_Syntax_Syntax.as_arg
-                   formula in
-               [uu___3] in
+               let uu___3 = FStar_Syntax_Syntax.as_arg formula in [uu___3] in
              let uu___3 = FStar_TypeChecker_Env.get_range env in
              FStar_Syntax_Syntax.mk_Tm_app pure_assume_wp uu___2 uu___3 in
            let r = FStar_TypeChecker_Env.get_range env in
            let pure_c =
              let uu___2 =
                let uu___3 =
-                 let uu___4 =
-                   FStar_Compiler_Effect.op_Bar_Greater pure_assume_wp1
-                     FStar_Syntax_Syntax.as_arg in
+                 let uu___4 = FStar_Syntax_Syntax.as_arg pure_assume_wp1 in
                  [uu___4] in
                {
                  FStar_Syntax_Syntax.comp_univs =
@@ -2999,25 +2862,23 @@ let (strengthen_precondition :
                  match uu___2 with
                  | (maybe_trivial_post, flags1) ->
                      let uu___3 =
-                       FStar_Compiler_Effect.op_Bar_Greater
-                         lc.FStar_TypeChecker_Common.cflags
-                         (FStar_Compiler_List.collect
-                            (fun uu___4 ->
-                               match uu___4 with
-                               | FStar_Syntax_Syntax.RETURN ->
-                                   [FStar_Syntax_Syntax.PARTIAL_RETURN]
-                               | FStar_Syntax_Syntax.PARTIAL_RETURN ->
-                                   [FStar_Syntax_Syntax.PARTIAL_RETURN]
-                               | FStar_Syntax_Syntax.SOMETRIVIAL when
-                                   Prims.op_Negation maybe_trivial_post ->
-                                   [FStar_Syntax_Syntax.TRIVIAL_POSTCONDITION]
-                               | FStar_Syntax_Syntax.TRIVIAL_POSTCONDITION
-                                   when Prims.op_Negation maybe_trivial_post
-                                   ->
-                                   [FStar_Syntax_Syntax.TRIVIAL_POSTCONDITION]
-                               | FStar_Syntax_Syntax.SHOULD_NOT_INLINE ->
-                                   [FStar_Syntax_Syntax.SHOULD_NOT_INLINE]
-                               | uu___5 -> [])) in
+                       FStar_Compiler_List.collect
+                         (fun uu___4 ->
+                            match uu___4 with
+                            | FStar_Syntax_Syntax.RETURN ->
+                                [FStar_Syntax_Syntax.PARTIAL_RETURN]
+                            | FStar_Syntax_Syntax.PARTIAL_RETURN ->
+                                [FStar_Syntax_Syntax.PARTIAL_RETURN]
+                            | FStar_Syntax_Syntax.SOMETRIVIAL when
+                                Prims.op_Negation maybe_trivial_post ->
+                                [FStar_Syntax_Syntax.TRIVIAL_POSTCONDITION]
+                            | FStar_Syntax_Syntax.TRIVIAL_POSTCONDITION when
+                                Prims.op_Negation maybe_trivial_post ->
+                                [FStar_Syntax_Syntax.TRIVIAL_POSTCONDITION]
+                            | FStar_Syntax_Syntax.SHOULD_NOT_INLINE ->
+                                [FStar_Syntax_Syntax.SHOULD_NOT_INLINE]
+                            | uu___5 -> [])
+                         lc.FStar_TypeChecker_Common.cflags in
                      FStar_Compiler_List.op_At flags1 uu___3 in
                let strengthen uu___2 =
                  let uu___3 = FStar_TypeChecker_Common.lcomp_comp lc in
@@ -3032,8 +2893,7 @@ let (strengthen_precondition :
                         | FStar_TypeChecker_Common.Trivial -> (c, g_c)
                         | FStar_TypeChecker_Common.NonTrivial f ->
                             ((let uu___7 =
-                                FStar_Compiler_Effect.op_Less_Bar
-                                  (FStar_TypeChecker_Env.debug env)
+                                FStar_TypeChecker_Env.debug env
                                   FStar_Options.Extreme in
                               if uu___7
                               then
@@ -3111,13 +2971,9 @@ let (maybe_capture_unit_refinement :
               then
                 let uu___ =
                   let uu___1 =
-                    let uu___2 =
-                      FStar_Compiler_Effect.op_Bar_Greater c
-                        FStar_Syntax_Util.comp_effect_name in
-                    FStar_Compiler_Effect.op_Bar_Greater uu___2
-                      (FStar_TypeChecker_Env.norm_eff_name env) in
-                  FStar_Compiler_Effect.op_Bar_Greater uu___1
-                    (FStar_TypeChecker_Env.is_layered_effect env) in
+                    FStar_TypeChecker_Env.norm_eff_name env
+                      (FStar_Syntax_Util.comp_effect_name c) in
+                  FStar_TypeChecker_Env.is_layered_effect env uu___1 in
                 (if uu___
                  then
                    let uu___1 = FStar_Syntax_Subst.open_term_bv b phi in
@@ -3151,8 +3007,7 @@ let (bind :
                   let uu___1 =
                     (FStar_TypeChecker_Env.debug env FStar_Options.Extreme)
                       ||
-                      (FStar_Compiler_Effect.op_Less_Bar
-                         (FStar_TypeChecker_Env.debug env)
+                      (FStar_TypeChecker_Env.debug env
                          (FStar_Options.Other "bind")) in
                   if uu___1 then f () else () in
                 let uu___1 =
@@ -3346,14 +3201,11 @@ let (bind :
                                                x) ->
                                                 let uu___12 =
                                                   let uu___13 =
-                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                      c2
-                                                      (FStar_Syntax_Subst.subst_comp
-                                                         [FStar_Syntax_Syntax.NT
-                                                            (x, e)]) in
-                                                  FStar_Compiler_Effect.op_Bar_Greater
-                                                    uu___13
-                                                    (close_with_type_of_x x) in
+                                                    FStar_Syntax_Subst.subst_comp
+                                                      [FStar_Syntax_Syntax.NT
+                                                         (x, e)] c2 in
+                                                  close_with_type_of_x x
+                                                    uu___13 in
                                                 (match uu___12 with
                                                  | (c21, g_close) ->
                                                      let uu___13 =
@@ -3380,9 +3232,7 @@ let (bind :
                                                FStar_Pervasives_Native.Some
                                                x) ->
                                                 let uu___13 =
-                                                  FStar_Compiler_Effect.op_Bar_Greater
-                                                    c2
-                                                    (close_with_type_of_x x) in
+                                                  close_with_type_of_x x c2 in
                                                 (match uu___13 with
                                                  | (c21, g_close) ->
                                                      let uu___14 =
@@ -3623,14 +3473,11 @@ let (assume_result_eq_pure_term_in_m :
         fun lc ->
           let m =
             let uu___ =
-              (FStar_Compiler_Effect.op_Bar_Greater m_opt
-                 FStar_Compiler_Util.is_none)
-                || (is_ghost_effect env lc.FStar_TypeChecker_Common.eff_name) in
+              (FStar_Compiler_Util.is_none m_opt) ||
+                (is_ghost_effect env lc.FStar_TypeChecker_Common.eff_name) in
             if uu___
             then FStar_Parser_Const.effect_PURE_lid
-            else
-              FStar_Compiler_Effect.op_Bar_Greater m_opt
-                FStar_Compiler_Util.must in
+            else FStar_Compiler_Util.must m_opt in
           let flags =
             let uu___ = FStar_TypeChecker_Common.is_total_lcomp lc in
             if uu___
@@ -3702,8 +3549,7 @@ let (assume_result_eq_pure_term_in_m :
                          let uu___5 =
                            FStar_TypeChecker_Env.comp_set_flags env_x ret
                              [FStar_Syntax_Syntax.PARTIAL_RETURN] in
-                         FStar_Compiler_Effect.op_Less_Bar
-                           FStar_TypeChecker_Common.lcomp_of_comp uu___5 in
+                         FStar_TypeChecker_Common.lcomp_of_comp uu___5 in
                        let eq = FStar_Syntax_Util.mk_eq2 u_t t xexp e in
                        let eq_ret =
                          weaken_precondition env_x ret1
@@ -3811,22 +3657,16 @@ let (maybe_return_e2_and_bind :
                               &&
                               (let uu___3 =
                                  FStar_TypeChecker_Env.join_opt env eff1 eff2 in
-                               FStar_Compiler_Effect.op_Bar_Greater uu___3
-                                 FStar_Compiler_Util.is_none))
+                               FStar_Compiler_Util.is_none uu___3))
                              &&
                              (let uu___3 =
                                 FStar_TypeChecker_Env.exists_polymonadic_bind
                                   env eff1 eff2 in
-                              FStar_Compiler_Effect.op_Bar_Greater uu___3
-                                FStar_Compiler_Util.is_none) in
+                              FStar_Compiler_Util.is_none uu___3) in
                          if uu___2
                          then
-                           let uu___3 =
-                             FStar_Compiler_Effect.op_Bar_Greater eff1
-                               (fun uu___4 ->
-                                  FStar_Pervasives_Native.Some uu___4) in
-                           assume_result_eq_pure_term_in_m env_x uu___3 e2
-                             lc21
+                           assume_result_eq_pure_term_in_m env_x
+                             (FStar_Pervasives_Native.Some eff1) e2 lc21
                          else
                            (let uu___4 =
                               ((let uu___5 = is_pure_or_ghost_effect env eff1 in
@@ -3835,12 +3675,8 @@ let (maybe_return_e2_and_bind :
                                 && (is_pure_or_ghost_effect env eff2) in
                             if uu___4
                             then
-                              let uu___5 =
-                                FStar_Compiler_Effect.op_Bar_Greater eff1
-                                  (fun uu___6 ->
-                                     FStar_Pervasives_Native.Some uu___6) in
                               maybe_assume_result_eq_pure_term_in_m env_x
-                                uu___5 e2 lc21
+                                (FStar_Pervasives_Native.Some eff1) e2 lc21
                             else lc21) in
                        bind r env e1opt lc11 (x, lc22))
 let (fvar_env :
@@ -3875,8 +3711,7 @@ let (substitutive_indexed_ite_substs :
                 fun num_effect_params ->
                   fun r ->
                     let debug =
-                      FStar_Compiler_Effect.op_Less_Bar
-                        (FStar_TypeChecker_Env.debug env)
+                      FStar_TypeChecker_Env.debug env
                         (FStar_Options.Other "LayeredEffectsApp") in
                     let uu___ =
                       let uu___1 = bs in
@@ -4095,8 +3930,7 @@ let (ad_hoc_indexed_ite_substs :
             fun ct_else ->
               fun r ->
                 let debug =
-                  FStar_Compiler_Effect.op_Less_Bar
-                    (FStar_TypeChecker_Env.debug env)
+                  FStar_TypeChecker_Env.debug env
                     (FStar_Options.Other "LayeredEffectsApp") in
                 let conjunction_name uu___ =
                   if debug
@@ -4148,8 +3982,7 @@ let (ad_hoc_indexed_ite_substs :
                                FStar_Ident.string_of_lid
                                  ct_then.FStar_Syntax_Syntax.effect_name in
                              let uu___4 =
-                               FStar_Compiler_Effect.op_Bar_Greater r
-                                 FStar_Compiler_Range_Ops.string_of_range in
+                               FStar_Compiler_Range_Ops.string_of_range r in
                              FStar_Compiler_Util.format3
                                "implicit var for binder %s of %s:conjunction at %s"
                                uu___2 uu___3 uu___4
@@ -4178,12 +4011,10 @@ let (ad_hoc_indexed_ite_substs :
                                    FStar_Syntax_Syntax.args = uu___4::is;_}
                                  ->
                                  let uu___5 =
-                                   FStar_Compiler_Effect.op_Bar_Greater is
-                                     (FStar_Compiler_List.map
-                                        FStar_Pervasives_Native.fst) in
-                                 FStar_Compiler_Effect.op_Bar_Greater uu___5
-                                   (FStar_Compiler_List.map
-                                      (FStar_Syntax_Subst.subst substs))
+                                   FStar_Compiler_List.map
+                                     FStar_Pervasives_Native.fst is in
+                                 FStar_Compiler_List.map
+                                   (FStar_Syntax_Subst.subst substs) uu___5
                              | uu___3 ->
                                  let uu___4 =
                                    conjunction_t_error
@@ -4219,12 +4050,10 @@ let (ad_hoc_indexed_ite_substs :
                                    FStar_Syntax_Syntax.args = uu___4::is;_}
                                  ->
                                  let uu___5 =
-                                   FStar_Compiler_Effect.op_Bar_Greater is
-                                     (FStar_Compiler_List.map
-                                        FStar_Pervasives_Native.fst) in
-                                 FStar_Compiler_Effect.op_Bar_Greater uu___5
-                                   (FStar_Compiler_List.map
-                                      (FStar_Syntax_Subst.subst substs))
+                                   FStar_Compiler_List.map
+                                     FStar_Pervasives_Native.fst is in
+                                 FStar_Compiler_List.map
+                                   (FStar_Syntax_Subst.subst substs) uu___5
                              | uu___3 ->
                                  let uu___4 =
                                    conjunction_t_error
@@ -4271,8 +4100,7 @@ let (mk_layered_conjunction :
               fun ct2 ->
                 fun r ->
                   let debug =
-                    FStar_Compiler_Effect.op_Less_Bar
-                      (FStar_TypeChecker_Env.debug env)
+                    FStar_TypeChecker_Env.debug env
                       (FStar_Options.Other "LayeredEffectsApp") in
                   let conjunction_t_error s =
                     let uu___ =
@@ -4286,19 +4114,16 @@ let (mk_layered_conjunction :
                   let uu___ =
                     let uu___1 =
                       let uu___2 =
-                        FStar_Compiler_Effect.op_Bar_Greater ed
-                          FStar_Syntax_Util.get_layered_if_then_else_combinator in
-                      FStar_Compiler_Effect.op_Bar_Greater uu___2
-                        FStar_Compiler_Util.must in
+                        FStar_Syntax_Util.get_layered_if_then_else_combinator
+                          ed in
+                      FStar_Compiler_Util.must uu___2 in
                     match uu___1 with
                     | (ts, kopt) ->
                         let uu___2 =
                           FStar_TypeChecker_Env.inst_tscheme_with ts [u_a] in
                         (match uu___2 with
                          | (uu___3, conjunction) ->
-                             let uu___4 =
-                               FStar_Compiler_Effect.op_Bar_Greater kopt
-                                 FStar_Compiler_Util.must in
+                             let uu___4 = FStar_Compiler_Util.must kopt in
                              (conjunction, uu___4)) in
                   match uu___ with
                   | (conjunction, kind) ->
@@ -4308,17 +4133,11 @@ let (mk_layered_conjunction :
                            (if debug
                             then
                               (let uu___4 =
-                                 let uu___5 =
-                                   FStar_Compiler_Effect.op_Bar_Greater ct1
-                                     FStar_Syntax_Syntax.mk_Comp in
-                                 FStar_Compiler_Effect.op_Bar_Greater uu___5
-                                   FStar_Syntax_Print.comp_to_string in
+                                 let uu___5 = FStar_Syntax_Syntax.mk_Comp ct1 in
+                                 FStar_Syntax_Print.comp_to_string uu___5 in
                                let uu___5 =
-                                 let uu___6 =
-                                   FStar_Compiler_Effect.op_Bar_Greater ct2
-                                     FStar_Syntax_Syntax.mk_Comp in
-                                 FStar_Compiler_Effect.op_Bar_Greater uu___6
-                                   FStar_Syntax_Print.comp_to_string in
+                                 let uu___6 = FStar_Syntax_Syntax.mk_Comp ct2 in
+                                 FStar_Syntax_Print.comp_to_string uu___6 in
                                FStar_Compiler_Util.print2
                                  "layered_ite c1: %s and c2: %s {\n" uu___4
                                  uu___5)
@@ -4364,10 +4183,8 @@ let (mk_layered_conjunction :
                                  let c =
                                    let uu___5 =
                                      let uu___6 =
-                                       FStar_Compiler_Effect.op_Bar_Greater
-                                         is
-                                         (FStar_Compiler_List.map
-                                            FStar_Syntax_Syntax.as_arg) in
+                                       FStar_Compiler_List.map
+                                         FStar_Syntax_Syntax.as_arg is in
                                      {
                                        FStar_Syntax_Syntax.comp_univs = [u_a];
                                        FStar_Syntax_Syntax.effect_name =
@@ -4405,10 +4222,8 @@ let (mk_non_layered_conjunction :
                   let p1 = FStar_Syntax_Util.b2t p in
                   let if_then_else =
                     let uu___1 =
-                      FStar_Compiler_Effect.op_Bar_Greater ed
-                        FStar_Syntax_Util.get_wp_if_then_else_combinator in
-                    FStar_Compiler_Effect.op_Bar_Greater uu___1
-                      FStar_Compiler_Util.must in
+                      FStar_Syntax_Util.get_wp_if_then_else_combinator ed in
+                    FStar_Compiler_Util.must uu___1 in
                   let uu___1 = destruct_wp_comp ct1 in
                   match uu___1 with
                   | (uu___2, uu___3, wp_t) ->
@@ -4482,32 +4297,24 @@ let (get_neg_branch_conds :
     let uu___ =
       let uu___1 =
         let uu___2 =
-          FStar_Compiler_Effect.op_Bar_Greater branch_conds
-            (FStar_Compiler_List.fold_left
-               (fun uu___3 ->
-                  fun g ->
-                    match uu___3 with
-                    | (conds, acc) ->
-                        let cond =
-                          let uu___4 =
-                            let uu___5 =
-                              FStar_Compiler_Effect.op_Bar_Greater g
-                                FStar_Syntax_Util.b2t in
-                            FStar_Compiler_Effect.op_Bar_Greater uu___5
-                              FStar_Syntax_Util.mk_neg in
-                          FStar_Syntax_Util.mk_conj acc uu___4 in
-                        ((FStar_Compiler_List.op_At conds [cond]), cond))
-               ([FStar_Syntax_Util.t_true], FStar_Syntax_Util.t_true)) in
-        FStar_Compiler_Effect.op_Bar_Greater uu___2
-          FStar_Pervasives_Native.fst in
-      FStar_Compiler_Effect.op_Bar_Greater uu___1
-        (fun l ->
-           FStar_Compiler_List.splitAt
-             ((FStar_Compiler_List.length l) - Prims.int_one) l) in
-    FStar_Compiler_Effect.op_Bar_Greater uu___
-      (fun uu___1 ->
-         match uu___1 with
-         | (l1, l2) -> let uu___2 = FStar_Compiler_List.hd l2 in (l1, uu___2))
+          FStar_Compiler_List.fold_left
+            (fun uu___3 ->
+               fun g ->
+                 match uu___3 with
+                 | (conds, acc) ->
+                     let cond =
+                       let uu___4 =
+                         let uu___5 = FStar_Syntax_Util.b2t g in
+                         FStar_Syntax_Util.mk_neg uu___5 in
+                       FStar_Syntax_Util.mk_conj acc uu___4 in
+                     ((FStar_Compiler_List.op_At conds [cond]), cond))
+            ([FStar_Syntax_Util.t_true], FStar_Syntax_Util.t_true)
+            branch_conds in
+        FStar_Pervasives_Native.fst uu___2 in
+      FStar_Compiler_List.splitAt
+        ((FStar_Compiler_List.length uu___1) - Prims.int_one) uu___1 in
+    match uu___ with
+    | (l1, l2) -> let uu___1 = FStar_Compiler_List.hd l2 in (l1, uu___1)
 let (bind_cases :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.typ ->
@@ -4522,9 +4329,7 @@ let (bind_cases :
         fun scrutinee ->
           let env =
             let uu___ =
-              let uu___1 =
-                FStar_Compiler_Effect.op_Bar_Greater scrutinee
-                  FStar_Syntax_Syntax.mk_binder in
+              let uu___1 = FStar_Syntax_Syntax.mk_binder scrutinee in
               [uu___1] in
             FStar_TypeChecker_Env.push_binders env0 uu___ in
           let eff =
@@ -4537,18 +4342,15 @@ let (bind_cases :
               FStar_Parser_Const.effect_PURE_lid lcases in
           let uu___ =
             let uu___1 =
-              FStar_Compiler_Effect.op_Bar_Greater lcases
-                (FStar_Compiler_Util.for_some
-                   (fun uu___2 ->
-                      match uu___2 with
-                      | (uu___3, uu___4, flags, uu___5) ->
-                          FStar_Compiler_Effect.op_Bar_Greater flags
-                            (FStar_Compiler_Util.for_some
-                               (fun uu___6 ->
-                                  match uu___6 with
-                                  | FStar_Syntax_Syntax.SHOULD_NOT_INLINE ->
-                                      true
-                                  | uu___7 -> false)))) in
+              FStar_Compiler_Util.for_some
+                (fun uu___2 ->
+                   match uu___2 with
+                   | (uu___3, uu___4, flags, uu___5) ->
+                       FStar_Compiler_Util.for_some
+                         (fun uu___6 ->
+                            match uu___6 with
+                            | FStar_Syntax_Syntax.SHOULD_NOT_INLINE -> true
+                            | uu___7 -> false) flags) lcases in
             if uu___1
             then (true, [FStar_Syntax_Syntax.SHOULD_NOT_INLINE])
             else (false, []) in
@@ -4571,11 +4373,10 @@ let (bind_cases :
                      if uu___4 then cthen true else cthen false in
                    let uu___4 =
                      let uu___5 =
-                       FStar_Compiler_Effect.op_Bar_Greater lcases
-                         (FStar_Compiler_List.map
-                            (fun uu___6 ->
-                               match uu___6 with
-                               | (g, uu___7, uu___8, uu___9) -> g)) in
+                       FStar_Compiler_List.map
+                         (fun uu___6 ->
+                            match uu___6 with
+                            | (g, uu___7, uu___8, uu___9) -> g) lcases in
                      get_neg_branch_conds uu___5 in
                    match uu___4 with
                    | (neg_branch_conds, exhaustiveness_branch_cond) ->
@@ -4590,36 +4391,25 @@ let (bind_cases :
                              let uu___7 =
                                let uu___8 =
                                  let uu___9 =
-                                   FStar_Compiler_Effect.op_Bar_Greater
-                                     neg_branch_conds
-                                     (FStar_Compiler_List.splitAt
-                                        ((FStar_Compiler_List.length lcases)
-                                           - Prims.int_one)) in
-                                 FStar_Compiler_Effect.op_Bar_Greater uu___9
-                                   (fun uu___10 ->
-                                      match uu___10 with
-                                      | (l1, l2) ->
-                                          let uu___11 =
-                                            FStar_Compiler_List.hd l2 in
-                                          (l1, uu___11)) in
+                                   FStar_Compiler_List.splitAt
+                                     ((FStar_Compiler_List.length lcases) -
+                                        Prims.int_one) neg_branch_conds in
+                                 match uu___9 with
+                                 | (l1, l2) ->
+                                     let uu___10 = FStar_Compiler_List.hd l2 in
+                                     (l1, uu___10) in
                                match uu___8 with
                                | (neg_branch_conds1, neg_last) ->
                                    let uu___9 =
                                      let uu___10 =
-                                       FStar_Compiler_Effect.op_Bar_Greater
-                                         lcases
-                                         (FStar_Compiler_List.splitAt
-                                            ((FStar_Compiler_List.length
-                                                lcases)
-                                               - Prims.int_one)) in
-                                     FStar_Compiler_Effect.op_Bar_Greater
-                                       uu___10
-                                       (fun uu___11 ->
-                                          match uu___11 with
-                                          | (l1, l2) ->
-                                              let uu___12 =
-                                                FStar_Compiler_List.hd l2 in
-                                              (l1, uu___12)) in
+                                       FStar_Compiler_List.splitAt
+                                         ((FStar_Compiler_List.length lcases)
+                                            - Prims.int_one) lcases in
+                                     match uu___10 with
+                                     | (l1, l2) ->
+                                         let uu___11 =
+                                           FStar_Compiler_List.hd l2 in
+                                         (l1, uu___11) in
                                    (match uu___9 with
                                     | (lcases1,
                                        (g_last, eff_last, uu___10, c_last))
@@ -4646,14 +4436,10 @@ let (bind_cases :
                                          | (c, g) ->
                                              let uu___12 =
                                                let uu___13 =
-                                                 FStar_Compiler_Effect.op_Bar_Greater
-                                                   eff_last
-                                                   (FStar_TypeChecker_Env.norm_eff_name
-                                                      env) in
-                                               FStar_Compiler_Effect.op_Bar_Greater
-                                                 uu___13
-                                                 (FStar_TypeChecker_Env.get_effect_decl
-                                                    env) in
+                                                 FStar_TypeChecker_Env.norm_eff_name
+                                                   env eff_last in
+                                               FStar_TypeChecker_Env.get_effect_decl
+                                                 env uu___13 in
                                              (lcases1, neg_branch_conds1,
                                                uu___12, c, g))) in
                              (match uu___7 with
@@ -4688,15 +4474,11 @@ let (bind_cases :
                                                             FStar_TypeChecker_Env.get_effect_decl
                                                               env m in
                                                           let uu___15 =
-                                                            FStar_Compiler_Effect.op_Bar_Greater
-                                                              cthen2
-                                                              (FStar_TypeChecker_Env.comp_to_comp_typ
-                                                                 env) in
+                                                            FStar_TypeChecker_Env.comp_to_comp_typ
+                                                              env cthen2 in
                                                           let uu___16 =
-                                                            FStar_Compiler_Effect.op_Bar_Greater
-                                                              celse1
-                                                              (FStar_TypeChecker_Env.comp_to_comp_typ
-                                                                 env) in
+                                                            FStar_TypeChecker_Env.comp_to_comp_typ
+                                                              env celse1 in
                                                           (md1, uu___15,
                                                             uu___16,
                                                             g_lift_then,
@@ -4707,9 +4489,8 @@ let (bind_cases :
                                                         g_lift_else) ->
                                                          let fn =
                                                            let uu___14 =
-                                                             FStar_Compiler_Effect.op_Bar_Greater
-                                                               md1
-                                                               FStar_Syntax_Util.is_layered in
+                                                             FStar_Syntax_Util.is_layered
+                                                               md1 in
                                                            if uu___14
                                                            then
                                                              mk_layered_conjunction
@@ -4806,10 +4587,8 @@ let (bind_cases :
                                   | uu___7 ->
                                       let uu___8 =
                                         let uu___9 =
-                                          FStar_Compiler_Effect.op_Bar_Greater
-                                            md FStar_Compiler_Util.must in
-                                        FStar_Compiler_Effect.op_Bar_Greater
-                                          uu___9 FStar_Syntax_Util.is_layered in
+                                          FStar_Compiler_Util.must md in
+                                        FStar_Syntax_Util.is_layered uu___9 in
                                       if uu___8
                                       then (comp1, g_comp1)
                                       else
@@ -4825,12 +4604,10 @@ let (bind_cases :
                                          | (uu___11, uu___12, wp) ->
                                              let ite_wp =
                                                let uu___13 =
-                                                 FStar_Compiler_Effect.op_Bar_Greater
-                                                   md1
-                                                   FStar_Syntax_Util.get_wp_ite_combinator in
-                                               FStar_Compiler_Effect.op_Bar_Greater
-                                                 uu___13
-                                                 FStar_Compiler_Util.must in
+                                                 FStar_Syntax_Util.get_wp_ite_combinator
+                                                   md1 in
+                                               FStar_Compiler_Util.must
+                                                 uu___13 in
                                              let wp1 =
                                                let uu___13 =
                                                  FStar_TypeChecker_Env.inst_effect_fun_with
@@ -4879,8 +4656,7 @@ let (check_comp :
               FStar_Syntax_Print.pretty_comp c'.FStar_Syntax_Syntax.pos
               "check_comp.c'" env c';
             (let uu___3 =
-               FStar_Compiler_Effect.op_Less_Bar
-                 (FStar_TypeChecker_Env.debug env) FStar_Options.Extreme in
+               FStar_TypeChecker_Env.debug env FStar_Options.Extreme in
              if uu___3
              then
                let uu___4 = FStar_Syntax_Print.term_to_string e in
@@ -4920,20 +4696,16 @@ let (universe_of_comp :
     fun u_res ->
       fun c ->
         let c_lid =
-          let uu___ =
-            FStar_Compiler_Effect.op_Bar_Greater c
-              FStar_Syntax_Util.comp_effect_name in
-          FStar_Compiler_Effect.op_Bar_Greater uu___
-            (FStar_TypeChecker_Env.norm_eff_name env) in
+          FStar_TypeChecker_Env.norm_eff_name env
+            (FStar_Syntax_Util.comp_effect_name c) in
         let uu___ = FStar_Syntax_Util.is_pure_or_ghost_effect c_lid in
         if uu___
         then u_res
         else
           (let is_total =
              let uu___2 = FStar_TypeChecker_Env.lookup_effect_quals env c_lid in
-             FStar_Compiler_Effect.op_Bar_Greater uu___2
-               (FStar_Compiler_List.existsb
-                  (fun q -> q = FStar_Syntax_Syntax.TotalEffect)) in
+             FStar_Compiler_List.existsb
+               (fun q -> q = FStar_Syntax_Syntax.TotalEffect) uu___2 in
            if Prims.op_Negation is_total
            then FStar_Syntax_Syntax.U_zero
            else
@@ -4958,9 +4730,7 @@ let (check_trivial_precondition_wp :
   =
   fun env ->
     fun c ->
-      let ct =
-        FStar_Compiler_Effect.op_Bar_Greater c
-          (FStar_TypeChecker_Env.unfold_effect_abbrev env) in
+      let ct = FStar_TypeChecker_Env.unfold_effect_abbrev env c in
       let md =
         FStar_TypeChecker_Env.get_effect_decl env
           ct.FStar_Syntax_Syntax.effect_name in
@@ -4970,11 +4740,8 @@ let (check_trivial_precondition_wp :
           let vc =
             let uu___1 =
               let uu___2 =
-                let uu___3 =
-                  FStar_Compiler_Effect.op_Bar_Greater md
-                    FStar_Syntax_Util.get_wp_trivial_combinator in
-                FStar_Compiler_Effect.op_Bar_Greater uu___3
-                  FStar_Compiler_Util.must in
+                let uu___3 = FStar_Syntax_Util.get_wp_trivial_combinator md in
+                FStar_Compiler_Util.must uu___3 in
               FStar_TypeChecker_Env.inst_effect_fun_with [u_t] env md uu___2 in
             let uu___2 =
               let uu___3 = FStar_Syntax_Syntax.as_arg t in
@@ -4984,8 +4751,7 @@ let (check_trivial_precondition_wp :
             let uu___3 = FStar_TypeChecker_Env.get_range env in
             FStar_Syntax_Syntax.mk_Tm_app uu___1 uu___2 uu___3 in
           let uu___1 =
-            FStar_Compiler_Effect.op_Less_Bar
-              FStar_TypeChecker_Env.guard_of_guard_formula
+            FStar_TypeChecker_Env.guard_of_guard_formula
               (FStar_TypeChecker_Common.NonTrivial vc) in
           (ct, vc, uu___1)
 let (maybe_lift :
@@ -5074,9 +4840,7 @@ let (coerce_with :
                         FStar_Compiler_Util.print1 "Coercing with %s!\n"
                           uu___4
                       else ());
-                     (let lc2 =
-                        FStar_Compiler_Effect.op_Less_Bar
-                          FStar_TypeChecker_Common.lcomp_of_comp comp2 in
+                     (let lc2 = FStar_TypeChecker_Common.lcomp_of_comp comp2 in
                       let lc_res =
                         bind e.FStar_Syntax_Syntax.pos env
                           (FStar_Pervasives_Native.Some e) lc
@@ -5112,10 +4876,8 @@ let (coerce_with :
                                let uu___6 =
                                  let uu___7 =
                                    let uu___8 =
-                                     FStar_Compiler_Effect.op_Bar_Greater x
-                                       FStar_Syntax_Syntax.bv_to_name in
-                                   FStar_Compiler_Effect.op_Bar_Greater
-                                     uu___8 FStar_Syntax_Syntax.as_arg in
+                                     FStar_Syntax_Syntax.bv_to_name x in
+                                   FStar_Syntax_Syntax.as_arg uu___8 in
                                  [uu___7] in
                                FStar_Compiler_List.op_At eargs uu___6 in
                              FStar_Syntax_Syntax.mk_Tm_app coercion1 uu___5
@@ -5221,39 +4983,29 @@ let rec (check_erased :
                  FStar_Syntax_Syntax.brs = branches;
                  FStar_Syntax_Syntax.rc_opt1 = uu___4;_},
                uu___5) ->
-                FStar_Compiler_Effect.op_Bar_Greater branches
-                  (FStar_Compiler_List.fold_left
-                     (fun acc ->
-                        fun br ->
-                          match acc with
-                          | Yes uu___6 -> Maybe
-                          | Maybe -> Maybe
-                          | No ->
-                              let uu___6 = FStar_Syntax_Subst.open_branch br in
-                              (match uu___6 with
-                               | (uu___7, uu___8, br_body) ->
-                                   let uu___9 =
-                                     let uu___10 =
-                                       let uu___11 =
-                                         let uu___12 =
-                                           let uu___13 =
-                                             FStar_Compiler_Effect.op_Bar_Greater
-                                               br_body
-                                               FStar_Syntax_Free.names in
-                                           FStar_Compiler_Effect.op_Bar_Greater
-                                             uu___13
-                                             (FStar_Compiler_Set.elems
-                                                FStar_Syntax_Syntax.ord_bv) in
-                                         FStar_Compiler_Effect.op_Bar_Greater
-                                           uu___12
-                                           (FStar_TypeChecker_Env.push_bvs
-                                              env) in
-                                       check_erased uu___11 in
-                                     FStar_Compiler_Effect.op_Bar_Greater
-                                       br_body uu___10 in
-                                   (match uu___9 with
-                                    | No -> No
-                                    | uu___10 -> Maybe))) No)
+                FStar_Compiler_List.fold_left
+                  (fun acc ->
+                     fun br ->
+                       match acc with
+                       | Yes uu___6 -> Maybe
+                       | Maybe -> Maybe
+                       | No ->
+                           let uu___6 = FStar_Syntax_Subst.open_branch br in
+                           (match uu___6 with
+                            | (uu___7, uu___8, br_body) ->
+                                let uu___9 =
+                                  let uu___10 =
+                                    let uu___11 =
+                                      let uu___12 =
+                                        FStar_Syntax_Free.names br_body in
+                                      FStar_Compiler_Set.elems
+                                        FStar_Syntax_Syntax.ord_bv uu___12 in
+                                    FStar_TypeChecker_Env.push_bvs env
+                                      uu___11 in
+                                  check_erased uu___10 br_body in
+                                (match uu___9 with
+                                 | No -> No
+                                 | uu___10 -> Maybe))) No branches
             | uu___2 -> No in
           r
 let rec first_opt :
@@ -5383,9 +5135,7 @@ let (find_coercion :
                                let uu___5 =
                                  FStar_Syntax_Syntax.mk_Total
                                    FStar_Syntax_Util.ktype0 in
-                               FStar_Compiler_Effect.op_Less_Bar
-                                 FStar_TypeChecker_Common.lcomp_of_comp
-                                 uu___5 in
+                               FStar_TypeChecker_Common.lcomp_of_comp uu___5 in
                              let lc_res =
                                bind e.FStar_Syntax_Syntax.pos env
                                  (FStar_Pervasives_Native.Some e) checked
@@ -5437,74 +5187,64 @@ let (find_coercion :
                                        let candidates =
                                          FStar_TypeChecker_Env.lookup_attr
                                            env "FStar.Pervasives.coercion" in
-                                       FStar_Compiler_Effect.op_Bar_Greater
-                                         candidates
-                                         (first_opt
-                                            (fun se ->
-                                               let uu___8 =
-                                                 match se.FStar_Syntax_Syntax.sigel
-                                                 with
-                                                 | FStar_Syntax_Syntax.Sig_let
-                                                     {
-                                                       FStar_Syntax_Syntax.lbs1
-                                                         = (uu___9, lb::[]);
-                                                       FStar_Syntax_Syntax.lids1
-                                                         = uu___10;_}
-                                                     ->
-                                                     let uu___11 =
-                                                       let uu___12 =
-                                                         let uu___13 =
-                                                           FStar_Compiler_Util.right
-                                                             lb.FStar_Syntax_Syntax.lbname in
-                                                         FStar_Syntax_Syntax.lid_of_fv
-                                                           uu___13 in
-                                                       (uu___12,
-                                                         (lb.FStar_Syntax_Syntax.lbunivs),
-                                                         (lb.FStar_Syntax_Syntax.lbtyp)) in
-                                                     FStar_Pervasives_Native.Some
-                                                       uu___11
-                                                 | FStar_Syntax_Syntax.Sig_declare_typ
-                                                     {
-                                                       FStar_Syntax_Syntax.lid2
-                                                         = lid;
-                                                       FStar_Syntax_Syntax.us2
-                                                         = us;
-                                                       FStar_Syntax_Syntax.t2
-                                                         = t;_}
-                                                     ->
-                                                     FStar_Pervasives_Native.Some
-                                                       (lid, us, t)
-                                                 | uu___9 ->
-                                                     FStar_Pervasives_Native.None in
-                                               (op_let_Question ()) uu___8
-                                                 (fun uu___9 ->
-                                                    match uu___9 with
-                                                    | (f_name, f_us, f_typ)
-                                                        ->
-                                                        let uu___10 =
-                                                          FStar_Syntax_Subst.open_univ_vars
-                                                            f_us f_typ in
-                                                        (match uu___10 with
-                                                         | (uu___11, f_typ1)
-                                                             ->
-                                                             let uu___12 =
-                                                               FStar_Syntax_Util.arrow_formals_comp
-                                                                 f_typ1 in
-                                                             (match uu___12
-                                                              with
-                                                              | (f_bs, f_c)
-                                                                  ->
-                                                                  let uu___13
-                                                                    =
-                                                                    bool_guard
-                                                                    (f_bs <>
+                                       first_opt
+                                         (fun se ->
+                                            let uu___8 =
+                                              match se.FStar_Syntax_Syntax.sigel
+                                              with
+                                              | FStar_Syntax_Syntax.Sig_let
+                                                  {
+                                                    FStar_Syntax_Syntax.lbs1
+                                                      = (uu___9, lb::[]);
+                                                    FStar_Syntax_Syntax.lids1
+                                                      = uu___10;_}
+                                                  ->
+                                                  let uu___11 =
+                                                    let uu___12 =
+                                                      let uu___13 =
+                                                        FStar_Compiler_Util.right
+                                                          lb.FStar_Syntax_Syntax.lbname in
+                                                      FStar_Syntax_Syntax.lid_of_fv
+                                                        uu___13 in
+                                                    (uu___12,
+                                                      (lb.FStar_Syntax_Syntax.lbunivs),
+                                                      (lb.FStar_Syntax_Syntax.lbtyp)) in
+                                                  FStar_Pervasives_Native.Some
+                                                    uu___11
+                                              | FStar_Syntax_Syntax.Sig_declare_typ
+                                                  {
+                                                    FStar_Syntax_Syntax.lid2
+                                                      = lid;
+                                                    FStar_Syntax_Syntax.us2 =
+                                                      us;
+                                                    FStar_Syntax_Syntax.t2 =
+                                                      t;_}
+                                                  ->
+                                                  FStar_Pervasives_Native.Some
+                                                    (lid, us, t)
+                                              | uu___9 ->
+                                                  FStar_Pervasives_Native.None in
+                                            (op_let_Question ()) uu___8
+                                              (fun uu___9 ->
+                                                 match uu___9 with
+                                                 | (f_name, f_us, f_typ) ->
+                                                     let uu___10 =
+                                                       FStar_Syntax_Subst.open_univ_vars
+                                                         f_us f_typ in
+                                                     (match uu___10 with
+                                                      | (uu___11, f_typ1) ->
+                                                          let uu___12 =
+                                                            FStar_Syntax_Util.arrow_formals_comp
+                                                              f_typ1 in
+                                                          (match uu___12 with
+                                                           | (f_bs, f_c) ->
+                                                               let uu___13 =
+                                                                 bool_guard
+                                                                   (f_bs <>
                                                                     []) in
-                                                                  (op_let_Question
-                                                                    ())
-                                                                    uu___13
-                                                                    (
-                                                                    fun
-                                                                    uu___14
+                                                               (op_let_Question
+                                                                  ()) uu___13
+                                                                 (fun uu___14
                                                                     ->
                                                                     let f_res
                                                                     =
@@ -5767,7 +5507,8 @@ let (find_coercion :
                                                                     (env.FStar_TypeChecker_Env.core_check)
                                                                     } tt in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu___21)))))))))))))))
+                                                                    uu___21)))))))))
+                                         candidates)))))
 let (maybe_coerce_lc :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
@@ -5942,9 +5683,8 @@ let (weaken_result_typ :
                       lc.FStar_TypeChecker_Common.eff_name in
                   match uu___1 with
                   | FStar_Pervasives_Native.Some (ed, qualifiers) ->
-                      FStar_Compiler_Effect.op_Bar_Greater qualifiers
-                        (FStar_Compiler_List.contains
-                           FStar_Syntax_Syntax.Reifiable)
+                      FStar_Compiler_List.contains
+                        FStar_Syntax_Syntax.Reifiable qualifiers
                   | uu___2 -> false) in
              let gopt =
                if use_eq1
@@ -5997,8 +5737,7 @@ let (weaken_result_typ :
                             if uu___4
                             then
                               ((let uu___6 =
-                                  FStar_Compiler_Effect.op_Less_Bar
-                                    (FStar_TypeChecker_Env.debug env)
+                                  FStar_TypeChecker_Env.debug env
                                     FStar_Options.Extreme in
                                 if uu___6
                                 then
@@ -6031,13 +5770,8 @@ let (weaken_result_typ :
                                      res_t in
                                  let uu___6 =
                                    let uu___7 =
-                                     let uu___8 =
-                                       FStar_Compiler_Effect.op_Bar_Greater c
-                                         FStar_Syntax_Util.comp_effect_name in
-                                     FStar_Compiler_Effect.op_Bar_Greater
-                                       uu___8
-                                       (FStar_TypeChecker_Env.norm_eff_name
-                                          env) in
+                                     FStar_TypeChecker_Env.norm_eff_name env
+                                       (FStar_Syntax_Util.comp_effect_name c) in
                                    let uu___8 =
                                      FStar_Syntax_Syntax.bv_to_name x in
                                    return_value env uu___7 (comp_univ_opt c)
@@ -6058,8 +5792,7 @@ let (weaken_result_typ :
                                          (FStar_Pervasives_Native.Some e)
                                          uu___7 uu___8 in
                                      ((let uu___8 =
-                                         FStar_Compiler_Effect.op_Less_Bar
-                                           (FStar_TypeChecker_Env.debug env)
+                                         FStar_TypeChecker_Env.debug env
                                            FStar_Options.Extreme in
                                        if uu___8
                                        then
@@ -6091,8 +5824,7 @@ let (weaken_result_typ :
                                            (uu___9, uu___10)))
                                else
                                  ((let uu___8 =
-                                     FStar_Compiler_Effect.op_Less_Bar
-                                       (FStar_TypeChecker_Env.debug env)
+                                     FStar_TypeChecker_Env.debug env
                                        FStar_Options.Extreme in
                                    if uu___8
                                    then
@@ -6175,8 +5907,7 @@ let (weaken_result_typ :
                                (match uu___7 with
                                 | (c, g_c) ->
                                     ((let uu___9 =
-                                        FStar_Compiler_Effect.op_Less_Bar
-                                          (FStar_TypeChecker_Env.debug env)
+                                        FStar_TypeChecker_Env.debug env
                                           FStar_Options.Extreme in
                                       if uu___9
                                       then
@@ -6206,14 +5937,10 @@ let (weaken_result_typ :
                                         FStar_Syntax_Syntax.bv_to_name x in
                                       let uu___9 =
                                         let uu___10 =
-                                          let uu___11 =
-                                            FStar_Compiler_Effect.op_Bar_Greater
-                                              c
-                                              FStar_Syntax_Util.comp_effect_name in
-                                          FStar_Compiler_Effect.op_Bar_Greater
-                                            uu___11
-                                            (FStar_TypeChecker_Env.norm_eff_name
-                                               env) in
+                                          FStar_TypeChecker_Env.norm_eff_name
+                                            env
+                                            (FStar_Syntax_Util.comp_effect_name
+                                               c) in
                                         return_value env uu___10 u_t_opt t
                                           xexp in
                                       match uu___9 with
@@ -6232,31 +5959,26 @@ let (weaken_result_typ :
                                             else f1 in
                                           let uu___10 =
                                             let uu___11 =
-                                              FStar_Compiler_Effect.op_Less_Bar
-                                                (fun uu___12 ->
-                                                   FStar_Pervasives_Native.Some
-                                                     uu___12)
-                                                (FStar_TypeChecker_Err.subtyping_failed
-                                                   env
-                                                   lc.FStar_TypeChecker_Common.res_typ
-                                                   t) in
-                                            let uu___12 =
-                                              let uu___13 =
+                                              let uu___12 =
                                                 FStar_TypeChecker_Env.push_bvs
                                                   env [x] in
                                               FStar_TypeChecker_Env.set_range
-                                                uu___13
+                                                uu___12
                                                 e.FStar_Syntax_Syntax.pos in
-                                            let uu___13 =
+                                            let uu___12 =
                                               FStar_TypeChecker_Common.lcomp_of_comp
                                                 cret in
-                                            let uu___14 =
-                                              FStar_Compiler_Effect.op_Less_Bar
-                                                FStar_TypeChecker_Env.guard_of_guard_formula
+                                            let uu___13 =
+                                              FStar_TypeChecker_Env.guard_of_guard_formula
                                                 (FStar_TypeChecker_Common.NonTrivial
                                                    guard) in
-                                            strengthen_precondition uu___11
-                                              uu___12 e uu___13 uu___14 in
+                                            strengthen_precondition
+                                              (FStar_Pervasives_Native.Some
+                                                 (FStar_TypeChecker_Err.subtyping_failed
+                                                    env
+                                                    lc.FStar_TypeChecker_Common.res_typ
+                                                    t)) uu___11 e uu___12
+                                              uu___13 in
                                           (match uu___10 with
                                            | (eq_ret,
                                               _trivial_so_ok_to_discard) ->
@@ -6288,9 +6010,8 @@ let (weaken_result_typ :
                                                (match uu___11 with
                                                 | (c2, g_lc) ->
                                                     ((let uu___13 =
-                                                        FStar_Compiler_Effect.op_Less_Bar
-                                                          (FStar_TypeChecker_Env.debug
-                                                             env)
+                                                        FStar_TypeChecker_Env.debug
+                                                          env
                                                           FStar_Options.Extreme in
                                                       if uu___13
                                                       then
@@ -6306,18 +6027,17 @@ let (weaken_result_typ :
                                                           [g_c; gret; g_lc] in
                                                       (c2, uu___13))))))))) in
                       let flags =
-                        FStar_Compiler_Effect.op_Bar_Greater
-                          lc.FStar_TypeChecker_Common.cflags
-                          (FStar_Compiler_List.collect
-                             (fun uu___2 ->
-                                match uu___2 with
-                                | FStar_Syntax_Syntax.RETURN ->
-                                    [FStar_Syntax_Syntax.PARTIAL_RETURN]
-                                | FStar_Syntax_Syntax.PARTIAL_RETURN ->
-                                    [FStar_Syntax_Syntax.PARTIAL_RETURN]
-                                | FStar_Syntax_Syntax.CPS ->
-                                    [FStar_Syntax_Syntax.CPS]
-                                | uu___3 -> [])) in
+                        FStar_Compiler_List.collect
+                          (fun uu___2 ->
+                             match uu___2 with
+                             | FStar_Syntax_Syntax.RETURN ->
+                                 [FStar_Syntax_Syntax.PARTIAL_RETURN]
+                             | FStar_Syntax_Syntax.PARTIAL_RETURN ->
+                                 [FStar_Syntax_Syntax.PARTIAL_RETURN]
+                             | FStar_Syntax_Syntax.CPS ->
+                                 [FStar_Syntax_Syntax.CPS]
+                             | uu___3 -> [])
+                          lc.FStar_TypeChecker_Common.cflags in
                       let lc1 =
                         let uu___2 =
                           FStar_TypeChecker_Env.norm_eff_name env
@@ -6389,7 +6109,7 @@ let (pure_or_ghost_pre_and_post :
                     let uu___7 =
                       let uu___8 =
                         mk_post_type ct.FStar_Syntax_Syntax.result_typ ens in
-                      FStar_Compiler_Effect.op_Less_Bar norm uu___8 in
+                      norm uu___8 in
                     (uu___6, uu___7)
                 | uu___3 ->
                     let uu___4 =
@@ -6410,16 +6130,14 @@ let (pure_or_ghost_pre_and_post :
                       let uu___7 =
                         FStar_TypeChecker_Env.lookup_lid env
                           FStar_Parser_Const.as_requires in
-                      FStar_Compiler_Effect.op_Less_Bar
-                        FStar_Pervasives_Native.fst uu___7 in
+                      FStar_Pervasives_Native.fst uu___7 in
                     (match uu___6 with
                      | (us_r, uu___7) ->
                          let uu___8 =
                            let uu___9 =
                              FStar_TypeChecker_Env.lookup_lid env
                                FStar_Parser_Const.as_ensures in
-                           FStar_Compiler_Effect.op_Less_Bar
-                             FStar_Pervasives_Native.fst uu___9 in
+                           FStar_Pervasives_Native.fst uu___9 in
                          (match uu___8 with
                           | (us_e, uu___9) ->
                               let r =
@@ -6502,8 +6220,7 @@ let (norm_reify :
                 FStar_TypeChecker_Env.Exclude FStar_TypeChecker_Env.Zeta]
                 steps) env t in
          (let uu___2 =
-            FStar_Compiler_Effect.op_Less_Bar
-              (FStar_TypeChecker_Env.debug env)
+            FStar_TypeChecker_Env.debug env
               (FStar_Options.Other "SMTEncodingReify") in
           if uu___2
           then
@@ -6599,20 +6316,19 @@ let (maybe_instantiate :
               let formals = unfolded_arrow_formals t1 in
               let n_implicits =
                 let uu___2 =
-                  FStar_Compiler_Effect.op_Bar_Greater formals
-                    (FStar_Compiler_Util.prefix_until
-                       (fun uu___3 ->
-                          match uu___3 with
-                          | { FStar_Syntax_Syntax.binder_bv = uu___4;
-                              FStar_Syntax_Syntax.binder_qual = imp;
-                              FStar_Syntax_Syntax.binder_positivity = uu___5;
-                              FStar_Syntax_Syntax.binder_attrs = uu___6;_} ->
-                              (FStar_Compiler_Option.isNone imp) ||
-                                (let uu___7 =
-                                   FStar_Syntax_Util.eq_bqual imp
-                                     (FStar_Pervasives_Native.Some
-                                        FStar_Syntax_Syntax.Equality) in
-                                 uu___7 = FStar_Syntax_Util.Equal))) in
+                  FStar_Compiler_Util.prefix_until
+                    (fun uu___3 ->
+                       match uu___3 with
+                       | { FStar_Syntax_Syntax.binder_bv = uu___4;
+                           FStar_Syntax_Syntax.binder_qual = imp;
+                           FStar_Syntax_Syntax.binder_positivity = uu___5;
+                           FStar_Syntax_Syntax.binder_attrs = uu___6;_} ->
+                           (FStar_Compiler_Option.isNone imp) ||
+                             (let uu___7 =
+                                FStar_Syntax_Util.eq_bqual imp
+                                  (FStar_Pervasives_Native.Some
+                                     FStar_Syntax_Syntax.Equality) in
+                              uu___7 = FStar_Syntax_Util.Equal)) formals in
                 match uu___2 with
                 | FStar_Pervasives_Native.None ->
                     FStar_Compiler_List.length formals
@@ -6813,9 +6529,8 @@ let (check_has_type :
                 let uu___ = FStar_TypeChecker_Rel.teq_nosmt_force env1 t1 t2 in
                 (if uu___
                  then
-                   FStar_Compiler_Effect.op_Bar_Greater
+                   FStar_Pervasives_Native.Some
                      FStar_TypeChecker_Env.trivial_guard
-                     (fun uu___1 -> FStar_Pervasives_Native.Some uu___1)
                  else FStar_Pervasives_Native.None)
               else
                 if use_eq
@@ -6828,8 +6543,7 @@ let (check_has_type :
                        FStar_Pervasives_Native.None
                    | FStar_Pervasives_Native.Some f ->
                        let uu___3 = FStar_TypeChecker_Env.apply_guard f e in
-                       FStar_Compiler_Effect.op_Bar_Greater uu___3
-                         (fun uu___4 -> FStar_Pervasives_Native.Some uu___4)) in
+                       FStar_Pervasives_Native.Some uu___3) in
             match g_opt with
             | FStar_Pervasives_Native.None ->
                 let uu___ =
@@ -6861,15 +6575,12 @@ let (check_has_type_maybe_coerce :
                   check_has_type env1 e1 lc1.FStar_TypeChecker_Common.res_typ
                     t2 use_eq in
                 ((let uu___2 =
-                    FStar_Compiler_Effect.op_Less_Bar
-                      (FStar_TypeChecker_Env.debug env1)
+                    FStar_TypeChecker_Env.debug env1
                       (FStar_Options.Other "Rel") in
                   if uu___2
                   then
                     let uu___3 = FStar_TypeChecker_Rel.guard_to_string env1 g in
-                    FStar_Compiler_Effect.op_Less_Bar
-                      (FStar_Compiler_Util.print1 "Applied guard is %s\n")
-                      uu___3
+                    FStar_Compiler_Util.print1 "Applied guard is %s\n" uu___3
                   else ());
                  (let uu___2 = FStar_TypeChecker_Env.conj_guard g g_c in
                   (e1, lc1, uu___2)))
@@ -6916,30 +6627,23 @@ let (check_top_level :
                      if uu___5
                      then
                        let c_eff = c1.FStar_Syntax_Syntax.effect_name in
-                       let ret_comp =
-                         FStar_Compiler_Effect.op_Bar_Greater c1
-                           FStar_Syntax_Syntax.mk_Comp in
+                       let ret_comp = FStar_Syntax_Syntax.mk_Comp c1 in
                        let steps =
                          [FStar_TypeChecker_Env.Eager_unfolding;
                          FStar_TypeChecker_Env.Simplify;
                          FStar_TypeChecker_Env.Primops;
                          FStar_TypeChecker_Env.NoFullNorm] in
                        let c2 =
-                         let uu___6 =
-                           FStar_Compiler_Effect.op_Bar_Greater c1
-                             FStar_Syntax_Syntax.mk_Comp in
-                         FStar_Compiler_Effect.op_Bar_Greater uu___6
-                           (FStar_TypeChecker_Normalize.normalize_comp steps
-                              env) in
+                         let uu___6 = FStar_Syntax_Syntax.mk_Comp c1 in
+                         FStar_TypeChecker_Normalize.normalize_comp steps env
+                           uu___6 in
                        let top_level_eff_opt =
                          FStar_TypeChecker_Env.get_top_level_effect env c_eff in
                        match top_level_eff_opt with
                        | FStar_Pervasives_Native.None ->
                            let uu___6 =
                              let uu___7 =
-                               let uu___8 =
-                                 FStar_Compiler_Effect.op_Bar_Greater c_eff
-                                   FStar_Ident.string_of_lid in
+                               let uu___8 = FStar_Ident.string_of_lid c_eff in
                                FStar_Compiler_Util.format1
                                  "Indexed effect %s cannot be used as a top-level effect"
                                  uu___8 in
@@ -6966,8 +6670,7 @@ let (check_top_level :
                                          FStar_Ident.string_of_lid
                                            top_level_eff in
                                        let uu___11 =
-                                         FStar_Compiler_Effect.op_Bar_Greater
-                                           c_eff FStar_Ident.string_of_lid in
+                                         FStar_Ident.string_of_lid c_eff in
                                        FStar_Compiler_Util.format2
                                          "Could not find top-level effect abbreviation %s for %s"
                                          uu___10 uu___11 in
@@ -6978,8 +6681,7 @@ let (check_top_level :
                                    FStar_Errors.raise_error uu___8 uu___9
                                | FStar_Pervasives_Native.Some (bs, uu___8) ->
                                    let debug =
-                                     FStar_Compiler_Effect.op_Less_Bar
-                                       (FStar_TypeChecker_Env.debug env)
+                                     FStar_TypeChecker_Env.debug env
                                        (FStar_Options.Other
                                           "LayeredEffectsApp") in
                                    let uu___9 =
@@ -7015,10 +6717,9 @@ let (check_top_level :
                                              let top_level_comp =
                                                let uu___11 =
                                                  let uu___12 =
-                                                   FStar_Compiler_Effect.op_Bar_Greater
-                                                     uvs
-                                                     (FStar_Compiler_List.map
-                                                        FStar_Syntax_Syntax.as_arg) in
+                                                   FStar_Compiler_List.map
+                                                     FStar_Syntax_Syntax.as_arg
+                                                     uvs in
                                                  {
                                                    FStar_Syntax_Syntax.comp_univs
                                                      = us;
@@ -7033,9 +6734,8 @@ let (check_top_level :
                                                    FStar_Syntax_Syntax.flags
                                                      = []
                                                  } in
-                                               FStar_Compiler_Effect.op_Bar_Greater
-                                                 uu___11
-                                                 FStar_Syntax_Syntax.mk_Comp in
+                                               FStar_Syntax_Syntax.mk_Comp
+                                                 uu___11 in
                                              let gopt =
                                                FStar_TypeChecker_Rel.eq_comp
                                                  env top_level_comp c2 in
@@ -7074,18 +6774,14 @@ let (check_top_level :
                           FStar_TypeChecker_Env.NoFullNorm;
                           FStar_TypeChecker_Env.DoNotUnfoldPureLets] in
                         let c2 =
-                          let uu___7 =
-                            FStar_Compiler_Effect.op_Bar_Greater c1
-                              FStar_Syntax_Syntax.mk_Comp in
-                          FStar_Compiler_Effect.op_Bar_Greater uu___7
-                            (FStar_TypeChecker_Normalize.normalize_comp steps
-                               env) in
+                          let uu___7 = FStar_Syntax_Syntax.mk_Comp c1 in
+                          FStar_TypeChecker_Normalize.normalize_comp steps
+                            env uu___7 in
                         let uu___7 = check_trivial_precondition_wp env c2 in
                         match uu___7 with
                         | (ct, vc, g_pre) ->
                             ((let uu___9 =
-                                FStar_Compiler_Effect.op_Less_Bar
-                                  (FStar_TypeChecker_Env.debug env)
+                                FStar_TypeChecker_Env.debug env
                                   (FStar_Options.Other "Simplification") in
                               if uu___9
                               then
@@ -7101,9 +6797,7 @@ let (check_top_level :
                                       g_pre in
                                   FStar_TypeChecker_Env.conj_guard g1 uu___11 in
                                 discharge uu___10 in
-                              let uu___10 =
-                                FStar_Compiler_Effect.op_Bar_Greater ct
-                                  FStar_Syntax_Syntax.mk_Comp in
+                              let uu___10 = FStar_Syntax_Syntax.mk_Comp ct in
                               (uu___9, uu___10)))))))
 let (short_circuit :
   FStar_Syntax_Syntax.term ->
@@ -7120,33 +6814,24 @@ let (short_circuit :
               "Unexpected args to binary operator" in
       let op_and_e e =
         let uu___ = FStar_Syntax_Util.b2t e in
-        FStar_Compiler_Effect.op_Bar_Greater uu___
-          (fun uu___1 -> FStar_TypeChecker_Common.NonTrivial uu___1) in
+        FStar_TypeChecker_Common.NonTrivial uu___ in
       let op_or_e e =
         let uu___ =
           let uu___1 = FStar_Syntax_Util.b2t e in
           FStar_Syntax_Util.mk_neg uu___1 in
-        FStar_Compiler_Effect.op_Bar_Greater uu___
-          (fun uu___1 -> FStar_TypeChecker_Common.NonTrivial uu___1) in
-      let op_and_t t =
-        FStar_Compiler_Effect.op_Bar_Greater t
-          (fun uu___ -> FStar_TypeChecker_Common.NonTrivial uu___) in
+        FStar_TypeChecker_Common.NonTrivial uu___ in
+      let op_and_t t = FStar_TypeChecker_Common.NonTrivial t in
       let op_or_t t =
-        let uu___ =
-          FStar_Compiler_Effect.op_Bar_Greater t FStar_Syntax_Util.mk_neg in
-        FStar_Compiler_Effect.op_Bar_Greater uu___
-          (fun uu___1 -> FStar_TypeChecker_Common.NonTrivial uu___1) in
-      let op_imp_t t =
-        FStar_Compiler_Effect.op_Bar_Greater t
-          (fun uu___ -> FStar_TypeChecker_Common.NonTrivial uu___) in
+        let uu___ = FStar_Syntax_Util.mk_neg t in
+        FStar_TypeChecker_Common.NonTrivial uu___ in
+      let op_imp_t t = FStar_TypeChecker_Common.NonTrivial t in
       let short_op_ite uu___ =
         match uu___ with
         | [] -> FStar_TypeChecker_Common.Trivial
         | (guard, uu___1)::[] -> FStar_TypeChecker_Common.NonTrivial guard
         | _then::(guard, uu___1)::[] ->
             let uu___2 = FStar_Syntax_Util.mk_neg guard in
-            FStar_Compiler_Effect.op_Bar_Greater uu___2
-              (fun uu___3 -> FStar_TypeChecker_Common.NonTrivial uu___3)
+            FStar_TypeChecker_Common.NonTrivial uu___2
         | uu___1 -> FStar_Compiler_Effect.failwith "Unexpected args to ITE" in
       let table =
         let uu___ =
@@ -7259,21 +6944,20 @@ let (maybe_add_implicit_binders :
                      | FStar_Pervasives_Native.Some (imps, uu___6, uu___7) ->
                          let r = pos bs in
                          let imps1 =
-                           FStar_Compiler_Effect.op_Bar_Greater imps
-                             (FStar_Compiler_List.map
-                                (fun b ->
-                                   let uu___8 =
-                                     FStar_Syntax_Syntax.set_range_of_bv
-                                       b.FStar_Syntax_Syntax.binder_bv r in
-                                   {
-                                     FStar_Syntax_Syntax.binder_bv = uu___8;
-                                     FStar_Syntax_Syntax.binder_qual =
-                                       (b.FStar_Syntax_Syntax.binder_qual);
-                                     FStar_Syntax_Syntax.binder_positivity =
-                                       (b.FStar_Syntax_Syntax.binder_positivity);
-                                     FStar_Syntax_Syntax.binder_attrs =
-                                       (b.FStar_Syntax_Syntax.binder_attrs)
-                                   })) in
+                           FStar_Compiler_List.map
+                             (fun b ->
+                                let uu___8 =
+                                  FStar_Syntax_Syntax.set_range_of_bv
+                                    b.FStar_Syntax_Syntax.binder_bv r in
+                                {
+                                  FStar_Syntax_Syntax.binder_bv = uu___8;
+                                  FStar_Syntax_Syntax.binder_qual =
+                                    (b.FStar_Syntax_Syntax.binder_qual);
+                                  FStar_Syntax_Syntax.binder_positivity =
+                                    (b.FStar_Syntax_Syntax.binder_positivity);
+                                  FStar_Syntax_Syntax.binder_attrs =
+                                    (b.FStar_Syntax_Syntax.binder_attrs)
+                                }) imps in
                          FStar_Compiler_List.op_At imps1 bs)
                 | uu___4 -> bs))
 let (check_sigelt_quals :
@@ -7319,140 +7003,126 @@ let (check_sigelt_quals :
       let quals_combo_ok quals q =
         match q with
         | FStar_Syntax_Syntax.Assumption ->
-            FStar_Compiler_Effect.op_Bar_Greater quals
-              (FStar_Compiler_List.for_all
-                 (fun x ->
-                    ((((((x = q) || (x = FStar_Syntax_Syntax.Logic)) ||
-                          (inferred x))
-                         || (visibility x))
-                        || (assumption x))
-                       ||
-                       (env.FStar_TypeChecker_Env.is_iface &&
-                          (x = FStar_Syntax_Syntax.Inline_for_extraction)))
-                      || (x = FStar_Syntax_Syntax.NoExtract)))
+            FStar_Compiler_List.for_all
+              (fun x ->
+                 ((((((x = q) || (x = FStar_Syntax_Syntax.Logic)) ||
+                       (inferred x))
+                      || (visibility x))
+                     || (assumption x))
+                    ||
+                    (env.FStar_TypeChecker_Env.is_iface &&
+                       (x = FStar_Syntax_Syntax.Inline_for_extraction)))
+                   || (x = FStar_Syntax_Syntax.NoExtract)) quals
         | FStar_Syntax_Syntax.New ->
-            FStar_Compiler_Effect.op_Bar_Greater quals
-              (FStar_Compiler_List.for_all
-                 (fun x ->
-                    (((x = q) || (inferred x)) || (visibility x)) ||
-                      (assumption x)))
+            FStar_Compiler_List.for_all
+              (fun x ->
+                 (((x = q) || (inferred x)) || (visibility x)) ||
+                   (assumption x)) quals
         | FStar_Syntax_Syntax.Inline_for_extraction ->
-            FStar_Compiler_Effect.op_Bar_Greater quals
-              (FStar_Compiler_List.for_all
-                 (fun x ->
-                    ((((((((x = q) || (x = FStar_Syntax_Syntax.Logic)) ||
-                            (visibility x))
-                           || (reducibility x))
-                          || (reification x))
-                         || (inferred x))
-                        || (has_eq x))
-                       ||
-                       (env.FStar_TypeChecker_Env.is_iface &&
-                          (x = FStar_Syntax_Syntax.Assumption)))
-                      || (x = FStar_Syntax_Syntax.NoExtract)))
+            FStar_Compiler_List.for_all
+              (fun x ->
+                 ((((((((x = q) || (x = FStar_Syntax_Syntax.Logic)) ||
+                         (visibility x))
+                        || (reducibility x))
+                       || (reification x))
+                      || (inferred x))
+                     || (has_eq x))
+                    ||
+                    (env.FStar_TypeChecker_Env.is_iface &&
+                       (x = FStar_Syntax_Syntax.Assumption)))
+                   || (x = FStar_Syntax_Syntax.NoExtract)) quals
         | FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen ->
-            FStar_Compiler_Effect.op_Bar_Greater quals
-              (FStar_Compiler_List.for_all
-                 (fun x ->
-                    (((((((x = q) || (x = FStar_Syntax_Syntax.Logic)) ||
-                           (x = FStar_Syntax_Syntax.Inline_for_extraction))
-                          || (x = FStar_Syntax_Syntax.NoExtract))
-                         || (has_eq x))
-                        || (inferred x))
-                       || (visibility x))
-                      || (reification x)))
+            FStar_Compiler_List.for_all
+              (fun x ->
+                 (((((((x = q) || (x = FStar_Syntax_Syntax.Logic)) ||
+                        (x = FStar_Syntax_Syntax.Inline_for_extraction))
+                       || (x = FStar_Syntax_Syntax.NoExtract))
+                      || (has_eq x))
+                     || (inferred x))
+                    || (visibility x))
+                   || (reification x)) quals
         | FStar_Syntax_Syntax.Visible_default ->
-            FStar_Compiler_Effect.op_Bar_Greater quals
-              (FStar_Compiler_List.for_all
-                 (fun x ->
-                    (((((((x = q) || (x = FStar_Syntax_Syntax.Logic)) ||
-                           (x = FStar_Syntax_Syntax.Inline_for_extraction))
-                          || (x = FStar_Syntax_Syntax.NoExtract))
-                         || (has_eq x))
-                        || (inferred x))
-                       || (visibility x))
-                      || (reification x)))
+            FStar_Compiler_List.for_all
+              (fun x ->
+                 (((((((x = q) || (x = FStar_Syntax_Syntax.Logic)) ||
+                        (x = FStar_Syntax_Syntax.Inline_for_extraction))
+                       || (x = FStar_Syntax_Syntax.NoExtract))
+                      || (has_eq x))
+                     || (inferred x))
+                    || (visibility x))
+                   || (reification x)) quals
         | FStar_Syntax_Syntax.Irreducible ->
-            FStar_Compiler_Effect.op_Bar_Greater quals
-              (FStar_Compiler_List.for_all
-                 (fun x ->
-                    (((((((x = q) || (x = FStar_Syntax_Syntax.Logic)) ||
-                           (x = FStar_Syntax_Syntax.Inline_for_extraction))
-                          || (x = FStar_Syntax_Syntax.NoExtract))
-                         || (has_eq x))
-                        || (inferred x))
-                       || (visibility x))
-                      || (reification x)))
+            FStar_Compiler_List.for_all
+              (fun x ->
+                 (((((((x = q) || (x = FStar_Syntax_Syntax.Logic)) ||
+                        (x = FStar_Syntax_Syntax.Inline_for_extraction))
+                       || (x = FStar_Syntax_Syntax.NoExtract))
+                      || (has_eq x))
+                     || (inferred x))
+                    || (visibility x))
+                   || (reification x)) quals
         | FStar_Syntax_Syntax.Noeq ->
-            FStar_Compiler_Effect.op_Bar_Greater quals
-              (FStar_Compiler_List.for_all
-                 (fun x ->
-                    (((((((x = q) || (x = FStar_Syntax_Syntax.Logic)) ||
-                           (x = FStar_Syntax_Syntax.Inline_for_extraction))
-                          || (x = FStar_Syntax_Syntax.NoExtract))
-                         || (has_eq x))
-                        || (inferred x))
-                       || (visibility x))
-                      || (reification x)))
+            FStar_Compiler_List.for_all
+              (fun x ->
+                 (((((((x = q) || (x = FStar_Syntax_Syntax.Logic)) ||
+                        (x = FStar_Syntax_Syntax.Inline_for_extraction))
+                       || (x = FStar_Syntax_Syntax.NoExtract))
+                      || (has_eq x))
+                     || (inferred x))
+                    || (visibility x))
+                   || (reification x)) quals
         | FStar_Syntax_Syntax.Unopteq ->
-            FStar_Compiler_Effect.op_Bar_Greater quals
-              (FStar_Compiler_List.for_all
-                 (fun x ->
-                    (((((((x = q) || (x = FStar_Syntax_Syntax.Logic)) ||
-                           (x = FStar_Syntax_Syntax.Inline_for_extraction))
-                          || (x = FStar_Syntax_Syntax.NoExtract))
-                         || (has_eq x))
-                        || (inferred x))
-                       || (visibility x))
-                      || (reification x)))
+            FStar_Compiler_List.for_all
+              (fun x ->
+                 (((((((x = q) || (x = FStar_Syntax_Syntax.Logic)) ||
+                        (x = FStar_Syntax_Syntax.Inline_for_extraction))
+                       || (x = FStar_Syntax_Syntax.NoExtract))
+                      || (has_eq x))
+                     || (inferred x))
+                    || (visibility x))
+                   || (reification x)) quals
         | FStar_Syntax_Syntax.TotalEffect ->
-            FStar_Compiler_Effect.op_Bar_Greater quals
-              (FStar_Compiler_List.for_all
-                 (fun x ->
-                    (((x = q) || (inferred x)) || (visibility x)) ||
-                      (reification x)))
+            FStar_Compiler_List.for_all
+              (fun x ->
+                 (((x = q) || (inferred x)) || (visibility x)) ||
+                   (reification x)) quals
         | FStar_Syntax_Syntax.Logic ->
-            FStar_Compiler_Effect.op_Bar_Greater quals
-              (FStar_Compiler_List.for_all
-                 (fun x ->
-                    ((((x = q) || (x = FStar_Syntax_Syntax.Assumption)) ||
-                        (inferred x))
-                       || (visibility x))
-                      || (reducibility x)))
+            FStar_Compiler_List.for_all
+              (fun x ->
+                 ((((x = q) || (x = FStar_Syntax_Syntax.Assumption)) ||
+                     (inferred x))
+                    || (visibility x))
+                   || (reducibility x)) quals
         | FStar_Syntax_Syntax.Reifiable ->
-            FStar_Compiler_Effect.op_Bar_Greater quals
-              (FStar_Compiler_List.for_all
-                 (fun x ->
-                    ((((reification x) || (inferred x)) || (visibility x)) ||
-                       (x = FStar_Syntax_Syntax.TotalEffect))
-                      || (x = FStar_Syntax_Syntax.Visible_default)))
+            FStar_Compiler_List.for_all
+              (fun x ->
+                 ((((reification x) || (inferred x)) || (visibility x)) ||
+                    (x = FStar_Syntax_Syntax.TotalEffect))
+                   || (x = FStar_Syntax_Syntax.Visible_default)) quals
         | FStar_Syntax_Syntax.Reflectable uu___ ->
-            FStar_Compiler_Effect.op_Bar_Greater quals
-              (FStar_Compiler_List.for_all
-                 (fun x ->
-                    ((((reification x) || (inferred x)) || (visibility x)) ||
-                       (x = FStar_Syntax_Syntax.TotalEffect))
-                      || (x = FStar_Syntax_Syntax.Visible_default)))
+            FStar_Compiler_List.for_all
+              (fun x ->
+                 ((((reification x) || (inferred x)) || (visibility x)) ||
+                    (x = FStar_Syntax_Syntax.TotalEffect))
+                   || (x = FStar_Syntax_Syntax.Visible_default)) quals
         | FStar_Syntax_Syntax.Private -> true
         | uu___ -> true in
       let check_erasable quals se1 r =
         let lids = FStar_Syntax_Util.lids_of_sigelt se1 in
         let val_exists =
-          FStar_Compiler_Effect.op_Bar_Greater lids
-            (FStar_Compiler_Util.for_some
-               (fun l ->
-                  let uu___ = FStar_TypeChecker_Env.try_lookup_val_decl env l in
-                  FStar_Compiler_Option.isSome uu___)) in
+          FStar_Compiler_Util.for_some
+            (fun l ->
+               let uu___ = FStar_TypeChecker_Env.try_lookup_val_decl env l in
+               FStar_Compiler_Option.isSome uu___) lids in
         let val_has_erasable_attr =
-          FStar_Compiler_Effect.op_Bar_Greater lids
-            (FStar_Compiler_Util.for_some
-               (fun l ->
-                  let attrs_opt =
-                    FStar_TypeChecker_Env.lookup_attrs_of_lid env l in
-                  (FStar_Compiler_Option.isSome attrs_opt) &&
-                    (let uu___ = FStar_Compiler_Option.get attrs_opt in
-                     FStar_Syntax_Util.has_attribute uu___
-                       FStar_Parser_Const.erasable_attr))) in
+          FStar_Compiler_Util.for_some
+            (fun l ->
+               let attrs_opt =
+                 FStar_TypeChecker_Env.lookup_attrs_of_lid env l in
+               (FStar_Compiler_Option.isSome attrs_opt) &&
+                 (let uu___ = FStar_Compiler_Option.get attrs_opt in
+                  FStar_Syntax_Util.has_attribute uu___
+                    FStar_Parser_Const.erasable_attr)) lids in
         let se_has_erasable_attr =
           FStar_Syntax_Util.has_attribute se1.FStar_Syntax_Syntax.sigattrs
             FStar_Parser_Const.erasable_attr in
@@ -7480,12 +7150,11 @@ let (check_sigelt_quals :
            | FStar_Syntax_Syntax.Sig_bundle uu___2 ->
                let uu___3 =
                  let uu___4 =
-                   FStar_Compiler_Effect.op_Bar_Greater quals
-                     (FStar_Compiler_Util.for_some
-                        (fun uu___5 ->
-                           match uu___5 with
-                           | FStar_Syntax_Syntax.Noeq -> true
-                           | uu___6 -> false)) in
+                   FStar_Compiler_Util.for_some
+                     (fun uu___5 ->
+                        match uu___5 with
+                        | FStar_Syntax_Syntax.Noeq -> true
+                        | uu___6 -> false) quals in
                  Prims.op_Negation uu___4 in
                if uu___3
                then
@@ -7570,19 +7239,17 @@ let (check_sigelt_quals :
         else () in
       check_no_subtyping_attribute se;
       (let quals =
-         FStar_Compiler_Effect.op_Bar_Greater
-           (FStar_Syntax_Util.quals_of_sigelt se)
-           (FStar_Compiler_List.filter
-              (fun x -> Prims.op_Negation (x = FStar_Syntax_Syntax.Logic))) in
+         FStar_Compiler_List.filter
+           (fun x -> Prims.op_Negation (x = FStar_Syntax_Syntax.Logic))
+           (FStar_Syntax_Util.quals_of_sigelt se) in
        let uu___1 =
          let uu___2 =
-           FStar_Compiler_Effect.op_Bar_Greater quals
-             (FStar_Compiler_Util.for_some
-                (fun uu___3 ->
-                   match uu___3 with
-                   | FStar_Syntax_Syntax.OnlyName -> true
-                   | uu___4 -> false)) in
-         FStar_Compiler_Effect.op_Bar_Greater uu___2 Prims.op_Negation in
+           FStar_Compiler_Util.for_some
+             (fun uu___3 ->
+                match uu___3 with
+                | FStar_Syntax_Syntax.OnlyName -> true
+                | uu___4 -> false) quals in
+         Prims.op_Negation uu___2 in
        if uu___1
        then
          let r = FStar_Syntax_Util.range_of_sigelt se in
@@ -7606,8 +7273,7 @@ let (check_sigelt_quals :
           else ();
           (let uu___4 =
              let uu___5 =
-               FStar_Compiler_Effect.op_Bar_Greater quals
-                 (FStar_Compiler_List.for_all (quals_combo_ok quals)) in
+               FStar_Compiler_List.for_all (quals_combo_ok quals) quals in
              Prims.op_Negation uu___5 in
            if uu___4 then err "ill-formed combination" else ());
           check_erasable quals se r;
@@ -7616,18 +7282,16 @@ let (check_sigelt_quals :
                { FStar_Syntax_Syntax.lbs1 = (is_rec, uu___5);
                  FStar_Syntax_Syntax.lids1 = uu___6;_}
                ->
-               ((let uu___8 =
-                   is_rec &&
-                     (FStar_Compiler_Effect.op_Bar_Greater quals
-                        (FStar_Compiler_List.contains
-                           FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen)) in
-                 if uu___8
-                 then err "recursive definitions cannot be marked inline"
-                 else ());
+               (if
+                  is_rec &&
+                    (FStar_Compiler_List.contains
+                       FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen
+                       quals)
+                then err "recursive definitions cannot be marked inline"
+                else ();
                 (let uu___8 =
-                   FStar_Compiler_Effect.op_Bar_Greater quals
-                     (FStar_Compiler_Util.for_some
-                        (fun x -> (assumption x) || (has_eq x))) in
+                   FStar_Compiler_Util.for_some
+                     (fun x -> (assumption x) || (has_eq x)) quals in
                  if uu___8
                  then
                    err
@@ -7636,24 +7300,21 @@ let (check_sigelt_quals :
            | FStar_Syntax_Syntax.Sig_bundle uu___5 ->
                ((let uu___7 =
                    let uu___8 =
-                     FStar_Compiler_Effect.op_Bar_Greater quals
-                       (FStar_Compiler_Util.for_all
-                          (fun x ->
-                             ((((x =
-                                   FStar_Syntax_Syntax.Inline_for_extraction)
-                                  || (x = FStar_Syntax_Syntax.NoExtract))
-                                 || (inferred x))
-                                || (visibility x))
-                               || (has_eq x))) in
+                     FStar_Compiler_Util.for_all
+                       (fun x ->
+                          ((((x = FStar_Syntax_Syntax.Inline_for_extraction)
+                               || (x = FStar_Syntax_Syntax.NoExtract))
+                              || (inferred x))
+                             || (visibility x))
+                            || (has_eq x)) quals in
                    Prims.op_Negation uu___8 in
                  if uu___7 then err'1 () else ());
                 (let uu___7 =
-                   (FStar_Compiler_Effect.op_Bar_Greater quals
-                      (FStar_Compiler_List.existsb
-                         (fun uu___8 ->
-                            match uu___8 with
-                            | FStar_Syntax_Syntax.Unopteq -> true
-                            | uu___9 -> false)))
+                   (FStar_Compiler_List.existsb
+                      (fun uu___8 ->
+                         match uu___8 with
+                         | FStar_Syntax_Syntax.Unopteq -> true
+                         | uu___9 -> false) quals)
                      &&
                      (FStar_Syntax_Util.has_attribute
                         se.FStar_Syntax_Syntax.sigattrs
@@ -7664,39 +7325,35 @@ let (check_sigelt_quals :
                      "unopteq is not allowed on an erasable inductives since they don't have decidable equality"
                  else ()))
            | FStar_Syntax_Syntax.Sig_declare_typ uu___5 ->
-               let uu___6 =
-                 FStar_Compiler_Effect.op_Bar_Greater quals
-                   (FStar_Compiler_Util.for_some has_eq) in
+               let uu___6 = FStar_Compiler_Util.for_some has_eq quals in
                if uu___6 then err'1 () else ()
            | FStar_Syntax_Syntax.Sig_assume uu___5 ->
                let uu___6 =
                  let uu___7 =
-                   FStar_Compiler_Effect.op_Bar_Greater quals
-                     (FStar_Compiler_Util.for_all
-                        (fun x ->
-                           ((visibility x) ||
-                              (x = FStar_Syntax_Syntax.Assumption))
-                             || (x = FStar_Syntax_Syntax.InternalAssumption))) in
+                   FStar_Compiler_Util.for_all
+                     (fun x ->
+                        ((visibility x) ||
+                           (x = FStar_Syntax_Syntax.Assumption))
+                          || (x = FStar_Syntax_Syntax.InternalAssumption))
+                     quals in
                  Prims.op_Negation uu___7 in
                if uu___6 then err'1 () else ()
            | FStar_Syntax_Syntax.Sig_new_effect uu___5 ->
                let uu___6 =
                  let uu___7 =
-                   FStar_Compiler_Effect.op_Bar_Greater quals
-                     (FStar_Compiler_Util.for_all
-                        (fun x ->
-                           (((x = FStar_Syntax_Syntax.TotalEffect) ||
-                               (inferred x))
-                              || (visibility x))
-                             || (reification x))) in
+                   FStar_Compiler_Util.for_all
+                     (fun x ->
+                        (((x = FStar_Syntax_Syntax.TotalEffect) ||
+                            (inferred x))
+                           || (visibility x))
+                          || (reification x)) quals in
                  Prims.op_Negation uu___7 in
                if uu___6 then err'1 () else ()
            | FStar_Syntax_Syntax.Sig_effect_abbrev uu___5 ->
                let uu___6 =
                  let uu___7 =
-                   FStar_Compiler_Effect.op_Bar_Greater quals
-                     (FStar_Compiler_Util.for_all
-                        (fun x -> (inferred x) || (visibility x))) in
+                   FStar_Compiler_Util.for_all
+                     (fun x -> (inferred x) || (visibility x)) quals in
                  Prims.op_Negation uu___7 in
                if uu___6 then err'1 () else ()
            | uu___5 -> ()))
@@ -7753,9 +7410,7 @@ let (must_erase_for_extraction :
         let res =
           (FStar_TypeChecker_Env.non_informative env t2) || (descend env t2) in
         (let uu___1 =
-           FStar_Compiler_Effect.op_Less_Bar
-             (FStar_TypeChecker_Env.debug env)
-             (FStar_Options.Other "Extraction") in
+           FStar_TypeChecker_Env.debug env (FStar_Options.Other "Extraction") in
          if uu___1
          then
            let uu___2 = FStar_Syntax_Print.term_to_string t2 in
@@ -7771,13 +7426,9 @@ let (effect_extraction_mode :
   fun env ->
     fun l ->
       let uu___ =
-        let uu___1 =
-          FStar_Compiler_Effect.op_Bar_Greater l
-            (FStar_TypeChecker_Env.norm_eff_name env) in
-        FStar_Compiler_Effect.op_Bar_Greater uu___1
-          (FStar_TypeChecker_Env.get_effect_decl env) in
-      FStar_Compiler_Effect.op_Bar_Greater uu___
-        (fun ed -> ed.FStar_Syntax_Syntax.extraction_mode)
+        let uu___1 = FStar_TypeChecker_Env.norm_eff_name env l in
+        FStar_TypeChecker_Env.get_effect_decl env uu___1 in
+      uu___.FStar_Syntax_Syntax.extraction_mode
 let (fresh_effect_repr :
   FStar_TypeChecker_Env.env ->
     FStar_Compiler_Range_Type.range ->
@@ -7804,8 +7455,7 @@ let (fresh_effect_repr :
                 match uu___ with
                 | (uu___1, signature) ->
                     let debug =
-                      FStar_Compiler_Effect.op_Less_Bar
-                        (FStar_TypeChecker_Env.debug env)
+                      FStar_TypeChecker_Env.debug env
                         (FStar_Options.Other "LayeredEffectsApp") in
                     let uu___2 =
                       let uu___3 = FStar_Syntax_Subst.compress signature in
@@ -7884,9 +7534,7 @@ let (fresh_effect_repr :
                                            let uu___6 =
                                              FStar_TypeChecker_Env.inst_tscheme_with
                                                repr_ts [u] in
-                                           FStar_Compiler_Effect.op_Bar_Greater
-                                             uu___6
-                                             FStar_Pervasives_Native.snd in
+                                           FStar_Pervasives_Native.snd uu___6 in
                                          let is_args =
                                            FStar_Compiler_List.map2
                                              (fun i ->
@@ -7917,18 +7565,12 @@ let (fresh_effect_repr_en :
       fun eff_name ->
         fun u ->
           fun a_tm ->
-            let uu___ =
-              FStar_Compiler_Effect.op_Bar_Greater eff_name
-                (FStar_TypeChecker_Env.get_effect_decl env) in
-            FStar_Compiler_Effect.op_Bar_Greater uu___
-              (fun ed ->
-                 let uu___1 =
-                   FStar_Syntax_Util.effect_sig_ts
-                     ed.FStar_Syntax_Syntax.signature in
-                 let uu___2 =
-                   FStar_Compiler_Effect.op_Bar_Greater ed
-                     FStar_Syntax_Util.get_eff_repr in
-                 fresh_effect_repr env r eff_name uu___1 uu___2 u a_tm)
+            let uu___ = FStar_TypeChecker_Env.get_effect_decl env eff_name in
+            let uu___1 =
+              FStar_Syntax_Util.effect_sig_ts
+                uu___.FStar_Syntax_Syntax.signature in
+            let uu___2 = FStar_Syntax_Util.get_eff_repr uu___ in
+            fresh_effect_repr env r eff_name uu___1 uu___2 u a_tm
 let (layered_effect_indices_as_binders :
   FStar_TypeChecker_Env.env ->
     FStar_Compiler_Range_Type.range ->
@@ -7966,9 +7608,8 @@ let (layered_effect_indices_as_binders :
                             FStar_Syntax_Syntax.binder_positivity = uu___5;
                             FStar_Syntax_Syntax.binder_attrs = uu___6;_}::bs2
                             ->
-                            FStar_Compiler_Effect.op_Bar_Greater bs2
-                              (FStar_Syntax_Subst.subst_binders
-                                 [FStar_Syntax_Syntax.NT (a', a_tm)])
+                            FStar_Syntax_Subst.subst_binders
+                              [FStar_Syntax_Syntax.NT (a', a_tm)] bs2
                         | uu___4 -> fail sig_tm)
                    | uu___3 -> fail sig_tm)
 let (check_non_informative_type_for_lift :
@@ -8018,8 +7659,7 @@ let (substitutive_indexed_lift_substs :
         fun lift_name ->
           fun r ->
             let debug =
-              FStar_Compiler_Effect.op_Less_Bar
-                (FStar_TypeChecker_Env.debug env)
+              FStar_TypeChecker_Env.debug env
                 (FStar_Options.Other "LayeredEffectsApp") in
             let uu___ =
               let uu___1 = bs in
@@ -8057,8 +7697,7 @@ let (substitutive_indexed_lift_substs :
                          FStar_Compiler_List.splitAt
                            ((FStar_Compiler_List.length bs2) - Prims.int_one)
                            bs2 in
-                       FStar_Compiler_Effect.op_Bar_Greater uu___2
-                         FStar_Pervasives_Native.fst in
+                       FStar_Pervasives_Native.fst uu___2 in
                      FStar_Compiler_List.fold_left
                        (fun uu___2 ->
                           fun b ->
@@ -8107,8 +7746,7 @@ let (ad_hoc_indexed_lift_substs :
         fun lift_name ->
           fun r ->
             let debug =
-              FStar_Compiler_Effect.op_Less_Bar
-                (FStar_TypeChecker_Env.debug env)
+              FStar_TypeChecker_Env.debug env
                 (FStar_Options.Other "LayeredEffectsApp") in
             let lift_t_shape_error s =
               FStar_Compiler_Util.format2
@@ -8161,11 +7799,9 @@ let (ad_hoc_indexed_lift_substs :
                      let guard_f =
                        let f_sort =
                          let uu___2 =
-                           FStar_Compiler_Effect.op_Bar_Greater
-                             (f_b.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort
-                             (FStar_Syntax_Subst.subst substs) in
-                         FStar_Compiler_Effect.op_Bar_Greater uu___2
-                           FStar_Syntax_Subst.compress in
+                           FStar_Syntax_Subst.subst substs
+                             (f_b.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort in
+                         FStar_Syntax_Subst.compress uu___2 in
                        let f_sort_is =
                          let uu___2 =
                            FStar_TypeChecker_Env.is_layered_effect env
@@ -8200,8 +7836,7 @@ let (lift_tf_layered_effect :
         fun env ->
           fun c ->
             let debug =
-              FStar_Compiler_Effect.op_Less_Bar
-                (FStar_TypeChecker_Env.debug env)
+              FStar_TypeChecker_Env.debug env
                 (FStar_Options.Other "LayeredEffectsApp") in
             if debug
             then
@@ -8248,10 +7883,9 @@ let (lift_tf_layered_effect :
                         | (substs, g) ->
                             let lift_ct =
                               let uu___6 =
-                                FStar_Compiler_Effect.op_Bar_Greater lift_c
-                                  (FStar_Syntax_Subst.subst_comp substs) in
-                              FStar_Compiler_Effect.op_Bar_Greater uu___6
-                                (FStar_TypeChecker_Env.comp_to_comp_typ env) in
+                                FStar_Syntax_Subst.subst_comp substs lift_c in
+                              FStar_TypeChecker_Env.comp_to_comp_typ env
+                                uu___6 in
                             let is =
                               let uu___6 =
                                 FStar_TypeChecker_Env.is_layered_effect env
@@ -8277,12 +7911,10 @@ let (lift_tf_layered_effect :
                                     lift_ct.FStar_Syntax_Syntax.result_typ wp
                                     FStar_Compiler_Range_Type.dummyRange in
                             ((let uu___7 =
-                                (FStar_Compiler_Effect.op_Less_Bar
-                                   (FStar_TypeChecker_Env.debug env)
+                                (FStar_TypeChecker_Env.debug env
                                    (FStar_Options.Other "LayeredEffects"))
                                   &&
-                                  (FStar_Compiler_Effect.op_Less_Bar
-                                     (FStar_TypeChecker_Env.debug env)
+                                  (FStar_TypeChecker_Env.debug env
                                      FStar_Options.Extreme) in
                               if uu___7
                               then
@@ -8294,9 +7926,8 @@ let (lift_tf_layered_effect :
                              (let c1 =
                                 let uu___7 =
                                   let uu___8 =
-                                    FStar_Compiler_Effect.op_Bar_Greater is
-                                      (FStar_Compiler_List.map
-                                         FStar_Syntax_Syntax.as_arg) in
+                                    FStar_Compiler_List.map
+                                      FStar_Syntax_Syntax.as_arg is in
                                   {
                                     FStar_Syntax_Syntax.comp_univs =
                                       (ct.FStar_Syntax_Syntax.comp_univs);
@@ -8341,23 +7972,16 @@ let lift_tf_layered_effect_term :
             let lift =
               let uu___ =
                 let uu___1 =
-                  FStar_Compiler_Effect.op_Bar_Greater
-                    sub.FStar_Syntax_Syntax.lift FStar_Compiler_Util.must in
-                FStar_Compiler_Effect.op_Bar_Greater uu___1
-                  (fun ts -> FStar_TypeChecker_Env.inst_tscheme_with ts [u]) in
-              FStar_Compiler_Effect.op_Bar_Greater uu___
-                FStar_Pervasives_Native.snd in
+                  FStar_Compiler_Util.must sub.FStar_Syntax_Syntax.lift in
+                FStar_TypeChecker_Env.inst_tscheme_with uu___1 [u] in
+              FStar_Pervasives_Native.snd uu___ in
             let rest_bs =
               let lift_t =
-                FStar_Compiler_Effect.op_Bar_Greater
-                  sub.FStar_Syntax_Syntax.lift_wp FStar_Compiler_Util.must in
+                FStar_Compiler_Util.must sub.FStar_Syntax_Syntax.lift_wp in
               let uu___ =
                 let uu___1 =
-                  let uu___2 =
-                    FStar_Compiler_Effect.op_Bar_Greater lift_t
-                      FStar_Pervasives_Native.snd in
-                  FStar_Compiler_Effect.op_Bar_Greater uu___2
-                    FStar_Syntax_Subst.compress in
+                  FStar_Syntax_Subst.compress
+                    (FStar_Pervasives_Native.snd lift_t) in
                 uu___1.FStar_Syntax_Syntax.n in
               match uu___ with
               | FStar_Syntax_Syntax.Tm_arrow
@@ -8365,11 +7989,9 @@ let lift_tf_layered_effect_term :
                     FStar_Syntax_Syntax.comp = uu___2;_}
                   when (FStar_Compiler_List.length bs) >= Prims.int_one ->
                   let uu___3 =
-                    FStar_Compiler_Effect.op_Bar_Greater bs
-                      (FStar_Compiler_List.splitAt
-                         ((FStar_Compiler_List.length bs) - Prims.int_one)) in
-                  FStar_Compiler_Effect.op_Bar_Greater uu___3
-                    FStar_Pervasives_Native.fst
+                    FStar_Compiler_List.splitAt
+                      ((FStar_Compiler_List.length bs) - Prims.int_one) bs in
+                  FStar_Pervasives_Native.fst uu___3
               | uu___1 ->
                   let uu___2 =
                     let uu___3 =
@@ -8385,11 +8007,10 @@ let lift_tf_layered_effect_term :
               let uu___ = FStar_Syntax_Syntax.as_arg a in
               let uu___1 =
                 let uu___2 =
-                  FStar_Compiler_Effect.op_Bar_Greater rest_bs
-                    (FStar_Compiler_List.map
-                       (fun uu___3 ->
-                          FStar_Syntax_Syntax.as_arg
-                            FStar_Syntax_Syntax.unit_const)) in
+                  FStar_Compiler_List.map
+                    (fun uu___3 ->
+                       FStar_Syntax_Syntax.as_arg
+                         FStar_Syntax_Syntax.unit_const) rest_bs in
                 let uu___3 =
                   let uu___4 = FStar_Syntax_Syntax.as_arg e in [uu___4] in
                 FStar_Compiler_List.op_At uu___2 uu___3 in
@@ -8431,20 +8052,18 @@ let (get_field_projector_name :
                    FStar_Syntax_Syntax.comp = uu___3;_}
                  ->
                  let bs1 =
-                   FStar_Compiler_Effect.op_Bar_Greater bs
-                     (FStar_Compiler_List.filter
-                        (fun uu___4 ->
-                           match uu___4 with
-                           | { FStar_Syntax_Syntax.binder_bv = uu___5;
-                               FStar_Syntax_Syntax.binder_qual = q;
-                               FStar_Syntax_Syntax.binder_positivity = uu___6;
-                               FStar_Syntax_Syntax.binder_attrs = uu___7;_}
-                               ->
-                               (match q with
-                                | FStar_Pervasives_Native.Some
-                                    (FStar_Syntax_Syntax.Implicit (true)) ->
-                                    false
-                                | uu___8 -> true))) in
+                   FStar_Compiler_List.filter
+                     (fun uu___4 ->
+                        match uu___4 with
+                        | { FStar_Syntax_Syntax.binder_bv = uu___5;
+                            FStar_Syntax_Syntax.binder_qual = q;
+                            FStar_Syntax_Syntax.binder_positivity = uu___6;
+                            FStar_Syntax_Syntax.binder_attrs = uu___7;_} ->
+                            (match q with
+                             | FStar_Pervasives_Native.Some
+                                 (FStar_Syntax_Syntax.Implicit (true)) ->
+                                 false
+                             | uu___8 -> true)) bs in
                  if (FStar_Compiler_List.length bs1) <= index
                  then err (FStar_Compiler_List.length bs1)
                  else
@@ -8468,11 +8087,8 @@ let (get_mlift_for_subeff :
       then
         let uu___1 =
           let uu___2 =
-            FStar_Compiler_Effect.op_Bar_Greater
-              sub.FStar_Syntax_Syntax.lift_wp FStar_Compiler_Util.must in
-          let uu___3 =
-            FStar_Compiler_Effect.op_Bar_Greater sub.FStar_Syntax_Syntax.kind
-              FStar_Compiler_Util.must in
+            FStar_Compiler_Util.must sub.FStar_Syntax_Syntax.lift_wp in
+          let uu___3 = FStar_Compiler_Util.must sub.FStar_Syntax_Syntax.kind in
           lift_tf_layered_effect sub.FStar_Syntax_Syntax.target uu___2 uu___3 in
         {
           FStar_TypeChecker_Env.mlift_wp = uu___1;
@@ -8513,8 +8129,7 @@ let (get_mlift_for_subeff :
                             FStar_Syntax_Syntax.Tm_app uu___11 in
                           FStar_Syntax_Syntax.mk uu___10
                             (FStar_Pervasives_Native.fst wp).FStar_Syntax_Syntax.pos in
-                        FStar_Compiler_Effect.op_Bar_Greater uu___9
-                          FStar_Syntax_Syntax.as_arg in
+                        FStar_Syntax_Syntax.as_arg uu___9 in
                       [uu___8] in
                     {
                       FStar_Syntax_Syntax.comp_univs =
@@ -8553,9 +8168,8 @@ let (get_mlift_for_subeff :
                FStar_Syntax_Syntax.mk uu___4 e.FStar_Syntax_Syntax.pos in
          let uu___2 =
            let uu___3 =
-             FStar_Compiler_Effect.op_Bar_Greater
-               sub.FStar_Syntax_Syntax.lift_wp FStar_Compiler_Util.must in
-           FStar_Compiler_Effect.op_Bar_Greater uu___3 mk_mlift_wp in
+             FStar_Compiler_Util.must sub.FStar_Syntax_Syntax.lift_wp in
+           mk_mlift_wp uu___3 in
          {
            FStar_TypeChecker_Env.mlift_wp = uu___2;
            FStar_TypeChecker_Env.mlift_term =
@@ -8964,9 +8578,8 @@ let (find_record_or_dc_from_typ :
                 let uu___ =
                   let uu___1 =
                     let uu___2 =
-                      FStar_Compiler_Effect.op_Bar_Greater
-                        rdc.FStar_Syntax_DsEnv.fields
-                        (FStar_Compiler_List.map FStar_Pervasives_Native.fst) in
+                      FStar_Compiler_List.map FStar_Pervasives_Native.fst
+                        rdc.FStar_Syntax_DsEnv.fields in
                     ((rdc.FStar_Syntax_DsEnv.typename), uu___2) in
                   FStar_Syntax_Syntax.Record_ctor uu___1 in
                 FStar_Pervasives_Native.Some uu___
@@ -9023,8 +8636,7 @@ let make_record_fields_in_order :
                              match uu___5 with
                              | (i, uu___6) -> FStar_Ident.string_of_id i)
                           rdc1.FStar_Syntax_DsEnv.fields in
-                      FStar_Compiler_Effect.op_Bar_Greater uu___4
-                        (FStar_Compiler_String.concat "; ") in
+                      FStar_Compiler_String.concat "; " uu___4 in
                     FStar_Compiler_Util.format3
                       "{typename=%s; constrname=%s; fields=[%s]}" uu___1
                       uu___2 uu___3 in
@@ -9034,8 +8646,7 @@ let make_record_fields_in_order :
                         (fun uu___2 ->
                            match uu___2 with
                            | (i, uu___3) -> FStar_Ident.string_of_lid i) fas1 in
-                    FStar_Compiler_Effect.op_Bar_Greater uu___1
-                      (FStar_Compiler_String.concat "; ") in
+                    FStar_Compiler_String.concat "; " uu___1 in
                   let print_topt topt1 =
                     match topt1 with
                     | FStar_Pervasives_Native.None ->
@@ -9078,8 +8689,7 @@ let make_record_fields_in_order :
                     let uu___3 =
                       FStar_Compiler_List.map FStar_Ident.string_of_lid
                         uc.FStar_Syntax_Syntax.uc_fields in
-                    FStar_Compiler_Effect.op_Bar_Greater uu___3
-                      (FStar_Compiler_String.concat "; ") in
+                    FStar_Compiler_String.concat "; " uu___3 in
                   let uu___3 = print_topt topt in
                   let uu___4 = print_rdc rdc in
                   let uu___5 = print_fas fas in

--- a/ocaml/fstar-lib/generated/FStar_Universal.ml
+++ b/ocaml/fstar-lib/generated/FStar_Universal.ml
@@ -782,16 +782,14 @@ let (tc_one_fragment :
           let uu___ =
             let uu___1 =
               FStar_ToSyntax_Interleave.interleave_module ast_modul false in
-            FStar_Compiler_Effect.op_Less_Bar (with_dsenv_of_tcenv env)
-              uu___1 in
+            with_dsenv_of_tcenv env uu___1 in
           match uu___ with
           | (ast_modul1, env1) ->
               let uu___1 =
                 let uu___2 =
                   FStar_ToSyntax_ToSyntax.partial_ast_modul_to_modul curmod
                     ast_modul1 in
-                FStar_Compiler_Effect.op_Less_Bar (with_dsenv_of_tcenv env1)
-                  uu___2 in
+                with_dsenv_of_tcenv env1 uu___2 in
               (match uu___1 with
                | (modul, env2) ->
                    ((let uu___3 =
@@ -841,8 +839,7 @@ let (tc_one_fragment :
                          let uu___2 =
                            FStar_ToSyntax_Interleave.prefix_with_interface_decls
                              modul.FStar_Syntax_Syntax.name a_decl in
-                         FStar_Compiler_Effect.op_Less_Bar
-                           (with_dsenv_of_tcenv env1) uu___2 in
+                         with_dsenv_of_tcenv env1 uu___2 in
                        match uu___1 with | (decls, env2) -> (env2, decls))
                   env ast_decls in
               (match uu___ with
@@ -851,8 +848,7 @@ let (tc_one_fragment :
                      let uu___2 =
                        FStar_ToSyntax_ToSyntax.decls_to_sigelts
                          (FStar_Compiler_List.flatten ast_decls_l) in
-                     FStar_Compiler_Effect.op_Less_Bar
-                       (with_dsenv_of_tcenv env1) uu___2 in
+                     with_dsenv_of_tcenv env1 uu___2 in
                    (match uu___1 with
                     | (sigelts, env2) ->
                         let uu___2 =
@@ -897,8 +893,7 @@ let (load_interface_decls :
           let uu___2 =
             let uu___3 =
               FStar_ToSyntax_Interleave.initialize_interface l decls in
-            FStar_Compiler_Effect.op_Less_Bar (with_dsenv_of_tcenv env)
-              uu___3 in
+            with_dsenv_of_tcenv env uu___3 in
           FStar_Pervasives_Native.snd uu___2
       | FStar_Parser_ParseIt.ASTFragment uu___ ->
           let uu___1 =
@@ -1014,8 +1009,7 @@ let (tc_one_file :
                Prims.op_Negation uu___3 in
              if uu___2
              then
-               let uu___3 = FStar_Options.restore_cmd_line_options true in
-               FStar_Compiler_Effect.op_Bar_Greater uu___3 (fun uu___4 -> ())
+               let uu___3 = FStar_Options.restore_cmd_line_options true in ()
              else () in
            let maybe_extract_mldefs tcmod env1 =
              let uu___1 = FStar_Options.codegen () in
@@ -1216,8 +1210,7 @@ let (tc_one_file :
                             tc_result.FStar_CheckedFiles.mii
                             (FStar_TypeChecker_Normalize.erase_universes
                                tcenv) in
-                        FStar_Compiler_Effect.op_Less_Bar
-                          (with_dsenv_of_tcenv tcenv) uu___5 in
+                        with_dsenv_of_tcenv tcenv uu___5 in
                       match uu___4 with
                       | (uu___5, tcenv1) ->
                           let env1 =
@@ -1238,8 +1231,7 @@ let (tc_one_file :
                        (fun uu___3 ->
                           let uu___4 =
                             with_tcenv_of_env env (extend_tcenv tcmod) in
-                          FStar_Compiler_Effect.op_Bar_Greater uu___4
-                            FStar_Pervasives_Native.snd)
+                          FStar_Pervasives_Native.snd uu___4)
                        FStar_Pervasives_Native.None
                        "FStar.Universal.extend_tcenv" in
                    let mllib =
@@ -1313,9 +1305,7 @@ let (tc_one_file_from_remaining :
           match remaining with
           | intf::impl::remaining1 when needs_interleaving intf impl ->
               let uu___1 =
-                let uu___2 =
-                  FStar_Compiler_Effect.op_Bar_Greater impl
-                    (FStar_Parser_Dep.parsing_data_of deps) in
+                let uu___2 = FStar_Parser_Dep.parsing_data_of deps impl in
                 tc_one_file env (FStar_Pervasives_Native.Some intf) impl
                   uu___2 in
               (match uu___1 with
@@ -1323,8 +1313,7 @@ let (tc_one_file_from_remaining :
           | intf_or_impl::remaining1 ->
               let uu___1 =
                 let uu___2 =
-                  FStar_Compiler_Effect.op_Bar_Greater intf_or_impl
-                    (FStar_Parser_Dep.parsing_data_of deps) in
+                  FStar_Parser_Dep.parsing_data_of deps intf_or_impl in
                 tc_one_file env FStar_Pervasives_Native.None intf_or_impl
                   uu___2 in
               (match uu___1 with
@@ -1393,8 +1382,8 @@ let (batch_mode_tc :
             (FStar_Compiler_String.concat " " filenames);
           (let uu___4 =
              let uu___5 =
-               FStar_Compiler_Effect.op_Bar_Greater filenames
-                 (FStar_Compiler_List.filter FStar_Options.should_verify_file) in
+               FStar_Compiler_List.filter FStar_Options.should_verify_file
+                 filenames in
              FStar_Compiler_String.concat " " uu___5 in
            FStar_Compiler_Util.print1
              "Here's the list of modules we will verify: %s\n" uu___4))
@@ -1425,6 +1414,5 @@ let (batch_mode_tc :
                          (tcenv.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.finish
                            ());
                       ((), tcenv)) in
-               FStar_Compiler_Effect.op_Less_Bar FStar_Pervasives_Native.snd
-                 uu___3 in
+               FStar_Pervasives_Native.snd uu___3 in
              (all_mods, env1, solver_refresh))))

--- a/ocaml/fstar-tests/generated/FStar_Tests_Norm.ml
+++ b/ocaml/fstar-tests/generated/FStar_Tests_Norm.ml
@@ -121,8 +121,7 @@ let (mk_match :
   fun h ->
     fun branches ->
       let branches1 =
-        FStar_Compiler_Effect.op_Bar_Greater branches
-          (FStar_Compiler_List.map FStar_Syntax_Util.branch) in
+        FStar_Compiler_List.map FStar_Syntax_Util.branch branches in
       FStar_Syntax_Syntax.mk
         (FStar_Syntax_Syntax.Tm_match
            {
@@ -1251,8 +1250,7 @@ let run_either :
           (let uu___1 = FStar_Compiler_Util.string_of_int i in
            FStar_Compiler_Util.print1 "%s: ... \n\n" uu___1);
           (let tcenv = FStar_Tests_Pars.init () in
-           (let uu___2 = FStar_Main.process_args () in
-            FStar_Compiler_Effect.op_Bar_Greater uu___2 (fun uu___3 -> ()));
+           (let uu___2 = FStar_Main.process_args () in ());
            (let x = normalizer tcenv r in
             FStar_Options.init ();
             FStar_Options.set_option "print_universes"

--- a/ocaml/fstar-tests/generated/FStar_Tests_Pars.ml
+++ b/ocaml/fstar-tests/generated/FStar_Tests_Pars.ml
@@ -333,11 +333,8 @@ let (pars : Prims.string -> FStar_Syntax_Syntax.term) =
          | () ->
              let tcenv = init () in
              let uu___1 =
-               let uu___2 =
-                 FStar_Compiler_Effect.op_Less_Bar
-                   (fun uu___3 -> FStar_Parser_ParseIt.Fragment uu___3)
-                   (frag_of_text s) in
-               FStar_Parser_ParseIt.parse uu___2 in
+               FStar_Parser_ParseIt.parse
+                 (FStar_Parser_ParseIt.Fragment (frag_of_text s)) in
              (match uu___1 with
               | FStar_Parser_ParseIt.Term t ->
                   FStar_ToSyntax_ToSyntax.desugar_term
@@ -350,8 +347,8 @@ let (pars : Prims.string -> FStar_Syntax_Syntax.term) =
         ()
     with
     | FStar_Errors.Error (err, msg, r, _ctx) when
-        let uu___1 = FStar_Options.trace_error () in
-        FStar_Compiler_Effect.op_Less_Bar Prims.op_Negation uu___1 ->
+        let uu___1 = FStar_Options.trace_error () in Prims.op_Negation uu___1
+        ->
         (if r = FStar_Compiler_Range_Type.dummyRange
          then
            (let uu___2 = FStar_Errors_Msg.rendermsg msg in
@@ -569,9 +566,7 @@ let (tc_term : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
 let (pars_and_tc_fragment : Prims.string -> unit) =
   fun s ->
     FStar_Options.set_option "trace_error" (FStar_Options.Bool true);
-    (let report uu___1 =
-       let uu___2 = FStar_Errors.report_all () in
-       FStar_Compiler_Effect.op_Bar_Greater uu___2 (fun uu___3 -> ()) in
+    (let report uu___1 = let uu___2 = FStar_Errors.report_all () in () in
      try
        (fun uu___1 ->
           match () with
@@ -623,8 +618,7 @@ let (pars_and_tc_fragment : Prims.string -> unit) =
              else Obj.magic (Obj.repr (failwith "unreachable")))) uu___1)
 let (test_hashes : unit -> unit) =
   fun uu___ ->
-    (let uu___2 = FStar_Main.process_args () in
-     FStar_Compiler_Effect.op_Bar_Greater uu___2 (fun uu___3 -> ()));
+    (let uu___2 = FStar_Main.process_args () in ());
     pars_and_tc_fragment "type unary_nat = | U0 | US of unary_nat";
     (let test_one_hash n =
        let rec aux n1 =

--- a/ocaml/fstar-tests/generated/FStar_Tests_Test.ml
+++ b/ocaml/fstar-tests/generated/FStar_Tests_Test.ml
@@ -19,9 +19,7 @@ let main : 'uuuuu 'uuuuu1 . 'uuuuu -> 'uuuuu1 =
                          FStar_Compiler_Effect.exit Prims.int_one)
                     | FStar_Getopt.Empty ->
                         (FStar_Main.setup_hooks ();
-                         (let uu___5 = FStar_Tests_Pars.init () in
-                          FStar_Compiler_Effect.op_Bar_Greater uu___5
-                            (fun uu___6 -> ()));
+                         (let uu___5 = FStar_Tests_Pars.init () in ());
                          FStar_Tests_Pars.parse_incremental_decls ();
                          FStar_Tests_Norm.run_all ();
                          (let uu___8 = FStar_Tests_Unif.run_all () in
@@ -31,9 +29,7 @@ let main : 'uuuuu 'uuuuu1 . 'uuuuu -> 'uuuuu1 =
                          FStar_Compiler_Effect.exit Prims.int_zero)
                     | FStar_Getopt.Success ->
                         (FStar_Main.setup_hooks ();
-                         (let uu___5 = FStar_Tests_Pars.init () in
-                          FStar_Compiler_Effect.op_Bar_Greater uu___5
-                            (fun uu___6 -> ()));
+                         (let uu___5 = FStar_Tests_Pars.init () in ());
                          FStar_Tests_Pars.parse_incremental_decls ();
                          FStar_Tests_Norm.run_all ();
                          (let uu___8 = FStar_Tests_Unif.run_all () in
@@ -44,7 +40,7 @@ let main : 'uuuuu 'uuuuu1 . 'uuuuu -> 'uuuuu1 =
      with
      | FStar_Errors.Error (err, msg, r, _ctx) when
          let uu___2 = FStar_Options.trace_error () in
-         FStar_Compiler_Effect.op_Less_Bar Prims.op_Negation uu___2 ->
+         Prims.op_Negation uu___2 ->
          (if r = FStar_Compiler_Range_Type.dummyRange
           then
             (let uu___3 = FStar_Errors_Msg.rendermsg msg in
@@ -56,7 +52,7 @@ let main : 'uuuuu 'uuuuu1 . 'uuuuu -> 'uuuuu1 =
           FStar_Compiler_Effect.exit Prims.int_one)
      | FStar_Errors.Err (raw_error, s, ls) when
          let uu___2 = FStar_Options.trace_error () in
-         FStar_Compiler_Effect.op_Less_Bar Prims.op_Negation uu___2 ->
+         Prims.op_Negation uu___2 ->
          ((let uu___3 = FStar_Errors_Msg.rendermsg s in
            FStar_Compiler_Util.print2 "%s : [%s]\n" uu___3
              (FStar_String.concat "; " ls));

--- a/ocaml/fstar-tests/generated/FStar_Tests_Unif.ml
+++ b/ocaml/fstar-tests/generated/FStar_Tests_Unif.ml
@@ -52,7 +52,7 @@ let (guard_eq :
                   FStar_Compiler_Util.format3
                     "Test %s failed:\n\tExpected guard %s;\n\tGot guard      %s\n"
                     uu___3 uu___4 uu___5 in
-                FStar_Compiler_Effect.op_Less_Bar fail uu___2)
+                fail uu___2)
              else ();
              (let uu___2 = (FStar_Compiler_Effect.op_Bang success) && b in
               FStar_Compiler_Effect.op_Colon_Equals success uu___2))
@@ -71,8 +71,7 @@ let (unify :
             fun check ->
               (let uu___1 = FStar_Compiler_Util.string_of_int i in
                FStar_Compiler_Util.print1 "%s ..." uu___1);
-              (let uu___2 = FStar_Main.process_args () in
-               FStar_Compiler_Effect.op_Bar_Greater uu___2 (fun uu___3 -> ()));
+              (let uu___2 = FStar_Main.process_args () in ());
               (let uu___3 = FStar_Syntax_Print.term_to_string x in
                let uu___4 = FStar_Syntax_Print.term_to_string y in
                FStar_Compiler_Util.print2 "Unify %s\nand %s\n" uu___3 uu___4);
@@ -81,10 +80,9 @@ let (unify :
                let g =
                  let uu___3 =
                    let uu___4 = FStar_TypeChecker_Rel.teq tcenv2 x y in
-                   FStar_Compiler_Effect.op_Bar_Greater uu___4
-                     (FStar_TypeChecker_Rel.solve_deferred_constraints tcenv2) in
-                 FStar_Compiler_Effect.op_Bar_Greater uu___3
-                   (FStar_TypeChecker_Rel.simplify_guard tcenv2) in
+                   FStar_TypeChecker_Rel.solve_deferred_constraints tcenv2
+                     uu___4 in
+                 FStar_TypeChecker_Rel.simplify_guard tcenv2 uu___3 in
                guard_eq i g.FStar_TypeChecker_Common.guard_f g';
                check ();
                FStar_Options.init ())
@@ -99,13 +97,12 @@ let (should_fail :
            match () with
            | () ->
                let g =
-                 let uu___1 =
-                   let uu___2 = tcenv () in
-                   FStar_TypeChecker_Rel.teq uu___2 x y in
+                 let uu___1 = tcenv () in
                  let uu___2 =
                    let uu___3 = tcenv () in
-                   FStar_TypeChecker_Rel.solve_deferred_constraints uu___3 in
-                 FStar_Compiler_Effect.op_Bar_Greater uu___1 uu___2 in
+                   FStar_TypeChecker_Rel.teq uu___3 x y in
+                 FStar_TypeChecker_Rel.solve_deferred_constraints uu___1
+                   uu___2 in
                (match g.FStar_TypeChecker_Common.guard_f with
                 | FStar_TypeChecker_Common.Trivial ->
                     let uu___1 =
@@ -131,12 +128,10 @@ let (unify' : Prims.string -> Prims.string -> unit) =
       let x1 = FStar_Tests_Pars.pars x in
       let y1 = FStar_Tests_Pars.pars y in
       let g =
-        let uu___ =
-          let uu___1 = tcenv () in FStar_TypeChecker_Rel.teq uu___1 x1 y1 in
+        let uu___ = tcenv () in
         let uu___1 =
-          let uu___2 = tcenv () in
-          FStar_TypeChecker_Rel.solve_deferred_constraints uu___2 in
-        FStar_Compiler_Effect.op_Bar_Greater uu___ uu___1 in
+          let uu___2 = tcenv () in FStar_TypeChecker_Rel.teq uu___2 x1 y1 in
+        FStar_TypeChecker_Rel.solve_deferred_constraints uu___ uu___1 in
       let uu___ = FStar_Syntax_Print.term_to_string x1 in
       let uu___1 = FStar_Syntax_Print.term_to_string y1 in
       let uu___2 = guard_to_string g.FStar_TypeChecker_Common.guard_f in
@@ -156,8 +151,7 @@ let (check_core :
       fun guard_ok ->
         fun x ->
           fun y ->
-            (let uu___1 = FStar_Main.process_args () in
-             FStar_Compiler_Effect.op_Bar_Greater uu___1 (fun uu___2 -> ()));
+            (let uu___1 = FStar_Main.process_args () in ());
             (let env = tcenv () in
              let res =
                if subtyping
@@ -187,8 +181,7 @@ let (check_core_typing :
   fun i ->
     fun e ->
       fun t ->
-        (let uu___1 = FStar_Main.process_args () in
-         FStar_Compiler_Effect.op_Bar_Greater uu___1 (fun uu___2 -> ()));
+        (let uu___1 = FStar_Main.process_args () in ());
         (let env = tcenv () in
          (let uu___2 = FStar_TypeChecker_Core.check_term env e t true in
           match uu___2 with
@@ -285,8 +278,7 @@ let (run_all : unit -> Prims.bool) =
                "(forall (x:int). (forall (y:int). (forall (z:int). y==z)))" in
            FStar_TypeChecker_Common.NonTrivial uu___15 in
          unify1 (Prims.of_int (8)) [] uu___12 uu___13 uu___14);
-        (let uu___13 = FStar_Main.process_args () in
-         FStar_Compiler_Effect.op_Bar_Greater uu___13 (fun uu___14 -> ()));
+        (let uu___13 = FStar_Main.process_args () in ());
         (let uu___13 =
            let uu___14 =
              FStar_Tests_Pars.tc "fun (u:Type0 -> Type0) (x:Type0) -> u x" in

--- a/src/basic/FStar.Compiler.Effect.fst
+++ b/src/basic/FStar.Compiler.Effect.fst
@@ -36,9 +36,6 @@ effect All (a:Type) (pre:all_pre) (post:(h:unit -> Tot (all_post' a (pre h)))) =
 
 effect ML (a:Type) = ALL a (fun (p:all_post a) (_:unit) -> forall (a:result a) (h:unit). p a h)
 
-let ( |> ) (x : 'a) (f : ('a -> ML 'b)) : ML 'b = f x
-let ( <| ) (f : ('a -> ML 'b)) (x : 'a) : ML 'b = f x
-
 assume
 val ref (a:Type0) : Type0
 

--- a/src/tosyntax/FStar.ToSyntax.ToSyntax.fst
+++ b/src/tosyntax/FStar.ToSyntax.ToSyntax.fst
@@ -1229,6 +1229,12 @@ and desugar_term_maybe_top (top_level:bool) (env:env_t) (top:term) : S.term * an
             " in non-universe context")
           top.range
 
+    | Op(s, [f;e]) when Ident.string_of_id s = "<|" ->
+      desugar_term_maybe_top top_level env (mkApp f [e,Nothing] top.range)
+
+    | Op(s, [e;f]) when Ident.string_of_id s = "|>" ->
+      desugar_term_maybe_top top_level env (mkApp f [e,Nothing] top.range)
+
     | Op(s, args) ->
       begin
       match op_as_term env (List.length args) s with

--- a/tests/micro-benchmarks/Pipes.fst
+++ b/tests/micro-benchmarks/Pipes.fst
@@ -1,0 +1,62 @@
+module Pipes
+
+open FStar.List.Tot
+
+assume val concat : string -> list string -> string
+
+let test (ls : list string) (s1 s2 : string) : string =
+  concat s1 <| ls @ [s2]
+
+let cat = (^)
+
+let testl (f : int -> int) (g : int -> bool) (h : bool -> string) : Tot string =
+  h <| g <| f 123
+
+let testl_dv (f : int -> Dv int) (g : int -> Dv bool) (h : bool -> Dv string) : Dv string =
+  h <| g <| f 123
+
+let testl2 (f : int -> int) (g : int -> bool) (h : int -> bool -> string) : Tot string =
+  h 42 <| g <| f 123
+
+let testl2_dv (f : int -> Dv int) (g : int -> Dv bool) (h : int -> bool -> Dv string) : Dv string =
+  h 42 <| g <| f 123
+
+let test1 (f g h i : _) = assert ((f <| g <| h <| i) == (f (g (h i))))
+let test2 (f g h i : _) = assert ((i |> h |> g |> f) == (f (g (h i))))
+
+let testr (f : int -> int) (g : int -> bool) (h : bool -> string) : Tot string =
+  f 123 |> g |> h
+
+let testr_dv (f : int -> Dv int) (g : int -> Dv bool) (h : bool -> Dv string) : Dv string =
+  f 123 |> g |> h
+
+let mktup2 x y : string & int =
+    let xx = string_of_int x |> id #string in
+    (xx, y)
+
+let mktup2_b x y : string & int =
+    id #string <| string_of_int x, y
+
+let mktup2_c x y : string & int =
+    (id #string <| string_of_int x), y
+
+let mktup2_d x y : string & int =
+    id #(string & int) <| (string_of_int x, y)
+
+let assoc1 #a #b #c (x:a) (y : b -> a -> c) (z : b) : c =
+  x |> y <| z
+
+let assoc1' #a #b #c (x:a) (y : b -> a -> c) (z : b) : c =
+  x |> (y <| z)
+
+let assoc1'' #a #b #c (x:a) (y : a -> b -> c) (z : b) : c =
+  (x |> y) <| z
+
+let assoc2 #a #b #c (x:a -> b) (y : a) (z : b -> c) : c =
+  x <| y |> z
+
+let assoc2' #a #b #c (x:a -> b) (y : a) (z : b -> c) : c =
+  (x <| y) |> z
+
+let assoc2'' #a #b #c (x:b -> c) (y : a) (z : a -> b) : c =
+  x <| (y |> z)

--- a/ulib/FStar.All.fst
+++ b/ulib/FStar.All.fst
@@ -36,12 +36,6 @@ effect All (a:Type) (pre:all_pre) (post:(h:heap -> Tot (all_post' a (pre h)))) =
     (fun (p : all_post a) (h : heap) -> pre h /\ (forall ra h1. post h ra h1 ==> p ra h1))
 effect ML (a:Type) = ALL a (fun (p:all_post a) (_:heap) -> forall (a:result a) (h:heap). p a h)
 
-let ( |> ) (x : 'a) (f : ('a -> ML 'b)) : ML 'b = f x
-let pipe_right = ( |> )
-
-let ( <| ) (f : ('a -> ML 'b)) (x : 'a) : ML 'b = f x
-let pipe_left = ( <| )
-
 assume val exit : int -> ML 'a
 assume val try_with : (unit -> ML 'a) -> (exn -> ML 'a) -> ML 'a
 

--- a/ulib/FStar.HyperStack.All.fst
+++ b/ulib/FStar.HyperStack.All.fst
@@ -34,8 +34,6 @@ effect All (a:Type) (pre:all_pre) (post: (h0:HyperStack.mem -> Tot (all_post' a 
 effect ML (a:Type) =
   ALL a (fun (p:all_post a) (_:HyperStack.mem) -> forall (a:result a) (h:HyperStack.mem). p a h)
 
-assume val pipe_right: 'a -> ('a -> ML 'b) -> ML 'b
-assume val pipe_left: ('a -> ML 'b) -> 'a -> ML 'b
 assume val failwith: string -> All 'a (fun h -> True) (fun h a h' -> Err? a /\ h==h')
 assume val exit: int -> ML 'a
 assume val try_with: (unit -> ML 'a) -> (exn -> ML 'a) -> ML 'a


### PR DESCRIPTION
This PR makes the operators `|>` and `<|` into primitives recognized by the parser and desugarer, which are interpreted as applications, just with different associativity and precedence.

This is good (IMO) since:
1- We get "effect polymorphism" for free: these are just applications, while if we define the operators must choose an effect
2- Base files in the compiler get a bit of cleanup, since they had these definitions
3- The generated OCaml looks simpler
4- SMT queries may be simpler
5- One does not inadvertedly lose equations if using an effectful `<|` or `|>`, when both the function and arguments are total. This actually led to a _regression_ in everparse, where the snippet
```fstar
let print_binding mname (td:type_decl)
  : ML (string & string)
  = let tdn = td.name in
    let typ = td.typ in
    let k = td.kind in
    let root_name = print_ident mname tdn.td_name in
    let print_binders binders =
        List.map (print_param mname) binders |>
        String.concat " "
    in
    let print_args binders =
        List.map (fun (i, _) -> print_ident mname i) binders |>
        String.concat " "
    in
    ...
```
was now failing, I suppose since `print_binders` and `print_args` now have SMT definitions and that was too much (but I didn't dig deep into it..). Annotating them as `ML string` fixes the issue here. I'd argue this is generally a good thing, though..?

Disadvantages:
1- The operators cannot be redefined (hence the patch in DoublyLinkedList)
2- The use of the operators is currently lost after desugaring, so it won't be printed by `--dump_module` (but `--print` works). This could be fixed by keeping some meta_desugared info.

*(paragraph edited, got confused)*
Note that F# has these operators too, where both of them associate to left. So `|>` behaves the same, but one can write `f <| X <| Y <| Z` to get `f (X) (Y) (Z)`. F* also had this behavior, so we are changing that by changing the associativity of `<|`, but we think the symmetry is nicer. A pipeline of passing `x` though functions `f`, `g` and `h` in that order can then be written `x |> f |> g |> h` or `h <| g <| f <| x`.

In the parser, I made `<|` have more precedence that `|>`, see tests [here](https://github.com/FStarLang/FStar/pull/3122/commits/4f59bece90dfef3a4c843c113d43101d77e7e75b#diff-6a870a390fede4aa691e401ded7ce1fedc2bde683b0e6764721918fffa5a4f8dR46). This is totally arbitrary, not sure if it's the right thing.

OCaml did something similar, also giving `|>` and `@@` (our `<|`) special handling as an application: see https://github.com/ocaml/ocaml/pull/10081. 

As a follow up I want to change the precedence rules to allow snippets like (slightly edited):
```fstar
let generalize env is_rec lecs = 
  Errors.with_ctx "While generalizing" (fun () ->
    Profiling.profile (fun () -> generalize' env is_rec lecs)
  )
```
be written in this form:
```fstar
let generalize env is_rec lecs = 
  Errors.with_ctx "While generalizing" <| fun () ->
  Profiling.profile <| fun () ->
  generalize' env is_rec lecs
```
which is a common (I think) style in OCaml. This requires some deeper parser surgery, so I'm not bundling it here.