### PR TITLE
Make `--MLish --lax` safer

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_Syntax_Embeddings.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Embeddings.ml
@@ -2145,85 +2145,73 @@ let e_sealed :
     'a FStar_Syntax_Embeddings_Base.embedding ->
       'a FStar_Syntax_Embeddings_Base.embedding
   =
-  fun uu___ ->
-    (fun ea ->
-       let typ =
-         let uu___ = FStar_Syntax_Embeddings_Base.type_of ea in
-         FStar_Syntax_Syntax.t_sealed_of uu___ in
-       let emb_ty_a =
-         let uu___ =
-           let uu___1 =
-             FStar_Compiler_Effect.op_Bar_Greater
-               FStar_Parser_Const.sealed_lid FStar_Ident.string_of_lid in
-           let uu___2 =
-             let uu___3 = FStar_Syntax_Embeddings_Base.emb_typ_of ea in
-             [uu___3] in
-           (uu___1, uu___2) in
-         FStar_Syntax_Syntax.ET_app uu___ in
-       let printer1 x =
-         let uu___ =
-           let uu___1 =
-             let uu___2 = FStar_Syntax_Embeddings_Base.printer_of ea in
-             uu___2 x in
-           Prims.op_Hat uu___1 ")" in
-         Prims.op_Hat "(seal " uu___ in
-       let em a1 rng shadow norm =
-         let shadow_a =
-           map_shadow shadow
-             (fun t ->
-                let unseal =
-                  FStar_Syntax_Util.fvar_const FStar_Parser_Const.unseal_lid in
-                let uu___ =
-                  FStar_Syntax_Syntax.mk_Tm_uinst unseal
-                    [FStar_Syntax_Syntax.U_zero] in
-                let uu___1 =
-                  let uu___2 =
-                    let uu___3 = FStar_Syntax_Embeddings_Base.type_of ea in
-                    FStar_Syntax_Syntax.iarg uu___3 in
-                  let uu___3 =
-                    let uu___4 = FStar_Syntax_Syntax.as_arg t in [uu___4] in
-                  uu___2 :: uu___3 in
-                FStar_Syntax_Syntax.mk_Tm_app uu___ uu___1 rng) in
-         let uu___ =
-           let uu___1 =
-             FStar_Syntax_Util.fvar_const FStar_Parser_Const.seal_lid in
-           FStar_Syntax_Syntax.mk_Tm_uinst uu___1
-             [FStar_Syntax_Syntax.U_zero] in
-         let uu___1 =
-           let uu___2 =
-             let uu___3 = FStar_Syntax_Embeddings_Base.type_of ea in
-             FStar_Syntax_Syntax.iarg uu___3 in
-           let uu___3 =
-             let uu___4 =
-               let uu___5 =
-                 let uu___6 = FStar_Syntax_Embeddings_Base.embed ea a1 in
-                 uu___6 rng shadow_a norm in
-               FStar_Syntax_Syntax.as_arg uu___5 in
-             [uu___4] in
-           uu___2 :: uu___3 in
-         FStar_Syntax_Syntax.mk_Tm_app uu___ uu___1 rng in
-       let un t norm =
-         let uu___ = FStar_Syntax_Util.head_and_args_full t in
-         match uu___ with
-         | (hd, args) ->
+  fun ea ->
+    let typ =
+      let uu___ = FStar_Syntax_Embeddings_Base.type_of ea in
+      FStar_Syntax_Syntax.t_sealed_of uu___ in
+    let emb_ty_a =
+      let uu___ =
+        let uu___1 =
+          FStar_Compiler_Effect.op_Bar_Greater FStar_Parser_Const.sealed_lid
+            FStar_Ident.string_of_lid in
+        let uu___2 =
+          let uu___3 = FStar_Syntax_Embeddings_Base.emb_typ_of ea in [uu___3] in
+        (uu___1, uu___2) in
+      FStar_Syntax_Syntax.ET_app uu___ in
+    let printer1 x =
+      let uu___ =
+        let uu___1 =
+          let uu___2 = FStar_Syntax_Embeddings_Base.printer_of ea in uu___2 x in
+        Prims.op_Hat uu___1 ")" in
+      Prims.op_Hat "(seal " uu___ in
+    let em a1 rng shadow norm =
+      let shadow_a =
+        map_shadow shadow
+          (fun t ->
+             let unseal =
+               FStar_Syntax_Util.fvar_const FStar_Parser_Const.unseal_lid in
+             let uu___ =
+               FStar_Syntax_Syntax.mk_Tm_uinst unseal
+                 [FStar_Syntax_Syntax.U_zero] in
              let uu___1 =
                let uu___2 =
-                 let uu___3 = FStar_Syntax_Util.un_uinst hd in
-                 uu___3.FStar_Syntax_Syntax.n in
-               (uu___2, args) in
-             (match uu___1 with
-              | (FStar_Syntax_Syntax.Tm_fvar fv, uu___2::(a1, uu___3)::[])
-                  when
-                  FStar_Syntax_Syntax.fv_eq_lid fv
-                    FStar_Parser_Const.seal_lid
-                  ->
-                  Obj.magic
-                    (Obj.repr
-                       (FStar_Syntax_Embeddings_Base.try_unembed ea a1 norm))
-              | uu___2 -> Obj.magic (Obj.repr FStar_Pervasives_Native.None)) in
-       Obj.magic
-         (FStar_Syntax_Embeddings_Base.mk_emb_full (Obj.magic em) un typ
-            (fun uu___ -> (Obj.magic printer1) uu___) emb_ty_a)) uu___
+                 let uu___3 = FStar_Syntax_Embeddings_Base.type_of ea in
+                 FStar_Syntax_Syntax.iarg uu___3 in
+               let uu___3 =
+                 let uu___4 = FStar_Syntax_Syntax.as_arg t in [uu___4] in
+               uu___2 :: uu___3 in
+             FStar_Syntax_Syntax.mk_Tm_app uu___ uu___1 rng) in
+      let uu___ =
+        let uu___1 = FStar_Syntax_Util.fvar_const FStar_Parser_Const.seal_lid in
+        FStar_Syntax_Syntax.mk_Tm_uinst uu___1 [FStar_Syntax_Syntax.U_zero] in
+      let uu___1 =
+        let uu___2 =
+          let uu___3 = FStar_Syntax_Embeddings_Base.type_of ea in
+          FStar_Syntax_Syntax.iarg uu___3 in
+        let uu___3 =
+          let uu___4 =
+            let uu___5 =
+              let uu___6 = FStar_Syntax_Embeddings_Base.embed ea a1 in
+              uu___6 rng shadow_a norm in
+            FStar_Syntax_Syntax.as_arg uu___5 in
+          [uu___4] in
+        uu___2 :: uu___3 in
+      FStar_Syntax_Syntax.mk_Tm_app uu___ uu___1 rng in
+    let un t norm =
+      let uu___ = FStar_Syntax_Util.head_and_args_full t in
+      match uu___ with
+      | (hd, args) ->
+          let uu___1 =
+            let uu___2 =
+              let uu___3 = FStar_Syntax_Util.un_uinst hd in
+              uu___3.FStar_Syntax_Syntax.n in
+            (uu___2, args) in
+          (match uu___1 with
+           | (FStar_Syntax_Syntax.Tm_fvar fv, uu___2::(a1, uu___3)::[]) when
+               FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.seal_lid
+               -> FStar_Syntax_Embeddings_Base.try_unembed ea a1 norm
+           | uu___2 -> FStar_Pervasives_Native.None) in
+    FStar_Syntax_Embeddings_Base.mk_emb_full em un typ printer1 emb_ty_a
 let (e___range :
   FStar_Compiler_Range_Type.range FStar_Syntax_Embeddings_Base.embedding) =
   let em r rng _shadow _norm =

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Err.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Err.ml
@@ -40,66 +40,58 @@ let (info_at_pos :
                        uu___3) in
                    FStar_Pervasives_Native.Some uu___1)
 let print_discrepancy : 'a 'b . ('a -> 'b) -> 'a -> 'a -> ('b * 'b) =
-  fun uu___2 ->
-    fun uu___1 ->
-      fun uu___ ->
-        (fun f ->
-           fun x ->
-             fun y ->
-               let print uu___ =
-                 let xs = f x in
-                 let ys = f y in ((Obj.magic xs), (Obj.magic ys), (xs <> ys)) in
-               let rec blist_leq l1 l2 =
-                 match (l1, l2) with
-                 | (h1::t1, h2::t2) ->
-                     ((Prims.op_Negation h1) || h2) && (blist_leq t1 t2)
-                 | ([], []) -> true
-                 | uu___ -> failwith "print_discrepancy: bad lists" in
-               let rec succ l =
-                 match l with
-                 | (false)::t -> true :: t
-                 | (true)::t -> let uu___ = succ t in false :: uu___
-                 | [] -> failwith "" in
-               let full l = FStar_Compiler_List.for_all (fun b1 -> b1) l in
-               let get_bool_option s =
-                 let uu___ = FStar_Options.get_option s in
-                 match uu___ with
-                 | FStar_Options.Bool b1 -> b1
-                 | uu___1 -> failwith "print_discrepancy: impossible" in
-               let set_bool_option s b1 =
-                 FStar_Options.set_option s (FStar_Options.Bool b1) in
-               let get uu___ =
-                 let pi = get_bool_option "print_implicits" in
-                 let pu = get_bool_option "print_universes" in
-                 let pea = get_bool_option "print_effect_args" in
-                 let pf = get_bool_option "print_full_names" in
-                 [pi; pu; pea; pf] in
-               let set l =
-                 match l with
-                 | pi::pu::pea::pf::[] ->
-                     (set_bool_option "print_implicits" pi;
-                      set_bool_option "print_universes" pu;
-                      set_bool_option "print_effect_args" pea;
-                      set_bool_option "print_full_names " pf)
-                 | uu___ -> failwith "impossible: print_discrepancy" in
-               let bas = get () in
-               let rec go cur =
-                 match () with
-                 | () when full cur ->
-                     let uu___ = print () in
-                     (match uu___ with | (xs, ys, uu___1) -> (xs, ys))
-                 | () when
-                     let uu___ = blist_leq bas cur in Prims.op_Negation uu___
-                     -> let uu___ = succ cur in go uu___
-                 | () ->
-                     (set cur;
-                      (let uu___1 = print () in
-                       match uu___1 with
-                       | (xs, ys, true) -> (xs, ys)
-                       | uu___2 -> let uu___3 = succ cur in go uu___3)) in
-               Obj.magic
-                 (FStar_Options.with_saved_options (fun uu___ -> go bas)))
-          uu___2 uu___1 uu___
+  fun f ->
+    fun x ->
+      fun y ->
+        let print uu___ =
+          let xs = f x in let ys = f y in (xs, ys, (xs <> ys)) in
+        let rec blist_leq l1 l2 =
+          match (l1, l2) with
+          | (h1::t1, h2::t2) ->
+              ((Prims.op_Negation h1) || h2) && (blist_leq t1 t2)
+          | ([], []) -> true
+          | uu___ -> failwith "print_discrepancy: bad lists" in
+        let rec succ l =
+          match l with
+          | (false)::t -> true :: t
+          | (true)::t -> let uu___ = succ t in false :: uu___
+          | [] -> failwith "" in
+        let full l = FStar_Compiler_List.for_all (fun b1 -> b1) l in
+        let get_bool_option s =
+          let uu___ = FStar_Options.get_option s in
+          match uu___ with
+          | FStar_Options.Bool b1 -> b1
+          | uu___1 -> failwith "print_discrepancy: impossible" in
+        let set_bool_option s b1 =
+          FStar_Options.set_option s (FStar_Options.Bool b1) in
+        let get uu___ =
+          let pi = get_bool_option "print_implicits" in
+          let pu = get_bool_option "print_universes" in
+          let pea = get_bool_option "print_effect_args" in
+          let pf = get_bool_option "print_full_names" in [pi; pu; pea; pf] in
+        let set l =
+          match l with
+          | pi::pu::pea::pf::[] ->
+              (set_bool_option "print_implicits" pi;
+               set_bool_option "print_universes" pu;
+               set_bool_option "print_effect_args" pea;
+               set_bool_option "print_full_names " pf)
+          | uu___ -> failwith "impossible: print_discrepancy" in
+        let bas = get () in
+        let rec go cur =
+          match () with
+          | () when full cur ->
+              let uu___ = print () in
+              (match uu___ with | (xs, ys, uu___1) -> (xs, ys))
+          | () when let uu___ = blist_leq bas cur in Prims.op_Negation uu___
+              -> let uu___ = succ cur in go uu___
+          | () ->
+              (set cur;
+               (let uu___1 = print () in
+                match uu___1 with
+                | (xs, ys, true) -> (xs, ys)
+                | uu___2 -> let uu___3 = succ cur in go uu___3)) in
+        FStar_Options.with_saved_options (fun uu___ -> go bas)
 let (errors_smt_detail :
   FStar_TypeChecker_Env.env ->
     FStar_Errors.error Prims.list ->

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Rel.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Rel.ml
@@ -13437,7 +13437,11 @@ let (try_teq :
             FStar_TypeChecker_Env.hasBinders_env
             FStar_Class_Binders.hasNames_term FStar_Syntax_Print.pretty_term
             t2.FStar_Syntax_Syntax.pos "try_teq.2" env t2;
-          (let uu___2 =
+          (let smt_ok1 =
+             smt_ok &&
+               (let uu___2 = FStar_Options.ml_ish () in
+                Prims.op_Negation uu___2) in
+           let uu___2 =
              let uu___3 =
                let uu___4 = FStar_TypeChecker_Env.current_module env in
                FStar_Ident.string_of_lid uu___4 in
@@ -13467,7 +13471,7 @@ let (try_teq :
                  | (prob, wl) ->
                      let g =
                        let uu___6 =
-                         solve_and_commit (singleton wl prob smt_ok)
+                         solve_and_commit (singleton wl prob smt_ok1)
                            (fun uu___7 -> FStar_Pervasives_Native.None) in
                        FStar_Compiler_Effect.op_Less_Bar
                          (with_guard env prob) uu___6 in
@@ -13896,6 +13900,10 @@ let (try_solve_deferred_constraints :
       fun deferred_to_tac_ok ->
         fun env ->
           fun g ->
+            let smt_ok1 =
+              smt_ok &&
+                (let uu___ = FStar_Options.ml_ish () in
+                 Prims.op_Negation uu___) in
             let uu___ =
               let uu___1 =
                 let uu___2 = FStar_TypeChecker_Env.current_module env in
@@ -13939,7 +13947,7 @@ let (try_solve_deferred_constraints :
                      wl_deferred_to_tac = (uu___2.wl_deferred_to_tac);
                      ctr = (uu___2.ctr);
                      defer_ok;
-                     smt_ok;
+                     smt_ok = smt_ok1;
                      umax_heuristic_ok = (uu___2.umax_heuristic_ok);
                      tcenv = (uu___2.tcenv);
                      wl_implicits = (uu___2.wl_implicits);
@@ -14048,7 +14056,8 @@ let (solve_deferred_constraints :
   fun env ->
     fun g ->
       let defer_ok = NoDefer in
-      let smt_ok = true in
+      let smt_ok =
+        let uu___ = FStar_Options.ml_ish () in Prims.op_Negation uu___ in
       let deferred_to_tac_ok = true in
       try_solve_deferred_constraints defer_ok smt_ok deferred_to_tac_ok env g
 let (solve_non_tactic_deferred_constraints :
@@ -14069,7 +14078,9 @@ let (solve_non_tactic_deferred_constraints :
                "solve_non_tactic_deferred_constraints.g" env g;
              (let defer_ok =
                 if maybe_defer_flex_flex then DeferFlexFlexOnly else NoDefer in
-              let smt_ok = true in
+              let smt_ok =
+                let uu___2 = FStar_Options.ml_ish () in
+                Prims.op_Negation uu___2 in
               let deferred_to_tac_ok = false in
               try_solve_deferred_constraints defer_ok smt_ok
                 deferred_to_tac_ok env g))

--- a/src/syntax/FStar.Syntax.Embeddings.fst
+++ b/src/syntax/FStar.Syntax.Embeddings.fst
@@ -990,7 +990,7 @@ let e_sealed (ea : embedding 'a) : embedding 'a =
                   [S.iarg (type_of ea); S.as_arg (embed ea a rng shadow_a norm)]
                   rng
     in
-    let un (t:term) norm : option (option 'a) =
+    let un (t:term) norm : option 'a =
       let hd, args = U.head_and_args_full t in
       match (U.un_uinst hd).n, args with
       | Tm_fvar fv, [_; (a, _)] when S.fv_eq_lid fv PC.seal_lid ->

--- a/src/typechecker/FStar.TypeChecker.Err.fst
+++ b/src/typechecker/FStar.TypeChecker.Err.fst
@@ -50,7 +50,7 @@ let info_at_pos env file row col =
  * a discrepancy of implicits before one of universes, etc.
  *)
 let print_discrepancy (#a:Type) (#b:eqtype) (f : a -> b) (x : a) (y : a) : b * b =
-    let print () : string * string * bool =
+    let print () : b * b * bool =
         let xs = f x in
         let ys = f y in
         xs, ys, xs <> ys

--- a/src/typechecker/FStar.TypeChecker.Rel.fst
+++ b/src/typechecker/FStar.TypeChecker.Rel.fst
@@ -4761,6 +4761,8 @@ let with_guard env prob dopt =
 let try_teq smt_ok env t1 t2 : option guard_t =
   def_check_scoped t1.pos "try_teq.1" env t1;
   def_check_scoped t2.pos "try_teq.2" env t2;
+  // --MLish disables use of SMT. See PR #3123 for explanation.
+  let smt_ok = smt_ok && not (Options.ml_ish ()) in
   Profiling.profile
     (fun () ->
       if Env.debug env <| Options.Other "Rel" then
@@ -4922,6 +4924,7 @@ let solve_universe_inequalities env ineqs : unit =
     UF.commit tx
 
 let try_solve_deferred_constraints (defer_ok:defer_ok_t) smt_ok deferred_to_tac_ok env (g:guard_t) : guard_t =
+  let smt_ok = smt_ok && not (Options.ml_ish ()) in
   Profiling.profile (fun () ->
    let typeclass_variables =
     g.implicits
@@ -4987,7 +4990,7 @@ let try_solve_deferred_constraints (defer_ok:defer_ok_t) smt_ok deferred_to_tac_
 
 let solve_deferred_constraints env (g:guard_t) =
     let defer_ok = NoDefer in
-    let smt_ok = true in
+    let smt_ok = not (Options.ml_ish ()) in
     let deferred_to_tac_ok = true in
     try_solve_deferred_constraints defer_ok smt_ok deferred_to_tac_ok env g
 
@@ -4995,7 +4998,7 @@ let solve_non_tactic_deferred_constraints maybe_defer_flex_flex env (g:guard_t) 
   Errors.with_ctx "solve_non_tactic_deferred_constraints" (fun () ->
     def_check_scoped Range.dummyRange "solve_non_tactic_deferred_constraints.g" env g;
     let defer_ok = if maybe_defer_flex_flex then DeferFlexFlexOnly else NoDefer in
-    let smt_ok = true in
+    let smt_ok = not (Options.ml_ish ()) in
     let deferred_to_tac_ok = false in
     try_solve_deferred_constraints defer_ok smt_ok deferred_to_tac_ok env g
   )


### PR DESCRIPTION
We've usually been bitten in compiler code by running in lax mode, since the unifier could "accept" an equality such as `'a = int` (where `'a` is some fresh polymorphic variable), since it would generate an SMT guard for it that would immediately be dropped. This leads to hard to find crashes when it does happen.

This PR prevents the unifier from generating these equalities in `--MLish` mode, and failing early instead. We had all the mechanism already implemented: the `smt_ok` flag, which we just force to false if we're using `--MLish`.

This uncovers two typing errors in compiler code!

cc @nikswamy who had the idea