### PR TITLE
primops: use embedding class to remove a ton of boilerplate

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_Class_Monad.ml
+++ b/ocaml/fstar-lib/generated/FStar_Class_Monad.ml
@@ -112,3 +112,11 @@ let op_Less_Star_Greater : 'm . 'm monad -> unit -> unit -> 'm -> 'm -> 'm =
                       (op_let_Bang uu___ () () x
                          (fun v -> let uu___1 = f v in return uu___ () uu___1)))
                    uu___1)
+let fmap : 'm . 'm monad -> unit -> unit -> (Obj.t -> Obj.t) -> 'm -> 'm =
+  fun uu___ ->
+    fun a ->
+      fun b ->
+        fun f ->
+          fun m1 ->
+            op_let_Bang uu___ () () m1
+              (fun v -> let uu___1 = f v in return uu___ () uu___1)

--- a/ocaml/fstar-lib/generated/FStar_Parser_Const.ml
+++ b/ocaml/fstar-lib/generated/FStar_Parser_Const.ml
@@ -252,6 +252,7 @@ let (labeled_lid : FStar_Ident.lident) = p2l ["FStar"; "Range"; "labeled"]
 let (__range_lid : FStar_Ident.lident) = p2l ["FStar"; "Range"; "__range"]
 let (range_lid : FStar_Ident.lident) = p2l ["FStar"; "Range"; "range"]
 let (range_0 : FStar_Ident.lident) = p2l ["FStar"; "Range"; "range_0"]
+let (mk_range_lid : FStar_Ident.lident) = p2l ["FStar"; "Range"; "mk_range"]
 let (guard_free : FStar_Ident.lident) = pconst "guard_free"
 let (inversion_lid : FStar_Ident.lident) =
   p2l ["FStar"; "Pervasives"; "inversion"]

--- a/ocaml/fstar-lib/generated/FStar_Reflection_V1_Embeddings.ml
+++ b/ocaml/fstar-lib/generated/FStar_Reflection_V1_Embeddings.ml
@@ -450,8 +450,7 @@ let rec e_pattern_aq :
             let uu___2 =
               let uu___3 =
                 let uu___4 =
-                  let uu___5 = FStar_Syntax_Embeddings.e_sealed e_term in
-                  embed uu___5 rng sort in
+                  embed (FStar_Syntax_Embeddings.e_sealed e_term) rng sort in
                 FStar_Syntax_Syntax.as_arg uu___4 in
               [uu___3] in
             uu___1 :: uu___2 in
@@ -528,8 +527,7 @@ let rec e_pattern_aq :
                FStar_Compiler_Util.bind_opt uu___4
                  (fun bv1 ->
                     let uu___5 =
-                      let uu___6 = FStar_Syntax_Embeddings.e_sealed e_term in
-                      unembed uu___6 sort in
+                      unembed (FStar_Syntax_Embeddings.e_sealed e_term) sort in
                     FStar_Compiler_Util.bind_opt uu___5
                       (fun sort1 ->
                          FStar_Pervasives_Native.Some
@@ -1185,9 +1183,10 @@ let (e_bv_view :
     let uu___ =
       let uu___1 =
         let uu___2 =
-          let uu___3 =
-            FStar_Syntax_Embeddings.e_sealed FStar_Syntax_Embeddings.e_string in
-          embed uu___3 rng bvv.FStar_Reflection_V1_Data.bv_ppname in
+          embed
+            (FStar_Syntax_Embeddings.e_sealed
+               FStar_Syntax_Embeddings.e_string) rng
+            bvv.FStar_Reflection_V1_Data.bv_ppname in
         FStar_Syntax_Syntax.as_arg uu___2 in
       let uu___2 =
         let uu___3 =
@@ -1217,10 +1216,9 @@ let (e_bv_view :
                FStar_Reflection_V1_Constants.ref_Mk_bv.FStar_Reflection_V1_Constants.lid
              ->
              let uu___4 =
-               let uu___5 =
-                 FStar_Syntax_Embeddings.e_sealed
-                   FStar_Syntax_Embeddings.e_string in
-               unembed uu___5 nm in
+               unembed
+                 (FStar_Syntax_Embeddings.e_sealed
+                    FStar_Syntax_Embeddings.e_string) nm in
              FStar_Compiler_Util.bind_opt uu___4
                (fun nm1 ->
                   let uu___5 = unembed FStar_Syntax_Embeddings.e_int idx in

--- a/ocaml/fstar-lib/generated/FStar_Tactics_V2_Interpreter.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_V2_Interpreter.ml
@@ -1492,11 +1492,10 @@ let unseal : 'uuuuu 'a . 'uuuuu -> 'a -> 'a FStar_Tactics_Monad.tac =
 let (unseal_step : FStar_TypeChecker_Primops.primitive_step) =
   let s =
     let uu___ =
-      FStar_Syntax_Embeddings.e_sealed FStar_Syntax_Embeddings.e_any in
-    let uu___1 =
       FStar_TypeChecker_NBETerm.e_sealed FStar_TypeChecker_NBETerm.e_any in
-    mk_tac_step_2 Prims.int_one "unseal" FStar_Syntax_Embeddings.e_any uu___
-      FStar_Syntax_Embeddings.e_any FStar_TypeChecker_NBETerm.e_any uu___1
+    mk_tac_step_2 Prims.int_one "unseal" FStar_Syntax_Embeddings.e_any
+      (FStar_Syntax_Embeddings.e_sealed FStar_Syntax_Embeddings.e_any)
+      FStar_Syntax_Embeddings.e_any FStar_TypeChecker_NBETerm.e_any uu___
       FStar_TypeChecker_NBETerm.e_any unseal unseal in
   {
     FStar_TypeChecker_Primops.name = FStar_Parser_Const.unseal_lid;

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_NBETerm.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_NBETerm.ml
@@ -1686,71 +1686,10 @@ let (arg_as_int : arg -> FStar_BigInt.t FStar_Pervasives_Native.option) =
   fun a -> unembed e_int bogus_cbs (FStar_Pervasives_Native.fst a)
 let (arg_as_bool : arg -> Prims.bool FStar_Pervasives_Native.option) =
   fun a -> unembed e_bool bogus_cbs (FStar_Pervasives_Native.fst a)
-let (arg_as_char : arg -> FStar_Char.char FStar_Pervasives_Native.option) =
-  fun a -> unembed e_char bogus_cbs (FStar_Pervasives_Native.fst a)
-let (arg_as_string : arg -> Prims.string FStar_Pervasives_Native.option) =
-  fun a -> unembed e_string bogus_cbs (FStar_Pervasives_Native.fst a)
 let arg_as_list :
   'a . 'a embedding -> arg -> 'a Prims.list FStar_Pervasives_Native.option =
   fun e ->
     fun a1 -> unembed (e_list e) bogus_cbs (FStar_Pervasives_Native.fst a1)
-let (arg_as_doc :
-  arg -> FStar_Pprint.document FStar_Pervasives_Native.option) =
-  fun a -> unembed e_document bogus_cbs (FStar_Pervasives_Native.fst a)
-let (arg_as_bounded_int :
-  arg ->
-    (FStar_Syntax_Syntax.fv * FStar_BigInt.t *
-      FStar_Syntax_Syntax.meta_source_info FStar_Pervasives_Native.option)
-      FStar_Pervasives_Native.option)
-  =
-  fun uu___ ->
-    match uu___ with
-    | (a, uu___1) ->
-        let uu___2 =
-          match a.nbe_t with
-          | Meta (t1, tm) ->
-              let uu___3 = FStar_Thunk.force tm in
-              (match uu___3 with
-               | FStar_Syntax_Syntax.Meta_desugared m ->
-                   (t1, (FStar_Pervasives_Native.Some m))
-               | uu___4 -> (a, FStar_Pervasives_Native.None))
-          | uu___3 -> (a, FStar_Pervasives_Native.None) in
-        (match uu___2 with
-         | (a1, m) ->
-             (match a1.nbe_t with
-              | FV
-                  (fv1, [],
-                   ({ nbe_t = Constant (Int i); nbe_r = uu___3;_}, uu___4)::[])
-                  when
-                  let uu___5 =
-                    FStar_Ident.string_of_lid
-                      (fv1.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                  FStar_Compiler_Util.ends_with uu___5 "int_to_t" ->
-                  FStar_Pervasives_Native.Some (fv1, i, m)
-              | uu___3 -> FStar_Pervasives_Native.None))
-let (int_as_bounded : FStar_Syntax_Syntax.fv -> FStar_BigInt.t -> t) =
-  fun int_to_t ->
-    fun n ->
-      let c = embed e_int bogus_cbs n in
-      let int_to_t1 args1 = mk_t (FV (int_to_t, [], args1)) in
-      let uu___ = let uu___1 = as_arg c in [uu___1] in int_to_t1 uu___
-let (with_meta_ds :
-  t ->
-    FStar_Syntax_Syntax.meta_source_info FStar_Pervasives_Native.option -> t)
-  =
-  fun t1 ->
-    fun m ->
-      match m with
-      | FStar_Pervasives_Native.None -> t1
-      | FStar_Pervasives_Native.Some m1 ->
-          let uu___ =
-            let uu___1 =
-              let uu___2 =
-                FStar_Thunk.mk
-                  (fun uu___3 -> FStar_Syntax_Syntax.Meta_desugared m1) in
-              (t1, uu___2) in
-            Meta uu___1 in
-          mk_t uu___
 let lift_unary :
   'a 'b .
     ('a -> 'b) ->
@@ -1776,67 +1715,6 @@ let lift_binary :
           a1)::[] ->
           let uu___ = f a0 a1 in FStar_Pervasives_Native.Some uu___
       | uu___ -> FStar_Pervasives_Native.None
-let unary_op :
-  'a .
-    (arg -> 'a FStar_Pervasives_Native.option) ->
-      ('a -> t) ->
-        FStar_Syntax_Syntax.universes ->
-          args -> t FStar_Pervasives_Native.option
-  =
-  fun as_a ->
-    fun f ->
-      fun us ->
-        fun args1 ->
-          let uu___ = FStar_Compiler_List.map as_a args1 in
-          lift_unary f uu___
-let binary_op :
-  'a .
-    (arg -> 'a FStar_Pervasives_Native.option) ->
-      ('a -> 'a -> t) ->
-        FStar_Syntax_Syntax.universes ->
-          args -> t FStar_Pervasives_Native.option
-  =
-  fun as_a ->
-    fun f ->
-      fun _us ->
-        fun args1 ->
-          let uu___ = FStar_Compiler_List.map as_a args1 in
-          lift_binary f uu___
-let (unary_int_op :
-  (FStar_BigInt.t -> FStar_BigInt.t) ->
-    FStar_Syntax_Syntax.universes -> args -> t FStar_Pervasives_Native.option)
-  =
-  fun f ->
-    unary_op arg_as_int
-      (fun x -> let uu___ = f x in embed e_int bogus_cbs uu___)
-let (binary_int_op :
-  (FStar_BigInt.t -> FStar_BigInt.t -> FStar_BigInt.t) ->
-    FStar_Syntax_Syntax.universes -> args -> t FStar_Pervasives_Native.option)
-  =
-  fun f ->
-    binary_op arg_as_int
-      (fun x -> fun y -> let uu___ = f x y in embed e_int bogus_cbs uu___)
-let (unary_bool_op :
-  (Prims.bool -> Prims.bool) ->
-    FStar_Syntax_Syntax.universes -> args -> t FStar_Pervasives_Native.option)
-  =
-  fun f ->
-    unary_op arg_as_bool
-      (fun x -> let uu___ = f x in embed e_bool bogus_cbs uu___)
-let (binary_bool_op :
-  (Prims.bool -> Prims.bool -> Prims.bool) ->
-    FStar_Syntax_Syntax.universes -> args -> t FStar_Pervasives_Native.option)
-  =
-  fun f ->
-    binary_op arg_as_bool
-      (fun x -> fun y -> let uu___ = f x y in embed e_bool bogus_cbs uu___)
-let (binary_string_op :
-  (Prims.string -> Prims.string -> Prims.string) ->
-    FStar_Syntax_Syntax.universes -> args -> t FStar_Pervasives_Native.option)
-  =
-  fun f ->
-    binary_op arg_as_string
-      (fun x -> fun y -> let uu___ = f x y in embed e_string bogus_cbs uu___)
 let mixed_binary_op :
   'a 'b 'c .
     (arg -> 'a FStar_Pervasives_Native.option) ->
@@ -1946,18 +1824,6 @@ let (dummy_interp :
         let uu___1 = FStar_Ident.string_of_lid lid in
         Prims.strcat "No interpretation for " uu___1 in
       FStar_Compiler_Effect.failwith uu___
-let (prims_to_fstar_range_step : args -> t FStar_Pervasives_Native.option) =
-  fun args1 ->
-    match args1 with
-    | (a1, uu___)::[] ->
-        let uu___1 = unembed e_range bogus_cbs a1 in
-        (match uu___1 with
-         | FStar_Pervasives_Native.Some r ->
-             let uu___2 = embed e_range bogus_cbs r in
-             FStar_Pervasives_Native.Some uu___2
-         | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None)
-    | uu___ ->
-        FStar_Compiler_Effect.failwith "Unexpected number of arguments"
 let (and_op : args -> t FStar_Pervasives_Native.option) =
   fun args1 ->
     match args1 with

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_NBETerm.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_NBETerm.ml
@@ -1907,58 +1907,6 @@ let mixed_ternary_op :
                           | uu___2 -> FStar_Pervasives_Native.None)
                      | uu___1 -> FStar_Pervasives_Native.None)
                 | uu___ -> FStar_Pervasives_Native.None
-let (list_of_string' : Prims.string -> t) =
-  fun s -> embed (e_list e_char) bogus_cbs (FStar_String.list_of_string s)
-let (string_of_list' : FStar_String.char Prims.list -> t) =
-  fun l ->
-    let s = FStar_String.string_of_list l in
-    mk_t (Constant (String (s, FStar_Compiler_Range_Type.dummyRange)))
-let (string_compare' : Prims.string -> Prims.string -> t) =
-  fun s1 ->
-    fun s2 ->
-      let r = FStar_Compiler_String.compare s1 s2 in
-      let uu___ =
-        let uu___1 = FStar_Compiler_Util.string_of_int r in
-        FStar_BigInt.big_int_of_string uu___1 in
-      embed e_int bogus_cbs uu___
-let (string_concat' : args -> t FStar_Pervasives_Native.option) =
-  fun args1 ->
-    match args1 with
-    | a1::a2::[] ->
-        let uu___ = arg_as_string a1 in
-        (match uu___ with
-         | FStar_Pervasives_Native.Some s1 ->
-             let uu___1 = arg_as_list e_string a2 in
-             (match uu___1 with
-              | FStar_Pervasives_Native.Some s2 ->
-                  let r = FStar_Compiler_String.concat s1 s2 in
-                  let uu___2 = embed e_string bogus_cbs r in
-                  FStar_Pervasives_Native.Some uu___2
-              | uu___2 -> FStar_Pervasives_Native.None)
-         | uu___1 -> FStar_Pervasives_Native.None)
-    | uu___ -> FStar_Pervasives_Native.None
-let (string_of_int : FStar_BigInt.t -> t) =
-  fun i ->
-    let uu___ = FStar_BigInt.string_of_big_int i in
-    embed e_string bogus_cbs uu___
-let (string_of_bool : Prims.bool -> t) =
-  fun b -> embed e_string bogus_cbs (if b then "true" else "false")
-let (int_of_string : Prims.string -> t) =
-  fun s ->
-    let uu___ = FStar_Compiler_Util.safe_int_of_string s in
-    embed (e_option e_fsint) bogus_cbs uu___
-let (bool_of_string : Prims.string -> t) =
-  fun s ->
-    let r =
-      match s with
-      | "true" -> FStar_Pervasives_Native.Some true
-      | "false" -> FStar_Pervasives_Native.Some false
-      | uu___ -> FStar_Pervasives_Native.None in
-    embed (e_option e_bool) bogus_cbs r
-let (string_lowercase : Prims.string -> t) =
-  fun s -> embed e_string bogus_cbs (FStar_Compiler_String.lowercase s)
-let (string_uppercase : Prims.string -> t) =
-  fun s -> embed e_string bogus_cbs (FStar_Compiler_String.lowercase s)
 let (decidable_eq : Prims.bool -> args -> t FStar_Pervasives_Native.option) =
   fun neg ->
     fun args1 ->
@@ -2010,115 +1958,6 @@ let (prims_to_fstar_range_step : args -> t FStar_Pervasives_Native.option) =
          | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None)
     | uu___ ->
         FStar_Compiler_Effect.failwith "Unexpected number of arguments"
-let (string_split' : args -> t FStar_Pervasives_Native.option) =
-  fun args1 ->
-    match args1 with
-    | a1::a2::[] ->
-        let uu___ = arg_as_list e_char a1 in
-        (match uu___ with
-         | FStar_Pervasives_Native.Some s1 ->
-             let uu___1 = arg_as_string a2 in
-             (match uu___1 with
-              | FStar_Pervasives_Native.Some s2 ->
-                  let r = FStar_Compiler_String.split s1 s2 in
-                  let uu___2 = embed (e_list e_string) bogus_cbs r in
-                  FStar_Pervasives_Native.Some uu___2
-              | uu___2 -> FStar_Pervasives_Native.None)
-         | uu___1 -> FStar_Pervasives_Native.None)
-    | uu___ -> FStar_Pervasives_Native.None
-let (string_index : args -> t FStar_Pervasives_Native.option) =
-  fun args1 ->
-    match args1 with
-    | a1::a2::[] ->
-        let uu___ =
-          let uu___1 = arg_as_string a1 in
-          let uu___2 = arg_as_int a2 in (uu___1, uu___2) in
-        (match uu___ with
-         | (FStar_Pervasives_Native.Some s, FStar_Pervasives_Native.Some i)
-             ->
-             (try
-                (fun uu___1 ->
-                   match () with
-                   | () ->
-                       let r = FStar_Compiler_String.index s i in
-                       let uu___2 = embed e_char bogus_cbs r in
-                       FStar_Pervasives_Native.Some uu___2) ()
-              with | uu___1 -> FStar_Pervasives_Native.None)
-         | uu___1 -> FStar_Pervasives_Native.None)
-    | uu___ -> FStar_Pervasives_Native.None
-let (string_index_of : args -> t FStar_Pervasives_Native.option) =
-  fun args1 ->
-    match args1 with
-    | a1::a2::[] ->
-        let uu___ =
-          let uu___1 = arg_as_string a1 in
-          let uu___2 = arg_as_char a2 in (uu___1, uu___2) in
-        (match uu___ with
-         | (FStar_Pervasives_Native.Some s, FStar_Pervasives_Native.Some c)
-             ->
-             (try
-                (fun uu___1 ->
-                   match () with
-                   | () ->
-                       let r = FStar_Compiler_String.index_of s c in
-                       let uu___2 = embed e_int bogus_cbs r in
-                       FStar_Pervasives_Native.Some uu___2) ()
-              with | uu___1 -> FStar_Pervasives_Native.None)
-         | uu___1 -> FStar_Pervasives_Native.None)
-    | uu___ -> FStar_Pervasives_Native.None
-let (string_substring' : args -> t FStar_Pervasives_Native.option) =
-  fun args1 ->
-    match args1 with
-    | a1::a2::a3::[] ->
-        let uu___ =
-          let uu___1 = arg_as_string a1 in
-          let uu___2 = arg_as_int a2 in
-          let uu___3 = arg_as_int a3 in (uu___1, uu___2, uu___3) in
-        (match uu___ with
-         | (FStar_Pervasives_Native.Some s1, FStar_Pervasives_Native.Some n1,
-            FStar_Pervasives_Native.Some n2) ->
-             let n11 = FStar_BigInt.to_int_fs n1 in
-             let n21 = FStar_BigInt.to_int_fs n2 in
-             (try
-                (fun uu___1 ->
-                   match () with
-                   | () ->
-                       let r = FStar_Compiler_String.substring s1 n11 n21 in
-                       let uu___2 = embed e_string bogus_cbs r in
-                       FStar_Pervasives_Native.Some uu___2) ()
-              with | uu___1 -> FStar_Pervasives_Native.None)
-         | uu___1 -> FStar_Pervasives_Native.None)
-    | uu___ -> FStar_Pervasives_Native.None
-let (mk_range : args -> t FStar_Pervasives_Native.option) =
-  fun args1 ->
-    match args1 with
-    | fn::from_line::from_col::to_line::to_col::[] ->
-        let uu___ =
-          let uu___1 = arg_as_string fn in
-          let uu___2 = arg_as_int from_line in
-          let uu___3 = arg_as_int from_col in
-          let uu___4 = arg_as_int to_line in
-          let uu___5 = arg_as_int to_col in
-          (uu___1, uu___2, uu___3, uu___4, uu___5) in
-        (match uu___ with
-         | (FStar_Pervasives_Native.Some fn1, FStar_Pervasives_Native.Some
-            from_l, FStar_Pervasives_Native.Some from_c,
-            FStar_Pervasives_Native.Some to_l, FStar_Pervasives_Native.Some
-            to_c) ->
-             let r =
-               let uu___1 =
-                 let uu___2 = FStar_BigInt.to_int_fs from_l in
-                 let uu___3 = FStar_BigInt.to_int_fs from_c in
-                 FStar_Compiler_Range_Type.mk_pos uu___2 uu___3 in
-               let uu___2 =
-                 let uu___3 = FStar_BigInt.to_int_fs to_l in
-                 let uu___4 = FStar_BigInt.to_int_fs to_c in
-                 FStar_Compiler_Range_Type.mk_pos uu___3 uu___4 in
-               FStar_Compiler_Range_Type.mk_range fn1 uu___1 uu___2 in
-             let uu___1 = embed e_range bogus_cbs r in
-             FStar_Pervasives_Native.Some uu___1
-         | uu___1 -> FStar_Pervasives_Native.None)
-    | uu___ -> FStar_Pervasives_Native.None
 let (and_op : args -> t FStar_Pervasives_Native.option) =
   fun args1 ->
     match args1 with
@@ -2147,32 +1986,6 @@ let (or_op : args -> t FStar_Pervasives_Native.option) =
          | uu___1 -> FStar_Pervasives_Native.None)
     | uu___ ->
         FStar_Compiler_Effect.failwith "Unexpected number of arguments"
-let (division_modulus_op :
-  (FStar_BigInt.bigint -> FStar_BigInt.bigint -> FStar_BigInt.bigint) ->
-    args -> t FStar_Pervasives_Native.option)
-  =
-  fun op ->
-    fun args1 ->
-      match args1 with
-      | a1::a2::[] ->
-          let uu___ =
-            let uu___1 = arg_as_int a1 in
-            let uu___2 = arg_as_int a2 in (uu___1, uu___2) in
-          (match uu___ with
-           | (FStar_Pervasives_Native.Some m, FStar_Pervasives_Native.Some n)
-               ->
-               let uu___1 =
-                 let uu___2 = FStar_BigInt.to_int_fs n in
-                 uu___2 <> Prims.int_zero in
-               if uu___1
-               then
-                 let uu___2 =
-                   let uu___3 = op m n in embed e_int bogus_cbs uu___3 in
-                 FStar_Pervasives_Native.Some uu___2
-               else FStar_Pervasives_Native.None
-           | uu___1 -> FStar_Pervasives_Native.None)
-      | uu___ ->
-          FStar_Compiler_Effect.failwith "Unexpected number of arguments"
 let arrow_as_prim_step_1 :
   'a 'b .
     'a embedding ->

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Primops.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Primops.ml
@@ -129,21 +129,11 @@ let (arg_as_int :
   fun a ->
     try_unembed_simple FStar_Syntax_Embeddings.e_int
       (FStar_Pervasives_Native.fst a)
-let (arg_as_bool :
-  FStar_Syntax_Syntax.arg -> Prims.bool FStar_Pervasives_Native.option) =
-  fun a ->
-    try_unembed_simple FStar_Syntax_Embeddings.e_bool
-      (FStar_Pervasives_Native.fst a)
 let (arg_as_char :
   FStar_Syntax_Syntax.arg -> FStar_Char.char FStar_Pervasives_Native.option)
   =
   fun a ->
     try_unembed_simple FStar_Syntax_Embeddings.e_char
-      (FStar_Pervasives_Native.fst a)
-let (arg_as_string :
-  FStar_Syntax_Syntax.arg -> Prims.string FStar_Pervasives_Native.option) =
-  fun a ->
-    try_unembed_simple FStar_Syntax_Embeddings.e_string
       (FStar_Pervasives_Native.fst a)
 let arg_as_list :
   'a .
@@ -154,13 +144,6 @@ let arg_as_list :
     fun a1 ->
       try_unembed_simple (FStar_Syntax_Embeddings.e_list e)
         (FStar_Pervasives_Native.fst a1)
-let (arg_as_doc :
-  FStar_Syntax_Syntax.arg ->
-    FStar_Pprint.document FStar_Pervasives_Native.option)
-  =
-  fun a ->
-    try_unembed_simple FStar_Syntax_Embeddings.e_document
-      (FStar_Pervasives_Native.fst a)
 let (arg_as_bounded_int :
   FStar_Syntax_Syntax.arg ->
     (FStar_Syntax_Syntax.fv * FStar_BigInt.t *
@@ -310,89 +293,6 @@ let (as_primitive_step_nbecbs :
             interpretation_nbe =
               ((fun cb -> fun univs -> fun args -> f_nbe cb univs args))
           }
-let mk1 :
-  'a 'b .
-    ('a -> 'b) ->
-      'a FStar_Syntax_Embeddings_Base.embedding ->
-        'b FStar_Syntax_Embeddings_Base.embedding -> interp_t
-  =
-  fun uu___2 ->
-    fun uu___1 ->
-      fun uu___ ->
-        (fun f ->
-           fun uu___ ->
-             fun uu___1 ->
-               fun psc1 ->
-                 fun cbs ->
-                   fun us ->
-                     fun args ->
-                       match args with
-                       | (a1, uu___2)::[] ->
-                           let uu___3 = try_unembed_simple uu___ a1 in
-                           Obj.magic
-                             (FStar_Class_Monad.op_let_Bang
-                                FStar_Class_Monad.monad_option () ()
-                                (Obj.magic uu___3)
-                                (fun uu___4 ->
-                                   (fun x ->
-                                      let x = Obj.magic x in
-                                      let r = f x in
-                                      let uu___4 =
-                                        embed_simple uu___1 psc1.psc_range r in
-                                      Obj.magic
-                                        (FStar_Class_Monad.return
-                                           FStar_Class_Monad.monad_option ()
-                                           (Obj.magic uu___4))) uu___4)))
-          uu___2 uu___1 uu___
-let mk2 :
-  'a 'b 'c .
-    ('a -> 'b -> 'c) ->
-      'a FStar_Syntax_Embeddings_Base.embedding ->
-        'b FStar_Syntax_Embeddings_Base.embedding ->
-          'c FStar_Syntax_Embeddings_Base.embedding -> interp_t
-  =
-  fun uu___3 ->
-    fun uu___2 ->
-      fun uu___1 ->
-        fun uu___ ->
-          (fun f ->
-             fun uu___ ->
-               fun uu___1 ->
-                 fun uu___2 ->
-                   fun psc1 ->
-                     fun cbs ->
-                       fun us ->
-                         fun args ->
-                           match args with
-                           | (a1, uu___3)::(a2, uu___4)::[] ->
-                               let uu___5 = try_unembed_simple uu___ a1 in
-                               Obj.magic
-                                 (FStar_Class_Monad.op_let_Bang
-                                    FStar_Class_Monad.monad_option () ()
-                                    (Obj.magic uu___5)
-                                    (fun uu___6 ->
-                                       (fun x ->
-                                          let x = Obj.magic x in
-                                          let uu___6 =
-                                            try_unembed_simple uu___1 a2 in
-                                          Obj.magic
-                                            (FStar_Class_Monad.op_let_Bang
-                                               FStar_Class_Monad.monad_option
-                                               () () (Obj.magic uu___6)
-                                               (fun uu___7 ->
-                                                  (fun y ->
-                                                     let y = Obj.magic y in
-                                                     let r = f x y in
-                                                     let uu___7 =
-                                                       embed_simple uu___2
-                                                         psc1.psc_range r in
-                                                     Obj.magic
-                                                       (FStar_Class_Monad.return
-                                                          FStar_Class_Monad.monad_option
-                                                          ()
-                                                          (Obj.magic uu___7)))
-                                                    uu___7))) uu___6)))
-            uu___3 uu___2 uu___1 uu___
 let (as_primitive_step :
   Prims.bool ->
     (FStar_Ident.lid * Prims.int * Prims.int *
@@ -414,79 +314,753 @@ let (as_primitive_step :
           as_primitive_step_nbecbs is_strong
             (l, arity, u_arity, f,
               (fun cb -> fun univs -> fun args -> f_nbe univs args))
-let (unary_int_op :
-  (FStar_BigInt.t -> FStar_BigInt.t) ->
-    psc ->
-      FStar_Syntax_Embeddings_Base.norm_cb ->
-        FStar_Syntax_Syntax.universes ->
-          FStar_Syntax_Syntax.args ->
-            FStar_Syntax_Syntax.term FStar_Pervasives_Native.option)
+let solve : 'a . 'a -> 'a = fun ev -> ev
+let mk1 :
+  'a 'r .
+    Prims.int ->
+      FStar_Ident.lid ->
+        'a FStar_Syntax_Embeddings_Base.embedding ->
+          'a FStar_TypeChecker_NBETerm.embedding ->
+            'r FStar_Syntax_Embeddings_Base.embedding ->
+              'r FStar_TypeChecker_NBETerm.embedding ->
+                ('a -> 'r) -> primitive_step
   =
-  fun f ->
-    unary_op arg_as_int
-      (fun r ->
-         fun x ->
-           let uu___ = f x in
-           embed_simple FStar_Syntax_Embeddings.e_int r uu___)
-let (binary_int_op :
-  (FStar_BigInt.t -> FStar_BigInt.t -> FStar_BigInt.t) ->
-    psc ->
-      FStar_Syntax_Embeddings_Base.norm_cb ->
-        FStar_Syntax_Syntax.universes ->
-          FStar_Syntax_Syntax.args ->
-            FStar_Syntax_Syntax.term FStar_Pervasives_Native.option)
+  fun u_arity ->
+    fun name ->
+      fun uu___ ->
+        fun uu___1 ->
+          fun uu___2 ->
+            fun uu___3 ->
+              fun f ->
+                let interp psc1 cb us args =
+                  match args with
+                  | (a1, uu___4)::[] ->
+                      Obj.magic
+                        (Obj.repr
+                           (let uu___5 = try_unembed_simple uu___ a1 in
+                            FStar_Class_Monad.op_let_Bang
+                              FStar_Class_Monad.monad_option () ()
+                              (Obj.magic uu___5)
+                              (fun uu___6 ->
+                                 (fun a2 ->
+                                    let a2 = Obj.magic a2 in
+                                    let uu___6 =
+                                      let uu___7 = f a2 in
+                                      embed_simple uu___2 psc1.psc_range
+                                        uu___7 in
+                                    Obj.magic
+                                      (FStar_Class_Monad.return
+                                         FStar_Class_Monad.monad_option ()
+                                         (Obj.magic uu___6))) uu___6)))
+                  | uu___4 ->
+                      Obj.magic (Obj.repr FStar_Pervasives_Native.None) in
+                let nbe_interp cbs us args =
+                  match args with
+                  | (a1, uu___4)::[] ->
+                      Obj.magic
+                        (Obj.repr
+                           (let uu___5 =
+                              let uu___6 =
+                                FStar_TypeChecker_NBETerm.unembed
+                                  (solve uu___1) cbs a1 in
+                              Obj.magic
+                                (FStar_Class_Monad.op_Less_Dollar_Greater
+                                   FStar_Class_Monad.monad_option () ()
+                                   (fun uu___7 -> (Obj.magic f) uu___7)
+                                   (Obj.magic uu___6)) in
+                            FStar_Class_Monad.op_let_Bang
+                              FStar_Class_Monad.monad_option () ()
+                              (Obj.magic uu___5)
+                              (fun uu___6 ->
+                                 (fun r1 ->
+                                    let r1 = Obj.magic r1 in
+                                    let uu___6 =
+                                      FStar_TypeChecker_NBETerm.embed
+                                        (solve uu___3) cbs r1 in
+                                    Obj.magic
+                                      (FStar_Class_Monad.return
+                                         FStar_Class_Monad.monad_option ()
+                                         (Obj.magic uu___6))) uu___6)))
+                  | uu___4 ->
+                      Obj.magic (Obj.repr FStar_Pervasives_Native.None) in
+                as_primitive_step_nbecbs true
+                  (name, Prims.int_one, u_arity, interp, nbe_interp)
+let mk2 :
+  'a 'b 'r .
+    Prims.int ->
+      FStar_Ident.lid ->
+        'a FStar_Syntax_Embeddings_Base.embedding ->
+          'a FStar_TypeChecker_NBETerm.embedding ->
+            'b FStar_Syntax_Embeddings_Base.embedding ->
+              'b FStar_TypeChecker_NBETerm.embedding ->
+                'r FStar_Syntax_Embeddings_Base.embedding ->
+                  'r FStar_TypeChecker_NBETerm.embedding ->
+                    ('a -> 'b -> 'r) -> primitive_step
   =
-  fun f ->
-    binary_op arg_as_int
-      (fun r ->
-         fun x ->
-           fun y ->
-             let uu___ = f x y in
-             embed_simple FStar_Syntax_Embeddings.e_int r uu___)
-let (unary_bool_op :
-  (Prims.bool -> Prims.bool) ->
-    psc ->
-      FStar_Syntax_Embeddings_Base.norm_cb ->
-        FStar_Syntax_Syntax.universes ->
-          FStar_Syntax_Syntax.args ->
-            FStar_Syntax_Syntax.term FStar_Pervasives_Native.option)
+  fun u_arity ->
+    fun name ->
+      fun uu___ ->
+        fun uu___1 ->
+          fun uu___2 ->
+            fun uu___3 ->
+              fun uu___4 ->
+                fun uu___5 ->
+                  fun f ->
+                    let interp psc1 cb us args =
+                      match args with
+                      | (a1, uu___6)::(b1, uu___7)::[] ->
+                          Obj.magic
+                            (Obj.repr
+                               (let uu___8 =
+                                  let uu___9 =
+                                    let uu___10 = try_unembed_simple uu___ a1 in
+                                    Obj.magic
+                                      (FStar_Class_Monad.op_Less_Dollar_Greater
+                                         FStar_Class_Monad.monad_option () ()
+                                         (fun uu___11 ->
+                                            (Obj.magic f) uu___11)
+                                         (Obj.magic uu___10)) in
+                                  let uu___10 = try_unembed_simple uu___2 b1 in
+                                  Obj.magic
+                                    (FStar_Class_Monad.op_Less_Star_Greater
+                                       FStar_Class_Monad.monad_option () ()
+                                       (Obj.magic uu___9) (Obj.magic uu___10)) in
+                                FStar_Class_Monad.op_let_Bang
+                                  FStar_Class_Monad.monad_option () ()
+                                  (Obj.magic uu___8)
+                                  (fun uu___9 ->
+                                     (fun r1 ->
+                                        let r1 = Obj.magic r1 in
+                                        let uu___9 =
+                                          embed_simple uu___4 psc1.psc_range
+                                            r1 in
+                                        Obj.magic
+                                          (FStar_Class_Monad.return
+                                             FStar_Class_Monad.monad_option
+                                             () (Obj.magic uu___9))) uu___9)))
+                      | uu___6 ->
+                          Obj.magic (Obj.repr FStar_Pervasives_Native.None) in
+                    let nbe_interp cbs us args =
+                      match args with
+                      | (a1, uu___6)::(b1, uu___7)::[] ->
+                          Obj.magic
+                            (Obj.repr
+                               (let uu___8 =
+                                  let uu___9 =
+                                    let uu___10 =
+                                      FStar_TypeChecker_NBETerm.unembed
+                                        (solve uu___1) cbs a1 in
+                                    Obj.magic
+                                      (FStar_Class_Monad.op_Less_Dollar_Greater
+                                         FStar_Class_Monad.monad_option () ()
+                                         (fun uu___11 ->
+                                            (Obj.magic f) uu___11)
+                                         (Obj.magic uu___10)) in
+                                  let uu___10 =
+                                    FStar_TypeChecker_NBETerm.unembed
+                                      (solve uu___3) cbs b1 in
+                                  Obj.magic
+                                    (FStar_Class_Monad.op_Less_Star_Greater
+                                       FStar_Class_Monad.monad_option () ()
+                                       (Obj.magic uu___9) (Obj.magic uu___10)) in
+                                FStar_Class_Monad.op_let_Bang
+                                  FStar_Class_Monad.monad_option () ()
+                                  (Obj.magic uu___8)
+                                  (fun uu___9 ->
+                                     (fun r1 ->
+                                        let r1 = Obj.magic r1 in
+                                        let uu___9 =
+                                          FStar_TypeChecker_NBETerm.embed
+                                            (solve uu___5) cbs r1 in
+                                        Obj.magic
+                                          (FStar_Class_Monad.return
+                                             FStar_Class_Monad.monad_option
+                                             () (Obj.magic uu___9))) uu___9)))
+                      | uu___6 ->
+                          Obj.magic (Obj.repr FStar_Pervasives_Native.None) in
+                    as_primitive_step_nbecbs true
+                      (name, (Prims.of_int (2)), u_arity, interp, nbe_interp)
+let mk2' :
+  'a 'b 'r .
+    Prims.int ->
+      FStar_Ident.lid ->
+        'a FStar_Syntax_Embeddings_Base.embedding ->
+          'a FStar_TypeChecker_NBETerm.embedding ->
+            'b FStar_Syntax_Embeddings_Base.embedding ->
+              'b FStar_TypeChecker_NBETerm.embedding ->
+                'r FStar_Syntax_Embeddings_Base.embedding ->
+                  'r FStar_TypeChecker_NBETerm.embedding ->
+                    ('a -> 'b -> 'r FStar_Pervasives_Native.option) ->
+                      primitive_step
   =
-  fun f ->
-    unary_op arg_as_bool
-      (fun r ->
-         fun x ->
-           let uu___ = f x in
-           embed_simple FStar_Syntax_Embeddings.e_bool r uu___)
-let (binary_bool_op :
-  (Prims.bool -> Prims.bool -> Prims.bool) ->
-    psc ->
-      FStar_Syntax_Embeddings_Base.norm_cb ->
-        FStar_Syntax_Syntax.universes ->
-          FStar_Syntax_Syntax.args ->
-            FStar_Syntax_Syntax.term FStar_Pervasives_Native.option)
+  fun u_arity ->
+    fun name ->
+      fun uu___ ->
+        fun uu___1 ->
+          fun uu___2 ->
+            fun uu___3 ->
+              fun uu___4 ->
+                fun uu___5 ->
+                  fun f ->
+                    let interp psc1 cb us args =
+                      match args with
+                      | (a1, uu___6)::(b1, uu___7)::[] ->
+                          Obj.magic
+                            (Obj.repr
+                               (let uu___8 =
+                                  let uu___9 =
+                                    let uu___10 = try_unembed_simple uu___ a1 in
+                                    Obj.magic
+                                      (FStar_Class_Monad.op_Less_Dollar_Greater
+                                         FStar_Class_Monad.monad_option () ()
+                                         (fun uu___11 ->
+                                            (Obj.magic f) uu___11)
+                                         (Obj.magic uu___10)) in
+                                  let uu___10 = try_unembed_simple uu___2 b1 in
+                                  Obj.magic
+                                    (FStar_Class_Monad.op_Less_Star_Greater
+                                       FStar_Class_Monad.monad_option () ()
+                                       (Obj.magic uu___9) (Obj.magic uu___10)) in
+                                FStar_Class_Monad.op_let_Bang
+                                  FStar_Class_Monad.monad_option () ()
+                                  (Obj.magic uu___8)
+                                  (fun uu___9 ->
+                                     (fun r1 ->
+                                        let r1 = Obj.magic r1 in
+                                        Obj.magic
+                                          (FStar_Class_Monad.op_let_Bang
+                                             FStar_Class_Monad.monad_option
+                                             () () (Obj.magic r1)
+                                             (fun uu___9 ->
+                                                (fun r2 ->
+                                                   let r2 = Obj.magic r2 in
+                                                   let uu___9 =
+                                                     embed_simple uu___4
+                                                       psc1.psc_range r2 in
+                                                   Obj.magic
+                                                     (FStar_Class_Monad.return
+                                                        FStar_Class_Monad.monad_option
+                                                        () (Obj.magic uu___9)))
+                                                  uu___9))) uu___9)))
+                      | uu___6 ->
+                          Obj.magic (Obj.repr FStar_Pervasives_Native.None) in
+                    let nbe_interp cbs us args =
+                      match args with
+                      | (a1, uu___6)::(b1, uu___7)::[] ->
+                          Obj.magic
+                            (Obj.repr
+                               (let uu___8 =
+                                  let uu___9 =
+                                    let uu___10 =
+                                      FStar_TypeChecker_NBETerm.unembed
+                                        (solve uu___1) cbs a1 in
+                                    Obj.magic
+                                      (FStar_Class_Monad.op_Less_Dollar_Greater
+                                         FStar_Class_Monad.monad_option () ()
+                                         (fun uu___11 ->
+                                            (Obj.magic f) uu___11)
+                                         (Obj.magic uu___10)) in
+                                  let uu___10 =
+                                    FStar_TypeChecker_NBETerm.unembed
+                                      (solve uu___3) cbs b1 in
+                                  Obj.magic
+                                    (FStar_Class_Monad.op_Less_Star_Greater
+                                       FStar_Class_Monad.monad_option () ()
+                                       (Obj.magic uu___9) (Obj.magic uu___10)) in
+                                FStar_Class_Monad.op_let_Bang
+                                  FStar_Class_Monad.monad_option () ()
+                                  (Obj.magic uu___8)
+                                  (fun uu___9 ->
+                                     (fun r1 ->
+                                        let r1 = Obj.magic r1 in
+                                        Obj.magic
+                                          (FStar_Class_Monad.op_let_Bang
+                                             FStar_Class_Monad.monad_option
+                                             () () (Obj.magic r1)
+                                             (fun uu___9 ->
+                                                (fun r2 ->
+                                                   let r2 = Obj.magic r2 in
+                                                   let uu___9 =
+                                                     FStar_TypeChecker_NBETerm.embed
+                                                       (solve uu___5) cbs r2 in
+                                                   Obj.magic
+                                                     (FStar_Class_Monad.return
+                                                        FStar_Class_Monad.monad_option
+                                                        () (Obj.magic uu___9)))
+                                                  uu___9))) uu___9)))
+                      | uu___6 ->
+                          Obj.magic (Obj.repr FStar_Pervasives_Native.None) in
+                    as_primitive_step_nbecbs true
+                      (name, (Prims.of_int (2)), u_arity, interp, nbe_interp)
+let mk3 :
+  'a 'b 'c 'r .
+    Prims.int ->
+      FStar_Ident.lid ->
+        'a FStar_Syntax_Embeddings_Base.embedding ->
+          'a FStar_TypeChecker_NBETerm.embedding ->
+            'b FStar_Syntax_Embeddings_Base.embedding ->
+              'b FStar_TypeChecker_NBETerm.embedding ->
+                'c FStar_Syntax_Embeddings_Base.embedding ->
+                  'c FStar_TypeChecker_NBETerm.embedding ->
+                    'r FStar_Syntax_Embeddings_Base.embedding ->
+                      'r FStar_TypeChecker_NBETerm.embedding ->
+                        ('a -> 'b -> 'c -> 'r) -> primitive_step
   =
-  fun f ->
-    binary_op arg_as_bool
-      (fun r ->
-         fun x ->
-           fun y ->
-             let uu___ = f x y in
-             embed_simple FStar_Syntax_Embeddings.e_bool r uu___)
-let (binary_string_op :
-  (Prims.string -> Prims.string -> Prims.string) ->
-    psc ->
-      FStar_Syntax_Embeddings_Base.norm_cb ->
-        FStar_Syntax_Syntax.universes ->
-          FStar_Syntax_Syntax.args ->
-            FStar_Syntax_Syntax.term FStar_Pervasives_Native.option)
+  fun u_arity ->
+    fun name ->
+      fun uu___ ->
+        fun uu___1 ->
+          fun uu___2 ->
+            fun uu___3 ->
+              fun uu___4 ->
+                fun uu___5 ->
+                  fun uu___6 ->
+                    fun uu___7 ->
+                      fun f ->
+                        let interp psc1 cb us args =
+                          match args with
+                          | (a1, uu___8)::(b1, uu___9)::(c1, uu___10)::[] ->
+                              Obj.magic
+                                (Obj.repr
+                                   (let uu___11 =
+                                      let uu___12 =
+                                        let uu___13 =
+                                          let uu___14 =
+                                            try_unembed_simple uu___ a1 in
+                                          Obj.magic
+                                            (FStar_Class_Monad.op_Less_Dollar_Greater
+                                               FStar_Class_Monad.monad_option
+                                               () ()
+                                               (fun uu___15 ->
+                                                  (Obj.magic f) uu___15)
+                                               (Obj.magic uu___14)) in
+                                        let uu___14 =
+                                          try_unembed_simple uu___2 b1 in
+                                        Obj.magic
+                                          (FStar_Class_Monad.op_Less_Star_Greater
+                                             FStar_Class_Monad.monad_option
+                                             () () (Obj.magic uu___13)
+                                             (Obj.magic uu___14)) in
+                                      let uu___13 =
+                                        try_unembed_simple uu___4 c1 in
+                                      Obj.magic
+                                        (FStar_Class_Monad.op_Less_Star_Greater
+                                           FStar_Class_Monad.monad_option ()
+                                           () (Obj.magic uu___12)
+                                           (Obj.magic uu___13)) in
+                                    FStar_Class_Monad.op_let_Bang
+                                      FStar_Class_Monad.monad_option () ()
+                                      (Obj.magic uu___11)
+                                      (fun uu___12 ->
+                                         (fun r1 ->
+                                            let r1 = Obj.magic r1 in
+                                            let uu___12 =
+                                              embed_simple uu___6
+                                                psc1.psc_range r1 in
+                                            Obj.magic
+                                              (FStar_Class_Monad.return
+                                                 FStar_Class_Monad.monad_option
+                                                 () (Obj.magic uu___12)))
+                                           uu___12)))
+                          | uu___8 ->
+                              Obj.magic
+                                (Obj.repr FStar_Pervasives_Native.None) in
+                        let nbe_interp cbs us args =
+                          match args with
+                          | (a1, uu___8)::(b1, uu___9)::(c1, uu___10)::[] ->
+                              Obj.magic
+                                (Obj.repr
+                                   (let uu___11 =
+                                      let uu___12 =
+                                        let uu___13 =
+                                          let uu___14 =
+                                            FStar_TypeChecker_NBETerm.unembed
+                                              (solve uu___1) cbs a1 in
+                                          Obj.magic
+                                            (FStar_Class_Monad.op_Less_Dollar_Greater
+                                               FStar_Class_Monad.monad_option
+                                               () ()
+                                               (fun uu___15 ->
+                                                  (Obj.magic f) uu___15)
+                                               (Obj.magic uu___14)) in
+                                        let uu___14 =
+                                          FStar_TypeChecker_NBETerm.unembed
+                                            (solve uu___3) cbs b1 in
+                                        Obj.magic
+                                          (FStar_Class_Monad.op_Less_Star_Greater
+                                             FStar_Class_Monad.monad_option
+                                             () () (Obj.magic uu___13)
+                                             (Obj.magic uu___14)) in
+                                      let uu___13 =
+                                        FStar_TypeChecker_NBETerm.unembed
+                                          (solve uu___5) cbs c1 in
+                                      Obj.magic
+                                        (FStar_Class_Monad.op_Less_Star_Greater
+                                           FStar_Class_Monad.monad_option ()
+                                           () (Obj.magic uu___12)
+                                           (Obj.magic uu___13)) in
+                                    FStar_Class_Monad.op_let_Bang
+                                      FStar_Class_Monad.monad_option () ()
+                                      (Obj.magic uu___11)
+                                      (fun uu___12 ->
+                                         (fun r1 ->
+                                            let r1 = Obj.magic r1 in
+                                            let uu___12 =
+                                              FStar_TypeChecker_NBETerm.embed
+                                                (solve uu___7) cbs r1 in
+                                            Obj.magic
+                                              (FStar_Class_Monad.return
+                                                 FStar_Class_Monad.monad_option
+                                                 () (Obj.magic uu___12)))
+                                           uu___12)))
+                          | uu___8 ->
+                              Obj.magic
+                                (Obj.repr FStar_Pervasives_Native.None) in
+                        as_primitive_step_nbecbs true
+                          (name, (Prims.of_int (3)), u_arity, interp,
+                            nbe_interp)
+let mk4 :
+  'a 'b 'c 'd 'r .
+    Prims.int ->
+      FStar_Ident.lid ->
+        'a FStar_Syntax_Embeddings_Base.embedding ->
+          'a FStar_TypeChecker_NBETerm.embedding ->
+            'b FStar_Syntax_Embeddings_Base.embedding ->
+              'b FStar_TypeChecker_NBETerm.embedding ->
+                'c FStar_Syntax_Embeddings_Base.embedding ->
+                  'c FStar_TypeChecker_NBETerm.embedding ->
+                    'd FStar_Syntax_Embeddings_Base.embedding ->
+                      'd FStar_TypeChecker_NBETerm.embedding ->
+                        'r FStar_Syntax_Embeddings_Base.embedding ->
+                          'r FStar_TypeChecker_NBETerm.embedding ->
+                            ('a -> 'b -> 'c -> 'd -> 'r) -> primitive_step
   =
-  fun f ->
-    binary_op arg_as_string
-      (fun r ->
-         fun x ->
-           fun y ->
-             let uu___ = f x y in
-             embed_simple FStar_Syntax_Embeddings.e_string r uu___)
+  fun u_arity ->
+    fun name ->
+      fun uu___ ->
+        fun uu___1 ->
+          fun uu___2 ->
+            fun uu___3 ->
+              fun uu___4 ->
+                fun uu___5 ->
+                  fun uu___6 ->
+                    fun uu___7 ->
+                      fun uu___8 ->
+                        fun uu___9 ->
+                          fun f ->
+                            let interp psc1 cb us args =
+                              match args with
+                              | (a1, uu___10)::(b1, uu___11)::(c1, uu___12)::
+                                  (d1, uu___13)::(e, uu___14)::[] ->
+                                  Obj.magic
+                                    (Obj.repr
+                                       (let uu___15 =
+                                          let uu___16 =
+                                            let uu___17 =
+                                              let uu___18 =
+                                                let uu___19 =
+                                                  try_unembed_simple uu___ a1 in
+                                                Obj.magic
+                                                  (FStar_Class_Monad.op_Less_Dollar_Greater
+                                                     FStar_Class_Monad.monad_option
+                                                     () ()
+                                                     (fun uu___20 ->
+                                                        (Obj.magic f) uu___20)
+                                                     (Obj.magic uu___19)) in
+                                              let uu___19 =
+                                                try_unembed_simple uu___2 b1 in
+                                              Obj.magic
+                                                (FStar_Class_Monad.op_Less_Star_Greater
+                                                   FStar_Class_Monad.monad_option
+                                                   () () (Obj.magic uu___18)
+                                                   (Obj.magic uu___19)) in
+                                            let uu___18 =
+                                              try_unembed_simple uu___4 c1 in
+                                            Obj.magic
+                                              (FStar_Class_Monad.op_Less_Star_Greater
+                                                 FStar_Class_Monad.monad_option
+                                                 () () (Obj.magic uu___17)
+                                                 (Obj.magic uu___18)) in
+                                          let uu___17 =
+                                            try_unembed_simple uu___6 d1 in
+                                          Obj.magic
+                                            (FStar_Class_Monad.op_Less_Star_Greater
+                                               FStar_Class_Monad.monad_option
+                                               () () (Obj.magic uu___16)
+                                               (Obj.magic uu___17)) in
+                                        FStar_Class_Monad.op_let_Bang
+                                          FStar_Class_Monad.monad_option ()
+                                          () (Obj.magic uu___15)
+                                          (fun uu___16 ->
+                                             (fun r1 ->
+                                                let r1 = Obj.magic r1 in
+                                                let uu___16 =
+                                                  embed_simple uu___8
+                                                    psc1.psc_range r1 in
+                                                Obj.magic
+                                                  (FStar_Class_Monad.return
+                                                     FStar_Class_Monad.monad_option
+                                                     () (Obj.magic uu___16)))
+                                               uu___16)))
+                              | uu___10 ->
+                                  Obj.magic
+                                    (Obj.repr FStar_Pervasives_Native.None) in
+                            let nbe_interp cbs us args =
+                              match args with
+                              | (a1, uu___10)::(b1, uu___11)::(c1, uu___12)::
+                                  (d1, uu___13)::[] ->
+                                  Obj.magic
+                                    (Obj.repr
+                                       (let uu___14 =
+                                          let uu___15 =
+                                            let uu___16 =
+                                              let uu___17 =
+                                                let uu___18 =
+                                                  FStar_TypeChecker_NBETerm.unembed
+                                                    (solve uu___1) cbs a1 in
+                                                Obj.magic
+                                                  (FStar_Class_Monad.op_Less_Dollar_Greater
+                                                     FStar_Class_Monad.monad_option
+                                                     () ()
+                                                     (fun uu___19 ->
+                                                        (Obj.magic f) uu___19)
+                                                     (Obj.magic uu___18)) in
+                                              let uu___18 =
+                                                FStar_TypeChecker_NBETerm.unembed
+                                                  (solve uu___3) cbs b1 in
+                                              Obj.magic
+                                                (FStar_Class_Monad.op_Less_Star_Greater
+                                                   FStar_Class_Monad.monad_option
+                                                   () () (Obj.magic uu___17)
+                                                   (Obj.magic uu___18)) in
+                                            let uu___17 =
+                                              FStar_TypeChecker_NBETerm.unembed
+                                                (solve uu___5) cbs c1 in
+                                            Obj.magic
+                                              (FStar_Class_Monad.op_Less_Star_Greater
+                                                 FStar_Class_Monad.monad_option
+                                                 () () (Obj.magic uu___16)
+                                                 (Obj.magic uu___17)) in
+                                          let uu___16 =
+                                            FStar_TypeChecker_NBETerm.unembed
+                                              (solve uu___7) cbs d1 in
+                                          Obj.magic
+                                            (FStar_Class_Monad.op_Less_Star_Greater
+                                               FStar_Class_Monad.monad_option
+                                               () () (Obj.magic uu___15)
+                                               (Obj.magic uu___16)) in
+                                        FStar_Class_Monad.op_let_Bang
+                                          FStar_Class_Monad.monad_option ()
+                                          () (Obj.magic uu___14)
+                                          (fun uu___15 ->
+                                             (fun r1 ->
+                                                let r1 = Obj.magic r1 in
+                                                let uu___15 =
+                                                  FStar_TypeChecker_NBETerm.embed
+                                                    (solve uu___9) cbs r1 in
+                                                Obj.magic
+                                                  (FStar_Class_Monad.return
+                                                     FStar_Class_Monad.monad_option
+                                                     () (Obj.magic uu___15)))
+                                               uu___15)))
+                              | uu___10 ->
+                                  Obj.magic
+                                    (Obj.repr FStar_Pervasives_Native.None) in
+                            as_primitive_step_nbecbs true
+                              (name, (Prims.of_int (4)), u_arity, interp,
+                                nbe_interp)
+let mk5 :
+  'a 'b 'c 'd 'e 'r .
+    Prims.int ->
+      FStar_Ident.lid ->
+        'a FStar_Syntax_Embeddings_Base.embedding ->
+          'a FStar_TypeChecker_NBETerm.embedding ->
+            'b FStar_Syntax_Embeddings_Base.embedding ->
+              'b FStar_TypeChecker_NBETerm.embedding ->
+                'c FStar_Syntax_Embeddings_Base.embedding ->
+                  'c FStar_TypeChecker_NBETerm.embedding ->
+                    'd FStar_Syntax_Embeddings_Base.embedding ->
+                      'd FStar_TypeChecker_NBETerm.embedding ->
+                        'e FStar_Syntax_Embeddings_Base.embedding ->
+                          'e FStar_TypeChecker_NBETerm.embedding ->
+                            'r FStar_Syntax_Embeddings_Base.embedding ->
+                              'r FStar_TypeChecker_NBETerm.embedding ->
+                                ('a -> 'b -> 'c -> 'd -> 'e -> 'r) ->
+                                  primitive_step
+  =
+  fun u_arity ->
+    fun name ->
+      fun uu___ ->
+        fun uu___1 ->
+          fun uu___2 ->
+            fun uu___3 ->
+              fun uu___4 ->
+                fun uu___5 ->
+                  fun uu___6 ->
+                    fun uu___7 ->
+                      fun uu___8 ->
+                        fun uu___9 ->
+                          fun uu___10 ->
+                            fun uu___11 ->
+                              fun f ->
+                                let interp psc1 cb us args =
+                                  match args with
+                                  | (a1, uu___12)::(b1, uu___13)::(c1,
+                                                                   uu___14)::
+                                      (d1, uu___15)::(e1, uu___16)::[] ->
+                                      Obj.magic
+                                        (Obj.repr
+                                           (let uu___17 =
+                                              let uu___18 =
+                                                let uu___19 =
+                                                  let uu___20 =
+                                                    let uu___21 =
+                                                      let uu___22 =
+                                                        try_unembed_simple
+                                                          uu___ a1 in
+                                                      Obj.magic
+                                                        (FStar_Class_Monad.op_Less_Dollar_Greater
+                                                           FStar_Class_Monad.monad_option
+                                                           () ()
+                                                           (fun uu___23 ->
+                                                              (Obj.magic f)
+                                                                uu___23)
+                                                           (Obj.magic uu___22)) in
+                                                    let uu___22 =
+                                                      try_unembed_simple
+                                                        uu___2 b1 in
+                                                    Obj.magic
+                                                      (FStar_Class_Monad.op_Less_Star_Greater
+                                                         FStar_Class_Monad.monad_option
+                                                         () ()
+                                                         (Obj.magic uu___21)
+                                                         (Obj.magic uu___22)) in
+                                                  let uu___21 =
+                                                    try_unembed_simple uu___4
+                                                      c1 in
+                                                  Obj.magic
+                                                    (FStar_Class_Monad.op_Less_Star_Greater
+                                                       FStar_Class_Monad.monad_option
+                                                       () ()
+                                                       (Obj.magic uu___20)
+                                                       (Obj.magic uu___21)) in
+                                                let uu___20 =
+                                                  try_unembed_simple uu___6
+                                                    d1 in
+                                                Obj.magic
+                                                  (FStar_Class_Monad.op_Less_Star_Greater
+                                                     FStar_Class_Monad.monad_option
+                                                     () ()
+                                                     (Obj.magic uu___19)
+                                                     (Obj.magic uu___20)) in
+                                              let uu___19 =
+                                                try_unembed_simple uu___8 e1 in
+                                              Obj.magic
+                                                (FStar_Class_Monad.op_Less_Star_Greater
+                                                   FStar_Class_Monad.monad_option
+                                                   () () (Obj.magic uu___18)
+                                                   (Obj.magic uu___19)) in
+                                            FStar_Class_Monad.op_let_Bang
+                                              FStar_Class_Monad.monad_option
+                                              () () (Obj.magic uu___17)
+                                              (fun uu___18 ->
+                                                 (fun r1 ->
+                                                    let r1 = Obj.magic r1 in
+                                                    let uu___18 =
+                                                      embed_simple uu___10
+                                                        psc1.psc_range r1 in
+                                                    Obj.magic
+                                                      (FStar_Class_Monad.return
+                                                         FStar_Class_Monad.monad_option
+                                                         ()
+                                                         (Obj.magic uu___18)))
+                                                   uu___18)))
+                                  | uu___12 ->
+                                      Obj.magic
+                                        (Obj.repr
+                                           FStar_Pervasives_Native.None) in
+                                let nbe_interp cbs us args =
+                                  match args with
+                                  | (a1, uu___12)::(b1, uu___13)::(c1,
+                                                                   uu___14)::
+                                      (d1, uu___15)::(e1, uu___16)::[] ->
+                                      Obj.magic
+                                        (Obj.repr
+                                           (let uu___17 =
+                                              let uu___18 =
+                                                let uu___19 =
+                                                  let uu___20 =
+                                                    let uu___21 =
+                                                      let uu___22 =
+                                                        FStar_TypeChecker_NBETerm.unembed
+                                                          (solve uu___1) cbs
+                                                          a1 in
+                                                      Obj.magic
+                                                        (FStar_Class_Monad.op_Less_Dollar_Greater
+                                                           FStar_Class_Monad.monad_option
+                                                           () ()
+                                                           (fun uu___23 ->
+                                                              (Obj.magic f)
+                                                                uu___23)
+                                                           (Obj.magic uu___22)) in
+                                                    let uu___22 =
+                                                      FStar_TypeChecker_NBETerm.unembed
+                                                        (solve uu___3) cbs b1 in
+                                                    Obj.magic
+                                                      (FStar_Class_Monad.op_Less_Star_Greater
+                                                         FStar_Class_Monad.monad_option
+                                                         () ()
+                                                         (Obj.magic uu___21)
+                                                         (Obj.magic uu___22)) in
+                                                  let uu___21 =
+                                                    FStar_TypeChecker_NBETerm.unembed
+                                                      (solve uu___5) cbs c1 in
+                                                  Obj.magic
+                                                    (FStar_Class_Monad.op_Less_Star_Greater
+                                                       FStar_Class_Monad.monad_option
+                                                       () ()
+                                                       (Obj.magic uu___20)
+                                                       (Obj.magic uu___21)) in
+                                                let uu___20 =
+                                                  FStar_TypeChecker_NBETerm.unembed
+                                                    (solve uu___7) cbs d1 in
+                                                Obj.magic
+                                                  (FStar_Class_Monad.op_Less_Star_Greater
+                                                     FStar_Class_Monad.monad_option
+                                                     () ()
+                                                     (Obj.magic uu___19)
+                                                     (Obj.magic uu___20)) in
+                                              let uu___19 =
+                                                FStar_TypeChecker_NBETerm.unembed
+                                                  (solve uu___9) cbs e1 in
+                                              Obj.magic
+                                                (FStar_Class_Monad.op_Less_Star_Greater
+                                                   FStar_Class_Monad.monad_option
+                                                   () () (Obj.magic uu___18)
+                                                   (Obj.magic uu___19)) in
+                                            FStar_Class_Monad.op_let_Bang
+                                              FStar_Class_Monad.monad_option
+                                              () () (Obj.magic uu___17)
+                                              (fun uu___18 ->
+                                                 (fun r1 ->
+                                                    let r1 = Obj.magic r1 in
+                                                    let uu___18 =
+                                                      FStar_TypeChecker_NBETerm.embed
+                                                        (solve uu___11) cbs
+                                                        r1 in
+                                                    Obj.magic
+                                                      (FStar_Class_Monad.return
+                                                         FStar_Class_Monad.monad_option
+                                                         ()
+                                                         (Obj.magic uu___18)))
+                                                   uu___18)))
+                                  | uu___12 ->
+                                      Obj.magic
+                                        (Obj.repr
+                                           FStar_Pervasives_Native.None) in
+                                as_primitive_step_nbecbs true
+                                  (name, (Prims.of_int (5)), u_arity, interp,
+                                    nbe_interp)
 let mixed_binary_op :
   'a 'b 'c .
     (FStar_Syntax_Syntax.arg -> 'a FStar_Pervasives_Native.option) ->
@@ -571,266 +1145,775 @@ let mixed_ternary_op :
                               | uu___2 -> FStar_Pervasives_Native.None)
                          | uu___1 -> FStar_Pervasives_Native.None)
                     | uu___ -> FStar_Pervasives_Native.None
+let decidable_eq :
+  'uuuuu 'uuuuu1 .
+    Prims.bool ->
+      psc ->
+        'uuuuu ->
+          'uuuuu1 ->
+            FStar_Syntax_Syntax.args ->
+              FStar_Syntax_Syntax.term FStar_Pervasives_Native.option
+  =
+  fun neg ->
+    fun psc1 ->
+      fun _norm_cb ->
+        fun _us ->
+          fun args ->
+            let r = psc1.psc_range in
+            let tru =
+              FStar_Syntax_Syntax.mk
+                (FStar_Syntax_Syntax.Tm_constant
+                   (FStar_Const.Const_bool true)) r in
+            let fal =
+              FStar_Syntax_Syntax.mk
+                (FStar_Syntax_Syntax.Tm_constant
+                   (FStar_Const.Const_bool false)) r in
+            match args with
+            | (_typ, uu___)::(a1, uu___1)::(a2, uu___2)::[] ->
+                let uu___3 = FStar_Syntax_Util.eq_tm a1 a2 in
+                (match uu___3 with
+                 | FStar_Syntax_Util.Equal ->
+                     FStar_Pervasives_Native.Some (if neg then fal else tru)
+                 | FStar_Syntax_Util.NotEqual ->
+                     FStar_Pervasives_Native.Some (if neg then tru else fal)
+                 | uu___4 -> FStar_Pervasives_Native.None)
+            | uu___ ->
+                FStar_Compiler_Effect.failwith
+                  "Unexpected number of arguments"
+let (and_op :
+  psc ->
+    FStar_Syntax_Embeddings_Base.norm_cb ->
+      FStar_Syntax_Syntax.universes ->
+        FStar_Syntax_Syntax.args ->
+          FStar_Syntax_Syntax.term FStar_Pervasives_Native.option)
+  =
+  fun psc1 ->
+    fun _norm_cb ->
+      fun _us ->
+        fun args ->
+          match args with
+          | (a1, FStar_Pervasives_Native.None)::(a2,
+                                                 FStar_Pervasives_Native.None)::[]
+              ->
+              let uu___ =
+                try_unembed_simple FStar_Syntax_Embeddings.e_bool a1 in
+              (match uu___ with
+               | FStar_Pervasives_Native.Some (false) ->
+                   let uu___1 =
+                     embed_simple FStar_Syntax_Embeddings.e_bool
+                       psc1.psc_range false in
+                   FStar_Pervasives_Native.Some uu___1
+               | FStar_Pervasives_Native.Some (true) ->
+                   FStar_Pervasives_Native.Some a2
+               | uu___1 -> FStar_Pervasives_Native.None)
+          | uu___ ->
+              FStar_Compiler_Effect.failwith "Unexpected number of arguments"
+let (or_op :
+  psc ->
+    FStar_Syntax_Embeddings_Base.norm_cb ->
+      FStar_Syntax_Syntax.universes ->
+        FStar_Syntax_Syntax.args ->
+          FStar_Syntax_Syntax.term FStar_Pervasives_Native.option)
+  =
+  fun psc1 ->
+    fun _norm_cb ->
+      fun _us ->
+        fun args ->
+          match args with
+          | (a1, FStar_Pervasives_Native.None)::(a2,
+                                                 FStar_Pervasives_Native.None)::[]
+              ->
+              let uu___ =
+                try_unembed_simple FStar_Syntax_Embeddings.e_bool a1 in
+              (match uu___ with
+               | FStar_Pervasives_Native.Some (true) ->
+                   let uu___1 =
+                     embed_simple FStar_Syntax_Embeddings.e_bool
+                       psc1.psc_range true in
+                   FStar_Pervasives_Native.Some uu___1
+               | FStar_Pervasives_Native.Some (false) ->
+                   FStar_Pervasives_Native.Some a2
+               | uu___1 -> FStar_Pervasives_Native.None)
+          | uu___ ->
+              FStar_Compiler_Effect.failwith "Unexpected number of arguments"
+let (division_modulus_op :
+  (FStar_BigInt.t -> FStar_BigInt.t -> FStar_BigInt.t) ->
+    FStar_BigInt.t ->
+      FStar_BigInt.t -> FStar_BigInt.t FStar_Pervasives_Native.option)
+  =
+  fun f ->
+    fun x ->
+      fun y ->
+        let uu___ =
+          let uu___1 = FStar_BigInt.to_int_fs y in uu___1 <> Prims.int_zero in
+        if uu___
+        then let uu___1 = f x y in FStar_Pervasives_Native.Some uu___1
+        else FStar_Pervasives_Native.None
+let (simple_ops : primitive_step Prims.list) =
+  let uu___ =
+    mk1 Prims.int_zero FStar_Parser_Const.string_of_int_lid
+      FStar_Syntax_Embeddings.e_int FStar_TypeChecker_NBETerm.e_int
+      FStar_Syntax_Embeddings.e_string FStar_TypeChecker_NBETerm.e_string
+      (fun z ->
+         let uu___1 = FStar_BigInt.to_int_fs z in Prims.string_of_int uu___1) in
+  let uu___1 =
+    let uu___2 =
+      mk1 Prims.int_zero FStar_Parser_Const.int_of_string_lid
+        FStar_Syntax_Embeddings.e_string FStar_TypeChecker_NBETerm.e_string
+        (FStar_Syntax_Embeddings.e_option FStar_Syntax_Embeddings.e_int)
+        (FStar_TypeChecker_NBETerm.e_option FStar_TypeChecker_NBETerm.e_int)
+        (fun s ->
+           let uu___3 = FStar_Compiler_Util.safe_int_of_string s in
+           FStar_Compiler_Util.map_opt uu___3 FStar_BigInt.of_int_fs) in
+    let uu___3 =
+      let uu___4 =
+        mk1 Prims.int_zero FStar_Parser_Const.string_of_bool_lid
+          FStar_Syntax_Embeddings.e_bool FStar_TypeChecker_NBETerm.e_bool
+          FStar_Syntax_Embeddings.e_string FStar_TypeChecker_NBETerm.e_string
+          Prims.string_of_bool in
+      let uu___5 =
+        let uu___6 =
+          mk1 Prims.int_zero FStar_Parser_Const.bool_of_string_lid
+            FStar_Syntax_Embeddings.e_string
+            FStar_TypeChecker_NBETerm.e_string
+            (FStar_Syntax_Embeddings.e_option FStar_Syntax_Embeddings.e_bool)
+            (FStar_TypeChecker_NBETerm.e_option
+               FStar_TypeChecker_NBETerm.e_bool)
+            (fun uu___7 ->
+               match uu___7 with
+               | "true" -> FStar_Pervasives_Native.Some true
+               | "false" -> FStar_Pervasives_Native.Some false
+               | uu___8 -> FStar_Pervasives_Native.None) in
+        let uu___7 =
+          let uu___8 =
+            mk1 Prims.int_zero FStar_Parser_Const.op_Minus
+              FStar_Syntax_Embeddings.e_int FStar_TypeChecker_NBETerm.e_int
+              FStar_Syntax_Embeddings.e_int FStar_TypeChecker_NBETerm.e_int
+              FStar_BigInt.minus_big_int in
+          let uu___9 =
+            let uu___10 =
+              mk2 Prims.int_zero FStar_Parser_Const.op_Addition
+                FStar_Syntax_Embeddings.e_int FStar_TypeChecker_NBETerm.e_int
+                FStar_Syntax_Embeddings.e_int FStar_TypeChecker_NBETerm.e_int
+                FStar_Syntax_Embeddings.e_int FStar_TypeChecker_NBETerm.e_int
+                FStar_BigInt.add_big_int in
+            let uu___11 =
+              let uu___12 =
+                mk2 Prims.int_zero FStar_Parser_Const.op_Subtraction
+                  FStar_Syntax_Embeddings.e_int
+                  FStar_TypeChecker_NBETerm.e_int
+                  FStar_Syntax_Embeddings.e_int
+                  FStar_TypeChecker_NBETerm.e_int
+                  FStar_Syntax_Embeddings.e_int
+                  FStar_TypeChecker_NBETerm.e_int FStar_BigInt.sub_big_int in
+              let uu___13 =
+                let uu___14 =
+                  mk2 Prims.int_zero FStar_Parser_Const.op_Multiply
+                    FStar_Syntax_Embeddings.e_int
+                    FStar_TypeChecker_NBETerm.e_int
+                    FStar_Syntax_Embeddings.e_int
+                    FStar_TypeChecker_NBETerm.e_int
+                    FStar_Syntax_Embeddings.e_int
+                    FStar_TypeChecker_NBETerm.e_int FStar_BigInt.mult_big_int in
+                let uu___15 =
+                  let uu___16 =
+                    mk2 Prims.int_zero FStar_Parser_Const.op_LT
+                      FStar_Syntax_Embeddings.e_int
+                      FStar_TypeChecker_NBETerm.e_int
+                      FStar_Syntax_Embeddings.e_int
+                      FStar_TypeChecker_NBETerm.e_int
+                      FStar_Syntax_Embeddings.e_bool
+                      FStar_TypeChecker_NBETerm.e_bool
+                      FStar_BigInt.lt_big_int in
+                  let uu___17 =
+                    let uu___18 =
+                      mk2 Prims.int_zero FStar_Parser_Const.op_LTE
+                        FStar_Syntax_Embeddings.e_int
+                        FStar_TypeChecker_NBETerm.e_int
+                        FStar_Syntax_Embeddings.e_int
+                        FStar_TypeChecker_NBETerm.e_int
+                        FStar_Syntax_Embeddings.e_bool
+                        FStar_TypeChecker_NBETerm.e_bool
+                        FStar_BigInt.le_big_int in
+                    let uu___19 =
+                      let uu___20 =
+                        mk2 Prims.int_zero FStar_Parser_Const.op_GT
+                          FStar_Syntax_Embeddings.e_int
+                          FStar_TypeChecker_NBETerm.e_int
+                          FStar_Syntax_Embeddings.e_int
+                          FStar_TypeChecker_NBETerm.e_int
+                          FStar_Syntax_Embeddings.e_bool
+                          FStar_TypeChecker_NBETerm.e_bool
+                          FStar_BigInt.gt_big_int in
+                      let uu___21 =
+                        let uu___22 =
+                          mk2 Prims.int_zero FStar_Parser_Const.op_GTE
+                            FStar_Syntax_Embeddings.e_int
+                            FStar_TypeChecker_NBETerm.e_int
+                            FStar_Syntax_Embeddings.e_int
+                            FStar_TypeChecker_NBETerm.e_int
+                            FStar_Syntax_Embeddings.e_bool
+                            FStar_TypeChecker_NBETerm.e_bool
+                            FStar_BigInt.ge_big_int in
+                        let uu___23 =
+                          let uu___24 =
+                            mk2' Prims.int_zero
+                              FStar_Parser_Const.op_Division
+                              FStar_Syntax_Embeddings.e_int
+                              FStar_TypeChecker_NBETerm.e_int
+                              FStar_Syntax_Embeddings.e_int
+                              FStar_TypeChecker_NBETerm.e_int
+                              FStar_Syntax_Embeddings.e_int
+                              FStar_TypeChecker_NBETerm.e_int
+                              (division_modulus_op FStar_BigInt.div_big_int) in
+                          let uu___25 =
+                            let uu___26 =
+                              mk2' Prims.int_zero
+                                FStar_Parser_Const.op_Modulus
+                                FStar_Syntax_Embeddings.e_int
+                                FStar_TypeChecker_NBETerm.e_int
+                                FStar_Syntax_Embeddings.e_int
+                                FStar_TypeChecker_NBETerm.e_int
+                                FStar_Syntax_Embeddings.e_int
+                                FStar_TypeChecker_NBETerm.e_int
+                                (division_modulus_op FStar_BigInt.mod_big_int) in
+                            let uu___27 =
+                              let uu___28 =
+                                mk1 Prims.int_zero
+                                  FStar_Parser_Const.op_Negation
+                                  FStar_Syntax_Embeddings.e_bool
+                                  FStar_TypeChecker_NBETerm.e_bool
+                                  FStar_Syntax_Embeddings.e_bool
+                                  FStar_TypeChecker_NBETerm.e_bool
+                                  Prims.op_Negation in
+                              let uu___29 =
+                                let uu___30 =
+                                  mk2 Prims.int_zero
+                                    FStar_Parser_Const.string_concat_lid
+                                    FStar_Syntax_Embeddings.e_string
+                                    FStar_TypeChecker_NBETerm.e_string
+                                    FStar_Syntax_Embeddings.e_string_list
+                                    FStar_TypeChecker_NBETerm.e_string_list
+                                    FStar_Syntax_Embeddings.e_string
+                                    FStar_TypeChecker_NBETerm.e_string
+                                    FStar_Compiler_String.concat in
+                                let uu___31 =
+                                  let uu___32 =
+                                    mk2 Prims.int_zero
+                                      FStar_Parser_Const.string_split_lid
+                                      (FStar_Syntax_Embeddings.e_list
+                                         FStar_Syntax_Embeddings.e_char)
+                                      (FStar_TypeChecker_NBETerm.e_list
+                                         FStar_TypeChecker_NBETerm.e_char)
+                                      FStar_Syntax_Embeddings.e_string
+                                      FStar_TypeChecker_NBETerm.e_string
+                                      FStar_Syntax_Embeddings.e_string_list
+                                      FStar_TypeChecker_NBETerm.e_string_list
+                                      FStar_Compiler_String.split in
+                                  let uu___33 =
+                                    let uu___34 =
+                                      mk2 Prims.int_zero
+                                        FStar_Parser_Const.prims_strcat_lid
+                                        FStar_Syntax_Embeddings.e_string
+                                        FStar_TypeChecker_NBETerm.e_string
+                                        FStar_Syntax_Embeddings.e_string
+                                        FStar_TypeChecker_NBETerm.e_string
+                                        FStar_Syntax_Embeddings.e_string
+                                        FStar_TypeChecker_NBETerm.e_string
+                                        (fun s1 ->
+                                           fun s2 -> Prims.strcat s1 s2) in
+                                    let uu___35 =
+                                      let uu___36 =
+                                        mk2 Prims.int_zero
+                                          FStar_Parser_Const.string_compare_lid
+                                          FStar_Syntax_Embeddings.e_string
+                                          FStar_TypeChecker_NBETerm.e_string
+                                          FStar_Syntax_Embeddings.e_string
+                                          FStar_TypeChecker_NBETerm.e_string
+                                          FStar_Syntax_Embeddings.e_int
+                                          FStar_TypeChecker_NBETerm.e_int
+                                          (fun s1 ->
+                                             fun s2 ->
+                                               FStar_BigInt.of_int_fs
+                                                 (FStar_Compiler_String.compare
+                                                    s1 s2)) in
+                                      let uu___37 =
+                                        let uu___38 =
+                                          mk1 Prims.int_zero
+                                            FStar_Parser_Const.string_string_of_list_lid
+                                            (FStar_Syntax_Embeddings.e_list
+                                               FStar_Syntax_Embeddings.e_char)
+                                            (FStar_TypeChecker_NBETerm.e_list
+                                               FStar_TypeChecker_NBETerm.e_char)
+                                            FStar_Syntax_Embeddings.e_string
+                                            FStar_TypeChecker_NBETerm.e_string
+                                            FStar_String.string_of_list in
+                                        let uu___39 =
+                                          let uu___40 =
+                                            mk2 Prims.int_zero
+                                              FStar_Parser_Const.string_make_lid
+                                              FStar_Syntax_Embeddings.e_int
+                                              FStar_TypeChecker_NBETerm.e_int
+                                              FStar_Syntax_Embeddings.e_char
+                                              FStar_TypeChecker_NBETerm.e_char
+                                              FStar_Syntax_Embeddings.e_string
+                                              FStar_TypeChecker_NBETerm.e_string
+                                              (fun x ->
+                                                 fun y ->
+                                                   let uu___41 =
+                                                     FStar_BigInt.to_int_fs x in
+                                                   FStar_Compiler_String.make
+                                                     uu___41 y) in
+                                          let uu___41 =
+                                            let uu___42 =
+                                              mk1 Prims.int_zero
+                                                FStar_Parser_Const.string_list_of_string_lid
+                                                FStar_Syntax_Embeddings.e_string
+                                                FStar_TypeChecker_NBETerm.e_string
+                                                (FStar_Syntax_Embeddings.e_list
+                                                   FStar_Syntax_Embeddings.e_char)
+                                                (FStar_TypeChecker_NBETerm.e_list
+                                                   FStar_TypeChecker_NBETerm.e_char)
+                                                FStar_String.list_of_string in
+                                            let uu___43 =
+                                              let uu___44 =
+                                                mk1 Prims.int_zero
+                                                  FStar_Parser_Const.string_lowercase_lid
+                                                  FStar_Syntax_Embeddings.e_string
+                                                  FStar_TypeChecker_NBETerm.e_string
+                                                  FStar_Syntax_Embeddings.e_string
+                                                  FStar_TypeChecker_NBETerm.e_string
+                                                  FStar_Compiler_String.lowercase in
+                                              let uu___45 =
+                                                let uu___46 =
+                                                  mk1 Prims.int_zero
+                                                    FStar_Parser_Const.string_uppercase_lid
+                                                    FStar_Syntax_Embeddings.e_string
+                                                    FStar_TypeChecker_NBETerm.e_string
+                                                    FStar_Syntax_Embeddings.e_string
+                                                    FStar_TypeChecker_NBETerm.e_string
+                                                    FStar_Compiler_String.uppercase in
+                                                let uu___47 =
+                                                  let uu___48 =
+                                                    mk2 Prims.int_zero
+                                                      FStar_Parser_Const.string_index_lid
+                                                      FStar_Syntax_Embeddings.e_string
+                                                      FStar_TypeChecker_NBETerm.e_string
+                                                      FStar_Syntax_Embeddings.e_int
+                                                      FStar_TypeChecker_NBETerm.e_int
+                                                      FStar_Syntax_Embeddings.e_char
+                                                      FStar_TypeChecker_NBETerm.e_char
+                                                      FStar_Compiler_String.index in
+                                                  let uu___49 =
+                                                    let uu___50 =
+                                                      mk2 Prims.int_zero
+                                                        FStar_Parser_Const.string_index_of_lid
+                                                        FStar_Syntax_Embeddings.e_string
+                                                        FStar_TypeChecker_NBETerm.e_string
+                                                        FStar_Syntax_Embeddings.e_char
+                                                        FStar_TypeChecker_NBETerm.e_char
+                                                        FStar_Syntax_Embeddings.e_int
+                                                        FStar_TypeChecker_NBETerm.e_int
+                                                        FStar_Compiler_String.index_of in
+                                                    let uu___51 =
+                                                      let uu___52 =
+                                                        mk3 Prims.int_zero
+                                                          FStar_Parser_Const.string_sub_lid
+                                                          FStar_Syntax_Embeddings.e_string
+                                                          FStar_TypeChecker_NBETerm.e_string
+                                                          FStar_Syntax_Embeddings.e_int
+                                                          FStar_TypeChecker_NBETerm.e_int
+                                                          FStar_Syntax_Embeddings.e_int
+                                                          FStar_TypeChecker_NBETerm.e_int
+                                                          FStar_Syntax_Embeddings.e_string
+                                                          FStar_TypeChecker_NBETerm.e_string
+                                                          (fun s ->
+                                                             fun o ->
+                                                               fun l ->
+                                                                 let uu___53
+                                                                   =
+                                                                   FStar_BigInt.to_int_fs
+                                                                    o in
+                                                                 let uu___54
+                                                                   =
+                                                                   FStar_BigInt.to_int_fs
+                                                                    l in
+                                                                 FStar_Compiler_String.substring
+                                                                   s uu___53
+                                                                   uu___54) in
+                                                      let uu___53 =
+                                                        let uu___54 =
+                                                          mk5 Prims.int_zero
+                                                            FStar_Parser_Const.mk_range_lid
+                                                            FStar_Syntax_Embeddings.e_string
+                                                            FStar_TypeChecker_NBETerm.e_string
+                                                            FStar_Syntax_Embeddings.e_int
+                                                            FStar_TypeChecker_NBETerm.e_int
+                                                            FStar_Syntax_Embeddings.e_int
+                                                            FStar_TypeChecker_NBETerm.e_int
+                                                            FStar_Syntax_Embeddings.e_int
+                                                            FStar_TypeChecker_NBETerm.e_int
+                                                            FStar_Syntax_Embeddings.e_int
+                                                            FStar_TypeChecker_NBETerm.e_int
+                                                            FStar_Syntax_Embeddings.e_range
+                                                            FStar_TypeChecker_NBETerm.e_range
+                                                            (fun fn ->
+                                                               fun from_l ->
+                                                                 fun from_c
+                                                                   ->
+                                                                   fun to_l
+                                                                    ->
+                                                                    fun to_c
+                                                                    ->
+                                                                    let uu___55
+                                                                    =
+                                                                    let uu___56
+                                                                    =
+                                                                    FStar_BigInt.to_int_fs
+                                                                    from_l in
+                                                                    let uu___57
+                                                                    =
+                                                                    FStar_BigInt.to_int_fs
+                                                                    from_c in
+                                                                    FStar_Compiler_Range_Type.mk_pos
+                                                                    uu___56
+                                                                    uu___57 in
+                                                                    let uu___56
+                                                                    =
+                                                                    let uu___57
+                                                                    =
+                                                                    FStar_BigInt.to_int_fs
+                                                                    to_l in
+                                                                    let uu___58
+                                                                    =
+                                                                    FStar_BigInt.to_int_fs
+                                                                    to_c in
+                                                                    FStar_Compiler_Range_Type.mk_pos
+                                                                    uu___57
+                                                                    uu___58 in
+                                                                    FStar_Compiler_Range_Type.mk_range
+                                                                    fn
+                                                                    uu___55
+                                                                    uu___56) in
+                                                        [uu___54] in
+                                                      uu___52 :: uu___53 in
+                                                    uu___50 :: uu___51 in
+                                                  uu___48 :: uu___49 in
+                                                uu___46 :: uu___47 in
+                                              uu___44 :: uu___45 in
+                                            uu___42 :: uu___43 in
+                                          uu___40 :: uu___41 in
+                                        uu___38 :: uu___39 in
+                                      uu___36 :: uu___37 in
+                                    uu___34 :: uu___35 in
+                                  uu___32 :: uu___33 in
+                                uu___30 :: uu___31 in
+                              uu___28 :: uu___29 in
+                            uu___26 :: uu___27 in
+                          uu___24 :: uu___25 in
+                        uu___22 :: uu___23 in
+                      uu___20 :: uu___21 in
+                    uu___18 :: uu___19 in
+                  uu___16 :: uu___17 in
+                uu___14 :: uu___15 in
+              uu___12 :: uu___13 in
+            uu___10 :: uu___11 in
+          uu___8 :: uu___9 in
+        uu___6 :: uu___7 in
+      uu___4 :: uu___5 in
+    uu___2 :: uu___3 in
+  uu___ :: uu___1
+let (bogus_cbs : FStar_TypeChecker_NBETerm.nbe_cbs) =
+  {
+    FStar_TypeChecker_NBETerm.iapp = (fun h -> fun _args -> h);
+    FStar_TypeChecker_NBETerm.translate =
+      (fun uu___ -> FStar_Compiler_Effect.failwith "bogus_cbs translate")
+  }
+let (issue_ops : primitive_step Prims.list) =
+  let mk_lid l = FStar_Parser_Const.p2l ["FStar"; "Issue"; l] in
+  let uu___ =
+    let uu___1 = mk_lid "message_of_issue" in
+    mk1 Prims.int_zero uu___1 FStar_Syntax_Embeddings.e_issue
+      FStar_TypeChecker_NBETerm.e_issue
+      (FStar_Syntax_Embeddings.e_list FStar_Syntax_Embeddings.e_document)
+      (FStar_TypeChecker_NBETerm.e_list FStar_TypeChecker_NBETerm.e_document)
+      FStar_Errors.__proj__Mkissue__item__issue_msg in
+  let uu___1 =
+    let uu___2 =
+      let uu___3 = mk_lid "level_of_issue" in
+      mk1 Prims.int_zero uu___3 FStar_Syntax_Embeddings.e_issue
+        FStar_TypeChecker_NBETerm.e_issue FStar_Syntax_Embeddings.e_string
+        FStar_TypeChecker_NBETerm.e_string
+        (fun i ->
+           FStar_Errors.string_of_issue_level i.FStar_Errors.issue_level) in
+    let uu___3 =
+      let uu___4 =
+        let uu___5 = mk_lid "number_of_issue" in
+        mk1 Prims.int_zero uu___5 FStar_Syntax_Embeddings.e_issue
+          FStar_TypeChecker_NBETerm.e_issue
+          (FStar_Syntax_Embeddings.e_option FStar_Syntax_Embeddings.e_int)
+          (FStar_TypeChecker_NBETerm.e_option FStar_TypeChecker_NBETerm.e_int)
+          (fun i ->
+             FStar_Compiler_Util.map_opt i.FStar_Errors.issue_number
+               FStar_BigInt.of_int_fs) in
+      let uu___5 =
+        let uu___6 =
+          let uu___7 = mk_lid "range_of_issue" in
+          mk1 Prims.int_zero uu___7 FStar_Syntax_Embeddings.e_issue
+            FStar_TypeChecker_NBETerm.e_issue
+            (FStar_Syntax_Embeddings.e_option FStar_Syntax_Embeddings.e_range)
+            (FStar_TypeChecker_NBETerm.e_option
+               FStar_TypeChecker_NBETerm.e_range)
+            FStar_Errors.__proj__Mkissue__item__issue_range in
+        let uu___7 =
+          let uu___8 =
+            let uu___9 = mk_lid "context_of_issue" in
+            mk1 Prims.int_zero uu___9 FStar_Syntax_Embeddings.e_issue
+              FStar_TypeChecker_NBETerm.e_issue
+              FStar_Syntax_Embeddings.e_string_list
+              FStar_TypeChecker_NBETerm.e_string_list
+              FStar_Errors.__proj__Mkissue__item__issue_ctx in
+          let uu___9 =
+            let uu___10 =
+              let uu___11 = mk_lid "render_issue" in
+              mk1 Prims.int_zero uu___11 FStar_Syntax_Embeddings.e_issue
+                FStar_TypeChecker_NBETerm.e_issue
+                FStar_Syntax_Embeddings.e_string
+                FStar_TypeChecker_NBETerm.e_string FStar_Errors.format_issue in
+            let uu___11 =
+              let uu___12 =
+                let uu___13 = mk_lid "mk_issue_doc" in
+                mk5 Prims.int_zero uu___13 FStar_Syntax_Embeddings.e_string
+                  FStar_TypeChecker_NBETerm.e_string
+                  (FStar_Syntax_Embeddings.e_list
+                     FStar_Syntax_Embeddings.e_document)
+                  (FStar_TypeChecker_NBETerm.e_list
+                     FStar_TypeChecker_NBETerm.e_document)
+                  (FStar_Syntax_Embeddings.e_option
+                     FStar_Syntax_Embeddings.e_range)
+                  (FStar_TypeChecker_NBETerm.e_option
+                     FStar_TypeChecker_NBETerm.e_range)
+                  (FStar_Syntax_Embeddings.e_option
+                     FStar_Syntax_Embeddings.e_int)
+                  (FStar_TypeChecker_NBETerm.e_option
+                     FStar_TypeChecker_NBETerm.e_int)
+                  FStar_Syntax_Embeddings.e_string_list
+                  FStar_TypeChecker_NBETerm.e_string_list
+                  FStar_Syntax_Embeddings.e_issue
+                  FStar_TypeChecker_NBETerm.e_issue
+                  (fun level ->
+                     fun msg ->
+                       fun range ->
+                         fun number ->
+                           fun context ->
+                             let uu___14 =
+                               FStar_Errors.issue_level_of_string level in
+                             let uu___15 =
+                               FStar_Compiler_Util.map_opt number
+                                 FStar_BigInt.to_int_fs in
+                             {
+                               FStar_Errors.issue_msg = msg;
+                               FStar_Errors.issue_level = uu___14;
+                               FStar_Errors.issue_range = range;
+                               FStar_Errors.issue_number = uu___15;
+                               FStar_Errors.issue_ctx = context
+                             }) in
+              [uu___12] in
+            uu___10 :: uu___11 in
+          uu___8 :: uu___9 in
+        uu___6 :: uu___7 in
+      uu___4 :: uu___5 in
+    uu___2 :: uu___3 in
+  uu___ :: uu___1
+let (doc_ops : primitive_step Prims.list) =
+  let mk_lid l = FStar_Parser_Const.p2l ["FStar"; "Stubs"; "Pprint"; l] in
+  let uu___ =
+    let uu___1 = mk_lid "arbitrary_string" in
+    mk1 Prims.int_zero uu___1 FStar_Syntax_Embeddings.e_string
+      FStar_TypeChecker_NBETerm.e_string FStar_Syntax_Embeddings.e_document
+      FStar_TypeChecker_NBETerm.e_document FStar_Pprint.arbitrary_string in
+  let uu___1 =
+    let uu___2 =
+      let uu___3 = mk_lid "render" in
+      mk1 Prims.int_zero uu___3 FStar_Syntax_Embeddings.e_document
+        FStar_TypeChecker_NBETerm.e_document FStar_Syntax_Embeddings.e_string
+        FStar_TypeChecker_NBETerm.e_string FStar_Pprint.render in
+    [uu___2] in
+  uu___ :: uu___1
+let (seal_steps : primitive_step Prims.list) =
+  FStar_Compiler_List.map
+    (fun p ->
+       let uu___ = as_primitive_step_nbecbs true p in
+       {
+         name = (uu___.name);
+         arity = (uu___.arity);
+         univ_arity = (uu___.univ_arity);
+         auto_reflect = (uu___.auto_reflect);
+         strong_reduction_ok = (uu___.strong_reduction_ok);
+         requires_binder_substitution = (uu___.requires_binder_substitution);
+         renorm_after = true;
+         interpretation = (uu___.interpretation);
+         interpretation_nbe = (uu___.interpretation_nbe)
+       })
+    [(FStar_Parser_Const.map_seal_lid, (Prims.of_int (4)),
+       (Prims.of_int (2)),
+       ((fun psc1 ->
+           fun univs ->
+             fun cbs ->
+               fun args ->
+                 match args with
+                 | (ta, uu___)::(tb, uu___1)::(s, uu___2)::(f, uu___3)::[] ->
+                     let try_unembed e x =
+                       FStar_Syntax_Embeddings_Base.try_unembed e x
+                         FStar_Syntax_Embeddings_Base.id_norm_cb in
+                     let uu___4 =
+                       let uu___5 =
+                         try_unembed FStar_Syntax_Embeddings.e_any ta in
+                       let uu___6 =
+                         try_unembed FStar_Syntax_Embeddings.e_any tb in
+                       let uu___7 =
+                         try_unembed
+                           (FStar_Syntax_Embeddings.e_sealed
+                              FStar_Syntax_Embeddings.e_any) s in
+                       let uu___8 =
+                         try_unembed FStar_Syntax_Embeddings.e_any f in
+                       (uu___5, uu___6, uu___7, uu___8) in
+                     (match uu___4 with
+                      | (FStar_Pervasives_Native.Some ta1,
+                         FStar_Pervasives_Native.Some tb1,
+                         FStar_Pervasives_Native.Some s1,
+                         FStar_Pervasives_Native.Some f1) ->
+                          let r =
+                            let uu___5 =
+                              let uu___6 = FStar_Syntax_Syntax.as_arg s1 in
+                              [uu___6] in
+                            FStar_Syntax_Util.mk_app f1 uu___5 in
+                          let emb =
+                            FStar_Syntax_Embeddings_Base.set_type ta1
+                              FStar_Syntax_Embeddings.e_any in
+                          let uu___5 =
+                            embed_simple
+                              (FStar_Syntax_Embeddings.e_sealed emb)
+                              psc1.psc_range r in
+                          FStar_Pervasives_Native.Some uu___5
+                      | uu___5 -> FStar_Pervasives_Native.None)
+                 | uu___ -> FStar_Pervasives_Native.None)),
+       ((fun cb ->
+           fun univs ->
+             fun args ->
+               match args with
+               | (ta, uu___)::(tb, uu___1)::(s, uu___2)::(f, uu___3)::[] ->
+                   let try_unembed e x =
+                     FStar_TypeChecker_NBETerm.unembed e bogus_cbs x in
+                   let uu___4 =
+                     let uu___5 =
+                       try_unembed FStar_TypeChecker_NBETerm.e_any ta in
+                     let uu___6 =
+                       try_unembed FStar_TypeChecker_NBETerm.e_any tb in
+                     let uu___7 =
+                       let uu___8 =
+                         FStar_TypeChecker_NBETerm.e_sealed
+                           FStar_TypeChecker_NBETerm.e_any in
+                       try_unembed uu___8 s in
+                     let uu___8 =
+                       try_unembed FStar_TypeChecker_NBETerm.e_any f in
+                     (uu___5, uu___6, uu___7, uu___8) in
+                   (match uu___4 with
+                    | (FStar_Pervasives_Native.Some ta1,
+                       FStar_Pervasives_Native.Some tb1,
+                       FStar_Pervasives_Native.Some s1,
+                       FStar_Pervasives_Native.Some f1) ->
+                        let r =
+                          let uu___5 =
+                            let uu___6 = FStar_TypeChecker_NBETerm.as_arg s1 in
+                            [uu___6] in
+                          cb.FStar_TypeChecker_NBETerm.iapp f1 uu___5 in
+                        let emb =
+                          FStar_TypeChecker_NBETerm.set_type ta1
+                            FStar_TypeChecker_NBETerm.e_any in
+                        let uu___5 =
+                          let uu___6 = FStar_TypeChecker_NBETerm.e_sealed emb in
+                          FStar_TypeChecker_NBETerm.embed uu___6 cb r in
+                        FStar_Pervasives_Native.Some uu___5
+                    | uu___5 -> FStar_Pervasives_Native.None)
+               | uu___ -> FStar_Pervasives_Native.None)));
+    (FStar_Parser_Const.bind_seal_lid, (Prims.of_int (4)),
+      (Prims.of_int (2)),
+      ((fun psc1 ->
+          fun univs ->
+            fun cbs ->
+              fun args ->
+                match args with
+                | (ta, uu___)::(tb, uu___1)::(s, uu___2)::(f, uu___3)::[] ->
+                    let try_unembed e x =
+                      FStar_Syntax_Embeddings_Base.try_unembed e x
+                        FStar_Syntax_Embeddings_Base.id_norm_cb in
+                    let uu___4 =
+                      let uu___5 =
+                        try_unembed FStar_Syntax_Embeddings.e_any ta in
+                      let uu___6 =
+                        try_unembed FStar_Syntax_Embeddings.e_any tb in
+                      let uu___7 =
+                        try_unembed
+                          (FStar_Syntax_Embeddings.e_sealed
+                             FStar_Syntax_Embeddings.e_any) s in
+                      let uu___8 =
+                        try_unembed FStar_Syntax_Embeddings.e_any f in
+                      (uu___5, uu___6, uu___7, uu___8) in
+                    (match uu___4 with
+                     | (FStar_Pervasives_Native.Some ta1,
+                        FStar_Pervasives_Native.Some tb1,
+                        FStar_Pervasives_Native.Some s1,
+                        FStar_Pervasives_Native.Some f1) ->
+                         let r =
+                           let uu___5 =
+                             let uu___6 = FStar_Syntax_Syntax.as_arg s1 in
+                             [uu___6] in
+                           FStar_Syntax_Util.mk_app f1 uu___5 in
+                         let uu___5 =
+                           embed_simple FStar_Syntax_Embeddings.e_any
+                             psc1.psc_range r in
+                         FStar_Pervasives_Native.Some uu___5
+                     | uu___5 -> FStar_Pervasives_Native.None)
+                | uu___ -> FStar_Pervasives_Native.None)),
+      ((fun cb ->
+          fun univs ->
+            fun args ->
+              match args with
+              | (ta, uu___)::(tb, uu___1)::(s, uu___2)::(f, uu___3)::[] ->
+                  let try_unembed e x =
+                    FStar_TypeChecker_NBETerm.unembed e bogus_cbs x in
+                  let uu___4 =
+                    let uu___5 =
+                      try_unembed FStar_TypeChecker_NBETerm.e_any ta in
+                    let uu___6 =
+                      try_unembed FStar_TypeChecker_NBETerm.e_any tb in
+                    let uu___7 =
+                      let uu___8 =
+                        FStar_TypeChecker_NBETerm.e_sealed
+                          FStar_TypeChecker_NBETerm.e_any in
+                      try_unembed uu___8 s in
+                    let uu___8 =
+                      try_unembed FStar_TypeChecker_NBETerm.e_any f in
+                    (uu___5, uu___6, uu___7, uu___8) in
+                  (match uu___4 with
+                   | (FStar_Pervasives_Native.Some ta1,
+                      FStar_Pervasives_Native.Some tb1,
+                      FStar_Pervasives_Native.Some s1,
+                      FStar_Pervasives_Native.Some f1) ->
+                       let r =
+                         let uu___5 =
+                           let uu___6 = FStar_TypeChecker_NBETerm.as_arg s1 in
+                           [uu___6] in
+                         cb.FStar_TypeChecker_NBETerm.iapp f1 uu___5 in
+                       let emb =
+                         FStar_TypeChecker_NBETerm.set_type ta1
+                           FStar_TypeChecker_NBETerm.e_any in
+                       let uu___5 = FStar_TypeChecker_NBETerm.embed emb cb r in
+                       FStar_Pervasives_Native.Some uu___5
+                   | uu___5 -> FStar_Pervasives_Native.None)
+              | uu___ -> FStar_Pervasives_Native.None)))]
 let (built_in_primitive_steps_list : primitive_step Prims.list) =
-  let list_of_string' rng s =
-    let name l =
-      let uu___ =
-        let uu___1 =
-          FStar_Syntax_Syntax.lid_as_fv l FStar_Pervasives_Native.None in
-        FStar_Syntax_Syntax.Tm_fvar uu___1 in
-      FStar_Syntax_Syntax.mk uu___ rng in
-    let char_t = name FStar_Parser_Const.char_lid in
-    let charterm c =
-      FStar_Syntax_Syntax.mk
-        (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_char c)) rng in
-    let uu___ =
-      FStar_Compiler_List.map charterm (FStar_String.list_of_string s) in
-    FStar_Syntax_Util.mk_list char_t rng uu___ in
-  let string_of_list' rng l =
-    let s = FStar_String.string_of_list l in FStar_Syntax_Util.exp_string s in
-  let string_compare' rng s1 s2 =
-    let r = FStar_Compiler_String.compare s1 s2 in
-    let uu___ =
-      let uu___1 = FStar_Compiler_Util.string_of_int r in
-      FStar_BigInt.big_int_of_string uu___1 in
-    embed_simple FStar_Syntax_Embeddings.e_int rng uu___ in
-  let string_concat' psc1 _n _us args =
-    match args with
-    | a1::a2::[] ->
-        let uu___ = arg_as_string a1 in
-        (match uu___ with
-         | FStar_Pervasives_Native.Some s1 ->
-             let uu___1 = arg_as_list FStar_Syntax_Embeddings.e_string a2 in
-             (match uu___1 with
-              | FStar_Pervasives_Native.Some s2 ->
-                  let r = FStar_Compiler_String.concat s1 s2 in
-                  let uu___2 =
-                    embed_simple FStar_Syntax_Embeddings.e_string
-                      psc1.psc_range r in
-                  FStar_Pervasives_Native.Some uu___2
-              | uu___2 -> FStar_Pervasives_Native.None)
-         | uu___1 -> FStar_Pervasives_Native.None)
-    | uu___ -> FStar_Pervasives_Native.None in
-  let string_split' psc1 _norm_cb _us args =
-    match args with
-    | a1::a2::[] ->
-        let uu___ = arg_as_list FStar_Syntax_Embeddings.e_char a1 in
-        (match uu___ with
-         | FStar_Pervasives_Native.Some s1 ->
-             let uu___1 = arg_as_string a2 in
-             (match uu___1 with
-              | FStar_Pervasives_Native.Some s2 ->
-                  let r = FStar_Compiler_String.split s1 s2 in
-                  let uu___2 =
-                    embed_simple FStar_Syntax_Embeddings.e_string_list
-                      psc1.psc_range r in
-                  FStar_Pervasives_Native.Some uu___2
-              | uu___2 -> FStar_Pervasives_Native.None)
-         | uu___1 -> FStar_Pervasives_Native.None)
-    | uu___ -> FStar_Pervasives_Native.None in
-  let string_substring' psc1 _norm_cb _us args =
-    match args with
-    | a1::a2::a3::[] ->
-        let uu___ =
-          let uu___1 = arg_as_string a1 in
-          let uu___2 = arg_as_int a2 in
-          let uu___3 = arg_as_int a3 in (uu___1, uu___2, uu___3) in
-        (match uu___ with
-         | (FStar_Pervasives_Native.Some s1, FStar_Pervasives_Native.Some n1,
-            FStar_Pervasives_Native.Some n2) ->
-             let n11 = FStar_BigInt.to_int_fs n1 in
-             let n21 = FStar_BigInt.to_int_fs n2 in
-             (try
-                (fun uu___1 ->
-                   match () with
-                   | () ->
-                       let r = FStar_Compiler_String.substring s1 n11 n21 in
-                       let uu___2 =
-                         embed_simple FStar_Syntax_Embeddings.e_string
-                           psc1.psc_range r in
-                       FStar_Pervasives_Native.Some uu___2) ()
-              with | uu___1 -> FStar_Pervasives_Native.None)
-         | uu___1 -> FStar_Pervasives_Native.None)
-    | uu___ -> FStar_Pervasives_Native.None in
-  let string_of_int rng i =
-    let uu___ = FStar_BigInt.string_of_big_int i in
-    embed_simple FStar_Syntax_Embeddings.e_string rng uu___ in
-  let string_of_bool rng b =
-    embed_simple FStar_Syntax_Embeddings.e_string rng
-      (if b then "true" else "false") in
-  let int_of_string rng s =
-    let r = FStar_Compiler_Util.safe_int_of_string s in
-    embed_simple
-      (FStar_Syntax_Embeddings.e_option FStar_Syntax_Embeddings.e_fsint) rng
-      r in
-  let bool_of_string rng s =
-    let r =
-      match s with
-      | "true" -> FStar_Pervasives_Native.Some true
-      | "false" -> FStar_Pervasives_Native.Some false
-      | uu___ -> FStar_Pervasives_Native.None in
-    embed_simple
-      (FStar_Syntax_Embeddings.e_option FStar_Syntax_Embeddings.e_bool) rng r in
-  let lowercase rng s =
-    embed_simple FStar_Syntax_Embeddings.e_string rng
-      (FStar_Compiler_String.lowercase s) in
-  let uppercase rng s =
-    embed_simple FStar_Syntax_Embeddings.e_string rng
-      (FStar_Compiler_String.uppercase s) in
-  let string_index psc1 _norm_cb _us args =
-    match args with
-    | a1::a2::[] ->
-        let uu___ =
-          let uu___1 = arg_as_string a1 in
-          let uu___2 = arg_as_int a2 in (uu___1, uu___2) in
-        (match uu___ with
-         | (FStar_Pervasives_Native.Some s, FStar_Pervasives_Native.Some i)
-             ->
-             (try
-                (fun uu___1 ->
-                   match () with
-                   | () ->
-                       let r = FStar_Compiler_String.index s i in
-                       let uu___2 =
-                         embed_simple FStar_Syntax_Embeddings.e_char
-                           psc1.psc_range r in
-                       FStar_Pervasives_Native.Some uu___2) ()
-              with | uu___1 -> FStar_Pervasives_Native.None)
-         | uu___1 -> FStar_Pervasives_Native.None)
-    | uu___ -> FStar_Pervasives_Native.None in
-  let string_index_of psc1 _norm_cb _us args =
-    match args with
-    | a1::a2::[] ->
-        let uu___ =
-          let uu___1 = arg_as_string a1 in
-          let uu___2 = arg_as_char a2 in (uu___1, uu___2) in
-        (match uu___ with
-         | (FStar_Pervasives_Native.Some s, FStar_Pervasives_Native.Some c)
-             ->
-             (try
-                (fun uu___1 ->
-                   match () with
-                   | () ->
-                       let r = FStar_Compiler_String.index_of s c in
-                       let uu___2 =
-                         embed_simple FStar_Syntax_Embeddings.e_int
-                           psc1.psc_range r in
-                       FStar_Pervasives_Native.Some uu___2) ()
-              with | uu___1 -> FStar_Pervasives_Native.None)
-         | uu___1 -> FStar_Pervasives_Native.None)
-    | uu___ -> FStar_Pervasives_Native.None in
-  let mk_range psc1 _norm_cb _us args =
-    match args with
-    | fn::from_line::from_col::to_line::to_col::[] ->
-        let uu___ =
-          let uu___1 = arg_as_string fn in
-          let uu___2 = arg_as_int from_line in
-          let uu___3 = arg_as_int from_col in
-          let uu___4 = arg_as_int to_line in
-          let uu___5 = arg_as_int to_col in
-          (uu___1, uu___2, uu___3, uu___4, uu___5) in
-        (match uu___ with
-         | (FStar_Pervasives_Native.Some fn1, FStar_Pervasives_Native.Some
-            from_l, FStar_Pervasives_Native.Some from_c,
-            FStar_Pervasives_Native.Some to_l, FStar_Pervasives_Native.Some
-            to_c) ->
-             let r =
-               let uu___1 =
-                 let uu___2 = FStar_BigInt.to_int_fs from_l in
-                 let uu___3 = FStar_BigInt.to_int_fs from_c in
-                 FStar_Compiler_Range_Type.mk_pos uu___2 uu___3 in
-               let uu___2 =
-                 let uu___3 = FStar_BigInt.to_int_fs to_l in
-                 let uu___4 = FStar_BigInt.to_int_fs to_c in
-                 FStar_Compiler_Range_Type.mk_pos uu___3 uu___4 in
-               FStar_Compiler_Range_Type.mk_range fn1 uu___1 uu___2 in
-             let uu___1 =
-               embed_simple FStar_Syntax_Embeddings.e_range psc1.psc_range r in
-             FStar_Pervasives_Native.Some uu___1
-         | uu___1 -> FStar_Pervasives_Native.None)
-    | uu___ -> FStar_Pervasives_Native.None in
-  let decidable_eq neg psc1 _norm_cb _us args =
-    let r = psc1.psc_range in
-    let tru =
-      FStar_Syntax_Syntax.mk
-        (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_bool true)) r in
-    let fal =
-      FStar_Syntax_Syntax.mk
-        (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_bool false)) r in
-    match args with
-    | (_typ, uu___)::(a1, uu___1)::(a2, uu___2)::[] ->
-        let uu___3 = FStar_Syntax_Util.eq_tm a1 a2 in
-        (match uu___3 with
-         | FStar_Syntax_Util.Equal ->
-             FStar_Pervasives_Native.Some (if neg then fal else tru)
-         | FStar_Syntax_Util.NotEqual ->
-             FStar_Pervasives_Native.Some (if neg then tru else fal)
-         | uu___4 -> FStar_Pervasives_Native.None)
-    | uu___ ->
-        FStar_Compiler_Effect.failwith "Unexpected number of arguments" in
-  let and_op psc1 _norm_cb _us args =
-    match args with
-    | (a1, FStar_Pervasives_Native.None)::(a2, FStar_Pervasives_Native.None)::[]
-        ->
-        let uu___ = try_unembed_simple FStar_Syntax_Embeddings.e_bool a1 in
-        (match uu___ with
-         | FStar_Pervasives_Native.Some (false) ->
-             let uu___1 =
-               embed_simple FStar_Syntax_Embeddings.e_bool psc1.psc_range
-                 false in
-             FStar_Pervasives_Native.Some uu___1
-         | FStar_Pervasives_Native.Some (true) ->
-             FStar_Pervasives_Native.Some a2
-         | uu___1 -> FStar_Pervasives_Native.None)
-    | uu___ ->
-        FStar_Compiler_Effect.failwith "Unexpected number of arguments" in
-  let or_op psc1 _norm_cb _us args =
-    match args with
-    | (a1, FStar_Pervasives_Native.None)::(a2, FStar_Pervasives_Native.None)::[]
-        ->
-        let uu___ = try_unembed_simple FStar_Syntax_Embeddings.e_bool a1 in
-        (match uu___ with
-         | FStar_Pervasives_Native.Some (true) ->
-             let uu___1 =
-               embed_simple FStar_Syntax_Embeddings.e_bool psc1.psc_range
-                 true in
-             FStar_Pervasives_Native.Some uu___1
-         | FStar_Pervasives_Native.Some (false) ->
-             FStar_Pervasives_Native.Some a2
-         | uu___1 -> FStar_Pervasives_Native.None)
-    | uu___ ->
-        FStar_Compiler_Effect.failwith "Unexpected number of arguments" in
-  let division_modulus_op op psc1 _norm_cb _us args =
-    match args with
-    | (a1, FStar_Pervasives_Native.None)::(a2, FStar_Pervasives_Native.None)::[]
-        ->
-        let uu___ =
-          let uu___1 = try_unembed_simple FStar_Syntax_Embeddings.e_int a1 in
-          let uu___2 = try_unembed_simple FStar_Syntax_Embeddings.e_int a2 in
-          (uu___1, uu___2) in
-        (match uu___ with
-         | (FStar_Pervasives_Native.Some m, FStar_Pervasives_Native.Some n)
-             ->
-             let uu___1 =
-               let uu___2 = FStar_BigInt.to_int_fs n in
-               uu___2 <> Prims.int_zero in
-             if uu___1
-             then
-               let uu___2 =
-                 let uu___3 = op m n in
-                 embed_simple FStar_Syntax_Embeddings.e_int psc1.psc_range
-                   uu___3 in
-               FStar_Pervasives_Native.Some uu___2
-             else FStar_Pervasives_Native.None
-         | uu___1 -> FStar_Pervasives_Native.None)
-    | uu___ ->
-        FStar_Compiler_Effect.failwith "Unexpected number of arguments" in
-  let bogus_cbs =
-    {
-      FStar_TypeChecker_NBETerm.iapp = (fun h -> fun _args -> h);
-      FStar_TypeChecker_NBETerm.translate =
-        (fun uu___ -> FStar_Compiler_Effect.failwith "bogus_cbs translate")
-    } in
   let int_as_bounded r int_to_t n =
     let c = embed_simple FStar_Syntax_Embeddings.e_int r n in
     let int_to_t1 = FStar_Syntax_Syntax.fv_to_tm int_to_t in
@@ -849,448 +1932,34 @@ let (built_in_primitive_steps_list : primitive_step Prims.list) =
              }) r in
   let basic_ops =
     let uu___ =
+      let u32_int_to_t =
+        let uu___1 = FStar_Parser_Const.p2l ["FStar"; "UInt32"; "uint_to_t"] in
+        FStar_Syntax_Syntax.lid_as_fv uu___1 FStar_Pervasives_Native.None in
       let uu___1 =
-        FStar_TypeChecker_NBETerm.unary_int_op
-          (fun x -> FStar_BigInt.minus_big_int x) in
-      (FStar_Parser_Const.op_Minus, Prims.int_one, Prims.int_zero,
-        (unary_int_op (fun x -> FStar_BigInt.minus_big_int x)), uu___1) in
-    let uu___1 =
-      let uu___2 =
-        let uu___3 =
-          FStar_TypeChecker_NBETerm.binary_int_op
-            (fun x -> fun y -> FStar_BigInt.add_big_int x y) in
-        (FStar_Parser_Const.op_Addition, (Prims.of_int (2)), Prims.int_zero,
-          (binary_int_op (fun x -> fun y -> FStar_BigInt.add_big_int x y)),
-          uu___3) in
-      let uu___3 =
-        let uu___4 =
-          let uu___5 =
-            FStar_TypeChecker_NBETerm.binary_int_op
-              (fun x -> fun y -> FStar_BigInt.sub_big_int x y) in
-          (FStar_Parser_Const.op_Subtraction, (Prims.of_int (2)),
-            Prims.int_zero,
-            (binary_int_op (fun x -> fun y -> FStar_BigInt.sub_big_int x y)),
-            uu___5) in
-        let uu___5 =
-          let uu___6 =
-            let uu___7 =
-              FStar_TypeChecker_NBETerm.binary_int_op
-                (fun x -> fun y -> FStar_BigInt.mult_big_int x y) in
-            (FStar_Parser_Const.op_Multiply, (Prims.of_int (2)),
-              Prims.int_zero,
-              (binary_int_op
-                 (fun x -> fun y -> FStar_BigInt.mult_big_int x y)), uu___7) in
-          let uu___7 =
-            let uu___8 =
-              let uu___9 = division_modulus_op FStar_BigInt.div_big_int in
-              (FStar_Parser_Const.op_Division, (Prims.of_int (2)),
-                Prims.int_zero, uu___9,
-                (fun _us ->
-                   FStar_TypeChecker_NBETerm.division_modulus_op
-                     FStar_BigInt.div_big_int)) in
-            let uu___9 =
-              let uu___10 =
-                let uu___11 =
-                  FStar_TypeChecker_NBETerm.binary_op
-                    FStar_TypeChecker_NBETerm.arg_as_int
-                    (fun x ->
-                       fun y ->
-                         let uu___12 = FStar_BigInt.lt_big_int x y in
-                         FStar_TypeChecker_NBETerm.embed
-                           FStar_TypeChecker_NBETerm.e_bool bogus_cbs uu___12) in
-                (FStar_Parser_Const.op_LT, (Prims.of_int (2)),
-                  Prims.int_zero,
-                  (binary_op arg_as_int
-                     (fun r ->
-                        fun x ->
-                          fun y ->
-                            let uu___12 = FStar_BigInt.lt_big_int x y in
-                            embed_simple FStar_Syntax_Embeddings.e_bool r
-                              uu___12)), uu___11) in
-              let uu___11 =
-                let uu___12 =
-                  let uu___13 =
-                    FStar_TypeChecker_NBETerm.binary_op
-                      FStar_TypeChecker_NBETerm.arg_as_int
-                      (fun x ->
-                         fun y ->
-                           let uu___14 = FStar_BigInt.le_big_int x y in
-                           FStar_TypeChecker_NBETerm.embed
-                             FStar_TypeChecker_NBETerm.e_bool bogus_cbs
-                             uu___14) in
-                  (FStar_Parser_Const.op_LTE, (Prims.of_int (2)),
-                    Prims.int_zero,
-                    (binary_op arg_as_int
-                       (fun r ->
-                          fun x ->
-                            fun y ->
-                              let uu___14 = FStar_BigInt.le_big_int x y in
-                              embed_simple FStar_Syntax_Embeddings.e_bool r
-                                uu___14)), uu___13) in
-                let uu___13 =
-                  let uu___14 =
-                    let uu___15 =
-                      FStar_TypeChecker_NBETerm.binary_op
-                        FStar_TypeChecker_NBETerm.arg_as_int
-                        (fun x ->
-                           fun y ->
-                             let uu___16 = FStar_BigInt.gt_big_int x y in
-                             FStar_TypeChecker_NBETerm.embed
-                               FStar_TypeChecker_NBETerm.e_bool bogus_cbs
-                               uu___16) in
-                    (FStar_Parser_Const.op_GT, (Prims.of_int (2)),
-                      Prims.int_zero,
-                      (binary_op arg_as_int
-                         (fun r ->
-                            fun x ->
-                              fun y ->
-                                let uu___16 = FStar_BigInt.gt_big_int x y in
-                                embed_simple FStar_Syntax_Embeddings.e_bool r
-                                  uu___16)), uu___15) in
-                  let uu___15 =
-                    let uu___16 =
-                      let uu___17 =
-                        FStar_TypeChecker_NBETerm.binary_op
-                          FStar_TypeChecker_NBETerm.arg_as_int
-                          (fun x ->
-                             fun y ->
-                               let uu___18 = FStar_BigInt.ge_big_int x y in
-                               FStar_TypeChecker_NBETerm.embed
-                                 FStar_TypeChecker_NBETerm.e_bool bogus_cbs
-                                 uu___18) in
-                      (FStar_Parser_Const.op_GTE, (Prims.of_int (2)),
-                        Prims.int_zero,
-                        (binary_op arg_as_int
-                           (fun r ->
-                              fun x ->
-                                fun y ->
-                                  let uu___18 = FStar_BigInt.ge_big_int x y in
-                                  embed_simple FStar_Syntax_Embeddings.e_bool
-                                    r uu___18)), uu___17) in
-                    let uu___17 =
-                      let uu___18 =
-                        let uu___19 =
-                          division_modulus_op FStar_BigInt.mod_big_int in
-                        (FStar_Parser_Const.op_Modulus, (Prims.of_int (2)),
-                          Prims.int_zero, uu___19,
-                          (fun _us ->
-                             FStar_TypeChecker_NBETerm.division_modulus_op
-                               FStar_BigInt.mod_big_int)) in
-                      let uu___19 =
-                        let uu___20 =
-                          let uu___21 =
-                            FStar_TypeChecker_NBETerm.unary_bool_op
-                              (fun x -> Prims.op_Negation x) in
-                          (FStar_Parser_Const.op_Negation, Prims.int_one,
-                            Prims.int_zero,
-                            (unary_bool_op (fun x -> Prims.op_Negation x)),
-                            uu___21) in
-                        let uu___21 =
-                          let uu___22 =
-                            let uu___23 =
-                              let uu___24 =
-                                let u32_int_to_t =
-                                  let uu___25 =
-                                    FStar_Parser_Const.p2l
-                                      ["FStar"; "UInt32"; "uint_to_t"] in
-                                  FStar_Syntax_Syntax.lid_as_fv uu___25
-                                    FStar_Pervasives_Native.None in
-                                let uu___25 =
-                                  FStar_TypeChecker_NBETerm.unary_op
-                                    FStar_TypeChecker_NBETerm.arg_as_char
-                                    (fun c ->
-                                       let uu___26 =
-                                         FStar_BigInt.of_int_fs
-                                           (FStar_Compiler_Util.int_of_char c) in
-                                       FStar_TypeChecker_NBETerm.int_as_bounded
-                                         u32_int_to_t uu___26) in
-                                (FStar_Parser_Const.char_u32_of_char,
-                                  Prims.int_one, Prims.int_zero,
-                                  (unary_op arg_as_char
-                                     (fun r ->
-                                        fun c ->
-                                          let uu___26 =
-                                            FStar_BigInt.of_int_fs
-                                              (FStar_Compiler_Util.int_of_char
-                                                 c) in
-                                          int_as_bounded r u32_int_to_t
-                                            uu___26)), uu___25) in
-                              let uu___25 =
-                                let uu___26 =
-                                  let uu___27 =
-                                    FStar_TypeChecker_NBETerm.unary_op
-                                      FStar_TypeChecker_NBETerm.arg_as_int
-                                      FStar_TypeChecker_NBETerm.string_of_int in
-                                  (FStar_Parser_Const.string_of_int_lid,
-                                    Prims.int_one, Prims.int_zero,
-                                    (unary_op arg_as_int string_of_int),
-                                    uu___27) in
-                                let uu___27 =
-                                  let uu___28 =
-                                    let uu___29 =
-                                      FStar_TypeChecker_NBETerm.unary_op
-                                        FStar_TypeChecker_NBETerm.arg_as_bool
-                                        FStar_TypeChecker_NBETerm.string_of_bool in
-                                    (FStar_Parser_Const.string_of_bool_lid,
-                                      Prims.int_one, Prims.int_zero,
-                                      (unary_op arg_as_bool string_of_bool),
-                                      uu___29) in
-                                  let uu___29 =
-                                    let uu___30 =
-                                      let uu___31 =
-                                        FStar_TypeChecker_NBETerm.unary_op
-                                          FStar_TypeChecker_NBETerm.arg_as_string
-                                          FStar_TypeChecker_NBETerm.bool_of_string in
-                                      (FStar_Parser_Const.bool_of_string_lid,
-                                        Prims.int_one, Prims.int_zero,
-                                        (unary_op arg_as_string
-                                           bool_of_string), uu___31) in
-                                    let uu___31 =
-                                      let uu___32 =
-                                        let uu___33 =
-                                          FStar_TypeChecker_NBETerm.unary_op
-                                            FStar_TypeChecker_NBETerm.arg_as_string
-                                            FStar_TypeChecker_NBETerm.int_of_string in
-                                        (FStar_Parser_Const.int_of_string_lid,
-                                          Prims.int_one, Prims.int_zero,
-                                          (unary_op arg_as_string
-                                             int_of_string), uu___33) in
-                                      let uu___33 =
-                                        let uu___34 =
-                                          let uu___35 =
-                                            FStar_TypeChecker_NBETerm.unary_op
-                                              FStar_TypeChecker_NBETerm.arg_as_string
-                                              FStar_TypeChecker_NBETerm.list_of_string' in
-                                          (FStar_Parser_Const.string_list_of_string_lid,
-                                            Prims.int_one, Prims.int_zero,
-                                            (unary_op arg_as_string
-                                               list_of_string'), uu___35) in
-                                        let uu___35 =
-                                          let uu___36 =
-                                            let uu___37 =
-                                              FStar_TypeChecker_NBETerm.unary_op
-                                                (FStar_TypeChecker_NBETerm.arg_as_list
-                                                   FStar_TypeChecker_NBETerm.e_char)
-                                                FStar_TypeChecker_NBETerm.string_of_list' in
-                                            (FStar_Parser_Const.string_string_of_list_lid,
-                                              Prims.int_one, Prims.int_zero,
-                                              (unary_op
-                                                 (arg_as_list
-                                                    FStar_Syntax_Embeddings.e_char)
-                                                 string_of_list'), uu___37) in
-                                          let uu___37 =
-                                            let uu___38 =
-                                              let uu___39 =
-                                                let uu___40 =
-                                                  let uu___41 =
-                                                    FStar_TypeChecker_NBETerm.binary_string_op
-                                                      (fun x ->
-                                                         fun y ->
-                                                           Prims.strcat x y) in
-                                                  (FStar_Parser_Const.prims_strcat_lid,
-                                                    (Prims.of_int (2)),
-                                                    Prims.int_zero,
-                                                    (binary_string_op
-                                                       (fun x ->
-                                                          fun y ->
-                                                            Prims.strcat x y)),
-                                                    uu___41) in
-                                                let uu___41 =
-                                                  let uu___42 =
-                                                    let uu___43 =
-                                                      let uu___44 =
-                                                        FStar_TypeChecker_NBETerm.binary_op
-                                                          FStar_TypeChecker_NBETerm.arg_as_string
-                                                          FStar_TypeChecker_NBETerm.string_compare' in
-                                                      (FStar_Parser_Const.string_compare_lid,
-                                                        (Prims.of_int (2)),
-                                                        Prims.int_zero,
-                                                        (binary_op
-                                                           arg_as_string
-                                                           string_compare'),
-                                                        uu___44) in
-                                                    let uu___44 =
-                                                      let uu___45 =
-                                                        let uu___46 =
-                                                          FStar_TypeChecker_NBETerm.unary_op
-                                                            FStar_TypeChecker_NBETerm.arg_as_string
-                                                            FStar_TypeChecker_NBETerm.string_lowercase in
-                                                        (FStar_Parser_Const.string_lowercase_lid,
-                                                          Prims.int_one,
-                                                          Prims.int_zero,
-                                                          (unary_op
-                                                             arg_as_string
-                                                             lowercase),
-                                                          uu___46) in
-                                                      let uu___46 =
-                                                        let uu___47 =
-                                                          let uu___48 =
-                                                            FStar_TypeChecker_NBETerm.unary_op
-                                                              FStar_TypeChecker_NBETerm.arg_as_string
-                                                              FStar_TypeChecker_NBETerm.string_uppercase in
-                                                          (FStar_Parser_Const.string_uppercase_lid,
-                                                            Prims.int_one,
-                                                            Prims.int_zero,
-                                                            (unary_op
-                                                               arg_as_string
-                                                               uppercase),
-                                                            uu___48) in
-                                                        let uu___48 =
-                                                          let uu___49 =
-                                                            let uu___50 =
-                                                              let uu___51 =
-                                                                let uu___52 =
-                                                                  let uu___53
-                                                                    =
-                                                                    let uu___54
-                                                                    =
-                                                                    let uu___55
-                                                                    =
-                                                                    FStar_Parser_Const.p2l
-                                                                    ["FStar";
-                                                                    "Range";
-                                                                    "mk_range"] in
-                                                                    (uu___55,
-                                                                    (Prims.of_int (5)),
-                                                                    Prims.int_zero,
-                                                                    mk_range,
-                                                                    (fun
-                                                                    uu___56
-                                                                    ->
-                                                                    FStar_TypeChecker_NBETerm.mk_range)) in
-                                                                    [uu___54] in
-                                                                  (FStar_Parser_Const.op_notEq,
-                                                                    (Prims.of_int (3)),
-                                                                    Prims.int_zero,
-                                                                    (
-                                                                    decidable_eq
-                                                                    true),
-                                                                    (
-                                                                    fun
-                                                                    uu___54
-                                                                    ->
-                                                                    FStar_TypeChecker_NBETerm.decidable_eq
-                                                                    true)) ::
-                                                                    uu___53 in
-                                                                (FStar_Parser_Const.op_Eq,
-                                                                  (Prims.of_int (3)),
-                                                                  Prims.int_zero,
-                                                                  (decidable_eq
-                                                                    false),
-                                                                  (fun
-                                                                    uu___53
-                                                                    ->
-                                                                    FStar_TypeChecker_NBETerm.decidable_eq
-                                                                    false))
-                                                                  :: uu___52 in
-                                                              (FStar_Parser_Const.string_sub_lid,
-                                                                (Prims.of_int (3)),
-                                                                Prims.int_zero,
-                                                                string_substring',
-                                                                (fun uu___52
-                                                                   ->
-                                                                   FStar_TypeChecker_NBETerm.string_substring'))
-                                                                :: uu___51 in
-                                                            (FStar_Parser_Const.string_index_of_lid,
-                                                              (Prims.of_int (2)),
-                                                              Prims.int_zero,
-                                                              string_index_of,
-                                                              (fun uu___51 ->
-                                                                 FStar_TypeChecker_NBETerm.string_index_of))
-                                                              :: uu___50 in
-                                                          (FStar_Parser_Const.string_index_lid,
-                                                            (Prims.of_int (2)),
-                                                            Prims.int_zero,
-                                                            string_index,
-                                                            (fun uu___50 ->
-                                                               FStar_TypeChecker_NBETerm.string_index))
-                                                            :: uu___49 in
-                                                        uu___47 :: uu___48 in
-                                                      uu___45 :: uu___46 in
-                                                    uu___43 :: uu___44 in
-                                                  (FStar_Parser_Const.string_concat_lid,
-                                                    (Prims.of_int (2)),
-                                                    Prims.int_zero,
-                                                    string_concat',
-                                                    (fun uu___43 ->
-                                                       FStar_TypeChecker_NBETerm.string_concat'))
-                                                    :: uu___42 in
-                                                uu___40 :: uu___41 in
-                                              (FStar_Parser_Const.string_split_lid,
-                                                (Prims.of_int (2)),
-                                                Prims.int_zero,
-                                                string_split',
-                                                (fun uu___40 ->
-                                                   FStar_TypeChecker_NBETerm.string_split'))
-                                                :: uu___39 in
-                                            (FStar_Parser_Const.string_make_lid,
-                                              (Prims.of_int (2)),
-                                              Prims.int_zero,
-                                              (mixed_binary_op
-                                                 (fun x -> arg_as_int x)
-                                                 (fun x -> arg_as_char x)
-                                                 (fun r ->
-                                                    fun s ->
-                                                      embed_simple
-                                                        FStar_Syntax_Embeddings.e_string
-                                                        r s)
-                                                 (fun r ->
-                                                    fun _us ->
-                                                      fun x ->
-                                                        fun y ->
-                                                          let uu___39 =
-                                                            let uu___40 =
-                                                              FStar_BigInt.to_int_fs
-                                                                x in
-                                                            FStar_Compiler_String.make
-                                                              uu___40 y in
-                                                          FStar_Pervasives_Native.Some
-                                                            uu___39)),
-                                              (FStar_TypeChecker_NBETerm.mixed_binary_op
-                                                 FStar_TypeChecker_NBETerm.arg_as_int
-                                                 FStar_TypeChecker_NBETerm.arg_as_char
-                                                 (FStar_TypeChecker_NBETerm.embed
-                                                    FStar_TypeChecker_NBETerm.e_string
-                                                    bogus_cbs)
-                                                 (fun _us ->
-                                                    fun x ->
-                                                      fun y ->
-                                                        let uu___39 =
-                                                          let uu___40 =
-                                                            FStar_BigInt.to_int_fs
-                                                              x in
-                                                          FStar_Compiler_String.make
-                                                            uu___40 y in
-                                                        FStar_Pervasives_Native.Some
-                                                          uu___39)))
-                                              :: uu___38 in
-                                          uu___36 :: uu___37 in
-                                        uu___34 :: uu___35 in
-                                      uu___32 :: uu___33 in
-                                    uu___30 :: uu___31 in
-                                  uu___28 :: uu___29 in
-                                uu___26 :: uu___27 in
-                              uu___24 :: uu___25 in
-                            (FStar_Parser_Const.op_Or, (Prims.of_int (2)),
-                              Prims.int_zero, or_op,
-                              (fun uu___24 -> FStar_TypeChecker_NBETerm.or_op))
-                              :: uu___23 in
-                          (FStar_Parser_Const.op_And, (Prims.of_int (2)),
-                            Prims.int_zero, and_op,
-                            (fun uu___23 -> FStar_TypeChecker_NBETerm.and_op))
-                            :: uu___22 in
-                        uu___20 :: uu___21 in
-                      uu___18 :: uu___19 in
-                    uu___16 :: uu___17 in
-                  uu___14 :: uu___15 in
-                uu___12 :: uu___13 in
-              uu___10 :: uu___11 in
-            uu___8 :: uu___9 in
-          uu___6 :: uu___7 in
-        uu___4 :: uu___5 in
-      uu___2 :: uu___3 in
-    uu___ :: uu___1 in
-  let weak_ops = [] in
+        FStar_TypeChecker_NBETerm.unary_op
+          FStar_TypeChecker_NBETerm.arg_as_char
+          (fun c ->
+             let uu___2 =
+               FStar_BigInt.of_int_fs (FStar_Compiler_Util.int_of_char c) in
+             FStar_TypeChecker_NBETerm.int_as_bounded u32_int_to_t uu___2) in
+      (FStar_Parser_Const.char_u32_of_char, Prims.int_one, Prims.int_zero,
+        (unary_op arg_as_char
+           (fun r ->
+              fun c ->
+                let uu___2 =
+                  FStar_BigInt.of_int_fs (FStar_Compiler_Util.int_of_char c) in
+                int_as_bounded r u32_int_to_t uu___2)), uu___1) in
+    [uu___;
+    (FStar_Parser_Const.op_And, (Prims.of_int (2)), Prims.int_zero, and_op,
+      ((fun uu___1 -> FStar_TypeChecker_NBETerm.and_op)));
+    (FStar_Parser_Const.op_Or, (Prims.of_int (2)), Prims.int_zero, or_op,
+      ((fun uu___1 -> FStar_TypeChecker_NBETerm.or_op)));
+    (FStar_Parser_Const.op_Eq, (Prims.of_int (3)), Prims.int_zero,
+      (decidable_eq false),
+      ((fun uu___1 -> FStar_TypeChecker_NBETerm.decidable_eq false)));
+    (FStar_Parser_Const.op_notEq, (Prims.of_int (3)), Prims.int_zero,
+      (decidable_eq true),
+      ((fun uu___1 -> FStar_TypeChecker_NBETerm.decidable_eq true)))] in
   let bounded_arith_ops =
     let bounded_signed_int_types =
       [("Int8", (Prims.of_int (8)));
@@ -2249,499 +2918,15 @@ let (built_in_primitive_steps_list : primitive_step Prims.list) =
                       FStar_Compiler_Util.array_index uu___1 i in
                     FStar_Pervasives_Native.Some uu___))) in
     [of_list_op; length_op; index_op] in
-  let issue_ops =
-    let mk_lid l = FStar_Parser_Const.p2l ["FStar"; "Issue"; l] in
-    let arg_as_issue x =
-      FStar_Syntax_Embeddings_Base.try_unembed
-        FStar_Syntax_Embeddings.e_issue (FStar_Pervasives_Native.fst x)
-        FStar_Syntax_Embeddings_Base.id_norm_cb in
-    let option_int_as_option_z oi =
-      match oi with
-      | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
-      | FStar_Pervasives_Native.Some i ->
-          let uu___ = FStar_BigInt.of_int_fs i in
-          FStar_Pervasives_Native.Some uu___ in
-    let option_z_as_option_int zi =
-      match zi with
-      | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
-      | FStar_Pervasives_Native.Some i ->
-          let uu___ = FStar_BigInt.to_int_fs i in
-          FStar_Pervasives_Native.Some uu___ in
-    let nbe_arg_as_issue x =
-      FStar_TypeChecker_NBETerm.unembed FStar_TypeChecker_NBETerm.e_issue
-        bogus_cbs (FStar_Pervasives_Native.fst x) in
-    let nbe_str s =
-      FStar_TypeChecker_NBETerm.embed FStar_TypeChecker_NBETerm.e_string
-        bogus_cbs s in
-    let nbe_int s =
-      FStar_TypeChecker_NBETerm.embed FStar_TypeChecker_NBETerm.e_int
-        bogus_cbs s in
-    let nbe_option_int oi =
-      let em =
-        FStar_TypeChecker_NBETerm.embed
-          (FStar_TypeChecker_NBETerm.e_option FStar_TypeChecker_NBETerm.e_int)
-          bogus_cbs in
-      let uu___ = option_int_as_option_z oi in em uu___ in
-    let uu___ =
-      let uu___1 = mk_lid "message_of_issue" in
-      let uu___2 =
-        FStar_TypeChecker_NBETerm.unary_op nbe_arg_as_issue
-          (fun issue ->
-             FStar_TypeChecker_NBETerm.embed
-               (FStar_TypeChecker_NBETerm.e_list
-                  FStar_TypeChecker_NBETerm.e_document) bogus_cbs
-               issue.FStar_Errors.issue_msg) in
-      (uu___1, Prims.int_one, Prims.int_zero,
-        (unary_op arg_as_issue
-           (fun _r ->
-              fun issue ->
-                embed_simple
-                  (FStar_Syntax_Embeddings.e_list
-                     FStar_Syntax_Embeddings.e_document)
-                  FStar_Compiler_Range_Type.dummyRange
-                  issue.FStar_Errors.issue_msg)), uu___2) in
-    let uu___1 =
-      let uu___2 =
-        let uu___3 = mk_lid "level_of_issue" in
-        let uu___4 =
-          FStar_TypeChecker_NBETerm.unary_op nbe_arg_as_issue
-            (fun issue ->
-               let uu___5 =
-                 FStar_Errors.string_of_issue_level
-                   issue.FStar_Errors.issue_level in
-               nbe_str uu___5) in
-        (uu___3, Prims.int_one, Prims.int_zero,
-          (unary_op arg_as_issue
-             (fun _r ->
-                fun issue ->
-                  let uu___5 =
-                    FStar_Errors.string_of_issue_level
-                      issue.FStar_Errors.issue_level in
-                  FStar_Syntax_Util.exp_string uu___5)), uu___4) in
-      let uu___3 =
-        let uu___4 =
-          let uu___5 = mk_lid "number_of_issue" in
-          let uu___6 =
-            FStar_TypeChecker_NBETerm.unary_op nbe_arg_as_issue
-              (fun issue -> nbe_option_int issue.FStar_Errors.issue_number) in
-          (uu___5, Prims.int_one, Prims.int_zero,
-            (unary_op arg_as_issue
-               (fun _r ->
-                  fun issue ->
-                    let uu___7 =
-                      option_int_as_option_z issue.FStar_Errors.issue_number in
-                    embed_simple
-                      (FStar_Syntax_Embeddings.e_option
-                         FStar_Syntax_Embeddings.e_int)
-                      FStar_Compiler_Range_Type.dummyRange uu___7)), uu___6) in
-        let uu___5 =
-          let uu___6 =
-            let uu___7 = mk_lid "range_of_issue" in
-            let uu___8 =
-              FStar_TypeChecker_NBETerm.unary_op nbe_arg_as_issue
-                (fun issue ->
-                   FStar_TypeChecker_NBETerm.embed
-                     (FStar_TypeChecker_NBETerm.e_option
-                        FStar_TypeChecker_NBETerm.e_range) bogus_cbs
-                     issue.FStar_Errors.issue_range) in
-            (uu___7, Prims.int_one, Prims.int_zero,
-              (unary_op arg_as_issue
-                 (fun _r ->
-                    fun issue ->
-                      embed_simple
-                        (FStar_Syntax_Embeddings.e_option
-                           FStar_Syntax_Embeddings.e_range)
-                        FStar_Compiler_Range_Type.dummyRange
-                        issue.FStar_Errors.issue_range)), uu___8) in
-          let uu___7 =
-            let uu___8 =
-              let uu___9 = mk_lid "context_of_issue" in
-              let uu___10 =
-                FStar_TypeChecker_NBETerm.unary_op nbe_arg_as_issue
-                  (fun issue ->
-                     FStar_TypeChecker_NBETerm.embed
-                       (FStar_TypeChecker_NBETerm.e_list
-                          FStar_TypeChecker_NBETerm.e_string) bogus_cbs
-                       issue.FStar_Errors.issue_ctx) in
-              (uu___9, Prims.int_one, Prims.int_zero,
-                (unary_op arg_as_issue
-                   (fun _r ->
-                      fun issue ->
-                        embed_simple FStar_Syntax_Embeddings.e_string_list
-                          FStar_Compiler_Range_Type.dummyRange
-                          issue.FStar_Errors.issue_ctx)), uu___10) in
-            let uu___9 =
-              let uu___10 =
-                let uu___11 = mk_lid "render_issue" in
-                let uu___12 =
-                  FStar_TypeChecker_NBETerm.unary_op nbe_arg_as_issue
-                    (fun issue ->
-                       let uu___13 = FStar_Errors.format_issue issue in
-                       nbe_str uu___13) in
-                (uu___11, Prims.int_one, Prims.int_zero,
-                  (unary_op arg_as_issue
-                     (fun _r ->
-                        fun issue ->
-                          let uu___13 = FStar_Errors.format_issue issue in
-                          FStar_Syntax_Util.exp_string uu___13)), uu___12) in
-              let uu___11 =
-                let uu___12 =
-                  let uu___13 = mk_lid "mk_issue_doc" in
-                  (uu___13, (Prims.of_int (5)), Prims.int_zero,
-                    (fun psc1 ->
-                       fun univs ->
-                         fun cbs ->
-                           fun args ->
-                             match args with
-                             | (level, uu___14)::(msg, uu___15)::(range,
-                                                                  uu___16)::
-                                 (number, uu___17)::(context, uu___18)::[] ->
-                                 let try_unembed e x =
-                                   FStar_Syntax_Embeddings_Base.try_unembed e
-                                     x
-                                     FStar_Syntax_Embeddings_Base.id_norm_cb in
-                                 let uu___19 =
-                                   let uu___20 =
-                                     try_unembed
-                                       FStar_Syntax_Embeddings.e_string level in
-                                   let uu___21 =
-                                     try_unembed
-                                       (FStar_Syntax_Embeddings.e_list
-                                          FStar_Syntax_Embeddings.e_document)
-                                       msg in
-                                   let uu___22 =
-                                     try_unembed
-                                       (FStar_Syntax_Embeddings.e_option
-                                          FStar_Syntax_Embeddings.e_range)
-                                       range in
-                                   let uu___23 =
-                                     try_unembed
-                                       (FStar_Syntax_Embeddings.e_option
-                                          FStar_Syntax_Embeddings.e_int)
-                                       number in
-                                   let uu___24 =
-                                     try_unembed
-                                       (FStar_Syntax_Embeddings.e_list
-                                          FStar_Syntax_Embeddings.e_string)
-                                       context in
-                                   (uu___20, uu___21, uu___22, uu___23,
-                                     uu___24) in
-                                 (match uu___19 with
-                                  | (FStar_Pervasives_Native.Some level1,
-                                     FStar_Pervasives_Native.Some msg1,
-                                     FStar_Pervasives_Native.Some range1,
-                                     FStar_Pervasives_Native.Some number1,
-                                     FStar_Pervasives_Native.Some context1)
-                                      ->
-                                      let issue =
-                                        let uu___20 =
-                                          FStar_Errors.issue_level_of_string
-                                            level1 in
-                                        let uu___21 =
-                                          option_z_as_option_int number1 in
-                                        {
-                                          FStar_Errors.issue_msg = msg1;
-                                          FStar_Errors.issue_level = uu___20;
-                                          FStar_Errors.issue_range = range1;
-                                          FStar_Errors.issue_number = uu___21;
-                                          FStar_Errors.issue_ctx = context1
-                                        } in
-                                      let uu___20 =
-                                        embed_simple
-                                          FStar_Syntax_Embeddings.e_issue
-                                          psc1.psc_range issue in
-                                      FStar_Pervasives_Native.Some uu___20
-                                  | uu___20 -> FStar_Pervasives_Native.None)
-                             | uu___14 -> FStar_Pervasives_Native.None),
-                    (fun univs ->
-                       fun args ->
-                         match args with
-                         | (level, uu___14)::(msg, uu___15)::(range, uu___16)::
-                             (number, uu___17)::(context, uu___18)::[] ->
-                             let try_unembed e x =
-                               FStar_TypeChecker_NBETerm.unembed e bogus_cbs
-                                 x in
-                             let uu___19 =
-                               let uu___20 =
-                                 try_unembed
-                                   FStar_TypeChecker_NBETerm.e_string level in
-                               let uu___21 =
-                                 try_unembed
-                                   (FStar_TypeChecker_NBETerm.e_list
-                                      FStar_TypeChecker_NBETerm.e_document)
-                                   msg in
-                               let uu___22 =
-                                 try_unembed
-                                   (FStar_TypeChecker_NBETerm.e_option
-                                      FStar_TypeChecker_NBETerm.e_range)
-                                   range in
-                               let uu___23 =
-                                 try_unembed
-                                   (FStar_TypeChecker_NBETerm.e_option
-                                      FStar_TypeChecker_NBETerm.e_int) number in
-                               let uu___24 =
-                                 try_unembed
-                                   (FStar_TypeChecker_NBETerm.e_list
-                                      FStar_TypeChecker_NBETerm.e_string)
-                                   context in
-                               (uu___20, uu___21, uu___22, uu___23, uu___24) in
-                             (match uu___19 with
-                              | (FStar_Pervasives_Native.Some level1,
-                                 FStar_Pervasives_Native.Some msg1,
-                                 FStar_Pervasives_Native.Some range1,
-                                 FStar_Pervasives_Native.Some number1,
-                                 FStar_Pervasives_Native.Some context1) ->
-                                  let issue =
-                                    let uu___20 =
-                                      FStar_Errors.issue_level_of_string
-                                        level1 in
-                                    let uu___21 =
-                                      option_z_as_option_int number1 in
-                                    {
-                                      FStar_Errors.issue_msg = msg1;
-                                      FStar_Errors.issue_level = uu___20;
-                                      FStar_Errors.issue_range = range1;
-                                      FStar_Errors.issue_number = uu___21;
-                                      FStar_Errors.issue_ctx = context1
-                                    } in
-                                  let uu___20 =
-                                    FStar_TypeChecker_NBETerm.embed
-                                      FStar_TypeChecker_NBETerm.e_issue
-                                      bogus_cbs issue in
-                                  FStar_Pervasives_Native.Some uu___20
-                              | uu___20 -> FStar_Pervasives_Native.None)
-                         | uu___14 -> FStar_Pervasives_Native.None)) in
-                [uu___12] in
-              uu___10 :: uu___11 in
-            uu___8 :: uu___9 in
-          uu___6 :: uu___7 in
-        uu___4 :: uu___5 in
-      uu___2 :: uu___3 in
-    uu___ :: uu___1 in
-  let doc_ops =
-    let mk_lid l = FStar_Parser_Const.p2l ["FStar"; "Stubs"; "Pprint"; l] in
-    let uu___ =
-      let uu___1 = mk_lid "arbitrary_string" in
-      let uu___2 =
-        FStar_TypeChecker_NBETerm.unary_op
-          FStar_TypeChecker_NBETerm.arg_as_string
-          (fun str ->
-             let uu___3 = FStar_Pprint.arbitrary_string str in
-             FStar_TypeChecker_NBETerm.embed
-               FStar_TypeChecker_NBETerm.e_document bogus_cbs uu___3) in
-      (uu___1, Prims.int_one, Prims.int_zero,
-        (unary_op arg_as_string
-           (fun r ->
-              fun str ->
-                let uu___3 = FStar_Pprint.arbitrary_string str in
-                embed_simple FStar_Syntax_Embeddings.e_document r uu___3)),
-        uu___2) in
-    let uu___1 =
-      let uu___2 =
-        let uu___3 = mk_lid "render" in
-        let uu___4 =
-          FStar_TypeChecker_NBETerm.unary_op
-            FStar_TypeChecker_NBETerm.arg_as_doc
-            (fun doc ->
-               let uu___5 = FStar_Pprint.render doc in
-               FStar_TypeChecker_NBETerm.embed
-                 FStar_TypeChecker_NBETerm.e_string bogus_cbs uu___5) in
-        (uu___3, Prims.int_one, Prims.int_zero,
-          (unary_op arg_as_doc
-             (fun r ->
-                fun doc ->
-                  let uu___5 = FStar_Pprint.render doc in
-                  embed_simple FStar_Syntax_Embeddings.e_string r uu___5)),
-          uu___4) in
-      [uu___2] in
-    uu___ :: uu___1 in
-  let seal_steps =
-    [(FStar_Parser_Const.map_seal_lid, (Prims.of_int (4)),
-       (Prims.of_int (2)),
-       ((fun psc1 ->
-           fun univs ->
-             fun cbs ->
-               fun args ->
-                 match args with
-                 | (ta, uu___)::(tb, uu___1)::(s, uu___2)::(f, uu___3)::[] ->
-                     let try_unembed e x =
-                       FStar_Syntax_Embeddings_Base.try_unembed e x
-                         FStar_Syntax_Embeddings_Base.id_norm_cb in
-                     let uu___4 =
-                       let uu___5 =
-                         try_unembed FStar_Syntax_Embeddings.e_any ta in
-                       let uu___6 =
-                         try_unembed FStar_Syntax_Embeddings.e_any tb in
-                       let uu___7 =
-                         let uu___8 =
-                           FStar_Syntax_Embeddings.e_sealed
-                             FStar_Syntax_Embeddings.e_any in
-                         try_unembed uu___8 s in
-                       let uu___8 =
-                         try_unembed FStar_Syntax_Embeddings.e_any f in
-                       (uu___5, uu___6, uu___7, uu___8) in
-                     (match uu___4 with
-                      | (FStar_Pervasives_Native.Some ta1,
-                         FStar_Pervasives_Native.Some tb1,
-                         FStar_Pervasives_Native.Some s1,
-                         FStar_Pervasives_Native.Some f1) ->
-                          let r =
-                            let uu___5 =
-                              let uu___6 = FStar_Syntax_Syntax.as_arg s1 in
-                              [uu___6] in
-                            FStar_Syntax_Util.mk_app f1 uu___5 in
-                          let emb =
-                            FStar_Syntax_Embeddings_Base.set_type ta1
-                              FStar_Syntax_Embeddings.e_any in
-                          let uu___5 =
-                            let uu___6 = FStar_Syntax_Embeddings.e_sealed emb in
-                            embed_simple uu___6 psc1.psc_range r in
-                          FStar_Pervasives_Native.Some uu___5
-                      | uu___5 -> FStar_Pervasives_Native.None)
-                 | uu___ -> FStar_Pervasives_Native.None)),
-       ((fun cb ->
-           fun univs ->
-             fun args ->
-               match args with
-               | (ta, uu___)::(tb, uu___1)::(s, uu___2)::(f, uu___3)::[] ->
-                   let try_unembed e x =
-                     FStar_TypeChecker_NBETerm.unembed e bogus_cbs x in
-                   let uu___4 =
-                     let uu___5 =
-                       try_unembed FStar_TypeChecker_NBETerm.e_any ta in
-                     let uu___6 =
-                       try_unembed FStar_TypeChecker_NBETerm.e_any tb in
-                     let uu___7 =
-                       let uu___8 =
-                         FStar_TypeChecker_NBETerm.e_sealed
-                           FStar_TypeChecker_NBETerm.e_any in
-                       try_unembed uu___8 s in
-                     let uu___8 =
-                       try_unembed FStar_TypeChecker_NBETerm.e_any f in
-                     (uu___5, uu___6, uu___7, uu___8) in
-                   (match uu___4 with
-                    | (FStar_Pervasives_Native.Some ta1,
-                       FStar_Pervasives_Native.Some tb1,
-                       FStar_Pervasives_Native.Some s1,
-                       FStar_Pervasives_Native.Some f1) ->
-                        let r =
-                          let uu___5 =
-                            let uu___6 = FStar_TypeChecker_NBETerm.as_arg s1 in
-                            [uu___6] in
-                          cb.FStar_TypeChecker_NBETerm.iapp f1 uu___5 in
-                        let emb =
-                          FStar_TypeChecker_NBETerm.set_type ta1
-                            FStar_TypeChecker_NBETerm.e_any in
-                        let uu___5 =
-                          let uu___6 = FStar_TypeChecker_NBETerm.e_sealed emb in
-                          FStar_TypeChecker_NBETerm.embed uu___6 cb r in
-                        FStar_Pervasives_Native.Some uu___5
-                    | uu___5 -> FStar_Pervasives_Native.None)
-               | uu___ -> FStar_Pervasives_Native.None)));
-    (FStar_Parser_Const.bind_seal_lid, (Prims.of_int (4)),
-      (Prims.of_int (2)),
-      ((fun psc1 ->
-          fun univs ->
-            fun cbs ->
-              fun args ->
-                match args with
-                | (ta, uu___)::(tb, uu___1)::(s, uu___2)::(f, uu___3)::[] ->
-                    let try_unembed e x =
-                      FStar_Syntax_Embeddings_Base.try_unembed e x
-                        FStar_Syntax_Embeddings_Base.id_norm_cb in
-                    let uu___4 =
-                      let uu___5 =
-                        try_unembed FStar_Syntax_Embeddings.e_any ta in
-                      let uu___6 =
-                        try_unembed FStar_Syntax_Embeddings.e_any tb in
-                      let uu___7 =
-                        let uu___8 =
-                          FStar_Syntax_Embeddings.e_sealed
-                            FStar_Syntax_Embeddings.e_any in
-                        try_unembed uu___8 s in
-                      let uu___8 =
-                        try_unembed FStar_Syntax_Embeddings.e_any f in
-                      (uu___5, uu___6, uu___7, uu___8) in
-                    (match uu___4 with
-                     | (FStar_Pervasives_Native.Some ta1,
-                        FStar_Pervasives_Native.Some tb1,
-                        FStar_Pervasives_Native.Some s1,
-                        FStar_Pervasives_Native.Some f1) ->
-                         let r =
-                           let uu___5 =
-                             let uu___6 = FStar_Syntax_Syntax.as_arg s1 in
-                             [uu___6] in
-                           FStar_Syntax_Util.mk_app f1 uu___5 in
-                         let uu___5 =
-                           embed_simple FStar_Syntax_Embeddings.e_any
-                             psc1.psc_range r in
-                         FStar_Pervasives_Native.Some uu___5
-                     | uu___5 -> FStar_Pervasives_Native.None)
-                | uu___ -> FStar_Pervasives_Native.None)),
-      ((fun cb ->
-          fun univs ->
-            fun args ->
-              match args with
-              | (ta, uu___)::(tb, uu___1)::(s, uu___2)::(f, uu___3)::[] ->
-                  let try_unembed e x =
-                    FStar_TypeChecker_NBETerm.unembed e bogus_cbs x in
-                  let uu___4 =
-                    let uu___5 =
-                      try_unembed FStar_TypeChecker_NBETerm.e_any ta in
-                    let uu___6 =
-                      try_unembed FStar_TypeChecker_NBETerm.e_any tb in
-                    let uu___7 =
-                      let uu___8 =
-                        FStar_TypeChecker_NBETerm.e_sealed
-                          FStar_TypeChecker_NBETerm.e_any in
-                      try_unembed uu___8 s in
-                    let uu___8 =
-                      try_unembed FStar_TypeChecker_NBETerm.e_any f in
-                    (uu___5, uu___6, uu___7, uu___8) in
-                  (match uu___4 with
-                   | (FStar_Pervasives_Native.Some ta1,
-                      FStar_Pervasives_Native.Some tb1,
-                      FStar_Pervasives_Native.Some s1,
-                      FStar_Pervasives_Native.Some f1) ->
-                       let r =
-                         let uu___5 =
-                           let uu___6 = FStar_TypeChecker_NBETerm.as_arg s1 in
-                           [uu___6] in
-                         cb.FStar_TypeChecker_NBETerm.iapp f1 uu___5 in
-                       let emb =
-                         FStar_TypeChecker_NBETerm.set_type ta1
-                           FStar_TypeChecker_NBETerm.e_any in
-                       let uu___5 = FStar_TypeChecker_NBETerm.embed emb cb r in
-                       FStar_Pervasives_Native.Some uu___5
-                   | uu___5 -> FStar_Pervasives_Native.None)
-              | uu___ -> FStar_Pervasives_Native.None)))] in
   let strong_steps =
-    let uu___ =
-      FStar_Compiler_List.map (as_primitive_step true)
-        (FStar_Compiler_List.op_At basic_ops
-           (FStar_Compiler_List.op_At bounded_arith_ops
-              (FStar_Compiler_List.op_At [reveal_hide]
-                 (FStar_Compiler_List.op_At array_ops
-                    (FStar_Compiler_List.op_At issue_ops doc_ops))))) in
-    let uu___1 =
-      FStar_Compiler_List.map
-        (fun p ->
-           let uu___2 = as_primitive_step_nbecbs true p in
-           {
-             name = (uu___2.name);
-             arity = (uu___2.arity);
-             univ_arity = (uu___2.univ_arity);
-             auto_reflect = (uu___2.auto_reflect);
-             strong_reduction_ok = (uu___2.strong_reduction_ok);
-             requires_binder_substitution =
-               (uu___2.requires_binder_substitution);
-             renorm_after = true;
-             interpretation = (uu___2.interpretation);
-             interpretation_nbe = (uu___2.interpretation_nbe)
-           }) seal_steps in
-    FStar_Compiler_List.op_At uu___ uu___1 in
-  let weak_steps = FStar_Compiler_List.map (as_primitive_step false) weak_ops in
-  FStar_Compiler_List.op_At strong_steps weak_steps
+    FStar_Compiler_List.map (as_primitive_step true)
+      (FStar_Compiler_List.op_At basic_ops
+         (FStar_Compiler_List.op_At bounded_arith_ops
+            (FStar_Compiler_List.op_At [reveal_hide] array_ops))) in
+  FStar_Compiler_List.op_At simple_ops
+    (FStar_Compiler_List.op_At issue_ops
+       (FStar_Compiler_List.op_At doc_ops
+          (FStar_Compiler_List.op_At strong_steps seal_steps)))
 let (equality_ops_list : primitive_step Prims.list) =
   let interp_prop_eq2 psc1 _norm_cb _univs args =
     let r = psc1.psc_range in

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Primops.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Primops.ml
@@ -1262,9 +1262,13 @@ let (simple_ops : primitive_step Prims.list) =
         FStar_Syntax_Embeddings.e_string FStar_TypeChecker_NBETerm.e_string
         (FStar_Syntax_Embeddings.e_option FStar_Syntax_Embeddings.e_int)
         (FStar_TypeChecker_NBETerm.e_option FStar_TypeChecker_NBETerm.e_int)
-        (fun s ->
-           let uu___3 = FStar_Compiler_Util.safe_int_of_string s in
-           FStar_Compiler_Util.map_opt uu___3 FStar_BigInt.of_int_fs) in
+        (fun uu___3 ->
+           (fun s ->
+              let uu___3 = FStar_Compiler_Util.safe_int_of_string s in
+              Obj.magic
+                (FStar_Class_Monad.fmap FStar_Class_Monad.monad_option () ()
+                   (fun uu___4 -> (Obj.magic FStar_BigInt.of_int_fs) uu___4)
+                   (Obj.magic uu___3))) uu___3) in
     let uu___3 =
       let uu___4 =
         mk1 Prims.int_zero FStar_Parser_Const.string_of_bool_lid
@@ -1653,9 +1657,13 @@ let (issue_ops : primitive_step Prims.list) =
           FStar_TypeChecker_NBETerm.e_issue
           (FStar_Syntax_Embeddings.e_option FStar_Syntax_Embeddings.e_int)
           (FStar_TypeChecker_NBETerm.e_option FStar_TypeChecker_NBETerm.e_int)
-          (fun i ->
-             FStar_Compiler_Util.map_opt i.FStar_Errors.issue_number
-               FStar_BigInt.of_int_fs) in
+          (fun uu___6 ->
+             (fun i ->
+                Obj.magic
+                  (FStar_Class_Monad.fmap FStar_Class_Monad.monad_option ()
+                     ()
+                     (fun uu___6 -> (Obj.magic FStar_BigInt.of_int_fs) uu___6)
+                     (Obj.magic i.FStar_Errors.issue_number))) uu___6) in
       let uu___5 =
         let uu___6 =
           let uu___7 = mk_lid "range_of_issue" in
@@ -1709,8 +1717,12 @@ let (issue_ops : primitive_step Prims.list) =
                              let uu___14 =
                                FStar_Errors.issue_level_of_string level in
                              let uu___15 =
-                               FStar_Compiler_Util.map_opt number
-                                 FStar_BigInt.to_int_fs in
+                               Obj.magic
+                                 (FStar_Class_Monad.fmap
+                                    FStar_Class_Monad.monad_option () ()
+                                    (fun uu___16 ->
+                                       (Obj.magic FStar_BigInt.to_int_fs)
+                                         uu___16) (Obj.magic number)) in
                              {
                                FStar_Errors.issue_msg = msg;
                                FStar_Errors.issue_level = uu___14;

--- a/src/class/FStar.Class.Monad.fst
+++ b/src/class/FStar.Class.Monad.fst
@@ -38,3 +38,7 @@ let (<*>) ff x =
   let! f = ff in
   let! v = x in
   return (f v)
+
+let fmap f m =
+  let! v = m in
+  return (f v)

--- a/src/class/FStar.Class.Monad.fsti
+++ b/src/class/FStar.Class.Monad.fsti
@@ -39,3 +39,10 @@ val (<*>)
   {| monad m |}
   (#a #b :Type)
 : m (a -> b) -> m a -> m b
+
+val fmap
+  (#m: Type -> Type)
+  {| monad m |}
+  (#a #b :Type)
+  (f : a -> b)
+: m a -> m b

--- a/src/parser/FStar.Parser.Const.fst
+++ b/src/parser/FStar.Parser.Const.fst
@@ -302,6 +302,7 @@ let labeled_lid    = p2l ["FStar"; "Range"; "labeled"]
 let __range_lid    = p2l ["FStar"; "Range"; "__range"]
 let range_lid      = p2l ["FStar"; "Range"; "range"] (* this is a sealed version of the above *)
 let range_0        = p2l ["FStar"; "Range"; "range_0"]
+let mk_range_lid   = p2l ["FStar"; "Range"; "mk_range"]
 
 let guard_free     = pconst "guard_free"
 let inversion_lid  = p2l ["FStar"; "Pervasives"; "inversion"]

--- a/src/reflection/FStar.Reflection.V2.Embeddings.fst
+++ b/src/reflection/FStar.Reflection.V2.Embeddings.fst
@@ -22,27 +22,27 @@ open FStar.Syntax.Embeddings
 open FStar.Order
 open FStar.Errors
 
-module S = FStar.Syntax.Syntax // TODO: remove, it's open
-
-module I = FStar.Ident
-module SS = FStar.Syntax.Subst
-module BU = FStar.Compiler.Util
-module Range = FStar.Compiler.Range
-module U = FStar.Syntax.Util
-module Print = FStar.Syntax.Print
-module Env = FStar.TypeChecker.Env
-module Err = FStar.Errors
-module Z = FStar.BigInt
-module EMB = FStar.Syntax.Embeddings
-open FStar.Reflection.V2.Builtins //needed for inspect_fv, but that feels wrong
+module BU      = FStar.Compiler.Util
+module EMB     = FStar.Syntax.Embeddings
+module Env     = FStar.TypeChecker.Env
+module Err     = FStar.Errors
+module I       = FStar.Ident
+module List    = FStar.Compiler.List
 module NBETerm = FStar.TypeChecker.NBETerm
-module PC = FStar.Parser.Const
-module O = FStar.Options
-module RD = FStar.Reflection.V2.Data
-module List = FStar.Compiler.List
+module O       = FStar.Options
+module PC      = FStar.Parser.Const
+module Print   = FStar.Syntax.Print
+module Range   = FStar.Compiler.Range
+module RD      = FStar.Reflection.V2.Data
+module S       = FStar.Syntax.Syntax // TODO: remove, it's open
+module SS      = FStar.Syntax.Subst
+module U       = FStar.Syntax.Util
+module Z       = FStar.BigInt
 
+open FStar.Reflection.V2.Builtins //needed for inspect_fv, but that feels wrong
 open FStar.Compiler.Dyn
 open FStar.Syntax.Embeddings.AppEmb
+open FStar.Class.Monad
 
 (* We only use simple embeddings here *)
 let mk_emb f g t =

--- a/src/syntax/FStar.Syntax.Embeddings.Base.fst
+++ b/src/syntax/FStar.Syntax.Embeddings.Base.fst
@@ -213,7 +213,7 @@ let unembed #a {| e:embedding a |} t n =
   r
 
 
-let embed_as (ea:embedding 'a) (ab : 'a -> 'b) (ba : 'b -> 'a) (o:option typ) =
+let embed_as (ea:embedding 'a) (ab : 'a -> 'b) (ba : 'b -> 'a) (o:option typ) : Tot (embedding 'b) =
     mk_emb_full (fun (x:'b) -> embed (ba x))
                 (fun (t:term) cb -> BU.map_opt (try_unembed t cb) ab)
                 (fun () -> match o with | Some t -> t | _ -> type_of ea)

--- a/src/syntax/FStar.Syntax.Embeddings.Base.fsti
+++ b/src/syntax/FStar.Syntax.Embeddings.Base.fsti
@@ -86,7 +86,7 @@ val embed_as     : embedding 'a ->
                    ('a -> 'b) ->
                    ('b -> 'a) ->
                    option typ -> (* optionally change the type *)
-                   embedding 'b
+                   Tot (embedding 'b)
 
 (* Construct a simple lazy embedding as a blob. *)
 val e_lazy        : lazy_kind ->

--- a/src/syntax/FStar.Syntax.Embeddings.fsti
+++ b/src/syntax/FStar.Syntax.Embeddings.fsti
@@ -50,8 +50,8 @@ instance val e_tuple2      : embedding 'a -> embedding 'b -> Tot (embedding ('a 
 instance val e_tuple3      : embedding 'a -> embedding 'b -> embedding 'c -> Tot (embedding ('a * 'b * 'c))
 instance val e_either      : embedding 'a -> embedding 'b -> Tot (embedding (either 'a 'b))
 instance val e_string_list : embedding (list string)
-instance val e_arrow       : embedding 'a -> embedding 'b -> Tot (embedding ('a -> 'b))
-val e_sealed      : embedding 'a -> embedding 'a
+val e_arrow       : embedding 'a -> embedding 'b -> Tot (embedding ('a -> 'b))
+val e_sealed      : embedding 'a -> Tot (embedding 'a)
 (* ^ This one is explicit. Or we could add a Sealed "newtype" in compiler land. *)
 
 instance val e___range     : embedding Range.range (* unsealed *)

--- a/src/typechecker/FStar.TypeChecker.NBETerm.fst
+++ b/src/typechecker/FStar.TypeChecker.NBETerm.fst
@@ -773,60 +773,6 @@ let mixed_ternary_op (as_a : arg -> option 'a)
                 end
              | _ -> None
 
-let list_of_string' (s:string) : t =
-  embed (e_list e_char) bogus_cbs (list_of_string s)
-  // let name l = mk (Tm_fvar (lid_as_fv l delta_constant None)) rng in
-  // let char_t = name PC.char_lid in
-  // let charterm c = mk (Tm_constant (Const_char c)) rng in
-  // U.mk_list char_t rng <| List.map charterm (list_of_string s)
-
-let string_of_list' (l:list char) : t =
-    let s = string_of_list l in
-    mk_t <| Constant (String (s, Range.dummyRange))
-
-let string_compare' (s1:string) (s2:string) : t =
-    let r = String.compare s1 s2 in
-    embed e_int bogus_cbs (Z.big_int_of_string (BU.string_of_int r))
-
-
-let string_concat' args : option t =
-    match args with
-    | [a1; a2] ->
-        begin match arg_as_string a1 with
-        | Some s1 ->
-            begin match arg_as_list e_string a2 with
-            | Some s2 ->
-                let r = String.concat s1 s2 in
-                Some (embed e_string bogus_cbs r)
-            | _ -> None
-            end
-        | _ -> None
-        end
-    | _ -> None             
-
-let string_of_int (i:Z.t) : t =
-    embed e_string bogus_cbs (Z.string_of_big_int i)
-
-let string_of_bool (b:bool) : t =
-    embed e_string bogus_cbs (if b then "true" else "false")
-
-let int_of_string (s:string) : t =
-    embed (e_option e_fsint) bogus_cbs (BU.safe_int_of_string s)
-
-let bool_of_string (s:string) : t =
-    let r = match s with
-            | "true" -> Some true
-            | "false" -> Some false
-            | _ -> None
-    in
-    embed (e_option e_bool) bogus_cbs r
-
-let string_lowercase (s:string) : t =
-    embed e_string bogus_cbs (String.lowercase s)
-
-let string_uppercase (s:string) : t =
-    embed e_string bogus_cbs (String.lowercase s)
-
 let decidable_eq (neg:bool) (args:args) : option t =
   let tru = embed e_bool bogus_cbs true in
   let fal = embed e_bool bogus_cbs false in
@@ -865,90 +811,6 @@ let prims_to_fstar_range_step (args:args) : option t =
       end
    | _ -> failwith "Unexpected number of arguments"
 
-
-let string_split' args : option t =
-    match args with
-    | [a1; a2] ->
-        begin match arg_as_list e_char a1 with
-        | Some s1 ->
-            begin match arg_as_string a2 with
-            | Some s2 ->
-                let r = String.split s1 s2 in
-                Some (embed (e_list e_string) bogus_cbs r)
-            | _ -> None
-            end
-        | _ -> None
-        end
-    | _ -> None
-
-
-let string_index args : option t =
-    match args with
-    | [a1; a2] ->
-        begin match arg_as_string a1, arg_as_int a2 with
-        | Some s, Some i ->
-          begin
-          try
-            let r = String.index s i in
-            Some (embed e_char bogus_cbs r)
-          with
-          | _ -> None
-          end
-        | _ -> None
-        end
-    | _ -> None
-
-let string_index_of args : option t =
-    match args with
-    | [a1; a2] ->
-        begin match arg_as_string a1, arg_as_char a2 with
-        | Some s, Some c ->
-          begin
-          try
-            let r = String.index_of s c in
-            Some (embed e_int bogus_cbs r)
-          with
-          | _ -> None
-          end
-        | _ -> None
-        end
-    | _ -> None
-
-
-let string_substring' args : option t =
-  match args with
-  | [a1; a2; a3] ->
-      begin match arg_as_string a1, arg_as_int a2, arg_as_int a3 with
-      | Some s1, Some n1, Some n2 ->
-        let n1 = Z.to_int_fs n1 in
-        let n2 = Z.to_int_fs n2 in
-        begin
-        try let r = String.substring s1 n1 n2 in
-            Some (embed e_string bogus_cbs r)
-        with | _ -> None
-        end
-    | _ -> None
-    end
-
-| _ -> None
-
-let mk_range args : option t =
-  match args with
-  | [fn; from_line; from_col; to_line; to_col] -> begin
-    match arg_as_string fn,
-          arg_as_int from_line,
-          arg_as_int from_col,
-          arg_as_int to_line,
-          arg_as_int to_col with
-    | Some fn, Some from_l, Some from_c, Some to_l, Some to_c ->
-      let r = FStar.Compiler.Range.mk_range fn
-                (FStar.Compiler.Range.mk_pos (Z.to_int_fs from_l) (Z.to_int_fs from_c))
-                (FStar.Compiler.Range.mk_pos (Z.to_int_fs to_l) (Z.to_int_fs to_c)) in
-      Some (embed e_range bogus_cbs r)
-    | _ -> None
-    end
-| _ -> None
-
 let and_op (args:args) : option t =
   match args with
   | [a1; a2] -> begin
@@ -969,18 +831,6 @@ let or_op (args:args) : option t =
       Some (embed e_bool bogus_cbs true)
     | Some false ->
       Some (fst a2)
-    | _ -> None
-    end
-  | _ -> failwith "Unexpected number of arguments"
-
-let division_modulus_op (op:Z.bigint -> Z.bigint -> Z.bigint) (args:args) : option t =
-  match args with
-  | [a1; a2] -> begin
-    match arg_as_int a1, arg_as_int a2 with
-    | Some m, Some n ->
-      if Z.to_int_fs n <> 0
-      then Some (embed e_int bogus_cbs (op m n))
-      else None
     | _ -> None
     end
   | _ -> failwith "Unexpected number of arguments"

--- a/src/typechecker/FStar.TypeChecker.NBETerm.fsti
+++ b/src/typechecker/FStar.TypeChecker.NBETerm.fsti
@@ -336,22 +336,6 @@ val binary_bool_op : (bool -> bool -> bool) -> (universes -> args -> option t)
 
 val binary_string_op : (string -> string -> string) -> (universes -> args -> option t)
 
-val string_of_int : Z.t -> t
-val string_of_bool : bool -> t
-val int_of_string : string -> t
-val bool_of_string : string -> t
-val string_of_list' : list char -> t
-val string_compare' : string -> string -> t
-val string_concat' : args -> option t
-val string_substring' : args -> option t
-val string_split' : args -> option t
-val string_lowercase : string -> t
-val string_uppercase : string -> t
-val string_index : args -> option t
-val string_index_of : args -> option t
-
-val list_of_string' : (string -> t)
-
 val decidable_eq : bool -> args -> option t
 val interp_prop_eq2 : args -> option t
 
@@ -372,7 +356,5 @@ val binary_op : (arg -> option 'a) -> ('a -> 'a -> t) -> (universes -> args -> o
 val dummy_interp : Ident.lid -> args -> option t
 val prims_to_fstar_range_step : args -> option t
 
-val mk_range : args -> option t
-val division_modulus_op (op:Z.bigint -> Z.bigint -> Z.bigint) : args -> option t
 val and_op : args -> option t
 val or_op : args -> option t

--- a/src/typechecker/FStar.TypeChecker.NBETerm.fsti
+++ b/src/typechecker/FStar.TypeChecker.NBETerm.fsti
@@ -318,23 +318,7 @@ val arrow_as_prim_step_3:  embedding 'a
 // Interface for NBE interpretations
 
 val arg_as_int : arg -> option Z.t
-val arg_as_bool : arg -> option bool
-val arg_as_char : arg -> option FStar.Char.char
-val arg_as_string : arg -> option string
 val arg_as_list : embedding 'a -> arg -> option (list 'a)
-val arg_as_doc : arg -> option FStar.Pprint.document
-val arg_as_bounded_int : arg -> option (fv * Z.t * option S.meta_source_info)
-
-val int_as_bounded : fv -> Z.t -> t
-val with_meta_ds : t -> option meta_source_info -> t
-
-val unary_int_op : (Z.t -> Z.t) -> (universes -> args -> option t)
-val binary_int_op : (Z.t -> Z.t -> Z.t) -> (universes -> args -> option t)
-
-val unary_bool_op : (bool -> bool) -> (universes -> args -> option t)
-val binary_bool_op : (bool -> bool -> bool) -> (universes -> args -> option t)
-
-val binary_string_op : (string -> string -> string) -> (universes -> args -> option t)
 
 val decidable_eq : bool -> args -> option t
 val interp_prop_eq2 : args -> option t
@@ -350,11 +334,7 @@ val mixed_ternary_op (as_a : arg -> option 'a)
                      (us:universes)
                      (args : args) : option t
 
-val unary_op : (arg -> option 'a) -> ('a -> t) -> (universes -> args -> option t)
-val binary_op : (arg -> option 'a) -> ('a -> 'a -> t) -> (universes -> args -> option t)
-
 val dummy_interp : Ident.lid -> args -> option t
-val prims_to_fstar_range_step : args -> option t
 
 val and_op : args -> option t
 val or_op : args -> option t

--- a/src/typechecker/FStar.TypeChecker.Primops.fst
+++ b/src/typechecker/FStar.TypeChecker.Primops.fst
@@ -43,15 +43,11 @@ let try_unembed_simple {| EMB.embedding 'a |} (x:term) : option 'a =
     EMB.try_unembed x EMB.id_norm_cb
 
 let arg_as_int    (a:arg) : option Z.t = fst a |> try_unembed_simple
-let arg_as_bool   (a:arg) : option bool = fst a |> try_unembed_simple
 let arg_as_char   (a:arg) : option char = fst a |> try_unembed_simple
-let arg_as_string (a:arg) : option string = fst a |> try_unembed_simple
 
 let arg_as_list {|e:EMB.embedding 'a|} (a:arg)
 : option (list 'a)
   = fst a |> try_unembed_simple
-
-let arg_as_doc (a:arg) : option Pprint.document = fst a |> try_unembed_simple
 
 let arg_as_bounded_int ((a, _) :arg) : option (fv * Z.t * option S.meta_source_info) =
     let (a, m) =
@@ -115,47 +111,182 @@ let as_primitive_step_nbecbs is_strong (l, arity, u_arity, f, f_nbe) : primitive
     interpretation_nbe=(fun cb univs args -> f_nbe cb univs args)
 }
 
-let mk1 (f : 'a -> 'b)
-        {| EMB.embedding 'a |} {| EMB.embedding 'b |}
-: interp_t =
-  fun psc cbs us args ->
-    match args with
-    | [(a1, _)] ->
-      let! x = try_unembed_simple a1 in
-      let r : 'b = f x in
-      return (embed_simple psc.psc_range r)
-
-let mk2 (f : 'a -> 'b -> 'c)
-        {| EMB.embedding 'a |} {| EMB.embedding 'b |} {| EMB.embedding 'c |}
-: interp_t =
-  fun psc cbs us args ->
-    match args with
-    | [(a1, _); (a2, _)] ->
-      let! x = try_unembed_simple a1 in
-      let! y = try_unembed_simple a2 in
-      let r : 'c = f x y in
-      return (embed_simple psc.psc_range r)
-
-
-
 (* Most primitive steps don't use the NBE cbs, so they can use this wrapper. *)
 let as_primitive_step is_strong (l, arity, u_arity, f, f_nbe) =
   as_primitive_step_nbecbs is_strong (l, arity, u_arity, f, (fun cb univs args -> f_nbe univs args))
 
-let unary_int_op (f:Z.t -> Z.t) =
-    unary_op arg_as_int (fun r x -> embed_simple r (f x))
+let solve (#a:Type) {| ev : a |} : Tot a = ev
 
-let binary_int_op (f:Z.t -> Z.t -> Z.t) =
-    binary_op arg_as_int (fun r x y -> embed_simple r (f x y))
+let mk1 #a #r
+  (u_arity : int)
+  (name : Ident.lid)
+  {| EMB.embedding a |} {| NBE.embedding a |}
+  {| EMB.embedding r |} {| NBE.embedding r |}
+  (f : a -> r)
+  : primitive_step =
+  let interp : interp_t =
+    fun psc cb us args ->
+      match args with
+      | [(a, _)] ->
+        let! a = try_unembed_simple a in
+        return (embed_simple psc.psc_range (f a))
+      | _ -> None
+  in
+  let nbe_interp : nbe_interp_t =
+    fun cbs us args ->
+      match args with
+      | [(a, _)] ->
+        let! r = f <$> NBE.unembed solve cbs a in
+        return (NBE.embed solve cbs r)
+      | _ ->
+        None
+  in
+  as_primitive_step_nbecbs true (name, 1, u_arity, interp, nbe_interp)
 
-let unary_bool_op (f:bool -> bool) =
-    unary_op arg_as_bool (fun r x -> embed_simple r (f x))
+let mk2 #a #b #r
+  (u_arity : int)
+  (name : Ident.lid)
+  {| EMB.embedding a |} {| NBE.embedding a |}
+  {| EMB.embedding b |} {| NBE.embedding b |}
+  {| EMB.embedding r |} {| NBE.embedding r |}
+  (f : a -> b -> r)
+  : primitive_step =
+  let interp : interp_t =
+    fun psc cb us args ->
+      match args with
+      | [(a, _); (b, _)] ->
+        let! r = f <$> try_unembed_simple a <*> try_unembed_simple b in
+        return (embed_simple psc.psc_range r)
+      | _ -> None
+  in
+  let nbe_interp : nbe_interp_t =
+    fun cbs us args ->
+      match args with
+      | [(a, _); (b, _)] ->
+        let! r = f <$> NBE.unembed solve cbs a <*> NBE.unembed solve cbs b in
+        return (NBE.embed solve cbs r)
+      | _ ->
+        None
+  in
+  as_primitive_step_nbecbs true (name, 2, u_arity, interp, nbe_interp)
 
-let binary_bool_op (f:bool -> bool -> bool) =
-    binary_op arg_as_bool (fun r x y -> embed_simple r (f x y))
+(* Duplication for op_Division / op_Modulus which can prevent reduction. The `f`
+already returns something in the option monad, so we add an extra join. *)
+let mk2' #a #b #r
+  (u_arity : int)
+  (name : Ident.lid)
+  {| EMB.embedding a |} {| NBE.embedding a |}
+  {| EMB.embedding b |} {| NBE.embedding b |}
+  {| EMB.embedding r |} {| NBE.embedding r |}
+  (f : a -> b -> option r)
+  : primitive_step =
+  let interp : interp_t =
+    fun psc cb us args ->
+      match args with
+      | [(a, _); (b, _)] ->
+        let! r = f <$> try_unembed_simple a <*> try_unembed_simple b in
+        let! r = r in
+        return (embed_simple psc.psc_range r)
+      | _ -> None
+  in
+  let nbe_interp : nbe_interp_t =
+    fun cbs us args ->
+      match args with
+      | [(a, _); (b, _)] ->
+        let! r = f <$> NBE.unembed solve cbs a <*> NBE.unembed solve cbs b in
+        let! r = r in
+        return (NBE.embed solve cbs r)
+      | _ ->
+        None
+  in
+  as_primitive_step_nbecbs true (name, 2, u_arity, interp, nbe_interp)
 
-let binary_string_op (f : string -> string -> string) =
-    binary_op arg_as_string (fun r x y -> embed_simple r (f x y))
+let mk3 #a #b #c #r
+  (u_arity : int)
+  (name : Ident.lid)
+  {| EMB.embedding a |} {| NBE.embedding a |}
+  {| EMB.embedding b |} {| NBE.embedding b |}
+  {| EMB.embedding c |} {| NBE.embedding c |}
+  {| EMB.embedding r |} {| NBE.embedding r |}
+  (f : a -> b -> c -> r)
+  : primitive_step =
+  let interp : interp_t =
+    fun psc cb us args ->
+      match args with
+      | [(a, _); (b, _); (c, _)] ->
+        let! r = f <$> try_unembed_simple a <*> try_unembed_simple b <*> try_unembed_simple c in
+        return (embed_simple psc.psc_range r)
+      | _ -> None
+  in
+  let nbe_interp : nbe_interp_t =
+    fun cbs us args ->
+      match args with
+      | [(a, _); (b, _); (c, _)] ->
+        let! r = f <$> NBE.unembed solve cbs a <*> NBE.unembed solve cbs b <*> NBE.unembed solve cbs c in
+        return (NBE.embed solve cbs r)
+      | _ ->
+        None
+  in
+  as_primitive_step_nbecbs true (name, 3, u_arity, interp, nbe_interp)
+
+let mk4 #a #b #c #d #r
+  (u_arity : int)
+  (name : Ident.lid)
+  {| EMB.embedding a |} {| NBE.embedding a |}
+  {| EMB.embedding b |} {| NBE.embedding b |}
+  {| EMB.embedding c |} {| NBE.embedding c |}
+  {| EMB.embedding d |} {| NBE.embedding d |}
+  {| EMB.embedding r |} {| NBE.embedding r |}
+  (f : a -> b -> c -> d -> r)
+  : primitive_step =
+  let interp : interp_t =
+    fun psc cb us args ->
+      match args with
+      | [(a, _); (b, _); (c, _); (d, _); (e, _)] ->
+        let! r = f <$> try_unembed_simple a <*> try_unembed_simple b <*> try_unembed_simple c <*> try_unembed_simple d in
+        return (embed_simple psc.psc_range r)
+      | _ -> None
+  in
+  let nbe_interp : nbe_interp_t =
+    fun cbs us args ->
+      match args with
+      | [(a, _); (b, _); (c, _); (d, _)] ->
+        let! r = f <$> NBE.unembed solve cbs a <*> NBE.unembed solve cbs b <*> NBE.unembed solve cbs c <*> NBE.unembed solve cbs d in
+        return (NBE.embed solve cbs r)
+      | _ ->
+        None
+  in
+  as_primitive_step_nbecbs true (name, 4, u_arity, interp, nbe_interp)
+
+let mk5 #a #b #c #d #e #r
+  (u_arity : int)
+  (name : Ident.lid)
+  {| EMB.embedding a |} {| NBE.embedding a |}
+  {| EMB.embedding b |} {| NBE.embedding b |}
+  {| EMB.embedding c |} {| NBE.embedding c |}
+  {| EMB.embedding d |} {| NBE.embedding d |}
+  {| EMB.embedding e |} {| NBE.embedding e |}
+  {| EMB.embedding r |} {| NBE.embedding r |}
+  (f : a -> b -> c -> d -> e -> r)
+  : primitive_step =
+  let interp : interp_t =
+    fun psc cb us args ->
+      match args with
+      | [(a, _); (b, _); (c, _); (d, _); (e, _)] ->
+        let! r = f <$> try_unembed_simple a <*> try_unembed_simple b <*> try_unembed_simple c <*> try_unembed_simple d <*> try_unembed_simple e in
+        return (embed_simple psc.psc_range r)
+      | _ -> None
+  in
+  let nbe_interp : nbe_interp_t =
+    fun cbs us args ->
+      match args with
+      | [(a, _); (b, _); (c, _); (d, _); (e, _)] ->
+        let! r = f <$> NBE.unembed solve cbs a <*> NBE.unembed solve cbs b <*> NBE.unembed solve cbs c <*> NBE.unembed solve cbs d <*> NBE.unembed solve cbs e in
+        return (NBE.embed solve cbs r)
+      | _ ->
+        None
+  in
+  as_primitive_step_nbecbs true (name, 5, u_arity, interp, nbe_interp)
 
 let mixed_binary_op
   (as_a : arg -> option 'a)
@@ -202,203 +333,221 @@ let mixed_ternary_op
        end
     | _ -> None
 
-let built_in_primitive_steps_list : list primitive_step =
-    let list_of_string' rng (s:string) : term =
-        let name l = mk (Tm_fvar (lid_as_fv l None)) rng in
-        let char_t = name PC.char_lid in
-        let charterm c = mk (Tm_constant (Const_char c)) rng in
-        U.mk_list char_t rng <| List.map charterm (list_of_string s)
-    in
-    let string_of_list' (rng:Range.range) (l:list char) : term =
-        let s = string_of_list l in
-        U.exp_string s
-    in
-    let string_compare' rng (s1:string) (s2:string) : term =
-        let r = String.compare s1 s2 in
-        embed_simple rng (Z.big_int_of_string (BU.string_of_int r))
-    in
-    let string_concat' psc _n _us args : option term =
-        match args with
-        | [a1; a2] ->
-            begin match arg_as_string a1 with
-            | Some s1 ->
-                begin match arg_as_list a2 with
-                | Some s2 ->
-                    let r = String.concat s1 s2 in
-                    Some (embed_simple psc.psc_range r)
-                | _ -> None
-                end
-            | _ -> None
-            end
-        | _ -> None
-    in
-    let string_split' psc _norm_cb _us args : option term =
-        match args with
-        | [a1; a2] ->
-            begin match arg_as_list a1 with
-            | Some s1 ->
-                begin match arg_as_string a2 with
-                | Some s2 ->
-                    let r = String.split s1 s2 in
-                    Some (embed_simple psc.psc_range r)
-                | _ -> None
-                end
-            | _ -> None
-            end
-        | _ -> None
-    in
-    let string_substring' psc _norm_cb _us args : option term =
-        match args with
-        | [a1; a2; a3] ->
-            begin match arg_as_string a1, arg_as_int a2, arg_as_int a3 with
-            | Some s1, Some n1, Some n2 ->
-                let n1 = Z.to_int_fs n1 in
-                let n2 = Z.to_int_fs n2 in
-                (* Might raise an OOB exception, but not if the precondition is proven *)
-                begin
-                try let r = String.substring s1 n1 n2 in
-                    Some (embed_simple psc.psc_range r)
-                with | _ -> None
-                end
-            | _ -> None
-            end
-        | _ -> None
-    in
-    let string_of_int rng (i:Z.t) : term =
-        embed_simple rng (Z.string_of_big_int i)
-    in
-    let string_of_bool rng (b:bool) : term =
-        embed_simple rng (if b then "true" else "false")
-    in
-    let int_of_string rng (s:string) : term =
-      let r = BU.safe_int_of_string s in
-      embed_simple rng r
-    in
-    let bool_of_string rng (s:string) : term =
-      let r =
-        match s with
-        | "true" -> Some true
-        | "false" -> Some false
-        | _ -> None
-      in
-      embed_simple rng r
-    in
-    let lowercase rng (s:string) : term =
-        embed_simple rng (String.lowercase s)
-    in
-    let uppercase rng (s:string) : term =
-        embed_simple rng (String.uppercase s)
-    in
-    let string_index psc _norm_cb _us args : option term =
-        match args with
-        | [a1; a2] ->
-            begin match arg_as_string a1, arg_as_int a2 with
-            | Some s, Some i ->
-              begin
-              try let r = String.index s i in
-                  Some (embed_simple psc.psc_range r)
-              with | _ -> None
-              end
-            | _  -> None
-            end
-        | _ -> None
-    in
-    let string_index_of psc _norm_cb _us args : option term =
-        match args with
-        | [a1; a2] ->
-            begin match arg_as_string a1, arg_as_char a2 with
-            | Some s, Some c ->
-              begin
-              try let r = String.index_of s c in
-                  Some (embed_simple psc.psc_range r)
-              with | _ -> None
-              end
-            | _ -> None
-            end
-        | _ -> None
-    in
-    let mk_range (psc:psc) _norm_cb _us args : option term =
-      match args with
-      | [fn; from_line; from_col; to_line; to_col] -> begin
-        match arg_as_string fn,
-              arg_as_int from_line,
-              arg_as_int from_col,
-              arg_as_int to_line,
-              arg_as_int to_col with
-        | Some fn, Some from_l, Some from_c, Some to_l, Some to_c ->
-          let r = FStar.Compiler.Range.mk_range fn
-                              (FStar.Compiler.Range.mk_pos (Z.to_int_fs from_l) (Z.to_int_fs from_c))
-                              (FStar.Compiler.Range.mk_pos (Z.to_int_fs to_l) (Z.to_int_fs to_c)) in
-          Some (embed_simple psc.psc_range r)
+let decidable_eq (neg:bool) (psc:psc) _norm_cb _us (args:args)
+    : option term =
+    let r = psc.psc_range in
+    let tru = mk (Tm_constant (FC.Const_bool true)) r in
+    let fal = mk (Tm_constant (FC.Const_bool false)) r in
+    match args with
+    | [(_typ, _); (a1, _); (a2, _)] ->
+        (match U.eq_tm a1 a2 with
+        | U.Equal -> Some (if neg then fal else tru)
+        | U.NotEqual -> Some (if neg then tru else fal)
+        | _ -> None)
+    | _ ->
+        failwith "Unexpected number of arguments"
+
+(* and_op and or_op are special cased because they are short-circuting,
+  * can run without unembedding its second argument. *)
+let and_op : psc -> EMB.norm_cb -> universes -> args -> option term
+  = fun psc _norm_cb _us args ->
+    match args with
+    | [(a1, None); (a2, None)] ->
+        begin match try_unembed_simple a1 with
+        | Some false ->
+          Some (embed_simple psc.psc_range false)
+        | Some true ->
+          Some a2
         | _ -> None
         end
-      | _ -> None
-    in
-    let decidable_eq (neg:bool) (psc:psc) _norm_cb _us (args:args)
-        : option term =
-        let r = psc.psc_range in
-        let tru = mk (Tm_constant (FC.Const_bool true)) r in
-        let fal = mk (Tm_constant (FC.Const_bool false)) r in
-        match args with
-        | [(_typ, _); (a1, _); (a2, _)] ->
-            (match U.eq_tm a1 a2 with
-            | U.Equal -> Some (if neg then fal else tru)
-            | U.NotEqual -> Some (if neg then tru else fal)
-            | _ -> None)
-        | _ ->
-            failwith "Unexpected number of arguments"
-    in
-    (* and_op and or_op are special cased because they are short-circuting,
-     * can run without unembedding its second argument. *)
-    let and_op : psc -> EMB.norm_cb -> universes -> args -> option term
-      = fun psc _norm_cb _us args ->
-        match args with
-        | [(a1, None); (a2, None)] ->
-            begin match try_unembed_simple a1 with
-            | Some false ->
-              Some (embed_simple psc.psc_range false)
-            | Some true ->
-              Some a2
-            | _ -> None
-            end
-        | _ -> failwith "Unexpected number of arguments"
-    in
-    let or_op : psc -> EMB.norm_cb -> universes -> args -> option term
-      = fun psc _norm_cb _us args ->
-        match args with
-        | [(a1, None); (a2, None)] ->
-            begin match try_unembed_simple a1 with
-            | Some true ->
-              Some (embed_simple psc.psc_range true)
-            | Some false ->
-              Some a2
-            | _ -> None
-            end
-        | _ -> failwith "Unexpected number of arguments"
-    in
+    | _ -> failwith "Unexpected number of arguments"
 
-    (* division and modulus are special cased since we must avoid zero denominators *)
-    let division_modulus_op op : psc -> EMB.norm_cb -> universes -> args -> option term
-      = fun psc _norm_cb _us args ->
+let or_op : psc -> EMB.norm_cb -> universes -> args -> option term
+  = fun psc _norm_cb _us args ->
+    match args with
+    | [(a1, None); (a2, None)] ->
+        begin match try_unembed_simple a1 with
+        | Some true ->
+          Some (embed_simple psc.psc_range true)
+        | Some false ->
+          Some a2
+        | _ -> None
+        end
+    | _ -> failwith "Unexpected number of arguments"
+
+
+let division_modulus_op (f : Z.t -> Z.t -> Z.t) (x y : Z.t) : option Z.t =
+  if Z.to_int_fs y <> 0
+  then Some (f x y)
+  else None
+
+(* Simple primops that are just implemented by some concrete function
+over embeddable types. *)
+let simple_ops = [
+  (* Basic *)
+  mk1 0 PC.string_of_int_lid (fun z -> string_of_int (Z.to_int_fs z));
+  mk1 0 PC.int_of_string_lid (fun s -> BU.map_opt (BU.safe_int_of_string s) Z.of_int_fs);
+  mk1 0 PC.string_of_bool_lid string_of_bool;
+  mk1 0 PC.bool_of_string_lid (function "true" -> Some true | "false" -> Some false | _ -> None);
+
+  (* Integer opts *)
+  mk1 0 PC.op_Minus Z.minus_big_int;
+  mk2 0 PC.op_Addition Z.add_big_int;
+  mk2 0 PC.op_Subtraction Z.sub_big_int;
+  mk2 0 PC.op_Multiply Z.mult_big_int;
+  mk2 0 PC.op_LT  Z.lt_big_int;
+  mk2 0 PC.op_LTE Z.le_big_int;
+  mk2 0 PC.op_GT  Z.gt_big_int;
+  mk2 0 PC.op_GTE Z.ge_big_int;
+
+  mk2' 0 PC.op_Division (division_modulus_op Z.div_big_int);
+  mk2' 0 PC.op_Modulus  (division_modulus_op Z.mod_big_int);
+
+  (* Bool opts. NB: && and || are special-cased since they are
+  short-circuiting, and can run even if their second arg does not
+  try_unembed_simple. Otherwise the strict variants are defined as below. *)
+  mk1 0 PC.op_Negation not;
+  // mk2 0 PC.op_And (&&);
+  // mk2 0 PC.op_Or  ( || );
+
+  (* Operations from FStar.String *)
+  mk2 0 PC.string_concat_lid String.concat;
+  mk2 0 PC.string_split_lid String.split;
+  mk2 0 PC.prims_strcat_lid (^);
+  mk2 0 PC.string_compare_lid (fun s1 s2 -> Z.of_int_fs (String.compare s1 s2));
+  mk1 0 PC.string_string_of_list_lid string_of_list;
+  mk2 0 PC.string_make_lid (fun x y -> String.make (Z.to_int_fs x) y);
+  mk1 0 PC.string_list_of_string_lid list_of_string;
+  mk1 0 PC.string_lowercase_lid String.lowercase;
+  mk1 0 PC.string_uppercase_lid String.uppercase;
+  mk2 0 PC.string_index_lid String.index;
+  mk2 0 PC.string_index_of_lid String.index_of;
+  mk3 0 PC.string_sub_lid (fun s o l -> String.substring s (Z.to_int_fs o) (Z.to_int_fs l));
+
+  (* Range ops *)
+  mk5 0 PC.mk_range_lid (fun fn from_l from_c to_l to_c ->
+      let open FStar.Compiler.Range in
+      mk_range fn (mk_pos (Z.to_int_fs from_l) (Z.to_int_fs from_c))
+                  (mk_pos (Z.to_int_fs to_l) (Z.to_int_fs to_c))
+  );
+]
+
+let bogus_cbs = {
+    NBE.iapp = (fun h _args -> h);
+    NBE.translate = (fun _ -> failwith "bogus_cbs translate");
+}
+
+let issue_ops : list primitive_step =
+  let mk_lid l = PC.p2l ["FStar"; "Issue"; l] in [
+    mk1 0 (mk_lid "message_of_issue") Mkissue?.issue_msg;
+    mk1 0 (mk_lid "level_of_issue") (fun i -> Errors.string_of_issue_level i.issue_level);
+    mk1 0 (mk_lid "number_of_issue") (fun i -> BU.map_opt i.issue_number Z.of_int_fs);
+    mk1 0 (mk_lid "range_of_issue") Mkissue?.issue_range;
+    mk1 0 (mk_lid "context_of_issue") Mkissue?.issue_ctx;
+    mk1 0 (mk_lid "render_issue") Errors.format_issue;
+    mk5 0 (mk_lid "mk_issue_doc") (fun level msg range number context ->
+          { issue_level = Errors.issue_level_of_string level;
+            issue_range = range;
+            issue_number = BU.map_opt number Z.to_int_fs;
+            issue_msg = msg;
+            issue_ctx = context}
+    );
+  ]
+
+let doc_ops =
+  let mk_lid l = PC.p2l ["FStar"; "Stubs"; "Pprint"; l] in
+    (* FIXME: we only implement the absolute minimum. The rest of the operations
+    are availabe to plugins. *)
+    let open FStar.Pprint in
+    [
+      mk1 0 (mk_lid "arbitrary_string") arbitrary_string;
+      mk1 0 (mk_lid "render") render;
+    ]
+
+let seal_steps =
+  List.map (fun p -> { as_primitive_step_nbecbs true p with renorm_after = true}) [
+    (PC.map_seal_lid, 4, 2,
+      (fun psc univs cbs args ->
         match args with
-        | [(a1, None); (a2, None)] ->
-            begin match try_unembed_simple a1,
-                        try_unembed_simple a2 with
-            | Some m, Some n ->
-              if Z.to_int_fs n <> 0
-              then Some (embed_simple psc.psc_range (op m n))
-              else None
+        | [(ta, _); (tb, _); (s, _); (f, _)] ->
+          begin
+          let open EMB in
+          let try_unembed (#a:Type) (e:embedding a) (x:term) : option a =
+              try_unembed x id_norm_cb
+          in
+          match try_unembed e_any ta,
+                try_unembed e_any tb,
+                try_unembed (e_sealed e_any) s,
+                try_unembed e_any f with
+          | Some ta, Some tb, Some s, Some f ->
+            let r = U.mk_app f [S.as_arg s] in
+            let emb = set_type ta e_any in
+            Some (embed_simple #_ #(e_sealed emb) psc.psc_range r)
+          | _ -> None
+          end
+        | _ -> None),
+      (fun cb univs args ->
+        match args with
+        | [(ta, _); (tb, _); (s, _); (f, _)] ->
+          begin
+          let open FStar.TypeChecker.NBETerm in
+          let try_unembed (#a:Type) (e:embedding a) (x:NBETerm.t) : option a =
+              unembed e bogus_cbs x
+          in
+          match try_unembed e_any ta,
+                try_unembed e_any tb,
+                try_unembed (e_sealed e_any) s,
+                try_unembed e_any f with
+          | Some ta, Some tb, Some s, Some f ->
+            let r = cb.iapp f [as_arg s] in
+            let emb = set_type ta e_any in
+            Some (embed (e_sealed emb) cb r)
+          | _ -> None
+          end
+        | _ -> None
+        ));
+    (PC.bind_seal_lid, 4, 2,
+      (fun psc univs cbs args ->
+        match args with
+        | [(ta, _); (tb, _); (s, _); (f, _)] ->
+          begin
+          let open EMB in
+          let try_unembed (#a:Type) (e:embedding a) (x:term) : option a =
+              try_unembed x id_norm_cb
+          in
+          match try_unembed e_any ta,
+                try_unembed e_any tb,
+                try_unembed (e_sealed e_any) s,
+                try_unembed e_any f with
+          | Some ta, Some tb, Some s, Some f ->
+            let r = U.mk_app f [S.as_arg s] in
+            Some (embed_simple #_ #e_any psc.psc_range r)
+          | _ -> None
+          end
+        | _ -> None),
+      (fun cb univs args ->
+        match args with
+        | [(ta, _); (tb, _); (s, _); (f, _)] ->
+          begin
+          let open FStar.TypeChecker.NBETerm in
+          let try_unembed (#a:Type) (e:embedding a) (x:NBETerm.t) : option a =
+              unembed e bogus_cbs x
+          in
+          match try_unembed e_any ta,
+                try_unembed e_any tb,
+                try_unembed (e_sealed e_any) s,
+                try_unembed e_any f with
+          | Some ta, Some tb, Some s, Some f ->
+            let r = cb.iapp f [as_arg s] in
+            let emb = set_type ta e_any in
+            Some (embed emb cb r)
+          | _ -> None
+          end
+        | _ -> None
+        ));
+  ]
 
-            | _ -> None
-            end
-        | _ -> failwith "Unexpected number of arguments"
-    in
-
-    let bogus_cbs = {
-        NBE.iapp = (fun h _args -> h);
-        NBE.translate = (fun _ -> failwith "bogus_cbs translate");
-    }
-    in
+let built_in_primitive_steps_list : list primitive_step =
     let int_as_bounded r int_to_t n =
       let c = embed_simple r n in
       let int_to_t = S.fv_to_tm int_to_t in
@@ -409,6 +558,7 @@ let built_in_primitive_steps_list : list primitive_step =
       | None -> t
       | Some m -> S.mk (Tm_meta {tm=t; meta=Meta_desugared m}) r
     in
+
     let basic_ops
       //because our support for F# style type-applications is very limited
       : list (Ident.lid * int * int * 
@@ -419,73 +569,7 @@ let built_in_primitive_steps_list : list primitive_step =
           //universe arity
           //interp for normalizer
           //interp for NBE
-      =
-        [(PC.op_Minus,
-             1,
-             0,
-             unary_int_op (fun x -> Z.minus_big_int x),
-             NBETerm.unary_int_op (fun x -> Z.minus_big_int x));
-         (PC.op_Addition,
-             2,
-             0,
-             binary_int_op (fun x y -> Z.add_big_int x y),
-             NBETerm.binary_int_op (fun x y -> Z.add_big_int x y));
-         (PC.op_Subtraction,
-             2,
-             0,
-             binary_int_op (fun x y -> Z.sub_big_int x y),
-             NBETerm.binary_int_op (fun x y -> Z.sub_big_int x y));
-         (PC.op_Multiply,
-             2,
-             0,
-             binary_int_op (fun x y -> Z.mult_big_int x y),
-             NBETerm.binary_int_op (fun x y -> Z.mult_big_int x y));
-         (PC.op_Division,
-             2,
-             0,
-             division_modulus_op Z.div_big_int,
-             (fun _us -> NBETerm.division_modulus_op Z.div_big_int));
-         (PC.op_LT,
-             2,
-             0,
-             binary_op arg_as_int (fun r x y -> embed_simple r (Z.lt_big_int x y)),
-             NBETerm.binary_op NBETerm.arg_as_int (fun x y -> NBETerm.embed NBETerm.e_bool bogus_cbs (Z.lt_big_int x y)));
-         (PC.op_LTE,
-             2,
-             0,
-             binary_op arg_as_int (fun r x y -> embed_simple r (Z.le_big_int x y)),
-             NBETerm.binary_op NBETerm.arg_as_int (fun  x y -> NBETerm.embed NBETerm.e_bool bogus_cbs (Z.le_big_int x y)));
-         (PC.op_GT,
-             2,
-             0,
-             binary_op arg_as_int (fun r x y -> embed_simple r (Z.gt_big_int x y)),
-             NBETerm.binary_op NBETerm.arg_as_int (fun x y -> NBETerm.embed NBETerm.e_bool bogus_cbs (Z.gt_big_int x y)));
-         (PC.op_GTE,
-             2,
-             0,
-             binary_op arg_as_int (fun r x y -> embed_simple r (Z.ge_big_int x y)),
-             NBETerm.binary_op NBETerm.arg_as_int (fun x y -> NBETerm.embed NBETerm.e_bool bogus_cbs (Z.ge_big_int x y)));
-         (PC.op_Modulus,
-             2,
-             0,
-             division_modulus_op Z.mod_big_int,
-             (fun _us -> NBETerm.division_modulus_op Z.mod_big_int));
-         (PC.op_Negation,
-             1,
-             0,
-             unary_bool_op (fun x -> not x),
-             NBETerm.unary_bool_op (fun x -> not x));
-         (PC.op_And,
-             2,
-             0,
-             and_op,
-             (fun _ -> NBETerm.and_op));
-         (PC.op_Or,
-             2,
-             0,
-             or_op,
-             (fun _ -> NBETerm.or_op));
-         (let u32_int_to_t =
+      = [(let u32_int_to_t =
             ["FStar"; "UInt32"; "uint_to_t"]
             |> PC.p2l
             |> (fun l -> S.lid_as_fv l None) in
@@ -498,97 +582,16 @@ let built_in_primitive_steps_list : list primitive_step =
              NBETerm.unary_op
                NBETerm.arg_as_char
                (fun c -> NBETerm.int_as_bounded u32_int_to_t (c |> BU.int_of_char |> Z.of_int_fs)));
-         (PC.string_of_int_lid,
-             1,
-             0,
-             unary_op arg_as_int string_of_int,
-             NBETerm.unary_op NBETerm.arg_as_int NBETerm.string_of_int);
-         (PC.string_of_bool_lid,
-             1,
-             0,
-             unary_op arg_as_bool string_of_bool,
-             NBETerm.unary_op NBETerm.arg_as_bool NBETerm.string_of_bool);
-
-         (PC.bool_of_string_lid,
-             1,
-             0,
-             unary_op arg_as_string bool_of_string,
-             NBETerm.unary_op NBETerm.arg_as_string NBETerm.bool_of_string);
-         (PC.int_of_string_lid,
-             1,
-             0,
-             unary_op arg_as_string int_of_string,
-             NBETerm.unary_op NBETerm.arg_as_string NBETerm.int_of_string);
-(* Operations from FStar.String *)
-         (PC.string_list_of_string_lid,
-             1,
-             0,
-             unary_op arg_as_string list_of_string',
-             NBETerm.unary_op NBETerm.arg_as_string NBETerm.list_of_string');
-         (PC.string_string_of_list_lid,
-             1,
-             0,
-             unary_op arg_as_list string_of_list',
-             NBETerm.unary_op (NBETerm.arg_as_list NBETerm.e_char) NBETerm.string_of_list');
-         (PC.string_make_lid,
+         (PC.op_And,
              2,
              0,
-             mixed_binary_op
-                   (fun (x:arg) -> arg_as_int x <: option Z.t)
-                   (fun (x:arg) -> arg_as_char x <: option char)
-                   (fun (r:Range.range) (s:string) -> embed_simple r s)
-                   (fun (r:Range.range) _us (x:BigInt.t) (y:char) -> Some (String.make (BigInt.to_int_fs x) y)),
-             NBETerm.mixed_binary_op
-                   NBETerm.arg_as_int
-                   NBETerm.arg_as_char
-                   (NBETerm.embed NBETerm.e_string bogus_cbs)
-                   (fun _us (x:BigInt.t) (y:char) -> Some (String.make (BigInt.to_int_fs x) y)));
-         (PC.string_split_lid,
+             and_op,
+             (fun _ -> NBETerm.and_op));
+         (PC.op_Or,
              2,
              0,
-             string_split',
-             (fun _ -> NBETerm.string_split'));
-         (PC.prims_strcat_lid,
-             2,
-             0,
-             binary_string_op (fun x y -> x ^ y),
-             NBETerm.binary_string_op (fun x y -> x ^ y));
-         (PC.string_concat_lid,
-             2,
-             0,
-             string_concat',
-             (fun _ -> NBETerm.string_concat'));
-         (PC.string_compare_lid,
-             2,
-             0,
-             binary_op arg_as_string string_compare',
-             NBETerm.binary_op NBETerm.arg_as_string NBETerm.string_compare');
-         (PC.string_lowercase_lid,
-             1,
-             0,
-             unary_op arg_as_string lowercase,
-             NBETerm.unary_op NBETerm.arg_as_string NBETerm.string_lowercase);
-         (PC.string_uppercase_lid,
-             1,
-             0,
-             unary_op arg_as_string uppercase,
-             NBETerm.unary_op NBETerm.arg_as_string NBETerm.string_uppercase);
-         (PC.string_index_lid,
-             2,
-             0,
-             string_index,
-             (fun _ -> NBETerm.string_index));
-         (PC.string_index_of_lid,
-             2,
-             0,
-             string_index_of,
-             (fun _ -> NBETerm.string_index_of));
-         (PC.string_sub_lid,
-             3,
-             0,
-             string_substring',
-             (fun _ -> NBETerm.string_substring'));
-(* END FStar.String functions *)
+             or_op,
+             (fun _ -> NBETerm.or_op));
          (PC.op_Eq,
              3,
              0,
@@ -599,22 +602,12 @@ let built_in_primitive_steps_list : list primitive_step =
              0,
              decidable_eq true,
              (fun _ -> NBETerm.decidable_eq true));
-         (PC.p2l ["FStar"; "Range"; "mk_range"],
-             5,
-             0,
-             mk_range,
-             (fun _ -> NBE.mk_range));
         ]
-    in
-    (* GM: Just remove strong_reduction_ok? There's currently no operator which requires that
-     * and it also seems unlikely since those that cannot work with open term might
-     * just fail to unembed their arguments. *)
-    let weak_ops =
-            [
-            ]
     in
     let bounded_arith_ops
         =
+        (* FIXME: using a newtype with custom embeddings should make this whole
+        section very straightforward, as for simple_ops above. *)
         let bounded_signed_int_types =
            [ "Int8", 8; "Int16", 16; "Int32", 32; "Int64", 64 ]
         in
@@ -944,7 +937,7 @@ let built_in_primitive_steps_list : list primitive_step =
         (  PC.immutable_array_of_list_lid, 2, 1,
            mixed_binary_op
               (fun (elt_t, _) -> Some elt_t) //the first arg of of_list is the element type
-              (fun (l, q) -> //2nd arg: unembed as a list term
+              (fun (l, q) -> //2nd arg: try_unembed_simple as a list term
                 match arg_as_list #_ #FStar.Syntax.Embeddings.e_any (l, q) with
                 | Some lst -> Some (l, lst)
                 | _ -> None)
@@ -985,7 +978,7 @@ let built_in_primitive_steps_list : list primitive_step =
       in
       let arg1_as_elt_t (x:arg) : option term = Some (fst x) in
       let arg2_as_blob (x:arg) : option FStar.Compiler.Dyn.dyn =
-          //unembed an arg as a IA.t blob if the emb_typ
+          //try_unembed_simple an arg as a IA.t blob if the emb_typ
           //of the lkind tells us it has the right type
           match (SS.compress (fst x)).n with
           | Tm_lazy {blob=blob; lkind=Lazy_embedding (ET_app(head, _), _)}
@@ -993,7 +986,7 @@ let built_in_primitive_steps_list : list primitive_step =
           | _ -> None
       in
       let arg2_as_blob_nbe (x:NBETerm.arg) : option FStar.Compiler.Dyn.dyn =
-          //unembed an arg as a IA.t blob if the emb_typ
+          //try_unembed_simple an arg as a IA.t blob if the emb_typ
           //tells us it has the right type      
           let open FStar.TypeChecker.NBETerm in
           match (fst x).nbe_t with
@@ -1034,236 +1027,11 @@ let built_in_primitive_steps_list : list primitive_step =
       in
       [of_list_op; length_op; index_op]
     in
-    let issue_ops =
-        let mk_lid l = PC.p2l ["FStar"; "Issue"; l] in
-        let arg_as_issue (x:arg) : option Errors.issue =
-            EMB.(try_unembed (fst x) id_norm_cb)
-        in
-        let option_int_as_option_z oi = 
-          match oi with
-          | None -> None
-          | Some i -> (Some (Z.of_int_fs i))
-        in
-        let option_z_as_option_int zi = 
-          match zi with
-          | None -> None
-          | Some i -> (Some (Z.to_int_fs i))
-        in
-        let nbe_arg_as_issue (x:NBETerm.arg) : option Errors.issue =
-          FStar.TypeChecker.NBETerm.(unembed e_issue bogus_cbs (fst x))
-        in
-        let nbe_str s = FStar.TypeChecker.NBETerm.(embed e_string bogus_cbs s) in
-        let nbe_int s = FStar.TypeChecker.NBETerm.(embed e_int bogus_cbs s) in
-        let nbe_option_int oi =
-          let em = FStar.TypeChecker.NBETerm.(embed (e_option e_int) bogus_cbs) in 
-          em (option_int_as_option_z oi)
-        in
-        [
-        (mk_lid "message_of_issue", 1, 0,
-         unary_op arg_as_issue
-                  (fun _r issue -> EMB.(embed_simple Range.dummyRange issue.issue_msg)),
-         NBETerm.unary_op
-                  nbe_arg_as_issue
-                  (fun issue -> FStar.TypeChecker.NBETerm.(embed (e_list e_document) bogus_cbs issue.issue_msg)));
-        (mk_lid "level_of_issue", 1, 0,
-         unary_op arg_as_issue
-                  (fun _r issue -> U.exp_string (Errors.string_of_issue_level issue.issue_level)),
-         NBETerm.unary_op
-                  nbe_arg_as_issue
-                  (fun issue -> nbe_str (Errors.string_of_issue_level issue.issue_level)));
-        (mk_lid "number_of_issue", 1, 0,
-         unary_op arg_as_issue
-                  (fun _r issue -> EMB.(embed_simple Range.dummyRange 
-                                                      (option_int_as_option_z issue.issue_number))),
-         NBETerm.unary_op
-                  nbe_arg_as_issue
-                  (fun issue -> nbe_option_int issue.issue_number));
-        (mk_lid "range_of_issue", 1, 0,
-         unary_op arg_as_issue
-                  (fun _r issue -> EMB.(embed_simple Range.dummyRange 
-                                                      issue.issue_range)),
-         NBETerm.unary_op
-                  nbe_arg_as_issue
-                  (fun issue -> FStar.TypeChecker.NBETerm.(embed (e_option e_range) bogus_cbs
-                                                      issue.issue_range)));
-        (mk_lid "context_of_issue", 1, 0,
-         unary_op arg_as_issue
-                  (fun _r issue -> EMB.(embed_simple Range.dummyRange 
-                                                      issue.issue_ctx)),
-         NBETerm.unary_op
-                  nbe_arg_as_issue
-                  (fun issue -> FStar.TypeChecker.NBETerm.(embed (e_list e_string) bogus_cbs
-                                                      issue.issue_ctx)));
-
-        (mk_lid "render_issue", 1, 0,
-         unary_op arg_as_issue
-                  (fun _r issue -> U.exp_string (Errors.format_issue issue)),
-         NBETerm.unary_op
-                  nbe_arg_as_issue
-                  (fun issue -> nbe_str (Errors.format_issue issue)));
-
-        (mk_lid "mk_issue_doc", 5, 0,
-          (fun psc univs cbs args -> 
-            match args with
-            | [(level, _); (msg, _); (range, _); (number, _); (context, _)] ->
-              begin
-              let open EMB in
-              let try_unembed (#a:Type) (e:embedding a) (x:term) : option a =
-                  try_unembed x id_norm_cb
-              in
-              match try_unembed e_string level,
-                    try_unembed (e_list e_document) msg,
-                    try_unembed (e_option e_range) range,
-                    try_unembed (e_option e_int) number,
-                    try_unembed (e_list e_string) context with
-              | Some level, Some msg, Some range, Some number, Some context ->
-                let issue = {issue_level = Errors.issue_level_of_string level;
-                             issue_range = range;
-                             issue_number = option_z_as_option_int number;
-                             issue_msg = msg;
-                             issue_ctx = context} in
-                Some (embed_simple psc.psc_range issue)
-              | _ -> None
-              end
-            | _ -> None),
-          (fun univs args -> 
-            match args with
-            | [(level, _); (msg, _); (range, _); (number, _); (context, _)] ->
-              begin
-              let open FStar.TypeChecker.NBETerm in 
-              let try_unembed (#a:Type) (e:embedding a) (x:NBETerm.t) : option a =
-                  unembed e bogus_cbs x
-              in
-              match try_unembed e_string level,
-                    try_unembed (e_list e_document) msg,
-                    try_unembed (e_option e_range) range,
-                    try_unembed (e_option e_int) number,
-                    try_unembed (e_list e_string) context with
-              | Some level, Some msg, Some range, Some number, Some context ->
-                let issue = {issue_level = Errors.issue_level_of_string level;
-                             issue_range = range;
-                             issue_number = option_z_as_option_int number;
-                             issue_msg = msg;
-                             issue_ctx = context} in
-                Some (NBETerm.embed e_issue bogus_cbs issue)
-              | _ -> None
-              end
-            | _ -> None))
-        ]
-    in
-    let doc_ops =
-        let mk_lid l = PC.p2l ["FStar"; "Stubs"; "Pprint"; l] in
-        (* FIXME: we only implement the absolute minimum. The rest of the operations
-        are availabe to plugins. *)
-        [
-        (mk_lid "arbitrary_string", 1, 0,
-         unary_op arg_as_string
-                  (fun r str ->
-                  embed_simple r (FStar.Pprint.arbitrary_string str)),
-         NBETerm.unary_op NBETerm.arg_as_string
-                  (fun str -> NBETerm.embed NBETerm.e_document bogus_cbs (FStar.Pprint.arbitrary_string str)));
-
-        (mk_lid "render", 1, 0,
-         unary_op arg_as_doc
-                  (fun r doc ->
-                  embed_simple r (FStar.Pprint.render doc)),
-         NBETerm.unary_op NBETerm.arg_as_doc
-                  (fun doc -> NBETerm.embed NBETerm.e_string bogus_cbs (FStar.Pprint.render doc)));
-        ]
-
-    in
-    let seal_steps =
-      [
-        (PC.map_seal_lid, 4, 2,
-          (fun psc univs cbs args ->
-            match args with
-            | [(ta, _); (tb, _); (s, _); (f, _)] ->
-              begin
-              let open EMB in
-              let try_unembed (#a:Type) (e:embedding a) (x:term) : option a =
-                  try_unembed x id_norm_cb
-              in
-              match try_unembed e_any ta,
-                    try_unembed e_any tb,
-                    try_unembed (e_sealed e_any) s,
-                    try_unembed e_any f with
-              | Some ta, Some tb, Some s, Some f ->
-                let r = U.mk_app f [S.as_arg s] in
-                let emb = set_type ta e_any in
-                Some (embed_simple #_ #(e_sealed emb) psc.psc_range r)
-              | _ -> None
-              end
-            | _ -> None),
-          (fun cb univs args ->
-            match args with
-            | [(ta, _); (tb, _); (s, _); (f, _)] ->
-              begin
-              let open FStar.TypeChecker.NBETerm in
-              let try_unembed (#a:Type) (e:embedding a) (x:NBETerm.t) : option a =
-                  unembed e bogus_cbs x
-              in
-              match try_unembed e_any ta,
-                    try_unembed e_any tb,
-                    try_unembed (e_sealed e_any) s,
-                    try_unembed e_any f with
-              | Some ta, Some tb, Some s, Some f ->
-                let r = cb.iapp f [as_arg s] in
-                let emb = set_type ta e_any in
-                Some (embed (e_sealed emb) cb r)
-              | _ -> None
-              end
-            | _ -> None
-            ));
-        (PC.bind_seal_lid, 4, 2,
-          (fun psc univs cbs args ->
-            match args with
-            | [(ta, _); (tb, _); (s, _); (f, _)] ->
-              begin
-              let open EMB in
-              let try_unembed (#a:Type) (e:embedding a) (x:term) : option a =
-                  try_unembed x id_norm_cb
-              in
-              match try_unembed e_any ta,
-                    try_unembed e_any tb,
-                    try_unembed (e_sealed e_any) s,
-                    try_unembed e_any f with
-              | Some ta, Some tb, Some s, Some f ->
-                let r = U.mk_app f [S.as_arg s] in
-                Some (embed_simple #_ #e_any psc.psc_range r)
-              | _ -> None
-              end
-            | _ -> None),
-          (fun cb univs args ->
-            match args with
-            | [(ta, _); (tb, _); (s, _); (f, _)] ->
-              begin
-              let open FStar.TypeChecker.NBETerm in
-              let try_unembed (#a:Type) (e:embedding a) (x:NBETerm.t) : option a =
-                  unembed e bogus_cbs x
-              in
-              match try_unembed e_any ta,
-                    try_unembed e_any tb,
-                    try_unembed (e_sealed e_any) s,
-                    try_unembed e_any f with
-              | Some ta, Some tb, Some s, Some f ->
-                let r = cb.iapp f [as_arg s] in
-                let emb = set_type ta e_any in
-                Some (embed emb cb r)
-              | _ -> None
-              end
-            | _ -> None
-            ));
-      ]
-    in
     let strong_steps =
       List.map (as_primitive_step true)
-               (basic_ops@bounded_arith_ops@[reveal_hide]@array_ops@issue_ops@doc_ops)
-      @
-      List.map (fun p -> { as_primitive_step_nbecbs true p with renorm_after = true})
-               seal_steps
+               (basic_ops@bounded_arith_ops@[reveal_hide]@array_ops)
     in
-    let weak_steps = List.map (as_primitive_step false) weak_ops in
-    strong_steps @ weak_steps
+    simple_ops @ issue_ops @ doc_ops @ strong_steps @ seal_steps
 
 let equality_ops_list : list primitive_step =
     let interp_prop_eq2 (psc:psc) _norm_cb _univs (args:args) : option term =

--- a/src/typechecker/FStar.TypeChecker.Primops.fst
+++ b/src/typechecker/FStar.TypeChecker.Primops.fst
@@ -386,7 +386,7 @@ over embeddable types. *)
 let simple_ops = [
   (* Basic *)
   mk1 0 PC.string_of_int_lid (fun z -> string_of_int (Z.to_int_fs z));
-  mk1 0 PC.int_of_string_lid (fun s -> BU.map_opt (BU.safe_int_of_string s) Z.of_int_fs);
+  mk1 0 PC.int_of_string_lid (fun s -> fmap Z.of_int_fs (BU.safe_int_of_string s));
   mk1 0 PC.string_of_bool_lid string_of_bool;
   mk1 0 PC.bool_of_string_lid (function "true" -> Some true | "false" -> Some false | _ -> None);
 
@@ -441,14 +441,14 @@ let issue_ops : list primitive_step =
   let mk_lid l = PC.p2l ["FStar"; "Issue"; l] in [
     mk1 0 (mk_lid "message_of_issue") Mkissue?.issue_msg;
     mk1 0 (mk_lid "level_of_issue") (fun i -> Errors.string_of_issue_level i.issue_level);
-    mk1 0 (mk_lid "number_of_issue") (fun i -> BU.map_opt i.issue_number Z.of_int_fs);
+    mk1 0 (mk_lid "number_of_issue") (fun i -> fmap Z.of_int_fs i.issue_number);
     mk1 0 (mk_lid "range_of_issue") Mkissue?.issue_range;
     mk1 0 (mk_lid "context_of_issue") Mkissue?.issue_ctx;
     mk1 0 (mk_lid "render_issue") Errors.format_issue;
     mk5 0 (mk_lid "mk_issue_doc") (fun level msg range number context ->
           { issue_level = Errors.issue_level_of_string level;
             issue_range = range;
-            issue_number = BU.map_opt number Z.to_int_fs;
+            issue_number = fmap Z.to_int_fs number;
             issue_msg = msg;
             issue_ctx = context}
     );


### PR DESCRIPTION
This makes use of the embedding typeclass to remove a bunch of boilerplate related to the implementation of primops. There is a bit still to be done, but already a nice improvement.