### PR TITLE
Fix #3213

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_Syntax_Resugar.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Resugar.ml
@@ -1436,17 +1436,11 @@ let rec (resugar_term' :
             | FStar_Syntax_Syntax.Masked_effect -> resugar_term' env e
             | FStar_Syntax_Syntax.Meta_smt_pat -> resugar_term' env e in
           (match m with
-           | FStar_Syntax_Syntax.Meta_pattern (uu___1, pats) ->
-               let pats1 =
-                 FStar_Compiler_List.map
-                   (fun uu___2 ->
-                      match uu___2 with | (x, uu___3) -> resugar_term' env x)
-                   (FStar_Compiler_List.flatten pats) in
-               mk (FStar_Parser_AST.Attributes pats1)
            | FStar_Syntax_Syntax.Meta_labeled uu___1 -> resugar_term' env e
            | FStar_Syntax_Syntax.Meta_desugared i -> resugar_meta_desugared i
            | FStar_Syntax_Syntax.Meta_named t1 ->
                mk (FStar_Parser_AST.Name t1)
+           | FStar_Syntax_Syntax.Meta_pattern uu___1 -> resugar_term' env e
            | FStar_Syntax_Syntax.Meta_monadic uu___1 -> resugar_term' env e
            | FStar_Syntax_Syntax.Meta_monadic_lift uu___1 ->
                resugar_term' env e)

--- a/src/syntax/FStar.Syntax.Resugar.fst
+++ b/src/syntax/FStar.Syntax.Resugar.fst
@@ -795,12 +795,6 @@ let rec resugar_term' (env: DsEnv.env) (t : S.term) : A.term =
               resugar_term' env e
       in
       begin match m with
-      | Meta_pattern (_, pats) ->
-        // This case is possible in TypeChecker when creating "haseq" for Sig_inductive_typ whose Sig_datacon has no binders.
-        let pats = List.flatten pats |> List.map (fun (x, _) -> resugar_term' env x) in
-        // Is it correct to resugar it to Attributes.
-        mk (A.Attributes pats)
-
       | Meta_labeled _ ->
           (* Ignore the label, we don't want to print it *)
           resugar_term' env e
@@ -808,6 +802,7 @@ let rec resugar_term' (env: DsEnv.env) (t : S.term) : A.term =
           resugar_meta_desugared i
       | Meta_named t ->
           mk (A.Name t)
+      | Meta_pattern _ // stray pattern, ignore
       | Meta_monadic _
       | Meta_monadic_lift _ -> resugar_term' env e
       end

--- a/tests/bug-reports/Bug3213.fst
+++ b/tests/bug-reports/Bug3213.fst
@@ -1,0 +1,25 @@
+module Bug3213
+
+#set-options "--debug Test --debug_level SMTQuery"
+
+let ff = nat -> Type0
+
+let bad2 ()
+  : Lemma (forall (f : ff). (forall (x : nat). f x) ==> (fun (_:nat) -> True) == f) = ()
+
+[@@expect_failure [19]]
+let bad ()
+  : Lemma (forall (f : int -> Type0). (forall (x : nat). f x) ==> f (-1)) = ()
+
+(* Replaying unsoundness from an axiom *)
+let bad_assumed ()
+  : Lemma (forall (f : int -> Type0). (forall (x : nat). f x) ==> f (-1)) = admit()
+
+let forall_elim (#a: Type) (p: (a -> GTot Type)) (x:a)
+  : Lemma (requires forall (x: a). p x) (ensures p x) = ()
+
+let falso () : Lemma False =
+  bad_assumed();
+  let f (x:int) : Type0 = x >= 0 in
+  forall_elim #(int -> Type0) (fun f -> (forall (x : nat). f x) ==> f (-1)) f;
+  ()

--- a/tests/bug-reports/Makefile
+++ b/tests/bug-reports/Makefile
@@ -54,7 +54,8 @@ SHOULD_VERIFY_CLOSED=Bug022.fst Bug024.fst Bug025.fst Bug026.fst Bug026b.fst Bug
   Bug2756.fst MutualRecPositivity.fst Bug2806a.fst Bug2806b.fst Bug2806c.fst Bug2806d.fst Bug2809.fst\
   Bug2849a.fst Bug2849b.fst Bug2045.fst Bug2876.fst Bug2882.fst Bug2895.fst Bug2894.fst \
   Bug2415.fst Bug3028.fst Bug2954.fst Bug3089.fst Bug3102.fst Bug2981.fst Bug2980.fst Bug3115.fst \
-  Bug2083.fst Bug2002.fst Bug1482.fst Bug1066.fst Bug3120a.fst Bug3120b.fst Bug3186.fst Bug3185.fst Bug3210.fst
+  Bug2083.fst Bug2002.fst Bug1482.fst Bug1066.fst Bug3120a.fst Bug3120b.fst Bug3186.fst Bug3185.fst Bug3210.fst \
+  Bug3213.fst
 
 SHOULD_VERIFY_INTERFACE_CLOSED=Bug771.fsti Bug771b.fsti
 SHOULD_VERIFY_AND_WARN_CLOSED=Bug016.fst

--- a/tests/error-messages/Bug3102.fst.expected
+++ b/tests/error-messages/Bug3102.fst.expected
@@ -16,19 +16,19 @@
 >>]
 >> Got issues: [
 * Error 56 at Bug3102.fst(33,29-35,27):
-  - Bound variable 'e2#993' would escape in the type of this letbinding
+  - Bound variable 'e2#1012' would escape in the type of this letbinding
   - Add a type annotation that does not mention it
 
 >>]
 >> Got issues: [
 * Error 56 at Bug3102.fst(41,16-43,8):
-  - Bound variable 'z#1112' would escape in the type of this letbinding
+  - Bound variable 'z#1131' would escape in the type of this letbinding
   - Add a type annotation that does not mention it
 
 >>]
 >> Got issues: [
 * Error 56 at Bug3102.fst(49,16-51,7):
-  - Bound variable 'z#1195' would escape in the type of this letbinding
+  - Bound variable 'z#1214' would escape in the type of this letbinding
   - Add a type annotation that does not mention it
 
 >>]


### PR DESCRIPTION
This fixes a simplification in the normalizer to consider the types of the `f` function that is being substituted.

Fixes #3213