### PR TITLE
Seq: reimplement seq_to_list and seq_of_list by casting

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_BV.ml
+++ b/ocaml/fstar-lib/generated/FStar_BV.ml
@@ -11,9 +11,9 @@ let (bv2int : Prims.pos -> unit bv_t -> unit FStar_UInt.uint_t) =
 let (int2bv_nat : Prims.pos -> Prims.nat -> unit bv_t) =
   fun n -> fun num -> FStar_UInt.to_vec n (num mod (Prims.pow2 n))
 let (list2bv : Prims.pos -> Prims.bool Prims.list -> unit bv_t) =
-  fun n -> fun l -> FStar_Seq_Properties.seq_of_list l
+  fun n -> fun l -> FStar_Seq_Base.seq_of_list l
 let (bv2list : Prims.pos -> unit bv_t -> Prims.bool Prims.list) =
-  fun n -> fun s -> FStar_Seq_Properties.seq_to_list s
+  fun n -> fun s -> FStar_Seq_Base.seq_to_list s
 let (bvand : Prims.pos -> unit bv_t -> unit bv_t -> unit bv_t) =
   FStar_BitVector.logand_vec
 let (bvxor : Prims.pos -> unit bv_t -> unit bv_t -> unit bv_t) =

--- a/ocaml/fstar-lib/generated/FStar_Class_Printable.ml
+++ b/ocaml/fstar-lib/generated/FStar_Class_Printable.ml
@@ -258,5 +258,5 @@ let printable_seq : 'b . 'b printable -> 'b FStar_Seq_Base.seq printable =
            Prims.strcat "<"
              (Prims.strcat
                 (FStar_String.concat "; "
-                   (FStar_Seq_Properties.seq_to_list strings_of_b)) ">"))
+                   (FStar_Seq_Base.seq_to_list strings_of_b)) ">"))
     }

--- a/ocaml/fstar-lib/generated/FStar_Endianness.ml
+++ b/ocaml/fstar-lib/generated/FStar_Endianness.ml
@@ -27,8 +27,7 @@ let rec (n_to_le : Prims.nat -> Prims.nat -> bytes) =
         (let len1 = len - Prims.int_one in
          let byte = FStar_UInt8.uint_to_t (n mod (Prims.of_int (256))) in
          let n' = n / (Prims.of_int (256)) in
-         let b' = n_to_le len1 n' in
-         let b = FStar_Seq_Properties.cons byte b' in b)
+         let b' = n_to_le len1 n' in let b = FStar_Seq_Base.cons byte b' in b)
 let rec (n_to_be : Prims.nat -> Prims.nat -> bytes) =
   fun len ->
     fun n ->
@@ -67,7 +66,7 @@ let rec (seq_uint32_of_le :
         (let uu___1 = FStar_Seq_Properties.split b (Prims.of_int (4)) in
          match uu___1 with
          | (hd, tl) ->
-             FStar_Seq_Properties.cons (uint32_of_le hd)
+             FStar_Seq_Base.cons (uint32_of_le hd)
                (seq_uint32_of_le (l - Prims.int_one) tl))
 let rec (le_of_seq_uint32 : FStar_UInt32.t FStar_Seq_Base.seq -> bytes) =
   fun s ->
@@ -86,7 +85,7 @@ let rec (seq_uint32_of_be :
         (let uu___1 = FStar_Seq_Properties.split b (Prims.of_int (4)) in
          match uu___1 with
          | (hd, tl) ->
-             FStar_Seq_Properties.cons (uint32_of_be hd)
+             FStar_Seq_Base.cons (uint32_of_be hd)
                (seq_uint32_of_be (l - Prims.int_one) tl))
 let rec (be_of_seq_uint32 : FStar_UInt32.t FStar_Seq_Base.seq -> bytes) =
   fun s ->
@@ -105,7 +104,7 @@ let rec (seq_uint64_of_le :
         (let uu___1 = FStar_Seq_Properties.split b (Prims.of_int (8)) in
          match uu___1 with
          | (hd, tl) ->
-             FStar_Seq_Properties.cons (uint64_of_le hd)
+             FStar_Seq_Base.cons (uint64_of_le hd)
                (seq_uint64_of_le (l - Prims.int_one) tl))
 let rec (le_of_seq_uint64 : FStar_UInt64.t FStar_Seq_Base.seq -> bytes) =
   fun s ->
@@ -124,7 +123,7 @@ let rec (seq_uint64_of_be :
         (let uu___1 = FStar_Seq_Properties.split b (Prims.of_int (8)) in
          match uu___1 with
          | (hd, tl) ->
-             FStar_Seq_Properties.cons (uint64_of_be hd)
+             FStar_Seq_Base.cons (uint64_of_be hd)
                (seq_uint64_of_be (l - Prims.int_one) tl))
 let rec (be_of_seq_uint64 : FStar_UInt64.t FStar_Seq_Base.seq -> bytes) =
   fun s ->

--- a/ocaml/fstar-lib/generated/FStar_Seq_Base.ml
+++ b/ocaml/fstar-lib/generated/FStar_Seq_Base.ml
@@ -6,9 +6,12 @@ let __proj__MkSeq__item__l : 'a . 'a seq -> 'a Prims.list =
   fun projectee -> match projectee with | MkSeq l -> l
 let length : 'uuuuu . 'uuuuu seq -> Prims.nat =
   fun s -> FStar_List_Tot_Base.length (__proj__MkSeq__item__l s)
+let seq_to_list : 'uuuuu . 'uuuuu seq -> 'uuuuu Prims.list =
+  fun s -> match s with | MkSeq l -> l
+let seq_of_list : 'uuuuu . 'uuuuu Prims.list -> 'uuuuu seq = fun l -> MkSeq l
 let index : 'uuuuu . 'uuuuu seq -> Prims.nat -> 'uuuuu =
   fun s -> fun i -> FStar_List_Tot_Base.index (__proj__MkSeq__item__l s) i
-let cons : 'a . 'a -> 'a seq -> 'a seq =
+let _cons : 'a . 'a -> 'a seq -> 'a seq =
   fun x -> fun s -> MkSeq (x :: (__proj__MkSeq__item__l s))
 let hd : 'a . 'a seq -> 'a =
   fun s -> FStar_List_Tot_Base.hd (__proj__MkSeq__item__l s)
@@ -19,7 +22,7 @@ let rec create : 'uuuuu . Prims.nat -> 'uuuuu -> 'uuuuu seq =
     fun v ->
       if len = Prims.int_zero
       then MkSeq []
-      else cons v (create (len - Prims.int_one) v)
+      else _cons v (create (len - Prims.int_one) v)
 let rec init_aux' :
   'a . Prims.nat -> Prims.nat -> (Prims.nat -> 'a) -> 'a seq =
   fun len ->
@@ -27,7 +30,7 @@ let rec init_aux' :
       fun contents ->
         if (k + Prims.int_one) = len
         then MkSeq [contents k]
-        else cons (contents k) (init_aux' len (k + Prims.int_one) contents)
+        else _cons (contents k) (init_aux' len (k + Prims.int_one) contents)
 let init_aux : 'a . Prims.nat -> Prims.nat -> (Prims.nat -> 'a) -> 'a seq =
   init_aux'
 let init : 'uuuuu . Prims.nat -> (Prims.nat -> 'uuuuu) -> 'uuuuu seq =
@@ -43,8 +46,8 @@ let rec upd' : 'a . 'a seq -> Prims.nat -> 'a -> 'a seq =
     fun n ->
       fun v ->
         if n = Prims.int_zero
-        then cons v (tl s)
-        else cons (hd s) (upd' (tl s) (n - Prims.int_one) v)
+        then _cons v (tl s)
+        else _cons (hd s) (upd' (tl s) (n - Prims.int_one) v)
 let upd : 'a . 'a seq -> Prims.nat -> 'a -> 'a seq = upd'
 let append : 'uuuuu . 'uuuuu seq -> 'uuuuu seq -> 'uuuuu seq =
   fun s1 ->
@@ -52,6 +55,8 @@ let append : 'uuuuu . 'uuuuu seq -> 'uuuuu seq -> 'uuuuu seq =
       MkSeq
         (FStar_List_Tot_Base.append (__proj__MkSeq__item__l s1)
            (__proj__MkSeq__item__l s2))
+let cons : 'a . 'a -> 'a seq -> 'a seq =
+  fun x -> fun s -> append (create Prims.int_one x) s
 let op_At_Bar : 'a . 'a seq -> 'a seq -> 'a seq =
   fun s1 -> fun s2 -> append s1 s2
 let rec slice' : 'a . 'a seq -> Prims.nat -> Prims.nat -> 'a seq =
@@ -63,7 +68,7 @@ let rec slice' : 'a . 'a seq -> Prims.nat -> Prims.nat -> 'a seq =
         else
           if j = Prims.int_zero
           then MkSeq []
-          else cons (hd s) (slice' (tl s) i (j - Prims.int_one))
+          else _cons (hd s) (slice' (tl s) i (j - Prims.int_one))
 let slice : 'a . 'a seq -> Prims.nat -> Prims.nat -> 'a seq = slice'
 type ('a, 's1, 's2) equal = unit
 let rec eq_i' : 'a . 'a seq -> 'a seq -> Prims.nat -> Prims.bool =

--- a/ocaml/fstar-lib/generated/FStar_Seq_Permutation.ml
+++ b/ocaml/fstar-lib/generated/FStar_Seq_Permutation.ml
@@ -17,8 +17,7 @@ let rec find :
         (let uu___1 = find x (FStar_Seq_Properties.tail s) in
          match uu___1 with
          | (pfx, sfx) ->
-             ((FStar_Seq_Properties.cons (FStar_Seq_Properties.head s) pfx),
-               sfx))
+             ((FStar_Seq_Base.cons (FStar_Seq_Properties.head s) pfx), sfx))
 let adapt_index_fun :
   'a .
     'a FStar_Seq_Base.seq ->

--- a/ocaml/fstar-lib/generated/FStar_Seq_Properties.ml
+++ b/ocaml/fstar-lib/generated/FStar_Seq_Properties.ml
@@ -7,9 +7,6 @@ let tail : 'a . 'a FStar_Seq_Base.seq -> 'a FStar_Seq_Base.seq =
   fun s -> FStar_Seq_Base.slice s Prims.int_one (FStar_Seq_Base.length s)
 let last : 'a . 'a FStar_Seq_Base.seq -> 'a =
   fun s -> FStar_Seq_Base.index s ((FStar_Seq_Base.length s) - Prims.int_one)
-let cons : 'a . 'a -> 'a FStar_Seq_Base.seq -> 'a FStar_Seq_Base.seq =
-  fun x ->
-    fun s -> FStar_Seq_Base.append (FStar_Seq_Base.create Prims.int_one x) s
 let split :
   'a .
     'a FStar_Seq_Base.seq ->
@@ -175,27 +172,13 @@ let for_all : 'a . ('a -> Prims.bool) -> 'a FStar_Seq_Base.seq -> Prims.bool
     fun l ->
       FStar_Pervasives_Native.uu___is_None
         (seq_find (fun i -> Prims.op_Negation (f i)) l)
-let rec seq_to_list : 'a . 'a FStar_Seq_Base.seq -> 'a Prims.list =
-  fun s ->
-    if (FStar_Seq_Base.length s) = Prims.int_zero
-    then []
-    else (FStar_Seq_Base.index s Prims.int_zero) ::
-      (seq_to_list
-         (FStar_Seq_Base.slice s Prims.int_one (FStar_Seq_Base.length s)))
-let rec seq_of_list : 'a . 'a Prims.list -> 'a FStar_Seq_Base.seq =
-  fun l ->
-    match l with
-    | [] -> FStar_Seq_Base.empty ()
-    | hd::tl ->
-        FStar_Seq_Base.op_At_Bar (FStar_Seq_Base.create Prims.int_one hd)
-          (seq_of_list tl)
 type ('a, 'l, 's) createL_post = unit
 let createL : 'a . 'a Prims.list -> 'a FStar_Seq_Base.seq =
-  fun l -> let s = seq_of_list l in s
+  fun l -> let s = FStar_Seq_Base.seq_of_list l in s
 type ('a, 's, 'x) contains = unit
 type ('a, 'susuff, 's) suffix_of = unit
 let of_list : 'a . 'a Prims.list -> 'a FStar_Seq_Base.seq =
-  fun l -> seq_of_list l
+  fun l -> FStar_Seq_Base.seq_of_list l
 type ('a, 'i, 's, 'l) explode_and = Obj.t
 type ('uuuuu, 's, 'l) pointwise_and = Obj.t
 let sortWith :
@@ -203,7 +186,9 @@ let sortWith :
     ('a -> 'a -> Prims.int) -> 'a FStar_Seq_Base.seq -> 'a FStar_Seq_Base.seq
   =
   fun f ->
-    fun s -> seq_of_list (FStar_List_Tot_Base.sortWith f (seq_to_list s))
+    fun s ->
+      FStar_Seq_Base.seq_of_list
+        (FStar_List_Tot_Base.sortWith f (FStar_Seq_Base.seq_to_list s))
 let sort_lseq :
   'a . Prims.nat -> 'a tot_ord -> ('a, unit) lseq -> ('a, unit) lseq =
   fun n ->
@@ -236,4 +221,5 @@ let rec map_seq :
       then FStar_Seq_Base.empty ()
       else
         (let uu___1 = ((head s), (tail s)) in
-         match uu___1 with | (hd, tl) -> cons (f hd) (map_seq f tl))
+         match uu___1 with
+         | (hd, tl) -> FStar_Seq_Base.cons (f hd) (map_seq f tl))

--- a/ocaml/fstar-lib/generated/LowStar_Monotonic_Buffer.ml
+++ b/ocaml/fstar-lib/generated/LowStar_Monotonic_Buffer.ml
@@ -341,7 +341,7 @@ let malloca_of_list : 'a 'rrel . 'a Prims.list -> ('a, 'rrel, 'rrel) mbuffer
   =
   fun init ->
     let len = FStar_UInt32.uint_to_t (FStar_List_Tot_Base.length init) in
-    let s = FStar_Seq_Properties.seq_of_list init in
+    let s = FStar_Seq_Base.seq_of_list init in
     let content = FStar_HyperStack_ST.salloc s in
     Buffer (len, content, Stdint.Uint32.zero, ())
 type ('a, 'r, 'init) gcmalloc_of_list_pre = unit
@@ -350,7 +350,7 @@ let mgcmalloc_of_list :
   fun r ->
     fun init ->
       let len = FStar_UInt32.uint_to_t (FStar_List_Tot_Base.length init) in
-      let s = FStar_Seq_Properties.seq_of_list init in
+      let s = FStar_Seq_Base.seq_of_list init in
       let content = FStar_HyperStack_ST.ralloc () s in
       Buffer (len, content, Stdint.Uint32.zero, ())
 let mgcmalloc_of_list_partial :

--- a/tests/ide/emacs/search.cons-snoc.out.expected
+++ b/tests/ide/emacs/search.cons-snoc.out.expected
@@ -1,4 +1,4 @@
 {"kind": "protocol-info", "rest": "[...]"}
 {"kind": "response", "query-id": "1", "response": [], "status": "success"}
-{"contents": "* Error 147 at FStar.Seq.Properties.fsti(774,0-776,62):\n  - Effect template STATE_h should be applied to arguments for its binders ((heap: Type)) before it can be used at an effect position\n  - See also <input>(1,0-1,0)\n\n", "kind": "message", "level": "error", "query-id": "2"}
+{"contents": "* Error 147 at FStar.Seq.Properties.fsti(760,0-762,62):\n  - Effect template STATE_h should be applied to arguments for its binders ((heap: Type)) before it can be used at an effect position\n  - See also <input>(1,0-1,0)\n\n", "kind": "message", "level": "error", "query-id": "2"}
 {"contents": "1 error was reported (see above)\n", "kind": "message", "level": "error", "query-id": "2"}

--- a/ulib/FStar.Seq.Base.fst
+++ b/ulib/FStar.Seq.Base.fst
@@ -25,22 +25,28 @@ type seq (a:Type u#a) :Type u#a =
 
 let length #_ s = List.length (MkSeq?.l s)
 
+let seq_to_list #_ s =
+  match s with
+  | MkSeq l -> l
+
+let seq_of_list #_ l = MkSeq l
+
 let index #_ s i = List.index (MkSeq?.l s) i
 
-let cons (#a:Type) (x:a) (s:seq a) : Tot (seq a) = MkSeq (x::(MkSeq?.l s))
+let _cons (#a:Type) (x:a) (s:seq a) : Tot (seq a) = MkSeq (x::(MkSeq?.l s))
 
 let hd (#a:Type) (s:seq a{length s > 0}) : Tot a = List.hd (MkSeq?.l s)
 
 let tl (#a:Type) (s:seq a{length s > 0}) : Tot (seq a) = MkSeq (List.tl (MkSeq?.l s))
 
-let rec create #_ len v = if len = 0 then MkSeq [] else cons v (create (len - 1) v)
+let rec create #_ len v = if len = 0 then MkSeq [] else _cons v (create (len - 1) v)
 
 private let rec init_aux' (#a:Type) (len:nat) (k:nat{k < len}) (contents: (i:nat{i < len} -> Tot a))
     : Tot (seq a)
       (decreases (len - k))
   = if k + 1 = len
     then MkSeq [contents k]
-    else cons (contents k) (init_aux' len (k+1) contents)
+    else _cons (contents k) (init_aux' len (k+1) contents)
 
 let init_aux = init_aux'
 
@@ -51,7 +57,7 @@ private let rec init_aux_ghost' (#a:Type) (len:nat) (k:nat{k < len}) (contents:(
       (decreases (len - k))
   = if k + 1 = len
     then MkSeq [contents k]
-    else cons (contents k) (init_aux_ghost' len (k+1) contents)
+    else _cons (contents k) (init_aux_ghost' len (k+1) contents)
 
 let init_aux_ghost = init_aux_ghost'
 
@@ -64,7 +70,7 @@ let lemma_empty #_ _ = ()
 private let rec upd' (#a:Type) (s:seq a) (n:nat{n < length s}) (v:a)
     : Tot (seq a)
       (decreases (length s))
-  = if n = 0 then cons v (tl s) else cons (hd s) (upd' (tl s) (n - 1) v)
+  = if n = 0 then _cons v (tl s) else _cons (hd s) (upd' (tl s) (n - 1) v)
 
 let upd = upd'
 
@@ -75,9 +81,14 @@ private let rec slice' (#a:Type) (s:seq a) (i:nat) (j:nat{i <= j && j <= length 
       (decreases (length s))
   =  if i > 0 then slice' #a (tl s) (i - 1) (j - 1)
      else if j = 0 then MkSeq []
-          else cons (hd s) (slice' #a (tl s) i (j - 1))
+          else _cons (hd s) (slice' #a (tl s) i (j - 1))
 
 let slice = slice'
+
+let lemma_seq_of_seq_to_list #_ s = ()
+let lemma_seq_to_seq_of_list #_ s = ()
+let lemma_seq_of_list_cons #_ x l = ()
+let lemma_seq_to_list_cons #_ x s = ()
 
 let rec lemma_create_len #_ n i = if n = 0 then () else lemma_create_len (n - 1) i
 

--- a/ulib/FStar.Seq.Base.fsti
+++ b/ulib/FStar.Seq.Base.fsti
@@ -25,6 +25,10 @@ new val seq ([@@@strictly_positive] a : Type u#a) : Type u#a
 (* Destructors *)
 val length: #a:Type -> seq a -> Tot nat
 
+val seq_to_list (#a:Type) (s:seq a) : Tot (l:list a{List.length l == length s})
+
+val seq_of_list (#a:Type) (l:list a) : Tot (s:seq a{List.length l == length s})
+
 val index:  #a:Type -> s:seq a -> i:nat{i < length s} -> Tot a
 
 val create: #a:Type -> nat -> a -> Tot (seq a)
@@ -53,9 +57,36 @@ val upd: #a:Type -> s:seq a -> n:nat{n < length s} -> a ->  Tot (seq a)
 
 val append: #a:Type -> seq a -> seq a -> Tot (seq a)
 
+let cons (#a:Type) (x:a) (s:seq a) : Tot (seq a) = append (create 1 x) s
+
 let op_At_Bar (#a:Type) (s1:seq a) (s2:seq a) = append s1 s2
 
 val slice:  #a:Type -> s:seq a -> i:nat -> j:nat{i <= j && j <= length s} -> Tot (seq a)
+
+(* Lemmas about seq_to_list/seq_of_list *)
+val lemma_seq_of_seq_to_list : #a:Type -> s:seq a ->
+  Lemma
+  (requires True)
+  (ensures seq_of_list (seq_to_list s) == s)
+  [SMTPat (seq_of_list (seq_to_list s))]
+
+val lemma_seq_to_seq_of_list : #a:Type -> l:list a ->
+  Lemma
+  (requires True)
+  (ensures seq_to_list (seq_of_list l) == l)
+  [SMTPat (seq_to_list (seq_of_list l))]
+
+val lemma_seq_of_list_cons : #a:Type -> x:a -> l:list a ->
+  Lemma
+  (requires True)
+  (ensures seq_of_list (x::l) == create 1 x @| seq_of_list l)
+  [SMTPat (seq_of_list (x::l))]
+
+val lemma_seq_to_list_cons : #a:Type -> x:a -> s:seq a ->
+  Lemma
+  (requires True)
+  (ensures seq_to_list (cons x s) == x :: seq_to_list s)
+  [SMTPat (seq_to_list (cons x s))]
 
 (* Lemmas about length *)
 val lemma_create_len: #a:Type -> n:nat -> i:a -> Lemma

--- a/ulib/FStar.Seq.Properties.fst
+++ b/ulib/FStar.Seq.Properties.fst
@@ -386,10 +386,8 @@ module L = FStar.List.Tot
 
 let lemma_seq_of_list_induction #_ l
   = match l with
-    | []    -> assert_norm (seq_of_list l == Seq.empty)
-    | hd::tl ->
-      assert_norm (seq_of_list (hd::tl) == create 1 hd @| seq_of_list tl);
-      lemma_tl hd (seq_of_list tl)
+    | [] -> ()
+    | hd::tl -> lemma_tl hd (seq_of_list tl)
 
 let rec lemma_seq_list_bij': #a:Type -> s:seq a -> Lemma
   (requires (True))
@@ -427,6 +425,7 @@ let rec lemma_index_is_nth': #a:Type -> s:seq a -> i:nat{i < length s} -> Lemma
   (ensures  (L.index (seq_to_list s) i == index s i))
   (decreases i)
 = fun #_ s i ->
+  assert (s `equal` cons (head s) (tail s));
   if i = 0 then ()
   else (
     lemma_index_is_nth' (slice s 1 (length s)) (i-1)
@@ -595,7 +594,10 @@ let elim_of_list #_ l = elim_of_list' 0 (seq_of_list l) l
 
 let rec lemma_seq_to_list_permutation' (#a:eqtype) (s:seq a)
   :Lemma (requires True) (ensures (forall x. count x s == List.Tot.Base.count x (seq_to_list s))) (decreases (length s))
-  = if length s > 0 then lemma_seq_to_list_permutation' (slice s 1 (length s))
+  = if length s > 0 then (
+      assert (equal s (cons (head s) (tail s)));
+      lemma_seq_to_list_permutation' (slice s 1 (length s))
+    )
 
 let lemma_seq_to_list_permutation = lemma_seq_to_list_permutation'
 

--- a/ulib/FStar.Seq.Properties.fsti
+++ b/ulib/FStar.Seq.Properties.fsti
@@ -49,8 +49,6 @@ val lemma_tail_append: #a:Type -> s1:seq a{length s1 > 0} -> s2:seq a -> Lemma
 
 let last (#a:Type) (s:seq a{length s > 0}) : Tot a = index s (length s - 1)
 
-let cons (#a:Type) (x:a) (s:seq a) : Tot (seq a) = append (create 1 x) s
-
 val lemma_cons_inj: #a:Type -> v1:a -> v2:a -> s1:seq a -> s2:seq a
   -> Lemma (requires (equal (cons v1 s1) (cons v2 s2)))
           (ensures (v1 == v2 /\ equal s1 s2))
@@ -426,18 +424,6 @@ val seq_mem_k: #a:eqtype -> s:seq a -> n:nat{n < Seq.length s} ->
           [SMTPat (mem (Seq.index s n) s)]
 
 module L = FStar.List.Tot
-
-let rec seq_to_list (#a:Type) (s:seq a)
-: Tot (l:list a{L.length l = length s})
-  (decreases (length s))
-= if length s = 0 then []
-  else index s 0::seq_to_list (slice s 1 (length s))
-
-[@@"opaque_to_smt"]
-let rec seq_of_list (#a:Type) (l:list a) : Tot (s:seq a{L.length l = length s})  =
-  match l with
-  | [] -> Seq.empty #a
-  | hd::tl -> create 1 hd @| seq_of_list tl
 
 val lemma_seq_of_list_induction (#a:Type) (l:list a)
   :Lemma (requires True)


### PR DESCRIPTION
This PR makes the implementations of seq_to_list and seq_of_list much faster (constant time as opposed to linear). There is a bit of refactoring and some new lemmas needed, but everything including everest seems to work (I'll post PRs for subprojects shortly).

For code that makes heavy use of sequences (at the value level) this can make a big difference. Apparently for MLS* it means a performance gain of 50%.

cc @msprotz 