### PR TITLE
FStar.Tactics.V2: embed Pat_Vars by sealing ppname

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_Reflection_V2_Embeddings.ml
+++ b/ocaml/fstar-lib/generated/FStar_Reflection_V2_Embeddings.ml
@@ -587,8 +587,7 @@ let rec e_pattern_aq :
               FStar_Syntax_Syntax.as_arg uu___2 in
             let uu___2 =
               let uu___3 =
-                let uu___4 =
-                  embed FStar_Syntax_Embeddings.e_string rng ppname in
+                let uu___4 = embed e_ppname rng ppname in
                 FStar_Syntax_Syntax.as_arg uu___4 in
               [uu___3] in
             uu___1 :: uu___2 in

--- a/src/reflection/FStar.Reflection.V2.Embeddings.fst
+++ b/src/reflection/FStar.Reflection.V2.Embeddings.fst
@@ -257,7 +257,7 @@ let rec e_pattern_aq aq =
         | Pat_Var sort ppname ->
             S.mk_Tm_app ref_Pat_Var.t [
               S.as_arg (embed #_ #e_sort rng sort);
-              S.as_arg (embed rng ppname);
+              S.as_arg (embed #_ #e_ppname rng ppname);
             ] rng
         | Pat_Dot_Term eopt ->
             S.mk_Tm_app ref_Pat_Dot_Term.t [S.as_arg (embed #_ #(e_option e_term) rng eopt)]

--- a/tests/bug-reports/Bug3210.fst
+++ b/tests/bug-reports/Bug3210.fst
@@ -1,0 +1,12 @@
+module Bug3210
+
+module Tac = FStar.Tactics
+
+let lift_ty: Tac.term -> Tac.Tac Tac.term =
+  let rec go (t: Tac.term): Tac.Tac Tac.term =
+    t
+  in Tac.visit_tm go
+
+[@@Tac.preprocess_with lift_ty]
+let rec count (x: int): int =
+  if x > 0 then count (x - 1) else 0

--- a/tests/bug-reports/Bug3210.fst
+++ b/tests/bug-reports/Bug3210.fst
@@ -1,6 +1,6 @@
 module Bug3210
 
-module Tac = FStar.Tactics
+module Tac = FStar.Tactics.V2
 
 let lift_ty: Tac.term -> Tac.Tac Tac.term =
   let rec go (t: Tac.term): Tac.Tac Tac.term =
@@ -10,3 +10,30 @@ let lift_ty: Tac.term -> Tac.Tac Tac.term =
 [@@Tac.preprocess_with lift_ty]
 let rec count (x: int): int =
   if x > 0 then count (x - 1) else 0
+
+(* Inspecting and packing back this term fails for the same reason. *)
+let test2 () : Tac.Tac unit =
+  let tm = `(match 0 with nm -> nm) in
+  let tv = Tac.inspect_ln tm in
+  let tm = Tac.pack_ln tv in
+  Tac.print (Tac.term_to_string tm)
+let _ = assert True by test2 ()
+
+(* This would surprisingly work in the NamedView, since it is a plugin
+and works behind the `sealed` abstraction. But, using --no_plugins
+did make it fail. *)
+
+let test3 () : Tac.Tac unit =
+  let open FStar.Tactics.V2 in
+  let open FStar.Tactics.NamedView in
+  let tm = `(match 0 with nm -> nm) in
+  let tv = inspect tm in
+  let tm = pack tv in
+  print (term_to_string tm)
+
+#push-options "--no_plugins"
+friend FStar.Tactics.NamedView
+// ^ We need this (at any point in the file) to bring the definitions into scope,
+// since NamedView has an interface.
+let _ = assert True by test3 ()
+#pop-options

--- a/tests/bug-reports/Bug3210.fsti
+++ b/tests/bug-reports/Bug3210.fsti
@@ -1,0 +1,1 @@
+module Bug3210

--- a/tests/bug-reports/Makefile
+++ b/tests/bug-reports/Makefile
@@ -54,7 +54,7 @@ SHOULD_VERIFY_CLOSED=Bug022.fst Bug024.fst Bug025.fst Bug026.fst Bug026b.fst Bug
   Bug2756.fst MutualRecPositivity.fst Bug2806a.fst Bug2806b.fst Bug2806c.fst Bug2806d.fst Bug2809.fst\
   Bug2849a.fst Bug2849b.fst Bug2045.fst Bug2876.fst Bug2882.fst Bug2895.fst Bug2894.fst \
   Bug2415.fst Bug3028.fst Bug2954.fst Bug3089.fst Bug3102.fst Bug2981.fst Bug2980.fst Bug3115.fst \
-  Bug2083.fst Bug2002.fst Bug1482.fst Bug1066.fst Bug3120a.fst Bug3120b.fst Bug3186.fst Bug3185.fst
+  Bug2083.fst Bug2002.fst Bug1482.fst Bug1066.fst Bug3120a.fst Bug3120b.fst Bug3186.fst Bug3185.fst Bug3210.fst
 
 SHOULD_VERIFY_INTERFACE_CLOSED=Bug771.fsti Bug771b.fsti
 SHOULD_VERIFY_AND_WARN_CLOSED=Bug016.fst


### PR DESCRIPTION
This (hopefully) fixes issue #3210. Pattern variables (Pat_Var) were being embedded as raw strings "", but the unembed requires them to be sealed. As such, the inspected values weren't always being packed.

I think the NamedView wrapper freshens the ppname or something, and reseals the result -- which is why NamedView was working OK.