### PR TITLE
Blocking unfolding of SIzeT into UInt64

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_Compiler_MachineInts.ml
+++ b/ocaml/fstar-lib/generated/FStar_Compiler_MachineInts.ml
@@ -139,6 +139,30 @@ let (mk :
   = fun k -> fun x -> fun m -> Mk (x, m)
 let (v : machint_kind -> unit machint -> FStar_BigInt.t) =
   fun k -> fun x -> let uu___ = x in match uu___ with | Mk (v1, uu___1) -> v1
+let (int_to_t : machint_kind -> FStar_BigInt.t -> unit machint) =
+  fun k ->
+    fun i ->
+      let meta =
+        if k = UInt128
+        then FStar_Pervasives_Native.None
+        else
+          (let signedness =
+             let uu___1 = is_unsigned k in
+             if uu___1 then FStar_Const.Unsigned else FStar_Const.Signed in
+           let width1 =
+             match k with
+             | Int8 -> FStar_Const.Int8
+             | UInt8 -> FStar_Const.Int8
+             | Int16 -> FStar_Const.Int16
+             | UInt16 -> FStar_Const.Int16
+             | Int32 -> FStar_Const.Int32
+             | UInt32 -> FStar_Const.Int32
+             | Int64 -> FStar_Const.Int64
+             | UInt64 -> FStar_Const.Int64
+             | SizeT -> FStar_Const.Sizet in
+           FStar_Pervasives_Native.Some
+             (FStar_Syntax_Syntax.Machine_integer (signedness, width1))) in
+      Mk (i, meta)
 let (meta :
   machint_kind ->
     unit machint ->
@@ -191,11 +215,11 @@ let (e_machint :
               FStar_Syntax_Embeddings_Base.embed
                 FStar_Syntax_Embeddings.e_int i in
             uu___1 rng FStar_Pervasives_Native.None cb in
-          let int_to_t = int_to_t_for k in
+          let int_to_t1 = int_to_t_for k in
           let t =
             let uu___1 =
               let uu___2 = FStar_Syntax_Syntax.as_arg it in [uu___2] in
-            FStar_Syntax_Syntax.mk_Tm_app int_to_t uu___1 rng in
+            FStar_Syntax_Syntax.mk_Tm_app int_to_t1 uu___1 rng in
           with_meta_ds rng t m in
     let un uu___1 uu___ =
       (fun t ->
@@ -277,7 +301,7 @@ let (nbe_machint :
           let it =
             FStar_TypeChecker_NBETerm.embed FStar_TypeChecker_NBETerm.e_int
               cbs i in
-          let int_to_t args =
+          let int_to_t1 args =
             let uu___1 =
               let uu___2 =
                 let uu___3 =
@@ -290,7 +314,7 @@ let (nbe_machint :
           let t =
             let uu___1 =
               let uu___2 = FStar_TypeChecker_NBETerm.as_arg it in [uu___2] in
-            int_to_t uu___1 in
+            int_to_t1 uu___1 in
           with_meta_ds t m in
     let un uu___1 uu___ =
       (fun cbs ->

--- a/ocaml/fstar-lib/generated/FStar_Int128.ml
+++ b/ocaml/fstar-lib/generated/FStar_Int128.ml
@@ -71,8 +71,7 @@ let (op_Less_Hat : t -> t -> Prims.bool) = lt
 let (op_Less_Equals_Hat : t -> t -> Prims.bool) = lte
 let (ct_abs : t -> t) =
   fun a ->
-    let mask =
-      shift_arithmetic_right a (FStar_UInt32.uint_to_t (Prims.of_int (127))) in
+    let mask = shift_arithmetic_right a (Stdint.Uint32.of_int (127)) in
     sub (logxor a mask) mask
 let (to_string : t -> Prims.string) = fun uu___ -> Prims.admit ()
 let (of_string : Prims.string -> t) = fun uu___ -> Prims.admit ()

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Primops_MachineInts.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Primops_MachineInts.ml
@@ -24,41 +24,31 @@ let (bounded_arith_ops_for :
             (FStar_Compiler_MachineInts.v k) in
         let uu___3 =
           let uu___4 =
-            let uu___5 = nm "add" in
-            FStar_TypeChecker_Primops_Base.mk2 Prims.int_zero uu___5
+            let uu___5 =
+              let uu___6 =
+                let uu___7 = FStar_Compiler_MachineInts.is_unsigned k in
+                if uu___7 then "uint_to_t" else "int_to_t" in
+              nm uu___6 in
+            FStar_TypeChecker_Primops_Base.mk1 Prims.int_zero uu___5
+              FStar_Syntax_Embeddings.e_int FStar_TypeChecker_NBETerm.e_int
               (FStar_Compiler_MachineInts.e_machint k)
               (FStar_Compiler_MachineInts.nbe_machint k)
-              (FStar_Compiler_MachineInts.e_machint k)
-              (FStar_Compiler_MachineInts.nbe_machint k)
-              (FStar_Compiler_MachineInts.e_machint k)
-              (FStar_Compiler_MachineInts.nbe_machint k)
-              (fun x ->
-                 fun y ->
-                   let uu___6 =
-                     let uu___7 = FStar_Compiler_MachineInts.v k x in
-                     let uu___8 = FStar_Compiler_MachineInts.v k y in
-                     FStar_BigInt.add_big_int uu___7 uu___8 in
-                   FStar_Compiler_MachineInts.make_as k x uu___6) in
+              (FStar_Compiler_MachineInts.int_to_t k) in
           let uu___5 =
             let uu___6 =
-              let uu___7 = nm "sub" in
-              FStar_TypeChecker_Primops_Base.mk2 Prims.int_zero uu___7
+              let uu___7 =
+                let uu___8 =
+                  let uu___9 = FStar_Compiler_MachineInts.is_unsigned k in
+                  if uu___9 then "__uint_to_t" else "__int_to_t" in
+                nm uu___8 in
+              FStar_TypeChecker_Primops_Base.mk1 Prims.int_zero uu___7
+                FStar_Syntax_Embeddings.e_int FStar_TypeChecker_NBETerm.e_int
                 (FStar_Compiler_MachineInts.e_machint k)
                 (FStar_Compiler_MachineInts.nbe_machint k)
-                (FStar_Compiler_MachineInts.e_machint k)
-                (FStar_Compiler_MachineInts.nbe_machint k)
-                (FStar_Compiler_MachineInts.e_machint k)
-                (FStar_Compiler_MachineInts.nbe_machint k)
-                (fun x ->
-                   fun y ->
-                     let uu___8 =
-                       let uu___9 = FStar_Compiler_MachineInts.v k x in
-                       let uu___10 = FStar_Compiler_MachineInts.v k y in
-                       FStar_BigInt.sub_big_int uu___9 uu___10 in
-                     FStar_Compiler_MachineInts.make_as k x uu___8) in
+                (FStar_Compiler_MachineInts.int_to_t k) in
             let uu___7 =
               let uu___8 =
-                let uu___9 = nm "mul" in
+                let uu___9 = nm "add" in
                 FStar_TypeChecker_Primops_Base.mk2 Prims.int_zero uu___9
                   (FStar_Compiler_MachineInts.e_machint k)
                   (FStar_Compiler_MachineInts.nbe_machint k)
@@ -71,41 +61,45 @@ let (bounded_arith_ops_for :
                        let uu___10 =
                          let uu___11 = FStar_Compiler_MachineInts.v k x in
                          let uu___12 = FStar_Compiler_MachineInts.v k y in
-                         FStar_BigInt.mult_big_int uu___11 uu___12 in
+                         FStar_BigInt.add_big_int uu___11 uu___12 in
                        FStar_Compiler_MachineInts.make_as k x uu___10) in
               let uu___9 =
                 let uu___10 =
-                  let uu___11 = nm "gt" in
+                  let uu___11 = nm "sub" in
                   FStar_TypeChecker_Primops_Base.mk2 Prims.int_zero uu___11
                     (FStar_Compiler_MachineInts.e_machint k)
                     (FStar_Compiler_MachineInts.nbe_machint k)
                     (FStar_Compiler_MachineInts.e_machint k)
                     (FStar_Compiler_MachineInts.nbe_machint k)
-                    FStar_Syntax_Embeddings.e_bool
-                    FStar_TypeChecker_NBETerm.e_bool
+                    (FStar_Compiler_MachineInts.e_machint k)
+                    (FStar_Compiler_MachineInts.nbe_machint k)
                     (fun x ->
                        fun y ->
-                         let uu___12 = FStar_Compiler_MachineInts.v k x in
-                         let uu___13 = FStar_Compiler_MachineInts.v k y in
-                         FStar_BigInt.gt_big_int uu___12 uu___13) in
+                         let uu___12 =
+                           let uu___13 = FStar_Compiler_MachineInts.v k x in
+                           let uu___14 = FStar_Compiler_MachineInts.v k y in
+                           FStar_BigInt.sub_big_int uu___13 uu___14 in
+                         FStar_Compiler_MachineInts.make_as k x uu___12) in
                 let uu___11 =
                   let uu___12 =
-                    let uu___13 = nm "gte" in
+                    let uu___13 = nm "mul" in
                     FStar_TypeChecker_Primops_Base.mk2 Prims.int_zero uu___13
                       (FStar_Compiler_MachineInts.e_machint k)
                       (FStar_Compiler_MachineInts.nbe_machint k)
                       (FStar_Compiler_MachineInts.e_machint k)
                       (FStar_Compiler_MachineInts.nbe_machint k)
-                      FStar_Syntax_Embeddings.e_bool
-                      FStar_TypeChecker_NBETerm.e_bool
+                      (FStar_Compiler_MachineInts.e_machint k)
+                      (FStar_Compiler_MachineInts.nbe_machint k)
                       (fun x ->
                          fun y ->
-                           let uu___14 = FStar_Compiler_MachineInts.v k x in
-                           let uu___15 = FStar_Compiler_MachineInts.v k y in
-                           FStar_BigInt.ge_big_int uu___14 uu___15) in
+                           let uu___14 =
+                             let uu___15 = FStar_Compiler_MachineInts.v k x in
+                             let uu___16 = FStar_Compiler_MachineInts.v k y in
+                             FStar_BigInt.mult_big_int uu___15 uu___16 in
+                           FStar_Compiler_MachineInts.make_as k x uu___14) in
                   let uu___13 =
                     let uu___14 =
-                      let uu___15 = nm "lt" in
+                      let uu___15 = nm "gt" in
                       FStar_TypeChecker_Primops_Base.mk2 Prims.int_zero
                         uu___15 (FStar_Compiler_MachineInts.e_machint k)
                         (FStar_Compiler_MachineInts.nbe_machint k)
@@ -117,10 +111,10 @@ let (bounded_arith_ops_for :
                            fun y ->
                              let uu___16 = FStar_Compiler_MachineInts.v k x in
                              let uu___17 = FStar_Compiler_MachineInts.v k y in
-                             FStar_BigInt.lt_big_int uu___16 uu___17) in
+                             FStar_BigInt.gt_big_int uu___16 uu___17) in
                     let uu___15 =
                       let uu___16 =
-                        let uu___17 = nm "lte" in
+                        let uu___17 = nm "gte" in
                         FStar_TypeChecker_Primops_Base.mk2 Prims.int_zero
                           uu___17 (FStar_Compiler_MachineInts.e_machint k)
                           (FStar_Compiler_MachineInts.nbe_machint k)
@@ -132,8 +126,45 @@ let (bounded_arith_ops_for :
                              fun y ->
                                let uu___18 = FStar_Compiler_MachineInts.v k x in
                                let uu___19 = FStar_Compiler_MachineInts.v k y in
-                               FStar_BigInt.le_big_int uu___18 uu___19) in
-                      [uu___16] in
+                               FStar_BigInt.ge_big_int uu___18 uu___19) in
+                      let uu___17 =
+                        let uu___18 =
+                          let uu___19 = nm "lt" in
+                          FStar_TypeChecker_Primops_Base.mk2 Prims.int_zero
+                            uu___19 (FStar_Compiler_MachineInts.e_machint k)
+                            (FStar_Compiler_MachineInts.nbe_machint k)
+                            (FStar_Compiler_MachineInts.e_machint k)
+                            (FStar_Compiler_MachineInts.nbe_machint k)
+                            FStar_Syntax_Embeddings.e_bool
+                            FStar_TypeChecker_NBETerm.e_bool
+                            (fun x ->
+                               fun y ->
+                                 let uu___20 =
+                                   FStar_Compiler_MachineInts.v k x in
+                                 let uu___21 =
+                                   FStar_Compiler_MachineInts.v k y in
+                                 FStar_BigInt.lt_big_int uu___20 uu___21) in
+                        let uu___19 =
+                          let uu___20 =
+                            let uu___21 = nm "lte" in
+                            FStar_TypeChecker_Primops_Base.mk2 Prims.int_zero
+                              uu___21
+                              (FStar_Compiler_MachineInts.e_machint k)
+                              (FStar_Compiler_MachineInts.nbe_machint k)
+                              (FStar_Compiler_MachineInts.e_machint k)
+                              (FStar_Compiler_MachineInts.nbe_machint k)
+                              FStar_Syntax_Embeddings.e_bool
+                              FStar_TypeChecker_NBETerm.e_bool
+                              (fun x ->
+                                 fun y ->
+                                   let uu___22 =
+                                     FStar_Compiler_MachineInts.v k x in
+                                   let uu___23 =
+                                     FStar_Compiler_MachineInts.v k y in
+                                   FStar_BigInt.le_big_int uu___22 uu___23) in
+                          [uu___20] in
+                        uu___18 :: uu___19 in
+                      uu___16 :: uu___17 in
                     uu___14 :: uu___15 in
                   uu___12 :: uu___13 in
                 uu___10 :: uu___11 in

--- a/ocaml/fstar-lib/generated/FStar_UInt128.ml
+++ b/ocaml/fstar-lib/generated/FStar_UInt128.ml
@@ -149,7 +149,7 @@ let (shift_left_large : t -> FStar_UInt32.t -> t) =
   fun a ->
     fun s ->
       {
-        low = (FStar_UInt64.uint_to_t Prims.int_zero);
+        low = Stdint.Uint64.zero;
         high = (FStar_UInt64.shift_left a.low (FStar_UInt32.sub s u32_64))
       }
 let (shift_left : t -> FStar_UInt32.t -> t) =
@@ -183,7 +183,7 @@ let (shift_right_large : t -> FStar_UInt32.t -> t) =
     fun s ->
       {
         low = (FStar_UInt64.shift_right a.high (FStar_UInt32.sub s u32_64));
-        high = (FStar_UInt64.uint_to_t Prims.int_zero)
+        high = Stdint.Uint64.zero
       }
 let (shift_right : t -> FStar_UInt32.t -> t) =
   fun a ->
@@ -243,14 +243,12 @@ let (gte_mask : t -> t -> t) =
                 (FStar_UInt64.gte_mask a.low b.low)))
       }
 let (uint64_to_uint128 : FStar_UInt64.t -> t) =
-  fun a -> { low = a; high = (FStar_UInt64.uint_to_t Prims.int_zero) }
+  fun a -> { low = a; high = Stdint.Uint64.zero }
 let (uint128_to_uint64 : t -> FStar_UInt64.t) = fun a -> a.low
 let (u64_l32_mask : FStar_UInt64.t) =
-  FStar_UInt64.uint_to_t (Prims.parse_int "0xffffffff")
+  FStar_UInt64.uint_to_t (Prims.parse_int "4294967295")
 let (u64_mod_32 : FStar_UInt64.t -> FStar_UInt64.t) =
-  fun a ->
-    FStar_UInt64.logand a
-      (FStar_UInt64.uint_to_t (Prims.parse_int "0xffffffff"))
+  fun a -> FStar_UInt64.logand a (Stdint.Uint64.of_string "4294967295")
 let (u32_32 : FStar_UInt32.t) = FStar_UInt32.uint_to_t (Prims.of_int (32))
 let (u32_combine : FStar_UInt64.t -> FStar_UInt64.t -> FStar_UInt64.t) =
   fun hi -> fun lo -> FStar_UInt64.add lo (FStar_UInt64.shift_left hi u32_32)

--- a/ocaml/fstar-lib/generated/LowStar_Vector.ml
+++ b/ocaml/fstar-lib/generated/LowStar_Vector.ml
@@ -1,6 +1,7 @@
 open Prims
 type uint32_t = FStar_UInt32.t
-let (max_uint32 : uint32_t) = (Stdint.Uint32.of_string "4294967295")
+let (max_uint32 : uint32_t) =
+  FStar_UInt32.uint_to_t (Prims.parse_int "4294967295")
 type 'a vector_str =
   | Vec of uint32_t * uint32_t * 'a LowStar_Buffer.buffer 
 let uu___is_Vec : 'a . 'a vector_str -> Prims.bool = fun projectee -> true
@@ -77,7 +78,7 @@ let assign : 'a . 'a vector -> uint32_t -> 'a -> unit =
          let h = FStar_HyperStack_ST.get () in
          LowStar_Monotonic_Buffer.upd' uu___1 Stdint.Uint32.zero v);
         (let hh1 = FStar_HyperStack_ST.get () in ())
-let (resize_ratio : uint32_t) = (Stdint.Uint32.of_int (2))
+let (resize_ratio : uint32_t) = FStar_UInt32.uint_to_t (Prims.of_int (2))
 let (new_capacity : uint32_t -> uint32_t) =
   fun cap ->
     if FStar_UInt32.gte cap (FStar_UInt32.div max_uint32 resize_ratio)

--- a/src/basic/FStar.Compiler.MachineInts.fst
+++ b/src/basic/FStar.Compiler.MachineInts.fst
@@ -92,6 +92,28 @@ type machint (k : machint_kind) = | Mk : Z.t -> option S.meta_source_info -> mac
 let mk #k x m = Mk #k x m
 let v #k (x : machint k) =
   let Mk v _ = x in v
+let int_to_t #k (i : Z.t) : machint k =
+  let meta =
+    (* UInt128 does not have literal syntax,
+    nor can it be embedded as an F* constant. *)
+    if k = UInt128 then None else
+    let signedness =
+      if is_unsigned k
+      then Const.Unsigned
+      else Const.Signed
+    in
+    let width =
+      match k with
+      | Int8 | UInt8 -> Const.Int8
+      | Int16 | UInt16 -> Const.Int16
+      | Int32 | UInt32 -> Const.Int32
+      | Int64 | UInt64 -> Const.Int64
+      | SizeT -> Const.Sizet
+    in
+    (Some (Machine_integer (signedness, width)))
+  in
+  Mk i meta
+
 let meta #k (x : machint k) =
   let Mk _ meta = x in meta
 let make_as #k (x : machint k) (z : Z.t) : machint k =

--- a/src/basic/FStar.Compiler.MachineInts.fsti
+++ b/src/basic/FStar.Compiler.MachineInts.fsti
@@ -35,6 +35,7 @@ new val machint (k : machint_kind) : Type0
 
 val mk (#k:_) (i : Z.t) (m : option S.meta_source_info) : machint k // no checks at all, use with care
 val v #k (x : machint k) : Z.t
+val int_to_t #k (i : Z.t) : machint k
 val meta #k (x : machint k) : option S.meta_source_info
 
 (* Make a machint k copying the meta off an existing one *)

--- a/src/typechecker/FStar.TypeChecker.Primops.MachineInts.fst
+++ b/src/typechecker/FStar.TypeChecker.Primops.MachineInts.fst
@@ -27,6 +27,9 @@ let bounded_arith_ops_for (k : machint_kind) : mymon unit =
   emit [
     mk1 0 (nm "v") (v #k);
 
+    mk1 0 (nm (if is_unsigned k then "uint_to_t" else "int_to_t")) (int_to_t #k);
+    mk1 0 (nm (if is_unsigned k then "__uint_to_t" else "__int_to_t")) (int_to_t #k);
+
     (* basic ops supported by all *)
     mk2 0 (nm "add") (fun (x y : machint k) -> make_as x (Z.add_big_int (v x) (v y)));
     mk2 0 (nm "sub") (fun (x y : machint k) -> make_as x (Z.sub_big_int (v x) (v y)));


### PR DESCRIPTION
This PR blocks the unfolding of `UIntN.uint_to_t` (& friends) into its definition. This is particularly bad for `SizeT` which is implemented as a `UInt64` with most operations reexported. However the primitive steps in the normalizer really expect "constants" of the right type, and `SizeT.add` will reduce when applied to some `SizeT.uint_to_t _`, but not when applied to a `UInt64.uint_to_t _`. Hence, if --cmi is on, this will cause some confusion between U64 and SizeT values, which will likely block reduction.

With this patch, the `int_to_t` variants become a primop, so they will never get unfolded.