### PR TITLE
Build fstarlib as bytecode too

### DIFF
--- a/ocaml/fstar-lib/dune
+++ b/ocaml/fstar-lib/dune
@@ -14,7 +14,7 @@
     process
     sedlex
  )
- (modes native)
+ (modes native byte)
  (wrapped false)
  (preprocess (pps ppx_deriving.show ppx_deriving_yojson sedlex.ppx))
 )


### PR DESCRIPTION
This PR makes it so that we build fstar_lib as bytecode (cma) in addition to the native mode (cmxa/cmxs). This was the case before moving to Dune, and we (at least I) did not realize we stopped bulding it.

It's required to compile F* programs to Javascript via js_of_ocaml , which consumes OCaml bytecode.

cc @msprotz @tahina-pro 