### PR TITLE
Tc: Allow for #_ to solve instances

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_Reflection_V2_Interpreter.ml
+++ b/ocaml/fstar-lib/generated/FStar_Reflection_V2_Interpreter.ml
@@ -99,15 +99,15 @@ let (reflection_primops :
   FStar_TypeChecker_Primops_Base.primitive_step Prims.list) =
   let uu___ =
     mk1 "inspect_ln" FStar_Reflection_V2_Embeddings.e_term
-      (solve FStar_Reflection_V2_Embeddings.e_term_view)
+      FStar_Reflection_V2_Embeddings.e_term_view
       FStar_Reflection_V2_NBEEmbeddings.e_term
-      (solve FStar_Reflection_V2_NBEEmbeddings.e_term_view)
+      FStar_Reflection_V2_NBEEmbeddings.e_term_view
       FStar_Reflection_V2_Builtins.inspect_ln in
   let uu___1 =
     let uu___2 =
-      mk1 "pack_ln" (solve FStar_Reflection_V2_Embeddings.e_term_view)
+      mk1 "pack_ln" FStar_Reflection_V2_Embeddings.e_term_view
         FStar_Reflection_V2_Embeddings.e_term
-        (solve FStar_Reflection_V2_NBEEmbeddings.e_term_view)
+        FStar_Reflection_V2_NBEEmbeddings.e_term_view
         FStar_Reflection_V2_NBEEmbeddings.e_term
         FStar_Reflection_V2_Builtins.pack_ln in
     let uu___3 =
@@ -247,8 +247,7 @@ let (reflection_primops :
                                       let uu___37 =
                                         let uu___38 =
                                           mk1 "embed_vconfig"
-                                            (solve
-                                               FStar_Syntax_Embeddings.e_vconfig)
+                                            FStar_Syntax_Embeddings.e_vconfig
                                             FStar_Reflection_V2_Embeddings.e_term
                                             FStar_TypeChecker_NBETerm.e_vconfig
                                             FStar_Reflection_V2_NBEEmbeddings.e_attribute
@@ -256,8 +255,7 @@ let (reflection_primops :
                                         let uu___39 =
                                           let uu___40 =
                                             mk1 "sigelt_attrs"
-                                              (solve
-                                                 FStar_Reflection_V2_Embeddings.e_sigelt)
+                                              FStar_Reflection_V2_Embeddings.e_sigelt
                                               (FStar_Syntax_Embeddings.e_list
                                                  FStar_Reflection_V2_Embeddings.e_term)
                                               FStar_Reflection_V2_NBEEmbeddings.e_sigelt
@@ -297,9 +295,8 @@ let (reflection_primops :
                                                 let uu___47 =
                                                   let uu___48 =
                                                     mk2 "subst_term"
-                                                      (solve
-                                                         (FStar_Syntax_Embeddings.e_list
-                                                            FStar_Reflection_V2_Embeddings.e_subst_elt))
+                                                      (FStar_Syntax_Embeddings.e_list
+                                                         FStar_Reflection_V2_Embeddings.e_subst_elt)
                                                       FStar_Reflection_V2_Embeddings.e_term
                                                       FStar_Reflection_V2_Embeddings.e_term
                                                       FStar_Reflection_V2_NBEEmbeddings.e_subst
@@ -322,12 +319,10 @@ let (reflection_primops :
                                                         mk2 "compare_bv"
                                                           FStar_Reflection_V2_Embeddings.e_bv
                                                           FStar_Reflection_V2_Embeddings.e_bv
-                                                          (solve
-                                                             FStar_Syntax_Embeddings.e_order)
+                                                          FStar_Syntax_Embeddings.e_order
                                                           FStar_Reflection_V2_NBEEmbeddings.e_bv
                                                           FStar_Reflection_V2_NBEEmbeddings.e_bv
-                                                          (solve
-                                                             FStar_TypeChecker_NBETerm.e_order)
+                                                          FStar_TypeChecker_NBETerm.e_order
                                                           FStar_Reflection_V2_Builtins.compare_bv in
                                                       let uu___53 =
                                                         let uu___54 =
@@ -335,12 +330,10 @@ let (reflection_primops :
                                                             "compare_namedv"
                                                             FStar_Reflection_V2_Embeddings.e_namedv
                                                             FStar_Reflection_V2_Embeddings.e_namedv
-                                                            (solve
-                                                               FStar_Syntax_Embeddings.e_order)
+                                                            FStar_Syntax_Embeddings.e_order
                                                             FStar_Reflection_V2_NBEEmbeddings.e_namedv
                                                             FStar_Reflection_V2_NBEEmbeddings.e_namedv
-                                                            (solve
-                                                               FStar_TypeChecker_NBETerm.e_order)
+                                                            FStar_TypeChecker_NBETerm.e_order
                                                             FStar_Reflection_V2_Builtins.compare_namedv in
                                                         let uu___55 =
                                                           let uu___56 =
@@ -481,16 +474,12 @@ let (reflection_primops :
                                                                     =
                                                                     mk2
                                                                     "push_namedv"
-                                                                    (solve
-                                                                    FStar_Reflection_V2_Embeddings.e_env)
+                                                                    FStar_Reflection_V2_Embeddings.e_env
                                                                     FStar_Reflection_V2_Embeddings.e_namedv
-                                                                    (solve
-                                                                    FStar_Reflection_V2_Embeddings.e_env)
-                                                                    (solve
-                                                                    FStar_Reflection_V2_NBEEmbeddings.e_env)
+                                                                    FStar_Reflection_V2_Embeddings.e_env
+                                                                    FStar_Reflection_V2_NBEEmbeddings.e_env
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_namedv
-                                                                    (solve
-                                                                    FStar_Reflection_V2_NBEEmbeddings.e_env)
+                                                                    FStar_Reflection_V2_NBEEmbeddings.e_env
                                                                     FStar_Reflection_V2_Builtins.push_namedv in
                                                                     let uu___79
                                                                     =

--- a/ocaml/fstar-lib/generated/FStar_Tactics_V1_Primops.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_V1_Primops.ml
@@ -490,11 +490,9 @@ let (ops : FStar_TypeChecker_Primops_Base.primitive_step Prims.list) =
                                                                     Prims.int_zero
                                                                     "tadmit_t"
                                                                     FStar_Reflection_V1_Embeddings.e_term
-                                                                    (solve
-                                                                    FStar_Syntax_Embeddings.e_unit)
+                                                                    FStar_Syntax_Embeddings.e_unit
                                                                     FStar_Reflection_V1_NBEEmbeddings.e_term
-                                                                    (solve
-                                                                    FStar_TypeChecker_NBETerm.e_unit)
+                                                                    FStar_TypeChecker_NBETerm.e_unit
                                                                     FStar_Tactics_V1_Basic.tadmit_t
                                                                     FStar_Tactics_V1_Basic.tadmit_t in
                                                                     let uu___71
@@ -518,17 +516,15 @@ let (ops : FStar_TypeChecker_Primops_Base.primitive_step Prims.list) =
                                                                     Prims.int_zero
                                                                     "t_destruct"
                                                                     FStar_Reflection_V1_Embeddings.e_term
-                                                                    (solve
                                                                     (FStar_Syntax_Embeddings.e_list
                                                                     (FStar_Syntax_Embeddings.e_tuple2
                                                                     FStar_Reflection_V2_Embeddings.e_fv
-                                                                    FStar_Syntax_Embeddings.e_int)))
+                                                                    FStar_Syntax_Embeddings.e_int))
                                                                     FStar_Reflection_V1_NBEEmbeddings.e_term
-                                                                    (solve
                                                                     (FStar_TypeChecker_NBETerm.e_list
                                                                     (FStar_TypeChecker_NBETerm.e_tuple2
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_fv
-                                                                    FStar_TypeChecker_NBETerm.e_int)))
+                                                                    FStar_TypeChecker_NBETerm.e_int))
                                                                     FStar_Tactics_V1_Basic.t_destruct
                                                                     FStar_Tactics_V1_Basic.t_destruct in
                                                                     let uu___75
@@ -552,11 +548,9 @@ let (ops : FStar_TypeChecker_Primops_Base.primitive_step Prims.list) =
                                                                     Prims.int_zero
                                                                     "inspect"
                                                                     FStar_Reflection_V1_Embeddings.e_term
-                                                                    (solve
-                                                                    FStar_Reflection_V1_Embeddings.e_term_view)
+                                                                    FStar_Reflection_V1_Embeddings.e_term_view
                                                                     FStar_Reflection_V1_NBEEmbeddings.e_term
-                                                                    (solve
-                                                                    FStar_Reflection_V1_NBEEmbeddings.e_term_view)
+                                                                    FStar_Reflection_V1_NBEEmbeddings.e_term_view
                                                                     FStar_Tactics_V1_Basic.inspect
                                                                     FStar_Tactics_V1_Basic.inspect in
                                                                     let uu___79
@@ -566,11 +560,9 @@ let (ops : FStar_TypeChecker_Primops_Base.primitive_step Prims.list) =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_1
                                                                     Prims.int_zero
                                                                     "pack"
-                                                                    (solve
-                                                                    FStar_Reflection_V1_Embeddings.e_term_view)
+                                                                    FStar_Reflection_V1_Embeddings.e_term_view
                                                                     FStar_Reflection_V1_Embeddings.e_term
-                                                                    (solve
-                                                                    FStar_Reflection_V1_NBEEmbeddings.e_term_view)
+                                                                    FStar_Reflection_V1_NBEEmbeddings.e_term_view
                                                                     FStar_Reflection_V1_NBEEmbeddings.e_term
                                                                     FStar_Tactics_V1_Basic.pack
                                                                     FStar_Tactics_V1_Basic.pack in
@@ -581,11 +573,9 @@ let (ops : FStar_TypeChecker_Primops_Base.primitive_step Prims.list) =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_1
                                                                     Prims.int_zero
                                                                     "pack_curried"
-                                                                    (solve
-                                                                    FStar_Reflection_V1_Embeddings.e_term_view)
+                                                                    FStar_Reflection_V1_Embeddings.e_term_view
                                                                     FStar_Reflection_V1_Embeddings.e_term
-                                                                    (solve
-                                                                    FStar_Reflection_V1_NBEEmbeddings.e_term_view)
+                                                                    FStar_Reflection_V1_NBEEmbeddings.e_term_view
                                                                     FStar_Reflection_V1_NBEEmbeddings.e_term
                                                                     FStar_Tactics_V1_Basic.pack_curried
                                                                     FStar_Tactics_V1_Basic.pack_curried in
@@ -622,13 +612,11 @@ let (ops : FStar_TypeChecker_Primops_Base.primitive_step Prims.list) =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_2
                                                                     Prims.int_zero
                                                                     "uvar_env"
-                                                                    (solve
-                                                                    FStar_Reflection_V2_Embeddings.e_env)
+                                                                    FStar_Reflection_V2_Embeddings.e_env
                                                                     (FStar_Syntax_Embeddings.e_option
                                                                     FStar_Reflection_V1_Embeddings.e_term)
                                                                     FStar_Reflection_V1_Embeddings.e_term
-                                                                    (solve
-                                                                    FStar_Reflection_V2_NBEEmbeddings.e_env)
+                                                                    FStar_Reflection_V2_NBEEmbeddings.e_env
                                                                     (FStar_TypeChecker_NBETerm.e_option
                                                                     FStar_Reflection_V1_NBEEmbeddings.e_term)
                                                                     FStar_Reflection_V1_NBEEmbeddings.e_term
@@ -641,12 +629,10 @@ let (ops : FStar_TypeChecker_Primops_Base.primitive_step Prims.list) =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_2
                                                                     Prims.int_zero
                                                                     "ghost_uvar_env"
-                                                                    (solve
-                                                                    FStar_Reflection_V2_Embeddings.e_env)
+                                                                    FStar_Reflection_V2_Embeddings.e_env
                                                                     FStar_Reflection_V1_Embeddings.e_term
                                                                     FStar_Reflection_V1_Embeddings.e_term
-                                                                    (solve
-                                                                    FStar_Reflection_V2_NBEEmbeddings.e_env)
+                                                                    FStar_Reflection_V2_NBEEmbeddings.e_env
                                                                     FStar_Reflection_V1_NBEEmbeddings.e_term
                                                                     FStar_Reflection_V1_NBEEmbeddings.e_term
                                                                     FStar_Tactics_V1_Basic.ghost_uvar_env
@@ -658,11 +644,9 @@ let (ops : FStar_TypeChecker_Primops_Base.primitive_step Prims.list) =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_1
                                                                     Prims.int_zero
                                                                     "fresh_universe_uvar"
-                                                                    (solve
-                                                                    FStar_Syntax_Embeddings.e_unit)
+                                                                    FStar_Syntax_Embeddings.e_unit
                                                                     FStar_Reflection_V1_Embeddings.e_term
-                                                                    (solve
-                                                                    FStar_TypeChecker_NBETerm.e_unit)
+                                                                    FStar_TypeChecker_NBETerm.e_unit
                                                                     FStar_Reflection_V1_NBEEmbeddings.e_term
                                                                     FStar_Tactics_V1_Basic.fresh_universe_uvar
                                                                     FStar_Tactics_V1_Basic.fresh_universe_uvar in
@@ -1053,13 +1037,11 @@ let (ops : FStar_TypeChecker_Primops_Base.primitive_step Prims.list) =
                                                                     Prims.int_zero
                                                                     "free_uvars"
                                                                     FStar_Reflection_V1_Embeddings.e_term
-                                                                    (solve
                                                                     (FStar_Syntax_Embeddings.e_list
-                                                                    FStar_Syntax_Embeddings.e_int))
+                                                                    FStar_Syntax_Embeddings.e_int)
                                                                     FStar_Reflection_V1_NBEEmbeddings.e_term
-                                                                    (solve
                                                                     (FStar_TypeChecker_NBETerm.e_list
-                                                                    FStar_TypeChecker_NBETerm.e_int))
+                                                                    FStar_TypeChecker_NBETerm.e_int)
                                                                     FStar_Tactics_V1_Basic.free_uvars
                                                                     FStar_Tactics_V1_Basic.free_uvars in
                                                                     [uu___142] in

--- a/ocaml/fstar-lib/generated/FStar_Tactics_V2_Primops.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_V2_Primops.ml
@@ -125,7 +125,7 @@ let (ops : FStar_TypeChecker_Primops_Base.primitive_step Prims.list) =
               let uu___14 =
                 let uu___15 =
                   FStar_Tactics_InterpFuns.mk_tot_step_1 Prims.int_zero
-                    "goal_type" (solve FStar_Tactics_Embedding.e_goal)
+                    "goal_type" FStar_Tactics_Embedding.e_goal
                     FStar_Reflection_V2_Embeddings.e_term
                     FStar_Tactics_Embedding.e_goal_nbe
                     FStar_Reflection_V2_NBEEmbeddings.e_attribute
@@ -134,7 +134,7 @@ let (ops : FStar_TypeChecker_Primops_Base.primitive_step Prims.list) =
                 let uu___16 =
                   let uu___17 =
                     FStar_Tactics_InterpFuns.mk_tot_step_1 Prims.int_zero
-                      "goal_witness" (solve FStar_Tactics_Embedding.e_goal)
+                      "goal_witness" FStar_Tactics_Embedding.e_goal
                       FStar_Reflection_V2_Embeddings.e_term
                       FStar_Tactics_Embedding.e_goal_nbe
                       FStar_Reflection_V2_NBEEmbeddings.e_attribute
@@ -291,11 +291,9 @@ let (ops : FStar_TypeChecker_Primops_Base.primitive_step Prims.list) =
                                               FStar_Tactics_InterpFuns.mk_tac_step_3
                                                 Prims.int_zero
                                                 "norm_term_env"
-                                                (solve
-                                                   FStar_Reflection_V2_Embeddings.e_env)
-                                                (solve
-                                                   (FStar_Syntax_Embeddings.e_list
-                                                      FStar_Syntax_Embeddings.e_norm_step))
+                                                FStar_Reflection_V2_Embeddings.e_env
+                                                (FStar_Syntax_Embeddings.e_list
+                                                   FStar_Syntax_Embeddings.e_norm_step)
                                                 FStar_Reflection_V2_Embeddings.e_term
                                                 FStar_Reflection_V2_Embeddings.e_term
                                                 FStar_Reflection_V2_NBEEmbeddings.e_env
@@ -404,10 +402,8 @@ let (ops : FStar_TypeChecker_Primops_Base.primitive_step Prims.list) =
                                                                 FStar_Tactics_InterpFuns.mk_tac_step_3
                                                                   Prims.int_zero
                                                                   "t_exact"
-                                                                  (solve
-                                                                    FStar_Syntax_Embeddings.e_bool)
-                                                                  (solve
-                                                                    FStar_Syntax_Embeddings.e_bool)
+                                                                  FStar_Syntax_Embeddings.e_bool
+                                                                  FStar_Syntax_Embeddings.e_bool
                                                                   FStar_Reflection_V2_Embeddings.e_term
                                                                   FStar_Syntax_Embeddings.e_unit
                                                                   FStar_TypeChecker_NBETerm.e_bool
@@ -421,15 +417,9 @@ let (ops : FStar_TypeChecker_Primops_Base.primitive_step Prims.list) =
                                                                   FStar_Tactics_InterpFuns.mk_tac_step_4
                                                                     Prims.int_zero
                                                                     "t_apply"
-                                                                    (
-                                                                    solve
-                                                                    FStar_Syntax_Embeddings.e_bool)
-                                                                    (
-                                                                    solve
-                                                                    FStar_Syntax_Embeddings.e_bool)
-                                                                    (
-                                                                    solve
-                                                                    FStar_Syntax_Embeddings.e_bool)
+                                                                    FStar_Syntax_Embeddings.e_bool
+                                                                    FStar_Syntax_Embeddings.e_bool
+                                                                    FStar_Syntax_Embeddings.e_bool
                                                                     FStar_Reflection_V2_Embeddings.e_term
                                                                     FStar_Syntax_Embeddings.e_unit
                                                                     FStar_TypeChecker_NBETerm.e_bool
@@ -445,10 +435,8 @@ let (ops : FStar_TypeChecker_Primops_Base.primitive_step Prims.list) =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_3
                                                                     Prims.int_zero
                                                                     "t_apply_lemma"
-                                                                    (solve
-                                                                    FStar_Syntax_Embeddings.e_bool)
-                                                                    (solve
-                                                                    FStar_Syntax_Embeddings.e_bool)
+                                                                    FStar_Syntax_Embeddings.e_bool
+                                                                    FStar_Syntax_Embeddings.e_bool
                                                                     FStar_Reflection_V2_Embeddings.e_term
                                                                     FStar_Syntax_Embeddings.e_unit
                                                                     FStar_TypeChecker_NBETerm.e_bool
@@ -477,8 +465,7 @@ let (ops : FStar_TypeChecker_Primops_Base.primitive_step Prims.list) =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_2
                                                                     Prims.int_zero
                                                                     "tcc"
-                                                                    (solve
-                                                                    FStar_Reflection_V2_Embeddings.e_env)
+                                                                    FStar_Reflection_V2_Embeddings.e_env
                                                                     FStar_Reflection_V2_Embeddings.e_term
                                                                     FStar_Reflection_V2_Embeddings.e_comp
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_env
@@ -493,8 +480,7 @@ let (ops : FStar_TypeChecker_Primops_Base.primitive_step Prims.list) =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_2
                                                                     Prims.int_zero
                                                                     "tc"
-                                                                    (solve
-                                                                    FStar_Reflection_V2_Embeddings.e_env)
+                                                                    FStar_Reflection_V2_Embeddings.e_env
                                                                     FStar_Reflection_V2_Embeddings.e_term
                                                                     FStar_Reflection_V2_Embeddings.e_term
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_env
@@ -788,8 +774,7 @@ let (ops : FStar_TypeChecker_Primops_Base.primitive_step Prims.list) =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_2
                                                                     Prims.int_zero
                                                                     "uvar_env"
-                                                                    (solve
-                                                                    FStar_Reflection_V2_Embeddings.e_env)
+                                                                    FStar_Reflection_V2_Embeddings.e_env
                                                                     (FStar_Syntax_Embeddings.e_option
                                                                     FStar_Reflection_V2_Embeddings.e_term)
                                                                     FStar_Reflection_V2_Embeddings.e_term
@@ -806,8 +791,7 @@ let (ops : FStar_TypeChecker_Primops_Base.primitive_step Prims.list) =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_2
                                                                     Prims.int_zero
                                                                     "ghost_uvar_env"
-                                                                    (solve
-                                                                    FStar_Reflection_V2_Embeddings.e_env)
+                                                                    FStar_Reflection_V2_Embeddings.e_env
                                                                     FStar_Reflection_V2_Embeddings.e_term
                                                                     FStar_Reflection_V2_Embeddings.e_term
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_env
@@ -822,8 +806,7 @@ let (ops : FStar_TypeChecker_Primops_Base.primitive_step Prims.list) =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_1
                                                                     Prims.int_zero
                                                                     "fresh_universe_uvar"
-                                                                    (solve
-                                                                    FStar_Syntax_Embeddings.e_unit)
+                                                                    FStar_Syntax_Embeddings.e_unit
                                                                     FStar_Reflection_V2_Embeddings.e_term
                                                                     FStar_TypeChecker_NBETerm.e_unit
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_attribute
@@ -836,8 +819,7 @@ let (ops : FStar_TypeChecker_Primops_Base.primitive_step Prims.list) =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_3
                                                                     Prims.int_zero
                                                                     "unify_env"
-                                                                    (solve
-                                                                    FStar_Reflection_V2_Embeddings.e_env)
+                                                                    FStar_Reflection_V2_Embeddings.e_env
                                                                     FStar_Reflection_V2_Embeddings.e_term
                                                                     FStar_Reflection_V2_Embeddings.e_term
                                                                     FStar_Syntax_Embeddings.e_bool
@@ -854,8 +836,7 @@ let (ops : FStar_TypeChecker_Primops_Base.primitive_step Prims.list) =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_3
                                                                     Prims.int_zero
                                                                     "unify_guard_env"
-                                                                    (solve
-                                                                    FStar_Reflection_V2_Embeddings.e_env)
+                                                                    FStar_Reflection_V2_Embeddings.e_env
                                                                     FStar_Reflection_V2_Embeddings.e_term
                                                                     FStar_Reflection_V2_Embeddings.e_term
                                                                     FStar_Syntax_Embeddings.e_bool
@@ -872,8 +853,7 @@ let (ops : FStar_TypeChecker_Primops_Base.primitive_step Prims.list) =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_3
                                                                     Prims.int_zero
                                                                     "match_env"
-                                                                    (solve
-                                                                    FStar_Reflection_V2_Embeddings.e_env)
+                                                                    FStar_Reflection_V2_Embeddings.e_env
                                                                     FStar_Reflection_V2_Embeddings.e_term
                                                                     FStar_Reflection_V2_Embeddings.e_term
                                                                     FStar_Syntax_Embeddings.e_bool
@@ -1047,10 +1027,8 @@ let (ops : FStar_TypeChecker_Primops_Base.primitive_step Prims.list) =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_2
                                                                     Prims.int_zero
                                                                     "string_to_term"
-                                                                    (solve
-                                                                    FStar_Reflection_V2_Embeddings.e_env)
-                                                                    (solve
-                                                                    FStar_Syntax_Embeddings.e_string)
+                                                                    FStar_Reflection_V2_Embeddings.e_env
+                                                                    FStar_Syntax_Embeddings.e_string
                                                                     FStar_Reflection_V2_Embeddings.e_term
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_env
                                                                     FStar_TypeChecker_NBETerm.e_string
@@ -1370,8 +1348,7 @@ let (ops : FStar_TypeChecker_Primops_Base.primitive_step Prims.list) =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_2
                                                                     Prims.int_zero
                                                                     "is_non_informative"
-                                                                    (solve
-                                                                    FStar_Reflection_V2_Embeddings.e_env)
+                                                                    FStar_Reflection_V2_Embeddings.e_env
                                                                     FStar_Reflection_V2_Embeddings.e_term
                                                                     (FStar_Syntax_Embeddings.e_tuple2
                                                                     (FStar_Syntax_Embeddings.e_option
@@ -1394,8 +1371,7 @@ let (ops : FStar_TypeChecker_Primops_Base.primitive_step Prims.list) =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_3
                                                                     Prims.int_zero
                                                                     "check_subtyping"
-                                                                    (solve
-                                                                    FStar_Reflection_V2_Embeddings.e_env)
+                                                                    FStar_Reflection_V2_Embeddings.e_env
                                                                     FStar_Reflection_V2_Embeddings.e_term
                                                                     FStar_Reflection_V2_Embeddings.e_term
                                                                     (FStar_Syntax_Embeddings.e_tuple2
@@ -1420,8 +1396,7 @@ let (ops : FStar_TypeChecker_Primops_Base.primitive_step Prims.list) =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_3
                                                                     Prims.int_zero
                                                                     "check_equiv"
-                                                                    (solve
-                                                                    FStar_Reflection_V2_Embeddings.e_env)
+                                                                    FStar_Reflection_V2_Embeddings.e_env
                                                                     FStar_Reflection_V2_Embeddings.e_term
                                                                     FStar_Reflection_V2_Embeddings.e_term
                                                                     (FStar_Syntax_Embeddings.e_tuple2
@@ -1453,8 +1428,7 @@ let (ops : FStar_TypeChecker_Primops_Base.primitive_step Prims.list) =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_2
                                                                     Prims.int_zero
                                                                     "core_compute_term_type"
-                                                                    (solve
-                                                                    FStar_Reflection_V2_Embeddings.e_env)
+                                                                    FStar_Reflection_V2_Embeddings.e_env
                                                                     FStar_Reflection_V2_Embeddings.e_term
                                                                     uu___185
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_env
@@ -1475,8 +1449,7 @@ let (ops : FStar_TypeChecker_Primops_Base.primitive_step Prims.list) =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_4
                                                                     Prims.int_zero
                                                                     "core_check_term"
-                                                                    (solve
-                                                                    FStar_Reflection_V2_Embeddings.e_env)
+                                                                    FStar_Reflection_V2_Embeddings.e_env
                                                                     FStar_Reflection_V2_Embeddings.e_term
                                                                     FStar_Reflection_V2_Embeddings.e_term
                                                                     FStar_Tactics_Embedding.e_tot_or_ghost
@@ -1503,8 +1476,7 @@ let (ops : FStar_TypeChecker_Primops_Base.primitive_step Prims.list) =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_3
                                                                     Prims.int_zero
                                                                     "core_check_term_at_type"
-                                                                    (solve
-                                                                    FStar_Reflection_V2_Embeddings.e_env)
+                                                                    FStar_Reflection_V2_Embeddings.e_env
                                                                     FStar_Reflection_V2_Embeddings.e_term
                                                                     FStar_Reflection_V2_Embeddings.e_term
                                                                     (FStar_Syntax_Embeddings.e_tuple2
@@ -1538,8 +1510,7 @@ let (ops : FStar_TypeChecker_Primops_Base.primitive_step Prims.list) =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_2
                                                                     Prims.int_zero
                                                                     "tc_term"
-                                                                    (solve
-                                                                    FStar_Reflection_V2_Embeddings.e_env)
+                                                                    FStar_Reflection_V2_Embeddings.e_env
                                                                     FStar_Reflection_V2_Embeddings.e_term
                                                                     uu___191
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_env
@@ -1562,8 +1533,7 @@ let (ops : FStar_TypeChecker_Primops_Base.primitive_step Prims.list) =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_2
                                                                     Prims.int_zero
                                                                     "universe_of"
-                                                                    (solve
-                                                                    FStar_Reflection_V2_Embeddings.e_env)
+                                                                    FStar_Reflection_V2_Embeddings.e_env
                                                                     FStar_Reflection_V2_Embeddings.e_term
                                                                     (FStar_Syntax_Embeddings.e_tuple2
                                                                     (FStar_Syntax_Embeddings.e_option
@@ -1586,8 +1556,7 @@ let (ops : FStar_TypeChecker_Primops_Base.primitive_step Prims.list) =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_2
                                                                     Prims.int_zero
                                                                     "check_prop_validity"
-                                                                    (solve
-                                                                    FStar_Reflection_V2_Embeddings.e_env)
+                                                                    FStar_Reflection_V2_Embeddings.e_env
                                                                     FStar_Reflection_V2_Embeddings.e_term
                                                                     (FStar_Syntax_Embeddings.e_tuple2
                                                                     (FStar_Syntax_Embeddings.e_option
@@ -1610,8 +1579,7 @@ let (ops : FStar_TypeChecker_Primops_Base.primitive_step Prims.list) =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_4
                                                                     Prims.int_zero
                                                                     "check_match_complete"
-                                                                    (solve
-                                                                    FStar_Reflection_V2_Embeddings.e_env)
+                                                                    FStar_Reflection_V2_Embeddings.e_env
                                                                     FStar_Reflection_V2_Embeddings.e_term
                                                                     FStar_Reflection_V2_Embeddings.e_term
                                                                     (FStar_Syntax_Embeddings.e_list
@@ -1670,15 +1638,11 @@ let (ops : FStar_TypeChecker_Primops_Base.primitive_step Prims.list) =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_2
                                                                     Prims.int_zero
                                                                     "instantiate_implicits"
-                                                                    (solve
-                                                                    FStar_Reflection_V2_Embeddings.e_env)
-                                                                    (solve
-                                                                    uu___2)
+                                                                    FStar_Reflection_V2_Embeddings.e_env
+                                                                    uu___2
                                                                     uu___199
-                                                                    (solve
-                                                                    FStar_Reflection_V2_NBEEmbeddings.e_env)
-                                                                    (solve
-                                                                    FStar_Reflection_V2_NBEEmbeddings.e_attribute)
+                                                                    FStar_Reflection_V2_NBEEmbeddings.e_env
+                                                                    FStar_Reflection_V2_NBEEmbeddings.e_attribute
                                                                     uu___200
                                                                     FStar_Tactics_V2_Basic.refl_instantiate_implicits
                                                                     FStar_Tactics_V2_Basic.refl_instantiate_implicits in
@@ -1769,19 +1733,15 @@ let (ops : FStar_TypeChecker_Primops_Base.primitive_step Prims.list) =
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_2
                                                                     Prims.int_zero
                                                                     "resolve_name"
-                                                                    (solve
-                                                                    FStar_Reflection_V2_Embeddings.e_env)
-                                                                    (solve
-                                                                    FStar_Syntax_Embeddings.e_string_list)
+                                                                    FStar_Reflection_V2_Embeddings.e_env
+                                                                    FStar_Syntax_Embeddings.e_string_list
                                                                     (FStar_Syntax_Embeddings.e_option
                                                                     (FStar_Syntax_Embeddings.e_either
                                                                     FStar_Reflection_V2_Embeddings.e_bv
                                                                     (solve
                                                                     FStar_Reflection_V2_Embeddings.e_fv)))
-                                                                    (solve
-                                                                    FStar_Reflection_V2_NBEEmbeddings.e_env)
-                                                                    (solve
-                                                                    FStar_TypeChecker_NBETerm.e_string_list)
+                                                                    FStar_Reflection_V2_NBEEmbeddings.e_env
+                                                                    FStar_TypeChecker_NBETerm.e_string_list
                                                                     (FStar_TypeChecker_NBETerm.e_option
                                                                     (FStar_TypeChecker_NBETerm.e_either
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_bv

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_TcTerm.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_TcTerm.ml
@@ -7238,6 +7238,121 @@ and (check_application_args :
                let rec tc_args head_info uu___1 bs args1 =
                  match uu___1 with
                  | (subst, outargs, arg_rets, g, fvs) ->
+                     let instantiate_one_meta_and_go b rest_bs args2 =
+                       let uu___2 = b in
+                       match uu___2 with
+                       | { FStar_Syntax_Syntax.binder_bv = x;
+                           FStar_Syntax_Syntax.binder_qual = qual;
+                           FStar_Syntax_Syntax.binder_positivity = uu___3;
+                           FStar_Syntax_Syntax.binder_attrs = attrs;_} ->
+                           let uu___4 =
+                             match (qual, attrs) with
+                             | (FStar_Pervasives_Native.Some
+                                (FStar_Syntax_Syntax.Meta tau), uu___5) ->
+                                 let tau1 =
+                                   FStar_Syntax_Subst.subst subst tau in
+                                 let uu___6 =
+                                   tc_tactic FStar_Syntax_Syntax.t_unit
+                                     FStar_Syntax_Syntax.t_unit env tau1 in
+                                 (match uu___6 with
+                                  | (tau2, uu___7, g_tau) ->
+                                      ((FStar_Syntax_Syntax.Ctx_uvar_meta_tac
+                                          tau2), g_tau))
+                             | (FStar_Pervasives_Native.Some
+                                (FStar_Syntax_Syntax.Implicit uu___5),
+                                attr::uu___6) ->
+                                 let attr1 =
+                                   FStar_Syntax_Subst.subst subst attr in
+                                 let uu___7 = tc_tot_or_gtot_term env attr1 in
+                                 (match uu___7 with
+                                  | (attr2, uu___8, g_attr) ->
+                                      ((FStar_Syntax_Syntax.Ctx_uvar_meta_attr
+                                          attr2), g_attr))
+                             | uu___5 ->
+                                 FStar_Compiler_Effect.failwith
+                                   "Impossible, match is under a guard" in
+                           (match uu___4 with
+                            | (ctx_uvar_meta, g_tau_or_attr) ->
+                                let t =
+                                  FStar_Syntax_Subst.subst subst
+                                    x.FStar_Syntax_Syntax.sort in
+                                let uu___5 =
+                                  check_no_escape
+                                    (FStar_Pervasives_Native.Some head) env
+                                    fvs t in
+                                (match uu___5 with
+                                 | (t1, g_ex) ->
+                                     let r1 =
+                                       match outargs with
+                                       | [] -> head.FStar_Syntax_Syntax.pos
+                                       | ((t2, uu___6), uu___7, uu___8)::uu___9
+                                           ->
+                                           let uu___10 =
+                                             FStar_Compiler_Range_Type.def_range
+                                               head.FStar_Syntax_Syntax.pos in
+                                           let uu___11 =
+                                             let uu___12 =
+                                               FStar_Compiler_Range_Type.use_range
+                                                 head.FStar_Syntax_Syntax.pos in
+                                             let uu___13 =
+                                               FStar_Compiler_Range_Type.use_range
+                                                 t2.FStar_Syntax_Syntax.pos in
+                                             FStar_Compiler_Range_Ops.union_rng
+                                               uu___12 uu___13 in
+                                           FStar_Compiler_Range_Type.range_of_rng
+                                             uu___10 uu___11 in
+                                     let uu___6 =
+                                       let msg =
+                                         let is_typeclass =
+                                           match ctx_uvar_meta with
+                                           | FStar_Syntax_Syntax.Ctx_uvar_meta_tac
+                                               tau ->
+                                               FStar_Syntax_Util.is_fvar
+                                                 FStar_Parser_Const.tcresolve_lid
+                                                 tau
+                                           | uu___7 -> false in
+                                         if is_typeclass
+                                         then "Typeclass constraint argument"
+                                         else
+                                           "Instantiating meta argument in application" in
+                                       FStar_TypeChecker_Env.new_implicit_var_aux
+                                         msg r1 env t1
+                                         FStar_Syntax_Syntax.Strict
+                                         (FStar_Pervasives_Native.Some
+                                            ctx_uvar_meta) in
+                                     (match uu___6 with
+                                      | (varg, uu___7, implicits) ->
+                                          let subst1 =
+                                            (FStar_Syntax_Syntax.NT (x, varg))
+                                            :: subst in
+                                          let aq =
+                                            let uu___8 =
+                                              FStar_Compiler_List.hd bs in
+                                            FStar_Syntax_Util.aqual_of_binder
+                                              uu___8 in
+                                          let arg = (varg, aq) in
+                                          let guard =
+                                            FStar_Compiler_List.fold_right
+                                              FStar_TypeChecker_Env.conj_guard
+                                              [g_ex; g; g_tau_or_attr]
+                                              implicits in
+                                          let uu___8 =
+                                            let uu___9 =
+                                              let uu___10 =
+                                                let uu___11 =
+                                                  let uu___12 =
+                                                    FStar_Syntax_Syntax.mk_Total
+                                                      t1 in
+                                                  FStar_TypeChecker_Common.lcomp_of_comp
+                                                    uu___12 in
+                                                (arg,
+                                                  FStar_Pervasives_Native.None,
+                                                  uu___11) in
+                                              uu___10 :: outargs in
+                                            (subst1, uu___9, (arg ::
+                                              arg_rets), guard, fvs) in
+                                          tc_args head_info uu___8 rest_bs
+                                            args2))) in
                      (match (bs, args1) with
                       | ({ FStar_Syntax_Syntax.binder_bv = x;
                            FStar_Syntax_Syntax.binder_qual =
@@ -7312,112 +7427,26 @@ and (check_application_args :
                           FStar_TypeChecker_Util.maybe_implicit_with_meta_or_attr
                             qual attrs
                           ->
-                          let uu___5 =
-                            match (qual, attrs) with
-                            | (FStar_Pervasives_Native.Some
-                               (FStar_Syntax_Syntax.Meta tau), uu___6) ->
-                                let tau1 = FStar_Syntax_Subst.subst subst tau in
-                                let uu___7 =
-                                  tc_tactic FStar_Syntax_Syntax.t_unit
-                                    FStar_Syntax_Syntax.t_unit env tau1 in
-                                (match uu___7 with
-                                 | (tau2, uu___8, g_tau) ->
-                                     ((FStar_Syntax_Syntax.Ctx_uvar_meta_tac
-                                         tau2), g_tau))
-                            | (FStar_Pervasives_Native.Some
-                               (FStar_Syntax_Syntax.Implicit uu___6),
-                               attr::uu___7) ->
-                                let attr1 =
-                                  FStar_Syntax_Subst.subst subst attr in
-                                let uu___8 = tc_tot_or_gtot_term env attr1 in
-                                (match uu___8 with
-                                 | (attr2, uu___9, g_attr) ->
-                                     ((FStar_Syntax_Syntax.Ctx_uvar_meta_attr
-                                         attr2), g_attr))
-                            | uu___6 ->
-                                FStar_Compiler_Effect.failwith
-                                  "Impossible, match is under a guard" in
-                          (match uu___5 with
-                           | (ctx_uvar_meta, g_tau_or_attr) ->
-                               let t =
-                                 FStar_Syntax_Subst.subst subst
-                                   x.FStar_Syntax_Syntax.sort in
-                               let uu___6 =
-                                 check_no_escape
-                                   (FStar_Pervasives_Native.Some head) env
-                                   fvs t in
-                               (match uu___6 with
-                                | (t1, g_ex) ->
-                                    let r1 =
-                                      match outargs with
-                                      | [] -> head.FStar_Syntax_Syntax.pos
-                                      | ((t2, uu___7), uu___8, uu___9)::uu___10
-                                          ->
-                                          let uu___11 =
-                                            FStar_Compiler_Range_Type.def_range
-                                              head.FStar_Syntax_Syntax.pos in
-                                          let uu___12 =
-                                            let uu___13 =
-                                              FStar_Compiler_Range_Type.use_range
-                                                head.FStar_Syntax_Syntax.pos in
-                                            let uu___14 =
-                                              FStar_Compiler_Range_Type.use_range
-                                                t2.FStar_Syntax_Syntax.pos in
-                                            FStar_Compiler_Range_Ops.union_rng
-                                              uu___13 uu___14 in
-                                          FStar_Compiler_Range_Type.range_of_rng
-                                            uu___11 uu___12 in
-                                    let uu___7 =
-                                      let msg =
-                                        let is_typeclass =
-                                          match ctx_uvar_meta with
-                                          | FStar_Syntax_Syntax.Ctx_uvar_meta_tac
-                                              tau ->
-                                              FStar_Syntax_Util.is_fvar
-                                                FStar_Parser_Const.tcresolve_lid
-                                                tau
-                                          | uu___8 -> false in
-                                        if is_typeclass
-                                        then "Typeclass constraint argument"
-                                        else
-                                          "Instantiating meta argument in application" in
-                                      FStar_TypeChecker_Env.new_implicit_var_aux
-                                        msg r1 env t1
-                                        FStar_Syntax_Syntax.Strict
-                                        (FStar_Pervasives_Native.Some
-                                           ctx_uvar_meta) in
-                                    (match uu___7 with
-                                     | (varg, uu___8, implicits) ->
-                                         let subst1 =
-                                           (FStar_Syntax_Syntax.NT (x, varg))
-                                           :: subst in
-                                         let aq =
-                                           let uu___9 =
-                                             FStar_Compiler_List.hd bs in
-                                           FStar_Syntax_Util.aqual_of_binder
-                                             uu___9 in
-                                         let arg = (varg, aq) in
-                                         let guard =
-                                           FStar_Compiler_List.fold_right
-                                             FStar_TypeChecker_Env.conj_guard
-                                             [g_ex; g; g_tau_or_attr]
-                                             implicits in
-                                         let uu___9 =
-                                           let uu___10 =
-                                             let uu___11 =
-                                               let uu___12 =
-                                                 let uu___13 =
-                                                   FStar_Syntax_Syntax.mk_Total
-                                                     t1 in
-                                                 FStar_TypeChecker_Common.lcomp_of_comp
-                                                   uu___13 in
-                                               (arg,
-                                                 FStar_Pervasives_Native.None,
-                                                 uu___12) in
-                                             uu___11 :: outargs in
-                                           (subst1, uu___10, (arg ::
-                                             arg_rets), guard, fvs) in
-                                         tc_args head_info uu___9 rest args1)))
+                          let uu___5 = FStar_Compiler_List.hd bs in
+                          instantiate_one_meta_and_go uu___5 rest args1
+                      | ({ FStar_Syntax_Syntax.binder_bv = x;
+                           FStar_Syntax_Syntax.binder_qual =
+                             FStar_Pervasives_Native.Some
+                             (FStar_Syntax_Syntax.Meta tau);
+                           FStar_Syntax_Syntax.binder_positivity = uu___2;
+                           FStar_Syntax_Syntax.binder_attrs = b_attrs;_}::rest,
+                         ({
+                            FStar_Syntax_Syntax.n =
+                              FStar_Syntax_Syntax.Tm_unknown;
+                            FStar_Syntax_Syntax.pos = uu___3;
+                            FStar_Syntax_Syntax.vars = uu___4;
+                            FStar_Syntax_Syntax.hash_code = uu___5;_},
+                          FStar_Pervasives_Native.Some
+                          { FStar_Syntax_Syntax.aqual_implicit = true;
+                            FStar_Syntax_Syntax.aqual_attributes = uu___6;_})::rest')
+                          ->
+                          let uu___7 = FStar_Compiler_List.hd bs in
+                          instantiate_one_meta_and_go uu___7 rest rest'
                       | ({ FStar_Syntax_Syntax.binder_bv = x;
                            FStar_Syntax_Syntax.binder_qual = bqual;
                            FStar_Syntax_Syntax.binder_positivity = uu___2;

--- a/src/reflection/FStar.Reflection.V2.Interpreter.fst
+++ b/src/reflection/FStar.Reflection.V2.Interpreter.fst
@@ -94,13 +94,13 @@ let mk3 nm f =
 let reflection_primops : list PO.primitive_step = [
   (****** Inspecting/packing various kinds of syntax ******)
   mk1 "inspect_ln"
-    #RE.e_term #solve
-    #NRE.e_term #solve
+    #RE.e_term #_
+    #NRE.e_term #_
     RB.inspect_ln;
 
   mk1 "pack_ln"
-    #solve #RE.e_term
-    #solve #NRE.e_term
+    #_ #RE.e_term
+    #_ #NRE.e_term
     RB.pack_ln;
 
   mk1 "inspect_fv" RB.inspect_fv;
@@ -136,11 +136,11 @@ let reflection_primops : list PO.primitive_step = [
 
   mk1 "sigelt_opts" RB.sigelt_opts;
   mk1 "embed_vconfig"
-    #solve #RE.e_term
+    #_ #RE.e_term
     RB.embed_vconfig;
 
   mk1 "sigelt_attrs"
-    #solve #(EMB.e_list RE.e_term)
+    #_ #(EMB.e_list RE.e_term)
     RB.sigelt_attrs;
 
   mk2 "set_sigelt_attrs"
@@ -150,17 +150,17 @@ let reflection_primops : list PO.primitive_step = [
   mk1 "sigelt_quals" RB.sigelt_quals;
   mk2 "set_sigelt_quals" RB.set_sigelt_quals;
   mk2 "subst_term"
-    #solve #RE.e_term #RE.e_term
+    #_ #RE.e_term #RE.e_term
     RB.subst_term;
 
   mk2 "subst_comp" RB.subst_comp;
   mk2 "compare_bv"
-    #RE.e_bv #RE.e_bv #solve
-    #NRE.e_bv #NRE.e_bv #solve
+    #RE.e_bv #RE.e_bv #_
+    #NRE.e_bv #NRE.e_bv #_
     RB.compare_bv;
   mk2 "compare_namedv"
-    #RE.e_namedv #RE.e_namedv #solve
-    #NRE.e_namedv #NRE.e_namedv #solve
+    #RE.e_namedv #RE.e_namedv #_
+    #NRE.e_namedv #NRE.e_namedv #_
     RB.compare_namedv;
 
   mk2 "lookup_attr"
@@ -186,8 +186,8 @@ let reflection_primops : list PO.primitive_step = [
   mk1 "explode_qn" RB.explode_qn;
   mk2 "compare_string" RB.compare_string;
   mk2 "push_namedv"
-    #solve #RE.e_namedv #solve
-    #solve #NRE.e_namedv #solve
+    #_ #RE.e_namedv #_
+    #_ #NRE.e_namedv #_
     RB.push_namedv;
 
   mk1 "range_of_term"

--- a/src/tactics/FStar.Tactics.V1.Primops.fst
+++ b/src/tactics/FStar.Tactics.V1.Primops.fst
@@ -125,12 +125,12 @@ let ops =
   mk_tac_step_1 0 "t_trefl" t_trefl t_trefl ;
   mk_tac_step_1 0 "dup" dup dup  ;
 
-  mk_tac_step_1 0 "tadmit_t" #RE.e_term #solve #NRE.e_term #solve tadmit_t tadmit_t ;
+  mk_tac_step_1 0 "tadmit_t" #RE.e_term #_ #NRE.e_term #_ tadmit_t tadmit_t ;
   mk_tac_step_1 0 "join" join join ;
 
   mk_tac_step_1 0 "t_destruct"
-    #RE.e_term #solve
-    #NRE.e_term #solve
+    #RE.e_term #_
+    #NRE.e_term #_
     t_destruct t_destruct;
 
   mk_tac_step_1 0 "top_env"
@@ -138,35 +138,35 @@ let ops =
     top_env ;
 
   mk_tac_step_1 0 "inspect"
-    #RE.e_term #solve
-    #NRE.e_term #solve
+    #RE.e_term #_
+    #NRE.e_term #_
     inspect inspect ;
 
   mk_tac_step_1 0 "pack"
-    #solve #RE.e_term
-    #solve #NRE.e_term
+    #_ #RE.e_term
+    #_ #NRE.e_term
     pack pack ;
 
   mk_tac_step_1 0 "pack_curried"
-    #solve #RE.e_term
-    #solve #NRE.e_term
+    #_ #RE.e_term
+    #_ #NRE.e_term
     pack_curried pack_curried;
 
   mk_tac_step_1 0 "fresh" fresh fresh ;
   mk_tac_step_1 0 "curms" curms curms ;
   mk_tac_step_2 0 "uvar_env"
-    #solve #(e_option RE.e_term) #RE.e_term
-    #solve #(NBET.e_option NRE.e_term) #NRE.e_term
+    #_ #(e_option RE.e_term) #RE.e_term
+    #_ #(NBET.e_option NRE.e_term) #NRE.e_term
     uvar_env uvar_env ;
 
   mk_tac_step_2 0 "ghost_uvar_env"
-    #solve #RE.e_term #RE.e_term
-    #solve #NRE.e_term #NRE.e_term
+    #_ #RE.e_term #RE.e_term
+    #_ #NRE.e_term #NRE.e_term
     ghost_uvar_env ghost_uvar_env ;
 
   mk_tac_step_1 0 "fresh_universe_uvar"
-    #solve #RE.e_term
-    #solve #NRE.e_term
+    #_ #RE.e_term
+    #_ #NRE.e_term
     fresh_universe_uvar
     fresh_universe_uvar ;
 
@@ -259,8 +259,8 @@ let ops =
   mk_tac_step_1 0 "t_smt_sync" t_smt_sync t_smt_sync ;
 
   mk_tac_step_1 0 "free_uvars"
-    #RE.e_term #solve
-    #NRE.e_term #solve
+    #RE.e_term #_
+    #NRE.e_term #_
     free_uvars free_uvars ;
 
 ]

--- a/src/tactics/FStar.Tactics.V2.Primops.fst
+++ b/src/tactics/FStar.Tactics.V2.Primops.fst
@@ -90,8 +90,8 @@ let ops = [
   mk_tot_step_1 0 "goals_of" goals_of goals_of;
   mk_tot_step_1 0 "smt_goals_of" smt_goals_of smt_goals_of;
   mk_tot_step_1 0 "goal_env" goal_env goal_env;
-  mk_tot_step_1 0 "goal_type" #solve #RE.e_term goal_type goal_type;
-  mk_tot_step_1 0 "goal_witness" #solve #RE.e_term goal_witness goal_witness;
+  mk_tot_step_1 0 "goal_type" #_ #RE.e_term goal_type goal_type;
+  mk_tot_step_1 0 "goal_witness" #_ #RE.e_term goal_witness goal_witness;
   mk_tot_step_1 0 "is_guard" is_guard is_guard;
   mk_tot_step_1 0 "get_label" get_label get_label;
   mk_tot_step_2 0 "set_label" set_label set_label;
@@ -119,7 +119,7 @@ let ops = [
   mk_tac_step_1 0 "intro" intro intro;
   mk_tac_step_1 0 "intro_rec" intro_rec intro_rec;
   mk_tac_step_1 0 "norm" norm norm;
-  mk_tac_step_3 0 "norm_term_env" #solve #solve #RE.e_term #RE.e_term norm_term_env norm_term_env;
+  mk_tac_step_3 0 "norm_term_env" #_ #_ #RE.e_term #RE.e_term norm_term_env norm_term_env;
   mk_tac_step_2 0 "norm_binding_type" norm_binding_type norm_binding_type;
   mk_tac_step_2 0 "rename_to" rename_to rename_to;
   mk_tac_step_1 0 "var_retype" var_retype var_retype;
@@ -128,12 +128,12 @@ let ops = [
   mk_tac_step_1 0 "clear" clear clear;
   mk_tac_step_1 0 "rewrite" rewrite rewrite;
   mk_tac_step_1 0 "refine_intro" refine_intro refine_intro;
-  mk_tac_step_3 0 "t_exact" #solve #solve #RE.e_term t_exact t_exact;
-  mk_tac_step_4 0 "t_apply" #solve #solve #solve #RE.e_term t_apply t_apply;
-  mk_tac_step_3 0 "t_apply_lemma" #solve #solve #RE.e_term t_apply_lemma t_apply_lemma;
+  mk_tac_step_3 0 "t_exact" #_ #_ #RE.e_term t_exact t_exact;
+  mk_tac_step_4 0 "t_apply" #_ #_ #_ #RE.e_term t_apply t_apply;
+  mk_tac_step_3 0 "t_apply_lemma" #_ #_ #RE.e_term t_apply_lemma t_apply_lemma;
   mk_tac_step_1 0 "set_options" set_options set_options;
-  mk_tac_step_2 0 "tcc" #solve #RE.e_term tcc tcc;
-  mk_tac_step_2 0 "tc" #solve #RE.e_term #RE.e_term tc tc;
+  mk_tac_step_2 0 "tcc" #_ #RE.e_term tcc tcc;
+  mk_tac_step_2 0 "tc" #_ #RE.e_term #RE.e_term tc tc;
   mk_tac_step_1 0 "unshelve" #RE.e_term unshelve unshelve;
 
   mk_tac_step_2 1 "unquote"
@@ -168,12 +168,12 @@ let ops = [
   mk_tac_step_1 0 "top_env" top_env top_env;
   mk_tac_step_1 0 "fresh" fresh fresh;
   mk_tac_step_1 0 "curms" curms curms;
-  mk_tac_step_2 0 "uvar_env" #solve #(e_option RE.e_term) #RE.e_term uvar_env uvar_env;
-  mk_tac_step_2 0 "ghost_uvar_env" #solve #RE.e_term #RE.e_term ghost_uvar_env ghost_uvar_env;
-  mk_tac_step_1 0 "fresh_universe_uvar" #solve #RE.e_term fresh_universe_uvar fresh_universe_uvar;
-  mk_tac_step_3 0 "unify_env" #solve #RE.e_term #RE.e_term unify_env unify_env;
-  mk_tac_step_3 0 "unify_guard_env" #solve #RE.e_term #RE.e_term unify_guard_env unify_guard_env;
-  mk_tac_step_3 0 "match_env" #solve #RE.e_term #RE.e_term match_env match_env;
+  mk_tac_step_2 0 "uvar_env" #_ #(e_option RE.e_term) #RE.e_term uvar_env uvar_env;
+  mk_tac_step_2 0 "ghost_uvar_env" #_ #RE.e_term #RE.e_term ghost_uvar_env ghost_uvar_env;
+  mk_tac_step_1 0 "fresh_universe_uvar" #_ #RE.e_term fresh_universe_uvar fresh_universe_uvar;
+  mk_tac_step_3 0 "unify_env" #_ #RE.e_term #RE.e_term unify_env unify_env;
+  mk_tac_step_3 0 "unify_guard_env" #_ #RE.e_term #RE.e_term unify_guard_env unify_guard_env;
+  mk_tac_step_3 0 "match_env" #_ #RE.e_term #RE.e_term match_env match_env;
   mk_tac_step_3 0 "launch_process" launch_process launch_process;
   mk_tac_step_1 0 "change" #RE.e_term change change;
   mk_tac_step_1 0 "get_guard_policy" get_guard_policy get_guard_policy;
@@ -197,7 +197,7 @@ let ops = [
   mk_tac_step_1 0 "gather_or_solve_explicit_guards_for_resolved_goals"
     gather_explicit_guards_for_resolved_goals
     gather_explicit_guards_for_resolved_goals;
-  mk_tac_step_2 0 "string_to_term" #solve #solve #RE.e_term string_to_term string_to_term;
+  mk_tac_step_2 0 "string_to_term" #_ #_ #RE.e_term string_to_term string_to_term;
   mk_tac_step_2 0 "push_bv_dsenv" push_bv_dsenv push_bv_dsenv;
   mk_tac_step_1 0 "term_to_string" #RE.e_term term_to_string term_to_string;
   mk_tac_step_1 0 "comp_to_string" comp_to_string comp_to_string;
@@ -240,27 +240,27 @@ let ops = [
 
   // reflection typechecker callbacks (part of the DSL framework)
 
-  mk_tac_step_2 0 "is_non_informative" #solve #RE.e_term refl_is_non_informative refl_is_non_informative;
-  mk_tac_step_3 0 "check_subtyping" #solve #RE.e_term #RE.e_term refl_check_subtyping refl_check_subtyping;
-  mk_tac_step_3 0 "check_equiv"  #solve #RE.e_term #RE.e_term refl_check_equiv refl_check_equiv;
-  mk_tac_step_2 0 "core_compute_term_type" #solve #RE.e_term #(e_ret_t (e_tuple2 solve RE.e_term)) refl_core_compute_term_type refl_core_compute_term_type;
-  mk_tac_step_4 0 "core_check_term" #solve #RE.e_term #RE.e_term refl_core_check_term refl_core_check_term;
-  mk_tac_step_3 0 "core_check_term_at_type" #solve #RE.e_term #RE.e_term refl_core_check_term_at_type refl_core_check_term_at_type;
-  mk_tac_step_2 0 "tc_term" #solve #RE.e_term #(e_ret_t (e_tuple2 RE.e_term (e_tuple2 solve RE.e_term))) refl_tc_term refl_tc_term;
-  mk_tac_step_2 0 "universe_of" #solve #RE.e_term refl_universe_of refl_universe_of;
-  mk_tac_step_2 0 "check_prop_validity" #solve #RE.e_term refl_check_prop_validity refl_check_prop_validity;
-  mk_tac_step_4 0 "check_match_complete" #solve #RE.e_term #RE.e_term refl_check_match_complete refl_check_match_complete;
+  mk_tac_step_2 0 "is_non_informative" #_ #RE.e_term refl_is_non_informative refl_is_non_informative;
+  mk_tac_step_3 0 "check_subtyping" #_ #RE.e_term #RE.e_term refl_check_subtyping refl_check_subtyping;
+  mk_tac_step_3 0 "check_equiv"  #_ #RE.e_term #RE.e_term refl_check_equiv refl_check_equiv;
+  mk_tac_step_2 0 "core_compute_term_type" #_ #RE.e_term #(e_ret_t (e_tuple2 solve RE.e_term)) refl_core_compute_term_type refl_core_compute_term_type;
+  mk_tac_step_4 0 "core_check_term" #_ #RE.e_term #RE.e_term refl_core_check_term refl_core_check_term;
+  mk_tac_step_3 0 "core_check_term_at_type" #_ #RE.e_term #RE.e_term refl_core_check_term_at_type refl_core_check_term_at_type;
+  mk_tac_step_2 0 "tc_term" #_ #RE.e_term #(e_ret_t (e_tuple2 RE.e_term (e_tuple2 solve RE.e_term))) refl_tc_term refl_tc_term;
+  mk_tac_step_2 0 "universe_of" #_ #RE.e_term refl_universe_of refl_universe_of;
+  mk_tac_step_2 0 "check_prop_validity" #_ #RE.e_term refl_check_prop_validity refl_check_prop_validity;
+  mk_tac_step_4 0 "check_match_complete" #_ #RE.e_term #RE.e_term refl_check_match_complete refl_check_match_complete;
   mk_tac_step_2 0 "instantiate_implicits"
-    #solve #solve #(e_ret_t (e_tuple3 (e_list (e_tuple2 RE.e_namedv solve)) solve solve))
-    #solve #solve #(nbe_e_ret_t (NBET.e_tuple3 (NBET.e_list (NBET.e_tuple2 NRE.e_namedv solve)) solve solve))
+    #_ #_ #(e_ret_t (e_tuple3 (e_list (e_tuple2 RE.e_namedv solve)) solve solve))
+    #_ #_ #(nbe_e_ret_t (NBET.e_tuple3 (NBET.e_list (NBET.e_tuple2 NRE.e_namedv solve)) solve solve))
     refl_instantiate_implicits refl_instantiate_implicits;
   mk_tac_step_3 0 "maybe_relate_after_unfolding" refl_maybe_relate_after_unfolding refl_maybe_relate_after_unfolding;
   mk_tac_step_2 0 "maybe_unfold_head" refl_maybe_unfold_head refl_maybe_unfold_head;
   mk_tac_step_2 0 "push_open_namespace" push_open_namespace push_open_namespace;
   mk_tac_step_3 0 "push_module_abbrev" push_module_abbrev push_module_abbrev;
   mk_tac_step_2 0 "resolve_name"
-    #solve #solve #(e_option (e_either RE.e_bv solve)) // disambiguate bv/namedv
-    #solve #solve #(NBET.e_option (NBET.e_either NRE.e_bv solve))
+    #_ #_ #(e_option (e_either RE.e_bv solve)) // disambiguate bv/namedv
+    #_ #_ #(NBET.e_option (NBET.e_either NRE.e_bv solve))
     resolve_name resolve_name;
   mk_tac_step_1 0 "log_issues" log_issues log_issues;
 ]

--- a/src/typechecker/FStar.TypeChecker.TcTerm.fst
+++ b/src/typechecker/FStar.TypeChecker.TcTerm.fst
@@ -2707,6 +2707,60 @@ and check_application_args env head (chead:comp) ghead args expected_topt : term
                      fvs)     (* unsubstituted formals, to check that they do not occur free elsewhere in the type of f *)
                      bs       (* formal parameters *)
                      args     (* remaining actual arguments *) : (term * lcomp * guard_t) =
+
+        (* We follow the exact same procedure as for instantiating an implicit,
+         * except that we keep track of the (uvar, env, metaprogram) pair in the environment
+         * so we can later come back to the implicit and, if it wasn't solved by unification,
+         * run the metaprogram on it.
+         *
+         * Why don't we run the metaprogram here? At this stage, it's very likely that `t`
+         * is full of unresolved uvars, and it wouldn't be a whole lot useful to try
+         * to find an instance for it. We might not even be able to, since instances
+         * are for concrete types.
+         *)
+        let instantiate_one_meta_and_go b rest_bs args =
+          let {binder_bv=x;binder_qual=qual;binder_attrs=attrs} = b in
+          let ctx_uvar_meta, g_tau_or_attr =
+              match qual, attrs with
+              | Some (Meta tau), _ ->
+                let tau = SS.subst subst tau in
+                let tau, _, g_tau = tc_tactic t_unit t_unit env tau in
+                Ctx_uvar_meta_tac tau, g_tau
+              | Some (Implicit _), attr::_ ->
+                let attr = SS.subst subst attr in
+                let attr, _, g_attr = tc_tot_or_gtot_term env attr in
+                Ctx_uvar_meta_attr attr, g_attr
+              | _ -> failwith "Impossible, match is under a guard"
+          in
+          let t = SS.subst subst x.sort in
+          let t, g_ex = check_no_escape (Some head) env fvs t in
+          let r = match outargs with
+                  | [] -> head.pos
+                  | ((t, _), _, _)::_ ->
+                      Range.range_of_rng (Range.def_range head.pos)
+                                        (Range.union_rng (Range.use_range head.pos)
+                                                          (Range.use_range t.pos))
+          in
+          let varg, _, implicits =
+            let msg =
+              let is_typeclass =
+                match ctx_uvar_meta with
+                | Ctx_uvar_meta_tac tau -> U.is_fvar Const.tcresolve_lid tau
+                | _ -> false
+              in
+              if is_typeclass
+              then "Typeclass constraint argument"
+              else "Instantiating meta argument in application"
+            in
+            Env.new_implicit_var_aux msg r env t Strict (Some ctx_uvar_meta)
+          in
+          let subst = NT(x, varg)::subst in
+          let aq = U.aqual_of_binder (List.hd bs) in
+          let arg = varg, aq in
+          let guard = List.fold_right Env.conj_guard [g_ex; g; g_tau_or_attr] implicits in
+          tc_args head_info (subst, (arg, None, S.mk_Total t |> TcComm.lcomp_of_comp)::outargs, arg::arg_rets, guard, fvs) rest_bs args
+        in
+
         match bs, args with
         | ({binder_bv=x;binder_qual=Some (Implicit _);binder_attrs=[]})::rest,
           (_, None)::_ -> (* instantiate an implicit arg that's not associated with a tactic, i.e. no Meta or attrs *)
@@ -2734,56 +2788,13 @@ and check_application_args env head (chead:comp) ghead args expected_topt : term
 
         | ({binder_bv=x;binder_qual=qual;binder_attrs=attrs})::rest,
           (_, None)::_
-          when (TcUtil.maybe_implicit_with_meta_or_attr qual attrs) -> (* instantiate a meta arg *)
-            (* We follow the exact same procedure as for instantiating an implicit,
-             * except that we keep track of the (uvar, env, metaprogram) pair in the environment
-             * so we can later come back to the implicit and, if it wasn't solved by unification,
-             * run the metaprogram on it.
-             *
-             * Why don't we run the metaprogram here? At this stage, it's very likely that `t`
-             * is full of unresolved uvars, and it wouldn't be a whole lot useful to try
-             * to find an instance for it. We might not even be able to, since instances
-             * are for concrete types.
-             *)
-            let ctx_uvar_meta, g_tau_or_attr =
-                match qual, attrs with
-                | Some (Meta tau), _ ->
-                  let tau = SS.subst subst tau in
-                  let tau, _, g_tau = tc_tactic t_unit t_unit env tau in
-                  Ctx_uvar_meta_tac tau, g_tau
-                | Some (Implicit _), attr::_ ->
-                  let attr = SS.subst subst attr in
-                  let attr, _, g_attr = tc_tot_or_gtot_term env attr in
-                  Ctx_uvar_meta_attr attr, g_attr
-                | _ -> failwith "Impossible, match is under a guard"
-            in
-            let t = SS.subst subst x.sort in
-            let t, g_ex = check_no_escape (Some head) env fvs t in
-            let r = match outargs with
-                    | [] -> head.pos
-                    | ((t, _), _, _)::_ ->
-                        Range.range_of_rng (Range.def_range head.pos)
-                                           (Range.union_rng (Range.use_range head.pos)
-                                                            (Range.use_range t.pos))
-            in
-            let varg, _, implicits =
-              let msg =
-                let is_typeclass =
-                  match ctx_uvar_meta with
-                  | Ctx_uvar_meta_tac tau -> U.is_fvar Const.tcresolve_lid tau
-                  | _ -> false
-                in
-                if is_typeclass
-                then "Typeclass constraint argument"
-                else "Instantiating meta argument in application"
-              in
-              Env.new_implicit_var_aux msg r env t Strict (Some ctx_uvar_meta)
-            in
-            let subst = NT(x, varg)::subst in
-            let aq = U.aqual_of_binder (List.hd bs) in
-            let arg = varg, aq in
-            let guard = List.fold_right Env.conj_guard [g_ex; g; g_tau_or_attr] implicits in
-            tc_args head_info (subst, (arg, None, S.mk_Total t |> TcComm.lcomp_of_comp)::outargs, arg::arg_rets, guard, fvs) rest args
+            when (TcUtil.maybe_implicit_with_meta_or_attr qual attrs) -> (* instantiate a meta arg *)
+          instantiate_one_meta_and_go (List.hd bs) rest args
+
+        (* User provided a _ for a meta arg, keep the meta for the unknown. *)
+        | ({binder_bv=x;binder_qual=Some (Meta tau);binder_attrs=b_attrs})::rest,
+          ({n = Tm_unknown}, Some {aqual_implicit=true})::rest' ->
+          instantiate_one_meta_and_go (List.hd bs) rest rest' (* NB: rest' instead of args, we consume the _ *)
 
         | ({binder_bv=x;binder_qual=bqual;binder_attrs=b_attrs})::rest, (e, aq)::rest' -> (* a concrete argument *)
             let aq = check_expected_aqual_for_binder aq (List.hd bs) e.pos in

--- a/tests/typeclasses/SolveUnderscore.fst
+++ b/tests/typeclasses/SolveUnderscore.fst
@@ -1,0 +1,25 @@
+module SolveUnderscore
+
+open FStar.Class.Eq.Raw
+
+let f (#a:Type) (x:a) {| deq a |} (y:a) = x = y
+
+let test0 = f 1 2
+let test1 = f #_ 1 2
+let test2 = f #int 1 2
+
+let test3 = f 1 #int_has_eq 2
+
+(* An underscore for an implicit that has a meta arg
+is solved by the tactic, instead of the unifier. *)
+let test4 = f 1 #_ 2
+
+(* This allows to specify only the relevant args for disambiguation
+in some cases. See this artificial example *)
+
+let g (#a:Type) {| deq a |} (#b:Type) {| deq b |} (x:a) : b -> a = (fun _ -> x)
+
+let use_g = g #_ #_ #int 5
+
+(* Otherwise, we'd have to provide the dicitionary in the second _, or
+call solve. *)


### PR DESCRIPTION
When using typeclasses and there is a need to disambiguate one implicit
out of many, say the 3rd, we either have to provide the dictionaries of
the preceding args explicitly:

    f #_ #d_int #bool

or call `solve` like

    f #int #solve #bool

Since just using `#_` for the dictionary will fail, as it will try to be
solved only by unification. This PR makes it so that using `#_` for an
implicit that has a meta (tactic or attr) retains the meta, and is then
solved exactly as if nothing was provided. Then we can disambiguate the
function above as

    f #_ #_ #bool