### PR TITLE
Slight refactor in discharge_guard pipeline

### DIFF
--- a/src/typechecker/FStar.TypeChecker.Common.fst
+++ b/src/typechecker/FStar.TypeChecker.Common.fst
@@ -230,7 +230,7 @@ let conj_guard_f g1 g2 = match g1, g2 with
   | g, Trivial -> g
   | NonTrivial f1, NonTrivial f2 -> NonTrivial (U.mk_conj f1 f2)
 
-let rec check_trivial t =
+let rec check_trivial (t:term) : guard_formula =
     let hd, args = U.head_and_args (U.unmeta t) in
     match (U.un_uinst (U.unmeta hd)).n, args with
     | Tm_fvar tc, [] 

--- a/tests/error-messages/Bug3102.fst.expected
+++ b/tests/error-messages/Bug3102.fst.expected
@@ -16,19 +16,19 @@
 >>]
 >> Got issues: [
 * Error 56 at Bug3102.fst(33,29-35,27):
-  - Bound variable 'e2#953' would escape in the type of this letbinding
+  - Bound variable 'e2#993' would escape in the type of this letbinding
   - Add a type annotation that does not mention it
 
 >>]
 >> Got issues: [
 * Error 56 at Bug3102.fst(41,16-43,8):
-  - Bound variable 'z#1072' would escape in the type of this letbinding
+  - Bound variable 'z#1112' would escape in the type of this letbinding
   - Add a type annotation that does not mention it
 
 >>]
 >> Got issues: [
 * Error 56 at Bug3102.fst(49,16-51,7):
-  - Bound variable 'z#1155' would escape in the type of this letbinding
+  - Bound variable 'z#1195' would escape in the type of this letbinding
   - Add a type annotation that does not mention it
 
 >>]


### PR DESCRIPTION
Prompted by a Slack thread noticing that `unfold` definitions were not inlined in VCs that remained after a tactic ran, so adding `by (dump "")` could cause a proof to fail. This does not make any functional change, that is still the case, but makes the code more understandable so we can discuss it.

The change is not totally invisible as some trivial goals may be dropped slightly earlier. I don't think that's noticeable except as seen in the output of the test below, which shows some gensym'd numbers.