### PR TITLE
FStar.Compiler.Sealed: add an internal sealed type

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_Compiler_Sealed.ml
+++ b/ocaml/fstar-lib/generated/FStar_Compiler_Sealed.ml
@@ -1,0 +1,4 @@
+open Prims
+type 'a sealed = 'a
+let seal : 'a . 'a -> 'a sealed = fun x -> x
+let unseal : 'a . 'a sealed -> 'a = fun x -> x

--- a/ocaml/fstar-lib/generated/FStar_Reflection_V1_Builtins.ml
+++ b/ocaml/fstar-lib/generated/FStar_Reflection_V1_Builtins.ml
@@ -301,7 +301,8 @@ let rec (inspect_ln :
               FStar_Reflection_V1_Data.Pat_Cons uu___1
           | FStar_Syntax_Syntax.Pat_var bv ->
               FStar_Reflection_V1_Data.Pat_Var
-                (bv, (bv.FStar_Syntax_Syntax.sort))
+                (bv,
+                  (FStar_Compiler_Sealed.seal bv.FStar_Syntax_Syntax.sort))
           | FStar_Syntax_Syntax.Pat_dot_term eopt ->
               FStar_Reflection_V1_Data.Pat_Dot_Term eopt in
         let brs1 =
@@ -1172,7 +1173,9 @@ let (inspect_bv : FStar_Syntax_Syntax.bv -> FStar_Reflection_V1_Data.bv_view)
          (FStar_Errors_Codes.Warning_CantInspect, uu___2) in
        FStar_Errors.log_issue FStar_Compiler_Range_Type.dummyRange uu___1)
     else ();
-    (let uu___1 = FStar_Ident.string_of_id bv.FStar_Syntax_Syntax.ppname in
+    (let uu___1 =
+       let uu___2 = FStar_Ident.string_of_id bv.FStar_Syntax_Syntax.ppname in
+       FStar_Compiler_Sealed.seal uu___2 in
      let uu___2 = FStar_BigInt.of_int_fs bv.FStar_Syntax_Syntax.index in
      {
        FStar_Reflection_V1_Data.bv_ppname = uu___1;
@@ -1194,13 +1197,15 @@ let (pack_bv : FStar_Reflection_V1_Data.bv_view -> FStar_Syntax_Syntax.bv) =
              Prims.string_of_int uu___5 in
            FStar_Compiler_Util.format2
              "pack_bv: index is negative (%s), index = %s"
-             bvv.FStar_Reflection_V1_Data.bv_ppname uu___4 in
+             (FStar_Compiler_Sealed.unseal
+                bvv.FStar_Reflection_V1_Data.bv_ppname) uu___4 in
          (FStar_Errors_Codes.Warning_CantInspect, uu___3) in
        FStar_Errors.log_issue FStar_Compiler_Range_Type.dummyRange uu___2
      else ());
     (let uu___1 =
        FStar_Ident.mk_ident
-         ((bvv.FStar_Reflection_V1_Data.bv_ppname),
+         ((FStar_Compiler_Sealed.unseal
+             bvv.FStar_Reflection_V1_Data.bv_ppname),
            FStar_Compiler_Range_Type.dummyRange) in
      let uu___2 =
        FStar_BigInt.to_int_fs bvv.FStar_Reflection_V1_Data.bv_index in

--- a/ocaml/fstar-lib/generated/FStar_Reflection_V1_Data.ml
+++ b/ocaml/fstar-lib/generated/FStar_Reflection_V1_Data.ml
@@ -45,7 +45,7 @@ type pattern =
   | Pat_Cons of (FStar_Syntax_Syntax.fv * FStar_Syntax_Syntax.universe
   Prims.list FStar_Pervasives_Native.option * (pattern * Prims.bool)
   Prims.list) 
-  | Pat_Var of (FStar_Syntax_Syntax.bv * typ) 
+  | Pat_Var of (FStar_Syntax_Syntax.bv * typ FStar_Compiler_Sealed.sealed) 
   | Pat_Dot_Term of FStar_Syntax_Syntax.term FStar_Pervasives_Native.option 
 let (uu___is_Pat_Constant : pattern -> Prims.bool) =
   fun projectee ->
@@ -62,7 +62,8 @@ let (__proj__Pat_Cons__item___0 :
   = fun projectee -> match projectee with | Pat_Cons _0 -> _0
 let (uu___is_Pat_Var : pattern -> Prims.bool) =
   fun projectee -> match projectee with | Pat_Var _0 -> true | uu___ -> false
-let (__proj__Pat_Var__item___0 : pattern -> (FStar_Syntax_Syntax.bv * typ)) =
+let (__proj__Pat_Var__item___0 :
+  pattern -> (FStar_Syntax_Syntax.bv * typ FStar_Compiler_Sealed.sealed)) =
   fun projectee -> match projectee with | Pat_Var _0 -> _0
 let (uu___is_Pat_Dot_Term : pattern -> Prims.bool) =
   fun projectee ->
@@ -84,11 +85,13 @@ let (uu___is_Q_Meta : aqualv -> Prims.bool) =
 let (__proj__Q_Meta__item___0 : aqualv -> FStar_Syntax_Syntax.term) =
   fun projectee -> match projectee with | Q_Meta _0 -> _0
 type argv = (FStar_Syntax_Syntax.term * aqualv)
-let (as_ppname : Prims.string -> Prims.string) = fun x -> x
+type ppname_t = Prims.string FStar_Compiler_Sealed.sealed
+let (as_ppname : Prims.string -> ppname_t) =
+  fun x -> FStar_Compiler_Sealed.seal x
 type bv_view = {
-  bv_ppname: Prims.string ;
+  bv_ppname: ppname_t ;
   bv_index: FStar_BigInt.t }
-let (__proj__Mkbv_view__item__bv_ppname : bv_view -> Prims.string) =
+let (__proj__Mkbv_view__item__bv_ppname : bv_view -> ppname_t) =
   fun projectee ->
     match projectee with | { bv_ppname; bv_index;_} -> bv_ppname
 let (__proj__Mkbv_view__item__bv_index : bv_view -> FStar_BigInt.t) =

--- a/ocaml/fstar-lib/generated/FStar_Reflection_V1_NBEEmbeddings.ml
+++ b/ocaml/fstar-lib/generated/FStar_Reflection_V1_NBEEmbeddings.ml
@@ -177,6 +177,14 @@ let (e_term_aq :
     }
 let (e_term : FStar_Syntax_Syntax.term FStar_TypeChecker_NBETerm.embedding) =
   e_term_aq (Prims.int_zero, [])
+let (e_sort :
+  FStar_Syntax_Syntax.term FStar_Compiler_Sealed.sealed
+    FStar_TypeChecker_NBETerm.embedding)
+  = FStar_TypeChecker_NBETerm.e_sealed e_term
+let (e_ppname :
+  Prims.string FStar_Compiler_Sealed.sealed
+    FStar_TypeChecker_NBETerm.embedding)
+  = FStar_TypeChecker_NBETerm.e_sealed FStar_TypeChecker_NBETerm.e_string
 let (e_aqualv :
   FStar_Reflection_V1_Data.aqualv FStar_TypeChecker_NBETerm.embedding) =
   let embed_aqualv cb q =
@@ -528,9 +536,7 @@ let rec e_pattern_aq :
               FStar_TypeChecker_NBETerm.as_arg uu___2 in
             let uu___2 =
               let uu___3 =
-                let uu___4 =
-                  let uu___5 = FStar_TypeChecker_NBETerm.e_sealed e_term in
-                  FStar_TypeChecker_NBETerm.embed uu___5 cb sort in
+                let uu___4 = FStar_TypeChecker_NBETerm.embed e_sort cb sort in
                 FStar_TypeChecker_NBETerm.as_arg uu___4 in
               [uu___3] in
             uu___1 :: uu___2 in
@@ -594,9 +600,7 @@ let rec e_pattern_aq :
           let uu___2 = FStar_TypeChecker_NBETerm.unembed e_bv cb bv in
           FStar_Compiler_Util.bind_opt uu___2
             (fun bv1 ->
-               let uu___3 =
-                 let uu___4 = FStar_TypeChecker_NBETerm.e_sealed e_term in
-                 FStar_TypeChecker_NBETerm.unembed uu___4 cb sort in
+               let uu___3 = FStar_TypeChecker_NBETerm.unembed e_sort cb sort in
                FStar_Compiler_Util.bind_opt uu___3
                  (fun sort1 ->
                     FStar_Pervasives_Native.Some
@@ -1390,10 +1394,9 @@ let (e_bv_view :
     let uu___ =
       let uu___1 =
         let uu___2 =
-          let uu___3 =
-            FStar_TypeChecker_NBETerm.e_sealed
-              FStar_TypeChecker_NBETerm.e_string in
-          FStar_TypeChecker_NBETerm.embed uu___3 cb
+          FStar_TypeChecker_NBETerm.embed
+            (FStar_TypeChecker_NBETerm.e_sealed
+               FStar_TypeChecker_NBETerm.e_string) cb
             bvv.FStar_Reflection_V1_Data.bv_ppname in
         FStar_TypeChecker_NBETerm.as_arg uu___2 in
       let uu___2 =
@@ -1415,10 +1418,9 @@ let (e_bv_view :
           FStar_Reflection_V1_Constants.ref_Mk_bv.FStar_Reflection_V1_Constants.lid
         ->
         let uu___3 =
-          let uu___4 =
-            FStar_TypeChecker_NBETerm.e_sealed
-              FStar_TypeChecker_NBETerm.e_string in
-          FStar_TypeChecker_NBETerm.unembed uu___4 cb nm in
+          FStar_TypeChecker_NBETerm.unembed
+            (FStar_TypeChecker_NBETerm.e_sealed
+               FStar_TypeChecker_NBETerm.e_string) cb nm in
         FStar_Compiler_Util.bind_opt uu___3
           (fun nm1 ->
              let uu___4 =

--- a/ocaml/fstar-lib/generated/FStar_Reflection_V2_Builtins.ml
+++ b/ocaml/fstar-lib/generated/FStar_Reflection_V2_Builtins.ml
@@ -164,9 +164,11 @@ let rec (inspect_pat :
                | (p1, b) -> let uu___2 = inspect_pat p1 in (uu___2, b)) ps in
         FStar_Reflection_V2_Data.Pat_Cons (fv, us_opt, uu___)
     | FStar_Syntax_Syntax.Pat_var bv ->
-        let uu___ = FStar_Ident.string_of_id bv.FStar_Syntax_Syntax.ppname in
+        let uu___ =
+          let uu___1 = FStar_Ident.string_of_id bv.FStar_Syntax_Syntax.ppname in
+          FStar_Compiler_Sealed.seal uu___1 in
         FStar_Reflection_V2_Data.Pat_Var
-          ((bv.FStar_Syntax_Syntax.sort), uu___)
+          ((FStar_Compiler_Sealed.seal bv.FStar_Syntax_Syntax.sort), uu___)
     | FStar_Syntax_Syntax.Pat_dot_term eopt ->
         FStar_Reflection_V2_Data.Pat_Dot_Term eopt
 let rec (inspect_ln :
@@ -469,7 +471,8 @@ let rec (pack_pat :
         wrap uu___
     | FStar_Reflection_V2_Data.Pat_Var (sort, ppname) ->
         let bv =
-          FStar_Syntax_Syntax.gen_bv ppname FStar_Pervasives_Native.None sort in
+          FStar_Syntax_Syntax.gen_bv (FStar_Compiler_Sealed.unseal ppname)
+            FStar_Pervasives_Native.None (FStar_Compiler_Sealed.unseal sort) in
         wrap (FStar_Syntax_Syntax.Pat_var bv)
     | FStar_Reflection_V2_Data.Pat_Dot_Term eopt ->
         wrap (FStar_Syntax_Syntax.Pat_dot_term eopt)
@@ -1032,10 +1035,13 @@ let (inspect_namedv :
        FStar_Errors.log_issue FStar_Compiler_Range_Type.dummyRange uu___1)
     else ();
     (let uu___1 = FStar_BigInt.of_int_fs v.FStar_Syntax_Syntax.index in
-     let uu___2 = FStar_Ident.string_of_id v.FStar_Syntax_Syntax.ppname in
+     let uu___2 =
+       let uu___3 = FStar_Ident.string_of_id v.FStar_Syntax_Syntax.ppname in
+       FStar_Compiler_Sealed.seal uu___3 in
      {
        FStar_Reflection_V2_Data.uniq = uu___1;
-       FStar_Reflection_V2_Data.sort = (v.FStar_Syntax_Syntax.sort);
+       FStar_Reflection_V2_Data.sort =
+         (FStar_Compiler_Sealed.seal v.FStar_Syntax_Syntax.sort);
        FStar_Reflection_V2_Data.ppname = uu___2
      })
 let (pack_namedv :
@@ -1054,19 +1060,21 @@ let (pack_namedv :
              Prims.string_of_int uu___5 in
            FStar_Compiler_Util.format2
              "pack_namedv: uniq is negative (%s), uniq = %s"
-             vv.FStar_Reflection_V2_Data.ppname uu___4 in
+             (FStar_Compiler_Sealed.unseal vv.FStar_Reflection_V2_Data.ppname)
+             uu___4 in
          (FStar_Errors_Codes.Warning_CantInspect, uu___3) in
        FStar_Errors.log_issue FStar_Compiler_Range_Type.dummyRange uu___2
      else ());
     (let uu___1 =
        FStar_Ident.mk_ident
-         ((vv.FStar_Reflection_V2_Data.ppname),
+         ((FStar_Compiler_Sealed.unseal vv.FStar_Reflection_V2_Data.ppname),
            FStar_Compiler_Range_Type.dummyRange) in
      let uu___2 = FStar_BigInt.to_int_fs vv.FStar_Reflection_V2_Data.uniq in
      {
        FStar_Syntax_Syntax.ppname = uu___1;
        FStar_Syntax_Syntax.index = uu___2;
-       FStar_Syntax_Syntax.sort = (vv.FStar_Reflection_V2_Data.sort)
+       FStar_Syntax_Syntax.sort =
+         (FStar_Compiler_Sealed.unseal vv.FStar_Reflection_V2_Data.sort)
      })
 let (inspect_bv : FStar_Syntax_Syntax.bv -> FStar_Reflection_V2_Data.bv_view)
   =
@@ -1086,10 +1094,13 @@ let (inspect_bv : FStar_Syntax_Syntax.bv -> FStar_Reflection_V2_Data.bv_view)
        FStar_Errors.log_issue FStar_Compiler_Range_Type.dummyRange uu___1)
     else ();
     (let uu___1 = FStar_BigInt.of_int_fs bv.FStar_Syntax_Syntax.index in
-     let uu___2 = FStar_Ident.string_of_id bv.FStar_Syntax_Syntax.ppname in
+     let uu___2 =
+       let uu___3 = FStar_Ident.string_of_id bv.FStar_Syntax_Syntax.ppname in
+       FStar_Compiler_Sealed.seal uu___3 in
      {
        FStar_Reflection_V2_Data.index = uu___1;
-       FStar_Reflection_V2_Data.sort1 = (bv.FStar_Syntax_Syntax.sort);
+       FStar_Reflection_V2_Data.sort1 =
+         (FStar_Compiler_Sealed.seal bv.FStar_Syntax_Syntax.sort);
        FStar_Reflection_V2_Data.ppname1 = uu___2
      })
 let (pack_bv : FStar_Reflection_V2_Data.bv_view -> FStar_Syntax_Syntax.bv) =
@@ -1107,19 +1118,21 @@ let (pack_bv : FStar_Reflection_V2_Data.bv_view -> FStar_Syntax_Syntax.bv) =
              Prims.string_of_int uu___5 in
            FStar_Compiler_Util.format2
              "pack_bv: index is negative (%s), index = %s"
-             bvv.FStar_Reflection_V2_Data.ppname1 uu___4 in
+             (FStar_Compiler_Sealed.unseal
+                bvv.FStar_Reflection_V2_Data.ppname1) uu___4 in
          (FStar_Errors_Codes.Warning_CantInspect, uu___3) in
        FStar_Errors.log_issue FStar_Compiler_Range_Type.dummyRange uu___2
      else ());
     (let uu___1 =
        FStar_Ident.mk_ident
-         ((bvv.FStar_Reflection_V2_Data.ppname1),
+         ((FStar_Compiler_Sealed.unseal bvv.FStar_Reflection_V2_Data.ppname1),
            FStar_Compiler_Range_Type.dummyRange) in
      let uu___2 = FStar_BigInt.to_int_fs bvv.FStar_Reflection_V2_Data.index in
      {
        FStar_Syntax_Syntax.ppname = uu___1;
        FStar_Syntax_Syntax.index = uu___2;
-       FStar_Syntax_Syntax.sort = (bvv.FStar_Reflection_V2_Data.sort1)
+       FStar_Syntax_Syntax.sort =
+         (FStar_Compiler_Sealed.unseal bvv.FStar_Reflection_V2_Data.sort1)
      })
 let (inspect_binder :
   FStar_Syntax_Syntax.binder -> FStar_Reflection_V2_Data.binder_view) =
@@ -1130,8 +1143,10 @@ let (inspect_binder :
         b.FStar_Syntax_Syntax.binder_attrs in
     let uu___ = inspect_bqual b.FStar_Syntax_Syntax.binder_qual in
     let uu___1 =
-      FStar_Ident.string_of_id
-        (b.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.ppname in
+      let uu___2 =
+        FStar_Ident.string_of_id
+          (b.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.ppname in
+      FStar_Compiler_Sealed.seal uu___2 in
     {
       FStar_Reflection_V2_Data.sort2 =
         ((b.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort);
@@ -1150,7 +1165,8 @@ let (pack_binder :
         let uu___1 =
           let uu___2 =
             FStar_Ident.mk_ident
-              ((bview.FStar_Reflection_V2_Data.ppname2),
+              ((FStar_Compiler_Sealed.unseal
+                  bview.FStar_Reflection_V2_Data.ppname2),
                 FStar_Compiler_Range_Type.dummyRange) in
           {
             FStar_Syntax_Syntax.ppname = uu___2;
@@ -1180,7 +1196,9 @@ let (bv_to_binding :
   FStar_Syntax_Syntax.bv -> FStar_Reflection_V2_Data.binding) =
   fun bv ->
     let uu___ = FStar_BigInt.of_int_fs bv.FStar_Syntax_Syntax.index in
-    let uu___1 = FStar_Ident.string_of_id bv.FStar_Syntax_Syntax.ppname in
+    let uu___1 =
+      let uu___2 = FStar_Ident.string_of_id bv.FStar_Syntax_Syntax.ppname in
+      FStar_Compiler_Sealed.seal uu___2 in
     {
       FStar_Reflection_V2_Data.uniq1 = uu___;
       FStar_Reflection_V2_Data.sort3 = (bv.FStar_Syntax_Syntax.sort);

--- a/ocaml/fstar-lib/generated/FStar_Reflection_V2_Data.ml
+++ b/ocaml/fstar-lib/generated/FStar_Reflection_V2_Data.ml
@@ -2,6 +2,9 @@ open Prims
 type name = Prims.string Prims.list
 type typ = FStar_Syntax_Syntax.term
 type binders = FStar_Syntax_Syntax.binder Prims.list
+type ppname_t = Prims.string FStar_Compiler_Sealed.sealed
+let (as_ppname : Prims.string -> ppname_t) =
+  fun x -> FStar_Compiler_Sealed.seal x
 type simple_binder = FStar_Reflection_Types.binder
 type ident_view = (Prims.string * FStar_Compiler_Range_Type.range)
 type namedv = FStar_Syntax_Syntax.bv
@@ -45,7 +48,8 @@ type pattern =
   | Pat_Constant of vconst 
   | Pat_Cons of FStar_Syntax_Syntax.fv * universes
   FStar_Pervasives_Native.option * (pattern * Prims.bool) Prims.list 
-  | Pat_Var of FStar_Syntax_Syntax.term * Prims.string 
+  | Pat_Var of FStar_Syntax_Syntax.term FStar_Compiler_Sealed.sealed *
+  ppname_t 
   | Pat_Dot_Term of FStar_Syntax_Syntax.term FStar_Pervasives_Native.option 
 let (uu___is_Pat_Constant : pattern -> Prims.bool) =
   fun projectee ->
@@ -71,9 +75,10 @@ let (__proj__Pat_Cons__item__subpats :
 let (uu___is_Pat_Var : pattern -> Prims.bool) =
   fun projectee ->
     match projectee with | Pat_Var (sort, ppname) -> true | uu___ -> false
-let (__proj__Pat_Var__item__sort : pattern -> FStar_Syntax_Syntax.term) =
+let (__proj__Pat_Var__item__sort :
+  pattern -> FStar_Syntax_Syntax.term FStar_Compiler_Sealed.sealed) =
   fun projectee -> match projectee with | Pat_Var (sort, ppname) -> sort
-let (__proj__Pat_Var__item__ppname : pattern -> Prims.string) =
+let (__proj__Pat_Var__item__ppname : pattern -> ppname_t) =
   fun projectee -> match projectee with | Pat_Var (sort, ppname) -> ppname
 let (uu___is_Pat_Dot_Term : pattern -> Prims.bool) =
   fun projectee ->
@@ -95,30 +100,32 @@ let (uu___is_Q_Meta : aqualv -> Prims.bool) =
 let (__proj__Q_Meta__item___0 : aqualv -> FStar_Syntax_Syntax.term) =
   fun projectee -> match projectee with | Q_Meta _0 -> _0
 type argv = (FStar_Syntax_Syntax.term * aqualv)
-type ppname_t = Prims.string
-let (as_ppname : Prims.string -> Prims.string) = fun x -> x
-type namedv_view = {
+type namedv_view =
+  {
   uniq: FStar_BigInt.t ;
-  sort: typ ;
-  ppname: Prims.string }
+  sort: typ FStar_Compiler_Sealed.sealed ;
+  ppname: ppname_t }
 let (__proj__Mknamedv_view__item__uniq : namedv_view -> FStar_BigInt.t) =
   fun projectee -> match projectee with | { uniq; sort; ppname;_} -> uniq
-let (__proj__Mknamedv_view__item__sort : namedv_view -> typ) =
+let (__proj__Mknamedv_view__item__sort :
+  namedv_view -> typ FStar_Compiler_Sealed.sealed) =
   fun projectee -> match projectee with | { uniq; sort; ppname;_} -> sort
-let (__proj__Mknamedv_view__item__ppname : namedv_view -> Prims.string) =
+let (__proj__Mknamedv_view__item__ppname : namedv_view -> ppname_t) =
   fun projectee -> match projectee with | { uniq; sort; ppname;_} -> ppname
-type bv_view = {
+type bv_view =
+  {
   index: FStar_BigInt.t ;
-  sort1: typ ;
-  ppname1: Prims.string }
+  sort1: typ FStar_Compiler_Sealed.sealed ;
+  ppname1: ppname_t }
 let (__proj__Mkbv_view__item__index : bv_view -> FStar_BigInt.t) =
   fun projectee ->
     match projectee with
     | { index; sort1 = sort; ppname1 = ppname;_} -> index
-let (__proj__Mkbv_view__item__sort : bv_view -> typ) =
+let (__proj__Mkbv_view__item__sort :
+  bv_view -> typ FStar_Compiler_Sealed.sealed) =
   fun projectee ->
     match projectee with | { index; sort1 = sort; ppname1 = ppname;_} -> sort
-let (__proj__Mkbv_view__item__ppname : bv_view -> Prims.string) =
+let (__proj__Mkbv_view__item__ppname : bv_view -> ppname_t) =
   fun projectee ->
     match projectee with
     | { index; sort1 = sort; ppname1 = ppname;_} -> ppname
@@ -127,7 +134,7 @@ type binder_view =
   sort2: typ ;
   qual: aqualv ;
   attrs: FStar_Syntax_Syntax.term Prims.list ;
-  ppname2: Prims.string }
+  ppname2: ppname_t }
 let (__proj__Mkbinder_view__item__sort : binder_view -> typ) =
   fun projectee ->
     match projectee with
@@ -141,14 +148,14 @@ let (__proj__Mkbinder_view__item__attrs :
   fun projectee ->
     match projectee with
     | { sort2 = sort; qual; attrs; ppname2 = ppname;_} -> attrs
-let (__proj__Mkbinder_view__item__ppname : binder_view -> Prims.string) =
+let (__proj__Mkbinder_view__item__ppname : binder_view -> ppname_t) =
   fun projectee ->
     match projectee with
     | { sort2 = sort; qual; attrs; ppname2 = ppname;_} -> ppname
 type binding = {
   uniq1: FStar_BigInt.t ;
   sort3: typ ;
-  ppname3: Prims.string }
+  ppname3: ppname_t }
 let (__proj__Mkbinding__item__uniq : binding -> FStar_BigInt.t) =
   fun projectee ->
     match projectee with
@@ -157,7 +164,7 @@ let (__proj__Mkbinding__item__sort : binding -> typ) =
   fun projectee ->
     match projectee with
     | { uniq1 = uniq; sort3 = sort; ppname3 = ppname;_} -> sort
-let (__proj__Mkbinding__item__ppname : binding -> Prims.string) =
+let (__proj__Mkbinding__item__ppname : binding -> ppname_t) =
   fun projectee ->
     match projectee with
     | { uniq1 = uniq; sort3 = sort; ppname3 = ppname;_} -> ppname

--- a/ocaml/fstar-lib/generated/FStar_Reflection_V2_Embeddings.ml
+++ b/ocaml/fstar-lib/generated/FStar_Reflection_V2_Embeddings.ml
@@ -186,9 +186,11 @@ let (e_term :
   FStar_Syntax_Syntax.term FStar_Syntax_Embeddings_Base.embedding) =
   e_term_aq noaqs
 let (e_sort :
-  FStar_Syntax_Syntax.term FStar_Syntax_Embeddings_Base.embedding) =
-  FStar_Syntax_Embeddings.e_sealed e_term
-let (e_ppname : Prims.string FStar_Syntax_Embeddings_Base.embedding) =
+  FStar_Syntax_Syntax.term FStar_Compiler_Sealed.sealed
+    FStar_Syntax_Embeddings_Base.embedding)
+  = FStar_Syntax_Embeddings.e_sealed e_term
+let (e_ppname :
+  FStar_Reflection_V2_Data.ppname_t FStar_Syntax_Embeddings_Base.embedding) =
   FStar_Syntax_Embeddings.e_sealed FStar_Syntax_Embeddings.e_string
 let (e_aqualv :
   FStar_Reflection_V2_Data.aqualv FStar_Syntax_Embeddings_Base.embedding) =
@@ -587,7 +589,10 @@ let rec e_pattern_aq :
               FStar_Syntax_Syntax.as_arg uu___2 in
             let uu___2 =
               let uu___3 =
-                let uu___4 = embed e_ppname rng ppname in
+                let uu___4 =
+                  embed
+                    (FStar_Syntax_Embeddings.e_sealed
+                       FStar_Syntax_Embeddings.e_string) rng ppname in
                 FStar_Syntax_Syntax.as_arg uu___4 in
               [uu___3] in
             uu___1 :: uu___2 in
@@ -1311,7 +1316,10 @@ let (e_namedv_view :
         let uu___4 =
           let uu___5 =
             let uu___6 =
-              embed e_ppname rng namedvv.FStar_Reflection_V2_Data.ppname in
+              embed
+                (FStar_Syntax_Embeddings.e_sealed
+                   FStar_Syntax_Embeddings.e_string) rng
+                namedvv.FStar_Reflection_V2_Data.ppname in
             FStar_Syntax_Syntax.as_arg uu___6 in
           [uu___5] in
         uu___3 :: uu___4 in
@@ -1365,7 +1373,10 @@ let (e_bv_view :
         let uu___4 =
           let uu___5 =
             let uu___6 =
-              embed e_ppname rng bvv.FStar_Reflection_V2_Data.ppname1 in
+              embed
+                (FStar_Syntax_Embeddings.e_sealed
+                   FStar_Syntax_Embeddings.e_string) rng
+                bvv.FStar_Reflection_V2_Data.ppname1 in
             FStar_Syntax_Syntax.as_arg uu___6 in
           [uu___5] in
         uu___3 :: uu___4 in
@@ -1420,7 +1431,10 @@ let (e_binding :
         let uu___4 =
           let uu___5 =
             let uu___6 =
-              embed e_ppname rng bindingv.FStar_Reflection_V2_Data.ppname3 in
+              embed
+                (FStar_Syntax_Embeddings.e_sealed
+                   FStar_Syntax_Embeddings.e_string) rng
+                bindingv.FStar_Reflection_V2_Data.ppname3 in
             FStar_Syntax_Syntax.as_arg uu___6 in
           [uu___5] in
         uu___3 :: uu___4 in
@@ -1484,7 +1498,10 @@ let (e_binder_view :
           let uu___6 =
             let uu___7 =
               let uu___8 =
-                embed e_ppname rng bview.FStar_Reflection_V2_Data.ppname2 in
+                embed
+                  (FStar_Syntax_Embeddings.e_sealed
+                     FStar_Syntax_Embeddings.e_string) rng
+                  bview.FStar_Reflection_V2_Data.ppname2 in
               FStar_Syntax_Syntax.as_arg uu___8 in
             [uu___7] in
           uu___5 :: uu___6 in

--- a/ocaml/fstar-lib/generated/FStar_Reflection_V2_NBEEmbeddings.ml
+++ b/ocaml/fstar-lib/generated/FStar_Reflection_V2_NBEEmbeddings.ml
@@ -204,6 +204,14 @@ let (e_term_aq :
     }
 let (e_term : FStar_Syntax_Syntax.term FStar_TypeChecker_NBETerm.embedding) =
   e_term_aq (Prims.int_zero, [])
+let (e_sort :
+  FStar_Syntax_Syntax.term FStar_Compiler_Sealed.sealed
+    FStar_TypeChecker_NBETerm.embedding)
+  = FStar_TypeChecker_NBETerm.e_sealed e_term
+let (e_ppname :
+  Prims.string FStar_Compiler_Sealed.sealed
+    FStar_TypeChecker_NBETerm.embedding)
+  = FStar_TypeChecker_NBETerm.e_sealed FStar_TypeChecker_NBETerm.e_string
 let (e_aqualv :
   FStar_Reflection_V2_Data.aqualv FStar_TypeChecker_NBETerm.embedding) =
   let embed_aqualv cb q =
@@ -551,17 +559,12 @@ let rec e_pattern_aq :
       | FStar_Reflection_V2_Data.Pat_Var (sort, ppname) ->
           let uu___ =
             let uu___1 =
-              let uu___2 =
-                let uu___3 = FStar_TypeChecker_NBETerm.e_sealed e_term in
-                FStar_TypeChecker_NBETerm.embed uu___3 cb sort in
+              let uu___2 = FStar_TypeChecker_NBETerm.embed e_sort cb sort in
               FStar_TypeChecker_NBETerm.as_arg uu___2 in
             let uu___2 =
               let uu___3 =
                 let uu___4 =
-                  let uu___5 =
-                    FStar_TypeChecker_NBETerm.e_sealed
-                      FStar_TypeChecker_NBETerm.e_string in
-                  FStar_TypeChecker_NBETerm.embed uu___5 cb ppname in
+                  FStar_TypeChecker_NBETerm.embed e_ppname cb ppname in
                 FStar_TypeChecker_NBETerm.as_arg uu___4 in
               [uu___3] in
             uu___1 :: uu___2 in
@@ -622,16 +625,11 @@ let rec e_pattern_aq :
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_V2_Constants.ref_Pat_Var.FStar_Reflection_V2_Constants.lid
           ->
-          let uu___2 =
-            let uu___3 = FStar_TypeChecker_NBETerm.e_sealed e_term in
-            FStar_TypeChecker_NBETerm.unembed uu___3 cb sort in
+          let uu___2 = FStar_TypeChecker_NBETerm.unembed e_sort cb sort in
           FStar_Compiler_Util.bind_opt uu___2
             (fun sort1 ->
                let uu___3 =
-                 let uu___4 =
-                   FStar_TypeChecker_NBETerm.e_sealed
-                     FStar_TypeChecker_NBETerm.e_string in
-                 FStar_TypeChecker_NBETerm.unembed uu___4 cb ppname in
+                 FStar_TypeChecker_NBETerm.unembed e_ppname cb ppname in
                FStar_Compiler_Util.bind_opt uu___3
                  (fun ppname1 ->
                     FStar_Pervasives_Native.Some
@@ -1616,16 +1614,13 @@ let (e_namedv_view :
       let uu___2 =
         let uu___3 =
           let uu___4 =
-            let uu___5 =
-              FStar_TypeChecker_NBETerm.e_sealed
-                FStar_TypeChecker_NBETerm.e_string in
-            FStar_TypeChecker_NBETerm.embed uu___5 cb
+            FStar_TypeChecker_NBETerm.embed e_ppname cb
               namedvv.FStar_Reflection_V2_Data.ppname in
           FStar_TypeChecker_NBETerm.as_arg uu___4 in
         let uu___4 =
           let uu___5 =
             let uu___6 =
-              FStar_TypeChecker_NBETerm.embed e_term cb
+              FStar_TypeChecker_NBETerm.embed e_sort cb
                 namedvv.FStar_Reflection_V2_Data.sort in
             FStar_TypeChecker_NBETerm.as_arg uu___6 in
           [uu___5] in
@@ -1648,14 +1643,11 @@ let (e_namedv_view :
         FStar_Compiler_Util.bind_opt uu___4
           (fun uniq1 ->
              let uu___5 =
-               let uu___6 =
-                 FStar_TypeChecker_NBETerm.e_sealed
-                   FStar_TypeChecker_NBETerm.e_string in
-               FStar_TypeChecker_NBETerm.unembed uu___6 cb ppname in
+               FStar_TypeChecker_NBETerm.unembed e_ppname cb ppname in
              FStar_Compiler_Util.bind_opt uu___5
                (fun ppname1 ->
                   let uu___6 =
-                    FStar_TypeChecker_NBETerm.unembed e_term cb sort in
+                    FStar_TypeChecker_NBETerm.unembed e_sort cb sort in
                   FStar_Compiler_Util.bind_opt uu___6
                     (fun sort1 ->
                        let r =
@@ -1688,16 +1680,13 @@ let (e_bv_view :
       let uu___2 =
         let uu___3 =
           let uu___4 =
-            let uu___5 =
-              FStar_TypeChecker_NBETerm.e_sealed
-                FStar_TypeChecker_NBETerm.e_string in
-            FStar_TypeChecker_NBETerm.embed uu___5 cb
+            FStar_TypeChecker_NBETerm.embed e_ppname cb
               bvv.FStar_Reflection_V2_Data.ppname1 in
           FStar_TypeChecker_NBETerm.as_arg uu___4 in
         let uu___4 =
           let uu___5 =
             let uu___6 =
-              FStar_TypeChecker_NBETerm.embed e_term cb
+              FStar_TypeChecker_NBETerm.embed e_sort cb
                 bvv.FStar_Reflection_V2_Data.sort1 in
             FStar_TypeChecker_NBETerm.as_arg uu___6 in
           [uu___5] in
@@ -1719,14 +1708,11 @@ let (e_bv_view :
         FStar_Compiler_Util.bind_opt uu___4
           (fun idx1 ->
              let uu___5 =
-               let uu___6 =
-                 FStar_TypeChecker_NBETerm.e_sealed
-                   FStar_TypeChecker_NBETerm.e_string in
-               FStar_TypeChecker_NBETerm.unembed uu___6 cb ppname in
+               FStar_TypeChecker_NBETerm.unembed e_ppname cb ppname in
              FStar_Compiler_Util.bind_opt uu___5
                (fun ppname1 ->
                   let uu___6 =
-                    FStar_TypeChecker_NBETerm.unembed e_term cb sort in
+                    FStar_TypeChecker_NBETerm.unembed e_sort cb sort in
                   FStar_Compiler_Util.bind_opt uu___6
                     (fun sort1 ->
                        let r =
@@ -1771,10 +1757,7 @@ let (e_binding :
         let uu___4 =
           let uu___5 =
             let uu___6 =
-              let uu___7 =
-                FStar_TypeChecker_NBETerm.e_sealed
-                  FStar_TypeChecker_NBETerm.e_string in
-              FStar_TypeChecker_NBETerm.embed uu___7 cb
+              FStar_TypeChecker_NBETerm.embed e_ppname cb
                 b.FStar_Reflection_V2_Data.ppname3 in
             FStar_TypeChecker_NBETerm.as_arg uu___6 in
           [uu___5] in
@@ -1800,10 +1783,7 @@ let (e_binding :
              FStar_Compiler_Util.bind_opt uu___5
                (fun sort1 ->
                   let uu___6 =
-                    let uu___7 =
-                      FStar_TypeChecker_NBETerm.e_sealed
-                        FStar_TypeChecker_NBETerm.e_string in
-                    FStar_TypeChecker_NBETerm.unembed uu___7 cb ppname in
+                    FStar_TypeChecker_NBETerm.unembed e_ppname cb ppname in
                   FStar_Compiler_Util.bind_opt uu___6
                     (fun ppname1 ->
                        let r =
@@ -1838,10 +1818,7 @@ let (e_binder_view :
           let uu___6 =
             let uu___7 =
               let uu___8 =
-                let uu___9 =
-                  FStar_TypeChecker_NBETerm.e_sealed
-                    FStar_TypeChecker_NBETerm.e_string in
-                FStar_TypeChecker_NBETerm.embed uu___9 cb
+                FStar_TypeChecker_NBETerm.embed e_ppname cb
                   bview.FStar_Reflection_V2_Data.ppname2 in
               FStar_TypeChecker_NBETerm.as_arg uu___8 in
             [uu___7] in
@@ -1871,10 +1848,7 @@ let (e_binder_view :
                   FStar_Compiler_Util.bind_opt uu___7
                     (fun attrs1 ->
                        let uu___8 =
-                         let uu___9 =
-                           FStar_TypeChecker_NBETerm.e_sealed
-                             FStar_TypeChecker_NBETerm.e_string in
-                         FStar_TypeChecker_NBETerm.unembed uu___9 cb ppname in
+                         FStar_TypeChecker_NBETerm.unembed e_ppname cb ppname in
                        FStar_Compiler_Util.bind_opt uu___8
                          (fun ppname1 ->
                             let r =

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Embeddings.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Embeddings.ml
@@ -2202,7 +2202,7 @@ let e_arrow :
 let e_sealed :
   'a .
     'a FStar_Syntax_Embeddings_Base.embedding ->
-      'a FStar_Syntax_Embeddings_Base.embedding
+      'a FStar_Compiler_Sealed.sealed FStar_Syntax_Embeddings_Base.embedding
   =
   fun ea ->
     let typ uu___ =
@@ -2219,7 +2219,8 @@ let e_sealed :
     let printer1 x =
       let uu___ =
         let uu___1 =
-          let uu___2 = FStar_Syntax_Embeddings_Base.printer_of ea in uu___2 x in
+          let uu___2 = FStar_Syntax_Embeddings_Base.printer_of ea in
+          uu___2 (FStar_Compiler_Sealed.unseal x) in
         Prims.strcat uu___1 ")" in
       Prims.strcat "(seal " uu___ in
     let em a1 rng shadow norm =
@@ -2249,26 +2250,43 @@ let e_sealed :
         let uu___3 =
           let uu___4 =
             let uu___5 =
-              let uu___6 = FStar_Syntax_Embeddings_Base.embed ea a1 in
+              let uu___6 =
+                FStar_Syntax_Embeddings_Base.embed ea
+                  (FStar_Compiler_Sealed.unseal a1) in
               uu___6 rng shadow_a norm in
             FStar_Syntax_Syntax.as_arg uu___5 in
           [uu___4] in
         uu___2 :: uu___3 in
       FStar_Syntax_Syntax.mk_Tm_app uu___ uu___1 rng in
-    let un t norm =
-      let uu___ = FStar_Syntax_Util.head_and_args_full t in
-      match uu___ with
-      | (hd, args) ->
-          let uu___1 =
-            let uu___2 =
-              let uu___3 = FStar_Syntax_Util.un_uinst hd in
-              uu___3.FStar_Syntax_Syntax.n in
-            (uu___2, args) in
-          (match uu___1 with
-           | (FStar_Syntax_Syntax.Tm_fvar fv, uu___2::(a1, uu___3)::[]) when
-               FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.seal_lid
-               -> FStar_Syntax_Embeddings_Base.try_unembed ea a1 norm
-           | uu___2 -> FStar_Pervasives_Native.None) in
+    let un uu___1 uu___ =
+      (fun t ->
+         fun norm ->
+           let uu___ = FStar_Syntax_Util.head_and_args_full t in
+           match uu___ with
+           | (hd, args) ->
+               let uu___1 =
+                 let uu___2 =
+                   let uu___3 = FStar_Syntax_Util.un_uinst hd in
+                   uu___3.FStar_Syntax_Syntax.n in
+                 (uu___2, args) in
+               (match uu___1 with
+                | (FStar_Syntax_Syntax.Tm_fvar fv, uu___2::(a1, uu___3)::[])
+                    when
+                    FStar_Syntax_Syntax.fv_eq_lid fv
+                      FStar_Parser_Const.seal_lid
+                    ->
+                    Obj.magic
+                      (Obj.repr
+                         (let uu___4 =
+                            FStar_Syntax_Embeddings_Base.try_unembed ea a1
+                              norm in
+                          FStar_Class_Monad.fmap
+                            FStar_Class_Monad.monad_option () ()
+                            (fun uu___5 ->
+                               (Obj.magic FStar_Compiler_Sealed.seal) uu___5)
+                            (Obj.magic uu___4)))
+                | uu___2 -> Obj.magic (Obj.repr FStar_Pervasives_Native.None)))
+        uu___1 uu___ in
     FStar_Syntax_Embeddings_Base.mk_emb_full em un typ printer1 emb_ty_a
 let (e___range :
   FStar_Compiler_Range_Type.range FStar_Syntax_Embeddings_Base.embedding) =
@@ -2293,7 +2311,9 @@ let (e___range :
        FStar_Syntax_Syntax.ET_app uu___1)
 let (e_range :
   FStar_Compiler_Range_Type.range FStar_Syntax_Embeddings_Base.embedding) =
-  e_sealed e___range
+  FStar_Syntax_Embeddings_Base.embed_as (e_sealed e___range)
+    FStar_Compiler_Sealed.unseal FStar_Compiler_Sealed.seal
+    FStar_Pervasives_Native.None
 let (e_issue : FStar_Errors.issue FStar_Syntax_Embeddings_Base.embedding) =
   let uu___ =
     FStar_Syntax_Syntax.fvar FStar_Parser_Const.issue_lid

--- a/ocaml/fstar-lib/generated/FStar_Tactics_V1_Basic.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_V1_Basic.ml
@@ -8518,7 +8518,9 @@ let rec (inspect :
                            FStar_Reflection_V1_Data.Pat_Cons uu___3
                        | FStar_Syntax_Syntax.Pat_var bv ->
                            FStar_Reflection_V1_Data.Pat_Var
-                             (bv, (bv.FStar_Syntax_Syntax.sort))
+                             (bv,
+                               (FStar_Compiler_Sealed.seal
+                                  bv.FStar_Syntax_Syntax.sort))
                        | FStar_Syntax_Syntax.Pat_dot_term eopt ->
                            FStar_Reflection_V1_Data.Pat_Dot_Term eopt in
                      let brs1 =

--- a/ocaml/fstar-lib/generated/FStar_Tactics_V2_Basic.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_V2_Basic.ml
@@ -3023,8 +3023,10 @@ let (bv_to_binding :
   fun bv ->
     let uu___ = FStar_BigInt.of_int_fs bv.FStar_Syntax_Syntax.index in
     let uu___1 =
-      FStar_Class_Show.show FStar_Ident.showable_ident
-        bv.FStar_Syntax_Syntax.ppname in
+      let uu___2 =
+        FStar_Class_Show.show FStar_Ident.showable_ident
+          bv.FStar_Syntax_Syntax.ppname in
+      FStar_Compiler_Sealed.seal uu___2 in
     {
       FStar_Reflection_V2_Data.uniq1 = uu___;
       FStar_Reflection_V2_Data.sort3 = (bv.FStar_Syntax_Syntax.sort);
@@ -3042,13 +3044,14 @@ let (binding_to_string : FStar_Reflection_V2_Data.binding -> Prims.string) =
           (FStar_Class_Show.printableshow FStar_Class_Printable.printable_int)
           uu___2 in
       Prims.strcat "#" uu___1 in
-    Prims.strcat b.FStar_Reflection_V2_Data.ppname3 uu___
+    Prims.strcat
+      (FStar_Compiler_Sealed.unseal b.FStar_Reflection_V2_Data.ppname3) uu___
 let (binding_to_bv :
   FStar_Reflection_V2_Data.binding -> FStar_Syntax_Syntax.bv) =
   fun b ->
     let uu___ =
       FStar_Ident.mk_ident
-        ((b.FStar_Reflection_V2_Data.ppname3),
+        ((FStar_Compiler_Sealed.unseal b.FStar_Reflection_V2_Data.ppname3),
           FStar_Compiler_Range_Type.dummyRange) in
     let uu___1 = FStar_BigInt.to_int_fs b.FStar_Reflection_V2_Data.uniq1 in
     {
@@ -5504,7 +5507,9 @@ let (rename_to :
                                                             =
                                                             (b.FStar_Reflection_V2_Data.sort3);
                                                           FStar_Reflection_V2_Data.ppname3
-                                                            = s
+                                                            =
+                                                            (FStar_Compiler_Sealed.seal
+                                                               s)
                                                         }))) uu___4))))
                              uu___2))) uu___1)) in
       FStar_Tactics_Monad.wrap_err "rename_to" uu___

--- a/ocaml/fstar-lib/generated/FStar_Tactics_V2_Primops.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_V2_Primops.ml
@@ -3,22 +3,24 @@ let solve : 'a . 'a -> 'a = fun ev -> ev
 let (uu___2 :
   FStar_Syntax_Syntax.term FStar_Syntax_Embeddings_Base.embedding) =
   FStar_Reflection_V2_Embeddings.e_term
-let unseal : 'uuuuu 'a . 'uuuuu -> 'a -> 'a FStar_Tactics_Monad.tac =
+let unseal :
+  'uuuuu 'a .
+    'uuuuu -> 'a FStar_Compiler_Sealed.sealed -> 'a FStar_Tactics_Monad.tac
+  =
   fun uu___1 ->
     fun uu___ ->
       (fun _typ ->
          fun x ->
            Obj.magic
              (FStar_Class_Monad.return FStar_Tactics_Monad.monad_tac ()
-                (Obj.magic x))) uu___1 uu___
+                (Obj.magic (FStar_Compiler_Sealed.unseal x)))) uu___1 uu___
 let (unseal_step : FStar_TypeChecker_Primops_Base.primitive_step) =
   let s =
-    let uu___ =
-      FStar_TypeChecker_NBETerm.e_sealed FStar_TypeChecker_NBETerm.e_any in
     FStar_Tactics_InterpFuns.mk_tac_step_2 Prims.int_one "unseal"
       FStar_Syntax_Embeddings.e_any
       (FStar_Syntax_Embeddings.e_sealed FStar_Syntax_Embeddings.e_any)
-      FStar_Syntax_Embeddings.e_any FStar_TypeChecker_NBETerm.e_any uu___
+      FStar_Syntax_Embeddings.e_any FStar_TypeChecker_NBETerm.e_any
+      (FStar_TypeChecker_NBETerm.e_sealed FStar_TypeChecker_NBETerm.e_any)
       FStar_TypeChecker_NBETerm.e_any unseal unseal in
   {
     FStar_TypeChecker_Primops_Base.name = FStar_Parser_Const.unseal_lid;

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_NBETerm.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_NBETerm.ml
@@ -1704,7 +1704,8 @@ let (e_norm_step : FStar_Pervasives.norm_step embedding) =
        mkFV uu___1 [] [])
     (FStar_Syntax_Embeddings_Base.emb_typ_of
        FStar_Syntax_Embeddings.e_norm_step)
-let e_sealed : 'a . 'a embedding -> 'a embedding =
+let e_sealed : 'a . 'a embedding -> 'a FStar_Compiler_Sealed.sealed embedding
+  =
   fun ea ->
     let etyp uu___ =
       let uu___1 =
@@ -1715,7 +1716,9 @@ let e_sealed : 'a . 'a embedding -> 'a embedding =
       lazy_embed etyp x
         (fun uu___ ->
            let uu___1 =
-             let uu___2 = let uu___3 = embed ea cb x in as_arg uu___3 in
+             let uu___2 =
+               let uu___3 = embed ea cb (FStar_Compiler_Sealed.unseal x) in
+               as_arg uu___3 in
              let uu___3 =
                let uu___4 = let uu___5 = type_of ea in as_iarg uu___5 in
                [uu___4] in
@@ -1724,12 +1727,23 @@ let e_sealed : 'a . 'a embedding -> 'a embedding =
              [FStar_Syntax_Syntax.U_zero] uu___1) in
     let un1 cb trm =
       lazy_unembed etyp trm
-        (fun trm1 ->
-           match trm1.nbe_t with
-           | Construct (fvar, us, (a1, uu___)::uu___1::[]) when
-               FStar_Syntax_Syntax.fv_eq_lid fvar FStar_Parser_Const.seal_lid
-               -> unembed ea cb a1
-           | uu___ -> FStar_Pervasives_Native.None) in
+        (fun uu___ ->
+           (fun trm1 ->
+              match trm1.nbe_t with
+              | Construct (fvar, us, (a1, uu___)::uu___1::[]) when
+                  FStar_Syntax_Syntax.fv_eq_lid fvar
+                    FStar_Parser_Const.seal_lid
+                  ->
+                  Obj.magic
+                    (Obj.repr
+                       (let uu___2 = unembed ea cb a1 in
+                        FStar_Class_Monad.fmap FStar_Class_Monad.monad_option
+                          () ()
+                          (fun uu___3 ->
+                             (Obj.magic FStar_Compiler_Sealed.seal) uu___3)
+                          (Obj.magic uu___2)))
+              | uu___ -> Obj.magic (Obj.repr FStar_Pervasives_Native.None))
+             uu___) in
     mk_emb em1 un1
       (fun uu___ ->
          let uu___1 =

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Primops.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Primops.ml
@@ -766,7 +766,9 @@ let (seal_steps : FStar_TypeChecker_Primops_Base.primitive_step Prims.list) =
                          FStar_Pervasives_Native.Some f1) ->
                           let r =
                             let uu___5 =
-                              let uu___6 = FStar_Syntax_Syntax.as_arg s1 in
+                              let uu___6 =
+                                FStar_Syntax_Syntax.as_arg
+                                  (FStar_Compiler_Sealed.unseal s1) in
                               [uu___6] in
                             FStar_Syntax_Util.mk_app f1 uu___5 in
                           let emb =
@@ -775,7 +777,8 @@ let (seal_steps : FStar_TypeChecker_Primops_Base.primitive_step Prims.list) =
                           let uu___5 =
                             FStar_TypeChecker_Primops_Base.embed_simple
                               (FStar_Syntax_Embeddings.e_sealed emb)
-                              psc.FStar_TypeChecker_Primops_Base.psc_range r in
+                              psc.FStar_TypeChecker_Primops_Base.psc_range
+                              (FStar_Compiler_Sealed.seal r) in
                           FStar_Pervasives_Native.Some uu___5
                       | uu___5 -> FStar_Pervasives_Native.None)
                  | uu___ -> FStar_Pervasives_Native.None)),
@@ -792,10 +795,9 @@ let (seal_steps : FStar_TypeChecker_Primops_Base.primitive_step Prims.list) =
                      let uu___6 =
                        try_unembed FStar_TypeChecker_NBETerm.e_any tb in
                      let uu___7 =
-                       let uu___8 =
-                         FStar_TypeChecker_NBETerm.e_sealed
-                           FStar_TypeChecker_NBETerm.e_any in
-                       try_unembed uu___8 s in
+                       try_unembed
+                         (FStar_TypeChecker_NBETerm.e_sealed
+                            FStar_TypeChecker_NBETerm.e_any) s in
                      let uu___8 =
                        try_unembed FStar_TypeChecker_NBETerm.e_any f in
                      (uu___5, uu___6, uu___7, uu___8) in
@@ -806,15 +808,18 @@ let (seal_steps : FStar_TypeChecker_Primops_Base.primitive_step Prims.list) =
                        FStar_Pervasives_Native.Some f1) ->
                         let r =
                           let uu___5 =
-                            let uu___6 = FStar_TypeChecker_NBETerm.as_arg s1 in
+                            let uu___6 =
+                              FStar_TypeChecker_NBETerm.as_arg
+                                (FStar_Compiler_Sealed.unseal s1) in
                             [uu___6] in
                           cb.FStar_TypeChecker_NBETerm.iapp f1 uu___5 in
                         let emb =
                           FStar_TypeChecker_NBETerm.set_type ta1
                             FStar_TypeChecker_NBETerm.e_any in
                         let uu___5 =
-                          let uu___6 = FStar_TypeChecker_NBETerm.e_sealed emb in
-                          FStar_TypeChecker_NBETerm.embed uu___6 cb r in
+                          FStar_TypeChecker_NBETerm.embed
+                            (FStar_TypeChecker_NBETerm.e_sealed emb) cb
+                            (FStar_Compiler_Sealed.seal r) in
                         FStar_Pervasives_Native.Some uu___5
                     | uu___5 -> FStar_Pervasives_Native.None)
                | uu___ -> FStar_Pervasives_Native.None)));
@@ -848,7 +853,9 @@ let (seal_steps : FStar_TypeChecker_Primops_Base.primitive_step Prims.list) =
                         FStar_Pervasives_Native.Some f1) ->
                          let r =
                            let uu___5 =
-                             let uu___6 = FStar_Syntax_Syntax.as_arg s1 in
+                             let uu___6 =
+                               FStar_Syntax_Syntax.as_arg
+                                 (FStar_Compiler_Sealed.unseal s1) in
                              [uu___6] in
                            FStar_Syntax_Util.mk_app f1 uu___5 in
                          let uu___5 =
@@ -871,10 +878,9 @@ let (seal_steps : FStar_TypeChecker_Primops_Base.primitive_step Prims.list) =
                     let uu___6 =
                       try_unembed FStar_TypeChecker_NBETerm.e_any tb in
                     let uu___7 =
-                      let uu___8 =
-                        FStar_TypeChecker_NBETerm.e_sealed
-                          FStar_TypeChecker_NBETerm.e_any in
-                      try_unembed uu___8 s in
+                      try_unembed
+                        (FStar_TypeChecker_NBETerm.e_sealed
+                           FStar_TypeChecker_NBETerm.e_any) s in
                     let uu___8 =
                       try_unembed FStar_TypeChecker_NBETerm.e_any f in
                     (uu___5, uu___6, uu___7, uu___8) in
@@ -885,7 +891,9 @@ let (seal_steps : FStar_TypeChecker_Primops_Base.primitive_step Prims.list) =
                       FStar_Pervasives_Native.Some f1) ->
                        let r =
                          let uu___5 =
-                           let uu___6 = FStar_TypeChecker_NBETerm.as_arg s1 in
+                           let uu___6 =
+                             FStar_TypeChecker_NBETerm.as_arg
+                               (FStar_Compiler_Sealed.unseal s1) in
                            [uu___6] in
                          cb.FStar_TypeChecker_NBETerm.iapp f1 uu___5 in
                        let emb =

--- a/src/basic/FStar.Compiler.Sealed.fst
+++ b/src/basic/FStar.Compiler.Sealed.fst
@@ -1,0 +1,33 @@
+(*
+   Copyright 2008-2024 Nikhil Swamy and Microsoft Research
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*)
+module FStar.Compiler.Sealed
+
+(* This is the compiler-space version of the Sealed module in ulib.
+Here, we define it as just an identity, but we do not expose that in
+the interface so we must use the seal/unseal operations. This allows us
+to
+
+  1) make sure we do not make mistakes forgetting to seal/unseal
+  2) make sure none of these operations have any runtime behavior.
+
+It would be nicer to just make this a box type and expose that (internally
+to the compiler) but that means extracted code would use the box. *)
+
+type sealed (a:Type u#a) : Type u#a = a
+
+let seal (x: 'a) : sealed 'a = x
+
+let unseal (x: sealed 'a) : 'a = x

--- a/src/basic/FStar.Compiler.Sealed.fsti
+++ b/src/basic/FStar.Compiler.Sealed.fsti
@@ -1,0 +1,22 @@
+(*
+   Copyright 2008-2024 Nikhil Swamy and Microsoft Research
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*)
+module FStar.Compiler.Sealed
+
+val sealed (a:Type u#a) : Type u#a
+
+val seal (x: 'a) : Tot (sealed 'a)
+
+val unseal (x: sealed 'a) : Tot 'a

--- a/src/reflection/FStar.Reflection.V1.Builtins.fst
+++ b/src/reflection/FStar.Reflection.V1.Builtins.fst
@@ -273,7 +273,7 @@ let rec inspect_ln (t:term) : term_view =
             match p.v with
             | Pat_constant c -> Pat_Constant (inspect_const c)
             | Pat_cons (fv, us_opt, ps) -> Pat_Cons (fv, us_opt, List.map (fun (p, b) -> inspect_pat p, b) ps)
-            | Pat_var bv -> Pat_Var (bv, bv.sort)
+            | Pat_var bv -> Pat_Var (bv, Sealed.seal bv.sort)
             | Pat_dot_term eopt -> Pat_Dot_Term eopt
         in
         let brs = List.map (function (pat, _, t) -> (inspect_pat pat, t)) brs in
@@ -708,7 +708,7 @@ let inspect_bv (bv:bv) : bv_view =
                                          (string_of_int bv.index))
     );
     {
-      bv_ppname = Ident.string_of_id bv.ppname;
+      bv_ppname = Sealed.seal <| Ident.string_of_id bv.ppname;
       bv_index = Z.of_int_fs bv.index;
     }
 
@@ -716,11 +716,11 @@ let pack_bv (bvv:bv_view) : bv =
     if Z.to_int_fs bvv.bv_index < 0 then (
         Err.log_issue Range.dummyRange
             (Err.Warning_CantInspect, BU.format2 "pack_bv: index is negative (%s), index = %s"
-                                         bvv.bv_ppname
+                                         (Sealed.unseal bvv.bv_ppname)
                                          (string_of_int (Z.to_int_fs bvv.bv_index)))
     );
     {
-      ppname = Ident.mk_ident (bvv.bv_ppname, Range.dummyRange);
+      ppname = Ident.mk_ident (Sealed.unseal <| bvv.bv_ppname, Range.dummyRange);
       index = Z.to_int_fs bvv.bv_index; // Guaranteed to be a nat
       sort = S.tun;
     }

--- a/src/reflection/FStar.Reflection.V1.Data.fst
+++ b/src/reflection/FStar.Reflection.V1.Data.fst
@@ -38,7 +38,7 @@ open FStar.Ident
    functions in the interface are not supported for extraction. So,
    we include them in this module implementation file to force them
    to be extracted *)
-let as_ppname (x:string) : Tot string = x
+let as_ppname (x:string) : Tot ppname_t = FStar.Compiler.Sealed.seal x
 
 let notAscription (tv:term_view) : Tot bool =
   not (Tv_AscribedT? tv) && not (Tv_AscribedC? tv)

--- a/src/reflection/FStar.Reflection.V1.Data.fsti
+++ b/src/reflection/FStar.Reflection.V1.Data.fsti
@@ -23,6 +23,7 @@ any .ml file from an interface. Hence we keep both, exactly equal to
 each other. *)
 open FStar.Compiler.List
 open FStar.Syntax.Syntax
+open FStar.Compiler.Sealed
 module Ident = FStar.Ident
 module Range = FStar.Compiler.Range
 module Z     = FStar.BigInt
@@ -49,7 +50,7 @@ type universes = list universe
 type pattern =
     | Pat_Constant of vconst
     | Pat_Cons     of fv * option (list universe) * list (pattern * bool)
-    | Pat_Var      of bv * typ
+    | Pat_Var      of bv * sealed typ
     | Pat_Dot_Term of option term
 
 type branch = pattern * term
@@ -61,10 +62,11 @@ type aqualv =
 
 type argv = term * aqualv
 
-val as_ppname (s:string) : Tot string
+type ppname_t = sealed string
+val as_ppname (s:string) : Tot ppname_t
 
 type bv_view = {
-    bv_ppname : string;
+    bv_ppname : ppname_t;
     bv_index : Z.t;
 }
 

--- a/src/reflection/FStar.Reflection.V1.NBEEmbeddings.fst
+++ b/src/reflection/FStar.Reflection.V1.NBEEmbeddings.fst
@@ -133,6 +133,9 @@ let e_term_aq aq =
 
 let e_term = e_term_aq (0, [])
 
+let e_sort = e_sealed e_term
+let e_ppname = e_sealed e_string
+
 let e_aqualv =
     let embed_aqualv cb (q : aqualv) : t =
         match q with
@@ -274,7 +277,7 @@ let rec e_pattern_aq aq =
                as_arg (embed (e_option (e_list e_universe)) cb us_opt);
                as_arg (embed (e_list (e_tuple2 (e_pattern_aq aq) e_bool)) cb ps)]
         | Pat_Var (bv, sort) ->
-            mkConstruct ref_Pat_Var.fv [] [as_arg (embed e_bv cb bv); as_arg (embed (e_sealed e_term) cb sort)]
+            mkConstruct ref_Pat_Var.fv [] [as_arg (embed e_bv cb bv); as_arg (embed e_sort cb sort)]
         | Pat_Dot_Term eopt ->
             mkConstruct ref_Pat_Dot_Term.fv [] [as_arg (embed (e_option e_term) cb eopt)]
     in
@@ -292,7 +295,7 @@ let rec e_pattern_aq aq =
 
         | Construct (fv, [], [(sort, _); (bv, _)]) when S.fv_eq_lid fv ref_Pat_Var.lid ->
             BU.bind_opt (unembed e_bv cb bv) (fun bv ->
-            BU.bind_opt (unembed (e_sealed e_term) cb sort) (fun sort ->
+            BU.bind_opt (unembed e_sort cb sort) (fun sort ->
             Some <| Pat_Var (bv, sort)))
 
         | Construct (fv, [], [(eopt, _)]) when S.fv_eq_lid fv ref_Pat_Dot_Term.lid ->

--- a/src/reflection/FStar.Reflection.V2.Data.fst
+++ b/src/reflection/FStar.Reflection.V2.Data.fst
@@ -38,8 +38,7 @@ open FStar.Ident
    functions in the interface are not supported for extraction. So,
    we include them in this module implementation file to force them
    to be extracted *)
-type ppname_t = string
-let as_ppname (x:string) : Tot string = x
+let as_ppname (x:string) : Tot ppname_t = FStar.Compiler.Sealed.seal x
 
 let notAscription (tv:term_view) : Tot bool =
   not (Tv_AscribedT? tv) && not (Tv_AscribedC? tv)

--- a/src/reflection/FStar.Reflection.V2.Data.fsti
+++ b/src/reflection/FStar.Reflection.V2.Data.fsti
@@ -27,10 +27,14 @@ module Ident = FStar.Ident
 module Range = FStar.Compiler.Range
 module Z     = FStar.BigInt
 open FStar.Ident
+open FStar.Compiler.Sealed
 
 type name = list string
 type typ  = term
 type binders = list binder
+
+type ppname_t = sealed string
+val as_ppname (s:string) : Tot ppname_t
 
 let binder_is_simple (b:Stubs.Reflection.Types.binder) : Tot Type0 = True
 
@@ -73,8 +77,8 @@ type pattern =
  // else here but a ppname, the variable is referred to by its DB index.
  // This means all Pat_Var are provably equal.
  | Pat_Var :
-     sort   : term ->
-     ppname : string ->
+     sort   : sealed term ->
+     ppname : ppname_t ->
      pattern
 
  // Dot pattern: resolved by other elements in the pattern and type
@@ -91,31 +95,29 @@ type aqualv =
 
 type argv = term * aqualv
 
-val as_ppname (s:string) : Tot string
-
 type namedv_view = {
   uniq   : Z.t;
-  sort   : typ;
-  ppname : string;
+  sort   : sealed typ;
+  ppname : ppname_t;
 }
 
 type bv_view = {
   index  : Z.t;
-  sort   : typ;
-  ppname : string;
+  sort   : sealed typ;
+  ppname : ppname_t;
 }
 
 type binder_view = {
   sort   : typ;
   qual   : aqualv;
   attrs  : list term;
-  ppname : string;
+  ppname : ppname_t;
 }
 
 type binding = {
   uniq   : Z.t;
   sort   : typ;
-  ppname : string;
+  ppname : ppname_t;
 }
 type bindings = list binding
 

--- a/src/reflection/FStar.Reflection.V2.Embeddings.fst
+++ b/src/reflection/FStar.Reflection.V2.Embeddings.fst
@@ -129,8 +129,8 @@ let e_term_aq aq =
 
 let e_term = e_term_aq noaqs
 
-let e_sort   : embedding term   = e_sealed e_term
-let e_ppname : embedding string = e_sealed e_string
+let e_sort   : embedding (Sealed.sealed term)   = e_sealed e_term
+let e_ppname : embedding ppname_t = e_sealed e_string
 
 let e_aqualv =
     let embed_aqualv (rng:Range.range) (q : aqualv) : term =
@@ -257,7 +257,7 @@ let rec e_pattern_aq aq =
         | Pat_Var sort ppname ->
             S.mk_Tm_app ref_Pat_Var.t [
               S.as_arg (embed #_ #e_sort rng sort);
-              S.as_arg (embed #_ #e_ppname rng ppname);
+              S.as_arg (embed rng ppname);
             ] rng
         | Pat_Dot_Term eopt ->
             S.mk_Tm_app ref_Pat_Dot_Term.t [S.as_arg (embed #_ #(e_option e_term) rng eopt)]
@@ -435,7 +435,7 @@ instance e_namedv_view =
         S.mk_Tm_app ref_Mk_namedv_view.t [
           S.as_arg (embed rng namedvv.uniq);
           S.as_arg (embed #_ #e_sort   rng namedvv.sort);
-          S.as_arg (embed #_ #e_ppname rng namedvv.ppname);
+          S.as_arg (embed rng namedvv.ppname);
         ]
                     rng
     in
@@ -453,7 +453,7 @@ instance e_bv_view =
         S.mk_Tm_app ref_Mk_bv_view.t [
           S.as_arg (embed rng bvv.index);
           S.as_arg (embed #_ #e_sort   rng bvv.sort);
-          S.as_arg (embed #_ #e_ppname rng bvv.ppname);
+          S.as_arg (embed rng bvv.ppname);
         ]
                     rng
     in
@@ -471,7 +471,7 @@ instance e_binding =
         S.mk_Tm_app ref_Mk_binding.t [
           S.as_arg (embed rng bindingv.uniq);
           S.as_arg (embed #_ #e_term   rng bindingv.sort);
-          S.as_arg (embed #_ #e_ppname rng bindingv.ppname);
+          S.as_arg (embed rng bindingv.ppname);
         ]
                     rng
     in
@@ -493,7 +493,7 @@ let e_binder_view =
       S.as_arg (embed #_ #e_term rng bview.sort);
       S.as_arg (embed rng bview.qual);
       S.as_arg (embed #_ #e_attributes rng bview.attrs);
-      S.as_arg (embed #_ #e_ppname rng bview.ppname);
+      S.as_arg (embed rng bview.ppname);
     ]
                 rng in
 

--- a/src/syntax/FStar.Syntax.Embeddings.fsti
+++ b/src/syntax/FStar.Syntax.Embeddings.fsti
@@ -52,10 +52,9 @@ instance val e_tuple3      : embedding 'a -> embedding 'b -> embedding 'c -> Tot
 instance val e_either      : embedding 'a -> embedding 'b -> Tot (embedding (either 'a 'b))
 instance val e_string_list : embedding (list string)
 val e_arrow       : embedding 'a -> embedding 'b -> Tot (embedding ('a -> 'b))
-val e_sealed      : embedding 'a -> Tot (embedding 'a)
-(* ^ This one is explicit. Or we could add a Sealed "newtype" in compiler land. *)
+instance val e_sealed      : embedding 'a -> Tot (embedding (Sealed.sealed 'a))
 
-instance val e___range     : embedding Range.range (* unsealed *)
+val e___range     : embedding Range.range (* unsealed *)
 instance val e_range       : embedding Range.range (* sealed *)
 instance val e_document    : embedding FStar.Pprint.document
 instance val e_issue       : embedding FStar.Errors.issue

--- a/src/tactics/FStar.Tactics.V1.Basic.fst
+++ b/src/tactics/FStar.Tactics.V1.Basic.fst
@@ -2046,7 +2046,7 @@ let rec inspect (t:term) : tac term_view = wrap_err "inspect" (
             match p.v with
             | Pat_constant c -> Pat_Constant (inspect_const c)
             | Pat_cons (fv, us_opt, ps) -> Pat_Cons (fv, us_opt, List.map (fun (p, b) -> inspect_pat p, b) ps)
-            | Pat_var bv -> Pat_Var (bv, bv.sort)
+            | Pat_var bv -> Pat_Var (bv, Sealed.seal bv.sort)
             | Pat_dot_term eopt -> Pat_Dot_Term eopt
         in
         let brs = List.map SS.open_branch brs in

--- a/src/tactics/FStar.Tactics.V2.Basic.fst
+++ b/src/tactics/FStar.Tactics.V2.Basic.fst
@@ -721,20 +721,20 @@ let bv_to_binding (bv : bv) : RD.binding =
   {
     uniq   = Z.of_int_fs bv.index;
     sort   = bv.sort;
-    ppname = show bv.ppname;
+    ppname = Sealed.seal (show bv.ppname);
   }
 
 let binder_to_binding (b:binder) : RD.binding =
   bv_to_binding b.binder_bv
 
 let binding_to_string (b : RD.binding) : string =
-  b.ppname ^ "#" ^ show (Z.to_int_fs b.uniq)
+  Sealed.unseal b.ppname ^ "#" ^ show (Z.to_int_fs b.uniq)
 
 
 let binding_to_bv (b : RD.binding) : bv =
   {
     sort = b.sort;
-    ppname = mk_ident(b.ppname, Range.dummyRange);
+    ppname = mk_ident (Sealed.unseal b.ppname, Range.dummyRange);
     index = Z.to_int_fs b.uniq;
   }
 
@@ -1284,7 +1284,7 @@ let rename_to (b : RD.binding) (s : string) : tac RD.binding = wrap_err "rename_
     | Some (bv', goal) ->
       replace_cur goal ;!
       let uniq = Z.of_int_fs bv'.index in
-      return {b with uniq=uniq; ppname = s}
+      return {b with uniq=uniq; ppname = Sealed.seal s}
     )
 
 let var_retype (b : RD.binding) : tac unit = wrap_err "binder_retype" <| (

--- a/src/tactics/FStar.Tactics.V2.Primops.fst
+++ b/src/tactics/FStar.Tactics.V2.Primops.fst
@@ -67,7 +67,7 @@ let solve (#a:Type) {| ev : a |} : Tot a = ev
 instance _ = RE.e_term (* REMOVE ME *)
 
 (* Takes a `sealed a`, but that's just a userspace abstraction. *)
-let unseal (_typ:_) (x:'a) : tac 'a = return x
+let unseal (_typ:_) (x:Sealed.sealed 'a) : tac 'a = return (Sealed.unseal x)
 let unseal_step =
   (* Unseal is not in builtins. *)
   let s =

--- a/src/typechecker/FStar.TypeChecker.NBETerm.fsti
+++ b/src/typechecker/FStar.TypeChecker.NBETerm.fsti
@@ -291,7 +291,7 @@ instance val e_option : embedding 'a -> Prims.Tot (embedding (option 'a))
 instance val e_tuple2 : embedding 'a -> embedding 'b -> Prims.Tot (embedding ('a * 'b))
 instance val e_tuple3 : embedding 'a -> embedding 'b -> embedding 'c -> Prims.Tot (embedding ('a * 'b * 'c))
 instance val e_either : embedding 'a -> embedding 'b -> Prims.Tot (embedding (either 'a 'b))
-val e_sealed : embedding 'a -> embedding 'a
+instance val e_sealed : embedding 'a -> Prims.Tot (embedding (FStar.Compiler.Sealed.sealed 'a))
 instance val e_string_list : embedding (list string)
 val e_arrow : embedding 'a -> embedding 'b -> embedding ('a -> 'b)
 

--- a/src/typechecker/FStar.TypeChecker.Primops.fst
+++ b/src/typechecker/FStar.TypeChecker.Primops.fst
@@ -214,9 +214,9 @@ let seal_steps =
                 try_unembed (e_sealed e_any) s,
                 try_unembed e_any f with
           | Some ta, Some tb, Some s, Some f ->
-            let r = U.mk_app f [S.as_arg s] in
+            let r = U.mk_app f [S.as_arg (Sealed.unseal s)] in
             let emb = set_type ta e_any in
-            Some (embed_simple #_ #(e_sealed emb) psc.psc_range r)
+            Some (embed_simple psc.psc_range (Sealed.seal r))
           | _ -> None
           end
         | _ -> None),
@@ -233,9 +233,9 @@ let seal_steps =
                 try_unembed (e_sealed e_any) s,
                 try_unembed e_any f with
           | Some ta, Some tb, Some s, Some f ->
-            let r = cb.iapp f [as_arg s] in
+            let r = cb.iapp f [as_arg (Sealed.unseal s)] in
             let emb = set_type ta e_any in
-            Some (embed (e_sealed emb) cb r)
+            Some (embed (e_sealed emb) cb (Sealed.seal r))
           | _ -> None
           end
         | _ -> None
@@ -254,7 +254,7 @@ let seal_steps =
                 try_unembed (e_sealed e_any) s,
                 try_unembed e_any f with
           | Some ta, Some tb, Some s, Some f ->
-            let r = U.mk_app f [S.as_arg s] in
+            let r = U.mk_app f [S.as_arg (Sealed.unseal s)] in
             Some (embed_simple #_ #e_any psc.psc_range r)
           | _ -> None
           end
@@ -272,7 +272,7 @@ let seal_steps =
                 try_unembed (e_sealed e_any) s,
                 try_unembed e_any f with
           | Some ta, Some tb, Some s, Some f ->
-            let r = cb.iapp f [as_arg s] in
+            let r = cb.iapp f [as_arg (Sealed.unseal s)] in
             let emb = set_type ta e_any in
             Some (embed emb cb r)
           | _ -> None


### PR DESCRIPTION
Motivated by #3210, this PR should make these bugs impossible.
    
We add an identity type internal to the compiler, called `sealed`, with
`seal` and `unseal` operations just like in user space. This type is
behind an interface so we must use seal and unseal correctly otherwise
the typechecker will reject it. This type constructor can now get an
embedding instance (e_sealed) and trigger automatically whenever needed.