### PR TITLE
Use a typeclass for ord and sets in the compiler

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_Class_Binders.ml
+++ b/ocaml/fstar-lib/generated/FStar_Class_Binders.ml
@@ -1,31 +1,24 @@
 open Prims
 type 'a hasNames =
   {
-  freeNames: 'a -> FStar_Syntax_Syntax.bv FStar_Compiler_Util.set }
+  freeNames: 'a -> FStar_Syntax_Syntax.bv FStar_Compiler_Set.set }
 let __proj__MkhasNames__item__freeNames :
-  'a . 'a hasNames -> 'a -> FStar_Syntax_Syntax.bv FStar_Compiler_Util.set =
+  'a . 'a hasNames -> 'a -> FStar_Syntax_Syntax.bv FStar_Compiler_Set.set =
   fun projectee -> match projectee with | { freeNames;_} -> freeNames
 let freeNames :
-  'a . 'a hasNames -> 'a -> FStar_Syntax_Syntax.bv FStar_Compiler_Util.set =
+  'a . 'a hasNames -> 'a -> FStar_Syntax_Syntax.bv FStar_Compiler_Set.set =
   fun projectee ->
     match projectee with | { freeNames = freeNames1;_} -> freeNames1
 type 'a hasBinders =
   {
-  boundNames: 'a -> FStar_Syntax_Syntax.bv FStar_Compiler_Util.set }
+  boundNames: 'a -> FStar_Syntax_Syntax.bv FStar_Compiler_Set.set }
 let __proj__MkhasBinders__item__boundNames :
-  'a . 'a hasBinders -> 'a -> FStar_Syntax_Syntax.bv FStar_Compiler_Util.set
-  = fun projectee -> match projectee with | { boundNames;_} -> boundNames
+  'a . 'a hasBinders -> 'a -> FStar_Syntax_Syntax.bv FStar_Compiler_Set.set =
+  fun projectee -> match projectee with | { boundNames;_} -> boundNames
 let boundNames :
-  'a . 'a hasBinders -> 'a -> FStar_Syntax_Syntax.bv FStar_Compiler_Util.set
-  =
+  'a . 'a hasBinders -> 'a -> FStar_Syntax_Syntax.bv FStar_Compiler_Set.set =
   fun projectee ->
     match projectee with | { boundNames = boundNames1;_} -> boundNames1
-let set_join :
-  'a . 'a FStar_Compiler_Util.set Prims.list -> 'a FStar_Compiler_Util.set =
-  fun uu___ ->
-    match uu___ with
-    | hd::tl ->
-        FStar_Compiler_List.fold_left FStar_Compiler_Util.set_union hd tl
 let (hasNames_term : FStar_Syntax_Syntax.term hasNames) =
   { freeNames = FStar_Syntax_Free.names }
 let (hasNames_comp : FStar_Syntax_Syntax.comp hasNames) =
@@ -37,22 +30,23 @@ let (hasNames_comp : FStar_Syntax_Syntax.comp hasNames) =
          | FStar_Syntax_Syntax.GTotal t -> FStar_Syntax_Free.names t
          | FStar_Syntax_Syntax.Comp ct ->
              let uu___ =
-               let uu___1 =
-                 FStar_Syntax_Free.names ct.FStar_Syntax_Syntax.result_typ in
+               FStar_Compiler_Set.empty FStar_Syntax_Syntax.ord_bv () in
+             let uu___1 =
                let uu___2 =
+                 FStar_Syntax_Free.names ct.FStar_Syntax_Syntax.result_typ in
+               let uu___3 =
                  FStar_Compiler_List.map
-                   (fun uu___3 ->
-                      match uu___3 with
-                      | (a, uu___4) -> FStar_Syntax_Free.names a)
+                   (fun uu___4 ->
+                      match uu___4 with
+                      | (a, uu___5) -> FStar_Syntax_Free.names a)
                    ct.FStar_Syntax_Syntax.effect_args in
-               uu___1 :: uu___2 in
-             set_join uu___)
+               uu___2 :: uu___3 in
+             FStar_Compiler_List.fold_left
+               (FStar_Compiler_Set.union FStar_Syntax_Syntax.ord_bv) uu___
+               uu___1)
   }
 let (hasBinders_list_bv : FStar_Syntax_Syntax.bv Prims.list hasBinders) =
-  {
-    boundNames =
-      (fun l -> FStar_Compiler_Util.as_set l FStar_Syntax_Syntax.order_bv)
-  }
+  { boundNames = (FStar_Compiler_Set.from_list FStar_Syntax_Syntax.ord_bv) }
 let (hasBinders_set_bv :
-  FStar_Syntax_Syntax.bv FStar_Compiler_Util.set hasBinders) =
+  FStar_Syntax_Syntax.bv FStar_Compiler_Set.set hasBinders) =
   { boundNames = FStar_Pervasives.id }

--- a/ocaml/fstar-lib/generated/FStar_Class_Deq.ml
+++ b/ocaml/fstar-lib/generated/FStar_Class_Deq.ml
@@ -19,6 +19,8 @@ let (deq_int : Prims.int deq) =
 let (deq_bool : Prims.bool deq) =
   { op_Equals_Question = (fun x -> fun y -> x = y) }
 let (deq_unit : unit deq) = { op_Equals_Question = (fun x -> fun y -> true) }
+let (deq_string : Prims.string deq) =
+  { op_Equals_Question = (fun x -> fun y -> x = y) }
 let deq_option : 'a . 'a deq -> 'a FStar_Pervasives_Native.option deq =
   fun uu___ ->
     {

--- a/ocaml/fstar-lib/generated/FStar_Class_Ord.ml
+++ b/ocaml/fstar-lib/generated/FStar_Class_Ord.ml
@@ -1,0 +1,260 @@
+open Prims
+type 'a ord =
+  {
+  super: 'a FStar_Class_Deq.deq ;
+  cmp: 'a -> 'a -> FStar_Compiler_Order.order }
+let __proj__Mkord__item__super : 'a . 'a ord -> 'a FStar_Class_Deq.deq =
+  fun projectee -> match projectee with | { super; cmp;_} -> super
+let __proj__Mkord__item__cmp :
+  'a . 'a ord -> 'a -> 'a -> FStar_Compiler_Order.order =
+  fun projectee -> match projectee with | { super; cmp;_} -> cmp
+let super : 'a . 'a ord -> 'a FStar_Class_Deq.deq =
+  fun projectee -> match projectee with | { super = super1; cmp;_} -> super1
+let cmp : 'a . 'a ord -> 'a -> 'a -> FStar_Compiler_Order.order =
+  fun projectee ->
+    match projectee with | { super = super1; cmp = cmp1;_} -> cmp1
+let op_Less_Question : 'a . 'a ord -> 'a -> 'a -> Prims.bool =
+  fun uu___ ->
+    fun x ->
+      fun y -> let uu___1 = cmp uu___ x y in uu___1 = FStar_Compiler_Order.Lt
+let op_Less_Equals_Question : 'a . 'a ord -> 'a -> 'a -> Prims.bool =
+  fun uu___ ->
+    fun x ->
+      fun y ->
+        let uu___1 = cmp uu___ x y in uu___1 <> FStar_Compiler_Order.Gt
+let op_Greater_Question : 'a . 'a ord -> 'a -> 'a -> Prims.bool =
+  fun uu___ ->
+    fun x ->
+      fun y -> let uu___1 = cmp uu___ x y in uu___1 = FStar_Compiler_Order.Gt
+let op_Greater_Equals_Question : 'a . 'a ord -> 'a -> 'a -> Prims.bool =
+  fun uu___ ->
+    fun x ->
+      fun y ->
+        let uu___1 = cmp uu___ x y in uu___1 <> FStar_Compiler_Order.Lt
+let ord_eq : 'a . 'a ord -> 'a FStar_Class_Deq.deq = fun d -> d.super
+let rec insert : 'a . 'a ord -> 'a -> 'a Prims.list -> 'a Prims.list =
+  fun uu___ ->
+    fun x ->
+      fun xs ->
+        match xs with
+        | [] -> [x]
+        | y::ys ->
+            let uu___1 = op_Less_Equals_Question uu___ x y in
+            if uu___1
+            then x :: y :: ys
+            else (let uu___3 = insert uu___ x ys in y :: uu___3)
+let rec sort : 'a . 'a ord -> 'a Prims.list -> 'a Prims.list =
+  fun uu___ ->
+    fun xs ->
+      match xs with
+      | [] -> []
+      | x::xs1 -> let uu___1 = sort uu___ xs1 in insert uu___ x uu___1
+let rec dedup : 'a . 'a ord -> 'a Prims.list -> 'a Prims.list =
+  fun uu___ ->
+    fun xs ->
+      let rec aux xs1 =
+        match xs1 with
+        | [] -> []
+        | x::xs2 ->
+            let uu___1 =
+              FStar_Compiler_List.existsb
+                (FStar_Class_Deq.op_Equals_Question (ord_eq uu___) x) xs2 in
+            if uu___1
+            then dedup uu___ xs2
+            else (let uu___3 = dedup uu___ xs2 in x :: uu___3) in
+      aux (FStar_Compiler_List.rev xs)
+let (ord_int : Prims.int ord) =
+  { super = FStar_Class_Deq.deq_int; cmp = FStar_Compiler_Order.compare_int }
+let (ord_bool : Prims.bool ord) =
+  { super = FStar_Class_Deq.deq_bool; cmp = FStar_Compiler_Order.compare_bool
+  }
+let (ord_unit : unit ord) =
+  {
+    super = FStar_Class_Deq.deq_unit;
+    cmp = (fun uu___ -> fun uu___1 -> FStar_Compiler_Order.Eq)
+  }
+let (ord_string : Prims.string ord) =
+  {
+    super = FStar_Class_Deq.deq_string;
+    cmp =
+      (fun x ->
+         fun y ->
+           FStar_Compiler_Order.order_from_int
+             (FStar_Compiler_String.compare x y))
+  }
+let ord_option : 'a . 'a ord -> 'a FStar_Pervasives_Native.option ord =
+  fun d ->
+    {
+      super = (FStar_Class_Deq.deq_option (ord_eq d));
+      cmp =
+        (fun x ->
+           fun y ->
+             match (x, y) with
+             | (FStar_Pervasives_Native.None, FStar_Pervasives_Native.None)
+                 -> FStar_Compiler_Order.Eq
+             | (FStar_Pervasives_Native.Some uu___,
+                FStar_Pervasives_Native.None) -> FStar_Compiler_Order.Gt
+             | (FStar_Pervasives_Native.None, FStar_Pervasives_Native.Some
+                uu___) -> FStar_Compiler_Order.Lt
+             | (FStar_Pervasives_Native.Some x1, FStar_Pervasives_Native.Some
+                y1) -> cmp d x1 y1)
+    }
+let ord_list : 'a . 'a ord -> 'a Prims.list ord =
+  fun d ->
+    {
+      super = (FStar_Class_Deq.deq_list (ord_eq d));
+      cmp =
+        (fun l1 -> fun l2 -> FStar_Compiler_Order.compare_list l1 l2 (cmp d))
+    }
+let ord_either :
+  'a 'b . 'a ord -> 'b ord -> ('a, 'b) FStar_Pervasives.either ord =
+  fun d1 ->
+    fun d2 ->
+      {
+        super = (FStar_Class_Deq.deq_either (ord_eq d1) (ord_eq d2));
+        cmp =
+          (fun x ->
+             fun y ->
+               match (x, y) with
+               | (FStar_Pervasives.Inl uu___, FStar_Pervasives.Inr uu___1) ->
+                   FStar_Compiler_Order.Lt
+               | (FStar_Pervasives.Inr uu___, FStar_Pervasives.Inl uu___1) ->
+                   FStar_Compiler_Order.Gt
+               | (FStar_Pervasives.Inl x1, FStar_Pervasives.Inl y1) ->
+                   cmp d1 x1 y1
+               | (FStar_Pervasives.Inr x1, FStar_Pervasives.Inr y1) ->
+                   cmp d2 x1 y1)
+      }
+let ord_tuple2 : 'a 'b . 'a ord -> 'b ord -> ('a * 'b) ord =
+  fun d1 ->
+    fun d2 ->
+      {
+        super = (FStar_Class_Deq.deq_tuple2 (ord_eq d1) (ord_eq d2));
+        cmp =
+          (fun uu___ ->
+             fun uu___1 ->
+               match (uu___, uu___1) with
+               | ((x1, x2), (y1, y2)) ->
+                   let uu___2 = cmp d1 x1 y1 in
+                   FStar_Compiler_Order.lex uu___2
+                     (fun uu___3 -> cmp d2 x2 y2))
+      }
+let ord_tuple3 : 'a 'b 'c . 'a ord -> 'b ord -> 'c ord -> ('a * 'b * 'c) ord
+  =
+  fun d1 ->
+    fun d2 ->
+      fun d3 ->
+        {
+          super =
+            (FStar_Class_Deq.deq_tuple3 (ord_eq d1) (ord_eq d2) (ord_eq d3));
+          cmp =
+            (fun uu___ ->
+               fun uu___1 ->
+                 match (uu___, uu___1) with
+                 | ((x1, x2, x3), (y1, y2, y3)) ->
+                     let uu___2 = cmp d1 x1 y1 in
+                     FStar_Compiler_Order.lex uu___2
+                       (fun uu___3 ->
+                          let uu___4 = cmp d2 x2 y2 in
+                          FStar_Compiler_Order.lex uu___4
+                            (fun uu___5 -> cmp d3 x3 y3)))
+        }
+let ord_tuple4 :
+  'a 'b 'c 'd .
+    'a ord -> 'b ord -> 'c ord -> 'd ord -> ('a * 'b * 'c * 'd) ord
+  =
+  fun d1 ->
+    fun d2 ->
+      fun d3 ->
+        fun d4 ->
+          {
+            super =
+              (FStar_Class_Deq.deq_tuple4 (ord_eq d1) (ord_eq d2) (ord_eq d3)
+                 (ord_eq d4));
+            cmp =
+              (fun uu___ ->
+                 fun uu___1 ->
+                   match (uu___, uu___1) with
+                   | ((x1, x2, x3, x4), (y1, y2, y3, y4)) ->
+                       let uu___2 = cmp d1 x1 y1 in
+                       FStar_Compiler_Order.lex uu___2
+                         (fun uu___3 ->
+                            let uu___4 = cmp d2 x2 y2 in
+                            FStar_Compiler_Order.lex uu___4
+                              (fun uu___5 ->
+                                 let uu___6 = cmp d3 x3 y3 in
+                                 FStar_Compiler_Order.lex uu___6
+                                   (fun uu___7 -> cmp d4 x4 y4))))
+          }
+let ord_tuple5 :
+  'a 'b 'c 'd 'e .
+    'a ord ->
+      'b ord -> 'c ord -> 'd ord -> 'e ord -> ('a * 'b * 'c * 'd * 'e) ord
+  =
+  fun d1 ->
+    fun d2 ->
+      fun d3 ->
+        fun d4 ->
+          fun d5 ->
+            {
+              super =
+                (FStar_Class_Deq.deq_tuple5 (ord_eq d1) (ord_eq d2)
+                   (ord_eq d3) (ord_eq d4) (ord_eq d5));
+              cmp =
+                (fun uu___ ->
+                   fun uu___1 ->
+                     match (uu___, uu___1) with
+                     | ((x1, x2, x3, x4, x5), (y1, y2, y3, y4, y5)) ->
+                         let uu___2 = cmp d1 x1 y1 in
+                         FStar_Compiler_Order.lex uu___2
+                           (fun uu___3 ->
+                              let uu___4 = cmp d2 x2 y2 in
+                              FStar_Compiler_Order.lex uu___4
+                                (fun uu___5 ->
+                                   let uu___6 = cmp d3 x3 y3 in
+                                   FStar_Compiler_Order.lex uu___6
+                                     (fun uu___7 ->
+                                        let uu___8 = cmp d4 x4 y4 in
+                                        FStar_Compiler_Order.lex uu___8
+                                          (fun uu___9 -> cmp d5 x5 y5)))))
+            }
+let ord_tuple6 :
+  'a 'b 'c 'd 'e 'f .
+    'a ord ->
+      'b ord ->
+        'c ord ->
+          'd ord -> 'e ord -> 'f ord -> ('a * 'b * 'c * 'd * 'e * 'f) ord
+  =
+  fun d1 ->
+    fun d2 ->
+      fun d3 ->
+        fun d4 ->
+          fun d5 ->
+            fun d6 ->
+              {
+                super =
+                  (FStar_Class_Deq.deq_tuple6 (ord_eq d1) (ord_eq d2)
+                     (ord_eq d3) (ord_eq d4) (ord_eq d5) (ord_eq d6));
+                cmp =
+                  (fun uu___ ->
+                     fun uu___1 ->
+                       match (uu___, uu___1) with
+                       | ((x1, x2, x3, x4, x5, x6), (y1, y2, y3, y4, y5, y6))
+                           ->
+                           let uu___2 = cmp d1 x1 y1 in
+                           FStar_Compiler_Order.lex uu___2
+                             (fun uu___3 ->
+                                let uu___4 = cmp d2 x2 y2 in
+                                FStar_Compiler_Order.lex uu___4
+                                  (fun uu___5 ->
+                                     let uu___6 = cmp d3 x3 y3 in
+                                     FStar_Compiler_Order.lex uu___6
+                                       (fun uu___7 ->
+                                          let uu___8 = cmp d4 x4 y4 in
+                                          FStar_Compiler_Order.lex uu___8
+                                            (fun uu___9 ->
+                                               let uu___10 = cmp d5 x5 y5 in
+                                               FStar_Compiler_Order.lex
+                                                 uu___10
+                                                 (fun uu___11 -> cmp d6 x6 y6))))))
+              }

--- a/ocaml/fstar-lib/generated/FStar_Class_Show.ml
+++ b/ocaml/fstar-lib/generated/FStar_Class_Show.ml
@@ -9,8 +9,6 @@ let printableshow : 'a . 'a FStar_Class_Printable.printable -> 'a showable =
   fun uu___ -> { show = (FStar_Class_Printable.to_string uu___) }
 let show_list : 'a . 'a showable -> 'a Prims.list showable =
   fun uu___ -> { show = ((FStar_Common.string_of_list ()) (show uu___)) }
-let show_set : 'a . 'a showable -> 'a FStar_Compiler_Util.set showable =
-  fun uu___ -> { show = (FStar_Common.string_of_set (show uu___)) }
 let show_option :
   'a . 'a showable -> 'a FStar_Pervasives_Native.option showable =
   fun uu___ -> { show = (FStar_Common.string_of_option (show uu___)) }

--- a/ocaml/fstar-lib/generated/FStar_Common.ml
+++ b/ocaml/fstar-lib/generated/FStar_Common.ml
@@ -100,25 +100,6 @@ let string_of_list' :
   'uuuuu .
     unit -> ('uuuuu -> Prims.string) -> 'uuuuu Prims.list -> Prims.string
   = fun uu___ -> __string_of_list "; "
-let string_of_set :
-  'a . ('a -> Prims.string) -> 'a FStar_Compiler_Util.set -> Prims.string =
-  fun f ->
-    fun l ->
-      let uu___ = FStar_Compiler_Util.set_elements l in
-      match uu___ with
-      | [] -> "{}"
-      | x::xs ->
-          let strb = FStar_Compiler_Util.new_string_builder () in
-          (FStar_Compiler_Util.string_builder_append strb "{";
-           (let uu___3 = f x in
-            FStar_Compiler_Util.string_builder_append strb uu___3);
-           FStar_Compiler_List.iter
-             (fun x1 ->
-                FStar_Compiler_Util.string_builder_append strb ", ";
-                (let uu___5 = f x1 in
-                 FStar_Compiler_Util.string_builder_append strb uu___5)) xs;
-           FStar_Compiler_Util.string_builder_append strb "}";
-           FStar_Compiler_Util.string_of_string_builder strb)
 let list_of_option : 'a . 'a FStar_Pervasives_Native.option -> 'a Prims.list
   =
   fun o ->

--- a/ocaml/fstar-lib/generated/FStar_Compiler_Order.ml
+++ b/ocaml/fstar-lib/generated/FStar_Compiler_Order.ml
@@ -1,0 +1,65 @@
+open Prims
+type order =
+  | Lt 
+  | Eq 
+  | Gt 
+let (uu___is_Lt : order -> Prims.bool) =
+  fun projectee -> match projectee with | Lt -> true | uu___ -> false
+let (uu___is_Eq : order -> Prims.bool) =
+  fun projectee -> match projectee with | Eq -> true | uu___ -> false
+let (uu___is_Gt : order -> Prims.bool) =
+  fun projectee -> match projectee with | Gt -> true | uu___ -> false
+let (ge : order -> Prims.bool) = fun o -> o <> Lt
+let (le : order -> Prims.bool) = fun o -> o <> Gt
+let (ne : order -> Prims.bool) = fun o -> o <> Eq
+let (gt : order -> Prims.bool) = fun o -> o = Gt
+let (lt : order -> Prims.bool) = fun o -> o = Lt
+let (eq : order -> Prims.bool) = fun o -> o = Eq
+let (lex : order -> (unit -> order) -> order) =
+  fun o1 ->
+    fun o2 ->
+      match (o1, o2) with
+      | (Lt, uu___) -> Lt
+      | (Eq, uu___) -> o2 ()
+      | (Gt, uu___) -> Gt
+let (order_from_int : Prims.int -> order) =
+  fun i ->
+    if i < Prims.int_zero then Lt else if i = Prims.int_zero then Eq else Gt
+let (compare_int : Prims.int -> Prims.int -> order) =
+  fun i -> fun j -> order_from_int (i - j)
+let (compare_bool : Prims.bool -> Prims.bool -> order) =
+  fun b1 ->
+    fun b2 ->
+      match (b1, b2) with
+      | (false, true) -> Lt
+      | (true, false) -> Gt
+      | uu___ -> Eq
+let rec compare_list :
+  'a . 'a Prims.list -> 'a Prims.list -> ('a -> 'a -> order) -> order =
+  fun l1 ->
+    fun l2 ->
+      fun f ->
+        match (l1, l2) with
+        | ([], []) -> Eq
+        | ([], uu___) -> Lt
+        | (uu___, []) -> Gt
+        | (x::xs, y::ys) ->
+            let uu___ = f x y in
+            lex uu___ (fun uu___1 -> compare_list xs ys f)
+let compare_option :
+  'a .
+    ('a -> 'a -> order) ->
+      'a FStar_Pervasives_Native.option ->
+        'a FStar_Pervasives_Native.option -> order
+  =
+  fun f ->
+    fun x ->
+      fun y ->
+        match (x, y) with
+        | (FStar_Pervasives_Native.None, FStar_Pervasives_Native.None) -> Eq
+        | (FStar_Pervasives_Native.None, FStar_Pervasives_Native.Some uu___)
+            -> Lt
+        | (FStar_Pervasives_Native.Some uu___, FStar_Pervasives_Native.None)
+            -> Gt
+        | (FStar_Pervasives_Native.Some x1, FStar_Pervasives_Native.Some y1)
+            -> f x1 y1

--- a/ocaml/fstar-lib/generated/FStar_Compiler_Set.ml
+++ b/ocaml/fstar-lib/generated/FStar_Compiler_Set.ml
@@ -1,0 +1,65 @@
+open Prims
+type 't set = 't FStar_Compiler_Util.set
+type 'a t = 'a set
+let add : 'a . 'a FStar_Class_Ord.ord -> 'a -> 'a set -> 'a set =
+  fun uu___ -> fun x -> fun s -> FStar_Compiler_Util.set_add x s
+let empty : 'a . 'a FStar_Class_Ord.ord -> unit -> 'a set =
+  fun uu___ ->
+    fun uu___1 ->
+      FStar_Compiler_Util.new_set
+        (fun x ->
+           fun y ->
+             let uu___2 = FStar_Class_Ord.cmp uu___ x y in
+             match uu___2 with
+             | FStar_Compiler_Order.Lt -> ~- Prims.int_one
+             | FStar_Compiler_Order.Eq -> Prims.int_zero
+             | FStar_Compiler_Order.Gt -> Prims.int_one)
+let from_list : 'a . 'a FStar_Class_Ord.ord -> 'a Prims.list -> 'a set =
+  fun uu___ ->
+    fun xs ->
+      FStar_Compiler_Util.as_set xs
+        (fun x ->
+           fun y ->
+             let uu___1 = FStar_Class_Ord.cmp uu___ x y in
+             match uu___1 with
+             | FStar_Compiler_Order.Lt -> ~- Prims.int_one
+             | FStar_Compiler_Order.Eq -> Prims.int_zero
+             | FStar_Compiler_Order.Gt -> Prims.int_one)
+let mem : 'a . 'a FStar_Class_Ord.ord -> 'a -> 'a set -> Prims.bool =
+  fun uu___ -> fun x -> fun s -> FStar_Compiler_Util.set_mem x s
+let singleton : 'a . 'a FStar_Class_Ord.ord -> 'a -> 'a set =
+  fun uu___ ->
+    fun x ->
+      let uu___1 = empty uu___ () in FStar_Compiler_Util.set_add x uu___1
+let is_empty : 'a . 'a FStar_Class_Ord.ord -> 'a set -> Prims.bool =
+  fun uu___ -> fun s -> FStar_Compiler_Util.set_is_empty s
+let addn : 'a . 'a FStar_Class_Ord.ord -> 'a Prims.list -> 'a set -> 'a set =
+  fun uu___ ->
+    fun xs -> fun ys -> FStar_Compiler_List.fold_right (add uu___) xs ys
+let remove : 'a . 'a FStar_Class_Ord.ord -> 'a -> 'a set -> 'a set =
+  fun uu___ -> fun x -> fun s -> FStar_Compiler_Util.set_remove x s
+let equal : 'a . 'a FStar_Class_Ord.ord -> 'a set -> 'a set -> Prims.bool =
+  fun uu___ -> fun s1 -> fun s2 -> FStar_Compiler_Util.set_eq s1 s2
+let inter : 'a . 'a FStar_Class_Ord.ord -> 'a set -> 'a set -> 'a set =
+  fun uu___ -> fun s1 -> fun s2 -> FStar_Compiler_Util.set_intersect s1 s2
+let union : 'a . 'a FStar_Class_Ord.ord -> 'a set -> 'a set -> 'a set =
+  fun uu___ -> fun s1 -> fun s2 -> FStar_Compiler_Util.set_union s1 s2
+let diff : 'a . 'a FStar_Class_Ord.ord -> 'a set -> 'a set -> 'a set =
+  fun uu___ -> fun s1 -> fun s2 -> FStar_Compiler_Util.set_difference s1 s2
+let subset : 'a . 'a FStar_Class_Ord.ord -> 'a set -> 'a set -> Prims.bool =
+  fun uu___ -> fun s1 -> fun s2 -> FStar_Compiler_Util.set_is_subset_of s1 s2
+let elems : 'a . 'a FStar_Class_Ord.ord -> 'a set -> 'a Prims.list =
+  fun uu___ -> fun s -> FStar_Compiler_Util.set_elements s
+let showable_set :
+  'a .
+    'a FStar_Class_Ord.ord ->
+      'a FStar_Class_Show.showable -> 'a set FStar_Class_Show.showable
+  =
+  fun uu___ ->
+    fun uu___1 ->
+      {
+        FStar_Class_Show.show =
+          (fun s ->
+             let uu___2 = elems uu___ s in
+             FStar_Class_Show.show (FStar_Class_Show.show_list uu___1) uu___2)
+      }

--- a/ocaml/fstar-lib/generated/FStar_Defensive.ml
+++ b/ocaml/fstar-lib/generated/FStar_Defensive.ml
@@ -8,26 +8,29 @@ let (pp_bv : FStar_Syntax_Syntax.bv FStar_Class_PP.pretty) =
   }
 let pp_set :
   'a .
-    'a FStar_Class_PP.pretty ->
-      'a FStar_Compiler_Util.set FStar_Class_PP.pretty
+    'a FStar_Class_Ord.ord ->
+      'a FStar_Class_PP.pretty ->
+        'a FStar_Compiler_Set.set FStar_Class_PP.pretty
   =
   fun uu___ ->
-    {
-      FStar_Class_PP.pp =
-        (fun s ->
-           let doclist ds =
-             let uu___1 = FStar_Pprint.doc_of_string "[]" in
+    fun uu___1 ->
+      {
+        FStar_Class_PP.pp =
+          (fun s ->
+             let doclist ds =
+               let uu___2 = FStar_Pprint.doc_of_string "[]" in
+               let uu___3 =
+                 let uu___4 = FStar_Pprint.break_ Prims.int_one in
+                 FStar_Pprint.op_Hat_Hat FStar_Pprint.semi uu___4 in
+               FStar_Pprint.surround_separate (Prims.of_int (2))
+                 Prims.int_zero uu___2 FStar_Pprint.lbracket uu___3
+                 FStar_Pprint.rbracket ds in
              let uu___2 =
-               let uu___3 = FStar_Pprint.break_ Prims.int_one in
-               FStar_Pprint.op_Hat_Hat FStar_Pprint.semi uu___3 in
-             FStar_Pprint.surround_separate (Prims.of_int (2)) Prims.int_zero
-               uu___1 FStar_Pprint.lbracket uu___2 FStar_Pprint.rbracket ds in
-           let uu___1 =
-             let uu___2 = FStar_Compiler_Util.set_elements s in
-             FStar_Compiler_Effect.op_Bar_Greater uu___2
-               (FStar_List.map (FStar_Class_PP.pp uu___)) in
-           doclist uu___1)
-    }
+               let uu___3 = FStar_Compiler_Set.elems uu___ s in
+               FStar_Compiler_Effect.op_Bar_Greater uu___3
+                 (FStar_Compiler_List.map (FStar_Class_PP.pp uu___1)) in
+             doclist uu___2)
+      }
 let __def_check_scoped :
   'envut 'thingut .
     'envut FStar_Class_Binders.hasBinders ->
@@ -47,10 +50,8 @@ let __def_check_scoped :
                 let scope = FStar_Class_Binders.boundNames uu___ env in
                 let uu___3 =
                   let uu___4 =
-                    let uu___5 =
-                      FStar_Compiler_Util.set_difference free scope in
-                    FStar_Compiler_Effect.op_Less_Bar
-                      FStar_Compiler_Util.set_is_empty uu___5 in
+                    FStar_Compiler_Set.subset FStar_Syntax_Syntax.ord_bv free
+                      scope in
                   Prims.op_Negation uu___4 in
                 if uu___3
                 then
@@ -73,22 +74,28 @@ let __def_check_scoped :
                           let uu___10 =
                             let uu___11 = FStar_Errors_Msg.text "FVs =" in
                             let uu___12 =
-                              FStar_Class_PP.pp (pp_set pp_bv) free in
+                              FStar_Class_PP.pp
+                                (pp_set FStar_Syntax_Syntax.ord_bv pp_bv)
+                                free in
                             FStar_Pprint.op_Hat_Slash_Hat uu___11 uu___12 in
                           let uu___11 =
                             let uu___12 =
                               let uu___13 = FStar_Errors_Msg.text "Scope =" in
                               let uu___14 =
-                                FStar_Class_PP.pp (pp_set pp_bv) scope in
+                                FStar_Class_PP.pp
+                                  (pp_set FStar_Syntax_Syntax.ord_bv pp_bv)
+                                  scope in
                               FStar_Pprint.op_Hat_Slash_Hat uu___13 uu___14 in
                             let uu___13 =
                               let uu___14 =
                                 let uu___15 = FStar_Errors_Msg.text "Diff =" in
                                 let uu___16 =
                                   let uu___17 =
-                                    FStar_Compiler_Util.set_difference free
-                                      scope in
-                                  FStar_Class_PP.pp (pp_set pp_bv) uu___17 in
+                                    FStar_Compiler_Set.diff
+                                      FStar_Syntax_Syntax.ord_bv free scope in
+                                  FStar_Class_PP.pp
+                                    (pp_set FStar_Syntax_Syntax.ord_bv pp_bv)
+                                    uu___17 in
                                 FStar_Pprint.op_Hat_Slash_Hat uu___15 uu___16 in
                               [uu___14] in
                             uu___12 :: uu___13 in

--- a/ocaml/fstar-lib/generated/FStar_Extraction_ML_RemoveUnusedParameters.ml
+++ b/ocaml/fstar-lib/generated/FStar_Extraction_ML_RemoveUnusedParameters.ml
@@ -45,17 +45,16 @@ let (lookup_tyname :
     fun name ->
       let uu___ = FStar_Extraction_ML_Syntax.string_of_mlpath name in
       FStar_Compiler_Util.psmap_try_find env.tydef_map uu___
-type var_set = FStar_Extraction_ML_Syntax.mlident FStar_Compiler_Util.set
-let (empty_var_set : Prims.string FStar_Compiler_Util.set) =
-  FStar_Compiler_Util.new_set
-    (fun x -> fun y -> FStar_Compiler_String.compare x y)
+type var_set = FStar_Extraction_ML_Syntax.mlident FStar_Compiler_Set.set
+let (empty_var_set : Prims.string FStar_Compiler_Set.set) =
+  FStar_Compiler_Set.empty FStar_Class_Ord.ord_string ()
 let rec (freevars_of_mlty' :
   var_set -> FStar_Extraction_ML_Syntax.mlty -> var_set) =
   fun vars ->
     fun t ->
       match t with
       | FStar_Extraction_ML_Syntax.MLTY_Var i ->
-          FStar_Compiler_Util.set_add i vars
+          FStar_Compiler_Set.add FStar_Class_Ord.ord_string i vars
       | FStar_Extraction_ML_Syntax.MLTY_Fun (t0, uu___, t1) ->
           let uu___1 = freevars_of_mlty' vars t0 in
           freevars_of_mlty' uu___1 t1
@@ -315,7 +314,9 @@ let (elim_tydef :
                    fun p ->
                      match uu___1 with
                      | (i, params, entry1) ->
-                         let uu___2 = FStar_Compiler_Util.set_mem p freevars in
+                         let uu___2 =
+                           FStar_Compiler_Set.mem FStar_Class_Ord.ord_string
+                             p freevars in
                          if uu___2
                          then
                            (if must_eliminate i

--- a/ocaml/fstar-lib/generated/FStar_Interactive_Ide.ml
+++ b/ocaml/fstar-lib/generated/FStar_Interactive_Ide.ml
@@ -2504,7 +2504,7 @@ type search_candidate =
       FStar_Compiler_Effect.ref
     ;
   sc_fvars:
-    FStar_Ident.lid FStar_Compiler_Util.set FStar_Pervasives_Native.option
+    FStar_Ident.lid FStar_Compiler_Set.t FStar_Pervasives_Native.option
       FStar_Compiler_Effect.ref
     }
 let (__proj__Mksearch_candidate__item__sc_lid :
@@ -2520,7 +2520,7 @@ let (__proj__Mksearch_candidate__item__sc_typ :
     match projectee with | { sc_lid; sc_typ; sc_fvars;_} -> sc_typ
 let (__proj__Mksearch_candidate__item__sc_fvars :
   search_candidate ->
-    FStar_Ident.lid FStar_Compiler_Util.set FStar_Pervasives_Native.option
+    FStar_Ident.lid FStar_Compiler_Set.t FStar_Pervasives_Native.option
       FStar_Compiler_Effect.ref)
   =
   fun projectee ->
@@ -2550,7 +2550,7 @@ let (sc_typ :
            typ)
 let (sc_fvars :
   FStar_TypeChecker_Env.env ->
-    search_candidate -> FStar_Ident.lident FStar_Compiler_Util.set)
+    search_candidate -> FStar_Ident.lident FStar_Compiler_Set.set)
   =
   fun tcenv ->
     fun sc ->
@@ -2608,7 +2608,7 @@ let run_search :
               FStar_Compiler_Util.contains uu___ str
           | TypeContainsLid lid ->
               let uu___ = sc_fvars tcenv candidate in
-              FStar_Compiler_Util.set_mem lid uu___ in
+              FStar_Compiler_Set.mem FStar_Syntax_Syntax.ord_fv lid uu___ in
         found <> term.st_negate in
       let parse search_str1 =
         let parse_one term =

--- a/ocaml/fstar-lib/generated/FStar_SMTEncoding_Encode.ml
+++ b/ocaml/fstar-lib/generated/FStar_SMTEncoding_Encode.ml
@@ -725,8 +725,7 @@ let (pretype_axiom :
   FStar_Compiler_Range_Type.range ->
     FStar_SMTEncoding_Env.env_t ->
       FStar_SMTEncoding_Term.term ->
-        (Prims.string * FStar_SMTEncoding_Term.sort * Prims.bool) Prims.list
-          -> FStar_SMTEncoding_Term.decl)
+        FStar_SMTEncoding_Term.fv Prims.list -> FStar_SMTEncoding_Term.decl)
   =
   fun rng ->
     fun env ->

--- a/ocaml/fstar-lib/generated/FStar_SMTEncoding_EncodeTerm.ml
+++ b/ocaml/fstar-lib/generated/FStar_SMTEncoding_EncodeTerm.ml
@@ -395,7 +395,8 @@ let check_pattern_vars :
                 (fun out ->
                    fun x ->
                      let uu___1 = FStar_Syntax_Free.names x in
-                     FStar_Compiler_Util.set_union out uu___1) uu___ tl in
+                     FStar_Compiler_Set.union FStar_Syntax_Syntax.ord_bv out
+                       uu___1) uu___ tl in
             let uu___ =
               FStar_Compiler_Effect.op_Bar_Greater vars
                 (FStar_Compiler_Util.find_opt
@@ -405,7 +406,9 @@ let check_pattern_vars :
                           FStar_Syntax_Syntax.binder_qual = uu___2;
                           FStar_Syntax_Syntax.binder_positivity = uu___3;
                           FStar_Syntax_Syntax.binder_attrs = uu___4;_} ->
-                          let uu___5 = FStar_Compiler_Util.set_mem b pat_vars in
+                          let uu___5 =
+                            FStar_Compiler_Set.mem FStar_Syntax_Syntax.ord_bv
+                              b pat_vars in
                           Prims.op_Negation uu___5)) in
             (match uu___ with
              | FStar_Pervasives_Native.None -> ()
@@ -1848,7 +1851,8 @@ and (encode_term :
                       let fvs =
                         let uu___6 = FStar_Syntax_Free.names t0 in
                         FStar_Compiler_Effect.op_Bar_Greater uu___6
-                          FStar_Compiler_Util.set_elements in
+                          (FStar_Compiler_Set.elems
+                             FStar_Syntax_Syntax.ord_bv) in
                       let getfreeV t2 =
                         match t2.FStar_SMTEncoding_Term.tm with
                         | FStar_SMTEncoding_Term.FreeV fv -> fv
@@ -2955,7 +2959,7 @@ and (encode_term :
                      let fvs =
                        let uu___5 = FStar_Syntax_Free.names t0 in
                        FStar_Compiler_Effect.op_Bar_Greater uu___5
-                         FStar_Compiler_Util.set_elements in
+                         (FStar_Compiler_Set.elems FStar_Syntax_Syntax.ord_bv) in
                      let tms =
                        FStar_Compiler_List.map
                          (FStar_SMTEncoding_Env.lookup_term_var env) fvs in

--- a/ocaml/fstar-lib/generated/FStar_SMTEncoding_Env.ml
+++ b/ocaml/fstar-lib/generated/FStar_SMTEncoding_Env.ml
@@ -918,7 +918,8 @@ let (force_thunk : fvar_binding -> FStar_SMTEncoding_Term.term) =
     then failwith "Forcing a non-thunk in the SMT encoding"
     else ();
     FStar_Compiler_Effect.op_Less_Bar FStar_SMTEncoding_Util.mkFreeV
-      ((fvb.smt_id), FStar_SMTEncoding_Term.Term_sort, true)
+      (FStar_SMTEncoding_Term.FV
+         ((fvb.smt_id), FStar_SMTEncoding_Term.Term_sort, true))
 let (try_lookup_free_var :
   env_t ->
     FStar_Ident.lident ->

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Compress.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Compress.ml
@@ -13,10 +13,7 @@ let (compress1_t :
             let uu___ =
               let uu___1 =
                 let uu___2 =
-                  let uu___3 =
-                    FStar_Syntax_Unionfind.uvar_id
-                      uv.FStar_Syntax_Syntax.ctx_uvar_head in
-                  FStar_Compiler_Util.string_of_int uu___3 in
+                  FStar_Class_Show.show FStar_Syntax_Print.showable_ctxu uv in
                 FStar_Compiler_Util.format1
                   "Internal error: unexpected unresolved uvar in deep_compress: %s"
                   uu___2 in
@@ -29,7 +26,8 @@ let (compress1_t :
               then
                 let uu___2 =
                   let uu___3 =
-                    let uu___4 = FStar_Syntax_Print.bv_to_string bv in
+                    let uu___4 =
+                      FStar_Class_Show.show FStar_Syntax_Print.showable_bv bv in
                     FStar_Compiler_Util.format1 "Tm_name %s in deep compress"
                       uu___4 in
                   (FStar_Errors_Codes.Warning_NameEscape, uu___3) in
@@ -73,23 +71,43 @@ let (compress1_t :
             mk uu___
         | uu___ -> t
 let (compress1_u :
-  Prims.bool -> FStar_Syntax_Syntax.universe -> FStar_Syntax_Syntax.universe)
+  Prims.bool ->
+    Prims.bool ->
+      FStar_Syntax_Syntax.universe -> FStar_Syntax_Syntax.universe)
   =
   fun allow_uvars ->
-    fun u ->
-      match u with
-      | FStar_Syntax_Syntax.U_unif uv when Prims.op_Negation allow_uvars ->
-          let uu___ =
-            let uu___1 =
-              let uu___2 =
-                let uu___3 = FStar_Syntax_Unionfind.univ_uvar_id uv in
-                FStar_Compiler_Util.string_of_int uu___3 in
-              FStar_Compiler_Util.format1
-                "Internal error: unexpected unresolved (universe) uvar in deep_compress: %s"
-                uu___2 in
-            (FStar_Errors_Codes.Error_UnexpectedUnresolvedUvar, uu___1) in
-          FStar_Errors.raise_err uu___
-      | uu___ -> u
+    fun allow_names ->
+      fun u ->
+        match u with
+        | FStar_Syntax_Syntax.U_name bv when Prims.op_Negation allow_names ->
+            ((let uu___1 = FStar_Options.debug_any () in
+              if uu___1
+              then
+                let uu___2 =
+                  let uu___3 =
+                    let uu___4 =
+                      FStar_Class_Show.show FStar_Ident.showable_ident bv in
+                    FStar_Compiler_Util.format1 "U_name %s in deep compress"
+                      uu___4 in
+                  (FStar_Errors_Codes.Warning_NameEscape, uu___3) in
+                FStar_Errors.log_issue FStar_Compiler_Range_Type.dummyRange
+                  uu___2
+              else ());
+             u)
+        | FStar_Syntax_Syntax.U_unif uv when Prims.op_Negation allow_uvars ->
+            let uu___ =
+              let uu___1 =
+                let uu___2 =
+                  let uu___3 = FStar_Syntax_Unionfind.univ_uvar_id uv in
+                  FStar_Class_Show.show
+                    (FStar_Class_Show.printableshow
+                       FStar_Class_Printable.printable_int) uu___3 in
+                FStar_Compiler_Util.format1
+                  "Internal error: unexpected unresolved (universe) uvar in deep_compress: %s"
+                  uu___2 in
+              (FStar_Errors_Codes.Error_UnexpectedUnresolvedUvar, uu___1) in
+            FStar_Errors.raise_err uu___
+        | uu___ -> u
 let (deep_compress :
   Prims.bool ->
     Prims.bool -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
@@ -101,7 +119,7 @@ let (deep_compress :
           (fun uu___ ->
              let uu___1 =
                let uu___2 = compress1_t allow_uvars allow_names in
-               let uu___3 = compress1_u allow_uvars in
+               let uu___3 = compress1_u allow_uvars allow_names in
                FStar_Syntax_Visit.visit_term_univs uu___2 uu___3 in
              uu___1 tm)
 let (deep_compress_uvars :
@@ -121,7 +139,7 @@ let (deep_compress_if_no_uvars :
                   let uu___2 =
                     let uu___3 =
                       let uu___4 = compress1_t false true in
-                      let uu___5 = compress1_u false in
+                      let uu___5 = compress1_u false true in
                       FStar_Syntax_Visit.visit_term_univs uu___4 uu___5 in
                     uu___3 tm in
                   FStar_Pervasives_Native.Some uu___2) ()
@@ -144,6 +162,6 @@ let (deep_compress_se :
           (fun uu___1 ->
              let uu___2 =
                let uu___3 = compress1_t allow_uvars allow_names in
-               let uu___4 = compress1_u allow_uvars in
+               let uu___4 = compress1_u allow_uvars allow_names in
                FStar_Syntax_Visit.visit_sigelt uu___3 uu___4 in
              uu___2 se)

--- a/ocaml/fstar-lib/generated/FStar_Syntax_DsEnv.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_DsEnv.ml
@@ -89,7 +89,7 @@ let (uu___is_Record_or_dc : scope_mod -> Prims.bool) =
     match projectee with | Record_or_dc _0 -> true | uu___ -> false
 let (__proj__Record_or_dc__item___0 : scope_mod -> record_or_dc) =
   fun projectee -> match projectee with | Record_or_dc _0 -> _0
-type string_set = Prims.string FStar_Compiler_Util.set
+type string_set = Prims.string FStar_Compiler_Set.t
 type exported_id_kind =
   | Exported_id_term_type 
   | Exported_id_field 
@@ -394,7 +394,7 @@ let (transitive_exported_ids :
             let uu___2 = exported_id_set1 Exported_id_term_type in
             FStar_Compiler_Effect.op_Bang uu___2 in
           FStar_Compiler_Effect.op_Bar_Greater uu___1
-            FStar_Compiler_Util.set_elements
+            (FStar_Compiler_Set.elems FStar_Class_Ord.ord_string)
 let (opens_and_abbrevs :
   env ->
     (FStar_Syntax_Syntax.open_module_or_namespace,
@@ -777,7 +777,8 @@ let find_in_module_with_includes :
                           let mexports =
                             let uu___2 = mex eikind in
                             FStar_Compiler_Effect.op_Bang uu___2 in
-                          FStar_Compiler_Util.set_mem idstr mexports in
+                          FStar_Compiler_Set.mem FStar_Class_Ord.ord_string
+                            idstr mexports in
                     let mincludes =
                       let uu___1 =
                         FStar_Compiler_Util.smap_try_find env1.includes mname in
@@ -2193,7 +2194,8 @@ let (extract_record :
                                                               let uu___31 =
                                                                 FStar_Compiler_Effect.op_Bang
                                                                   my_exported_ids in
-                                                              FStar_Compiler_Util.set_add
+                                                              FStar_Compiler_Set.add
+                                                                FStar_Class_Ord.ord_string
                                                                 uu___30
                                                                 uu___31 in
                                                             FStar_Compiler_Effect.op_Colon_Equals
@@ -2221,7 +2223,8 @@ let (extract_record :
                                                                     =
                                                                     FStar_Compiler_Effect.op_Bang
                                                                     my_exported_ids in
-                                                                  FStar_Compiler_Util.set_add
+                                                                  FStar_Compiler_Set.add
+                                                                    FStar_Class_Ord.ord_string
                                                                     projname
                                                                     uu___31 in
                                                                 FStar_Compiler_Effect.op_Colon_Equals
@@ -2335,14 +2338,14 @@ let (try_lookup_dc_by_field_name :
           FStar_Pervasives_Native.Some uu___1
       | uu___1 -> FStar_Pervasives_Native.None
 let (string_set_ref_new :
-  unit -> Prims.string FStar_Compiler_Util.set FStar_Compiler_Effect.ref) =
+  unit -> Prims.string FStar_Compiler_Set.t FStar_Compiler_Effect.ref) =
   fun uu___ ->
-    let uu___1 = FStar_Compiler_Util.new_set FStar_Compiler_Util.compare in
+    let uu___1 = FStar_Compiler_Set.empty FStar_Class_Ord.ord_string () in
     FStar_Compiler_Util.mk_ref uu___1
 let (exported_id_set_new :
   unit ->
     exported_id_kind ->
-      Prims.string FStar_Compiler_Util.set FStar_Compiler_Effect.ref)
+      Prims.string FStar_Compiler_Set.t FStar_Compiler_Effect.ref)
   =
   fun uu___ ->
     let term_type_set = string_set_ref_new () in
@@ -2610,7 +2613,8 @@ let (push_sigelt' : Prims.bool -> env -> FStar_Syntax_Syntax.sigelt -> env) =
                                               let uu___8 =
                                                 FStar_Compiler_Effect.op_Bang
                                                   my_exported_ids in
-                                              FStar_Compiler_Util.set_add
+                                              FStar_Compiler_Set.add
+                                                FStar_Class_Ord.ord_string
                                                 uu___7 uu___8 in
                                             FStar_Compiler_Effect.op_Colon_Equals
                                               my_exported_ids uu___6
@@ -2742,8 +2746,8 @@ let (push_include : env -> FStar_Ident.lident -> env) =
                               (let uu___7 =
                                  let uu___8 =
                                    FStar_Compiler_Effect.op_Bang ex in
-                                 FStar_Compiler_Util.set_difference uu___8
-                                   ns_ex in
+                                 FStar_Compiler_Set.diff
+                                   FStar_Class_Ord.ord_string uu___8 ns_ex in
                                FStar_Compiler_Effect.op_Colon_Equals ex
                                  uu___7);
                               (match () with
@@ -2752,7 +2756,8 @@ let (push_include : env -> FStar_Ident.lident -> env) =
                                    let uu___8 =
                                      let uu___9 =
                                        FStar_Compiler_Effect.op_Bang trans_ex in
-                                     FStar_Compiler_Util.set_union uu___9
+                                     FStar_Compiler_Set.union
+                                       FStar_Class_Ord.ord_string uu___9
                                        ns_ex in
                                    FStar_Compiler_Effect.op_Colon_Equals
                                      trans_ex uu___8) in
@@ -3047,7 +3052,8 @@ let (finish : env -> FStar_Syntax_Syntax.modul -> env) =
               let uu___3 =
                 let uu___4 =
                   FStar_Compiler_Effect.op_Bang cur_trans_ex_set_ref in
-                FStar_Compiler_Util.set_union cur_ex_set uu___4 in
+                FStar_Compiler_Set.union FStar_Class_Ord.ord_string
+                  cur_ex_set uu___4 in
               FStar_Compiler_Effect.op_Colon_Equals cur_trans_ex_set_ref
                 uu___3 in
             FStar_Compiler_List.iter update_exports all_exported_id_kinds
@@ -3202,17 +3208,17 @@ let (as_exported_ids : exported_id_set -> exported_ids) =
       let uu___ =
         let uu___1 = e Exported_id_term_type in
         FStar_Compiler_Effect.op_Bang uu___1 in
-      FStar_Compiler_Util.set_elements uu___ in
+      FStar_Compiler_Set.elems FStar_Class_Ord.ord_string uu___ in
     let fields =
       let uu___ =
         let uu___1 = e Exported_id_field in
         FStar_Compiler_Effect.op_Bang uu___1 in
-      FStar_Compiler_Util.set_elements uu___ in
+      FStar_Compiler_Set.elems FStar_Class_Ord.ord_string uu___ in
     { exported_id_terms = terms; exported_id_fields = fields }
 let (as_exported_id_set :
   exported_ids FStar_Pervasives_Native.option ->
     exported_id_kind ->
-      Prims.string FStar_Compiler_Util.set FStar_Compiler_Effect.ref)
+      Prims.string FStar_Compiler_Set.t FStar_Compiler_Effect.ref)
   =
   fun e ->
     match e with
@@ -3220,13 +3226,13 @@ let (as_exported_id_set :
     | FStar_Pervasives_Native.Some e1 ->
         let terms =
           let uu___ =
-            FStar_Compiler_Util.as_set e1.exported_id_terms
-              FStar_Compiler_Util.compare in
+            FStar_Compiler_Set.from_list FStar_Class_Ord.ord_string
+              e1.exported_id_terms in
           FStar_Compiler_Util.mk_ref uu___ in
         let fields =
           let uu___ =
-            FStar_Compiler_Util.as_set e1.exported_id_fields
-              FStar_Compiler_Util.compare in
+            FStar_Compiler_Set.from_list FStar_Class_Ord.ord_string
+              e1.exported_id_fields in
           FStar_Compiler_Util.mk_ref uu___ in
         (fun uu___ ->
            match uu___ with

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Print.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Print.ml
@@ -2061,3 +2061,5 @@ let (showable_binding :
              let uu___1 = FStar_Class_Show.show FStar_Ident.showable_ident x in
              Prims.op_Hat "Binding_univ " uu___1)
   }
+let (showable_pragma : FStar_Syntax_Syntax.pragma FStar_Class_Show.showable)
+  = { FStar_Class_Show.show = pragma_to_string }

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Resugar.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Resugar.ml
@@ -1952,7 +1952,7 @@ and (resugar_bv_as_pat' :
   FStar_Syntax_DsEnv.env ->
     FStar_Syntax_Syntax.bv ->
       FStar_Parser_AST.arg_qualifier FStar_Pervasives_Native.option ->
-        FStar_Syntax_Syntax.bv FStar_Compiler_Util.set ->
+        FStar_Syntax_Syntax.bv FStar_Compiler_Set.set ->
           FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
             FStar_Pervasives_Native.option -> FStar_Parser_AST.pattern)
   =
@@ -1964,7 +1964,8 @@ and (resugar_bv_as_pat' :
             let mk a =
               let uu___ = FStar_Syntax_Syntax.range_of_bv v in
               FStar_Parser_AST.mk_pattern a uu___ in
-            let used = FStar_Compiler_Util.set_mem v body_bv in
+            let used =
+              FStar_Compiler_Set.mem FStar_Syntax_Syntax.ord_bv v body_bv in
             let pat =
               let uu___ =
                 if used
@@ -1999,7 +2000,7 @@ and (resugar_bv_as_pat :
   FStar_Syntax_DsEnv.env ->
     FStar_Syntax_Syntax.bv ->
       FStar_Syntax_Syntax.binder_qualifier FStar_Pervasives_Native.option ->
-        FStar_Syntax_Syntax.bv FStar_Compiler_Util.set ->
+        FStar_Syntax_Syntax.bv FStar_Compiler_Set.set ->
           FStar_Parser_AST.pattern FStar_Pervasives_Native.option)
   =
   fun env ->
@@ -2018,8 +2019,7 @@ and (resugar_bv_as_pat :
 and (resugar_pat' :
   FStar_Syntax_DsEnv.env ->
     FStar_Syntax_Syntax.pat ->
-      FStar_Syntax_Syntax.bv FStar_Compiler_Util.set ->
-        FStar_Parser_AST.pattern)
+      FStar_Syntax_Syntax.bv FStar_Compiler_Set.t -> FStar_Parser_AST.pattern)
   =
   fun env ->
     fun p ->
@@ -2042,7 +2042,8 @@ and (resugar_pat' :
                         let might_be_used =
                           match pattern.FStar_Syntax_Syntax.v with
                           | FStar_Syntax_Syntax.Pat_var bv ->
-                              FStar_Compiler_Util.set_mem bv branch_bv
+                              FStar_Compiler_Set.mem
+                                FStar_Syntax_Syntax.ord_bv bv branch_bv
                           | uu___2 -> true in
                         is_implicit && might_be_used) args in
              Prims.op_Negation uu___) in
@@ -3057,8 +3058,7 @@ let (resugar_comp : FStar_Syntax_Syntax.comp -> FStar_Parser_AST.term) =
   fun c -> let uu___ = noenv resugar_comp' in uu___ c
 let (resugar_pat :
   FStar_Syntax_Syntax.pat ->
-    FStar_Syntax_Syntax.bv FStar_Compiler_Util.set ->
-      FStar_Parser_AST.pattern)
+    FStar_Syntax_Syntax.bv FStar_Compiler_Set.t -> FStar_Parser_AST.pattern)
   =
   fun p ->
     fun branch_bv -> let uu___ = noenv resugar_pat' in uu___ p branch_bv

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Syntax.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Syntax.ml
@@ -65,32 +65,6 @@ let (uu___is_ET_app : emb_typ -> Prims.bool) =
 let (__proj__ET_app__item___0 :
   emb_typ -> (Prims.string * emb_typ Prims.list)) =
   fun projectee -> match projectee with | ET_app _0 -> _0
-let rec (emb_typ_to_string : emb_typ -> Prims.string) =
-  fun uu___ ->
-    match uu___ with
-    | ET_abstract -> "abstract"
-    | ET_app (h, []) -> h
-    | ET_app (h, args) ->
-        let uu___1 =
-          let uu___2 =
-            let uu___3 =
-              let uu___4 =
-                let uu___5 = FStar_Compiler_List.map emb_typ_to_string args in
-                FStar_Compiler_Effect.op_Bar_Greater uu___5
-                  (FStar_Compiler_String.concat " ") in
-              Prims.op_Hat uu___4 ")" in
-            Prims.op_Hat " " uu___3 in
-          Prims.op_Hat h uu___2 in
-        Prims.op_Hat "(" uu___1
-    | ET_fun (a, b) ->
-        let uu___1 =
-          let uu___2 = emb_typ_to_string a in
-          let uu___3 =
-            let uu___4 = emb_typ_to_string b in Prims.op_Hat ") -> " uu___4 in
-          Prims.op_Hat uu___2 uu___3 in
-        Prims.op_Hat "(" uu___1
-let (showable_emb_typ : emb_typ FStar_Class_Show.showable) =
-  { FStar_Class_Show.show = emb_typ_to_string }
 type version = {
   major: Prims.int ;
   minor: Prims.int }[@@deriving yojson,show]
@@ -185,21 +159,6 @@ let (uu___is_Delta_abstract : delta_depth -> Prims.bool) =
     match projectee with | Delta_abstract _0 -> true | uu___ -> false
 let (__proj__Delta_abstract__item___0 : delta_depth -> delta_depth) =
   fun projectee -> match projectee with | Delta_abstract _0 -> _0
-let rec (delta_depth_to_string : delta_depth -> Prims.string) =
-  fun uu___ ->
-    match uu___ with
-    | Delta_constant_at_level i ->
-        let uu___1 = FStar_Compiler_Util.string_of_int i in
-        Prims.op_Hat "Delta_constant_at_level " uu___1
-    | Delta_equational_at_level i ->
-        let uu___1 = FStar_Compiler_Util.string_of_int i in
-        Prims.op_Hat "Delta_equational_at_level " uu___1
-    | Delta_abstract d ->
-        let uu___1 =
-          let uu___2 = delta_depth_to_string d in Prims.op_Hat uu___2 ")" in
-        Prims.op_Hat "Delta_abstract (" uu___1
-let (showable_delta_depth : delta_depth FStar_Class_Show.showable) =
-  { FStar_Class_Show.show = delta_depth_to_string }
 type should_check_uvar =
   | Allow_unresolved of Prims.string 
   | Allow_untyped of Prims.string 
@@ -1169,7 +1128,7 @@ type term = term' syntax
 type uvar =
   ((term' syntax FStar_Pervasives_Native.option * uvar_decoration)
     FStar_Unionfind.p_uvar * version * FStar_Compiler_Range_Type.range)
-type uvars = ctx_uvar FStar_Compiler_Util.set
+type uvars = ctx_uvar FStar_Compiler_Set.t
 type comp = comp' syntax
 type ascription =
   ((term' syntax, comp' syntax) FStar_Pervasives.either * term' syntax
@@ -1190,7 +1149,7 @@ type args =
 type binders = binder Prims.list
 type lbname = (bv, fv) FStar_Pervasives.either
 type letbindings = (Prims.bool * letbinding Prims.list)
-type freenames = bv FStar_Compiler_Util.set
+type freenames = bv FStar_Compiler_Set.t
 type attribute = term' syntax
 type tscheme = (univ_name Prims.list * term' syntax)
 type gamma = binding Prims.list
@@ -1303,6 +1262,59 @@ let (uu___is_OnlyName : qualifier -> Prims.bool) =
 let (uu___is_InternalAssumption : qualifier -> Prims.bool) =
   fun projectee ->
     match projectee with | InternalAssumption -> true | uu___ -> false
+let rec (emb_typ_to_string : emb_typ -> Prims.string) =
+  fun uu___ ->
+    match uu___ with
+    | ET_abstract -> "abstract"
+    | ET_app (h, []) -> h
+    | ET_app (h, args1) ->
+        let uu___1 =
+          let uu___2 =
+            let uu___3 =
+              let uu___4 =
+                let uu___5 = FStar_Compiler_List.map emb_typ_to_string args1 in
+                FStar_Compiler_Effect.op_Bar_Greater uu___5
+                  (FStar_Compiler_String.concat " ") in
+              Prims.op_Hat uu___4 ")" in
+            Prims.op_Hat " " uu___3 in
+          Prims.op_Hat h uu___2 in
+        Prims.op_Hat "(" uu___1
+    | ET_fun (a, b) ->
+        let uu___1 =
+          let uu___2 = emb_typ_to_string a in
+          let uu___3 =
+            let uu___4 = emb_typ_to_string b in Prims.op_Hat ") -> " uu___4 in
+          Prims.op_Hat uu___2 uu___3 in
+        Prims.op_Hat "(" uu___1
+let (showable_emb_typ : emb_typ FStar_Class_Show.showable) =
+  { FStar_Class_Show.show = emb_typ_to_string }
+let rec (delta_depth_to_string : delta_depth -> Prims.string) =
+  fun uu___ ->
+    match uu___ with
+    | Delta_constant_at_level i ->
+        let uu___1 = FStar_Compiler_Util.string_of_int i in
+        Prims.op_Hat "Delta_constant_at_level " uu___1
+    | Delta_equational_at_level i ->
+        let uu___1 = FStar_Compiler_Util.string_of_int i in
+        Prims.op_Hat "Delta_equational_at_level " uu___1
+    | Delta_abstract d ->
+        let uu___1 =
+          let uu___2 = delta_depth_to_string d in Prims.op_Hat uu___2 ")" in
+        Prims.op_Hat "Delta_abstract (" uu___1
+let (showable_delta_depth : delta_depth FStar_Class_Show.showable) =
+  { FStar_Class_Show.show = delta_depth_to_string }
+let (showable_should_check_uvar :
+  should_check_uvar FStar_Class_Show.showable) =
+  {
+    FStar_Class_Show.show =
+      (fun uu___ ->
+         match uu___ with
+         | Allow_unresolved s -> Prims.op_Hat "Allow_unresolved " s
+         | Allow_untyped s -> Prims.op_Hat "Allow_untyped " s
+         | Allow_ghost s -> Prims.op_Hat "Allow_ghost " s
+         | Strict -> "Strict"
+         | Already_checked -> "Already_checked")
+  }
 let (lazy_chooser :
   (lazy_kind -> lazyinfo -> term) FStar_Pervasives_Native.option
     FStar_Compiler_Effect.ref)
@@ -2259,6 +2271,74 @@ let (lookup_aq : bv -> antiquotations -> term) =
                      - bv1.index)
                     + (FStar_Pervasives_Native.fst aq))) ()
       with | uu___ -> failwith "antiquotation out of bounds"
+let deq_instance_from_cmp :
+  'uuuuu .
+    ('uuuuu -> 'uuuuu -> FStar_Compiler_Order.order) ->
+      'uuuuu FStar_Class_Deq.deq
+  =
+  fun f ->
+    {
+      FStar_Class_Deq.op_Equals_Question =
+        (fun x -> fun y -> let uu___ = f x y in FStar_Compiler_Order.eq uu___)
+    }
+let ord_instance_from_cmp :
+  'uuuuu .
+    ('uuuuu -> 'uuuuu -> FStar_Compiler_Order.order) ->
+      'uuuuu FStar_Class_Ord.ord
+  =
+  fun f ->
+    {
+      FStar_Class_Ord.super = (deq_instance_from_cmp f);
+      FStar_Class_Ord.cmp = f
+    }
+let (order_univ_name : univ_name -> univ_name -> Prims.int) =
+  fun x ->
+    fun y ->
+      let uu___ = FStar_Ident.string_of_id x in
+      let uu___1 = FStar_Ident.string_of_id y in
+      FStar_Compiler_String.compare uu___ uu___1
+let (deq_bv : bv FStar_Class_Deq.deq) =
+  deq_instance_from_cmp
+    (fun x ->
+       fun y ->
+         let uu___ = order_bv x y in
+         FStar_Compiler_Order.order_from_int uu___)
+let (deq_ident : FStar_Ident.ident FStar_Class_Deq.deq) =
+  deq_instance_from_cmp
+    (fun x ->
+       fun y ->
+         let uu___ = order_ident x y in
+         FStar_Compiler_Order.order_from_int uu___)
+let (deq_fv : FStar_Ident.lident FStar_Class_Deq.deq) =
+  deq_instance_from_cmp
+    (fun x ->
+       fun y ->
+         let uu___ = order_fv x y in
+         FStar_Compiler_Order.order_from_int uu___)
+let (deq_univ_name : univ_name FStar_Class_Deq.deq) =
+  deq_instance_from_cmp
+    (fun x ->
+       fun y ->
+         let uu___ = order_univ_name x y in
+         FStar_Compiler_Order.order_from_int uu___)
+let (ord_bv : bv FStar_Class_Ord.ord) =
+  ord_instance_from_cmp
+    (fun x ->
+       fun y ->
+         let uu___ = order_bv x y in
+         FStar_Compiler_Order.order_from_int uu___)
+let (ord_ident : FStar_Ident.ident FStar_Class_Ord.ord) =
+  ord_instance_from_cmp
+    (fun x ->
+       fun y ->
+         let uu___ = order_ident x y in
+         FStar_Compiler_Order.order_from_int uu___)
+let (ord_fv : FStar_Ident.lident FStar_Class_Ord.ord) =
+  ord_instance_from_cmp
+    (fun x ->
+       fun y ->
+         let uu___ = order_fv x y in
+         FStar_Compiler_Order.order_from_int uu___)
 let syn :
   'uuuuu 'uuuuu1 'uuuuu2 .
     'uuuuu -> 'uuuuu1 -> ('uuuuu1 -> 'uuuuu -> 'uuuuu2) -> 'uuuuu2
@@ -2271,31 +2351,24 @@ let mk_uvs :
   'uuuuu .
     unit -> 'uuuuu FStar_Pervasives_Native.option FStar_Compiler_Effect.ref
   = fun uu___ -> FStar_Compiler_Util.mk_ref FStar_Pervasives_Native.None
-let (new_bv_set : unit -> bv FStar_Compiler_Util.set) =
-  fun uu___ -> FStar_Compiler_Util.new_set order_bv
-let (new_id_set : unit -> FStar_Ident.ident FStar_Compiler_Util.set) =
-  fun uu___ -> FStar_Compiler_Util.new_set order_ident
-let (new_fv_set : unit -> FStar_Ident.lident FStar_Compiler_Util.set) =
-  fun uu___ -> FStar_Compiler_Util.new_set order_fv
-let (order_univ_name : univ_name -> univ_name -> Prims.int) =
-  fun x ->
-    fun y ->
-      let uu___ = FStar_Ident.string_of_id x in
-      let uu___1 = FStar_Ident.string_of_id y in
-      FStar_Compiler_String.compare uu___ uu___1
-let (new_universe_names_set : unit -> univ_name FStar_Compiler_Util.set) =
-  fun uu___ -> FStar_Compiler_Util.new_set order_univ_name
+let (new_bv_set : unit -> bv FStar_Compiler_Set.t) =
+  fun uu___ -> FStar_Compiler_Set.empty ord_bv ()
+let (new_id_set : unit -> FStar_Ident.ident FStar_Compiler_Set.t) =
+  fun uu___ -> FStar_Compiler_Set.empty ord_ident ()
+let (new_fv_set : unit -> FStar_Ident.lident FStar_Compiler_Set.t) =
+  fun uu___ -> FStar_Compiler_Set.empty ord_fv ()
+let (new_universe_names_set : unit -> univ_name FStar_Compiler_Set.t) =
+  fun uu___ -> FStar_Compiler_Set.empty ord_ident ()
 type path = Prims.string Prims.list
 type subst_t = subst_elt Prims.list
 let (no_names : freenames) = new_bv_set ()
-let (no_fvars : FStar_Ident.lident FStar_Compiler_Util.set) = new_fv_set ()
-let (no_universe_names : univ_name FStar_Compiler_Util.set) =
+let (no_fvars : FStar_Ident.lident FStar_Compiler_Set.t) = new_fv_set ()
+let (no_universe_names : univ_name FStar_Compiler_Set.t) =
   new_universe_names_set ()
 let (freenames_of_list : bv Prims.list -> freenames) =
-  fun l ->
-    FStar_Compiler_List.fold_right FStar_Compiler_Util.set_add l no_names
+  fun l -> FStar_Compiler_Set.addn ord_bv l no_names
 let (list_of_freenames : freenames -> bv Prims.list) =
-  fun fvs -> FStar_Compiler_Util.set_elements fvs
+  fun fvs -> FStar_Compiler_Set.elems ord_bv fvs
 let mk : 'a . 'a -> FStar_Compiler_Range_Type.range -> 'a syntax =
   fun t ->
     fun r ->
@@ -2501,7 +2574,7 @@ let (is_top_level : letbinding Prims.list -> Prims.bool) =
 let (freenames_of_binders : binders -> freenames) =
   fun bs ->
     FStar_Compiler_List.fold_right
-      (fun b -> fun out -> FStar_Compiler_Util.set_add b.binder_bv out) bs
+      (fun b -> fun out -> FStar_Compiler_Set.add ord_bv b.binder_bv out) bs
       no_names
 let (binders_of_list : bv Prims.list -> binders) =
   fun fvs ->
@@ -2509,7 +2582,7 @@ let (binders_of_list : bv Prims.list -> binders) =
       (FStar_Compiler_List.map (fun t -> mk_binder t))
 let (binders_of_freenames : freenames -> binders) =
   fun fvs ->
-    let uu___ = FStar_Compiler_Util.set_elements fvs in
+    let uu___ = FStar_Compiler_Set.elems ord_bv fvs in
     FStar_Compiler_Effect.op_Bar_Greater uu___ binders_of_list
 let (is_bqual_implicit : bqual -> Prims.bool) =
   fun uu___ ->

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Util.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Util.ml
@@ -217,11 +217,11 @@ let (binders_of_tks :
                 FStar_Syntax_Syntax.mk_binder_with_attrs uu___1 imp
                   FStar_Pervasives_Native.None []))
 let (binders_of_freevars :
-  FStar_Syntax_Syntax.bv FStar_Compiler_Util.set ->
+  FStar_Syntax_Syntax.bv FStar_Compiler_Set.set ->
     FStar_Syntax_Syntax.binder Prims.list)
   =
   fun fvs ->
-    let uu___ = FStar_Compiler_Util.set_elements fvs in
+    let uu___ = FStar_Compiler_Set.elems FStar_Syntax_Syntax.ord_bv fvs in
     FStar_Compiler_Effect.op_Bar_Greater uu___
       (FStar_Compiler_List.map FStar_Syntax_Syntax.mk_binder)
 let mk_subst : 'uuuuu . 'uuuuu -> 'uuuuu Prims.list = fun s -> [s]
@@ -2039,25 +2039,27 @@ let (let_rec_arity :
                  | FStar_Syntax_Syntax.Decreases_lex l ->
                      let uu___2 =
                        let uu___3 =
-                         FStar_Compiler_Util.new_set
-                           FStar_Syntax_Syntax.order_bv in
+                         FStar_Compiler_Set.empty FStar_Syntax_Syntax.ord_bv
+                           () in
                        FStar_Compiler_List.fold_left
                          (fun s ->
                             fun t ->
                               let uu___4 = FStar_Syntax_Free.names t in
-                              FStar_Compiler_Util.set_union s uu___4) uu___3 in
+                              FStar_Compiler_Set.union
+                                FStar_Syntax_Syntax.ord_bv s uu___4) uu___3 in
                      FStar_Compiler_Effect.op_Bar_Greater l uu___2
                  | FStar_Syntax_Syntax.Decreases_wf (rel, e) ->
                      let uu___2 = FStar_Syntax_Free.names rel in
                      let uu___3 = FStar_Syntax_Free.names e in
-                     FStar_Compiler_Util.set_union uu___2 uu___3 in
+                     FStar_Compiler_Set.union FStar_Syntax_Syntax.ord_bv
+                       uu___2 uu___3 in
                let uu___2 =
                  FStar_Common.tabulate n_univs (fun uu___3 -> false) in
                let uu___3 =
                  FStar_Compiler_Effect.op_Bar_Greater bs
                    (FStar_Compiler_List.map
                       (fun b ->
-                         FStar_Compiler_Util.set_mem
+                         FStar_Compiler_Set.mem FStar_Syntax_Syntax.ord_bv
                            b.FStar_Syntax_Syntax.binder_bv d_bvs)) in
                FStar_Compiler_List.op_At uu___2 uu___3) in
         ((n_univs + (FStar_Compiler_List.length bs)), uu___1)
@@ -3078,7 +3080,7 @@ let (un_squash :
                          | uu___3 -> failwith "impossible" in
                        let uu___3 =
                          let uu___4 = FStar_Syntax_Free.names p1 in
-                         FStar_Compiler_Util.set_mem
+                         FStar_Compiler_Set.mem FStar_Syntax_Syntax.ord_bv
                            b1.FStar_Syntax_Syntax.binder_bv uu___4 in
                        if uu___3
                        then FStar_Pervasives_Native.None
@@ -3249,7 +3251,7 @@ let (is_free_in :
   fun bv ->
     fun t ->
       let uu___ = FStar_Syntax_Free.names t in
-      FStar_Compiler_Util.set_mem bv uu___
+      FStar_Compiler_Set.mem FStar_Syntax_Syntax.ord_bv bv uu___
 type qpats = FStar_Syntax_Syntax.args Prims.list
 type connective =
   | QAll of (FStar_Syntax_Syntax.binders * qpats * FStar_Syntax_Syntax.typ) 

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Visit.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Visit.ml
@@ -810,11 +810,33 @@ let rec (on_sub_sigelt' :
               FStar_Syntax_Syntax.typ1 = (us_ty, ty1);
               FStar_Syntax_Syntax.kind2 = k
             }
-      | FStar_Syntax_Syntax.Sig_fail uu___ ->
-          failwith "Sig_fail and Sig_splice not supported in visit"
-      | FStar_Syntax_Syntax.Sig_splice uu___ ->
-          failwith "Sig_fail and Sig_splice not supported in visit"
-      | uu___ -> failwith "sorry"
+      | FStar_Syntax_Syntax.Sig_fail
+          { FStar_Syntax_Syntax.errs = errs;
+            FStar_Syntax_Syntax.fail_in_lax = fail_in_lax;
+            FStar_Syntax_Syntax.ses1 = ses;_}
+          ->
+          let uu___ =
+            let uu___1 = FStar_Compiler_List.map (on_sub_sigelt vfs) ses in
+            {
+              FStar_Syntax_Syntax.errs = errs;
+              FStar_Syntax_Syntax.fail_in_lax = fail_in_lax;
+              FStar_Syntax_Syntax.ses1 = uu___1
+            } in
+          FStar_Syntax_Syntax.Sig_fail uu___
+      | FStar_Syntax_Syntax.Sig_splice
+          { FStar_Syntax_Syntax.is_typed = is_typed;
+            FStar_Syntax_Syntax.lids2 = lids;
+            FStar_Syntax_Syntax.tac = tac;_}
+          ->
+          let uu___ =
+            let uu___1 = f_term vfs tac in
+            {
+              FStar_Syntax_Syntax.is_typed = is_typed;
+              FStar_Syntax_Syntax.lids2 = lids;
+              FStar_Syntax_Syntax.tac = uu___1
+            } in
+          FStar_Syntax_Syntax.Sig_splice uu___
+      | uu___ -> failwith "on_sub_sigelt: missing case"
 and (on_sub_sigelt :
   vfs_t -> FStar_Syntax_Syntax.sigelt -> FStar_Syntax_Syntax.sigelt) =
   fun vfs ->

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Monad.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Monad.ml
@@ -20,7 +20,8 @@ let (is_goal_safe_as_well_typed : FStar_Tactics_Types.goal -> Prims.bool) =
            match uu___1 with
            | FStar_Pervasives_Native.Some t ->
                let uu___2 = FStar_Syntax_Free.uvars t in
-               FStar_Compiler_Util.set_is_empty uu___2
+               FStar_Compiler_Set.is_empty FStar_Syntax_Free.ord_ctx_uvar
+                 uu___2
            | uu___2 -> false) uu___ in
     all_deps_resolved
 let (register_goal : FStar_Tactics_Types.goal -> unit) =

--- a/ocaml/fstar-lib/generated/FStar_Tactics_V1_Basic.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_V1_Basic.ml
@@ -236,7 +236,7 @@ let (dump_uvars_of :
                let uu___1 = FStar_Tactics_Types.goal_type g in
                FStar_Syntax_Free.uvars uu___1 in
              FStar_Compiler_Effect.op_Bar_Greater uu___
-               FStar_Compiler_Util.set_elements in
+               (FStar_Compiler_Set.elems FStar_Syntax_Free.ord_ctx_uvar) in
            let gs =
              FStar_Compiler_List.map (FStar_Tactics_Types.goal_of_ctx_uvar g)
                uvs in
@@ -871,9 +871,10 @@ let (__do_unify_wflags :
                      | Check_both ->
                          let uu___2 = FStar_Syntax_Free.uvars t1 in
                          let uu___3 = FStar_Syntax_Free.uvars t2 in
-                         FStar_Compiler_Util.set_union uu___2 uu___3 in
+                         FStar_Compiler_Set.union
+                           FStar_Syntax_Free.ord_ctx_uvar uu___2 uu___3 in
                    FStar_Compiler_Effect.op_Bar_Greater uu___1
-                     FStar_Compiler_Util.set_elements in
+                     (FStar_Compiler_Set.elems FStar_Syntax_Free.ord_ctx_uvar) in
                  let uu___1 =
                    let uu___2 =
                      let uu___3 =
@@ -1076,7 +1077,9 @@ let (do_match :
                     then
                       let uvs2 = FStar_Syntax_Free.uvars_uncached t1 in
                       let uu___2 =
-                        let uu___3 = FStar_Compiler_Util.set_eq uvs1 uvs2 in
+                        let uu___3 =
+                          FStar_Compiler_Set.equal
+                            FStar_Syntax_Free.ord_ctx_uvar uvs1 uvs2 in
                         Prims.op_Negation uu___3 in
                       (if uu___2
                        then
@@ -1115,7 +1118,9 @@ let (do_match_on_lhs :
                         then
                           let uvs2 = FStar_Syntax_Free.uvars_uncached lhs in
                           let uu___4 =
-                            let uu___5 = FStar_Compiler_Util.set_eq uvs1 uvs2 in
+                            let uu___5 =
+                              FStar_Compiler_Set.equal
+                                FStar_Syntax_Free.ord_ctx_uvar uvs1 uvs2 in
                             Prims.op_Negation uu___5 in
                           (if uu___4
                            then
@@ -3035,12 +3040,14 @@ let (t_apply :
                                                                     uv in
                                                                    FStar_Syntax_Free.uvars
                                                                     uu___16 in
-                                                                 FStar_Compiler_Util.set_union
+                                                                 FStar_Compiler_Set.union
+                                                                   FStar_Syntax_Free.ord_ctx_uvar
                                                                    s uu___15)
                                                         uvs uu___11 in
                                                     let free_in_some_goal uv
                                                       =
-                                                      FStar_Compiler_Util.set_mem
+                                                      FStar_Compiler_Set.mem
+                                                        FStar_Syntax_Free.ord_ctx_uvar
                                                         uv uvset in
                                                     let uu___11 =
                                                       solve' goal w in
@@ -3431,7 +3438,8 @@ let (t_apply_lemma :
                                                                     =
                                                                     FStar_Syntax_Free.uvars
                                                                     t1 in
-                                                                    FStar_Compiler_Util.set_elements
+                                                                    FStar_Compiler_Set.elems
+                                                                    FStar_Syntax_Free.ord_ctx_uvar
                                                                     uu___17 in
                                                                     FStar_Compiler_List.map
                                                                     (fun x ->
@@ -4066,7 +4074,7 @@ let (free_in :
   fun bv ->
     fun t ->
       let uu___ = FStar_Syntax_Free.names t in
-      FStar_Compiler_Util.set_mem bv uu___
+      FStar_Compiler_Set.mem FStar_Syntax_Syntax.ord_bv bv uu___
 let (clear : FStar_Syntax_Syntax.binder -> unit FStar_Tactics_Monad.tac) =
   fun b ->
     let bv = b.FStar_Syntax_Syntax.binder_bv in
@@ -4235,7 +4243,7 @@ let (_t_trefl :
                  g.FStar_Tactics_Types.goal_ctx_uvar in
              let uvars =
                let uu___2 = FStar_Syntax_Free.uvars t in
-               FStar_Compiler_Util.set_elements uu___2 in
+               FStar_Compiler_Set.elems FStar_Syntax_Free.ord_ctx_uvar uu___2 in
              let uu___2 =
                FStar_Compiler_Util.for_all is_uvar_untyped_or_already_checked
                  uvars in
@@ -7306,7 +7314,7 @@ let (free_uvars :
            let uu___1 =
              let uu___2 = FStar_Syntax_Free.uvars_uncached tm in
              FStar_Compiler_Effect.op_Bar_Greater uu___2
-               FStar_Compiler_Util.set_elements in
+               (FStar_Compiler_Set.elems FStar_Syntax_Free.ord_ctx_uvar) in
            FStar_Compiler_Effect.op_Bar_Greater uu___1
              (FStar_Compiler_List.map
                 (fun u ->
@@ -7364,12 +7372,12 @@ let (no_uvars_in_term : FStar_Syntax_Syntax.term -> Prims.bool) =
     (let uu___ =
        FStar_Compiler_Effect.op_Bar_Greater t FStar_Syntax_Free.uvars in
      FStar_Compiler_Effect.op_Bar_Greater uu___
-       FStar_Compiler_Util.set_is_empty)
+       (FStar_Compiler_Set.is_empty FStar_Syntax_Free.ord_ctx_uvar))
       &&
       (let uu___ =
          FStar_Compiler_Effect.op_Bar_Greater t FStar_Syntax_Free.univs in
        FStar_Compiler_Effect.op_Bar_Greater uu___
-         FStar_Compiler_Util.set_is_empty)
+         (FStar_Compiler_Set.is_empty FStar_Syntax_Free.ord_univ_uvar))
 let (no_uvars_in_g : env -> Prims.bool) =
   fun g ->
     FStar_Compiler_Effect.op_Bar_Greater g.FStar_TypeChecker_Env.gamma

--- a/ocaml/fstar-lib/generated/FStar_Tactics_V2_Basic.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_V2_Basic.ml
@@ -245,7 +245,7 @@ let (dump_uvars_of :
                let uu___1 = FStar_Tactics_Types.goal_type g in
                FStar_Syntax_Free.uvars uu___1 in
              FStar_Compiler_Effect.op_Bar_Greater uu___
-               FStar_Compiler_Util.set_elements in
+               (FStar_Compiler_Set.elems FStar_Syntax_Free.ord_ctx_uvar) in
            let gs =
              FStar_Compiler_List.map (FStar_Tactics_Types.goal_of_ctx_uvar g)
                uvs in
@@ -890,9 +890,10 @@ let (__do_unify_wflags :
                      | Check_both ->
                          let uu___2 = FStar_Syntax_Free.uvars t1 in
                          let uu___3 = FStar_Syntax_Free.uvars t2 in
-                         FStar_Compiler_Util.set_union uu___2 uu___3 in
+                         FStar_Compiler_Set.union
+                           FStar_Syntax_Free.ord_ctx_uvar uu___2 uu___3 in
                    FStar_Compiler_Effect.op_Bar_Greater uu___1
-                     FStar_Compiler_Util.set_elements in
+                     (FStar_Compiler_Set.elems FStar_Syntax_Free.ord_ctx_uvar) in
                  let uu___1 =
                    let uu___2 =
                      let uu___3 =
@@ -1095,7 +1096,9 @@ let (do_match :
                     then
                       let uvs2 = FStar_Syntax_Free.uvars_uncached t1 in
                       let uu___2 =
-                        let uu___3 = FStar_Compiler_Util.set_eq uvs1 uvs2 in
+                        let uu___3 =
+                          FStar_Compiler_Set.equal
+                            FStar_Syntax_Free.ord_ctx_uvar uvs1 uvs2 in
                         Prims.op_Negation uu___3 in
                       (if uu___2
                        then
@@ -1134,7 +1137,9 @@ let (do_match_on_lhs :
                         then
                           let uvs2 = FStar_Syntax_Free.uvars_uncached lhs in
                           let uu___4 =
-                            let uu___5 = FStar_Compiler_Util.set_eq uvs1 uvs2 in
+                            let uu___5 =
+                              FStar_Compiler_Set.equal
+                                FStar_Syntax_Free.ord_ctx_uvar uvs1 uvs2 in
                             Prims.op_Negation uu___5 in
                           (if uu___4
                            then
@@ -3047,7 +3052,8 @@ let (t_apply :
                                                    let uu___11 =
                                                      FStar_Syntax_Free.uvars_uncached
                                                        typ1 in
-                                                   FStar_Compiler_Util.set_is_empty
+                                                   FStar_Compiler_Set.is_empty
+                                                     FStar_Syntax_Free.ord_ctx_uvar
                                                      uu___11 in
                                                  Prims.op_Negation uu___10) in
                                             if uu___9
@@ -3127,12 +3133,14 @@ let (t_apply :
                                                                     uv in
                                                                     FStar_Syntax_Free.uvars
                                                                     uu___18 in
-                                                                    FStar_Compiler_Util.set_union
+                                                                    FStar_Compiler_Set.union
+                                                                    FStar_Syntax_Free.ord_ctx_uvar
                                                                     s uu___17)
                                                              uvs uu___13 in
                                                          let free_in_some_goal
                                                            uv =
-                                                           FStar_Compiler_Util.set_mem
+                                                           FStar_Compiler_Set.mem
+                                                             FStar_Syntax_Free.ord_ctx_uvar
                                                              uv uvset in
                                                          let uu___13 =
                                                            solve' goal w in
@@ -3528,7 +3536,8 @@ let (t_apply_lemma :
                                                                     =
                                                                     FStar_Syntax_Free.uvars
                                                                     t1 in
-                                                                    FStar_Compiler_Util.set_elements
+                                                                    FStar_Compiler_Set.elems
+                                                                    FStar_Syntax_Free.ord_ctx_uvar
                                                                     uu___17 in
                                                                     FStar_Compiler_List.map
                                                                     (fun x ->
@@ -4165,7 +4174,7 @@ let (free_in :
   fun bv ->
     fun t ->
       let uu___ = FStar_Syntax_Free.names t in
-      FStar_Compiler_Util.set_mem bv uu___
+      FStar_Compiler_Set.mem FStar_Syntax_Syntax.ord_bv bv uu___
 let (clear :
   FStar_Reflection_V2_Data.binding -> unit FStar_Tactics_Monad.tac) =
   fun b ->
@@ -4334,7 +4343,7 @@ let (_t_trefl :
                  g.FStar_Tactics_Types.goal_ctx_uvar in
              let uvars =
                let uu___2 = FStar_Syntax_Free.uvars t in
-               FStar_Compiler_Util.set_elements uu___2 in
+               FStar_Compiler_Set.elems FStar_Syntax_Free.ord_ctx_uvar uu___2 in
              let uu___2 =
                FStar_Compiler_Util.for_all is_uvar_untyped_or_already_checked
                  uvars in
@@ -6967,7 +6976,7 @@ let (free_uvars :
            let uu___1 =
              let uu___2 = FStar_Syntax_Free.uvars_uncached tm in
              FStar_Compiler_Effect.op_Bar_Greater uu___2
-               FStar_Compiler_Util.set_elements in
+               (FStar_Compiler_Set.elems FStar_Syntax_Free.ord_ctx_uvar) in
            FStar_Compiler_Effect.op_Bar_Greater uu___1
              (FStar_Compiler_List.map
                 (fun u ->
@@ -7169,18 +7178,18 @@ let (no_uvars_in_term : FStar_Syntax_Syntax.term -> Prims.bool) =
     (let uu___ =
        FStar_Compiler_Effect.op_Bar_Greater t FStar_Syntax_Free.uvars in
      FStar_Compiler_Effect.op_Bar_Greater uu___
-       FStar_Compiler_Util.set_is_empty)
+       (FStar_Compiler_Set.is_empty FStar_Syntax_Free.ord_ctx_uvar))
       &&
       (let uu___ =
          FStar_Compiler_Effect.op_Bar_Greater t FStar_Syntax_Free.univs in
        FStar_Compiler_Effect.op_Bar_Greater uu___
-         FStar_Compiler_Util.set_is_empty)
+         (FStar_Compiler_Set.is_empty FStar_Syntax_Free.ord_univ_uvar))
 let (no_univ_uvars_in_term : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t ->
     let uu___ =
       FStar_Compiler_Effect.op_Bar_Greater t FStar_Syntax_Free.univs in
     FStar_Compiler_Effect.op_Bar_Greater uu___
-      FStar_Compiler_Util.set_is_empty
+      (FStar_Compiler_Set.is_empty FStar_Syntax_Free.ord_univ_uvar)
 let (no_uvars_in_g : env -> Prims.bool) =
   fun g ->
     FStar_Compiler_Effect.op_Bar_Greater g.FStar_TypeChecker_Env.gamma

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Core.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Core.ml
@@ -1212,7 +1212,8 @@ let (check_no_escape :
         FStar_Compiler_Util.for_all
           (fun b ->
              let uu___1 =
-               FStar_Compiler_Util.set_mem b.FStar_Syntax_Syntax.binder_bv xs in
+               FStar_Compiler_Set.mem FStar_Syntax_Syntax.ord_bv
+                 b.FStar_Syntax_Syntax.binder_bv xs in
              Prims.op_Negation uu___1) bs in
       if uu___ then return () else fail "Name escapes its scope"
 let rec map :
@@ -4448,7 +4449,8 @@ let (check_term_top_gh :
                         (let guard_names =
                            let uu___7 = FStar_Syntax_Free.names guard1 in
                            FStar_Compiler_Effect.op_Bar_Greater uu___7
-                             FStar_Compiler_Util.set_elements in
+                             (FStar_Compiler_Set.elems
+                                FStar_Syntax_Syntax.ord_bv) in
                          let uu___7 =
                            FStar_Compiler_List.tryFind
                              (fun bv ->

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_DMFF.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_DMFF.ml
@@ -1613,7 +1613,8 @@ and (star_type' :
           ->
           let debug t2 s =
             let string_of_set f s1 =
-              let elts = FStar_Compiler_Util.set_elements s1 in
+              let elts =
+                FStar_Compiler_Set.elems FStar_Syntax_Syntax.ord_bv s1 in
               match elts with
               | [] -> "{}"
               | x::xs ->
@@ -1659,10 +1660,12 @@ and (star_type' :
                             let non_dependent_or_raise s ty1 =
                               let sinter =
                                 let uu___4 = FStar_Syntax_Free.names ty1 in
-                                FStar_Compiler_Util.set_intersect uu___4 s in
+                                FStar_Compiler_Set.inter
+                                  FStar_Syntax_Syntax.ord_bv uu___4 s in
                               let uu___4 =
                                 let uu___5 =
-                                  FStar_Compiler_Util.set_is_empty sinter in
+                                  FStar_Compiler_Set.is_empty
+                                    FStar_Syntax_Syntax.ord_bv sinter in
                                 Prims.op_Negation uu___5 in
                               if uu___4
                               then
@@ -1690,8 +1693,9 @@ and (star_type' :
                                               ->
                                               (non_dependent_or_raise s1
                                                  bv.FStar_Syntax_Syntax.sort;
-                                               FStar_Compiler_Util.set_add bv
-                                                 s1))
+                                               FStar_Compiler_Set.add
+                                                 FStar_Syntax_Syntax.ord_bv
+                                                 bv s1))
                                      FStar_Syntax_Syntax.no_names binders1 in
                                  let ct = FStar_Syntax_Util.comp_result c1 in
                                  (non_dependent_or_raise s ct;
@@ -4908,7 +4912,8 @@ let (cps_and_elaborate :
                                                                     bv.FStar_Syntax_Syntax.sort in
                                                                     FStar_Compiler_Effect.op_Bar_Greater
                                                                     uu___28
-                                                                    (FStar_Compiler_Util.set_mem
+                                                                    (FStar_Compiler_Set.mem
+                                                                    FStar_Syntax_Syntax.ord_bv
                                                                     type_param1.FStar_Syntax_Syntax.binder_bv) in
                                                                     FStar_Compiler_Effect.op_Bar_Greater
                                                                     uu___27

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_DeferredImplicits.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_DeferredImplicits.ml
@@ -58,8 +58,8 @@ type goal_dep =
   goal_dep_id: Prims.int ;
   goal_type: goal_type ;
   goal_imp: FStar_TypeChecker_Common.implicit ;
-  assignees: FStar_Syntax_Syntax.ctx_uvar FStar_Compiler_Util.set ;
-  goal_dep_uvars: FStar_Syntax_Syntax.ctx_uvar FStar_Compiler_Util.set ;
+  assignees: FStar_Syntax_Syntax.ctx_uvar FStar_Compiler_Set.t ;
+  goal_dep_uvars: FStar_Syntax_Syntax.ctx_uvar FStar_Compiler_Set.t ;
   dependences: goal_dep Prims.list FStar_Compiler_Effect.ref ;
   visited: Prims.int FStar_Compiler_Effect.ref }
 let (__proj__Mkgoal_dep__item__goal_dep_id : goal_dep -> Prims.int) =
@@ -79,13 +79,13 @@ let (__proj__Mkgoal_dep__item__goal_imp :
     | { goal_dep_id; goal_type = goal_type1; goal_imp; assignees;
         goal_dep_uvars; dependences; visited;_} -> goal_imp
 let (__proj__Mkgoal_dep__item__assignees :
-  goal_dep -> FStar_Syntax_Syntax.ctx_uvar FStar_Compiler_Util.set) =
+  goal_dep -> FStar_Syntax_Syntax.ctx_uvar FStar_Compiler_Set.t) =
   fun projectee ->
     match projectee with
     | { goal_dep_id; goal_type = goal_type1; goal_imp; assignees;
         goal_dep_uvars; dependences; visited;_} -> assignees
 let (__proj__Mkgoal_dep__item__goal_dep_uvars :
-  goal_dep -> FStar_Syntax_Syntax.ctx_uvar FStar_Compiler_Util.set) =
+  goal_dep -> FStar_Syntax_Syntax.ctx_uvar FStar_Compiler_Set.t) =
   fun projectee ->
     match projectee with
     | { goal_dep_id; goal_type = goal_type1; goal_imp; assignees;
@@ -104,10 +104,10 @@ let (__proj__Mkgoal_dep__item__visited :
         goal_dep_uvars; dependences; visited;_} -> visited
 type goal_deps = goal_dep Prims.list
 let (print_uvar_set :
-  FStar_Syntax_Syntax.ctx_uvar FStar_Compiler_Util.set -> Prims.string) =
+  FStar_Syntax_Syntax.ctx_uvar FStar_Compiler_Set.t -> Prims.string) =
   fun s ->
     let uu___ =
-      let uu___1 = FStar_Compiler_Util.set_elements s in
+      let uu___1 = FStar_Compiler_Set.elems FStar_Syntax_Free.ord_ctx_uvar s in
       FStar_Compiler_Effect.op_Bar_Greater uu___1
         (FStar_Compiler_List.map
            (fun u ->

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Env.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Env.ml
@@ -4659,7 +4659,7 @@ let (hasBinders_env : env FStar_Class_Binders.hasBinders) =
     FStar_Class_Binders.boundNames =
       (fun e ->
          let uu___ = bound_vars e in
-         FStar_Compiler_Util.as_set uu___ FStar_Syntax_Syntax.order_bv)
+         FStar_Compiler_Set.from_list FStar_Syntax_Syntax.ord_bv uu___)
   }
 let (hasNames_lcomp :
   FStar_TypeChecker_Common.lcomp FStar_Class_Binders.hasNames) =
@@ -4680,7 +4680,7 @@ let (hasNames_guard : guard_t FStar_Class_Binders.hasNames) =
       (fun g ->
          match g.FStar_TypeChecker_Common.guard_f with
          | FStar_TypeChecker_Common.Trivial ->
-             FStar_Compiler_Util.new_set FStar_Syntax_Syntax.order_bv
+             FStar_Compiler_Set.empty FStar_Syntax_Syntax.ord_bv ()
          | FStar_TypeChecker_Common.NonTrivial f ->
              FStar_Class_Binders.freeNames FStar_Class_Binders.hasNames_term
                f)
@@ -6186,7 +6186,8 @@ let (finish_module : env -> FStar_Syntax_Syntax.modul -> env) =
 let (uvars_in_env : env -> FStar_Syntax_Syntax.uvars) =
   fun env1 ->
     let no_uvs = FStar_Syntax_Free.new_uv_set () in
-    let ext out uvs = FStar_Compiler_Util.set_union out uvs in
+    let ext out uvs =
+      FStar_Compiler_Set.union FStar_Syntax_Free.ord_ctx_uvar out uvs in
     let rec aux out g =
       match g with
       | [] -> out
@@ -6205,10 +6206,11 @@ let (uvars_in_env : env -> FStar_Syntax_Syntax.uvars) =
           aux uu___2 tl in
     aux no_uvs env1.gamma
 let (univ_vars :
-  env -> FStar_Syntax_Syntax.universe_uvar FStar_Compiler_Util.set) =
+  env -> FStar_Syntax_Syntax.universe_uvar FStar_Compiler_Set.set) =
   fun env1 ->
     let no_univs = FStar_Syntax_Free.new_universe_uvar_set () in
-    let ext out uvs = FStar_Compiler_Util.set_union out uvs in
+    let ext out uvs =
+      FStar_Compiler_Set.union FStar_Syntax_Free.ord_univ_uvar out uvs in
     let rec aux out g =
       match g with
       | [] -> out
@@ -6226,16 +6228,19 @@ let (univ_vars :
             let uu___3 = FStar_Syntax_Free.univs t in ext out uu___3 in
           aux uu___2 tl in
     aux no_univs env1.gamma
-let (univnames :
-  env -> FStar_Syntax_Syntax.univ_name FStar_Compiler_Util.set) =
+let (univnames : env -> FStar_Syntax_Syntax.univ_name FStar_Compiler_Set.set)
+  =
   fun env1 ->
     let no_univ_names = FStar_Syntax_Syntax.no_universe_names in
-    let ext out uvs = FStar_Compiler_Util.set_union out uvs in
+    let ext out uvs =
+      FStar_Compiler_Set.union FStar_Syntax_Syntax.ord_ident out uvs in
     let rec aux out g =
       match g with
       | [] -> out
       | (FStar_Syntax_Syntax.Binding_univ uname)::tl ->
-          let uu___ = FStar_Compiler_Util.set_add uname out in aux uu___ tl
+          let uu___ =
+            FStar_Compiler_Set.add FStar_Syntax_Syntax.ord_ident uname out in
+          aux uu___ tl
       | (FStar_Syntax_Syntax.Binding_lid (uu___, (uu___1, t)))::tl ->
           let uu___2 =
             let uu___3 = FStar_Syntax_Free.univnames t in ext out uu___3 in
@@ -6416,23 +6421,26 @@ let (set_proof_ns : proof_namespace -> env -> env) =
       }
 let (unbound_vars :
   env ->
-    FStar_Syntax_Syntax.term ->
-      FStar_Syntax_Syntax.bv FStar_Compiler_Util.set)
+    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.bv FStar_Compiler_Set.set)
   =
   fun e ->
     fun t ->
       let uu___ = FStar_Syntax_Free.names t in
       let uu___1 = bound_vars e in
       FStar_Compiler_List.fold_left
-        (fun s -> fun bv -> FStar_Compiler_Util.set_remove bv s) uu___ uu___1
+        (fun s ->
+           fun bv ->
+             FStar_Compiler_Set.remove FStar_Syntax_Syntax.ord_bv bv s) uu___
+        uu___1
 let (closed : env -> FStar_Syntax_Syntax.term -> Prims.bool) =
   fun e ->
     fun t ->
-      let uu___ = unbound_vars e t in FStar_Compiler_Util.set_is_empty uu___
+      let uu___ = unbound_vars e t in
+      FStar_Compiler_Set.is_empty FStar_Syntax_Syntax.ord_bv uu___
 let (closed' : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t ->
     let uu___ = FStar_Syntax_Free.names t in
-    FStar_Compiler_Util.set_is_empty uu___
+    FStar_Compiler_Set.is_empty FStar_Syntax_Syntax.ord_bv uu___
 let (string_of_proof_ns : env -> Prims.string) =
   fun env1 ->
     let aux uu___ =

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Generalize.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Generalize.ml
@@ -1,10 +1,10 @@
 open Prims
 let (string_of_univs :
-  FStar_Syntax_Syntax.universe_uvar FStar_Compiler_Util.set -> Prims.string)
-  =
+  FStar_Syntax_Syntax.universe_uvar FStar_Compiler_Set.set -> Prims.string) =
   fun univs ->
     let uu___ =
-      let uu___1 = FStar_Compiler_Util.set_elements univs in
+      let uu___1 =
+        FStar_Compiler_Set.elems FStar_Syntax_Free.ord_univ_uvar univs in
       FStar_Compiler_Effect.op_Bar_Greater uu___1
         (FStar_Compiler_List.map
            (fun u ->
@@ -15,21 +15,22 @@ let (string_of_univs :
       (FStar_Compiler_String.concat ", ")
 let (gen_univs :
   FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.universe_uvar FStar_Compiler_Util.set ->
+    FStar_Syntax_Syntax.universe_uvar FStar_Compiler_Set.t ->
       FStar_Syntax_Syntax.univ_name Prims.list)
   =
   fun env ->
     fun x ->
-      let uu___ = FStar_Compiler_Util.set_is_empty x in
+      let uu___ =
+        FStar_Compiler_Set.is_empty FStar_Syntax_Free.ord_univ_uvar x in
       if uu___
       then []
       else
         (let s =
            let uu___2 =
              let uu___3 = FStar_TypeChecker_Env.univ_vars env in
-             FStar_Compiler_Util.set_difference x uu___3 in
+             FStar_Compiler_Set.diff FStar_Syntax_Free.ord_univ_uvar x uu___3 in
            FStar_Compiler_Effect.op_Bar_Greater uu___2
-             FStar_Compiler_Util.set_elements in
+             (FStar_Compiler_Set.elems FStar_Syntax_Free.ord_univ_uvar) in
          (let uu___3 =
             FStar_Compiler_Effect.op_Less_Bar
               (FStar_TypeChecker_Env.debug env) (FStar_Options.Other "Gen") in
@@ -74,14 +75,15 @@ let (gen_univs :
 let (gather_free_univnames :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
-      FStar_Syntax_Syntax.univ_name FStar_Compiler_Util.set)
+      FStar_Syntax_Syntax.univ_name FStar_Compiler_Set.t)
   =
   fun env ->
     fun t ->
       let ctx_univnames = FStar_TypeChecker_Env.univnames env in
       let tm_univnames = FStar_Syntax_Free.univnames t in
       let univnames =
-        FStar_Compiler_Util.set_difference tm_univnames ctx_univnames in
+        FStar_Compiler_Set.diff FStar_Syntax_Syntax.ord_ident tm_univnames
+          ctx_univnames in
       univnames
 let (check_universe_generalization :
   FStar_Syntax_Syntax.univ_name Prims.list ->
@@ -119,7 +121,7 @@ let (generalize_universes :
                FStar_TypeChecker_Env.DoNotUnfoldPureLets] env t0 in
            let univnames =
              let uu___1 = gather_free_univnames env t in
-             FStar_Compiler_Util.set_elements uu___1 in
+             FStar_Compiler_Set.elems FStar_Syntax_Syntax.ord_ident uu___1 in
            (let uu___2 =
               FStar_Compiler_Effect.op_Less_Bar
                 (FStar_TypeChecker_Env.debug env) (FStar_Options.Other "Gen") in
@@ -207,9 +209,11 @@ let (gen :
               c1) in
            let env_uvars = FStar_TypeChecker_Env.uvars_in_env env in
            let gen_uvars uvs =
-             let uu___2 = FStar_Compiler_Util.set_difference uvs env_uvars in
+             let uu___2 =
+               FStar_Compiler_Set.diff FStar_Syntax_Free.ord_ctx_uvar uvs
+                 env_uvars in
              FStar_Compiler_Effect.op_Bar_Greater uu___2
-               FStar_Compiler_Util.set_elements in
+               (FStar_Compiler_Set.elems FStar_Syntax_Free.ord_ctx_uvar) in
            let univs_and_uvars_of_lec uu___2 =
              match uu___2 with
              | (lbname, e, c) ->
@@ -225,7 +229,9 @@ let (gen :
                    then
                      let uu___5 =
                        let uu___6 =
-                         let uu___7 = FStar_Compiler_Util.set_elements univs in
+                         let uu___7 =
+                           FStar_Compiler_Set.elems
+                             FStar_Syntax_Free.ord_univ_uvar univs in
                          FStar_Compiler_Effect.op_Bar_Greater uu___7
                            (FStar_Compiler_List.map
                               (fun u ->
@@ -235,7 +241,9 @@ let (gen :
                          (FStar_Compiler_String.concat ", ") in
                      let uu___6 =
                        let uu___7 =
-                         let uu___8 = FStar_Compiler_Util.set_elements uvt in
+                         let uu___8 =
+                           FStar_Compiler_Set.elems
+                             FStar_Syntax_Free.ord_ctx_uvar uvt in
                          FStar_Compiler_Effect.op_Bar_Greater uu___8
                            (FStar_Compiler_List.map
                               (fun u ->
@@ -255,14 +263,17 @@ let (gen :
                        uu___6
                    else ());
                   (let univs1 =
-                     let uu___4 = FStar_Compiler_Util.set_elements uvt in
+                     let uu___4 =
+                       FStar_Compiler_Set.elems
+                         FStar_Syntax_Free.ord_ctx_uvar uvt in
                      FStar_Compiler_List.fold_left
                        (fun univs2 ->
                           fun uv ->
                             let uu___5 =
                               let uu___6 = FStar_Syntax_Util.ctx_uvar_typ uv in
                               FStar_Syntax_Free.univs uu___6 in
-                            FStar_Compiler_Util.set_union univs2 uu___5)
+                            FStar_Compiler_Set.union
+                              FStar_Syntax_Free.ord_univ_uvar univs2 uu___5)
                        univs uu___4 in
                    let uvs = gen_uvars uvt in
                    (let uu___5 =
@@ -274,7 +285,8 @@ let (gen :
                       let uu___6 =
                         let uu___7 =
                           let uu___8 =
-                            FStar_Compiler_Util.set_elements univs1 in
+                            FStar_Compiler_Set.elems
+                              FStar_Syntax_Free.ord_univ_uvar univs1 in
                           FStar_Compiler_Effect.op_Bar_Greater uu___8
                             (FStar_Compiler_List.map
                                (fun u ->
@@ -311,8 +323,11 @@ let (gen :
            | (univs, uvs, lec_hd) ->
                let force_univs_eq lec2 u1 u2 =
                  let uu___3 =
-                   (FStar_Compiler_Util.set_is_subset_of u1 u2) &&
-                     (FStar_Compiler_Util.set_is_subset_of u2 u1) in
+                   (FStar_Compiler_Set.subset FStar_Syntax_Free.ord_univ_uvar
+                      u1 u2)
+                     &&
+                     (FStar_Compiler_Set.subset
+                        FStar_Syntax_Free.ord_univ_uvar u2 u1) in
                  if uu___3
                  then ()
                  else
@@ -425,7 +440,8 @@ let (gen :
                                             FStar_Syntax_Free.names kres in
                                           let uu___9 =
                                             let uu___10 =
-                                              FStar_Compiler_Util.set_is_empty
+                                              FStar_Compiler_Set.is_empty
+                                                FStar_Syntax_Syntax.ord_bv
                                                 free in
                                             Prims.op_Negation uu___10 in
                                           if uu___9
@@ -602,17 +618,18 @@ let (generalize' :
          else ());
         (let univnames_lecs =
            let empty =
-             FStar_Compiler_Util.as_set []
-               FStar_Syntax_Syntax.order_univ_name in
+             FStar_Compiler_Set.from_list FStar_Syntax_Syntax.ord_ident [] in
            FStar_Compiler_List.fold_left
              (fun out ->
                 fun uu___2 ->
                   match uu___2 with
                   | (l, t, c) ->
                       let uu___3 = gather_free_univnames env t in
-                      FStar_Compiler_Util.set_union out uu___3) empty lecs in
+                      FStar_Compiler_Set.union FStar_Syntax_Syntax.ord_ident
+                        out uu___3) empty lecs in
          let univnames_lecs1 =
-           FStar_Compiler_Util.set_elements univnames_lecs in
+           FStar_Compiler_Set.elems FStar_Syntax_Syntax.ord_ident
+             univnames_lecs in
          let generalized_lecs =
            let uu___2 = gen env is_rec lecs in
            match uu___2 with

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Positivity.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Positivity.ml
@@ -90,7 +90,7 @@ let (ty_occurs_in :
   fun ty_lid ->
     fun t ->
       let uu___ = FStar_Syntax_Free.fvars t in
-      FStar_Compiler_Util.set_mem ty_lid uu___
+      FStar_Compiler_Set.mem FStar_Syntax_Syntax.ord_fv ty_lid uu___
 let rec (term_as_fv_or_name :
   FStar_Syntax_Syntax.term ->
     ((FStar_Syntax_Syntax.fv * FStar_Syntax_Syntax.universes),

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Rel.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Rel.ml
@@ -78,12 +78,12 @@ let (is_base_type :
            | uu___2 -> false)
 let (binders_as_bv_set :
   FStar_Syntax_Syntax.binders ->
-    FStar_Syntax_Syntax.bv FStar_Compiler_Util.set)
+    FStar_Syntax_Syntax.bv FStar_Compiler_Set.set)
   =
   fun bs ->
     let uu___ =
       FStar_Compiler_List.map (fun b -> b.FStar_Syntax_Syntax.binder_bv) bs in
-    FStar_Compiler_Util.as_set uu___ FStar_Syntax_Syntax.order_bv
+    FStar_Compiler_Set.from_list FStar_Syntax_Syntax.ord_bv uu___
 type lstring = Prims.string FStar_Thunk.t
 let (mklstr : (unit -> Prims.string) -> Prims.string FStar_Thunk.thunk) =
   fun f ->
@@ -809,7 +809,7 @@ let (hasBinders_prob :
            FStar_Compiler_Effect.op_Less_Bar
              (FStar_Compiler_List.map
                 (fun b -> b.FStar_Syntax_Syntax.binder_bv)) uu___1 in
-         FStar_Compiler_Util.as_set uu___ FStar_Syntax_Syntax.order_bv)
+         FStar_Compiler_Set.from_list FStar_Syntax_Syntax.ord_bv uu___)
   }
 let (def_check_term_scoped_in_prob :
   Prims.string ->
@@ -962,10 +962,10 @@ let (uvis_to_string :
   fun env ->
     fun uvis -> (FStar_Common.string_of_list ()) (uvi_to_string env) uvis
 let (names_to_string :
-  FStar_Syntax_Syntax.bv FStar_Compiler_Util.set -> Prims.string) =
+  FStar_Syntax_Syntax.bv FStar_Compiler_Set.set -> Prims.string) =
   fun nms ->
     let uu___ =
-      let uu___1 = FStar_Compiler_Util.set_elements nms in
+      let uu___1 = FStar_Compiler_Set.elems FStar_Syntax_Syntax.ord_bv nms in
       FStar_Compiler_Effect.op_Bar_Greater uu___1
         (FStar_Compiler_List.map FStar_Syntax_Print.bv_to_string) in
     FStar_Compiler_Effect.op_Bar_Greater uu___
@@ -2099,9 +2099,9 @@ let (ensure_no_uvar_subst :
 let (no_free_uvars : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t ->
     (let uu___ = FStar_Syntax_Free.uvars t in
-     FStar_Compiler_Util.set_is_empty uu___) &&
+     FStar_Compiler_Set.is_empty FStar_Syntax_Free.ord_ctx_uvar uu___) &&
       (let uu___ = FStar_Syntax_Free.univs t in
-       FStar_Compiler_Util.set_is_empty uu___)
+       FStar_Compiler_Set.is_empty FStar_Syntax_Free.ord_univ_uvar uu___)
 let rec (may_relate_with_logical_guard :
   FStar_TypeChecker_Env.env ->
     Prims.bool -> FStar_Syntax_Syntax.typ -> Prims.bool)
@@ -2389,7 +2389,7 @@ let (occurs :
       let uvars =
         let uu___ = FStar_Syntax_Free.uvars t in
         FStar_Compiler_Effect.op_Bar_Greater uu___
-          FStar_Compiler_Util.set_elements in
+          (FStar_Compiler_Set.elems FStar_Syntax_Free.ord_ctx_uvar) in
       let occurs1 =
         FStar_Compiler_Effect.op_Bar_Greater uvars
           (FStar_Compiler_Util.for_some
@@ -2430,7 +2430,7 @@ let (occurs_full :
       let uvars =
         let uu___ = FStar_Syntax_Free.uvars_full t in
         FStar_Compiler_Effect.op_Bar_Greater uu___
-          FStar_Compiler_Util.set_elements in
+          (FStar_Compiler_Set.elems FStar_Syntax_Free.ord_ctx_uvar) in
       let occurs1 =
         FStar_Compiler_Effect.op_Bar_Greater uvars
           (FStar_Compiler_Util.for_some
@@ -2629,7 +2629,8 @@ let restrict_all_uvars :
                          binders_as_bv_set
                            src.FStar_Syntax_Syntax.ctx_uvar_binders in
                        let uu___ =
-                         FStar_Compiler_Util.set_is_subset_of ctx_src ctx_tgt in
+                         FStar_Compiler_Set.subset FStar_Syntax_Syntax.ord_bv
+                           ctx_src ctx_tgt in
                        if uu___ then wl1 else restrict_ctx env tgt [] src wl1)
                   sources wl
             | uu___ ->
@@ -2648,7 +2649,7 @@ let (intersect_binders :
             (FStar_Compiler_List.fold_left
                (fun out ->
                   fun x ->
-                    FStar_Compiler_Util.set_add
+                    FStar_Compiler_Set.add FStar_Syntax_Syntax.ord_bv
                       x.FStar_Syntax_Syntax.binder_bv out)
                FStar_Syntax_Syntax.no_names) in
         let v1_set = as_set v1 in
@@ -2658,7 +2659,7 @@ let (intersect_binders :
                fun b ->
                  match b with
                  | FStar_Syntax_Syntax.Binding_var x ->
-                     FStar_Compiler_Util.set_add x out
+                     FStar_Compiler_Set.add FStar_Syntax_Syntax.ord_bv x out
                  | uu___ -> out) FStar_Syntax_Syntax.no_names g in
         let uu___ =
           FStar_Compiler_Effect.op_Bar_Greater v2
@@ -2674,7 +2675,8 @@ let (intersect_binders :
                          | (x, imp) ->
                              let uu___3 =
                                let uu___4 =
-                                 FStar_Compiler_Util.set_mem x v1_set in
+                                 FStar_Compiler_Set.mem
+                                   FStar_Syntax_Syntax.ord_bv x v1_set in
                                FStar_Compiler_Effect.op_Less_Bar
                                  Prims.op_Negation uu___4 in
                              if uu___3
@@ -2684,12 +2686,13 @@ let (intersect_binders :
                                   FStar_Syntax_Free.names
                                     x.FStar_Syntax_Syntax.sort in
                                 let uu___5 =
-                                  FStar_Compiler_Util.set_is_subset_of fvs
-                                    isect_set in
+                                  FStar_Compiler_Set.subset
+                                    FStar_Syntax_Syntax.ord_bv fvs isect_set in
                                 if uu___5
                                 then
                                   let uu___6 =
-                                    FStar_Compiler_Util.set_add x isect_set in
+                                    FStar_Compiler_Set.add
+                                      FStar_Syntax_Syntax.ord_bv x isect_set in
                                   ((b :: isect), uu___6)
                                 else (isect, isect_set)))) ([], ctx_binders)) in
         match uu___ with | (isect, uu___1) -> FStar_Compiler_List.rev isect
@@ -4974,7 +4977,7 @@ let (has_free_uvars : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t ->
     let uu___ =
       let uu___1 = FStar_Syntax_Free.uvars_uncached t in
-      FStar_Compiler_Util.set_is_empty uu___1 in
+      FStar_Compiler_Set.is_empty FStar_Syntax_Free.ord_ctx_uvar uu___1 in
     Prims.op_Negation uu___
 let (env_has_free_uvars : FStar_TypeChecker_Env.env_t -> Prims.bool) =
   fun e ->
@@ -6709,7 +6712,8 @@ and (solve_t_flex_rigid_eq :
                           let uu___7 =
                             FStar_Syntax_Free.names
                               (FStar_Pervasives_Native.fst arg) in
-                          FStar_Compiler_Util.set_mem x uu___7 in
+                          FStar_Compiler_Set.mem FStar_Syntax_Syntax.ord_bv x
+                            uu___7 in
                         Prims.op_Negation uu___6 in
                       let bv_not_free_in_args x args1 =
                         FStar_Compiler_Util.for_all (bv_not_free_in_arg x)
@@ -6818,8 +6822,9 @@ and (solve_t_flex_rigid_eq :
                                   let fvs_rhs = FStar_Syntax_Free.names rhs1 in
                                   let uu___9 =
                                     let uu___10 =
-                                      FStar_Compiler_Util.set_is_subset_of
-                                        fvs_rhs fvs_lhs in
+                                      FStar_Compiler_Set.subset
+                                        FStar_Syntax_Syntax.ord_bv fvs_rhs
+                                        fvs_lhs in
                                     Prims.op_Negation uu___10 in
                                   if uu___9
                                   then
@@ -7162,7 +7167,8 @@ and (solve_t_flex_rigid_eq :
                                              let uu___14 =
                                                binders_as_bv_set
                                                  ctx_uv.FStar_Syntax_Syntax.ctx_uvar_binders in
-                                             FStar_Compiler_Util.set_is_subset_of
+                                             FStar_Compiler_Set.subset
+                                               FStar_Syntax_Syntax.ord_bv
                                                uu___13 uu___14 in
                                            Prims.op_Negation uu___12 in
                                          if uu___11
@@ -7493,7 +7499,8 @@ and (solve_t_flex_rigid_eq :
                                                               FStar_Syntax_Free.uvars in
                                                           FStar_Compiler_Effect.op_Bar_Greater
                                                             uu___20
-                                                            FStar_Compiler_Util.set_elements in
+                                                            (FStar_Compiler_Set.elems
+                                                               FStar_Syntax_Free.ord_ctx_uvar) in
                                                         solve_sub_probs_if_head_types_equal
                                                           uu___19 wl2
                                                     | FStar_Pervasives.Inr
@@ -7542,7 +7549,8 @@ and (solve_t_flex_rigid_eq :
                               let names_to_string1 fvs =
                                 let uu___6 =
                                   let uu___7 =
-                                    FStar_Compiler_Util.set_elements fvs in
+                                    FStar_Compiler_Set.elems
+                                      FStar_Syntax_Syntax.ord_bv fvs in
                                   FStar_Compiler_List.map
                                     FStar_Syntax_Print.bv_to_string uu___7 in
                                 FStar_Compiler_Effect.op_Bar_Greater uu___6
@@ -7571,8 +7579,8 @@ and (solve_t_flex_rigid_eq :
                                       uu___7
                                   else
                                     (let uu___8 =
-                                       FStar_Compiler_Util.set_is_subset_of
-                                         fvs2 fvs1 in
+                                       FStar_Compiler_Set.subset
+                                         FStar_Syntax_Syntax.ord_bv fvs2 fvs1 in
                                      if uu___8
                                      then
                                        let sol =
@@ -9694,13 +9702,15 @@ and (solve_t' : tprob -> worklist -> solution) =
                                        (let uu___12 =
                                           let uu___13 =
                                             FStar_Syntax_Free.uvars phi12 in
-                                          FStar_Compiler_Util.set_is_empty
+                                          FStar_Compiler_Set.is_empty
+                                            FStar_Syntax_Free.ord_ctx_uvar
                                             uu___13 in
                                         Prims.op_Negation uu___12) ||
                                          (let uu___12 =
                                             let uu___13 =
                                               FStar_Syntax_Free.uvars phi22 in
-                                            FStar_Compiler_Util.set_is_empty
+                                            FStar_Compiler_Set.is_empty
+                                              FStar_Syntax_Free.ord_ctx_uvar
                                               uu___13 in
                                           Prims.op_Negation uu___12) in
                                      if
@@ -14234,7 +14244,8 @@ let (try_solve_deferred_constraints :
                                            let uvs =
                                              FStar_Syntax_Free.uvars
                                                goal_type in
-                                           FStar_Compiler_Util.set_elements
+                                           FStar_Compiler_Set.elems
+                                             FStar_Syntax_Free.ord_ctx_uvar
                                              uvs
                                          else [])
                                 | uu___3 -> [])) in
@@ -15338,7 +15349,7 @@ let (is_tac_implicit_resolved :
           FStar_Compiler_Effect.op_Bar_Greater
             i.FStar_TypeChecker_Common.imp_tm FStar_Syntax_Free.uvars in
         FStar_Compiler_Effect.op_Bar_Greater uu___1
-          FStar_Compiler_Util.set_elements in
+          (FStar_Compiler_Set.elems FStar_Syntax_Free.ord_ctx_uvar) in
       FStar_Compiler_Effect.op_Bar_Greater uu___
         (FStar_Compiler_List.for_all
            (fun uv ->
@@ -15459,9 +15470,13 @@ let (resolve_implicits' :
                                        (FStar_Class_Show.printableshow
                                           FStar_Class_Printable.printable_bool)
                                        is_tac in
-                                   FStar_Compiler_Util.print3
-                                     "resolve_implicits' loop, imp_tm = %s and ctx_u = %s, is_tac: %s\n"
-                                     uu___6 uu___7 uu___8
+                                   let uu___9 =
+                                     FStar_Class_Show.show
+                                       FStar_Syntax_Syntax.showable_should_check_uvar
+                                       uvar_decoration_should_check in
+                                   FStar_Compiler_Util.print4
+                                     "resolve_implicits' loop, imp_tm=%s and ctx_u=%s, is_tac=%s, should_check=%s\n"
+                                     uu___6 uu___7 uu___8 uu___9
                                  else ());
                                 (match () with
                                  | uu___5 when

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Tc.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Tc.ml
@@ -2017,7 +2017,8 @@ let (tc_sig_let :
                                                        lb.FStar_Syntax_Syntax.lbtyp in
                                                    FStar_Compiler_Effect.op_Bar_Greater
                                                      uu___10
-                                                     FStar_Compiler_Util.set_elements in
+                                                     (FStar_Compiler_Set.elems
+                                                        FStar_Syntax_Syntax.ord_fv) in
                                                  FStar_Compiler_Effect.op_Bar_Greater
                                                    uu___9
                                                    (FStar_Compiler_List.tryFind

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_TcTerm.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_TcTerm.ml
@@ -263,7 +263,9 @@ let (check_no_escape :
                      let fvs' = FStar_Syntax_Free.names t1 in
                      let uu___2 =
                        FStar_Compiler_List.tryFind
-                         (fun x -> FStar_Compiler_Util.set_mem x fvs') fvs in
+                         (fun x ->
+                            FStar_Compiler_Set.mem FStar_Syntax_Syntax.ord_bv
+                              x fvs') fvs in
                      match uu___2 with
                      | FStar_Pervasives_Native.None ->
                          (t1, FStar_TypeChecker_Env.trivial_guard)
@@ -880,8 +882,7 @@ let (print_expected_ty : FStar_TypeChecker_Env.env -> unit) =
 let rec (get_pat_vars' :
   FStar_Syntax_Syntax.bv Prims.list ->
     Prims.bool ->
-      FStar_Syntax_Syntax.term ->
-        FStar_Syntax_Syntax.bv FStar_Compiler_Util.set)
+      FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.bv FStar_Compiler_Set.t)
   =
   fun all ->
     fun andlist ->
@@ -901,10 +902,9 @@ let rec (get_pat_vars' :
                  ->
                  if andlist
                  then
-                   FStar_Compiler_Util.as_set all
-                     FStar_Syntax_Syntax.order_bv
-                 else
-                   FStar_Compiler_Util.new_set FStar_Syntax_Syntax.order_bv
+                   FStar_Compiler_Set.from_list FStar_Syntax_Syntax.ord_bv
+                     all
+                 else FStar_Compiler_Set.empty FStar_Syntax_Syntax.ord_bv ()
              | (FStar_Syntax_Syntax.Tm_fvar fv,
                 (uu___2, FStar_Pervasives_Native.Some
                  { FStar_Syntax_Syntax.aqual_implicit = true;
@@ -917,8 +917,12 @@ let rec (get_pat_vars' :
                  let hdvs = get_pat_vars' all false hd in
                  let tlvs = get_pat_vars' all andlist tl in
                  if andlist
-                 then FStar_Compiler_Util.set_intersect hdvs tlvs
-                 else FStar_Compiler_Util.set_union hdvs tlvs
+                 then
+                   FStar_Compiler_Set.inter FStar_Syntax_Syntax.ord_bv hdvs
+                     tlvs
+                 else
+                   FStar_Compiler_Set.union FStar_Syntax_Syntax.ord_bv hdvs
+                     tlvs
              | (FStar_Syntax_Syntax.Tm_fvar fv,
                 (uu___2, FStar_Pervasives_Native.Some
                  { FStar_Syntax_Syntax.aqual_implicit = true;
@@ -933,11 +937,10 @@ let rec (get_pat_vars' :
                    FStar_Parser_Const.smtpatOr_lid
                  -> get_pat_vars' all true subpats
              | uu___2 ->
-                 FStar_Compiler_Util.new_set FStar_Syntax_Syntax.order_bv)
+                 FStar_Compiler_Set.empty FStar_Syntax_Syntax.ord_bv ())
 let (get_pat_vars :
   FStar_Syntax_Syntax.bv Prims.list ->
-    FStar_Syntax_Syntax.term ->
-      FStar_Syntax_Syntax.bv FStar_Compiler_Util.set)
+    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.bv FStar_Compiler_Set.t)
   = fun all -> fun pats -> get_pat_vars' all false pats
 let (check_pat_fvs :
   FStar_Compiler_Range_Type.range ->
@@ -966,7 +969,9 @@ let (check_pat_fvs :
                         FStar_Syntax_Syntax.binder_qual = uu___2;
                         FStar_Syntax_Syntax.binder_positivity = uu___3;
                         FStar_Syntax_Syntax.binder_attrs = uu___4;_} ->
-                        let uu___5 = FStar_Compiler_Util.set_mem b pat_vars in
+                        let uu___5 =
+                          FStar_Compiler_Set.mem FStar_Syntax_Syntax.ord_bv b
+                            pat_vars in
                         Prims.op_Negation uu___5)) in
           match uu___ with
           | FStar_Pervasives_Native.None -> ()
@@ -11268,8 +11273,9 @@ and (check_inner_let_rec :
                                           if uu___6
                                           then
                                             let bvss =
-                                              FStar_Compiler_Util.as_set bvs
-                                                FStar_Syntax_Syntax.order_bv in
+                                              FStar_Compiler_Set.from_list
+                                                FStar_Syntax_Syntax.ord_bv
+                                                bvs in
                                             FStar_TypeChecker_Common.apply_lcomp
                                               (fun c ->
                                                  let uu___7 =
@@ -11293,11 +11299,13 @@ and (check_inner_let_rec :
                                                                     FStar_Syntax_Free.names in
                                                                    FStar_Compiler_Effect.op_Bar_Greater
                                                                     uu___13
-                                                                    (FStar_Compiler_Util.set_intersect
+                                                                    (FStar_Compiler_Set.inter
+                                                                    FStar_Syntax_Syntax.ord_bv
                                                                     bvss) in
                                                                  FStar_Compiler_Effect.op_Bar_Greater
                                                                    uu___12
-                                                                   FStar_Compiler_Util.set_is_empty in
+                                                                   (FStar_Compiler_Set.is_empty
+                                                                    FStar_Syntax_Syntax.ord_bv) in
                                                                FStar_Compiler_Effect.op_Bar_Greater
                                                                  uu___11
                                                                  Prims.op_Negation)) in

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Util.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Util.ml
@@ -108,13 +108,15 @@ let (check_uvars :
     fun t ->
       let uvs = FStar_Syntax_Free.uvars t in
       let uu___ =
-        let uu___1 = FStar_Compiler_Util.set_is_empty uvs in
+        let uu___1 =
+          FStar_Compiler_Set.is_empty FStar_Syntax_Free.ord_ctx_uvar uvs in
         Prims.op_Negation uu___1 in
       if uu___
       then
         let us =
           let uu___1 =
-            let uu___2 = FStar_Compiler_Util.set_elements uvs in
+            let uu___2 =
+              FStar_Compiler_Set.elems FStar_Syntax_Free.ord_ctx_uvar uvs in
             FStar_Compiler_List.map
               (fun u ->
                  FStar_Syntax_Print.uvar_to_string
@@ -5237,7 +5239,8 @@ let rec (check_erased :
                                                FStar_Syntax_Free.names in
                                            FStar_Compiler_Effect.op_Bar_Greater
                                              uu___13
-                                             FStar_Compiler_Util.set_elements in
+                                             (FStar_Compiler_Set.elems
+                                                FStar_Syntax_Syntax.ord_bv) in
                                          FStar_Compiler_Effect.op_Bar_Greater
                                            uu___12
                                            (FStar_TypeChecker_Env.push_bvs

--- a/src/basic/FStar.Common.fst
+++ b/src/basic/FStar.Common.fst
@@ -90,20 +90,6 @@ breaking change to anything that parses F* source code (like Vale). *)
 let string_of_list = __string_of_list ", "
 let string_of_list' = __string_of_list "; "
 
-let string_of_set (f : 'a -> string) (l : BU.set 'a) : string =
-  match BU.set_elements l with
-  | [] -> "{}"
-  | x::xs ->
-    let strb = BU.new_string_builder () in
-    BU.string_builder_append strb "{";
-    BU.string_builder_append strb (f x);
-    List.iter (fun x ->
-               BU.string_builder_append strb ", ";
-               BU.string_builder_append strb (f x)
-               ) xs ;
-    BU.string_builder_append strb "}";
-    BU.string_of_string_builder strb
-
 let list_of_option (o:option 'a) : list 'a =
     match o with
     | None -> []

--- a/src/basic/FStar.Compiler.Order.fst
+++ b/src/basic/FStar.Compiler.Order.fst
@@ -44,6 +44,12 @@ let order_from_int (i : int) : order =
 
 let compare_int (i : int) (j : int) : order = order_from_int (i - j)
 
+let compare_bool (b1 b2 : bool) : order =
+  match b1, b2 with
+  | false, true -> Lt
+  | true, false -> Gt
+  | _ -> Eq
+
 (*
  * It promises to call the comparator in strictly smaller elements
  * Useful when writing a comparator for an inductive type,

--- a/src/basic/FStar.Compiler.Set.fst
+++ b/src/basic/FStar.Compiler.Set.fst
@@ -1,0 +1,48 @@
+(*
+   Copyright 2008-2017 Microsoft Research
+
+   Authors: Aseem Rastogi, Nikhil Swamy, Jonathan Protzenko
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*)
+
+module FStar.Compiler.Set
+
+open FStar.Class.Ord
+open FStar.Compiler.Order
+open FStar.Compiler.Util
+
+(* This is a dummy implementation referring to FStar.Compiler.Util.set, which
+is implemented with lists. To be changed soon. *)
+
+let set t = Util.set t
+
+let add x s = set_add x s
+let empty () = new_set (fun x y -> match (cmp x y) with | Lt -> -1 | Eq -> 0 | Gt -> 1)
+let from_list xs = as_set xs (fun x y -> match (cmp x y) with | Lt -> -1 | Eq -> 0 | Gt -> 1)
+let mem x s = set_mem x s
+let singleton x = set_add x (empty ())
+let is_empty s = set_is_empty s
+let addn xs ys = List.fold_right add xs ys
+let remove x s = set_remove x s
+let equal s1 s2 = set_eq s1 s2
+let inter s1 s2 = set_intersect s1 s2
+let union s1 s2 = set_union s1 s2
+let diff s1 s2 = set_difference s1 s2
+let subset s1 s2 = set_is_subset_of s1 s2
+let elems s = set_elements s
+
+(* Note: no deduplication in the internal list, so duplicate elements will be printed here. *)
+instance showable_set (a:Type) (_ : ord a) (_ : showable a) : Tot (showable (set a)) = {
+    show = (fun s -> show (elems s));
+}

--- a/src/basic/FStar.Compiler.Set.fsti
+++ b/src/basic/FStar.Compiler.Set.fsti
@@ -1,0 +1,107 @@
+(*
+   Copyright 2008-2017 Microsoft Research
+
+   Authors: Aseem Rastogi, Nikhil Swamy, Jonathan Protzenko
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*)
+
+module FStar.Compiler.Set
+
+open FStar.Class.Ord
+open FStar.Class.Show
+
+val set (a:Type0) : Type0
+
+type t = set
+
+val empty
+  (#a:Type) {| ord a |}
+  (_:unit)
+  : set a
+
+val is_empty
+  (#a:Type) {| ord a |}
+  (s:set a)
+  : bool
+
+val add
+  (#a:Type) {| ord a |}
+  (x:a)
+  (s:set a)
+  : set a
+
+val addn
+  (#a:Type) {| ord a |}
+  (x:list a)
+  (s:set a)
+  : set a
+
+val remove
+  (#a:Type) {| ord a |}
+  (x:a)
+  (s:set a)
+  : set a
+
+val mem
+  (#a:Type) {| ord a |}
+  (x:a)
+  (s:set a)
+  : bool
+
+val equal
+  (#a:Type) {| ord a |}
+  (s1:set a)
+  (s2:set a)
+  : bool
+
+val subset
+  (#a:Type) {| ord a |}
+  (s1:set a)
+  (s2:set a)
+  : bool
+
+val singleton
+  (#a:Type) {| ord a |}
+  (x:a)
+  : set a
+  
+val from_list
+  (#a:Type) {| ord a |}
+  (l:list a)
+  : set a
+
+val union
+  (#a:Type) {| ord a |}
+  (s1:set a)
+  (s2:set a)
+  : set a
+
+val inter
+  (#a:Type) {| ord a |}
+  (s1:set a)
+  (s2:set a)
+  : set a
+
+val diff
+  (#a:Type) {| ord a |}
+  (s1:set a)
+  (s2:set a)
+  : set a
+  
+val elems
+  (#a:Type) {| ord a |}
+  (s:set a)
+  : list a
+
+instance val showable_set (a:Type) (_ : ord a) (_ : showable a) : Tot (showable (set a))

--- a/src/basic/FStar.Defensive.fst
+++ b/src/basic/FStar.Defensive.fst
@@ -1,9 +1,11 @@
 ﻿module FStar.Defensive
 
+open FStar.Compiler
 open FStar.Compiler.Effect
 open FStar.Compiler.Util
 open FStar.Class.Binders
 open FStar.Class.Show
+open FStar.Class.Ord
 open FStar.Errors
 open FStar.Errors.Msg
 open FStar.Pprint
@@ -22,24 +24,24 @@ instance pp_bv : pretty FStar.Syntax.Syntax.bv = {
   pp = (fun bv -> arbitrary_string (show bv));
 }
 
-instance pp_set #a (_ : pretty a) : Tot (pretty (set a)) = {
+instance pp_set #a (_ : ord a) (_ : pretty a) : Tot (pretty (Set.set a)) = {
   pp = (fun s ->
     let doclist (ds : list Pprint.document) : Pprint.document =
       surround_separate 2 0 (doc_of_string "[]") lbracket (semi ^^ break_ 1) rbracket ds
     in
-    doclist (set_elements s |> List.map pp))
+    doclist (Set.elems s |> List.map pp))
 }
 
 let __def_check_scoped rng msg env thing =
   let free = freeNames thing in
   let scope = boundNames env in
-  if not (set_is_empty <| set_difference free scope) then
+  if not (Set.subset free scope) then
     Errors.log_issue_doc rng (Errors.Warning_Defensive, [
          text "Internal: term is not well-scoped " ^/^ parens (doc_of_string msg);
          text "t =" ^/^ pp thing;
          text "FVs =" ^/^ pp free;
          text "Scope =" ^/^ pp scope;
-         text "Diff =" ^/^ pp (set_difference free scope);
+         text "Diff =" ^/^ pp (Set.diff free scope);
        ])
 
 let def_check_scoped rng msg env thing =

--- a/src/class/FStar.Class.Binders.fst
+++ b/src/class/FStar.Class.Binders.fst
@@ -4,13 +4,11 @@ open FStar.Compiler
 open FStar.Compiler.Effect
 open FStar.Compiler.Range
 open FStar.Compiler.Util
+open FStar.Compiler.Set
 open FStar.Syntax.Syntax
 module F = FStar.Syntax.Free
 open FStar.Errors
 open FStar.Errors.Msg
-
-val set_join : l:(list (set 'a)){Cons? l} -> set 'a
-let set_join (hd::tl) = List.fold_left set_union hd tl
 
 instance hasNames_term : hasNames term = {
   freeNames = F.names;
@@ -20,11 +18,12 @@ instance hasNames_comp : hasNames comp = {
   freeNames = (fun c -> match c.n with
                | Total t
                | GTotal t -> F.names t
-               | Comp ct -> set_join (F.names ct.result_typ :: (List.map (fun (a,_) -> F.names a) ct.effect_args)))
+               | Comp ct -> List.fold_left Set.union (Set.empty ())
+                             (F.names ct.result_typ :: (List.map (fun (a,_) -> F.names a) ct.effect_args)))
 }
 
 instance hasBinders_list_bv = {
-  boundNames = (fun l -> as_set l order_bv);
+  boundNames = Set.from_list;
 }
 
 instance hasBinders_set_bv = {

--- a/src/class/FStar.Class.Binders.fsti
+++ b/src/class/FStar.Class.Binders.fsti
@@ -1,6 +1,7 @@
 module FStar.Class.Binders
 
 open FStar.Compiler.Util
+open FStar.Compiler.Set
 open FStar.Syntax.Syntax
 
 class hasNames (a:Type) = {

--- a/src/class/FStar.Class.Deq.fst
+++ b/src/class/FStar.Class.Deq.fst
@@ -16,6 +16,10 @@ instance deq_unit : deq unit = {
    (=?) = (fun x y -> true);
 }
 
+instance deq_string : deq string = {
+   (=?) = (fun x y -> x = y);
+}
+
 instance deq_option #a (_ : deq a) : Tot (deq (option a)) = {
    (=?) = (fun x y -> match x, y with
            | None, None -> true

--- a/src/class/FStar.Class.Deq.fsti
+++ b/src/class/FStar.Class.Deq.fsti
@@ -8,9 +8,10 @@ class deq (a:Type) = {
 
 val (<>?) : #a:Type -> {| deq a |} -> a -> a -> bool
 
-instance val deq_int : deq int
-instance val deq_bool : deq bool
-instance val deq_unit : deq unit
+instance val deq_int    : deq int
+instance val deq_bool   : deq bool
+instance val deq_unit   : deq unit
+instance val deq_string : deq string
 
 instance val deq_option
    (_ : deq 'a)

--- a/src/class/FStar.Class.Monoid.fst
+++ b/src/class/FStar.Class.Monoid.fst
@@ -1,0 +1,42 @@
+module FStar.Class.Monoid
+
+open FStar.Compiler
+open FStar.Compiler.Effect
+open FStar.Compiler.List
+
+class monoid (a:Type) = {
+   mzero : a;
+   mplus : a -> a -> a;
+}
+
+val msum (#a:Type) {|monoid a|} (xs:list a) : a
+let msum xs = fold_left mplus mzero xs
+
+instance monoid_int : monoid int = {
+   mzero = 0;
+   mplus = (fun x y -> x + y);
+}
+
+instance monoid_string : monoid string = {
+   mzero = "";
+   mplus = (fun x y -> x ^ y);
+}
+
+instance monoid_list (a:Type) : Tot (monoid (list a)) = {
+   mzero = [];
+   mplus = (fun x y -> x @ y);
+}
+
+instance monoid_set (a:Type) : Tot (monoid (Util.set a)) = {
+   mzero = Set.empty;
+   mplus = Set.union;
+}
+
+(* Funny output from Copilot... not bad!
+
+instance monoid_effect (a:Type) (e:effect) : monoid (a!e) = {
+   mzero = return mzero;
+   mplus = (fun x y -> x >>= (fun x -> y >>= (fun y -> return (mplus x y))));
+}
+
+*)

--- a/src/class/FStar.Class.Ord.fst
+++ b/src/class/FStar.Class.Ord.fst
@@ -1,14 +1,33 @@
 module FStar.Class.Ord
 
+open FStar.Compiler
 open FStar.Compiler.Effect
 open FStar.Tactics.Typeclasses
-
-instance ord_eq (a:Type) (d : ord a) : Tot (deq a) = d.super
 
 let (<?)  x y = cmp x y =  Lt
 let (<=?) x y = cmp x y <> Gt
 let (>?)  x y = cmp x y =  Gt
 let (>=?) x y = cmp x y <> Lt
+
+instance ord_eq (a:Type) (d : ord a) : Tot (deq a) = d.super
+
+let rec insert (#a:Type) {| ord a |} (x:a) (xs:list a) : list a =
+  match xs with
+  | [] -> [x]
+  | y::ys -> if x <=? y then x :: y :: ys else y :: insert x ys
+
+let rec sort xs =
+  match xs with
+  | [] -> []
+  | x::xs -> insert x (sort xs)
+
+let rec dedup #a xs =
+  let rec aux (xs:list a) : list a =
+    match xs with
+    | [] -> []
+    | x :: xs -> if List.existsb ((=?) x) xs then dedup xs else x :: dedup xs
+  in
+  aux (List.rev xs)
 
 instance ord_int : ord int = {
    super = solve;

--- a/src/class/FStar.Class.Ord.fst
+++ b/src/class/FStar.Class.Ord.fst
@@ -1,0 +1,101 @@
+module FStar.Class.Ord
+
+open FStar.Compiler.Effect
+open FStar.Tactics.Typeclasses
+
+instance ord_eq (a:Type) (d : ord a) : Tot (deq a) = d.super
+
+let (<?)  x y = cmp x y =  Lt
+let (<=?) x y = cmp x y <> Gt
+let (>?)  x y = cmp x y =  Gt
+let (>=?) x y = cmp x y <> Lt
+
+instance ord_int : ord int = {
+   super = solve;
+   cmp = compare_int;
+}
+
+instance ord_bool : ord bool = {
+   super = solve;
+   cmp = compare_bool;
+}
+
+instance ord_unit : ord unit = {
+   super = solve;
+   cmp = (fun _ _ -> Eq);
+}
+
+instance ord_string : ord string = {
+   super = solve;
+   cmp = (fun x y -> order_from_int (String.compare x y));
+}
+
+instance ord_option #a (d : ord a) : Tot (ord (option a)) = {
+   super = solve;
+   cmp = (fun x y -> match x, y with
+          | None, None -> Eq
+          | Some _, None -> Gt
+          | None, Some _ -> Lt
+          | Some x, Some y -> cmp x y
+          );
+}
+
+instance ord_list #a (d : ord a) : Tot (ord (list a)) = {
+   super = solve;
+   cmp = (fun l1 l2 -> compare_list l1 l2 cmp);
+}
+
+instance ord_either #a #b (d1 : ord a) (d2 : ord b) : Tot (ord (either a b)) = {
+   super = solve;
+   cmp = (fun x y -> match x, y with
+          | Inl _, Inr _ -> Lt
+          | Inr _, Inl _ -> Gt
+          | Inl x, Inl y -> cmp x y
+          | Inr x, Inr y -> cmp x y
+          );
+}
+
+instance ord_tuple2 #a #b (d1 : ord a) (d2 : ord b) : Tot (ord (a * b)) = {
+   super = solve;
+   cmp = (fun (x1, x2) (y1, y2) -> 
+          lex (cmp x1 y1) (fun () ->
+          cmp x2 y2));
+}
+
+instance ord_tuple3 #a #b #c (d1 : ord a) (d2 : ord b) (d3 : ord c): Tot (ord (a & b & c)) = {
+   super = solve;
+   cmp = (fun (x1, x2, x3) (y1, y2, y3) -> 
+          lex (cmp x1 y1) (fun () ->
+          lex (cmp x2 y2) (fun () ->
+          cmp x3 y3)));
+}
+
+instance ord_tuple4 #a #b #c #d (d1 : ord a) (d2 : ord b) (d3 : ord c) (d4 : ord d): Tot (ord (a & b & c & d)) = {
+   super = solve;
+   cmp = (fun (x1, x2, x3, x4) (y1, y2, y3, y4) -> 
+          lex (cmp x1 y1) (fun () ->
+          lex (cmp x2 y2) (fun () ->
+          lex (cmp x3 y3) (fun () ->
+          cmp x4 y4))));
+}
+
+instance ord_tuple5 #a #b #c #d #e (d1 : ord a) (d2 : ord b) (d3 : ord c) (d4 : ord d) (d5 : ord e): Tot (ord (a & b & c & d & e)) = {
+   super = solve;
+   cmp = (fun (x1, x2, x3, x4, x5) (y1, y2, y3, y4, y5) -> 
+          lex (cmp x1 y1) (fun () ->
+          lex (cmp x2 y2) (fun () ->
+          lex (cmp x3 y3) (fun () ->
+          lex (cmp x4 y4) (fun () ->
+          cmp x5 y5)))));
+}
+
+instance ord_tuple6 #a #b #c #d #e #f (d1 : ord a) (d2 : ord b) (d3 : ord c) (d4 : ord d) (d5 : ord e) (d6 : ord f): Tot (ord (a & b & c & d & e & f)) = {
+   super = solve;
+   cmp = (fun (x1, x2, x3, x4, x5, x6) (y1, y2, y3, y4, y5, y6) -> 
+          lex (cmp x1 y1) (fun () ->
+          lex (cmp x2 y2) (fun () ->
+          lex (cmp x3 y3) (fun () ->
+          lex (cmp x4 y4) (fun () ->
+          lex (cmp x5 y5) (fun () ->
+          cmp x6 y6))))));
+}

--- a/src/class/FStar.Class.Ord.fsti
+++ b/src/class/FStar.Class.Ord.fsti
@@ -1,0 +1,72 @@
+module FStar.Class.Ord
+
+open FStar.Compiler.Effect
+open FStar.Compiler.Order
+include FStar.Class.Deq
+open FStar.Class.Deq
+
+class ord (a:Type) = {
+  super : deq a;
+  cmp : a -> a -> order;
+}
+
+instance val ord_eq (a:Type) (d : ord a) : Tot (deq a)
+
+val (<?)  : #a:Type -> {| ord a |} -> a -> a -> bool
+val (<=?) : #a:Type -> {| ord a |} -> a -> a -> bool
+val (>?)  : #a:Type -> {| ord a |} -> a -> a -> bool
+val (>=?) : #a:Type -> {| ord a |} -> a -> a -> bool
+
+instance val ord_int    : ord int
+instance val ord_bool   : ord bool
+instance val ord_unit   : ord unit
+instance val ord_string : ord string
+
+instance val ord_option
+   (_ : ord 'a)
+: Tot (ord (option 'a))
+
+instance val ord_list
+   (_ : ord 'a)
+: Tot (ord (list 'a))
+
+instance val ord_either
+   (_ : ord 'a)
+   (_ : ord 'b)
+: Tot (ord (either 'a 'b))
+
+instance val ord_tuple2
+   (_ : ord 'a)
+   (_ : ord 'b)
+: Tot (ord ('a & 'b))
+
+instance val ord_tuple3
+   (_ : ord 'a)
+   (_ : ord 'b)
+   (_ : ord 'c)
+: Tot (ord ('a & 'b & 'c))
+
+instance val ord_tuple4
+   (_ : ord 'a)
+   (_ : ord 'b)
+   (_ : ord 'c)
+   (_ : ord 'd)
+: Tot (ord ('a & 'b & 'c & 'd))
+
+instance val ord_tuple5
+   (_ : ord 'a)
+   (_ : ord 'b)
+   (_ : ord 'c)
+   (_ : ord 'd)
+   (_ : ord 'e)
+: Tot (ord ('a & 'b & 'c & 'd & 'e))
+
+instance val ord_tuple6
+   (_ : ord 'a)
+   (_ : ord 'b)
+   (_ : ord 'c)
+   (_ : ord 'd)
+   (_ : ord 'e)
+   (_ : ord 'f)
+: Tot (ord ('a & 'b & 'c & 'd & 'e & 'f))
+

--- a/src/class/FStar.Class.Ord.fsti
+++ b/src/class/FStar.Class.Ord.fsti
@@ -10,6 +10,18 @@ class ord (a:Type) = {
   cmp : a -> a -> order;
 }
 
+val sort
+  (#a:Type) {| ord a |}
+  (xs : list a)
+  : list a
+
+(* Deduplicate elements, preserving order as determined by the leftmost occurrence.
+So dedup [a,b,c,a,f,e,c] = [a,b,c,f,e] *)
+val dedup
+  (#a:Type) {| ord a |}
+  (xs : list a)
+  : list a
+
 instance val ord_eq (a:Type) (d : ord a) : Tot (deq a)
 
 val (<?)  : #a:Type -> {| ord a |} -> a -> a -> bool
@@ -69,4 +81,3 @@ instance val ord_tuple6
    (_ : ord 'e)
    (_ : ord 'f)
 : Tot (ord ('a & 'b & 'c & 'd & 'e & 'f))
-

--- a/src/class/FStar.Class.Show.fst
+++ b/src/class/FStar.Class.Show.fst
@@ -11,10 +11,6 @@ instance show_list (a:Type) (_ : showable a) : Tot (showable (list a)) = {
   show = FStar.Common.string_of_list show;
 }
 
-instance show_set (a:Type) (_ : showable a) : Tot (showable (BU.set a)) = {
-  show = FStar.Common.string_of_set show;
-}
-
 instance show_option (a:Type) (_ : showable a) : Tot (showable (option a)) = {
   show = FStar.Common.string_of_option show;
 }

--- a/src/class/FStar.Class.Show.fsti
+++ b/src/class/FStar.Class.Show.fsti
@@ -13,7 +13,6 @@ ML effect of the `printer. *)
 instance val printableshow (_ : printable 'a) : Tot (showable 'a)
 
 instance val show_list (a:Type) (_ : showable a) : Tot (showable (list a))
-instance val show_set  (a:Type) (_ : showable a) : Tot (showable (BU.set a))
 
 instance val show_option (a:Type) (_ : showable a) : Tot (showable (option a))
 

--- a/src/extraction/FStar.Extraction.ML.RemoveUnusedParameters.fst
+++ b/src/extraction/FStar.Extraction.ML.RemoveUnusedParameters.fst
@@ -75,12 +75,12 @@ let lookup_tyname (env:env_t) (name:mlpath)
   = BU.psmap_try_find env.tydef_map (string_of_mlpath name)
 
 (** Free variables of a type: Computed to check which parameters are used *)
-type var_set = BU.set mlident
-let empty_var_set = BU.new_set (fun x y -> String.compare x y)
+type var_set = Set.set mlident
+let empty_var_set : Set.set string = Set.empty ()
 let rec freevars_of_mlty' (vars:var_set) (t:mlty) =
   match t with
   | MLTY_Var i ->
-    BU.set_add i vars
+    Set.add i vars
   | MLTY_Fun (t0, _, t1) ->
     freevars_of_mlty' (freevars_of_mlty' vars t0) t1
   | MLTY_Named (tys, _)
@@ -202,7 +202,7 @@ let elim_tydef (env:env_t) name metadata parameters mlty
     let _, parameters, entry =
         List.fold_left
           (fun (i, params, entry) p ->
-             if BU.set_mem p freevars
+             if Set.mem p freevars
              then begin
                if must_eliminate i
                then begin

--- a/src/fstar/FStar.Interactive.Ide.fst
+++ b/src/fstar/FStar.Interactive.Ide.fst
@@ -968,7 +968,7 @@ let st_cost = function
 
 type search_candidate = { sc_lid: lid; sc_typ:
                           ref (option Syntax.Syntax.typ);
-                          sc_fvars: ref (option (set lid)) }
+                          sc_fvars: ref (option (Set.t lid)) }
 
 let sc_of_lid lid = { sc_lid = lid;
                       sc_typ = Util.mk_ref None;
@@ -1003,7 +1003,7 @@ let run_search st search_str =
     let found =
       match term.st_term with
       | NameContainsStr str -> Util.contains (string_of_lid candidate.sc_lid) str
-      | TypeContainsLid lid -> set_mem lid (sc_fvars tcenv candidate) in
+      | TypeContainsLid lid -> Set.mem lid (sc_fvars tcenv candidate) in
     found <> term.st_negate in
 
   let parse search_str =

--- a/src/smtencoding/FStar.SMTEncoding.EncodeTerm.fst
+++ b/src/smtencoding/FStar.SMTEncoding.EncodeTerm.fst
@@ -221,8 +221,8 @@ let check_pattern_vars env vars pats =
     match pats with
     | [] -> ()
     | hd::tl ->
-        let pat_vars = List.fold_left (fun out x -> BU.set_union out (Free.names x)) (Free.names hd) tl in
-        match vars |> BU.find_opt (fun ({binder_bv=b}) -> not(BU.set_mem b pat_vars)) with
+        let pat_vars = List.fold_left (fun out x -> Set.union out (Free.names x)) (Free.names hd) tl in
+        match vars |> BU.find_opt (fun ({binder_bv=b}) -> not(Set.mem b pat_vars)) with
         | None -> ()
         | Some ({binder_bv=x}) ->
         let pos = List.fold_left (fun out t -> Range.union_ranges out t.pos) hd.pos tl in
@@ -819,7 +819,7 @@ and encode_term (t:typ) (env:env_t) : (term         (* encoding of t, expects t 
              issue #3028 *)
              let env0 = env in
              let fstar_fvs, (env, fv_decls, fv_vars, fv_tms, fv_guards) =
-               let fvs = Free.names t0 |> BU.set_elements in
+               let fvs = Free.names t0 |> Set.elems in
 
                let getfreeV (t:term) : fv =
                  match t.tm with
@@ -1188,7 +1188,7 @@ and encode_term (t:typ) (env:env_t) : (term         (* encoding of t, expects t 
               (* We need to compute all free variables of this lambda
               expression and parametrize the encoding wrt to them. See
               issue #3028 *)
-              let fvs = Free.names t0 |> BU.set_elements in
+              let fvs = Free.names t0 |> Set.elems in
               let tms = List.map (lookup_term_var env) fvs in
               (List.map (fun _ -> Term_sort) fvs <: list sort),
               tms

--- a/src/smtencoding/FStar.SMTEncoding.Env.fst
+++ b/src/smtencoding/FStar.SMTEncoding.Env.fst
@@ -299,7 +299,7 @@ let push_zfuel_name env (x:lident) f ftok =
 let force_thunk fvb =
     if not (fvb.fvb_thunked) || fvb.smt_arity <> 0
     then failwith "Forcing a non-thunk in the SMT encoding";
-    mkFreeV <| (fvb.smt_id, Term_sort, true)
+    mkFreeV <| FV (fvb.smt_id, Term_sort, true)
 module TcEnv = FStar.TypeChecker.Env
 let try_lookup_free_var env l =
     match lookup_fvar_binding env l with

--- a/src/smtencoding/FStar.SMTEncoding.Term.fsti
+++ b/src/smtencoding/FStar.SMTEncoding.Term.fsti
@@ -87,7 +87,7 @@ type term' =
   | LblPos     of term * string
 and pat  = term
 and term = {tm:term'; freevars:S.memo fvs; rng:Range.range}
-and fv = string * sort * bool (* bool iff variable must be forced/unthunked *)
+and fv = | FV of string * sort * bool (* bool iff variable must be forced/unthunked *)
 and fvs = list fv
 
 type caption = option string

--- a/src/syntax/FStar.Syntax.DsEnv.fst
+++ b/src/syntax/FStar.Syntax.DsEnv.fst
@@ -44,7 +44,7 @@ type scope_mod =
 | Top_level_def            of ident           (* top-level definition for an unqualified identifier x to be resolved as curmodule.x. *)
 | Record_or_dc             of record_or_dc    (* to honor interleavings of "open" and record definitions *)
 
-type string_set = set string
+type string_set = Set.t string
 
 type exported_id_kind = (* kinds of identifiers exported by a module *)
 | Exported_id_term_type (* term and type identifiers *)
@@ -105,7 +105,7 @@ let transitive_exported_ids env lid =
     let module_name = Ident.string_of_lid lid in
     match BU.smap_try_find env.trans_exported_ids module_name with
     | None -> []
-    | Some exported_id_set -> !(exported_id_set Exported_id_term_type) |> BU.set_elements
+    | Some exported_id_set -> !(exported_id_set Exported_id_term_type) |> Set.elems
 let opens_and_abbrevs env : list (either open_module_or_namespace module_abbrev) =
     List.collect
        (function
@@ -253,7 +253,7 @@ let find_in_module_with_includes
     | None -> true
     | Some mex ->
       let mexports = !(mex eikind) in
-      BU.set_mem idstr mexports
+      Set.mem idstr mexports
     in
     let mincludes = match BU.smap_try_find env.includes mname with
     | None -> []
@@ -873,13 +873,13 @@ let extract_record (e:env) (new_globs: ref (list scope_mod)) = fun se -> match s
                     match get_exported_id_set e modul with
                     | Some my_ex ->
                       let my_exported_ids = my_ex Exported_id_field in
-                      let () = my_exported_ids := BU.set_add (string_of_id id) !my_exported_ids in
+                      let () = my_exported_ids := Set.add (string_of_id id) !my_exported_ids in
                       (* also add the projector name *)
                       let projname = mk_field_projector_name_from_ident constrname id
                                      |> ident_of_lid
                                      |> string_of_id
                       in
-                      let () = my_exported_ids := BU.set_add projname !my_exported_ids in
+                      let () = my_exported_ids := Set.add projname !my_exported_ids in
                       ()
                     | None -> () (* current module was not prepared? should not happen *)
                   in
@@ -951,7 +951,7 @@ let try_lookup_dc_by_field_name env (fieldname:lident) =
         | Some r -> Some (set_lid_range (lid_of_ids (ns_of_lid r.typename @ [r.constrname])) (range_of_lid fieldname), r.is_record)
         | _ -> None
 
-let string_set_ref_new () = BU.mk_ref (BU.new_set BU.compare)
+let string_set_ref_new () : ref (Set.t string) = BU.mk_ref (Set.empty ())
 let exported_id_set_new () =
     let term_type_set = string_set_ref_new () in
     let field_set = string_set_ref_new () in
@@ -1033,7 +1033,7 @@ let push_sigelt' fail_on_dup env s =
       let () = match get_exported_id_set env modul with
       | Some f ->
         let my_exported_ids = f Exported_id_term_type in
-        my_exported_ids := BU.set_add (string_of_id (ident_of_lid lid)) !my_exported_ids
+        my_exported_ids := Set.add (string_of_id (ident_of_lid lid)) !my_exported_ids
       | None -> () (* current module was not prepared? should not happen *)
       in
       let is_iface = env.iface && not env.admitted_iface in
@@ -1097,9 +1097,9 @@ let push_include env ns =
           let update_exports (k: exported_id_kind) =
             let ns_ex = ! (ns_trans_exports k) in
             let ex = cur_exports k in
-            let () = ex := BU.set_difference (!ex) ns_ex in
+            let () = ex := Set.diff (!ex) ns_ex in
             let trans_ex = cur_trans_exports k in
-            let () = trans_ex := BU.set_union (!trans_ex) ns_ex in
+            let () = trans_ex := Set.union (!trans_ex) ns_ex in
             ()
           in
           List.iter update_exports all_exported_id_kinds
@@ -1180,7 +1180,7 @@ let finish env modul =
       let update_exports eikind =
         let cur_ex_set = ! (cur_ex eikind) in
         let cur_trans_ex_set_ref = cur_trans_ex eikind in
-        cur_trans_ex_set_ref := BU.set_union cur_ex_set (!cur_trans_ex_set_ref)
+        cur_trans_ex_set_ref := Set.union cur_ex_set (!cur_trans_ex_set_ref)
        in
        List.iter update_exports all_exported_id_kinds
     | _ -> ()
@@ -1246,8 +1246,8 @@ type exported_ids = {
     exported_id_fields:list string
 }
 let as_exported_ids (e:exported_id_set) =
-    let terms = FStar.Compiler.Util.set_elements (!(e Exported_id_term_type)) in
-    let fields = FStar.Compiler.Util.set_elements (!(e Exported_id_field)) in
+    let terms  = Set.elems (!(e Exported_id_term_type)) in
+    let fields = Set.elems (!(e Exported_id_field)) in
     {exported_id_terms=terms;
      exported_id_fields=fields}
 
@@ -1256,9 +1256,9 @@ let as_exported_id_set (e:option exported_ids) =
     | None -> exported_id_set_new ()
     | Some e ->
       let terms =
-          BU.mk_ref (FStar.Compiler.Util.as_set e.exported_id_terms BU.compare) in
+          BU.mk_ref (Set.from_list e.exported_id_terms) in
       let fields =
-          BU.mk_ref (FStar.Compiler.Util.as_set e.exported_id_fields BU.compare) in
+          BU.mk_ref (Set.from_list e.exported_id_fields) in
       function
         | Exported_id_term_type -> terms
         | Exported_id_field -> fields

--- a/src/syntax/FStar.Syntax.Free.fst
+++ b/src/syntax/FStar.Syntax.Free.fst
@@ -22,10 +22,14 @@ open FStar.Compiler.List
 open FStar
 open FStar.Compiler
 open FStar.Compiler.Util
+open FStar.Compiler.Set
 open FStar.Syntax
 open FStar.Syntax.Syntax
 module Util = FStar.Compiler.Util
 module UF = FStar.Syntax.Unionfind
+
+open FStar.Class.Ord
+
 let ctx_uvar_typ (u:ctx_uvar) = 
     (UF.find_decoration u.ctx_uvar_head).uvar_decoration_typ
 
@@ -50,7 +54,7 @@ let no_free_vars = {
 
 let singleton_fvar fv =
     fst no_free_vars,
-    Util.set_add fv.fv_name.v (new_fv_set ())
+    Set.add fv.fv_name.v (new_fv_set ())
 
 let singleton_bv x   = {fst no_free_vars with free_names=[x]}, snd no_free_vars
 let singleton_uv x   = {fst no_free_vars with free_uvars=[x]}, snd no_free_vars
@@ -63,7 +67,7 @@ let union (f1 : free_vars_and_fvars) (f2 : free_vars_and_fvars) = {
     free_univs=(fst f1).free_univs @ (fst f2).free_univs;
     free_univ_names=(fst f1).free_univ_names @ (fst f2).free_univ_names; //THE ORDER HERE IS IMPORTANT!
     //We expect the free_univ_names list to be in fifo order to get the right order of universe generalization
-}, Util.set_union (snd f1) (snd f2)
+}, Set.union (snd f1) (snd f2)
 
 let rec free_univs u = match Subst.compress_univ u with
   | U_zero
@@ -260,23 +264,37 @@ and should_invalidate_cache n use_cache =
 //note use_cache is set false ONLY for fvars, which is not maintained at each AST node
 //see the comment above
 let compare_uv uv1 uv2 = UF.uvar_id uv1.ctx_uvar_head - UF.uvar_id uv2.ctx_uvar_head
-let new_uv_set () : uvars = Util.new_set compare_uv
-
 let compare_universe_uvar x y = UF.univ_uvar_id x - UF.univ_uvar_id y
-let new_universe_uvar_set () : set universe_uvar =
-    Util.new_set compare_universe_uvar
 
-let empty = Util.new_set Syntax.order_bv
-let names t = FStar.Compiler.Util.as_set (fst (free_names_and_uvars t Def)).free_names Syntax.order_bv
-let uvars t = FStar.Compiler.Util.as_set (fst (free_names_and_uvars t Def)).free_uvars compare_uv
-let univs t = FStar.Compiler.Util.as_set (fst (free_names_and_uvars t Def)).free_univs compare_universe_uvar
-let univnames t = FStar.Compiler.Util.as_set (fst (free_names_and_uvars t Def)).free_univ_names Syntax.order_univ_name
-let univnames_comp c = FStar.Compiler.Util.as_set (fst (free_names_and_uvars_comp c Def)).free_univ_names Syntax.order_univ_name
+instance deq_ctx_uvar : deq ctx_uvar = {
+  (=?) = (fun u v -> UF.uvar_id u.ctx_uvar_head =? UF.uvar_id v.ctx_uvar_head);
+}
+instance ord_ctx_uvar : ord ctx_uvar = {
+  super = Tactics.Typeclasses.solve;
+  cmp = (fun u v -> UF.uvar_id u.ctx_uvar_head `cmp` UF.uvar_id v.ctx_uvar_head);
+}
+instance deq_univ_uvar : deq universe_uvar = {
+  (=?) = (fun u v -> UF.univ_uvar_id u =? UF.univ_uvar_id v);
+}
+instance ord_univ_uvar : ord universe_uvar = {
+  super = Tactics.Typeclasses.solve;
+  cmp = (fun u v -> UF.univ_uvar_id u `cmp` UF.univ_uvar_id v);
+}
+
+let new_uv_set () : uvars = Set.empty ()
+let new_universe_uvar_set () : set universe_uvar = Set.empty ()
+let empty = Set.empty ()
+
+let names t = Set.from_list (fst (free_names_and_uvars t Def)).free_names
+let uvars t = Set.from_list (fst (free_names_and_uvars t Def)).free_uvars
+let univs t = Set.from_list (fst (free_names_and_uvars t Def)).free_univs
+
+let univnames t = Set.from_list (fst (free_names_and_uvars t Def)).free_univ_names
+let univnames_comp c = Set.from_list (fst (free_names_and_uvars_comp c Def)).free_univ_names
+
 let fvars t = snd (free_names_and_uvars t NoCache)
 let names_of_binders (bs:binders) =
-  FStar.Compiler.Util.as_set
-    ((fst (free_names_and_uvars_binders bs Def)).free_names)
-    Syntax.order_bv
+  Set.from_list ((fst (free_names_and_uvars_binders bs Def)).free_names)
 
-let uvars_uncached t = FStar.Compiler.Util.as_set (fst (free_names_and_uvars t NoCache)).free_uvars compare_uv
-let uvars_full t = FStar.Compiler.Util.as_set (fst (free_names_and_uvars t Full)).free_uvars compare_uv
+let uvars_uncached t = Set.from_list (fst (free_names_and_uvars t NoCache)).free_uvars
+let uvars_full t = Set.from_list (fst (free_names_and_uvars t Full)).free_uvars

--- a/src/syntax/FStar.Syntax.Free.fsti
+++ b/src/syntax/FStar.Syntax.Free.fsti
@@ -19,6 +19,7 @@ open Prims
 open FStar
 open FStar.Compiler
 open FStar.Compiler.Util
+open FStar.Compiler.Set
 open FStar.Syntax
 open FStar.Syntax.Syntax
 
@@ -36,3 +37,8 @@ val names_of_binders: binders -> set bv
 
 val uvars_uncached: term -> set ctx_uvar
 val uvars_full: term -> set ctx_uvar
+
+(* Bad place for these instances. But they cannot be instance
+Syntax.Syntax since they reference the UF graph. *)
+instance val ord_ctx_uvar  : Class.Ord.ord ctx_uvar
+instance val ord_univ_uvar : Class.Ord.ord universe_uvar

--- a/src/syntax/FStar.Syntax.Print.fst
+++ b/src/syntax/FStar.Syntax.Print.fst
@@ -999,10 +999,10 @@ instance showable_bv     = { show = bv_to_string; }
 instance showable_binder = { show = binder_to_string; }
 instance showable_uvar   = { show = uvar_to_string; }
 instance showable_ctxu   = { show = ctx_uvar_to_string; }
-
 instance showable_binding = {
   show = (function
           | Binding_var x -> "Binding_var " ^ show x
           | Binding_lid x -> "Binding_lid " ^ show x
           | Binding_univ x -> "Binding_univ " ^ show x);
 }
+instance showable_pragma = { show = pragma_to_string; }

--- a/src/syntax/FStar.Syntax.Print.fsti
+++ b/src/syntax/FStar.Syntax.Print.fsti
@@ -103,3 +103,4 @@ instance val showable_binder    : showable binder
 instance val showable_uvar      : showable uvar
 instance val showable_ctxu      : showable ctx_uvar
 instance val showable_binding   : showable binding
+instance val showable_pragma    : showable pragma

--- a/src/syntax/FStar.Syntax.Resugar.fst
+++ b/src/syntax/FStar.Syntax.Resugar.fst
@@ -1028,9 +1028,9 @@ and resugar_binder' env (b:S.binder) r : option A.binder =
         A.mk_binder (A.Annotated (bv_as_unique_ident b.binder_bv, e)) r A.Type_level imp
   end
 
-and resugar_bv_as_pat' env (v: S.bv) aqual (body_bv: BU.set bv) typ_opt =
+and resugar_bv_as_pat' env (v: S.bv) aqual (body_bv: Set.set bv) typ_opt =
   let mk a = A.mk_pattern a (S.range_of_bv v) in
-  let used = BU.set_mem v body_bv in
+  let used = Set.mem v body_bv in
   let pat =
     mk (if used
         then A.PatVar (bv_as_unique_ident v, aqual, [])
@@ -1046,7 +1046,7 @@ and resugar_bv_as_pat env (x:S.bv) qual body_bv: option A.pattern =
    (resugar_bqual env qual)
    (fun bq -> resugar_bv_as_pat' env x bq body_bv (Some <| SS.compress x.sort))
 
-and resugar_pat' env (p:S.pat) (branch_bv: set bv) : A.pattern =
+and resugar_pat' env (p:S.pat) (branch_bv: Set.set bv) : A.pattern =
   (* We lose information when desugar PatAscribed to able to resugar it back *)
   let mk a = A.mk_pattern a p.p in
   let to_arg_qual bopt = // FIXME do (Some false) and None mean the same thing?
@@ -1057,7 +1057,7 @@ and resugar_pat' env (p:S.pat) (branch_bv: set bv) : A.pattern =
       //FIXME
              let might_be_used =
                match pattern.v with
-               | Pat_var bv -> Util.set_mem bv branch_bv
+               | Pat_var bv -> Set.mem bv branch_bv
                | _ -> true in
              is_implicit && might_be_used) args) in
   let resugar_plain_pat_cons' fv args =
@@ -1477,7 +1477,7 @@ let resugar_sigelt se : option A.decl =
 let resugar_comp (c:S.comp) : A.term =
   noenv resugar_comp' c
 
-let resugar_pat (p:S.pat) (branch_bv: set bv) : A.pattern =
+let resugar_pat (p:S.pat) (branch_bv: Set.set bv) : A.pattern =
   noenv resugar_pat' p branch_bv
 
 let resugar_binder (b:S.binder) r : option A.binder =

--- a/src/syntax/FStar.Syntax.Resugar.fsti
+++ b/src/syntax/FStar.Syntax.Resugar.fsti
@@ -15,6 +15,7 @@
 *)
 module FStar.Syntax.Resugar //we should rename FStar.ToSyntax to something else
 
+open FStar.Compiler
 open FStar.Compiler.Effect
 open FStar.Syntax.Syntax
 open FStar.Ident
@@ -35,7 +36,7 @@ module DsEnv = FStar.Syntax.DsEnv
 val resugar_term: S.term -> A.term
 val resugar_sigelt: S.sigelt -> option A.decl
 val resugar_comp: S.comp -> A.term
-val resugar_pat: S.pat -> set S.bv -> A.pattern
+val resugar_pat: S.pat -> Set.t S.bv -> A.pattern
 val resugar_universe: S.universe -> Range.range -> A.term
 val resugar_binder: S.binder -> Range.range -> option A.binder
 val resugar_tscheme: S.tscheme -> A.decl
@@ -44,7 +45,7 @@ val resugar_eff_decl: Range.range -> list S.qualifier -> eff_decl -> A.decl
 val resugar_term': DsEnv.env -> S.term -> A.term
 val resugar_sigelt': DsEnv.env -> S.sigelt -> option A.decl
 val resugar_comp': DsEnv.env -> S.comp -> A.term
-val resugar_pat': DsEnv.env -> S.pat -> set S.bv -> A.pattern
+val resugar_pat': DsEnv.env -> S.pat -> Set.t S.bv -> A.pattern
 val resugar_universe': DsEnv.env -> S.universe -> Range.range -> A.term
 val resugar_binder': DsEnv.env -> S.binder -> Range.range -> option A.binder
 val resugar_tscheme': DsEnv.env -> S.tscheme -> A.decl

--- a/src/syntax/FStar.Syntax.Syntax.fst
+++ b/src/syntax/FStar.Syntax.Syntax.fst
@@ -26,10 +26,16 @@ open FStar.Ident
 open FStar.Const
 open FStar.Compiler.Dyn
 open FStar.VConfig
+
+open FStar.Class.Ord
+open FStar.Class.HasRange
+
+
 module O    = FStar.Options
 module PC   = FStar.Parser.Const
 module Err  = FStar.Errors
 module GS   = FStar.GenSym
+module Set  = FStar.Compiler.Set
 
 let rec emb_typ_to_string = function
     | ET_abstract -> "abstract"
@@ -122,22 +128,46 @@ let lookup_aq (bv : bv) (aq : antiquotations) : term =
 (* Syntax builders *)
 (*********************************************************************************)
 
+// Cleanup this mess please
+let deq_instance_from_cmp f = {
+  (=?) = (fun x y -> Order.eq (f x y));
+}
+let ord_instance_from_cmp f = {
+  super = deq_instance_from_cmp f;
+  cmp = f;
+}
+let order_univ_name x y = String.compare (Ident.string_of_id x) (Ident.string_of_id y)
+
+instance deq_bv : deq bv =
+  deq_instance_from_cmp (fun x y -> Order.order_from_int (order_bv x y))
+instance deq_ident : deq ident =
+  deq_instance_from_cmp (fun x y -> Order.order_from_int (order_ident x y))
+instance deq_fv : deq lident =
+  deq_instance_from_cmp (fun x y -> Order.order_from_int (order_fv x y))
+instance deq_univ_name : deq univ_name =
+  deq_instance_from_cmp (fun x y -> Order.order_from_int (order_univ_name x y))
+instance ord_bv : ord bv =
+  ord_instance_from_cmp (fun x y -> Order.order_from_int (order_bv x y))
+instance ord_ident : ord ident =
+  ord_instance_from_cmp (fun x y -> Order.order_from_int (order_ident x y))
+instance ord_fv : ord lident =
+  ord_instance_from_cmp (fun x y -> Order.order_from_int (order_fv x y))
+
 let syn p k f = f k p
 let mk_fvs () = Util.mk_ref None
 let mk_uvs () = Util.mk_ref None
-let new_bv_set () : set bv = Util.new_set order_bv
-let new_id_set () : set ident = Util.new_set order_ident
-let new_fv_set () :set lident = Util.new_set order_fv
-let order_univ_name x y = String.compare (Ident.string_of_id x) (Ident.string_of_id y)
-let new_universe_names_set () : set univ_name = Util.new_set order_univ_name
+let new_bv_set () : Set.t bv = Set.empty ()
+let new_id_set () : Set.t ident = Set.empty ()
+let new_fv_set () : Set.t lident = Set.empty ()
+let new_universe_names_set () : Set.t univ_name = Set.empty ()
 
 let no_names  = new_bv_set()
 let no_fvars  = new_fv_set()
 let no_universe_names = new_universe_names_set ()
 //let memo_no_uvs = Util.mk_ref (Some no_uvs)
 //let memo_no_names = Util.mk_ref (Some no_names)
-let freenames_of_list l = List.fold_right Util.set_add l no_names
-let list_of_freenames (fvs:freenames) = Util.set_elements fvs
+let freenames_of_list l = Set.addn l no_names
+let list_of_freenames (fvs:freenames) = Set.elems fvs
 
 (* Constructors for each term form; NO HASH CONSING; just makes all the auxiliary data at each node *)
 let mk (t:'a) r = {
@@ -260,10 +290,10 @@ let is_top_level = function
     | _ -> false
 
 let freenames_of_binders (bs:binders) : freenames =
-    List.fold_right (fun b out -> Util.set_add b.binder_bv out) bs no_names
+    List.fold_right (fun b out -> Set.add b.binder_bv out) bs no_names
 
 let binders_of_list fvs : binders = (fvs |> List.map (fun t -> mk_binder t))
-let binders_of_freenames (fvs:freenames) = Util.set_elements fvs |> binders_of_list
+let binders_of_freenames (fvs:freenames) = Set.elems fvs |> binders_of_list
 let is_bqual_implicit = function Some (Implicit _) -> true | _ -> false
 let is_aqual_implicit = function Some { aqual_implicit = b } -> b | _ -> false
 let is_bqual_implicit_or_meta = function Some (Implicit _) | Some (Meta _) -> true | _ -> false
@@ -404,8 +434,6 @@ let t_sealed_of t = mk_Tm_app
 
 let unit_const_with_range r = mk (Tm_constant FStar.Const.Const_unit) r
 let unit_const = unit_const_with_range Range.dummyRange
-
-open FStar.Class.HasRange
 
 instance has_range_syntax #a : Tot (hasRange (syntax a)) = {
   pos = (fun (t:term) -> t.pos);

--- a/src/syntax/FStar.Syntax.Syntax.fst
+++ b/src/syntax/FStar.Syntax.Syntax.fst
@@ -51,6 +51,15 @@ instance showable_delta_depth = {
   show = delta_depth_to_string;
 }
 
+instance showable_should_check_uvar = {
+  show = (function
+          | Allow_unresolved s -> "Allow_unresolved " ^ s
+          | Allow_untyped s -> "Allow_untyped " ^ s
+          | Allow_ghost s -> "Allow_ghost " ^ s
+          | Strict -> "Strict"
+          | Already_checked -> "Already_checked");
+}
+
 // This is set in FStar.Main.main, where all modules are in-scope.
 let lazy_chooser : ref (option (lazy_kind -> lazyinfo -> term)) = mk_ref None
 

--- a/src/syntax/FStar.Syntax.Syntax.fsti
+++ b/src/syntax/FStar.Syntax.Syntax.fsti
@@ -30,6 +30,7 @@ open FStar.VConfig
 include FStar.Class.HasRange
 open FStar.Class.Show
 open FStar.Class.Deq
+open FStar.Class.Ord
 
 (* Objects with metadata *)
 [@@ PpxDerivingYoJson; PpxDerivingShow ]
@@ -65,8 +66,6 @@ type emb_typ =
   | ET_abstract
   | ET_fun  of emb_typ * emb_typ
   | ET_app  of string * list emb_typ
-
-instance val showable_emb_typ : showable emb_typ
 
 //versioning for unification variables
 [@@ PpxDerivingYoJson; PpxDerivingShow ]
@@ -112,7 +111,6 @@ type delta_depth =
   | Delta_equational_at_level of int  //level 0 is a symbol that may be equated to another by extensional reasoning, n > 0 can be unfolded n times to a Delta_equational_at_level 0 term
   | Delta_abstract of delta_depth   //A symbol marked abstract whose depth is the argument d
 
-instance val showable_delta_depth : showable delta_depth
 
 [@@ PpxDerivingYoJson; PpxDerivingShow ]
 type should_check_uvar =
@@ -121,8 +119,6 @@ type should_check_uvar =
   | Allow_ghost of string       (* In some cases, e.g., in ctrl_rewrite, we introduce uvars in Ghost context *)
   | Strict                      (* Strict uvar that must be typechecked *)
   | Already_checked             (* A uvar whose solution has already been checked *)
-
-instance val showable_should_check_uvar : showable should_check_uvar
 
 type positivity_qualifier =
   | BinderStrictlyPositive
@@ -200,7 +196,7 @@ and uvar_decoration = {
 }
 
 and uvar = Unionfind.p_uvar (option term * uvar_decoration) * version * Range.range
-and uvars = set ctx_uvar
+and uvars = Set.t ctx_uvar
 and match_returns_ascription = binder * ascription               (* as x returns C|t *)
 and branch = pat * option term * term                           (* optional when clause in each branch *)
 and ascription = either term comp * option term * bool        (* e <: t [by tac] or e <: C [by tac] *)
@@ -360,7 +356,7 @@ and subst_elt =
    | NT of bv  * term                          (* NT x t: replace a local name with a term t                                 *)
    | UN of int * universe                      (* UN u v: replace universes variable u with universe term v                  *)
    | UD of univ_name * int                     (* UD x i: replace universe name x with de Bruijn index i                     *)
-and freenames = set bv
+and freenames = Set.t bv
 and syntax 'a = {
     n:'a;
     pos:Range.range;
@@ -754,10 +750,10 @@ val lookup_aq : bv -> antiquotations -> term
 
 // This is set in FStar.Main.main, where all modules are in-scope.
 val lazy_chooser : ref (option (lazy_kind -> lazyinfo -> term))
-val new_bv_set: unit -> set bv
-val new_id_set: unit -> set ident
-val new_fv_set: unit -> set lident
-val new_universe_names_set: unit -> set univ_name
+val new_bv_set: unit -> Set.t bv
+val new_id_set: unit -> Set.t ident
+val new_fv_set: unit -> Set.t lident
+val new_universe_names_set: unit -> Set.t univ_name
 
 val mod_name: modul -> lident
 
@@ -808,8 +804,8 @@ val is_teff:  term -> bool
 val is_type:  term -> bool
 
 val no_names:          freenames
-val no_universe_names: set univ_name
-val no_fvars:          set lident
+val no_universe_names: Set.t univ_name
+val no_fvars:          Set.t lident
 
 val freenames_of_list:    list bv -> freenames
 val freenames_of_binders: binders -> freenames
@@ -904,5 +900,18 @@ instance val has_range_syntax #a : Tot (hasRange (syntax a))
 instance val has_range_withinfo #a : Tot (hasRange (withinfo_t a))
 instance val has_range_sigelt : hasRange sigelt
 
-instance val deq_lazy_kind : deq lazy_kind
+instance val showable_emb_typ : showable emb_typ
+instance val showable_delta_depth : showable delta_depth
+instance val showable_should_check_uvar : showable should_check_uvar
+
 instance val showable_lazy_kind : showable lazy_kind
+
+instance val deq_lazy_kind : deq lazy_kind
+instance val deq_bv         : deq bv
+instance val deq_ident      : deq ident
+instance val deq_fv         : deq lident
+instance val deq_univ_name  : deq univ_name
+
+instance val ord_bv         : ord bv
+instance val ord_ident      : ord ident
+instance val ord_fv         : ord lident

--- a/src/syntax/FStar.Syntax.Syntax.fsti
+++ b/src/syntax/FStar.Syntax.Syntax.fsti
@@ -122,6 +122,8 @@ type should_check_uvar =
   | Strict                      (* Strict uvar that must be typechecked *)
   | Already_checked             (* A uvar whose solution has already been checked *)
 
+instance val showable_should_check_uvar : showable should_check_uvar
+
 type positivity_qualifier =
   | BinderStrictlyPositive
   | BinderUnused

--- a/src/syntax/FStar.Syntax.Util.fst
+++ b/src/syntax/FStar.Syntax.Util.fst
@@ -104,7 +104,7 @@ let null_binders_of_tks (tks:list (typ * bqual)) : binders =
 let binders_of_tks (tks:list (typ * bqual)) : binders =
     tks |> List.map (fun (t, imp) -> mk_binder_with_attrs (new_bv (Some t.pos) t) imp None [])
 
-let binders_of_freevars fvs = U.set_elements fvs |> List.map mk_binder
+let binders_of_freevars fvs = Set.elems fvs |> List.map mk_binder
 
 let mk_subst s = [s]
 
@@ -1104,11 +1104,11 @@ let let_rec_arity (lb:letbinding) : int * option (list bool) =
          match d with
          | Decreases_lex l ->
            l |> List.fold_left (fun s t ->
-             set_union s (FStar.Syntax.Free.names t)) (new_set Syntax.order_bv)
+             Set.union s (FStar.Syntax.Free.names t)) (Set.empty ())
          | Decreases_wf (rel, e) ->
-           set_union (FStar.Syntax.Free.names rel) (FStar.Syntax.Free.names e) in
+           Set.union (FStar.Syntax.Free.names rel) (FStar.Syntax.Free.names e) in
        Common.tabulate n_univs (fun _ -> false)
-       @ (bs |> List.map (fun b -> U.set_mem b.binder_bv d_bvs)))
+       @ (bs |> List.map (fun b -> Set.mem b.binder_bv d_bvs)))
 
 let abs_formals_maybe_unascribe_body maybe_unascribe t =
     let subst_lcomp_opt s l = match l with
@@ -1447,7 +1447,7 @@ let un_squash t =
                     | _ -> failwith "impossible"
             in
             // A bit paranoid, but need this check for terms like `u:unit{u == ()}`
-            if set_mem b.binder_bv (Free.names p)
+            if Set.mem b.binder_bv (Free.names p)
             then None
             else Some p
         | _ -> None
@@ -1519,7 +1519,7 @@ let arrow_one (t:typ) : option (binder * comp) =
     Some (b, c))
 
 let is_free_in (bv:bv) (t:term) : bool =
-    U.set_mem bv (FStar.Syntax.Free.names t)
+    Set.mem bv (FStar.Syntax.Free.names t)
 
 (**************************************************************************************)
 (* Destructing a type as a formula *)

--- a/src/syntax/FStar.Syntax.Visit.fst
+++ b/src/syntax/FStar.Syntax.Visit.fst
@@ -420,11 +420,16 @@ let rec on_sub_sigelt' vfs (se : sigelt') : sigelt' =
                              typ=(us_ty, ty);
                              kind=k}
 
-  | Sig_fail _
-  | Sig_splice _ ->
-    failwith "Sig_fail and Sig_splice not supported in visit"
+  (* These two below are hardly used, since they disappear after
+  typechecking, but are still useful so the desugarer can make use of
+  deep_compress_se. *)
+  | Sig_fail {errs; fail_in_lax; ses} ->
+    Sig_fail {errs; fail_in_lax; ses=map (on_sub_sigelt vfs) ses}
 
-  | _ -> failwith "sorry"
+  | Sig_splice {is_typed; lids; tac} ->
+    Sig_splice {is_typed; lids; tac=(f_term vfs) tac}
+
+  | _ -> failwith "on_sub_sigelt: missing case"
 
 and on_sub_sigelt vfs (se : sigelt) : sigelt =
   {

--- a/src/tactics/FStar.Tactics.Monad.fst
+++ b/src/tactics/FStar.Tactics.Monad.fst
@@ -52,7 +52,7 @@ let is_goal_safe_as_well_typed (g:goal) =
       List.for_all 
           (fun uv -> 
             match UF.find uv.ctx_uvar_head with
-            | Some t -> BU.set_is_empty (FStar.Syntax.Free.uvars t)
+            | Some t -> Set.is_empty (FStar.Syntax.Free.uvars t)
             | _ -> false)
           (U.ctx_uvar_typedness_deps uv)
   in

--- a/src/tactics/FStar.Tactics.V1.Basic.fst
+++ b/src/tactics/FStar.Tactics.V1.Basic.fst
@@ -175,7 +175,7 @@ let dump_all (print_resolved:bool) (msg:string) : tac unit =
 
 let dump_uvars_of (g:goal) (msg:string) : tac unit =
   mk_tac (fun ps ->
-    let uvs = SF.uvars (goal_type g) |> BU.set_elements in
+    let uvs = SF.uvars (goal_type g) |> Set.elems in
     let gs = List.map (goal_of_ctx_uvar g) uvs in
     let gs = List.filter (fun g -> not (check_goal_solved g)) gs in
     let ps' = { ps with smt_goals = [] ; goals = gs } in
@@ -375,8 +375,8 @@ let __do_unify_wflags
        | Check_none -> Free.new_uv_set ()
        | Check_left_only -> Free.uvars t1
        | Check_right_only -> Free.uvars t2
-       | Check_both -> BU.set_union (Free.uvars t1) (Free.uvars t2))
-      |> BU.set_elements in
+       | Check_both -> Set.union (Free.uvars t1) (Free.uvars t2))
+      |> Set.elems in
 
     match!
       catch (//restore UF graph in case anything fails
@@ -465,7 +465,7 @@ let do_match (must_tot:bool) (env:Env.env) (t1:term) (t2:term) : tac bool =
     bind (do_unify_aux must_tot Check_right_only env t1 t2) (fun r ->
     if r then begin
         let uvs2 = SF.uvars_uncached t1 in
-        if not (set_eq uvs1 uvs2)
+        if not (Set.equal uvs1 uvs2)
         then (UF.rollback tx; ret false)
         else ret true
     end
@@ -486,7 +486,7 @@ let do_match_on_lhs (must_tot:bool) (env:Env.env) (t1:term) (t2:term) : tac bool
     bind (do_unify_aux must_tot Check_right_only env t1 t2) (fun r ->
     if r then begin
         let uvs2 = SF.uvars_uncached lhs in
-        if not (set_eq uvs1 uvs2)
+        if not (Set.equal uvs1 uvs2)
         then (UF.rollback tx; ret false)
         else ret true
     end
@@ -976,11 +976,11 @@ let t_apply (uopt:bool) (only_match:bool) (tc_resolved_uvars:bool) (tm:term) : t
     let w = List.fold_right (fun (uvt, q, _) w -> U.mk_app w [(uvt, q)]) uvs tm in
     let uvset =
       List.fold_right
-        (fun (_, _, uv) s -> BU.set_union s (SF.uvars (U.ctx_uvar_typ uv)))
+        (fun (_, _, uv) s -> Set.union s (SF.uvars (U.ctx_uvar_typ uv)))
         uvs
         (SF.new_uv_set ())
     in
-    let free_in_some_goal uv = BU.set_mem uv uvset in
+    let free_in_some_goal uv = Set.mem uv uvset in
     solve' goal w ;!
     //
     //process uvs
@@ -1094,7 +1094,7 @@ let t_apply_lemma (noinst:bool) (noinst_lhs:bool)
         let goal_sc = should_check_goal_uvar goal in
         solve' goal U.exp_unit ;!
         let is_free_uvar uv t =
-            let free_uvars = List.map (fun x -> x.ctx_uvar_head) (BU.set_elements (SF.uvars t)) in
+            let free_uvars = List.map (fun x -> x.ctx_uvar_head) (Set.elems (SF.uvars t)) in
             List.existsML (fun u -> UF.equiv u uv) free_uvars
         in
         let appears uv goals = List.existsML (fun g' -> is_free_uvar uv (goal_type g')) goals in
@@ -1290,7 +1290,7 @@ let revert () : tac unit =
       let g = mk_goal env' u_r goal.opts goal.is_guard goal.label in
       replace_cur g
 
-let free_in bv t = Util.set_mem bv (SF.names t)
+let free_in bv t = Set.mem bv (SF.names t)
 
 let clear (b : binder) : tac unit =
     let bv = b.binder_bv in
@@ -1383,7 +1383,7 @@ let _t_trefl (allow_guards:bool) (l : term) (r : term) : tac unit =
         | Inl (u, _, _) -> is_uvar_untyped_or_already_checked u
       in
       let t = U.ctx_uvar_typ g.goal_ctx_uvar in
-      let uvars = BU.set_elements (FStar.Syntax.Free.uvars t) in
+      let uvars = Set.elems (FStar.Syntax.Free.uvars t) in
       if BU.for_all is_uvar_untyped_or_already_checked uvars
       then skip_register //all the uvars are already checked or untyped
       else (
@@ -2281,7 +2281,7 @@ let t_smt_sync (vcfg : vconfig) : tac unit = wrap_err "t_smt_sync" <| (
 
 let free_uvars (tm : term) : tac (list Z.t)
   = idtac ;!
-    let uvs = Syntax.Free.uvars_uncached tm |> BU.set_elements |> List.map (fun u -> Z.of_int_fs (UF.uvar_id u.ctx_uvar_head)) in
+    let uvs = Syntax.Free.uvars_uncached tm |> Set.elems |> List.map (fun u -> Z.of_int_fs (UF.uvar_id u.ctx_uvar_head)) in
     ret uvs
 
 (***** Builtins used in the meta DSL framework *****)
@@ -2311,8 +2311,8 @@ let refl_typing_builtin_wrapper (f:unit -> 'a) : tac (option 'a & issues) =
   else ret (r, errs)
 
 let no_uvars_in_term (t:term) : bool =
-  t |> Free.uvars |> BU.set_is_empty &&
-  t |> Free.univs |> BU.set_is_empty
+  t |> Free.uvars |> Set.is_empty &&
+  t |> Free.univs |> Set.is_empty
 
 let no_uvars_in_g (g:env) : bool =
   g.gamma |> BU.for_all (function

--- a/src/typechecker/FStar.TypeChecker.Core.fst
+++ b/src/typechecker/FStar.TypeChecker.Core.fst
@@ -583,7 +583,7 @@ let lookup (g:env) (e:term) : result (tot_or_ghost & typ) =
 
 let check_no_escape (bs:binders) t =
     let xs = FStar.Syntax.Free.names t in
-    if BU.for_all (fun b -> not (BU.set_mem b.binder_bv xs)) bs
+    if BU.for_all (fun b -> not (Set.mem b.binder_bv xs)) bs
     then return ()
     else fail "Name escapes its scope"
 
@@ -1870,7 +1870,7 @@ let check_term_top_gh g e topt (must_tot:bool) (gh:option guard_handler_t)
             (BU.string_of_int (get_goal_ctr()))
             (P.term_to_string guard0)
             (P.term_to_string guard);
-          let guard_names = Syntax.Free.names guard |> BU.set_elements in
+          let guard_names = Syntax.Free.names guard |> Set.elems in
           match List.tryFind (fun bv -> List.for_all (fun binding_env ->
             match binding_env with
             | Binding_var bv_env -> not (S.bv_eq bv_env bv)

--- a/src/typechecker/FStar.TypeChecker.DMFF.fst
+++ b/src/typechecker/FStar.TypeChecker.DMFF.fst
@@ -581,7 +581,7 @@ and star_type' env t =
       // (st a)* every time.
       let debug t s =
         let string_of_set f s =
-            let elts = BU.set_elements s in
+            let elts = Set.elems s in
             match elts with
             | [] -> "{}"
             | x::xs ->
@@ -605,14 +605,14 @@ and star_type' env t =
                 else
                     try
                         let non_dependent_or_raise s ty =
-                            let sinter = set_intersect (Free.names ty) s in
-                            if  not (set_is_empty sinter)
+                            let sinter = Set.inter (Free.names ty) s in
+                            if  not (Set.is_empty sinter)
                             then (debug ty sinter ; raise Not_found)
                         in
                         let binders, c = SS.open_comp binders c in
                         let s = List.fold_left (fun s ({binder_bv=bv}) ->
                             non_dependent_or_raise s bv.sort ;
-                            set_add bv s
+                            Set.add bv s
                         ) S.no_names binders in
                         let ct = U.comp_result c in
                         non_dependent_or_raise s ct ;
@@ -1651,7 +1651,7 @@ let cps_and_elaborate (env:FStar.TypeChecker.Env.env) (ed:S.eff_decl)
             let wp_binders, c = SS.open_comp wp_binders c in
             let pre_args, post_args =
                 List.partition (fun ({binder_bv=bv}) ->
-                  Free.names bv.sort |> BU.set_mem type_param.binder_bv |> not
+                  Free.names bv.sort |> Set.mem type_param.binder_bv |> not
                 ) wp_binders
             in
             let post = match post_args with

--- a/src/typechecker/FStar.TypeChecker.DeferredImplicits.fst
+++ b/src/typechecker/FStar.TypeChecker.DeferredImplicits.fst
@@ -56,18 +56,18 @@ type goal_type =
 
 type goal_dep =
   {
-    goal_dep_id:int;       //Assign each goal an id, for cycle detection
-    goal_type:goal_type; //What sort of goal ...
-    goal_imp:implicit;   //The entire implicit from which this was generated
-    assignees:BU.set ctx_uvar; //The set of uvars assigned by the goal
-    goal_dep_uvars:BU.set ctx_uvar; //The set of uvars this goal depends on
-    dependences:ref goal_deps; //NB: mutable; the goals that must precede this one in the order
-    visited:ref int //NB: mutable; a field to mark visited goals during the sort
+    goal_dep_id    : int;             // Assign each goal an id, for cycle detection
+    goal_type      : goal_type;       // What sort of goal ...
+    goal_imp       : implicit;        // The entire implicit from which this was generated
+    assignees      : Set.t ctx_uvar;  // The set of uvars assigned by the goal
+    goal_dep_uvars : Set.t ctx_uvar;  // The set of uvars this goal depends on
+    dependences    : ref goal_deps;   // NB: mutable; the goals that must precede this one in the order
+    visited        : ref int          // NB: mutable; a field to mark visited goals during the sort
   }
 and goal_deps = list goal_dep
 
-let print_uvar_set (s:BU.set ctx_uvar) =
-    (BU.set_elements s
+let print_uvar_set (s:Set.t ctx_uvar) =
+    (Set.elems s
      |> List.map (fun u -> "?" ^ (string_of_int <| Unionfind.uvar_id u.ctx_uvar_head))
      |> String.concat "; ")
 

--- a/src/typechecker/FStar.TypeChecker.Env.fst
+++ b/src/typechecker/FStar.TypeChecker.Env.fst
@@ -1181,7 +1181,7 @@ let all_binders env = binders_of_bindings env.gamma
 let bound_vars env = bound_vars_of_bindings env.gamma
 
 instance hasBinders_env : hasBinders env = {
-  boundNames = (fun e -> BU.as_set (bound_vars e) Syntax.order_bv);
+  boundNames = (fun e -> Set.from_list (bound_vars e) );
 }
 
 instance hasNames_lcomp : hasNames lcomp = {
@@ -1194,7 +1194,7 @@ instance pretty_lcomp : pretty lcomp = {
 
 instance hasNames_guard : hasNames guard_t = {
   freeNames = (fun g -> match g.guard_f with
-                        | Trivial -> new_set Syntax.order_bv
+                        | Trivial -> Set.empty ()
                         | NonTrivial f -> freeNames f);
 }
 
@@ -1686,7 +1686,7 @@ let finish_module =
 ////////////////////////////////////////////////////////////
 let uvars_in_env env =
   let no_uvs = Free.new_uv_set () in
-  let ext out uvs = BU.set_union out uvs in
+  let ext out uvs = Set.union out uvs in
   let rec aux out g = match g with
     | [] -> out
     | Binding_univ _ :: tl -> aux out tl
@@ -1697,7 +1697,7 @@ let uvars_in_env env =
 
 let univ_vars env =
     let no_univs = Free.new_universe_uvar_set () in
-    let ext out uvs = BU.set_union out uvs in
+    let ext out uvs = Set.union out uvs in
     let rec aux out g = match g with
       | [] -> out
       | Binding_univ _ :: tl -> aux out tl
@@ -1708,10 +1708,10 @@ let univ_vars env =
 
 let univnames env =
     let no_univ_names = Syntax.no_universe_names in
-    let ext out uvs = BU.set_union out uvs in
+    let ext out uvs = Set.union out uvs in
     let rec aux out g = match g with
         | [] -> out
-        | Binding_univ uname :: tl -> aux (BU.set_add uname out) tl
+        | Binding_univ uname :: tl -> aux (Set.add uname out) tl
         | Binding_lid(_, (_, t))::tl
         | Binding_var({sort=t})::tl -> aux (ext out (Free.univnames t)) tl
     in
@@ -1750,15 +1750,15 @@ let rem_proof_ns e path = cons_proof_ns false e path
 let get_proof_ns e = e.proof_ns
 let set_proof_ns ns e = {e with proof_ns = ns}
 
-let unbound_vars (e : env) (t : term) : BU.set bv =
+let unbound_vars (e : env) (t : term) : Set.t bv =
     // FV(t) \ Vars(Γ)
-    List.fold_left (fun s bv -> BU.set_remove bv s) (Free.names t) (bound_vars e)
+    List.fold_left (fun s bv -> Set.remove bv s) (Free.names t) (bound_vars e)
 
 let closed (e : env) (t : term) =
-    BU.set_is_empty (unbound_vars e t)
+    Set.is_empty (unbound_vars e t)
 
 let closed' (t : term) =
-    BU.set_is_empty (Free.names t)
+    Set.is_empty (Free.names t)
 
 let string_of_proof_ns env =
     let aux (p,b) =

--- a/src/typechecker/FStar.TypeChecker.Env.fsti
+++ b/src/typechecker/FStar.TypeChecker.Env.fsti
@@ -399,8 +399,8 @@ val bound_vars   : env -> list bv
 val all_binders  : env -> binders
 val modules      : env -> list modul
 val uvars_in_env : env -> uvars
-val univ_vars    : env -> FStar.Compiler.Util.set universe_uvar
-val univnames    : env -> FStar.Compiler.Util.set univ_name
+val univ_vars    : env -> Set.set universe_uvar
+val univnames    : env -> Set.set univ_name
 val lidents      : env -> list lident
 
 (* operations on monads *)
@@ -450,7 +450,7 @@ val set_proof_ns    : proof_namespace -> env -> env
 val string_of_proof_ns : env -> string
 
 (* Check that all free variables of the term are defined in the environment *)
-val unbound_vars    : env -> term -> BU.set bv
+val unbound_vars    : env -> term -> Set.set bv
 val closed          : env -> term -> bool
 val closed'         : term -> bool
 

--- a/src/typechecker/FStar.TypeChecker.Positivity.fst
+++ b/src/typechecker/FStar.TypeChecker.Positivity.fst
@@ -184,7 +184,7 @@ let apply_constr_arrow (dlid:lident) (dt:term) (all_params:list arg)
 let ty_occurs_in (ty_lid:lident)
                  (t:term)
   : bool
-  = FStar.Compiler.Util.set_mem ty_lid (Free.fvars t)
+  = Set.mem ty_lid (Free.fvars t)
 
 (* Checks if `t` is a name or fv and returns it, if so. *)
 let rec term_as_fv_or_name (t:term) 

--- a/src/typechecker/FStar.TypeChecker.Rel.fst
+++ b/src/typechecker/FStar.TypeChecker.Rel.fst
@@ -5487,8 +5487,8 @@ let resolve_implicits' env is_tac is_gen (implicits:Env.implicits)
       let { imp_reason = reason; imp_tm = tm; imp_uvar = ctx_u; imp_range = r } = hd in
       let { uvar_decoration_typ; uvar_decoration_should_check } = UF.find_decoration ctx_u.ctx_uvar_head in
       if Env.debug env <| Options.Other "Rel" then
-        BU.print3 "resolve_implicits' loop, imp_tm = %s and ctx_u = %s, is_tac: %s\n"
-             (show tm) (show ctx_u) (show is_tac);
+        BU.print4 "resolve_implicits' loop, imp_tm=%s and ctx_u=%s, is_tac=%s, should_check=%s\n"
+             (show tm) (show ctx_u) (show is_tac) (show uvar_decoration_should_check);
       begin match () with
       | _ when Allow_unresolved? uvar_decoration_should_check ->
         until_fixpoint (out, true) tl

--- a/src/typechecker/FStar.TypeChecker.Rel.fst
+++ b/src/typechecker/FStar.TypeChecker.Rel.fst
@@ -67,8 +67,7 @@ let is_base_type env typ =
     | _ -> false
 
 let binders_as_bv_set (bs:binders) =
-    FStar.Compiler.Util.as_set (List.map (fun b -> b.binder_bv) bs)
-                               Syntax.order_bv
+  Set.from_list (List.map (fun b -> b.binder_bv) bs)
 
 (* lazy string, for error reporting *)
 type lstring = Thunk.t string
@@ -288,7 +287,7 @@ let def_scope_wf msg rng r =
     in aux [] r
 
 instance hasBinders_prob : Class.Binders.hasBinders prob = {
-  boundNames = (fun prob -> BU.as_set (List.map (fun b -> b.binder_bv) <| p_scope prob) Syntax.order_bv);
+  boundNames = (fun prob -> Set.from_list (List.map (fun b -> b.binder_bv) <| p_scope prob));
 }
 
 let def_check_term_scoped_in_prob msg prob phi =
@@ -368,7 +367,7 @@ let uvi_to_string env = function
       let x = if (Options.hide_uvar_nums()) then "?" else UF.uvar_id u.ctx_uvar_head |> string_of_int in
       BU.format2 "TERM %s <- %s" x (N.term_to_string env t)
 let uvis_to_string env uvis = FStar.Common.string_of_list (uvi_to_string env) uvis
-let names_to_string nms = BU.set_elements nms |> List.map Print.bv_to_string |> String.concat ", "
+let names_to_string nms = Set.elems nms |> List.map Print.bv_to_string |> String.concat ", "
 let args_to_string (args : S.args) = args |> List.map (fun (x, _) -> show x) |> String.concat " "
 
 (* ------------------------------------------------*)
@@ -919,7 +918,7 @@ let ensure_no_uvar_subst env (t0:term) (wl:worklist)
                            (Print.tag_of_term head)
                            (Print.tag_of_term (SS.compress head)))
 
-let no_free_uvars t = BU.set_is_empty (Free.uvars t) && BU.set_is_empty (Free.univs t)
+let no_free_uvars t = Set.is_empty (Free.uvars t) && Set.is_empty (Free.univs t)
 
 (* Deciding when it's okay to issue an SMT query for
  * equating a term whose head symbol is `head` with another term
@@ -1060,7 +1059,7 @@ let solve_prob (prob : prob) (logical_guard : option term) (uvis : list uvi) (wl
 let occurs (uk:ctx_uvar) t =
     let uvars =
         Free.uvars t
-        |> BU.set_elements
+        |> Set.elems
     in
     let occurs =
         (uvars
@@ -1079,7 +1078,7 @@ let occurs_check (uk:ctx_uvar) t =
 let occurs_full (uk:ctx_uvar) t =
     let uvars =
         Free.uvars_full t
-        |> BU.set_elements
+        |> Set.elems
     in
     let occurs =
         (uvars
@@ -1165,7 +1164,7 @@ let restrict_all_uvars env (tgt:ctx_uvar) (bs:binders) (sources:list ctx_uvar) w
     List.fold_right 
       (fun (src:ctx_uvar) wl ->
         let ctx_src = binders_as_bv_set src.ctx_uvar_binders in
-        if BU.set_is_subset_of ctx_src ctx_tgt
+        if Set.subset ctx_src ctx_tgt
         then wl // no need to restrict source, it's context is included in the context of the tgt
         else restrict_ctx env tgt [] src wl)
       sources
@@ -1176,23 +1175,23 @@ let restrict_all_uvars env (tgt:ctx_uvar) (bs:binders) (sources:list ctx_uvar) w
 
 let intersect_binders (g:gamma) (v1:binders) (v2:binders) : binders =
     let as_set v =
-        v |> List.fold_left (fun out x -> BU.set_add x.binder_bv out) S.no_names in
+        v |> List.fold_left (fun out x -> Set.add x.binder_bv out) S.no_names in
     let v1_set = as_set v1 in
     let ctx_binders =
-        List.fold_left (fun out b -> match b with Binding_var x -> BU.set_add x out | _ -> out)
+        List.fold_left (fun out b -> match b with Binding_var x -> Set.add x out | _ -> out)
                         S.no_names
                         g
     in
     let isect, _ =
         v2 |> List.fold_left (fun (isect, isect_set) b ->
             let x, imp = b.binder_bv, b.binder_qual in
-            if not <| BU.set_mem x v1_set
+            if not <| Set.mem x v1_set
             then //definitely not in the intersection
                  isect, isect_set
             else //maybe in the intersect, if its type is only dependent on prior elements in the telescope
                  let fvs = Free.names x.sort in
-                 if BU.set_is_subset_of fvs isect_set
-                 then b::isect, BU.set_add x isect_set
+                 if Set.subset fvs isect_set
+                 then b::isect, Set.add x isect_set
                  else isect, isect_set)
         ([], ctx_binders) in
     List.rev isect
@@ -2110,7 +2109,7 @@ let lazy_complete_repr (k:lazy_kind) : bool =
   | _ -> false
 
 let has_free_uvars (t:term) : bool =
-  not (BU.set_is_empty (Free.uvars_uncached t))
+  not (Set.is_empty (Free.uvars_uncached t))
 
 let env_has_free_uvars (e:env_t) : bool =
   List.existsb (fun b -> has_free_uvars b.binder_bv.sort) (Env.all_binders e)
@@ -2824,7 +2823,7 @@ and solve_t_flex_rigid_eq (orig:prob) (wl:worklist) (lhs:flex_t) (rhs:term)
         let (Flex (_, ctx_u, args)) = lhs in
         let bs, rhs =
           let bv_not_free_in_arg x arg =
-              not (BU.set_mem x (Free.names (fst arg)))
+              not (Set.mem x (Free.names (fst arg)))
           in
           let bv_not_free_in_args x args =
               BU.for_all (bv_not_free_in_arg x) args
@@ -2932,7 +2931,7 @@ and solve_t_flex_rigid_eq (orig:prob) (wl:worklist) (lhs:flex_t) (rhs:term)
           then Inl ("quasi-pattern, occurs-check failed: " ^ (Option.get msg)), wl
           else let fvs_lhs = binders_as_bv_set (ctx_u.ctx_uvar_binders@bs) in
                let fvs_rhs = Free.names rhs in
-               if not (BU.set_is_subset_of fvs_rhs fvs_lhs)
+               if not (Set.subset fvs_rhs fvs_lhs)
                then Inl ("quasi-pattern, free names on the RHS are not included in the LHS"), wl
                else Inr (mk_solution env lhs bs rhs), restrict_all_uvars env ctx_u [] uvars wl
     in
@@ -3113,7 +3112,7 @@ and solve_t_flex_rigid_eq (orig:prob) (wl:worklist) (lhs:flex_t) (rhs:term)
         let uvars_head, occurs_ok, _ = occurs_check ctx_uv head in
         if not occurs_ok
         then inapplicable "occurs check failed" None
-        else if not (BU.set_is_subset_of (Free.names head)
+        else if not (Set.subset (Free.names head)
                                          (binders_as_bv_set ctx_uv.ctx_uvar_binders))
         then inapplicable "free name inclusion failed" None
         else (
@@ -3176,7 +3175,7 @@ and solve_t_flex_rigid_eq (orig:prob) (wl:worklist) (lhs:flex_t) (rhs:term)
                 //   will also try to restrict them
                 //
                 solve_sub_probs_if_head_types_equal
-                  (head |> Free.uvars |> BU.set_elements)
+                  (head |> Free.uvars |> Set.elems)
                   wl
               | Inr msg ->
                 UF.rollback tx;
@@ -3200,7 +3199,7 @@ and solve_t_flex_rigid_eq (orig:prob) (wl:worklist) (lhs:flex_t) (rhs:term)
           BU.print_string "it's a pattern\n";
         let rhs = sn env rhs in
         let names_to_string fvs =
-            List.map Print.bv_to_string (BU.set_elements fvs) |> String.concat ", "
+            List.map Print.bv_to_string (Set.elems fvs) |> String.concat ", "
         in
         let fvs1 = binders_as_bv_set (ctx_uv.ctx_uvar_binders @ lhs_binders) in
         let fvs2 = Free.names rhs in
@@ -3218,7 +3217,7 @@ and solve_t_flex_rigid_eq (orig:prob) (wl:worklist) (lhs:flex_t) (rhs:term)
         then giveup_or_defer orig wl
                Deferred_occur_check_failed
                (Thunk.mkv <| "occurs-check failed: " ^ (Option.get msg))
-        else if BU.set_is_subset_of fvs2 fvs1
+        else if Set.subset fvs2 fvs1
         then let sol = mk_solution env lhs lhs_binders rhs in
              let wl = restrict_all_uvars env ctx_uv lhs_binders uvars wl in
              solve (solve_prob orig None sol wl)
@@ -4009,8 +4008,8 @@ and solve_t' (problem:tprob) (wl:worklist) : solution =
                 solve (attempt [base_prob] wl)
              in
         let has_uvars =
-            not (BU.set_is_empty (FStar.Syntax.Free.uvars phi1))
-            || not (BU.set_is_empty (FStar.Syntax.Free.uvars phi2))
+            not (Set.is_empty (FStar.Syntax.Free.uvars phi1))
+            || not (Set.is_empty (FStar.Syntax.Free.uvars phi2))
         in
         if problem.relation = EQ
         || (not env.uvar_subtyping && has_uvars)
@@ -4953,7 +4952,7 @@ let try_solve_deferred_constraints (defer_ok:defer_ok_t) smt_ok deferred_to_tac_
               then (
                 let goal_type = U.ctx_uvar_typ i.imp_uvar in
                 let uvs = Free.uvars goal_type in
-                BU.set_elements uvs
+                Set.elems uvs
               )
               else []
             | _ -> [])
@@ -5408,7 +5407,7 @@ let pick_a_univ_deffered_implicit (out : tagged_implicits)
 let is_tac_implicit_resolved (env:env) (i:implicit) : bool =
     i.imp_tm
     |> Free.uvars
-    |> BU.set_elements
+    |> Set.elems
     |> List.for_all (fun uv -> Allow_unresolved? (U.ctx_uvar_should_check uv))
 
 

--- a/src/typechecker/FStar.TypeChecker.Tc.fst
+++ b/src/typechecker/FStar.TypeChecker.Tc.fst
@@ -603,7 +603,7 @@ let tc_sig_let env r se lbs lids : list sigelt * list sigelt * Env.env =
         then err ("no_subtype annotation on a non-lemma") lb.lbpos
         else let lid_opt =
                    Free.fvars lb.lbtyp
-                   |> BU.set_elements
+                   |> Set.elems
                    |> List.tryFind (fun lid ->
                                    not (lid |> Ident.path_of_lid |> List.hd = "Prims" ||
                                         lid_equals lid PC.pattern_lid)) in

--- a/src/typechecker/FStar.TypeChecker.Util.fst
+++ b/src/typechecker/FStar.TypeChecker.Util.fst
@@ -76,9 +76,9 @@ let close_guard_implicits env solve_deferred (xs:binders) (g:guard_t) : guard_t 
 
 let check_uvars r t =
   let uvs = Free.uvars t in
-  if not (BU.set_is_empty uvs)
+  if not (Set.is_empty uvs)
   then
-    let us = List.map (fun u -> Print.uvar_to_string u.ctx_uvar_head) (BU.set_elements uvs) |> String.concat ", " in
+    let us = List.map (fun u -> Print.uvar_to_string u.ctx_uvar_head) (Set.elems uvs) |> String.concat ", " in
     (* ignoring the hide_uvar_nums and print_implicits flags here *)
     Options.push();
     Options.set_option "hide_uvar_nums" (Options.Bool false);
@@ -2378,7 +2378,7 @@ let rec check_erased (env:Env.env) (t:term) : isErased =
             |> check_erased
                 (br_body
                  |> Free.names
-                 |> BU.set_elements
+                 |> Set.elems
                  |> Env.push_bvs env) with
           | No -> No
           | _ -> Maybe) No

--- a/ulib/FStar.Tactics.Typeclasses.fsti
+++ b/ulib/FStar.Tactics.Typeclasses.fsti
@@ -38,4 +38,5 @@ declaration. *)
 val mk_class (nm:string) : Tac decls
 
 (* Helper to solve an explicit argument by typeclass resolution *)
+[@@tcnorm]
 unfold let solve (#a:Type) (#[tcresolve ()] ev : a) : Tot a = ev


### PR DESCRIPTION
This is just a big cleanup in a way. In an upcoming PR I want to replace the underlying implementation of sets, since currently they are lists!