### PR TITLE
An option to log (only) failing queries

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_Options.ml
+++ b/ocaml/fstar-lib/generated/FStar_Options.ml
@@ -326,6 +326,7 @@ let (defaults : (Prims.string * option_val) Prims.list) =
   ("load", (List []));
   ("load_cmxs", (List []));
   ("log_queries", (Bool false));
+  ("log_failing_queries", (Bool false));
   ("log_types", (Bool false));
   ("max_fuel", (Int (Prims.of_int (8))));
   ("max_ifuel", (Int (Prims.of_int (2))));
@@ -555,6 +556,8 @@ let (get_load_cmxs : unit -> Prims.string Prims.list) =
   fun uu___ -> lookup_opt "load_cmxs" (as_list as_string)
 let (get_log_queries : unit -> Prims.bool) =
   fun uu___ -> lookup_opt "log_queries" as_bool
+let (get_log_failing_queries : unit -> Prims.bool) =
+  fun uu___ -> lookup_opt "log_failing_queries" as_bool
 let (get_log_types : unit -> Prims.bool) =
   fun uu___ -> lookup_opt "log_types" as_bool
 let (get_max_fuel : unit -> Prims.int) =
@@ -1013,7 +1016,7 @@ let (interp_quake_arg : Prims.string -> (Prims.int * Prims.int * Prims.bool))
           let uu___ = ios f1 in let uu___1 = ios f2 in (uu___, uu___1, true)
         else FStar_Compiler_Effect.failwith "unexpected value for --quake"
     | uu___ -> FStar_Compiler_Effect.failwith "unexpected value for --quake"
-let (uu___460 : (((Prims.string -> unit) -> unit) * (Prims.string -> unit)))
+let (uu___461 : (((Prims.string -> unit) -> unit) * (Prims.string -> unit)))
   =
   let cb = FStar_Compiler_Util.mk_ref FStar_Pervasives_Native.None in
   let set1 f =
@@ -1025,11 +1028,11 @@ let (uu___460 : (((Prims.string -> unit) -> unit) * (Prims.string -> unit)))
     | FStar_Pervasives_Native.Some f -> f msg in
   (set1, call)
 let (set_option_warning_callback_aux : (Prims.string -> unit) -> unit) =
-  match uu___460 with
+  match uu___461 with
   | (set_option_warning_callback_aux1, option_warning_callback) ->
       set_option_warning_callback_aux1
 let (option_warning_callback : Prims.string -> unit) =
-  match uu___460 with
+  match uu___461 with
   | (set_option_warning_callback_aux1, option_warning_callback1) ->
       option_warning_callback1
 let (set_option_warning_callback : (Prims.string -> unit) -> unit) =
@@ -1692,7 +1695,7 @@ let rec (specs_with_types :
                                                                     let uu___91
                                                                     =
                                                                     text
-                                                                    "Retain comments in the logged SMT queries (requires --log_queries; default true)" in
+                                                                    "Retain comments in the logged SMT queries (requires --log_queries or --log_failing_queries; default true)" in
                                                                     (FStar_Getopt.noshort,
                                                                     "keep_query_captions",
                                                                     BoolStr,
@@ -1784,11 +1787,12 @@ let rec (specs_with_types :
                                                                     let uu___103
                                                                     =
                                                                     text
-                                                                    "Number of unrolling of recursive functions to try at most (default 8)" in
+                                                                    "As --log_queries, but only save the failing queries. Each query is\n    saved in its own file regardless of whether they were checked during the\n    same invocation. The SMT2 file names begin with \"failedQueries\"" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "max_fuel",
-                                                                    (IntStr
-                                                                    "non-negative integer"),
+                                                                    "log_failing_queries",
+                                                                    (Const
+                                                                    (Bool
+                                                                    true)),
                                                                     uu___103) in
                                                                     let uu___103
                                                                     =
@@ -1797,9 +1801,9 @@ let rec (specs_with_types :
                                                                     let uu___105
                                                                     =
                                                                     text
-                                                                    "Number of unrolling of inductive datatypes to try at most (default 2)" in
+                                                                    "Number of unrolling of recursive functions to try at most (default 8)" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "max_ifuel",
+                                                                    "max_fuel",
                                                                     (IntStr
                                                                     "non-negative integer"),
                                                                     uu___105) in
@@ -1810,12 +1814,11 @@ let rec (specs_with_types :
                                                                     let uu___107
                                                                     =
                                                                     text
-                                                                    "Trigger various specializations for compiling the F* compiler itself (not meant for user code)" in
+                                                                    "Number of unrolling of inductive datatypes to try at most (default 2)" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "MLish",
-                                                                    (Const
-                                                                    (Bool
-                                                                    true)),
+                                                                    "max_ifuel",
+                                                                    (IntStr
+                                                                    "non-negative integer"),
                                                                     uu___107) in
                                                                     let uu___107
                                                                     =
@@ -1824,9 +1827,9 @@ let rec (specs_with_types :
                                                                     let uu___109
                                                                     =
                                                                     text
-                                                                    "Ignore the default module search paths" in
+                                                                    "Trigger various specializations for compiling the F* compiler itself (not meant for user code)" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "no_default_includes",
+                                                                    "MLish",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -1838,12 +1841,12 @@ let rec (specs_with_types :
                                                                     let uu___111
                                                                     =
                                                                     text
-                                                                    "Deprecated: use --extract instead; Do not extract code from this module" in
+                                                                    "Ignore the default module search paths" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "no_extract",
-                                                                    (Accumulated
-                                                                    (PathStr
-                                                                    "module name")),
+                                                                    "no_default_includes",
+                                                                    (Const
+                                                                    (Bool
+                                                                    true)),
                                                                     uu___111) in
                                                                     let uu___111
                                                                     =
@@ -1852,12 +1855,12 @@ let rec (specs_with_types :
                                                                     let uu___113
                                                                     =
                                                                     text
-                                                                    "Suppress location information in the generated OCaml output (only relevant with --codegen OCaml)" in
+                                                                    "Deprecated: use --extract instead; Do not extract code from this module" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "no_location_info",
-                                                                    (Const
-                                                                    (Bool
-                                                                    true)),
+                                                                    "no_extract",
+                                                                    (Accumulated
+                                                                    (PathStr
+                                                                    "module name")),
                                                                     uu___113) in
                                                                     let uu___113
                                                                     =
@@ -1866,9 +1869,9 @@ let rec (specs_with_types :
                                                                     let uu___115
                                                                     =
                                                                     text
-                                                                    "Do not send any queries to the SMT solver, and fail on them instead" in
+                                                                    "Suppress location information in the generated OCaml output (only relevant with --codegen OCaml)" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "no_smt",
+                                                                    "no_location_info",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -1880,9 +1883,9 @@ let rec (specs_with_types :
                                                                     let uu___117
                                                                     =
                                                                     text
-                                                                    "Extract top-level pure terms after normalizing them. This can lead to very large code, but can result in more partial evaluation and compile-time specialization." in
+                                                                    "Do not send any queries to the SMT solver, and fail on them instead" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "normalize_pure_terms_for_extraction",
+                                                                    "no_smt",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -1894,13 +1897,12 @@ let rec (specs_with_types :
                                                                     let uu___119
                                                                     =
                                                                     text
-                                                                    "Place output in directory  dir" in
+                                                                    "Extract top-level pure terms after normalizing them. This can lead to very large code, but can result in more partial evaluation and compile-time specialization." in
                                                                     (FStar_Getopt.noshort,
-                                                                    "odir",
-                                                                    (PostProcessed
-                                                                    (pp_validate_dir,
-                                                                    (PathStr
-                                                                    "dir"))),
+                                                                    "normalize_pure_terms_for_extraction",
+                                                                    (Const
+                                                                    (Bool
+                                                                    true)),
                                                                     uu___119) in
                                                                     let uu___119
                                                                     =
@@ -1909,11 +1911,13 @@ let rec (specs_with_types :
                                                                     let uu___121
                                                                     =
                                                                     text
-                                                                    "Output the result of --dep into this file instead of to standard output." in
+                                                                    "Place output in directory  dir" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "output_deps_to",
+                                                                    "odir",
+                                                                    (PostProcessed
+                                                                    (pp_validate_dir,
                                                                     (PathStr
-                                                                    "file"),
+                                                                    "dir"))),
                                                                     uu___121) in
                                                                     let uu___121
                                                                     =
@@ -1922,9 +1926,9 @@ let rec (specs_with_types :
                                                                     let uu___123
                                                                     =
                                                                     text
-                                                                    "Use a custom prims.fst file. Do not use if you do not know exactly what you're doing." in
+                                                                    "Output the result of --dep into this file instead of to standard output." in
                                                                     (FStar_Getopt.noshort,
-                                                                    "prims",
+                                                                    "output_deps_to",
                                                                     (PathStr
                                                                     "file"),
                                                                     uu___123) in
@@ -1935,12 +1939,11 @@ let rec (specs_with_types :
                                                                     let uu___125
                                                                     =
                                                                     text
-                                                                    "Print the types of bound variables" in
+                                                                    "Use a custom prims.fst file. Do not use if you do not know exactly what you're doing." in
                                                                     (FStar_Getopt.noshort,
-                                                                    "print_bound_var_types",
-                                                                    (Const
-                                                                    (Bool
-                                                                    true)),
+                                                                    "prims",
+                                                                    (PathStr
+                                                                    "file"),
                                                                     uu___125) in
                                                                     let uu___125
                                                                     =
@@ -1949,9 +1952,9 @@ let rec (specs_with_types :
                                                                     let uu___127
                                                                     =
                                                                     text
-                                                                    "Print inferred predicate transformers for all computation types" in
+                                                                    "Print the types of bound variables" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "print_effect_args",
+                                                                    "print_bound_var_types",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -1963,9 +1966,9 @@ let rec (specs_with_types :
                                                                     let uu___129
                                                                     =
                                                                     text
-                                                                    "Print the errors generated by declarations marked with expect_failure, useful for debugging error locations" in
+                                                                    "Print inferred predicate transformers for all computation types" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "print_expected_failures",
+                                                                    "print_effect_args",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -1977,9 +1980,9 @@ let rec (specs_with_types :
                                                                     let uu___131
                                                                     =
                                                                     text
-                                                                    "Print full names of variables" in
+                                                                    "Print the errors generated by declarations marked with expect_failure, useful for debugging error locations" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "print_full_names",
+                                                                    "print_expected_failures",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -1991,9 +1994,9 @@ let rec (specs_with_types :
                                                                     let uu___133
                                                                     =
                                                                     text
-                                                                    "Print implicit arguments" in
+                                                                    "Print full names of variables" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "print_implicits",
+                                                                    "print_full_names",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2005,9 +2008,9 @@ let rec (specs_with_types :
                                                                     let uu___135
                                                                     =
                                                                     text
-                                                                    "Print universes" in
+                                                                    "Print implicit arguments" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "print_universes",
+                                                                    "print_implicits",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2019,9 +2022,9 @@ let rec (specs_with_types :
                                                                     let uu___137
                                                                     =
                                                                     text
-                                                                    "Print Z3 statistics for each SMT query (details such as relevant modules, facts, etc. for each proof)" in
+                                                                    "Print universes" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "print_z3_statistics",
+                                                                    "print_universes",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2033,9 +2036,9 @@ let rec (specs_with_types :
                                                                     let uu___139
                                                                     =
                                                                     text
-                                                                    "Print full names (deprecated; use --print_full_names instead)" in
+                                                                    "Print Z3 statistics for each SMT query (details such as relevant modules, facts, etc. for each proof)" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "prn",
+                                                                    "print_z3_statistics",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2047,9 +2050,9 @@ let rec (specs_with_types :
                                                                     let uu___141
                                                                     =
                                                                     text
-                                                                    "Proof recovery mode: before failing an SMT query, retry 3 times, increasing rlimits. If the query goes through after retrying, verification will succeed, but a warning will be emitted. This feature is useful to restore a project after some change to its libraries or F* upgrade. Importantly, then, this option cannot be used in a pragma (#set-options, etc)." in
+                                                                    "Print full names (deprecated; use --print_full_names instead)" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "proof_recovery",
+                                                                    "prn",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2060,76 +2063,90 @@ let rec (specs_with_types :
                                                                     =
                                                                     let uu___143
                                                                     =
+                                                                    text
+                                                                    "Proof recovery mode: before failing an SMT query, retry 3 times, increasing rlimits. If the query goes through after retrying, verification will succeed, but a warning will be emitted. This feature is useful to restore a project after some change to its libraries or F* upgrade. Importantly, then, this option cannot be used in a pragma (#set-options, etc)." in
+                                                                    (FStar_Getopt.noshort,
+                                                                    "proof_recovery",
+                                                                    (Const
+                                                                    (Bool
+                                                                    true)),
+                                                                    uu___143) in
+                                                                    let uu___143
+                                                                    =
                                                                     let uu___144
                                                                     =
-                                                                    text
-                                                                    "Repeats SMT queries to check for robustness" in
                                                                     let uu___145
                                                                     =
                                                                     let uu___146
                                                                     =
+                                                                    text
+                                                                    "Repeats SMT queries to check for robustness" in
                                                                     let uu___147
                                                                     =
                                                                     let uu___148
                                                                     =
-                                                                    text
-                                                                    "--quake N/M repeats each query checks that it succeeds at least N out of M times, aborting early if possible" in
                                                                     let uu___149
                                                                     =
                                                                     let uu___150
                                                                     =
                                                                     text
-                                                                    "--quake N/M/k works as above, except it will unconditionally run M times" in
+                                                                    "--quake N/M repeats each query checks that it succeeds at least N out of M times, aborting early if possible" in
                                                                     let uu___151
                                                                     =
                                                                     let uu___152
                                                                     =
                                                                     text
-                                                                    "--quake N is an alias for --quake N/N" in
+                                                                    "--quake N/M/k works as above, except it will unconditionally run M times" in
                                                                     let uu___153
                                                                     =
                                                                     let uu___154
                                                                     =
                                                                     text
+                                                                    "--quake N is an alias for --quake N/N" in
+                                                                    let uu___155
+                                                                    =
+                                                                    let uu___156
+                                                                    =
+                                                                    text
                                                                     "--quake N/k is an alias for --quake N/N/k" in
-                                                                    [uu___154] in
+                                                                    [uu___156] in
+                                                                    uu___154
+                                                                    ::
+                                                                    uu___155 in
                                                                     uu___152
                                                                     ::
                                                                     uu___153 in
                                                                     uu___150
                                                                     ::
                                                                     uu___151 in
-                                                                    uu___148
-                                                                    ::
-                                                                    uu___149 in
                                                                     FStar_Errors_Msg.bulleted
-                                                                    uu___147 in
-                                                                    let uu___147
+                                                                    uu___149 in
+                                                                    let uu___149
                                                                     =
                                                                     text
                                                                     "Using --quake disables --retry. When quake testing, queries are not splitted for error reporting unless '--split_queries always' is given. Queries from the smt_sync tactic are not quake-tested." in
                                                                     FStar_Pprint.op_Hat_Hat
+                                                                    uu___148
+                                                                    uu___149 in
+                                                                    FStar_Pprint.op_Hat_Hat
                                                                     uu___146
                                                                     uu___147 in
-                                                                    FStar_Pprint.op_Hat_Hat
-                                                                    uu___144
-                                                                    uu___145 in
                                                                     (FStar_Getopt.noshort,
                                                                     "quake",
                                                                     (PostProcessed
                                                                     ((fun
-                                                                    uu___144
+                                                                    uu___146
                                                                     ->
-                                                                    match uu___144
+                                                                    match uu___146
                                                                     with
                                                                     | 
                                                                     String s
                                                                     ->
-                                                                    let uu___145
+                                                                    let uu___147
                                                                     =
                                                                     interp_quake_arg
                                                                     s in
-                                                                    (match uu___145
+                                                                    (match uu___147
                                                                     with
                                                                     | 
                                                                     (min,
@@ -2150,26 +2167,12 @@ let rec (specs_with_types :
                                                                     false);
                                                                     String s))
                                                                     | 
-                                                                    uu___145
+                                                                    uu___147
                                                                     ->
                                                                     FStar_Compiler_Effect.failwith
                                                                     "impos"),
                                                                     (SimpleStr
                                                                     "positive integer or pair of positive integers"))),
-                                                                    uu___143) in
-                                                                    let uu___143
-                                                                    =
-                                                                    let uu___144
-                                                                    =
-                                                                    let uu___145
-                                                                    =
-                                                                    text
-                                                                    "Print SMT query statistics" in
-                                                                    (FStar_Getopt.noshort,
-                                                                    "query_stats",
-                                                                    (Const
-                                                                    (Bool
-                                                                    true)),
                                                                     uu___145) in
                                                                     let uu___145
                                                                     =
@@ -2178,9 +2181,9 @@ let rec (specs_with_types :
                                                                     let uu___147
                                                                     =
                                                                     text
-                                                                    "Record a database of hints for efficient proof replay" in
+                                                                    "Print SMT query statistics" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "record_hints",
+                                                                    "query_stats",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2192,9 +2195,9 @@ let rec (specs_with_types :
                                                                     let uu___149
                                                                     =
                                                                     text
-                                                                    "Record the state of options used to check each sigelt, useful for the `check_with` attribute and metaprogramming. Note that this implies a performance hit and increases the size of checked files." in
+                                                                    "Record a database of hints for efficient proof replay" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "record_options",
+                                                                    "record_hints",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2206,14 +2209,28 @@ let rec (specs_with_types :
                                                                     let uu___151
                                                                     =
                                                                     text
+                                                                    "Record the state of options used to check each sigelt, useful for the `check_with` attribute and metaprogramming. Note that this implies a performance hit and increases the size of checked files." in
+                                                                    (FStar_Getopt.noshort,
+                                                                    "record_options",
+                                                                    (Const
+                                                                    (Bool
+                                                                    true)),
+                                                                    uu___151) in
+                                                                    let uu___151
+                                                                    =
+                                                                    let uu___152
+                                                                    =
+                                                                    let uu___153
+                                                                    =
+                                                                    text
                                                                     "Retry each SMT query N times and succeed on the first try. Using --retry disables --quake." in
                                                                     (FStar_Getopt.noshort,
                                                                     "retry",
                                                                     (PostProcessed
                                                                     ((fun
-                                                                    uu___152
+                                                                    uu___154
                                                                     ->
-                                                                    match uu___152
+                                                                    match uu___154
                                                                     with
                                                                     | 
                                                                     Int i ->
@@ -2234,25 +2251,12 @@ let rec (specs_with_types :
                                                                     true);
                                                                     Bool true)
                                                                     | 
-                                                                    uu___153
+                                                                    uu___155
                                                                     ->
                                                                     FStar_Compiler_Effect.failwith
                                                                     "impos"),
                                                                     (IntStr
                                                                     "positive integer"))),
-                                                                    uu___151) in
-                                                                    let uu___151
-                                                                    =
-                                                                    let uu___152
-                                                                    =
-                                                                    let uu___153
-                                                                    =
-                                                                    text
-                                                                    "Optimistically, attempt using the recorded hint for  toplevel_name (a top-level name in the current module) when trying to verify some other term 'g'" in
-                                                                    (FStar_Getopt.noshort,
-                                                                    "reuse_hint_for",
-                                                                    (SimpleStr
-                                                                    "toplevel_name"),
                                                                     uu___153) in
                                                                     let uu___153
                                                                     =
@@ -2261,12 +2265,11 @@ let rec (specs_with_types :
                                                                     let uu___155
                                                                     =
                                                                     text
-                                                                    "Report every use of an escape hatch, include assume, admit, etc." in
+                                                                    "Optimistically, attempt using the recorded hint for  toplevel_name (a top-level name in the current module) when trying to verify some other term 'g'" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "report_assumes",
-                                                                    (EnumStr
-                                                                    ["warn";
-                                                                    "error"]),
+                                                                    "reuse_hint_for",
+                                                                    (SimpleStr
+                                                                    "toplevel_name"),
                                                                     uu___155) in
                                                                     let uu___155
                                                                     =
@@ -2275,12 +2278,12 @@ let rec (specs_with_types :
                                                                     let uu___157
                                                                     =
                                                                     text
-                                                                    "Disable all non-critical output" in
+                                                                    "Report every use of an escape hatch, include assume, admit, etc." in
                                                                     (FStar_Getopt.noshort,
-                                                                    "silent",
-                                                                    (Const
-                                                                    (Bool
-                                                                    true)),
+                                                                    "report_assumes",
+                                                                    (EnumStr
+                                                                    ["warn";
+                                                                    "error"]),
                                                                     uu___157) in
                                                                     let uu___157
                                                                     =
@@ -2289,11 +2292,12 @@ let rec (specs_with_types :
                                                                     let uu___159
                                                                     =
                                                                     text
-                                                                    "Path to the Z3 SMT solver (we could eventually support other solvers)" in
+                                                                    "Disable all non-critical output" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "smt",
-                                                                    (PathStr
-                                                                    "path"),
+                                                                    "silent",
+                                                                    (Const
+                                                                    (Bool
+                                                                    true)),
                                                                     uu___159) in
                                                                     let uu___159
                                                                     =
@@ -2302,10 +2306,11 @@ let rec (specs_with_types :
                                                                     let uu___161
                                                                     =
                                                                     text
-                                                                    "Toggle a peephole optimization that eliminates redundant uses of boxing/unboxing in the SMT encoding (default 'false')" in
+                                                                    "Path to the Z3 SMT solver (we could eventually support other solvers)" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "smtencoding.elim_box",
-                                                                    BoolStr,
+                                                                    "smt",
+                                                                    (PathStr
+                                                                    "path"),
                                                                     uu___161) in
                                                                     let uu___161
                                                                     =
@@ -2313,57 +2318,11 @@ let rec (specs_with_types :
                                                                     =
                                                                     let uu___163
                                                                     =
-                                                                    let uu___164
-                                                                    =
                                                                     text
-                                                                    "Control the representation of non-linear arithmetic functions in the SMT encoding:" in
-                                                                    let uu___165
-                                                                    =
-                                                                    let uu___166
-                                                                    =
-                                                                    let uu___167
-                                                                    =
-                                                                    let uu___168
-                                                                    =
-                                                                    text
-                                                                    "if 'boxwrap' use 'Prims.op_Multiply, Prims.op_Division, Prims.op_Modulus'" in
-                                                                    let uu___169
-                                                                    =
-                                                                    let uu___170
-                                                                    =
-                                                                    text
-                                                                    "if 'native' use '*, div, mod'" in
-                                                                    let uu___171
-                                                                    =
-                                                                    let uu___172
-                                                                    =
-                                                                    text
-                                                                    "if 'wrapped' use '_mul, _div, _mod : Int*Int -> Int'" in
-                                                                    [uu___172] in
-                                                                    uu___170
-                                                                    ::
-                                                                    uu___171 in
-                                                                    uu___168
-                                                                    ::
-                                                                    uu___169 in
-                                                                    FStar_Errors_Msg.bulleted
-                                                                    uu___167 in
-                                                                    let uu___167
-                                                                    =
-                                                                    text
-                                                                    "(default 'boxwrap')" in
-                                                                    FStar_Pprint.op_Hat_Hat
-                                                                    uu___166
-                                                                    uu___167 in
-                                                                    FStar_Pprint.op_Hat_Hat
-                                                                    uu___164
-                                                                    uu___165 in
+                                                                    "Toggle a peephole optimization that eliminates redundant uses of boxing/unboxing in the SMT encoding (default 'false')" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "smtencoding.nl_arith_repr",
-                                                                    (EnumStr
-                                                                    ["native";
-                                                                    "wrapped";
-                                                                    "boxwrap"]),
+                                                                    "smtencoding.elim_box",
+                                                                    BoolStr,
                                                                     uu___163) in
                                                                     let uu___163
                                                                     =
@@ -2374,7 +2333,7 @@ let rec (specs_with_types :
                                                                     let uu___166
                                                                     =
                                                                     text
-                                                                    "Toggle the representation of linear arithmetic functions in the SMT encoding:" in
+                                                                    "Control the representation of non-linear arithmetic functions in the SMT encoding:" in
                                                                     let uu___167
                                                                     =
                                                                     let uu___168
@@ -2384,14 +2343,23 @@ let rec (specs_with_types :
                                                                     let uu___170
                                                                     =
                                                                     text
-                                                                    "if 'boxwrap', use 'Prims.op_Addition, Prims.op_Subtraction, Prims.op_Minus'" in
+                                                                    "if 'boxwrap' use 'Prims.op_Multiply, Prims.op_Division, Prims.op_Modulus'" in
                                                                     let uu___171
                                                                     =
                                                                     let uu___172
                                                                     =
                                                                     text
-                                                                    "if 'native', use '+, -, -'" in
-                                                                    [uu___172] in
+                                                                    "if 'native' use '*, div, mod'" in
+                                                                    let uu___173
+                                                                    =
+                                                                    let uu___174
+                                                                    =
+                                                                    text
+                                                                    "if 'wrapped' use '_mul, _div, _mod : Int*Int -> Int'" in
+                                                                    [uu___174] in
+                                                                    uu___172
+                                                                    ::
+                                                                    uu___173 in
                                                                     uu___170
                                                                     ::
                                                                     uu___171 in
@@ -2408,9 +2376,10 @@ let rec (specs_with_types :
                                                                     uu___166
                                                                     uu___167 in
                                                                     (FStar_Getopt.noshort,
-                                                                    "smtencoding.l_arith_repr",
+                                                                    "smtencoding.nl_arith_repr",
                                                                     (EnumStr
                                                                     ["native";
+                                                                    "wrapped";
                                                                     "boxwrap"]),
                                                                     uu___165) in
                                                                     let uu___165
@@ -2419,24 +2388,10 @@ let rec (specs_with_types :
                                                                     =
                                                                     let uu___167
                                                                     =
-                                                                    text
-                                                                    "Include an axiom in the SMT encoding to introduce proof-irrelevance from a constructive proof" in
-                                                                    (FStar_Getopt.noshort,
-                                                                    "smtencoding.valid_intro",
-                                                                    BoolStr,
-                                                                    uu___167) in
-                                                                    let uu___167
-                                                                    =
                                                                     let uu___168
                                                                     =
-                                                                    let uu___169
-                                                                    =
                                                                     text
-                                                                    "Include an axiom in the SMT encoding to eliminate proof-irrelevance into the existence of a proof witness" in
-                                                                    (FStar_Getopt.noshort,
-                                                                    "smtencoding.valid_elim",
-                                                                    BoolStr,
-                                                                    uu___169) in
+                                                                    "Toggle the representation of linear arithmetic functions in the SMT encoding:" in
                                                                     let uu___169
                                                                     =
                                                                     let uu___170
@@ -2446,45 +2401,58 @@ let rec (specs_with_types :
                                                                     let uu___172
                                                                     =
                                                                     text
-                                                                    "Split SMT verification conditions into several separate queries, one per goal. Helps with localizing errors." in
+                                                                    "if 'boxwrap', use 'Prims.op_Addition, Prims.op_Subtraction, Prims.op_Minus'" in
                                                                     let uu___173
                                                                     =
                                                                     let uu___174
                                                                     =
-                                                                    let uu___175
-                                                                    =
                                                                     text
-                                                                    "Use 'no' to disable (this may reduce the quality of error messages)." in
-                                                                    let uu___176
-                                                                    =
-                                                                    let uu___177
-                                                                    =
-                                                                    text
-                                                                    "Use 'on_failure' to split queries and retry when discharging fails (the default)" in
-                                                                    let uu___178
-                                                                    =
-                                                                    let uu___179
-                                                                    =
-                                                                    text
-                                                                    "Use 'yes' to always split." in
-                                                                    [uu___179] in
-                                                                    uu___177
-                                                                    ::
-                                                                    uu___178 in
-                                                                    uu___175
-                                                                    ::
-                                                                    uu___176 in
-                                                                    FStar_Errors_Msg.bulleted
-                                                                    uu___174 in
-                                                                    FStar_Pprint.op_Hat_Hat
+                                                                    "if 'native', use '+, -, -'" in
+                                                                    [uu___174] in
                                                                     uu___172
+                                                                    ::
                                                                     uu___173 in
+                                                                    FStar_Errors_Msg.bulleted
+                                                                    uu___171 in
+                                                                    let uu___171
+                                                                    =
+                                                                    text
+                                                                    "(default 'boxwrap')" in
+                                                                    FStar_Pprint.op_Hat_Hat
+                                                                    uu___170
+                                                                    uu___171 in
+                                                                    FStar_Pprint.op_Hat_Hat
+                                                                    uu___168
+                                                                    uu___169 in
                                                                     (FStar_Getopt.noshort,
-                                                                    "split_queries",
+                                                                    "smtencoding.l_arith_repr",
                                                                     (EnumStr
-                                                                    ["no";
-                                                                    "on_failure";
-                                                                    "always"]),
+                                                                    ["native";
+                                                                    "boxwrap"]),
+                                                                    uu___167) in
+                                                                    let uu___167
+                                                                    =
+                                                                    let uu___168
+                                                                    =
+                                                                    let uu___169
+                                                                    =
+                                                                    text
+                                                                    "Include an axiom in the SMT encoding to introduce proof-irrelevance from a constructive proof" in
+                                                                    (FStar_Getopt.noshort,
+                                                                    "smtencoding.valid_intro",
+                                                                    BoolStr,
+                                                                    uu___169) in
+                                                                    let uu___169
+                                                                    =
+                                                                    let uu___170
+                                                                    =
+                                                                    let uu___171
+                                                                    =
+                                                                    text
+                                                                    "Include an axiom in the SMT encoding to eliminate proof-irrelevance into the existence of a proof witness" in
+                                                                    (FStar_Getopt.noshort,
+                                                                    "smtencoding.valid_elim",
+                                                                    BoolStr,
                                                                     uu___171) in
                                                                     let uu___171
                                                                     =
@@ -2492,13 +2460,48 @@ let rec (specs_with_types :
                                                                     =
                                                                     let uu___173
                                                                     =
+                                                                    let uu___174
+                                                                    =
                                                                     text
-                                                                    "Do not use the lexical scope of tactics to improve binder names" in
+                                                                    "Split SMT verification conditions into several separate queries, one per goal. Helps with localizing errors." in
+                                                                    let uu___175
+                                                                    =
+                                                                    let uu___176
+                                                                    =
+                                                                    let uu___177
+                                                                    =
+                                                                    text
+                                                                    "Use 'no' to disable (this may reduce the quality of error messages)." in
+                                                                    let uu___178
+                                                                    =
+                                                                    let uu___179
+                                                                    =
+                                                                    text
+                                                                    "Use 'on_failure' to split queries and retry when discharging fails (the default)" in
+                                                                    let uu___180
+                                                                    =
+                                                                    let uu___181
+                                                                    =
+                                                                    text
+                                                                    "Use 'yes' to always split." in
+                                                                    [uu___181] in
+                                                                    uu___179
+                                                                    ::
+                                                                    uu___180 in
+                                                                    uu___177
+                                                                    ::
+                                                                    uu___178 in
+                                                                    FStar_Errors_Msg.bulleted
+                                                                    uu___176 in
+                                                                    FStar_Pprint.op_Hat_Hat
+                                                                    uu___174
+                                                                    uu___175 in
                                                                     (FStar_Getopt.noshort,
-                                                                    "tactic_raw_binders",
-                                                                    (Const
-                                                                    (Bool
-                                                                    true)),
+                                                                    "split_queries",
+                                                                    (EnumStr
+                                                                    ["no";
+                                                                    "on_failure";
+                                                                    "always"]),
                                                                     uu___173) in
                                                                     let uu___173
                                                                     =
@@ -2507,9 +2510,9 @@ let rec (specs_with_types :
                                                                     let uu___175
                                                                     =
                                                                     text
-                                                                    "Do not recover from metaprogramming errors, and abort if one occurs" in
+                                                                    "Do not use the lexical scope of tactics to improve binder names" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "tactics_failhard",
+                                                                    "tactic_raw_binders",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2521,9 +2524,9 @@ let rec (specs_with_types :
                                                                     let uu___177
                                                                     =
                                                                     text
-                                                                    "Print some rough information on tactics, such as the time they take to run" in
+                                                                    "Do not recover from metaprogramming errors, and abort if one occurs" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "tactics_info",
+                                                                    "tactics_failhard",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2535,9 +2538,9 @@ let rec (specs_with_types :
                                                                     let uu___179
                                                                     =
                                                                     text
-                                                                    "Print a depth-indexed trace of tactic execution (Warning: very verbose)" in
+                                                                    "Print some rough information on tactics, such as the time they take to run" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "tactic_trace",
+                                                                    "tactics_info",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2549,11 +2552,12 @@ let rec (specs_with_types :
                                                                     let uu___181
                                                                     =
                                                                     text
-                                                                    "Trace tactics up to a certain binding depth" in
+                                                                    "Print a depth-indexed trace of tactic execution (Warning: very verbose)" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "tactic_trace_d",
-                                                                    (IntStr
-                                                                    "positive_integer"),
+                                                                    "tactic_trace",
+                                                                    (Const
+                                                                    (Bool
+                                                                    true)),
                                                                     uu___181) in
                                                                     let uu___181
                                                                     =
@@ -2562,12 +2566,11 @@ let rec (specs_with_types :
                                                                     let uu___183
                                                                     =
                                                                     text
-                                                                    "Use NBE to evaluate metaprograms (experimental)" in
+                                                                    "Trace tactics up to a certain binding depth" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "__tactics_nbe",
-                                                                    (Const
-                                                                    (Bool
-                                                                    true)),
+                                                                    "tactic_trace_d",
+                                                                    (IntStr
+                                                                    "positive_integer"),
                                                                     uu___183) in
                                                                     let uu___183
                                                                     =
@@ -2576,10 +2579,12 @@ let rec (specs_with_types :
                                                                     let uu___185
                                                                     =
                                                                     text
-                                                                    "Attempt to normalize definitions marked as tcnorm (default 'true')" in
+                                                                    "Use NBE to evaluate metaprograms (experimental)" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "tcnorm",
-                                                                    BoolStr,
+                                                                    "__tactics_nbe",
+                                                                    (Const
+                                                                    (Bool
+                                                                    true)),
                                                                     uu___185) in
                                                                     let uu___185
                                                                     =
@@ -2588,12 +2593,10 @@ let rec (specs_with_types :
                                                                     let uu___187
                                                                     =
                                                                     text
-                                                                    "Print the time it takes to verify each top-level definition. This is just an alias for an invocation of the profiler, so it may not work well if combined with --profile. In particular, it implies --profile_group_by_decls." in
+                                                                    "Attempt to normalize definitions marked as tcnorm (default 'true')" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "timing",
-                                                                    (Const
-                                                                    (Bool
-                                                                    true)),
+                                                                    "tcnorm",
+                                                                    BoolStr,
                                                                     uu___187) in
                                                                     let uu___187
                                                                     =
@@ -2602,9 +2605,9 @@ let rec (specs_with_types :
                                                                     let uu___189
                                                                     =
                                                                     text
-                                                                    "Attach stack traces on errors" in
+                                                                    "Print the time it takes to verify each top-level definition. This is just an alias for an invocation of the profiler, so it may not work well if combined with --profile. In particular, it implies --profile_group_by_decls." in
                                                                     (FStar_Getopt.noshort,
-                                                                    "trace_error",
+                                                                    "timing",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2616,9 +2619,9 @@ let rec (specs_with_types :
                                                                     let uu___191
                                                                     =
                                                                     text
-                                                                    "Emit output formatted for debugging" in
+                                                                    "Attach stack traces on errors" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "ugly",
+                                                                    "trace_error",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2630,9 +2633,9 @@ let rec (specs_with_types :
                                                                     let uu___193
                                                                     =
                                                                     text
-                                                                    "Let the SMT solver unfold inductive types to arbitrary depths (may affect verifier performance)" in
+                                                                    "Emit output formatted for debugging" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "unthrottle_inductives",
+                                                                    "ugly",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2644,9 +2647,9 @@ let rec (specs_with_types :
                                                                     let uu___195
                                                                     =
                                                                     text
-                                                                    "Allow tactics to run external processes. WARNING: checking an untrusted F* file while using this option can have disastrous effects." in
+                                                                    "Let the SMT solver unfold inductive types to arbitrary depths (may affect verifier performance)" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "unsafe_tactic_exec",
+                                                                    "unthrottle_inductives",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2658,9 +2661,9 @@ let rec (specs_with_types :
                                                                     let uu___197
                                                                     =
                                                                     text
-                                                                    "Use equality constraints when comparing higher-order types (Temporary)" in
+                                                                    "Allow tactics to run external processes. WARNING: checking an untrusted F* file while using this option can have disastrous effects." in
                                                                     (FStar_Getopt.noshort,
-                                                                    "use_eq_at_higher_order",
+                                                                    "unsafe_tactic_exec",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2672,9 +2675,9 @@ let rec (specs_with_types :
                                                                     let uu___199
                                                                     =
                                                                     text
-                                                                    "Use a previously recorded hints database for proof replay" in
+                                                                    "Use equality constraints when comparing higher-order types (Temporary)" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "use_hints",
+                                                                    "use_eq_at_higher_order",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2686,9 +2689,9 @@ let rec (specs_with_types :
                                                                     let uu___201
                                                                     =
                                                                     text
-                                                                    "Admit queries if their hash matches the hash recorded in the hints database" in
+                                                                    "Use a previously recorded hints database for proof replay" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "use_hint_hashes",
+                                                                    "use_hints",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2700,11 +2703,12 @@ let rec (specs_with_types :
                                                                     let uu___203
                                                                     =
                                                                     text
-                                                                    "Use compiled tactics from  path" in
+                                                                    "Admit queries if their hash matches the hash recorded in the hints database" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "use_native_tactics",
-                                                                    (PathStr
-                                                                    "path"),
+                                                                    "use_hint_hashes",
+                                                                    (Const
+                                                                    (Bool
+                                                                    true)),
                                                                     uu___203) in
                                                                     let uu___203
                                                                     =
@@ -2713,12 +2717,11 @@ let rec (specs_with_types :
                                                                     let uu___205
                                                                     =
                                                                     text
-                                                                    "Do not run plugins natively and interpret them as usual instead" in
+                                                                    "Use compiled tactics from  path" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "no_plugins",
-                                                                    (Const
-                                                                    (Bool
-                                                                    true)),
+                                                                    "use_native_tactics",
+                                                                    (PathStr
+                                                                    "path"),
                                                                     uu___205) in
                                                                     let uu___205
                                                                     =
@@ -2727,9 +2730,9 @@ let rec (specs_with_types :
                                                                     let uu___207
                                                                     =
                                                                     text
-                                                                    "Do not run the tactic engine before discharging a VC" in
+                                                                    "Do not run plugins natively and interpret them as usual instead" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "no_tactics",
+                                                                    "no_plugins",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2741,12 +2744,12 @@ let rec (specs_with_types :
                                                                     let uu___209
                                                                     =
                                                                     text
-                                                                    "Prunes the context to include only the facts from the given namespace or fact id. Facts can be include or excluded using the [+|-] qualifier. For example --using_facts_from '* -FStar.Reflection +FStar.Compiler.List -FStar.Compiler.List.Tot' will remove all facts from FStar.Compiler.List.Tot.*, retain all remaining facts from FStar.Compiler.List.*, remove all facts from FStar.Reflection.*, and retain all the rest. Note, the '+' is optional: --using_facts_from 'FStar.Compiler.List' is equivalent to --using_facts_from '+FStar.Compiler.List'. Multiple uses of this option accumulate, e.g., --using_facts_from A --using_facts_from B is interpreted as --using_facts_from A^B." in
+                                                                    "Do not run the tactic engine before discharging a VC" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "using_facts_from",
-                                                                    (ReverseAccumulated
-                                                                    (SimpleStr
-                                                                    "One or more space-separated occurrences of '[+|-]( * | namespace | fact id)'")),
+                                                                    "no_tactics",
+                                                                    (Const
+                                                                    (Bool
+                                                                    true)),
                                                                     uu___209) in
                                                                     let uu___209
                                                                     =
@@ -2755,12 +2758,12 @@ let rec (specs_with_types :
                                                                     let uu___211
                                                                     =
                                                                     text
-                                                                    "This does nothing and will be removed" in
+                                                                    "Prunes the context to include only the facts from the given namespace or fact id. Facts can be include or excluded using the [+|-] qualifier. For example --using_facts_from '* -FStar.Reflection +FStar.Compiler.List -FStar.Compiler.List.Tot' will remove all facts from FStar.Compiler.List.Tot.*, retain all remaining facts from FStar.Compiler.List.*, remove all facts from FStar.Reflection.*, and retain all the rest. Note, the '+' is optional: --using_facts_from 'FStar.Compiler.List' is equivalent to --using_facts_from '+FStar.Compiler.List'. Multiple uses of this option accumulate, e.g., --using_facts_from A --using_facts_from B is interpreted as --using_facts_from A^B." in
                                                                     (FStar_Getopt.noshort,
-                                                                    "__temp_fast_implicits",
-                                                                    (Const
-                                                                    (Bool
-                                                                    true)),
+                                                                    "using_facts_from",
+                                                                    (ReverseAccumulated
+                                                                    (SimpleStr
+                                                                    "One or more space-separated occurrences of '[+|-]( * | namespace | fact id)'")),
                                                                     uu___211) in
                                                                     let uu___211
                                                                     =
@@ -2769,20 +2772,12 @@ let rec (specs_with_types :
                                                                     let uu___213
                                                                     =
                                                                     text
-                                                                    "Display version number" in
-                                                                    (118,
-                                                                    "version",
-                                                                    (WithSideEffect
-                                                                    ((fun
-                                                                    uu___214
-                                                                    ->
-                                                                    display_version
-                                                                    ();
-                                                                    FStar_Compiler_Effect.exit
-                                                                    Prims.int_zero),
+                                                                    "This does nothing and will be removed" in
+                                                                    (FStar_Getopt.noshort,
+                                                                    "__temp_fast_implicits",
                                                                     (Const
                                                                     (Bool
-                                                                    true)))),
+                                                                    true)),
                                                                     uu___213) in
                                                                     let uu___213
                                                                     =
@@ -2791,12 +2786,20 @@ let rec (specs_with_types :
                                                                     let uu___215
                                                                     =
                                                                     text
-                                                                    "Warn when (a -> b) is desugared to (a -> Tot b)" in
-                                                                    (FStar_Getopt.noshort,
-                                                                    "warn_default_effects",
+                                                                    "Display version number" in
+                                                                    (118,
+                                                                    "version",
+                                                                    (WithSideEffect
+                                                                    ((fun
+                                                                    uu___216
+                                                                    ->
+                                                                    display_version
+                                                                    ();
+                                                                    FStar_Compiler_Effect.exit
+                                                                    Prims.int_zero),
                                                                     (Const
                                                                     (Bool
-                                                                    true)),
+                                                                    true)))),
                                                                     uu___215) in
                                                                     let uu___215
                                                                     =
@@ -2805,12 +2808,12 @@ let rec (specs_with_types :
                                                                     let uu___217
                                                                     =
                                                                     text
-                                                                    "Z3 command line options" in
+                                                                    "Warn when (a -> b) is desugared to (a -> Tot b)" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "z3cliopt",
-                                                                    (ReverseAccumulated
-                                                                    (SimpleStr
-                                                                    "option")),
+                                                                    "warn_default_effects",
+                                                                    (Const
+                                                                    (Bool
+                                                                    true)),
                                                                     uu___217) in
                                                                     let uu___217
                                                                     =
@@ -2819,9 +2822,9 @@ let rec (specs_with_types :
                                                                     let uu___219
                                                                     =
                                                                     text
-                                                                    "Z3 options in smt2 format" in
+                                                                    "Z3 command line options" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "z3smtopt",
+                                                                    "z3cliopt",
                                                                     (ReverseAccumulated
                                                                     (SimpleStr
                                                                     "option")),
@@ -2833,12 +2836,12 @@ let rec (specs_with_types :
                                                                     let uu___221
                                                                     =
                                                                     text
-                                                                    "Restart Z3 after each query; useful for ensuring proof robustness" in
+                                                                    "Z3 options in smt2 format" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "z3refresh",
-                                                                    (Const
-                                                                    (Bool
-                                                                    true)),
+                                                                    "z3smtopt",
+                                                                    (ReverseAccumulated
+                                                                    (SimpleStr
+                                                                    "option")),
                                                                     uu___221) in
                                                                     let uu___221
                                                                     =
@@ -2847,11 +2850,12 @@ let rec (specs_with_types :
                                                                     let uu___223
                                                                     =
                                                                     text
-                                                                    "Set the Z3 per-query resource limit (default 5 units, taking roughtly 5s)" in
+                                                                    "Restart Z3 after each query; useful for ensuring proof robustness" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "z3rlimit",
-                                                                    (IntStr
-                                                                    "positive_integer"),
+                                                                    "z3refresh",
+                                                                    (Const
+                                                                    (Bool
+                                                                    true)),
                                                                     uu___223) in
                                                                     let uu___223
                                                                     =
@@ -2860,9 +2864,9 @@ let rec (specs_with_types :
                                                                     let uu___225
                                                                     =
                                                                     text
-                                                                    "Set the Z3 per-query resource limit multiplier. This is useful when, say, regenerating hints and you want to be more lax. (default 1)" in
+                                                                    "Set the Z3 per-query resource limit (default 5 units, taking roughtly 5s)" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "z3rlimit_factor",
+                                                                    "z3rlimit",
                                                                     (IntStr
                                                                     "positive_integer"),
                                                                     uu___225) in
@@ -2873,9 +2877,9 @@ let rec (specs_with_types :
                                                                     let uu___227
                                                                     =
                                                                     text
-                                                                    "Set the Z3 random seed (default 0)" in
+                                                                    "Set the Z3 per-query resource limit multiplier. This is useful when, say, regenerating hints and you want to be more lax. (default 1)" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "z3seed",
+                                                                    "z3rlimit_factor",
                                                                     (IntStr
                                                                     "positive_integer"),
                                                                     uu___227) in
@@ -2886,11 +2890,11 @@ let rec (specs_with_types :
                                                                     let uu___229
                                                                     =
                                                                     text
-                                                                    "Set the version of Z3 that is to be used. Default: 4.8.5" in
+                                                                    "Set the Z3 random seed (default 0)" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "z3version",
-                                                                    (SimpleStr
-                                                                    "version"),
+                                                                    "z3seed",
+                                                                    (IntStr
+                                                                    "positive_integer"),
                                                                     uu___229) in
                                                                     let uu___229
                                                                     =
@@ -2899,12 +2903,25 @@ let rec (specs_with_types :
                                                                     let uu___231
                                                                     =
                                                                     text
+                                                                    "Set the version of Z3 that is to be used. Default: 4.8.5" in
+                                                                    (FStar_Getopt.noshort,
+                                                                    "z3version",
+                                                                    (SimpleStr
+                                                                    "version"),
+                                                                    uu___231) in
+                                                                    let uu___231
+                                                                    =
+                                                                    let uu___232
+                                                                    =
+                                                                    let uu___233
+                                                                    =
+                                                                    text
                                                                     "Don't check positivity of inductive types" in
                                                                     (FStar_Getopt.noshort,
                                                                     "__no_positivity",
                                                                     (WithSideEffect
                                                                     ((fun
-                                                                    uu___232
+                                                                    uu___234
                                                                     ->
                                                                     if
                                                                     warn_unsafe
@@ -2915,63 +2932,6 @@ let rec (specs_with_types :
                                                                     (Const
                                                                     (Bool
                                                                     true)))),
-                                                                    uu___231) in
-                                                                    let uu___231
-                                                                    =
-                                                                    let uu___232
-                                                                    =
-                                                                    let uu___233
-                                                                    =
-                                                                    let uu___234
-                                                                    =
-                                                                    text
-                                                                    "The [-warn_error] option follows the OCaml syntax, namely:" in
-                                                                    let uu___235
-                                                                    =
-                                                                    let uu___236
-                                                                    =
-                                                                    let uu___237
-                                                                    =
-                                                                    text
-                                                                    "[r] is a range of warnings (either a number [n], or a range [n..n])" in
-                                                                    let uu___238
-                                                                    =
-                                                                    let uu___239
-                                                                    =
-                                                                    text
-                                                                    "[-r] silences range [r]" in
-                                                                    let uu___240
-                                                                    =
-                                                                    let uu___241
-                                                                    =
-                                                                    text
-                                                                    "[+r] enables range [r] as warnings (NOTE: \"enabling\" an error will downgrade it to a warning)" in
-                                                                    let uu___242
-                                                                    =
-                                                                    let uu___243
-                                                                    =
-                                                                    text
-                                                                    "[@r] makes range [r] fatal." in
-                                                                    [uu___243] in
-                                                                    uu___241
-                                                                    ::
-                                                                    uu___242 in
-                                                                    uu___239
-                                                                    ::
-                                                                    uu___240 in
-                                                                    uu___237
-                                                                    ::
-                                                                    uu___238 in
-                                                                    FStar_Errors_Msg.bulleted
-                                                                    uu___236 in
-                                                                    FStar_Pprint.op_Hat_Hat
-                                                                    uu___234
-                                                                    uu___235 in
-                                                                    (FStar_Getopt.noshort,
-                                                                    "warn_error",
-                                                                    (ReverseAccumulated
-                                                                    (SimpleStr
-                                                                    "")),
                                                                     uu___233) in
                                                                     let uu___233
                                                                     =
@@ -2979,11 +2939,56 @@ let rec (specs_with_types :
                                                                     =
                                                                     let uu___235
                                                                     =
+                                                                    let uu___236
+                                                                    =
                                                                     text
-                                                                    "Use normalization by evaluation as the default normalization strategy (default 'false')" in
+                                                                    "The [-warn_error] option follows the OCaml syntax, namely:" in
+                                                                    let uu___237
+                                                                    =
+                                                                    let uu___238
+                                                                    =
+                                                                    let uu___239
+                                                                    =
+                                                                    text
+                                                                    "[r] is a range of warnings (either a number [n], or a range [n..n])" in
+                                                                    let uu___240
+                                                                    =
+                                                                    let uu___241
+                                                                    =
+                                                                    text
+                                                                    "[-r] silences range [r]" in
+                                                                    let uu___242
+                                                                    =
+                                                                    let uu___243
+                                                                    =
+                                                                    text
+                                                                    "[+r] enables range [r] as warnings (NOTE: \"enabling\" an error will downgrade it to a warning)" in
+                                                                    let uu___244
+                                                                    =
+                                                                    let uu___245
+                                                                    =
+                                                                    text
+                                                                    "[@r] makes range [r] fatal." in
+                                                                    [uu___245] in
+                                                                    uu___243
+                                                                    ::
+                                                                    uu___244 in
+                                                                    uu___241
+                                                                    ::
+                                                                    uu___242 in
+                                                                    uu___239
+                                                                    ::
+                                                                    uu___240 in
+                                                                    FStar_Errors_Msg.bulleted
+                                                                    uu___238 in
+                                                                    FStar_Pprint.op_Hat_Hat
+                                                                    uu___236
+                                                                    uu___237 in
                                                                     (FStar_Getopt.noshort,
-                                                                    "use_nbe",
-                                                                    BoolStr,
+                                                                    "warn_error",
+                                                                    (ReverseAccumulated
+                                                                    (SimpleStr
+                                                                    "")),
                                                                     uu___235) in
                                                                     let uu___235
                                                                     =
@@ -2992,9 +2997,9 @@ let rec (specs_with_types :
                                                                     let uu___237
                                                                     =
                                                                     text
-                                                                    "Use normalization by evaluation for normalizing terms before extraction (default 'false')" in
+                                                                    "Use normalization by evaluation as the default normalization strategy (default 'false')" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "use_nbe_for_extraction",
+                                                                    "use_nbe",
                                                                     BoolStr,
                                                                     uu___237) in
                                                                     let uu___237
@@ -3004,9 +3009,9 @@ let rec (specs_with_types :
                                                                     let uu___239
                                                                     =
                                                                     text
-                                                                    "Enforce trivial preconditions for unannotated effectful functions (default 'true')" in
+                                                                    "Use normalization by evaluation for normalizing terms before extraction (default 'false')" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "trivial_pre_for_unannotated_effectful_fns",
+                                                                    "use_nbe_for_extraction",
                                                                     BoolStr,
                                                                     uu___239) in
                                                                     let uu___239
@@ -3016,19 +3021,10 @@ let rec (specs_with_types :
                                                                     let uu___241
                                                                     =
                                                                     text
-                                                                    "Debug messages for embeddings/unembeddings of natively compiled terms" in
+                                                                    "Enforce trivial preconditions for unannotated effectful functions (default 'true')" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "__debug_embedding",
-                                                                    (WithSideEffect
-                                                                    ((fun
-                                                                    uu___242
-                                                                    ->
-                                                                    FStar_Compiler_Effect.op_Colon_Equals
-                                                                    debug_embedding
-                                                                    true),
-                                                                    (Const
-                                                                    (Bool
-                                                                    true)))),
+                                                                    "trivial_pre_for_unannotated_effectful_fns",
+                                                                    BoolStr,
                                                                     uu___241) in
                                                                     let uu___241
                                                                     =
@@ -3037,15 +3033,15 @@ let rec (specs_with_types :
                                                                     let uu___243
                                                                     =
                                                                     text
-                                                                    "Eagerly embed and unembed terms to primitive operations and plugins: not recommended except for benchmarking" in
+                                                                    "Debug messages for embeddings/unembeddings of natively compiled terms" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "eager_embedding",
+                                                                    "__debug_embedding",
                                                                     (WithSideEffect
                                                                     ((fun
                                                                     uu___244
                                                                     ->
                                                                     FStar_Compiler_Effect.op_Colon_Equals
-                                                                    eager_embedding
+                                                                    debug_embedding
                                                                     true),
                                                                     (Const
                                                                     (Bool
@@ -3058,12 +3054,19 @@ let rec (specs_with_types :
                                                                     let uu___245
                                                                     =
                                                                     text
-                                                                    "Emit profiles grouped by declaration rather than by module" in
+                                                                    "Eagerly embed and unembed terms to primitive operations and plugins: not recommended except for benchmarking" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "profile_group_by_decl",
+                                                                    "eager_embedding",
+                                                                    (WithSideEffect
+                                                                    ((fun
+                                                                    uu___246
+                                                                    ->
+                                                                    FStar_Compiler_Effect.op_Colon_Equals
+                                                                    eager_embedding
+                                                                    true),
                                                                     (Const
                                                                     (Bool
-                                                                    true)),
+                                                                    true)))),
                                                                     uu___245) in
                                                                     let uu___245
                                                                     =
@@ -3072,12 +3075,12 @@ let rec (specs_with_types :
                                                                     let uu___247
                                                                     =
                                                                     text
-                                                                    "Specific source locations in the compiler are instrumented with profiling counters. Pass `--profile_component FStar.TypeChecker` to enable all counters in the FStar.TypeChecker namespace. This option is a module or namespace selector, like many other options (e.g., `--extract`)" in
+                                                                    "Emit profiles grouped by declaration rather than by module" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "profile_component",
-                                                                    (Accumulated
-                                                                    (SimpleStr
-                                                                    "One or more space-separated occurrences of '[+|-]( * | namespace | module | identifier)'")),
+                                                                    "profile_group_by_decl",
+                                                                    (Const
+                                                                    (Bool
+                                                                    true)),
                                                                     uu___247) in
                                                                     let uu___247
                                                                     =
@@ -3086,12 +3089,12 @@ let rec (specs_with_types :
                                                                     let uu___249
                                                                     =
                                                                     text
-                                                                    "Profiling can be enabled when the compiler is processing a given set of source modules. Pass `--profile FStar.Pervasives` to enable profiling when the compiler is processing any module in FStar.Pervasives. This option is a module or namespace selector, like many other options (e.g., `--extract`)" in
+                                                                    "Specific source locations in the compiler are instrumented with profiling counters. Pass `--profile_component FStar.TypeChecker` to enable all counters in the FStar.TypeChecker namespace. This option is a module or namespace selector, like many other options (e.g., `--extract`)" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "profile",
+                                                                    "profile_component",
                                                                     (Accumulated
                                                                     (SimpleStr
-                                                                    "One or more space-separated occurrences of '[+|-]( * | namespace | module)'")),
+                                                                    "One or more space-separated occurrences of '[+|-]( * | namespace | module | identifier)'")),
                                                                     uu___249) in
                                                                     let uu___249
                                                                     =
@@ -3100,27 +3103,44 @@ let rec (specs_with_types :
                                                                     let uu___251
                                                                     =
                                                                     text
+                                                                    "Profiling can be enabled when the compiler is processing a given set of source modules. Pass `--profile FStar.Pervasives` to enable profiling when the compiler is processing any module in FStar.Pervasives. This option is a module or namespace selector, like many other options (e.g., `--extract`)" in
+                                                                    (FStar_Getopt.noshort,
+                                                                    "profile",
+                                                                    (Accumulated
+                                                                    (SimpleStr
+                                                                    "One or more space-separated occurrences of '[+|-]( * | namespace | module)'")),
+                                                                    uu___251) in
+                                                                    let uu___251
+                                                                    =
+                                                                    let uu___252
+                                                                    =
+                                                                    let uu___253
+                                                                    =
+                                                                    text
                                                                     "Display this information" in
                                                                     (104,
                                                                     "help",
                                                                     (WithSideEffect
                                                                     ((fun
-                                                                    uu___252
+                                                                    uu___254
                                                                     ->
                                                                     (
-                                                                    let uu___254
+                                                                    let uu___256
                                                                     =
                                                                     specs
                                                                     warn_unsafe in
                                                                     display_usage_aux
-                                                                    uu___254);
+                                                                    uu___256);
                                                                     FStar_Compiler_Effect.exit
                                                                     Prims.int_zero),
                                                                     (Const
                                                                     (Bool
                                                                     true)))),
-                                                                    uu___251) in
-                                                                    [uu___250] in
+                                                                    uu___253) in
+                                                                    [uu___252] in
+                                                                    uu___250
+                                                                    ::
+                                                                    uu___251 in
                                                                     uu___248
                                                                     ::
                                                                     uu___249 in
@@ -3482,6 +3502,7 @@ let (settable : Prims.string -> Prims.bool) =
     | "load" -> true
     | "load_cmxs" -> true
     | "log_queries" -> true
+    | "log_failing_queries" -> true
     | "log_types" -> true
     | "max_fuel" -> true
     | "max_ifuel" -> true
@@ -3556,7 +3577,7 @@ let (settable_specs :
     (fun uu___ ->
        match uu___ with | ((uu___1, x, uu___2), uu___3) -> settable x)
     all_specs
-let (uu___656 :
+let (uu___658 :
   (((unit -> FStar_Getopt.parse_cmdline_res) -> unit) *
     (unit -> FStar_Getopt.parse_cmdline_res)))
   =
@@ -3573,11 +3594,11 @@ let (uu___656 :
   (set1, call)
 let (set_error_flags_callback_aux :
   (unit -> FStar_Getopt.parse_cmdline_res) -> unit) =
-  match uu___656 with
+  match uu___658 with
   | (set_error_flags_callback_aux1, set_error_flags) ->
       set_error_flags_callback_aux1
 let (set_error_flags : unit -> FStar_Getopt.parse_cmdline_res) =
-  match uu___656 with
+  match uu___658 with
   | (set_error_flags_callback_aux1, set_error_flags1) -> set_error_flags1
 let (set_error_flags_callback :
   (unit -> FStar_Getopt.parse_cmdline_res) -> unit) =
@@ -4020,8 +4041,12 @@ let (load_cmxs : unit -> Prims.string Prims.list) =
 let (legacy_interactive : unit -> Prims.bool) = fun uu___ -> get_in ()
 let (lsp_server : unit -> Prims.bool) = fun uu___ -> get_lsp ()
 let (log_queries : unit -> Prims.bool) = fun uu___ -> get_log_queries ()
+let (log_failing_queries : unit -> Prims.bool) =
+  fun uu___ -> get_log_failing_queries ()
 let (keep_query_captions : unit -> Prims.bool) =
-  fun uu___ -> (log_queries ()) && (get_keep_query_captions ())
+  fun uu___ ->
+    (get_keep_query_captions ()) &&
+      ((log_queries ()) || (log_failing_queries ()))
 let (log_types : unit -> Prims.bool) = fun uu___ -> get_log_types ()
 let (max_fuel : unit -> Prims.int) = fun uu___ -> get_max_fuel ()
 let (max_ifuel : unit -> Prims.int) = fun uu___ -> get_max_ifuel ()
@@ -4497,6 +4522,11 @@ let (set_options : Prims.string -> FStar_Getopt.parse_cmdline_res) =
         let uu___1 =
           FStar_Compiler_Util.format1 "File %s is not a valid option" s1 in
         FStar_Getopt.Error uu___1
+let with_options : 'a . Prims.string -> (unit -> 'a) -> 'a =
+  fun s ->
+    fun f ->
+      with_saved_options
+        (fun uu___ -> (let uu___2 = set_options s in ()); f ())
 let (get_vconfig : unit -> FStar_VConfig.vconfig) =
   fun uu___ ->
     let vcfg =

--- a/ocaml/fstar-lib/generated/FStar_SMTEncoding_Encode.ml
+++ b/ocaml/fstar-lib/generated/FStar_SMTEncoding_Encode.ml
@@ -7707,7 +7707,9 @@ let (encode_query :
                                    | (label_prefix, label_suffix) ->
                                        let caption =
                                          let uu___8 =
-                                           FStar_Options.log_queries () in
+                                           (FStar_Options.log_queries ()) ||
+                                             (FStar_Options.log_failing_queries
+                                                ()) in
                                          if uu___8
                                          then
                                            let uu___9 =

--- a/ocaml/fstar-lib/generated/FStar_SMTEncoding_Solver.ml
+++ b/ocaml/fstar-lib/generated/FStar_SMTEncoding_Solver.ml
@@ -1325,6 +1325,34 @@ let (ans_fail : answer) =
     total_ran = (ans_ok.total_ran);
     tried_recovery = (ans_ok.tried_recovery)
   }
+let (uu___548 : answer FStar_Class_Show.showable) =
+  {
+    FStar_Class_Show.show =
+      (fun ans ->
+         let uu___ =
+           FStar_Class_Show.show
+             (FStar_Class_Show.printableshow
+                FStar_Class_Printable.printable_bool) ans.ok in
+         let uu___1 =
+           FStar_Class_Show.show
+             (FStar_Class_Show.printableshow
+                FStar_Class_Printable.printable_int) ans.nsuccess in
+         let uu___2 =
+           FStar_Class_Show.show
+             (FStar_Class_Show.printableshow
+                FStar_Class_Printable.printable_int) ans.lo in
+         let uu___3 =
+           FStar_Class_Show.show
+             (FStar_Class_Show.printableshow
+                FStar_Class_Printable.printable_int) ans.hi in
+         let uu___4 =
+           FStar_Class_Show.show
+             (FStar_Class_Show.printableshow
+                FStar_Class_Printable.printable_bool) ans.tried_recovery in
+         FStar_Compiler_Util.format5
+           "ok=%s nsuccess=%s lo=%s hi=%s tried_recovery=%s" uu___ uu___1
+           uu___2 uu___3 uu___4)
+  }
 let (make_solver_configs :
   Prims.bool ->
     Prims.bool ->
@@ -1849,7 +1877,7 @@ let (maybe_save_failing_query :
   fun env ->
     fun prefix ->
       fun qs ->
-        let uu___ = FStar_Options.proof_recovery () in
+        let uu___ = FStar_Options.log_failing_queries () in
         if uu___
         then
           let mod1 =
@@ -1932,10 +1960,9 @@ let (ask_solver :
                         else
                           (FStar_SMTEncoding_Z3.giveZ3 prefix;
                            (let ans1 = ask_solver_recover configs in
+                            let cfg = FStar_Compiler_List.last configs in
                             if Prims.op_Negation ans1.ok
-                            then
-                              (let uu___4 = FStar_Compiler_List.last configs in
-                               maybe_save_failing_query env prefix uu___4)
+                            then maybe_save_failing_query env prefix cfg
                             else ();
                             ans1)) in
                       (configs, ans)

--- a/ocaml/fstar-lib/generated/FStar_SMTEncoding_Z3.ml
+++ b/ocaml/fstar-lib/generated/FStar_SMTEncoding_Z3.ml
@@ -1040,6 +1040,16 @@ let (mk_input :
   fun fresh ->
     fun theory ->
       let ver = FStar_Options.z3_version () in
+      let theory1 =
+        let uu___ =
+          let uu___1 =
+            let uu___2 = FStar_Compiler_Effect.op_Bang FStar_Options._version in
+            let uu___3 = FStar_Compiler_Effect.op_Bang FStar_Options._commit in
+            FStar_Compiler_Util.format3
+              "Z3 invocation started by F*\nF* version: %s -- commit hash: %s\nZ3 version (according to F*): %s"
+              uu___2 uu___3 ver in
+          FStar_SMTEncoding_Term.Caption uu___1 in
+        uu___ :: theory in
       let options = z3_options ver in
       let options1 =
         let uu___ =
@@ -1049,7 +1059,7 @@ let (mk_input :
           Prims.strcat uu___1 "\n\n" in
         Prims.strcat options uu___ in
       (let uu___1 = FStar_Options.print_z3_statistics () in
-       if uu___1 then context_profile theory else ());
+       if uu___1 then context_profile theory1 else ());
       (let uu___1 =
          let uu___2 =
            (FStar_Options.record_hints ()) ||
@@ -1063,27 +1073,15 @@ let (mk_input :
                  (fun uu___5 ->
                     match uu___5 with
                     | FStar_SMTEncoding_Term.CheckSat -> true
-                    | uu___6 -> false) theory in
+                    | uu___6 -> false) theory1 in
              FStar_Compiler_Option.get uu___4 in
            match uu___3 with
            | (prefix, check_sat, suffix) ->
-               let prefix1 =
-                 let uu___4 =
-                   let uu___5 =
-                     let uu___6 =
-                       FStar_Compiler_Effect.op_Bang FStar_Options._version in
-                     let uu___7 =
-                       FStar_Compiler_Effect.op_Bang FStar_Options._commit in
-                     FStar_Compiler_Util.format3
-                       "Z3 invocation started by F*\nF* version: %s -- commit hash: %s\nZ3 version (according to F*): %s"
-                       uu___6 uu___7 ver in
-                   FStar_SMTEncoding_Term.Caption uu___5 in
-                 uu___4 :: prefix in
                let pp =
                  FStar_Compiler_List.map
                    (FStar_SMTEncoding_Term.declToSmt options1) in
                let suffix1 = check_sat :: suffix in
-               let ps_lines = pp prefix1 in
+               let ps_lines = pp prefix in
                let ss_lines = pp suffix1 in
                let ps = FStar_Compiler_String.concat "\n" ps_lines in
                let ss = FStar_Compiler_String.concat "\n" ss_lines in
@@ -1094,7 +1092,7 @@ let (mk_input :
                    let uu___5 =
                      FStar_Compiler_List.map
                        (FStar_SMTEncoding_Term.declToSmt_no_caps options1)
-                       prefix1 in
+                       prefix in
                    FStar_Compiler_String.concat "\n" uu___5
                  else ps in
                let hs1 = Prims.strcat hs (Prims.strcat "Z3 version: " ver) in
@@ -1106,7 +1104,7 @@ let (mk_input :
            (let uu___4 =
               let uu___5 =
                 FStar_Compiler_List.map
-                  (FStar_SMTEncoding_Term.declToSmt options1) theory in
+                  (FStar_SMTEncoding_Term.declToSmt options1) theory1 in
               FStar_Compiler_String.concat "\n" uu___5 in
             (uu___4, FStar_Pervasives_Native.None)) in
        match uu___1 with

--- a/src/basic/FStar.Options.fst
+++ b/src/basic/FStar.Options.fst
@@ -2162,6 +2162,10 @@ let set_options s =
     with
     | File_argument s -> Getopt.Error (Util.format1 "File %s is not a valid option" s)
 
+let with_options s f =
+  with_saved_options (fun () ->
+    ignore (set_options s);
+    f ())
 
 let get_vconfig () =
   let vcfg = {

--- a/src/basic/FStar.Options.fsti
+++ b/src/basic/FStar.Options.fsti
@@ -154,6 +154,7 @@ val load_cmxs                   : unit    -> list string
 val legacy_interactive          : unit    -> bool
 val lsp_server                  : unit    -> bool
 val log_queries                 : unit    -> bool
+val log_failing_queries         : unit    -> bool
 val log_types                   : unit    -> bool
 val max_fuel                    : unit    -> int
 val max_ifuel                   : unit    -> int

--- a/src/basic/FStar.Options.fsti
+++ b/src/basic/FStar.Options.fsti
@@ -232,6 +232,7 @@ val use_tactics                 : unit    -> bool
 val using_facts_from            : unit    -> list (list string * bool)
 val warn_default_effects        : unit    -> bool
 val with_saved_options          : (unit -> 'a) -> 'a
+val with_options                : string -> (unit -> 'a) -> 'a
 val z3_cliopt                   : unit    -> list string
 val z3_smtopt                   : unit    -> list string
 val z3_refresh                  : unit    -> bool

--- a/src/smtencoding/FStar.SMTEncoding.Encode.fst
+++ b/src/smtencoding/FStar.SMTEncoding.Encode.fst
@@ -1967,10 +1967,12 @@ let encode_query use_env_msg (tcenv:Env.env) (q:S.term)
     let labels, phi = ErrorReporting.label_goals use_env_msg (Env.get_range tcenv) phi in
     let label_prefix, label_suffix = encode_labels labels in
     let caption =
-        if Options.log_queries ()
-        then [Caption ("Encoding query formula : " ^ (Print.term_to_string q));
-              Caption ("Context: " ^ String.concat "\n" (Errors.get_ctx ()))]
-        else []
+      (* If these options are off, the Captions will be dropped anyway,
+      but by checking here we can skip the printing. *)
+      if Options.log_queries () || Options.log_failing_queries ()
+      then [Caption ("Encoding query formula : " ^ (Print.term_to_string q));
+            Caption ("Context: " ^ String.concat "\n" (Errors.get_ctx ()))]
+      else []
     in
     let query_prelude =
         env_decls

--- a/src/smtencoding/FStar.SMTEncoding.Solver.fst
+++ b/src/smtencoding/FStar.SMTEncoding.Solver.fst
@@ -1106,7 +1106,7 @@ let ask_solver_recover
 let failing_query_ctr : ref int = BU.mk_ref 0
 
 let maybe_save_failing_query (env:env_t) (prefix:list decl) (qs:query_settings) : unit =
-  if Options.proof_recovery () then (
+  if Options.log_failing_queries () then (
     let mod = show (Env.current_module env) in
     let n = (failing_query_ctr := !failing_query_ctr + 1; !failing_query_ctr) in
     let file_name = BU.format2 "failedQueries-%s-%s.smt2" mod (show n) in
@@ -1162,8 +1162,9 @@ let ask_solver
         // whatever else they encode.
         Z3.giveZ3 prefix;
         let ans = ask_solver_recover configs in
+        let cfg = List.last configs in
         if not ans.ok then
-          maybe_save_failing_query env prefix (List.last configs);
+          maybe_save_failing_query env prefix cfg;
         ans
 
       )

--- a/src/smtencoding/FStar.SMTEncoding.Solver.fst
+++ b/src/smtencoding/FStar.SMTEncoding.Solver.fst
@@ -784,6 +784,15 @@ let ans_ok : answer = {
 let ans_fail : answer =
   { ans_ok with ok = false; nsuccess = 0 }
 
+instance _ : showable answer = {
+  show = (fun ans -> BU.format5 "ok=%s nsuccess=%s lo=%s hi=%s tried_recovery=%s"
+                            (show ans.ok)
+                            (show ans.nsuccess)
+                            (show ans.lo)
+                            (show ans.hi)
+                            (show ans.tried_recovery));
+}
+
 let make_solver_configs
     (can_split : bool)
     (is_retry : bool)

--- a/src/smtencoding/FStar.SMTEncoding.Z3.fst
+++ b/src/smtencoding/FStar.SMTEncoding.Z3.fst
@@ -603,6 +603,15 @@ let context_profile (theory:list decl) =
 
 let mk_input (fresh : bool) (theory : list decl) : string & option string & option string =
     let ver = Options.z3_version () in
+    let theory =
+      (* Add a caption with some version info. *)
+      ( Caption <|
+          BU.format3 "Z3 invocation started by F*\n\
+                      F* version: %s -- commit hash: %s\n\
+                      Z3 version (according to F*): %s"
+                        (!Options._version) (!Options._commit) ver
+      ) :: theory
+    in
     let options = z3_options ver in
     let options = options ^ (Options.z3_smtopt() |> String.concat "\n") ^ "\n\n" in
     if Options.print_z3_statistics() then context_profile theory;
@@ -619,15 +628,6 @@ let mk_input (fresh : bool) (theory : list decl) : string & option string & opti
                 theory |>
                 BU.prefix_until (function CheckSat -> true | _ -> false) |>
                 Option.get
-            in
-            let prefix =
-              (* Add a caption with some version info. *)
-              ( Caption <|
-                  BU.format3 "Z3 invocation started by F*\n\
-                              F* version: %s -- commit hash: %s\n\
-                              Z3 version (according to F*): %s"
-                                (!Options._version) (!Options._commit) ver
-              ) :: prefix
             in
             let pp = List.map (declToSmt options) in
             let suffix = check_sat::suffix in


### PR DESCRIPTION
Combined with ignoring error 19, it's a way to obtain a bunch of SMT2 files from a full project to then analyze.