### PR TITLE
Allow --cache_dir to create parent directories

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_Options.ml
+++ b/ocaml/fstar-lib/generated/FStar_Options.ml
@@ -988,7 +988,7 @@ let (arg_spec_of_opt_type :
       | FStar_Pervasives_Native.Some desc ->
           let desc1 = wrap desc in FStar_Getopt.OneArg (parser, desc1)
 let (pp_validate_dir : option_val -> option_val) =
-  fun p -> let pp = as_string p in FStar_Compiler_Util.mkdir false pp; p
+  fun p -> let pp = as_string p in FStar_Compiler_Util.mkdir false true pp; p
 let (pp_lowercase : option_val -> option_val) =
   fun s ->
     let uu___ =

--- a/src/basic/FStar.Compiler.Util.fsti
+++ b/src/basic/FStar.Compiler.Util.fsti
@@ -159,7 +159,14 @@ val copy_file: string -> string -> unit
 val delete_file: string -> unit
 val file_get_contents: string -> string
 val file_get_lines: string -> list string
-val mkdir: bool-> string -> unit (* [mkdir clean d] a new dir with user read/write; else delete content of [d] if it exists && clean *)
+
+(** [mkdir clean mkparents d] a new dir with user read/write.
+If clean is set and the directory exists, its contents are deleted and nothing else is done.
+If clean is not set and the directory exists, do nothing.
+If mkparents is true, the needed parents of the path will be created too, as mkdir -p does.
+*)
+val mkdir: bool-> bool -> string -> unit
+
 val concat_dir_filename: string -> string -> string
 
 type stream_reader

--- a/src/basic/FStar.Options.fst
+++ b/src/basic/FStar.Options.fst
@@ -618,7 +618,7 @@ let arg_spec_of_opt_type opt_name typ : opt_variant option_val =
 
 let pp_validate_dir p =
   let pp = as_string p in
-  mkdir false pp;
+  mkdir (*clean=*)false (*mkparents=*)true pp;
   p
 
 let pp_lowercase s =


### PR DESCRIPTION
The `--cache_dir` option will try to `mkdir` the directory if it does not exist. However, it will not create parents, so if we pass `--cache_dir a/b` and `a` does not exist, we simply fail.

This PR makes it so that we create the parents if needed, like `mkdir -p` would do.