### PR TITLE
Some fixes related to #3207

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_Syntax_Resugar.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Resugar.ml
@@ -110,72 +110,73 @@ let rec (resugar_universe :
   fun u ->
     fun r ->
       let mk a r1 = FStar_Parser_AST.mk_term a r1 FStar_Parser_AST.Un in
-      match u with
+      let uu___ = FStar_Syntax_Subst.compress_univ u in
+      match uu___ with
       | FStar_Syntax_Syntax.U_zero ->
           mk
             (FStar_Parser_AST.Const
                (FStar_Const.Const_int ("0", FStar_Pervasives_Native.None))) r
-      | FStar_Syntax_Syntax.U_succ uu___ ->
-          let uu___1 = universe_to_int Prims.int_zero u in
-          (match uu___1 with
+      | FStar_Syntax_Syntax.U_succ uu___1 ->
+          let uu___2 = universe_to_int Prims.int_zero u in
+          (match uu___2 with
            | (n, u1) ->
                (match u1 with
                 | FStar_Syntax_Syntax.U_zero ->
-                    let uu___2 =
-                      let uu___3 =
-                        let uu___4 =
-                          let uu___5 = FStar_Compiler_Util.string_of_int n in
-                          (uu___5, FStar_Pervasives_Native.None) in
-                        FStar_Const.Const_int uu___4 in
-                      FStar_Parser_AST.Const uu___3 in
-                    mk uu___2 r
-                | uu___2 ->
-                    let e1 =
-                      let uu___3 =
-                        let uu___4 =
-                          let uu___5 =
-                            let uu___6 = FStar_Compiler_Util.string_of_int n in
-                            (uu___6, FStar_Pervasives_Native.None) in
-                          FStar_Const.Const_int uu___5 in
-                        FStar_Parser_AST.Const uu___4 in
-                      mk uu___3 r in
-                    let e2 = resugar_universe u1 r in
                     let uu___3 =
                       let uu___4 =
-                        let uu___5 = FStar_Ident.id_of_text "+" in
-                        (uu___5, [e1; e2]) in
-                      FStar_Parser_AST.Op uu___4 in
-                    mk uu___3 r))
+                        let uu___5 =
+                          let uu___6 = FStar_Compiler_Util.string_of_int n in
+                          (uu___6, FStar_Pervasives_Native.None) in
+                        FStar_Const.Const_int uu___5 in
+                      FStar_Parser_AST.Const uu___4 in
+                    mk uu___3 r
+                | uu___3 ->
+                    let e1 =
+                      let uu___4 =
+                        let uu___5 =
+                          let uu___6 =
+                            let uu___7 = FStar_Compiler_Util.string_of_int n in
+                            (uu___7, FStar_Pervasives_Native.None) in
+                          FStar_Const.Const_int uu___6 in
+                        FStar_Parser_AST.Const uu___5 in
+                      mk uu___4 r in
+                    let e2 = resugar_universe u1 r in
+                    let uu___4 =
+                      let uu___5 =
+                        let uu___6 = FStar_Ident.id_of_text "+" in
+                        (uu___6, [e1; e2]) in
+                      FStar_Parser_AST.Op uu___5 in
+                    mk uu___4 r))
       | FStar_Syntax_Syntax.U_max l ->
           (match l with
            | [] ->
                FStar_Compiler_Effect.failwith
                  "Impossible: U_max without arguments"
-           | uu___ ->
+           | uu___1 ->
                let t =
-                 let uu___1 =
-                   let uu___2 = FStar_Ident.lid_of_path ["max"] r in
-                   FStar_Parser_AST.Var uu___2 in
-                 mk uu___1 r in
+                 let uu___2 =
+                   let uu___3 = FStar_Ident.lid_of_path ["max"] r in
+                   FStar_Parser_AST.Var uu___3 in
+                 mk uu___2 r in
                FStar_Compiler_List.fold_left
                  (fun acc ->
                     fun x ->
-                      let uu___1 =
-                        let uu___2 =
-                          let uu___3 = resugar_universe x r in
-                          (acc, uu___3, FStar_Parser_AST.Nothing) in
-                        FStar_Parser_AST.App uu___2 in
-                      mk uu___1 r) t l)
+                      let uu___2 =
+                        let uu___3 =
+                          let uu___4 = resugar_universe x r in
+                          (acc, uu___4, FStar_Parser_AST.Nothing) in
+                        FStar_Parser_AST.App uu___3 in
+                      mk uu___2 r) t l)
       | FStar_Syntax_Syntax.U_name u1 -> mk (FStar_Parser_AST.Uvar u1) r
-      | FStar_Syntax_Syntax.U_unif uu___ -> mk FStar_Parser_AST.Wild r
+      | FStar_Syntax_Syntax.U_unif uu___1 -> mk FStar_Parser_AST.Wild r
       | FStar_Syntax_Syntax.U_bvar x ->
           let id =
-            let uu___ =
-              let uu___1 =
-                let uu___2 = FStar_Compiler_Util.string_of_int x in
-                FStar_Compiler_Util.strcat "uu__univ_bvar_" uu___2 in
-              (uu___1, r) in
-            FStar_Ident.mk_ident uu___ in
+            let uu___1 =
+              let uu___2 =
+                let uu___3 = FStar_Compiler_Util.string_of_int x in
+                FStar_Compiler_Util.strcat "uu__univ_bvar_" uu___3 in
+              (uu___2, r) in
+            FStar_Ident.mk_ident uu___1 in
           mk (FStar_Parser_AST.Uvar id) r
       | FStar_Syntax_Syntax.U_unknown -> mk FStar_Parser_AST.Wild r
 let (resugar_universe' :

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Util.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Util.ml
@@ -302,16 +302,17 @@ let rec (univ_kernel :
   FStar_Syntax_Syntax.universe -> (FStar_Syntax_Syntax.universe * Prims.int))
   =
   fun u ->
-    match u with
+    let uu___ = FStar_Syntax_Subst.compress_univ u in
+    match uu___ with
     | FStar_Syntax_Syntax.U_unknown -> (u, Prims.int_zero)
-    | FStar_Syntax_Syntax.U_name uu___ -> (u, Prims.int_zero)
-    | FStar_Syntax_Syntax.U_unif uu___ -> (u, Prims.int_zero)
-    | FStar_Syntax_Syntax.U_max uu___ -> (u, Prims.int_zero)
+    | FStar_Syntax_Syntax.U_name uu___1 -> (u, Prims.int_zero)
+    | FStar_Syntax_Syntax.U_unif uu___1 -> (u, Prims.int_zero)
+    | FStar_Syntax_Syntax.U_max uu___1 -> (u, Prims.int_zero)
     | FStar_Syntax_Syntax.U_zero -> (u, Prims.int_zero)
     | FStar_Syntax_Syntax.U_succ u1 ->
-        let uu___ = univ_kernel u1 in
-        (match uu___ with | (k, n) -> (k, (n + Prims.int_one)))
-    | FStar_Syntax_Syntax.U_bvar uu___ ->
+        let uu___1 = univ_kernel u1 in
+        (match uu___1 with | (k, n) -> (k, (n + Prims.int_one)))
+    | FStar_Syntax_Syntax.U_bvar uu___1 ->
         FStar_Compiler_Effect.failwith "Imposible: univ_kernel (U_bvar _)"
 let (constant_univ_as_nat : FStar_Syntax_Syntax.universe -> Prims.int) =
   fun u -> let uu___ = univ_kernel u in FStar_Pervasives_Native.snd uu___
@@ -321,35 +322,39 @@ let rec (compare_univs :
   fun u1 ->
     fun u2 ->
       let rec compare_kernel uk1 uk2 =
-        match (uk1, uk2) with
-        | (FStar_Syntax_Syntax.U_bvar uu___, uu___1) ->
+        let uu___ =
+          let uu___1 = FStar_Syntax_Subst.compress_univ uk1 in
+          let uu___2 = FStar_Syntax_Subst.compress_univ uk2 in
+          (uu___1, uu___2) in
+        match uu___ with
+        | (FStar_Syntax_Syntax.U_bvar uu___1, uu___2) ->
             FStar_Compiler_Effect.failwith "Impossible: compare_kernel bvar"
-        | (uu___, FStar_Syntax_Syntax.U_bvar uu___1) ->
+        | (uu___1, FStar_Syntax_Syntax.U_bvar uu___2) ->
             FStar_Compiler_Effect.failwith "Impossible: compare_kernel bvar"
-        | (FStar_Syntax_Syntax.U_succ uu___, uu___1) ->
+        | (FStar_Syntax_Syntax.U_succ uu___1, uu___2) ->
             FStar_Compiler_Effect.failwith "Impossible: compare_kernel succ"
-        | (uu___, FStar_Syntax_Syntax.U_succ uu___1) ->
+        | (uu___1, FStar_Syntax_Syntax.U_succ uu___2) ->
             FStar_Compiler_Effect.failwith "Impossible: compare_kernel succ"
         | (FStar_Syntax_Syntax.U_unknown, FStar_Syntax_Syntax.U_unknown) ->
             Prims.int_zero
-        | (FStar_Syntax_Syntax.U_unknown, uu___) -> (Prims.of_int (-1))
-        | (uu___, FStar_Syntax_Syntax.U_unknown) -> Prims.int_one
+        | (FStar_Syntax_Syntax.U_unknown, uu___1) -> (Prims.of_int (-1))
+        | (uu___1, FStar_Syntax_Syntax.U_unknown) -> Prims.int_one
         | (FStar_Syntax_Syntax.U_zero, FStar_Syntax_Syntax.U_zero) ->
             Prims.int_zero
-        | (FStar_Syntax_Syntax.U_zero, uu___) -> (Prims.of_int (-1))
-        | (uu___, FStar_Syntax_Syntax.U_zero) -> Prims.int_one
+        | (FStar_Syntax_Syntax.U_zero, uu___1) -> (Prims.of_int (-1))
+        | (uu___1, FStar_Syntax_Syntax.U_zero) -> Prims.int_one
         | (FStar_Syntax_Syntax.U_name u11, FStar_Syntax_Syntax.U_name u21) ->
-            let uu___ = FStar_Ident.string_of_id u11 in
-            let uu___1 = FStar_Ident.string_of_id u21 in
-            FStar_Compiler_String.compare uu___ uu___1
-        | (FStar_Syntax_Syntax.U_name uu___, uu___1) -> (Prims.of_int (-1))
-        | (uu___, FStar_Syntax_Syntax.U_name uu___1) -> Prims.int_one
+            let uu___1 = FStar_Ident.string_of_id u11 in
+            let uu___2 = FStar_Ident.string_of_id u21 in
+            FStar_Compiler_String.compare uu___1 uu___2
+        | (FStar_Syntax_Syntax.U_name uu___1, uu___2) -> (Prims.of_int (-1))
+        | (uu___1, FStar_Syntax_Syntax.U_name uu___2) -> Prims.int_one
         | (FStar_Syntax_Syntax.U_unif u11, FStar_Syntax_Syntax.U_unif u21) ->
-            let uu___ = FStar_Syntax_Unionfind.univ_uvar_id u11 in
-            let uu___1 = FStar_Syntax_Unionfind.univ_uvar_id u21 in
-            uu___ - uu___1
-        | (FStar_Syntax_Syntax.U_unif uu___, uu___1) -> (Prims.of_int (-1))
-        | (uu___, FStar_Syntax_Syntax.U_unif uu___1) -> Prims.int_one
+            let uu___1 = FStar_Syntax_Unionfind.univ_uvar_id u11 in
+            let uu___2 = FStar_Syntax_Unionfind.univ_uvar_id u21 in
+            uu___1 - uu___2
+        | (FStar_Syntax_Syntax.U_unif uu___1, uu___2) -> (Prims.of_int (-1))
+        | (uu___1, FStar_Syntax_Syntax.U_unif uu___2) -> Prims.int_one
         | (FStar_Syntax_Syntax.U_max us1, FStar_Syntax_Syntax.U_max us2) ->
             let n1 = FStar_Compiler_List.length us1 in
             let n2 = FStar_Compiler_List.length us2 in
@@ -357,10 +362,10 @@ let rec (compare_univs :
             then n1 - n2
             else
               (let copt =
-                 let uu___1 = FStar_Compiler_List.zip us1 us2 in
-                 FStar_Compiler_Util.find_map uu___1
-                   (fun uu___2 ->
-                      match uu___2 with
+                 let uu___2 = FStar_Compiler_List.zip us1 us2 in
+                 FStar_Compiler_Util.find_map uu___2
+                   (fun uu___3 ->
+                      match uu___3 with
                       | (u11, u21) ->
                           let c = compare_univs u11 u21 in
                           if c <> Prims.int_zero

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Cfg.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Cfg.ml
@@ -34,7 +34,8 @@ type fsteps =
   weakly_reduce_scrutinee: Prims.bool ;
   nbe_step: Prims.bool ;
   for_extraction: Prims.bool ;
-  unrefine: Prims.bool }
+  unrefine: Prims.bool ;
+  default_univs_to_zero: Prims.bool }
 let (__proj__Mkfsteps__item__beta : fsteps -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -44,8 +45,8 @@ let (__proj__Mkfsteps__item__beta : fsteps -> Prims.bool) =
         pure_subterms_within_computations; simplify; erase_universes;
         allow_unbound_universes; reify_; compress_uvars; no_full_norm;
         check_no_uvars; unmeta; unascribe; in_full_norm_request;
-        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;_} ->
-        beta
+        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;
+        default_univs_to_zero;_} -> beta
 let (__proj__Mkfsteps__item__iota : fsteps -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -55,8 +56,8 @@ let (__proj__Mkfsteps__item__iota : fsteps -> Prims.bool) =
         pure_subterms_within_computations; simplify; erase_universes;
         allow_unbound_universes; reify_; compress_uvars; no_full_norm;
         check_no_uvars; unmeta; unascribe; in_full_norm_request;
-        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;_} ->
-        iota
+        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;
+        default_univs_to_zero;_} -> iota
 let (__proj__Mkfsteps__item__zeta : fsteps -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -66,8 +67,8 @@ let (__proj__Mkfsteps__item__zeta : fsteps -> Prims.bool) =
         pure_subterms_within_computations; simplify; erase_universes;
         allow_unbound_universes; reify_; compress_uvars; no_full_norm;
         check_no_uvars; unmeta; unascribe; in_full_norm_request;
-        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;_} ->
-        zeta
+        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;
+        default_univs_to_zero;_} -> zeta
 let (__proj__Mkfsteps__item__zeta_full : fsteps -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -77,8 +78,8 @@ let (__proj__Mkfsteps__item__zeta_full : fsteps -> Prims.bool) =
         pure_subterms_within_computations; simplify; erase_universes;
         allow_unbound_universes; reify_; compress_uvars; no_full_norm;
         check_no_uvars; unmeta; unascribe; in_full_norm_request;
-        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;_} ->
-        zeta_full
+        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;
+        default_univs_to_zero;_} -> zeta_full
 let (__proj__Mkfsteps__item__weak : fsteps -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -88,8 +89,8 @@ let (__proj__Mkfsteps__item__weak : fsteps -> Prims.bool) =
         pure_subterms_within_computations; simplify; erase_universes;
         allow_unbound_universes; reify_; compress_uvars; no_full_norm;
         check_no_uvars; unmeta; unascribe; in_full_norm_request;
-        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;_} ->
-        weak
+        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;
+        default_univs_to_zero;_} -> weak
 let (__proj__Mkfsteps__item__hnf : fsteps -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -99,7 +100,8 @@ let (__proj__Mkfsteps__item__hnf : fsteps -> Prims.bool) =
         pure_subterms_within_computations; simplify; erase_universes;
         allow_unbound_universes; reify_; compress_uvars; no_full_norm;
         check_no_uvars; unmeta; unascribe; in_full_norm_request;
-        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;_} -> hnf
+        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;
+        default_univs_to_zero;_} -> hnf
 let (__proj__Mkfsteps__item__primops : fsteps -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -109,8 +111,8 @@ let (__proj__Mkfsteps__item__primops : fsteps -> Prims.bool) =
         pure_subterms_within_computations; simplify; erase_universes;
         allow_unbound_universes; reify_; compress_uvars; no_full_norm;
         check_no_uvars; unmeta; unascribe; in_full_norm_request;
-        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;_} ->
-        primops
+        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;
+        default_univs_to_zero;_} -> primops
 let (__proj__Mkfsteps__item__do_not_unfold_pure_lets : fsteps -> Prims.bool)
   =
   fun projectee ->
@@ -121,8 +123,8 @@ let (__proj__Mkfsteps__item__do_not_unfold_pure_lets : fsteps -> Prims.bool)
         pure_subterms_within_computations; simplify; erase_universes;
         allow_unbound_universes; reify_; compress_uvars; no_full_norm;
         check_no_uvars; unmeta; unascribe; in_full_norm_request;
-        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;_} ->
-        do_not_unfold_pure_lets
+        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;
+        default_univs_to_zero;_} -> do_not_unfold_pure_lets
 let (__proj__Mkfsteps__item__unfold_until :
   fsteps -> FStar_Syntax_Syntax.delta_depth FStar_Pervasives_Native.option) =
   fun projectee ->
@@ -133,8 +135,8 @@ let (__proj__Mkfsteps__item__unfold_until :
         pure_subterms_within_computations; simplify; erase_universes;
         allow_unbound_universes; reify_; compress_uvars; no_full_norm;
         check_no_uvars; unmeta; unascribe; in_full_norm_request;
-        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;_} ->
-        unfold_until
+        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;
+        default_univs_to_zero;_} -> unfold_until
 let (__proj__Mkfsteps__item__unfold_only :
   fsteps -> FStar_Ident.lid Prims.list FStar_Pervasives_Native.option) =
   fun projectee ->
@@ -145,8 +147,8 @@ let (__proj__Mkfsteps__item__unfold_only :
         pure_subterms_within_computations; simplify; erase_universes;
         allow_unbound_universes; reify_; compress_uvars; no_full_norm;
         check_no_uvars; unmeta; unascribe; in_full_norm_request;
-        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;_} ->
-        unfold_only
+        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;
+        default_univs_to_zero;_} -> unfold_only
 let (__proj__Mkfsteps__item__unfold_fully :
   fsteps -> FStar_Ident.lid Prims.list FStar_Pervasives_Native.option) =
   fun projectee ->
@@ -157,8 +159,8 @@ let (__proj__Mkfsteps__item__unfold_fully :
         pure_subterms_within_computations; simplify; erase_universes;
         allow_unbound_universes; reify_; compress_uvars; no_full_norm;
         check_no_uvars; unmeta; unascribe; in_full_norm_request;
-        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;_} ->
-        unfold_fully
+        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;
+        default_univs_to_zero;_} -> unfold_fully
 let (__proj__Mkfsteps__item__unfold_attr :
   fsteps -> FStar_Ident.lid Prims.list FStar_Pervasives_Native.option) =
   fun projectee ->
@@ -169,8 +171,8 @@ let (__proj__Mkfsteps__item__unfold_attr :
         pure_subterms_within_computations; simplify; erase_universes;
         allow_unbound_universes; reify_; compress_uvars; no_full_norm;
         check_no_uvars; unmeta; unascribe; in_full_norm_request;
-        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;_} ->
-        unfold_attr
+        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;
+        default_univs_to_zero;_} -> unfold_attr
 let (__proj__Mkfsteps__item__unfold_qual :
   fsteps -> Prims.string Prims.list FStar_Pervasives_Native.option) =
   fun projectee ->
@@ -181,8 +183,8 @@ let (__proj__Mkfsteps__item__unfold_qual :
         pure_subterms_within_computations; simplify; erase_universes;
         allow_unbound_universes; reify_; compress_uvars; no_full_norm;
         check_no_uvars; unmeta; unascribe; in_full_norm_request;
-        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;_} ->
-        unfold_qual
+        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;
+        default_univs_to_zero;_} -> unfold_qual
 let (__proj__Mkfsteps__item__unfold_namespace :
   fsteps ->
     (Prims.string, Prims.bool) FStar_Compiler_Path.forest
@@ -196,8 +198,8 @@ let (__proj__Mkfsteps__item__unfold_namespace :
         pure_subterms_within_computations; simplify; erase_universes;
         allow_unbound_universes; reify_; compress_uvars; no_full_norm;
         check_no_uvars; unmeta; unascribe; in_full_norm_request;
-        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;_} ->
-        unfold_namespace
+        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;
+        default_univs_to_zero;_} -> unfold_namespace
 let (__proj__Mkfsteps__item__unfold_tac : fsteps -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -207,8 +209,8 @@ let (__proj__Mkfsteps__item__unfold_tac : fsteps -> Prims.bool) =
         pure_subterms_within_computations; simplify; erase_universes;
         allow_unbound_universes; reify_; compress_uvars; no_full_norm;
         check_no_uvars; unmeta; unascribe; in_full_norm_request;
-        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;_} ->
-        unfold_tac
+        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;
+        default_univs_to_zero;_} -> unfold_tac
 let (__proj__Mkfsteps__item__pure_subterms_within_computations :
   fsteps -> Prims.bool) =
   fun projectee ->
@@ -219,8 +221,8 @@ let (__proj__Mkfsteps__item__pure_subterms_within_computations :
         pure_subterms_within_computations; simplify; erase_universes;
         allow_unbound_universes; reify_; compress_uvars; no_full_norm;
         check_no_uvars; unmeta; unascribe; in_full_norm_request;
-        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;_} ->
-        pure_subterms_within_computations
+        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;
+        default_univs_to_zero;_} -> pure_subterms_within_computations
 let (__proj__Mkfsteps__item__simplify : fsteps -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -230,8 +232,8 @@ let (__proj__Mkfsteps__item__simplify : fsteps -> Prims.bool) =
         pure_subterms_within_computations; simplify; erase_universes;
         allow_unbound_universes; reify_; compress_uvars; no_full_norm;
         check_no_uvars; unmeta; unascribe; in_full_norm_request;
-        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;_} ->
-        simplify
+        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;
+        default_univs_to_zero;_} -> simplify
 let (__proj__Mkfsteps__item__erase_universes : fsteps -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -241,8 +243,8 @@ let (__proj__Mkfsteps__item__erase_universes : fsteps -> Prims.bool) =
         pure_subterms_within_computations; simplify; erase_universes;
         allow_unbound_universes; reify_; compress_uvars; no_full_norm;
         check_no_uvars; unmeta; unascribe; in_full_norm_request;
-        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;_} ->
-        erase_universes
+        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;
+        default_univs_to_zero;_} -> erase_universes
 let (__proj__Mkfsteps__item__allow_unbound_universes : fsteps -> Prims.bool)
   =
   fun projectee ->
@@ -253,8 +255,8 @@ let (__proj__Mkfsteps__item__allow_unbound_universes : fsteps -> Prims.bool)
         pure_subterms_within_computations; simplify; erase_universes;
         allow_unbound_universes; reify_; compress_uvars; no_full_norm;
         check_no_uvars; unmeta; unascribe; in_full_norm_request;
-        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;_} ->
-        allow_unbound_universes
+        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;
+        default_univs_to_zero;_} -> allow_unbound_universes
 let (__proj__Mkfsteps__item__reify_ : fsteps -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -264,8 +266,8 @@ let (__proj__Mkfsteps__item__reify_ : fsteps -> Prims.bool) =
         pure_subterms_within_computations; simplify; erase_universes;
         allow_unbound_universes; reify_; compress_uvars; no_full_norm;
         check_no_uvars; unmeta; unascribe; in_full_norm_request;
-        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;_} ->
-        reify_
+        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;
+        default_univs_to_zero;_} -> reify_
 let (__proj__Mkfsteps__item__compress_uvars : fsteps -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -275,8 +277,8 @@ let (__proj__Mkfsteps__item__compress_uvars : fsteps -> Prims.bool) =
         pure_subterms_within_computations; simplify; erase_universes;
         allow_unbound_universes; reify_; compress_uvars; no_full_norm;
         check_no_uvars; unmeta; unascribe; in_full_norm_request;
-        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;_} ->
-        compress_uvars
+        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;
+        default_univs_to_zero;_} -> compress_uvars
 let (__proj__Mkfsteps__item__no_full_norm : fsteps -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -286,8 +288,8 @@ let (__proj__Mkfsteps__item__no_full_norm : fsteps -> Prims.bool) =
         pure_subterms_within_computations; simplify; erase_universes;
         allow_unbound_universes; reify_; compress_uvars; no_full_norm;
         check_no_uvars; unmeta; unascribe; in_full_norm_request;
-        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;_} ->
-        no_full_norm
+        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;
+        default_univs_to_zero;_} -> no_full_norm
 let (__proj__Mkfsteps__item__check_no_uvars : fsteps -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -297,8 +299,8 @@ let (__proj__Mkfsteps__item__check_no_uvars : fsteps -> Prims.bool) =
         pure_subterms_within_computations; simplify; erase_universes;
         allow_unbound_universes; reify_; compress_uvars; no_full_norm;
         check_no_uvars; unmeta; unascribe; in_full_norm_request;
-        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;_} ->
-        check_no_uvars
+        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;
+        default_univs_to_zero;_} -> check_no_uvars
 let (__proj__Mkfsteps__item__unmeta : fsteps -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -308,8 +310,8 @@ let (__proj__Mkfsteps__item__unmeta : fsteps -> Prims.bool) =
         pure_subterms_within_computations; simplify; erase_universes;
         allow_unbound_universes; reify_; compress_uvars; no_full_norm;
         check_no_uvars; unmeta; unascribe; in_full_norm_request;
-        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;_} ->
-        unmeta
+        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;
+        default_univs_to_zero;_} -> unmeta
 let (__proj__Mkfsteps__item__unascribe : fsteps -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -319,8 +321,8 @@ let (__proj__Mkfsteps__item__unascribe : fsteps -> Prims.bool) =
         pure_subterms_within_computations; simplify; erase_universes;
         allow_unbound_universes; reify_; compress_uvars; no_full_norm;
         check_no_uvars; unmeta; unascribe; in_full_norm_request;
-        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;_} ->
-        unascribe
+        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;
+        default_univs_to_zero;_} -> unascribe
 let (__proj__Mkfsteps__item__in_full_norm_request : fsteps -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -330,8 +332,8 @@ let (__proj__Mkfsteps__item__in_full_norm_request : fsteps -> Prims.bool) =
         pure_subterms_within_computations; simplify; erase_universes;
         allow_unbound_universes; reify_; compress_uvars; no_full_norm;
         check_no_uvars; unmeta; unascribe; in_full_norm_request;
-        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;_} ->
-        in_full_norm_request
+        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;
+        default_univs_to_zero;_} -> in_full_norm_request
 let (__proj__Mkfsteps__item__weakly_reduce_scrutinee : fsteps -> Prims.bool)
   =
   fun projectee ->
@@ -342,8 +344,8 @@ let (__proj__Mkfsteps__item__weakly_reduce_scrutinee : fsteps -> Prims.bool)
         pure_subterms_within_computations; simplify; erase_universes;
         allow_unbound_universes; reify_; compress_uvars; no_full_norm;
         check_no_uvars; unmeta; unascribe; in_full_norm_request;
-        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;_} ->
-        weakly_reduce_scrutinee
+        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;
+        default_univs_to_zero;_} -> weakly_reduce_scrutinee
 let (__proj__Mkfsteps__item__nbe_step : fsteps -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -353,8 +355,8 @@ let (__proj__Mkfsteps__item__nbe_step : fsteps -> Prims.bool) =
         pure_subterms_within_computations; simplify; erase_universes;
         allow_unbound_universes; reify_; compress_uvars; no_full_norm;
         check_no_uvars; unmeta; unascribe; in_full_norm_request;
-        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;_} ->
-        nbe_step
+        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;
+        default_univs_to_zero;_} -> nbe_step
 let (__proj__Mkfsteps__item__for_extraction : fsteps -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -364,8 +366,8 @@ let (__proj__Mkfsteps__item__for_extraction : fsteps -> Prims.bool) =
         pure_subterms_within_computations; simplify; erase_universes;
         allow_unbound_universes; reify_; compress_uvars; no_full_norm;
         check_no_uvars; unmeta; unascribe; in_full_norm_request;
-        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;_} ->
-        for_extraction
+        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;
+        default_univs_to_zero;_} -> for_extraction
 let (__proj__Mkfsteps__item__unrefine : fsteps -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -375,8 +377,19 @@ let (__proj__Mkfsteps__item__unrefine : fsteps -> Prims.bool) =
         pure_subterms_within_computations; simplify; erase_universes;
         allow_unbound_universes; reify_; compress_uvars; no_full_norm;
         check_no_uvars; unmeta; unascribe; in_full_norm_request;
-        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;_} ->
-        unrefine
+        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;
+        default_univs_to_zero;_} -> unrefine
+let (__proj__Mkfsteps__item__default_univs_to_zero : fsteps -> Prims.bool) =
+  fun projectee ->
+    match projectee with
+    | { beta; iota; zeta; zeta_full; weak; hnf; primops;
+        do_not_unfold_pure_lets; unfold_until; unfold_only; unfold_fully;
+        unfold_attr; unfold_qual; unfold_namespace; unfold_tac;
+        pure_subterms_within_computations; simplify; erase_universes;
+        allow_unbound_universes; reify_; compress_uvars; no_full_norm;
+        check_no_uvars; unmeta; unascribe; in_full_norm_request;
+        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;
+        default_univs_to_zero;_} -> default_univs_to_zero
 let (steps_to_string : fsteps -> Prims.string) =
   fun f ->
     let format_opt f1 o =
@@ -499,7 +512,13 @@ let (steps_to_string : fsteps -> Prims.string) =
                                                             let uu___56 =
                                                               let uu___57 =
                                                                 b f.unrefine in
-                                                              [uu___57] in
+                                                              let uu___58 =
+                                                                let uu___59 =
+                                                                  b
+                                                                    f.default_univs_to_zero in
+                                                                [uu___59] in
+                                                              uu___57 ::
+                                                                uu___58 in
                                                             uu___55 ::
                                                               uu___56 in
                                                           uu___53 :: uu___54 in
@@ -530,7 +549,7 @@ let (steps_to_string : fsteps -> Prims.string) =
         uu___3 :: uu___4 in
       uu___1 :: uu___2 in
     FStar_Compiler_Util.format
-      "{\nbeta = %s;\niota = %s;\nzeta = %s;\nzeta_full = %s;\nweak = %s;\nhnf  = %s;\nprimops = %s;\ndo_not_unfold_pure_lets = %s;\nunfold_until = %s;\nunfold_only = %s;\nunfold_fully = %s;\nunfold_attr = %s;\nunfold_qual = %s;\nunfold_namespace = %s;\nunfold_tac = %s;\npure_subterms_within_computations = %s;\nsimplify = %s;\nerase_universes = %s;\nallow_unbound_universes = %s;\nreify_ = %s;\ncompress_uvars = %s;\nno_full_norm = %s;\ncheck_no_uvars = %s;\nunmeta = %s;\nunascribe = %s;\nin_full_norm_request = %s;\nweakly_reduce_scrutinee = %s;\nfor_extraction = %s;\nunrefine = %s;\n}"
+      "{\nbeta = %s;\niota = %s;\nzeta = %s;\nzeta_full = %s;\nweak = %s;\nhnf  = %s;\nprimops = %s;\ndo_not_unfold_pure_lets = %s;\nunfold_until = %s;\nunfold_only = %s;\nunfold_fully = %s;\nunfold_attr = %s;\nunfold_qual = %s;\nunfold_namespace = %s;\nunfold_tac = %s;\npure_subterms_within_computations = %s;\nsimplify = %s;\nerase_universes = %s;\nallow_unbound_universes = %s;\nreify_ = %s;\ncompress_uvars = %s;\nno_full_norm = %s;\ncheck_no_uvars = %s;\nunmeta = %s;\nunascribe = %s;\nin_full_norm_request = %s;\nweakly_reduce_scrutinee = %s;\nfor_extraction = %s;\nunrefine = %s;\ndefault_univs_to_zero = %s;\n}"
       uu___
 let (default_steps : fsteps) =
   {
@@ -563,7 +582,8 @@ let (default_steps : fsteps) =
     weakly_reduce_scrutinee = true;
     nbe_step = false;
     for_extraction = false;
-    unrefine = false
+    unrefine = false;
+    default_univs_to_zero = false
   }
 let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
   fun s ->
@@ -601,7 +621,8 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
             weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
             nbe_step = (fs.nbe_step);
             for_extraction = (fs.for_extraction);
-            unrefine = (fs.unrefine)
+            unrefine = (fs.unrefine);
+            default_univs_to_zero = (fs.default_univs_to_zero)
           }
       | FStar_TypeChecker_Env.Iota ->
           {
@@ -635,7 +656,8 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
             weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
             nbe_step = (fs.nbe_step);
             for_extraction = (fs.for_extraction);
-            unrefine = (fs.unrefine)
+            unrefine = (fs.unrefine);
+            default_univs_to_zero = (fs.default_univs_to_zero)
           }
       | FStar_TypeChecker_Env.Zeta ->
           {
@@ -669,7 +691,8 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
             weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
             nbe_step = (fs.nbe_step);
             for_extraction = (fs.for_extraction);
-            unrefine = (fs.unrefine)
+            unrefine = (fs.unrefine);
+            default_univs_to_zero = (fs.default_univs_to_zero)
           }
       | FStar_TypeChecker_Env.ZetaFull ->
           {
@@ -703,7 +726,8 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
             weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
             nbe_step = (fs.nbe_step);
             for_extraction = (fs.for_extraction);
-            unrefine = (fs.unrefine)
+            unrefine = (fs.unrefine);
+            default_univs_to_zero = (fs.default_univs_to_zero)
           }
       | FStar_TypeChecker_Env.Exclude (FStar_TypeChecker_Env.Beta) ->
           {
@@ -737,7 +761,8 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
             weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
             nbe_step = (fs.nbe_step);
             for_extraction = (fs.for_extraction);
-            unrefine = (fs.unrefine)
+            unrefine = (fs.unrefine);
+            default_univs_to_zero = (fs.default_univs_to_zero)
           }
       | FStar_TypeChecker_Env.Exclude (FStar_TypeChecker_Env.Iota) ->
           {
@@ -771,7 +796,8 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
             weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
             nbe_step = (fs.nbe_step);
             for_extraction = (fs.for_extraction);
-            unrefine = (fs.unrefine)
+            unrefine = (fs.unrefine);
+            default_univs_to_zero = (fs.default_univs_to_zero)
           }
       | FStar_TypeChecker_Env.Exclude (FStar_TypeChecker_Env.Zeta) ->
           {
@@ -805,7 +831,8 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
             weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
             nbe_step = (fs.nbe_step);
             for_extraction = (fs.for_extraction);
-            unrefine = (fs.unrefine)
+            unrefine = (fs.unrefine);
+            default_univs_to_zero = (fs.default_univs_to_zero)
           }
       | FStar_TypeChecker_Env.Exclude uu___ ->
           FStar_Compiler_Effect.failwith "Bad exclude"
@@ -841,7 +868,8 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
             weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
             nbe_step = (fs.nbe_step);
             for_extraction = (fs.for_extraction);
-            unrefine = (fs.unrefine)
+            unrefine = (fs.unrefine);
+            default_univs_to_zero = (fs.default_univs_to_zero)
           }
       | FStar_TypeChecker_Env.HNF ->
           {
@@ -875,7 +903,8 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
             weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
             nbe_step = (fs.nbe_step);
             for_extraction = (fs.for_extraction);
-            unrefine = (fs.unrefine)
+            unrefine = (fs.unrefine);
+            default_univs_to_zero = (fs.default_univs_to_zero)
           }
       | FStar_TypeChecker_Env.Primops ->
           {
@@ -909,7 +938,8 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
             weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
             nbe_step = (fs.nbe_step);
             for_extraction = (fs.for_extraction);
-            unrefine = (fs.unrefine)
+            unrefine = (fs.unrefine);
+            default_univs_to_zero = (fs.default_univs_to_zero)
           }
       | FStar_TypeChecker_Env.Eager_unfolding -> fs
       | FStar_TypeChecker_Env.Inlining -> fs
@@ -945,7 +975,8 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
             weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
             nbe_step = (fs.nbe_step);
             for_extraction = (fs.for_extraction);
-            unrefine = (fs.unrefine)
+            unrefine = (fs.unrefine);
+            default_univs_to_zero = (fs.default_univs_to_zero)
           }
       | FStar_TypeChecker_Env.UnfoldUntil d ->
           {
@@ -979,7 +1010,8 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
             weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
             nbe_step = (fs.nbe_step);
             for_extraction = (fs.for_extraction);
-            unrefine = (fs.unrefine)
+            unrefine = (fs.unrefine);
+            default_univs_to_zero = (fs.default_univs_to_zero)
           }
       | FStar_TypeChecker_Env.UnfoldOnly lids ->
           {
@@ -1013,7 +1045,8 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
             weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
             nbe_step = (fs.nbe_step);
             for_extraction = (fs.for_extraction);
-            unrefine = (fs.unrefine)
+            unrefine = (fs.unrefine);
+            default_univs_to_zero = (fs.default_univs_to_zero)
           }
       | FStar_TypeChecker_Env.UnfoldFully lids ->
           {
@@ -1047,7 +1080,8 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
             weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
             nbe_step = (fs.nbe_step);
             for_extraction = (fs.for_extraction);
-            unrefine = (fs.unrefine)
+            unrefine = (fs.unrefine);
+            default_univs_to_zero = (fs.default_univs_to_zero)
           }
       | FStar_TypeChecker_Env.UnfoldAttr lids ->
           {
@@ -1081,7 +1115,8 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
             weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
             nbe_step = (fs.nbe_step);
             for_extraction = (fs.for_extraction);
-            unrefine = (fs.unrefine)
+            unrefine = (fs.unrefine);
+            default_univs_to_zero = (fs.default_univs_to_zero)
           }
       | FStar_TypeChecker_Env.UnfoldQual strs ->
           let fs1 =
@@ -1116,7 +1151,8 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
               weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
               nbe_step = (fs.nbe_step);
               for_extraction = (fs.for_extraction);
-              unrefine = (fs.unrefine)
+              unrefine = (fs.unrefine);
+              default_univs_to_zero = (fs.default_univs_to_zero)
             } in
           if
             FStar_Compiler_List.contains "pure_subterms_within_computations"
@@ -1152,7 +1188,8 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
               weakly_reduce_scrutinee = (fs1.weakly_reduce_scrutinee);
               nbe_step = (fs1.nbe_step);
               for_extraction = (fs1.for_extraction);
-              unrefine = (fs1.unrefine)
+              unrefine = (fs1.unrefine);
+              default_univs_to_zero = (fs1.default_univs_to_zero)
             }
           else fs1
       | FStar_TypeChecker_Env.UnfoldNamespace strs ->
@@ -1196,7 +1233,8 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
             weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
             nbe_step = (fs.nbe_step);
             for_extraction = (fs.for_extraction);
-            unrefine = (fs.unrefine)
+            unrefine = (fs.unrefine);
+            default_univs_to_zero = (fs.default_univs_to_zero)
           }
       | FStar_TypeChecker_Env.UnfoldTac ->
           {
@@ -1230,7 +1268,8 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
             weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
             nbe_step = (fs.nbe_step);
             for_extraction = (fs.for_extraction);
-            unrefine = (fs.unrefine)
+            unrefine = (fs.unrefine);
+            default_univs_to_zero = (fs.default_univs_to_zero)
           }
       | FStar_TypeChecker_Env.PureSubtermsWithinComputations ->
           {
@@ -1263,7 +1302,8 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
             weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
             nbe_step = (fs.nbe_step);
             for_extraction = (fs.for_extraction);
-            unrefine = (fs.unrefine)
+            unrefine = (fs.unrefine);
+            default_univs_to_zero = (fs.default_univs_to_zero)
           }
       | FStar_TypeChecker_Env.Simplify ->
           {
@@ -1297,7 +1337,8 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
             weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
             nbe_step = (fs.nbe_step);
             for_extraction = (fs.for_extraction);
-            unrefine = (fs.unrefine)
+            unrefine = (fs.unrefine);
+            default_univs_to_zero = (fs.default_univs_to_zero)
           }
       | FStar_TypeChecker_Env.EraseUniverses ->
           {
@@ -1331,7 +1372,8 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
             weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
             nbe_step = (fs.nbe_step);
             for_extraction = (fs.for_extraction);
-            unrefine = (fs.unrefine)
+            unrefine = (fs.unrefine);
+            default_univs_to_zero = (fs.default_univs_to_zero)
           }
       | FStar_TypeChecker_Env.AllowUnboundUniverses ->
           {
@@ -1365,7 +1407,8 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
             weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
             nbe_step = (fs.nbe_step);
             for_extraction = (fs.for_extraction);
-            unrefine = (fs.unrefine)
+            unrefine = (fs.unrefine);
+            default_univs_to_zero = (fs.default_univs_to_zero)
           }
       | FStar_TypeChecker_Env.Reify ->
           {
@@ -1399,7 +1442,8 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
             weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
             nbe_step = (fs.nbe_step);
             for_extraction = (fs.for_extraction);
-            unrefine = (fs.unrefine)
+            unrefine = (fs.unrefine);
+            default_univs_to_zero = (fs.default_univs_to_zero)
           }
       | FStar_TypeChecker_Env.CompressUvars ->
           {
@@ -1433,7 +1477,8 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
             weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
             nbe_step = (fs.nbe_step);
             for_extraction = (fs.for_extraction);
-            unrefine = (fs.unrefine)
+            unrefine = (fs.unrefine);
+            default_univs_to_zero = (fs.default_univs_to_zero)
           }
       | FStar_TypeChecker_Env.NoFullNorm ->
           {
@@ -1467,7 +1512,8 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
             weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
             nbe_step = (fs.nbe_step);
             for_extraction = (fs.for_extraction);
-            unrefine = (fs.unrefine)
+            unrefine = (fs.unrefine);
+            default_univs_to_zero = (fs.default_univs_to_zero)
           }
       | FStar_TypeChecker_Env.CheckNoUvars ->
           {
@@ -1501,7 +1547,8 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
             weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
             nbe_step = (fs.nbe_step);
             for_extraction = (fs.for_extraction);
-            unrefine = (fs.unrefine)
+            unrefine = (fs.unrefine);
+            default_univs_to_zero = (fs.default_univs_to_zero)
           }
       | FStar_TypeChecker_Env.Unmeta ->
           {
@@ -1535,7 +1582,8 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
             weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
             nbe_step = (fs.nbe_step);
             for_extraction = (fs.for_extraction);
-            unrefine = (fs.unrefine)
+            unrefine = (fs.unrefine);
+            default_univs_to_zero = (fs.default_univs_to_zero)
           }
       | FStar_TypeChecker_Env.Unascribe ->
           {
@@ -1569,7 +1617,8 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
             weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
             nbe_step = (fs.nbe_step);
             for_extraction = (fs.for_extraction);
-            unrefine = (fs.unrefine)
+            unrefine = (fs.unrefine);
+            default_univs_to_zero = (fs.default_univs_to_zero)
           }
       | FStar_TypeChecker_Env.NBE ->
           {
@@ -1603,7 +1652,8 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
             weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
             nbe_step = true;
             for_extraction = (fs.for_extraction);
-            unrefine = (fs.unrefine)
+            unrefine = (fs.unrefine);
+            default_univs_to_zero = (fs.default_univs_to_zero)
           }
       | FStar_TypeChecker_Env.ForExtraction ->
           {
@@ -1637,7 +1687,8 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
             weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
             nbe_step = (fs.nbe_step);
             for_extraction = true;
-            unrefine = (fs.unrefine)
+            unrefine = (fs.unrefine);
+            default_univs_to_zero = (fs.default_univs_to_zero)
           }
       | FStar_TypeChecker_Env.Unrefine ->
           {
@@ -1671,9 +1722,45 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
             weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
             nbe_step = (fs.nbe_step);
             for_extraction = (fs.for_extraction);
-            unrefine = true
+            unrefine = true;
+            default_univs_to_zero = (fs.default_univs_to_zero)
           }
       | FStar_TypeChecker_Env.NormDebug -> fs
+      | FStar_TypeChecker_Env.DefaultUnivsToZero ->
+          {
+            beta = (fs.beta);
+            iota = (fs.iota);
+            zeta = (fs.zeta);
+            zeta_full = (fs.zeta_full);
+            weak = (fs.weak);
+            hnf = (fs.hnf);
+            primops = (fs.primops);
+            do_not_unfold_pure_lets = (fs.do_not_unfold_pure_lets);
+            unfold_until = (fs.unfold_until);
+            unfold_only = (fs.unfold_only);
+            unfold_fully = (fs.unfold_fully);
+            unfold_attr = (fs.unfold_attr);
+            unfold_qual = (fs.unfold_qual);
+            unfold_namespace = (fs.unfold_namespace);
+            unfold_tac = (fs.unfold_tac);
+            pure_subterms_within_computations =
+              (fs.pure_subterms_within_computations);
+            simplify = (fs.simplify);
+            erase_universes = (fs.erase_universes);
+            allow_unbound_universes = (fs.allow_unbound_universes);
+            reify_ = (fs.reify_);
+            compress_uvars = (fs.compress_uvars);
+            no_full_norm = (fs.no_full_norm);
+            check_no_uvars = (fs.check_no_uvars);
+            unmeta = (fs.unmeta);
+            unascribe = (fs.unascribe);
+            in_full_norm_request = (fs.in_full_norm_request);
+            weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
+            nbe_step = (fs.nbe_step);
+            for_extraction = (fs.for_extraction);
+            unrefine = (fs.unrefine);
+            default_univs_to_zero = true
+          }
 let (to_fsteps : FStar_TypeChecker_Env.step Prims.list -> fsteps) =
   fun s -> FStar_Compiler_List.fold_right fstep_add_one s default_steps
 type debug_switches =
@@ -2050,7 +2137,8 @@ let (add_nbe : fsteps -> fsteps) =
         weakly_reduce_scrutinee = (s.weakly_reduce_scrutinee);
         nbe_step = true;
         for_extraction = (s.for_extraction);
-        unrefine = (s.unrefine)
+        unrefine = (s.unrefine);
+        default_univs_to_zero = (s.default_univs_to_zero)
       }
     else s
 let (config' :

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Env.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Env.ml
@@ -32,6 +32,7 @@ type step =
   | ForExtraction 
   | Unrefine 
   | NormDebug 
+  | DefaultUnivsToZero 
 let (uu___is_Beta : step -> Prims.bool) =
   fun projectee -> match projectee with | Beta -> true | uu___ -> false
 let (uu___is_Iota : step -> Prims.bool) =
@@ -126,6 +127,9 @@ let (uu___is_Unrefine : step -> Prims.bool) =
   fun projectee -> match projectee with | Unrefine -> true | uu___ -> false
 let (uu___is_NormDebug : step -> Prims.bool) =
   fun projectee -> match projectee with | NormDebug -> true | uu___ -> false
+let (uu___is_DefaultUnivsToZero : step -> Prims.bool) =
+  fun projectee ->
+    match projectee with | DefaultUnivsToZero -> true | uu___ -> false
 type steps = step Prims.list
 let rec (eq_step : step -> step -> Prims.bool) =
   fun s1 ->

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_NBE.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_NBE.ml
@@ -217,7 +217,9 @@ let (zeta_false : config -> config) =
                FStar_TypeChecker_Cfg.for_extraction =
                  (uu___.FStar_TypeChecker_Cfg.for_extraction);
                FStar_TypeChecker_Cfg.unrefine =
-                 (uu___.FStar_TypeChecker_Cfg.unrefine)
+                 (uu___.FStar_TypeChecker_Cfg.unrefine);
+               FStar_TypeChecker_Cfg.default_univs_to_zero =
+                 (uu___.FStar_TypeChecker_Cfg.default_univs_to_zero)
              });
           FStar_TypeChecker_Cfg.tcenv =
             (cfg_core.FStar_TypeChecker_Cfg.tcenv);
@@ -3333,7 +3335,9 @@ let (normalize :
                    FStar_TypeChecker_Cfg.for_extraction =
                      (uu___.FStar_TypeChecker_Cfg.for_extraction);
                    FStar_TypeChecker_Cfg.unrefine =
-                     (uu___.FStar_TypeChecker_Cfg.unrefine)
+                     (uu___.FStar_TypeChecker_Cfg.unrefine);
+                   FStar_TypeChecker_Cfg.default_univs_to_zero =
+                     (uu___.FStar_TypeChecker_Cfg.default_univs_to_zero)
                  });
               FStar_TypeChecker_Cfg.tcenv = (cfg.FStar_TypeChecker_Cfg.tcenv);
               FStar_TypeChecker_Cfg.debug = (cfg.FStar_TypeChecker_Cfg.debug);
@@ -3445,7 +3449,9 @@ let (normalize_for_unit_test :
                  FStar_TypeChecker_Cfg.for_extraction =
                    (uu___.FStar_TypeChecker_Cfg.for_extraction);
                  FStar_TypeChecker_Cfg.unrefine =
-                   (uu___.FStar_TypeChecker_Cfg.unrefine)
+                   (uu___.FStar_TypeChecker_Cfg.unrefine);
+                 FStar_TypeChecker_Cfg.default_univs_to_zero =
+                   (uu___.FStar_TypeChecker_Cfg.default_univs_to_zero)
                });
             FStar_TypeChecker_Cfg.tcenv = (cfg.FStar_TypeChecker_Cfg.tcenv);
             FStar_TypeChecker_Cfg.debug = (cfg.FStar_TypeChecker_Cfg.debug);

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Normalize.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Normalize.ml
@@ -395,8 +395,22 @@ let (norm_universe :
                         Prims.strcat "Universe variable not found: u@" uu___3 in
                       FStar_Compiler_Effect.failwith uu___2))
           | FStar_Syntax_Syntax.U_unif uu___ when
-              (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.check_no_uvars
+              (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.default_univs_to_zero
               -> [FStar_Syntax_Syntax.U_zero]
+          | FStar_Syntax_Syntax.U_unif uu___ when
+              (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.check_no_uvars
+              ->
+              let uu___1 =
+                let uu___2 =
+                  let uu___3 =
+                    FStar_TypeChecker_Env.get_range
+                      cfg.FStar_TypeChecker_Cfg.tcenv in
+                  FStar_Compiler_Range_Ops.string_of_range uu___3 in
+                let uu___3 = FStar_Syntax_Print.univ_to_string u2 in
+                FStar_Compiler_Util.format2
+                  "(%s) CheckNoUvars: unexpected universes variable remains: %s"
+                  uu___2 uu___3 in
+              FStar_Compiler_Effect.failwith uu___1
           | FStar_Syntax_Syntax.U_zero -> [u2]
           | FStar_Syntax_Syntax.U_unif uu___ -> [u2]
           | FStar_Syntax_Syntax.U_name uu___ -> [u2]
@@ -1623,7 +1637,9 @@ let (reduce_equality :
                 FStar_TypeChecker_Cfg.for_extraction =
                   (FStar_TypeChecker_Cfg.default_steps.FStar_TypeChecker_Cfg.for_extraction);
                 FStar_TypeChecker_Cfg.unrefine =
-                  (FStar_TypeChecker_Cfg.default_steps.FStar_TypeChecker_Cfg.unrefine)
+                  (FStar_TypeChecker_Cfg.default_steps.FStar_TypeChecker_Cfg.unrefine);
+                FStar_TypeChecker_Cfg.default_univs_to_zero =
+                  (FStar_TypeChecker_Cfg.default_steps.FStar_TypeChecker_Cfg.default_univs_to_zero)
               };
             FStar_TypeChecker_Cfg.tcenv = (cfg.FStar_TypeChecker_Cfg.tcenv);
             FStar_TypeChecker_Cfg.debug = (cfg.FStar_TypeChecker_Cfg.debug);
@@ -2769,7 +2785,9 @@ let decide_unfolding :
                          FStar_TypeChecker_Cfg.for_extraction =
                            (uu___.FStar_TypeChecker_Cfg.for_extraction);
                          FStar_TypeChecker_Cfg.unrefine =
-                           (uu___.FStar_TypeChecker_Cfg.unrefine)
+                           (uu___.FStar_TypeChecker_Cfg.unrefine);
+                         FStar_TypeChecker_Cfg.default_univs_to_zero =
+                           (uu___.FStar_TypeChecker_Cfg.default_univs_to_zero)
                        });
                     FStar_TypeChecker_Cfg.tcenv =
                       (cfg.FStar_TypeChecker_Cfg.tcenv);
@@ -3660,7 +3678,9 @@ let rec (norm :
                           FStar_TypeChecker_Cfg.for_extraction =
                             (uu___3.FStar_TypeChecker_Cfg.for_extraction);
                           FStar_TypeChecker_Cfg.unrefine =
-                            (uu___3.FStar_TypeChecker_Cfg.unrefine)
+                            (uu___3.FStar_TypeChecker_Cfg.unrefine);
+                          FStar_TypeChecker_Cfg.default_univs_to_zero =
+                            (uu___3.FStar_TypeChecker_Cfg.default_univs_to_zero)
                         });
                      FStar_TypeChecker_Cfg.tcenv =
                        (cfg.FStar_TypeChecker_Cfg.tcenv);
@@ -3835,7 +3855,9 @@ let rec (norm :
                            FStar_TypeChecker_Cfg.for_extraction =
                              ((cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.for_extraction);
                            FStar_TypeChecker_Cfg.unrefine =
-                             (uu___5.FStar_TypeChecker_Cfg.unrefine)
+                             (uu___5.FStar_TypeChecker_Cfg.unrefine);
+                           FStar_TypeChecker_Cfg.default_univs_to_zero =
+                             (uu___5.FStar_TypeChecker_Cfg.default_univs_to_zero)
                          } in
                        {
                          FStar_TypeChecker_Cfg.steps = uu___4;
@@ -4498,7 +4520,9 @@ let rec (norm :
                           FStar_TypeChecker_Cfg.for_extraction =
                             (uu___2.FStar_TypeChecker_Cfg.for_extraction);
                           FStar_TypeChecker_Cfg.unrefine =
-                            (uu___2.FStar_TypeChecker_Cfg.unrefine)
+                            (uu___2.FStar_TypeChecker_Cfg.unrefine);
+                          FStar_TypeChecker_Cfg.default_univs_to_zero =
+                            (uu___2.FStar_TypeChecker_Cfg.default_univs_to_zero)
                         });
                      FStar_TypeChecker_Cfg.tcenv =
                        (cfg.FStar_TypeChecker_Cfg.tcenv);
@@ -8176,7 +8200,9 @@ and (do_rebuild :
                             FStar_TypeChecker_Cfg.for_extraction =
                               (uu___4.FStar_TypeChecker_Cfg.for_extraction);
                             FStar_TypeChecker_Cfg.unrefine =
-                              (uu___4.FStar_TypeChecker_Cfg.unrefine)
+                              (uu___4.FStar_TypeChecker_Cfg.unrefine);
+                            FStar_TypeChecker_Cfg.default_univs_to_zero =
+                              (uu___4.FStar_TypeChecker_Cfg.default_univs_to_zero)
                           } in
                         {
                           FStar_TypeChecker_Cfg.steps = steps;
@@ -8428,7 +8454,10 @@ and (do_rebuild :
                                       FStar_TypeChecker_Cfg.for_extraction =
                                         (uu___7.FStar_TypeChecker_Cfg.for_extraction);
                                       FStar_TypeChecker_Cfg.unrefine =
-                                        (uu___7.FStar_TypeChecker_Cfg.unrefine)
+                                        (uu___7.FStar_TypeChecker_Cfg.unrefine);
+                                      FStar_TypeChecker_Cfg.default_univs_to_zero
+                                        =
+                                        (uu___7.FStar_TypeChecker_Cfg.default_univs_to_zero)
                                     });
                                  FStar_TypeChecker_Cfg.tcenv =
                                    (cfg1.FStar_TypeChecker_Cfg.tcenv);
@@ -9207,7 +9236,11 @@ let (reduce_or_remove_uvar_solutions :
       fun t ->
         normalize
           (FStar_Compiler_List.op_At
-             (if remove then [FStar_TypeChecker_Env.CheckNoUvars] else [])
+             (if remove
+              then
+                [FStar_TypeChecker_Env.DefaultUnivsToZero;
+                FStar_TypeChecker_Env.CheckNoUvars]
+              else [])
              [FStar_TypeChecker_Env.Beta;
              FStar_TypeChecker_Env.DoNotUnfoldPureLets;
              FStar_TypeChecker_Env.CompressUvars;
@@ -10289,7 +10322,7 @@ let (get_n_binders :
       FStar_Syntax_Syntax.term ->
         (FStar_Syntax_Syntax.binder Prims.list * FStar_Syntax_Syntax.comp))
   = fun env1 -> fun n -> fun t -> get_n_binders' env1 [] n t
-let (uu___3993 : unit) =
+let (uu___3995 : unit) =
   FStar_Compiler_Effect.op_Colon_Equals __get_n_binders get_n_binders'
 let (maybe_unfold_head_fv :
   FStar_TypeChecker_Env.env ->

--- a/src/syntax/FStar.Syntax.Resugar.fst
+++ b/src/syntax/FStar.Syntax.Resugar.fst
@@ -97,7 +97,7 @@ let rec resugar_universe (u:S.universe) r: A.term =
       //augment `a` an Unknown level (the level is unimportant ... we should maybe remove it altogether)
       A.mk_term a r A.Un
   in
-  begin match u with
+  begin match Subst.compress_univ u with
     | U_zero ->
       mk (A.Const(Const_int ("0", None))) r
 

--- a/src/syntax/FStar.Syntax.Util.fst
+++ b/src/syntax/FStar.Syntax.Util.fst
@@ -154,7 +154,7 @@ let unmeta_lift (t:term) : term =
 (* kernel u = (k_u, n)
         where u is of the form S^n k_u
         i.e., k_u is the "kernel" and n is the offset *)
-let rec univ_kernel u = match u with
+let rec univ_kernel u = match Subst.compress_univ u with
     | U_unknown
     | U_name _
     | U_unif _
@@ -175,7 +175,7 @@ let constant_univ_as_nat u = snd (univ_kernel u)
 //e.g, [Z; S Z; S S Z; u1; S u1; u2; S u2; S S u2; ?v1; S ?v1; ?v2]
 let rec compare_univs (u1:universe) (u2:universe) : int =
   let rec compare_kernel (uk1:universe) (uk2:universe) : int =
-    match uk1, uk2 with
+    match Subst.compress_univ uk1, Subst.compress_univ uk2 with
     | U_bvar _, _
     | _, U_bvar _  -> failwith "Impossible: compare_kernel bvar"
 

--- a/src/typechecker/FStar.TypeChecker.Cfg.fst
+++ b/src/typechecker/FStar.TypeChecker.Cfg.fst
@@ -65,6 +65,7 @@ let steps_to_string f =
     weakly_reduce_scrutinee = %s;\n\
     for_extraction = %s;\n\
     unrefine = %s;\n\
+    default_univs_to_zero = %s;\n\
   }"
   [ f.beta |> b;
     f.iota |> b;
@@ -95,6 +96,7 @@ let steps_to_string f =
     f.weakly_reduce_scrutinee |> b;
     f.for_extraction |> b;
     f.unrefine |> b;
+    f.default_univs_to_zero |> b;
    ]
 
 let default_steps : fsteps = {
@@ -128,6 +130,7 @@ let default_steps : fsteps = {
     nbe_step = false;
     for_extraction = false;
     unrefine = false;
+    default_univs_to_zero = false;
 }
 
 let fstep_add_one s fs =
@@ -173,6 +176,7 @@ let fstep_add_one s fs =
     | ForExtraction -> {fs with for_extraction = true }
     | Unrefine -> {fs with unrefine = true }
     | NormDebug -> fs // handled above, affects only dbg flags
+    | DefaultUnivsToZero -> {fs with default_univs_to_zero = true}
 
 let to_fsteps (s : list step) : fsteps =
     List.fold_right fstep_add_one s default_steps

--- a/src/typechecker/FStar.TypeChecker.Cfg.fsti
+++ b/src/typechecker/FStar.TypeChecker.Cfg.fsti
@@ -64,7 +64,7 @@ type fsteps = {
      simplify : bool;
      erase_universes : bool;
      allow_unbound_universes : bool;
-     reify_ : bool; // fun fact: calling it 'reify' won't bootstrap :)
+     reify_ : bool; // 'reify' is reserved
      compress_uvars : bool;
      no_full_norm : bool;
      check_no_uvars : bool;
@@ -75,6 +75,7 @@ type fsteps = {
      nbe_step:bool;
      for_extraction:bool;
      unrefine:bool;
+     default_univs_to_zero:bool; (* Default unresolved universe levels to zero *)
 }
 
 val default_steps : fsteps

--- a/src/typechecker/FStar.TypeChecker.Env.fsti
+++ b/src/typechecker/FStar.TypeChecker.Env.fsti
@@ -60,6 +60,7 @@ type step =
   | ForExtraction   //marking an invocation of the normalizer for extraction
   | Unrefine
   | NormDebug       //force debugging
+  | DefaultUnivsToZero // default al unresolved universe uvars to zero
 and steps = list step
 
 val eq_step : step -> step -> bool

--- a/src/typechecker/FStar.TypeChecker.Normalize.fst
+++ b/src/typechecker/FStar.TypeChecker.Normalize.fst
@@ -225,11 +225,13 @@ let norm_universe cfg (env:env) u =
                           then [U_unknown]
                           else failwith ("Universe variable not found: u@" ^ string_of_int x)
             end
+          | U_unif _ when cfg.steps.default_univs_to_zero ->
+            [U_zero]
+
           | U_unif _ when cfg.steps.check_no_uvars ->
-            [U_zero] // GM: why?
-//            failwith (BU.format2 "(%s) CheckNoUvars: unexpected universes variable remains: %s"
-//                                       (Range.string_of_range (Env.get_range cfg.tcenv))
-//                                       (Print.univ_to_string u))
+            failwith (BU.format2 "(%s) CheckNoUvars: unexpected universes variable remains: %s"
+                                       (Range.string_of_range (Env.get_range cfg.tcenv))
+                                       (Print.univ_to_string u))
 
           | U_zero
           | U_unif _
@@ -3341,7 +3343,7 @@ let unfold_whnf' steps env t = normalize (steps@whnf_steps) env t
 let unfold_whnf  env t = unfold_whnf' [] env t
 
 let reduce_or_remove_uvar_solutions remove env t =
-    normalize ((if remove then [CheckNoUvars] else [])
+    normalize ((if remove then [DefaultUnivsToZero; CheckNoUvars] else [])
               @[Beta; DoNotUnfoldPureLets; CompressUvars; Exclude Zeta; Exclude Iota; NoFullNorm;])
               env
               t

--- a/src/typechecker/FStar.TypeChecker.Normalize.fsti
+++ b/src/typechecker/FStar.TypeChecker.Normalize.fsti
@@ -72,6 +72,7 @@ val comp_to_string:  Env.env -> comp -> string
 val elim_uvars: Env.env -> sigelt -> sigelt
 val erase_universes: Env.env -> term -> term
 
+(* Note: This will default any unresolved universe variables to U_zero. *)
 val remove_uvar_solutions: Env.env -> term -> term
 
 val unfold_head_once: Env.env -> term -> option term

--- a/tests/bug-reports/Bug3207.fst
+++ b/tests/bug-reports/Bug3207.fst
@@ -1,0 +1,641 @@
+module Bug3207
+
+(* Based on file FStar/examples/metatheory/StlcStrongDbParSubst.fst *)
+
+open FStar.Tactics
+open FStar.Constructive
+open FStar.Classical
+open FStar.FunctionalExtensionality
+
+(* Constructive-style progress and preservation proof for STLC with
+   strong reduction, using deBruijn indices and parallel substitution. *)
+
+type typ =
+  | TArr    : typ -> typ -> typ
+  | TSum    : typ -> typ -> typ
+  | TPair   : typ -> typ -> typ
+  | TUnit   : typ
+  | TNat    : typ
+
+type var = nat
+
+open FStar.Bytes
+
+type exp =
+  | EVar         : var -> exp
+  | EApp         : exp -> exp -> exp
+  | ELam         : typ -> exp -> exp
+  | EUnit        : exp
+  | EZero        : exp
+  | ESucc        : v:exp -> exp
+  | ENRec        : exp -> exp -> exp -> exp
+  | EInl         : v:exp -> exp
+  | EInr         : v:exp -> exp
+  | ECase        : exp -> exp -> exp -> exp
+  | EFst         : exp -> exp
+  | ESnd         : exp -> exp
+  | EPair        : fst:exp -> snd:exp -> exp
+
+
+(* Type system; as inductive relation (not strictly necessary for STLC) *)
+
+type env = var -> Tot (option typ)
+
+val empty : env
+let empty _ = None
+
+(* we only need extend at 0 *)
+val extend : typ -> env -> Tot env
+let extend t g y = if y = 0 then Some t
+                   else g (y-1)
+
+noeq type typing : env -> exp -> typ -> Type =
+  | TyVar : #g:env ->
+             x:var{Some? (g x)} ->
+             typing g (EVar x) (Some?.v (g x))
+  | TyLam : #g :env ->
+             t :typ ->
+            #e1:exp ->
+            #t':typ ->
+            $hbody:typing (extend t g) e1 t' ->
+                   typing g (ELam t e1) (TArr t t')
+  | TyApp : #g:env ->
+            #e1:exp ->
+            #e2:exp ->
+            #t11:typ ->
+            #t12:typ ->
+            $h1:typing g e1 (TArr t11 t12) ->
+            $h2:typing g e2 t11 ->
+                typing g (EApp e1 e2) t12
+  | TyUnit : #g:env ->
+             typing g EUnit TUnit
+  | TyZero : #g:env ->
+             typing g EZero TNat
+  | TySucc : #g:env ->
+             #e:exp ->
+             $h1:typing g e TNat ->
+                 typing g (ESucc e) TNat
+  | TyNRec : #g:env ->
+             #e1:exp ->
+             #e2:exp ->
+             #e3:exp ->
+             #t1:typ ->
+             $h1:typing g e1 TNat ->
+             $h2:typing g e2 t1 ->
+             $h3:typing g e3 (TArr t1 t1) ->
+                 typing g (ENRec e1 e2 e3) t1
+  | TyInl  : #g:env ->
+             #e:exp ->
+             #t1:typ ->
+             t2:typ ->
+             $h1:typing g e t1 ->
+                 typing g (EInl e) (TSum t1 t2)
+  | TyInr  : #g:env ->
+             #e:exp ->
+             t1:typ ->
+             #t2:typ ->
+             $h1:typing g e t2 ->
+                 typing g (EInr e) (TSum t1 t2)
+  | TyCase : #g:env ->
+             #e1:exp ->
+             #e2:exp ->
+             #e3:exp ->
+             #t1:typ ->
+             #t2:typ ->
+             #t3:typ ->
+             $h1:typing g e1 (TSum t1 t2) ->
+             $h2:typing g e2 (TArr t1 t3) ->
+             $h3:typing g e3 (TArr t2 t3) ->
+                 typing g (ECase e1 e2 e3) t3
+  | TyFst         : #g:env ->
+                    #e:exp ->
+                    #t1:typ ->
+                    #t2:typ ->
+                    $h1:typing g e (TPair t1 t2) ->
+                        typing g (EFst e) t1
+  | TySnd         : #g:env ->
+                    #e:exp ->
+                    #t1:typ ->
+                    #t2:typ ->
+                    $h1:typing g e (TPair t1 t2) ->
+                        typing g (ESnd e) t2
+  | TyPair        : #g:env ->
+                    #e1:exp ->
+                    #e2:exp ->
+                    #t1:typ ->
+                    #t2:typ ->
+                    $h1:typing g e1 t1 ->
+                    $h2:typing g e2 t2 ->
+                        typing g (EPair e1 e2) (TPair t1 t2)
+
+(* Parallel substitution operation `subst` *)
+let sub (renaming:bool) = 
+    f:(var -> exp){ renaming <==> (forall x. EVar? (f x)) }
+
+let bool_order (b:bool) = if b then 0 else 1
+
+let sub_inc 
+  : sub true
+  = fun y -> EVar (y+1)
+
+let is_var (e:exp) : int = if EVar? e then 0 else 1
+
+let rec subst (#r:bool)
+              (s:sub r)
+              (e:exp)
+  : Tot (e':exp { r ==> (EVar? e <==> EVar? e') })
+        (decreases %[bool_order (EVar? e); 
+                     bool_order r;
+                     1;
+                     e])
+  = match e with
+  | EVar x -> s x
+  | ELam t e1 -> ELam t (subst (sub_elam s) e1)
+  | EApp e1 e2 -> EApp (subst s e1) (subst s e2)
+  | EUnit -> EUnit
+  | EZero -> EZero
+  | ESucc e -> ESucc (subst s e)
+  | ENRec e1 e2 e3 -> ENRec (subst s e1) (subst s e2) (subst s e3)
+  | EInl e -> EInl (subst s e)
+  | EInr e -> EInr (subst s e)
+  | ECase e1 e2 e3 -> ECase (subst s e1) (subst s e2) (subst s e3)
+  | EFst e -> EFst (subst s e)
+  | ESnd e -> ESnd (subst s e)
+  | EPair e1 e2 -> EPair (subst s e1) (subst s e2)
+
+and sub_elam (#r:bool) (s:sub r) 
+  : Tot (sub r)
+        (decreases %[1;
+                     bool_order r;
+                     0;
+                     EVar 0])
+  = let f : var -> exp = 
+      fun y ->
+        if y=0
+        then EVar y
+        else subst sub_inc (s (y - 1))
+    in
+    introduce not r ==> (exists x. ~ (EVar? (f x)))
+    with not_r. 
+      eliminate exists y. ~ (EVar? (s y))
+      returns (exists x. ~ (EVar? (f x)))
+      with (not_evar_sy:squash (~(EVar? (s y)))). 
+        introduce exists x. ~(EVar? (f x))
+        with (y + 1)
+        and ()
+    ;
+    f
+
+let sub_beta (e:exp)
+  : sub (EVar? e)
+  = let f = 
+      fun (y:var) ->
+        if y = 0 then e      (* substitute *)
+        else (EVar (y-1))    (* shift -1 *)
+    in
+    if not (EVar? e)
+    then introduce exists (x:var). ~(EVar? (f x))
+         with 0 and ();
+    f
+
+(* Small-step operational semantics; strong / full-beta reduction is
+   non-deterministic, so necessarily as inductive relation *)
+
+type step : exp -> exp -> Type =
+  | SBeta : t:typ ->
+            e1:exp ->
+            e2:exp ->
+            step (EApp (ELam t e1) e2) (subst (sub_beta e2) e1)
+  | SApp1 : #e1:exp ->
+             e2:exp ->
+            #e1':exp ->
+            $hst:step e1 e1' ->
+                 step (EApp e1 e2) (EApp e1' e2)
+  | SApp2 :   e1:exp ->
+             #e2:exp ->
+            #e2':exp ->
+            $hst:step e2 e2' ->
+                 step (EApp e1 e2) (EApp e1 e2')
+  | SSucc :    e:exp ->
+             #e':exp ->
+            $hst:step e e' ->
+                 step (ESucc e) (ESucc e')     
+  | SNRecV :  #e1:exp ->
+             #e1':exp ->
+               e2:exp ->
+               e3:exp ->
+             $hst:step e1 e1' ->
+                 step (ENRec e1 e2 e3) (ENRec e1' e2 e3)
+  | SNRec0 : e2:exp ->
+             e3:exp ->
+                 step (ENRec EZero e2 e3) e2
+  | SNRecIter :  v:exp ->
+                e2:exp ->
+                e3:exp ->
+                step (ENRec (ESucc v) e2 e3) (ENRec v (EApp e3 e2) e3)
+  | SInl  :    e:exp ->
+             #e':exp ->
+            $hst:step e e' ->
+                 step (EInl e) (EInl e')
+  | SInr  :    e:exp ->
+             #e':exp ->
+            $hst:step e e' ->
+                 step (EInr e) (EInr e')
+  | SCase :  #e1:exp ->
+            #e1':exp ->
+              e2:exp ->
+              e3:exp ->
+            $hst:step e1 e1' ->
+                 step (ECase e1 e2 e3) (ECase e1' e2 e3)
+  | SCaseInl :  v:exp ->
+               e2:exp ->
+               e3:exp ->
+                 step (ECase (EInl v) e2 e3) (EApp e2 v)
+  | SCaseInr :  v:exp ->
+               e2:exp ->
+               e3:exp ->
+                 step (ECase (EInr v) e2 e3) (EApp e3 v)
+  | SFst0 :    #e:exp ->
+              #e':exp ->
+             $hst:step e e' ->
+                 step (EFst e) (EFst e')
+  | SFst :  e1:exp ->
+            e2:exp ->
+               step (EFst (EPair e1 e2)) e1
+  | SSnd0 :    #e:exp ->
+              #e':exp ->
+             $hst:step e e' ->
+                 step (ESnd e) (ESnd e')
+  | SSnd :  e1:exp ->
+            e2:exp ->
+               step (ESnd (EPair e1 e2)) e2
+  | SPair1  : #e1:exp ->
+             #e1':exp ->
+             $hst:step e1 e1' ->
+               e2:exp ->
+                 step (EPair e1 e2) (EPair e1' e2)
+  | SPair2  :  e1:exp ->
+              #e2:exp ->
+             #e2':exp ->
+             $hst:step e2 e2' ->
+                 step (EPair e1 e2) (EPair e1 e2')
+
+
+let rec is_value (e:exp) : bool = 
+     ELam? e || 
+     EUnit? e || 
+     EZero? e || 
+     (ESucc? e && is_value (ESucc?.v e)) || 
+     (EInl? e && is_value (EInl?.v e)) ||
+     (EInr? e && is_value (EInr?.v e)) || 
+     (EPair? e && is_value (EPair?.fst e) && is_value (EPair?.snd e) )
+
+let rec progress (#e:exp { ~(is_value e) })
+                 (#t:typ)
+                 (h:typing empty e t)
+  : e':exp & step e e'
+  =  match h with
+     | TyApp #g #e1 #e2 #t11 #t12 h1 h2 -> 
+     begin
+          match e1 with
+          | ELam t e1' -> (| subst (sub_beta e2) e1', SBeta t e1' e2 |)
+          | _          -> let (| e1', h1' |) = progress h1 in
+                              (| EApp e1' e2, SApp1 e2 h1'|) (** TODO: call-by-name **)
+     end
+     | TySucc #g #e h1 ->
+          let (| e', h1' |) = progress h1 in
+          (| ESucc e', SSucc e h1'|)
+     | TyNRec #g #e1 #e2 #e3 #t1 h1 h2 h3 -> begin
+          match e1 with
+          | EZero -> (| e2, SNRec0 e2 e3 |)
+          | ESucc v -> (| ENRec v (EApp e3 e2) e3, SNRecIter v e2 e3 |)
+          | _ -> let (| e1', h1' |) = progress h1 in
+                 (| ENRec e1' e2 e3, SNRecV e2 e3 h1' |)
+     end
+     | TyInl #g #e #t1 #t2 h1 -> 
+          let (| e', h1' |) = progress h1 in
+          (| EInl e', SInl e h1'|)
+     | TyInr #g #e #t1 #t2 h1 -> 
+          let (| e', h1' |) = progress h1 in
+          (| EInr e', SInr e h1'|)
+     | TyCase #g #e1 #e2 #e3 #t1 #t2 #t3 h1 h2 h3 -> begin
+          match e1 with
+          | EInl v -> (| EApp e2 v, SCaseInl v e2 e3 |)
+          | EInr v -> (| EApp e3 v, SCaseInr v e2 e3 |)
+          | _ ->
+               let (| e1', h1' |) = progress h1 in
+               (| ECase e1' e2 e3, SCase e2 e3 h1' |)
+     end
+     | TyFst #g #e #t1 #t2 h1 -> begin
+          match e with
+          | EPair e1 e2 -> (| e1, SFst e1 e2 |)
+          | _ -> let (| e', h1' |) = progress h1 in
+                 (| EFst e', SFst0 h1' |)
+     end
+     | TySnd #g #e #t1 #t2 h1 -> begin
+          match e with
+          | EPair e1 e2 -> (| e2, SSnd e1 e2 |)
+          | _ -> let (| e', h1' |) = progress h1 in
+                 (| ESnd e', SSnd0 h1' |)
+     end
+     | TyPair #g #e1 #e2 #t1 #t2 h1 h2 -> 
+          if is_value e1 then
+               let (| e2', h2' |) = progress h2 in
+               (| EPair e1 e2', SPair2 e1 h2' |)
+          else 
+               let (| e1', h1' |) = progress h1 in
+               (| EPair e1' e2, SPair1 h1' e2 |)
+
+
+(* Typing of substitutions (very easy, actually) *)
+let subst_typing #r (s:sub r) (g1:env) (g2:env) =
+    x:var{Some? (g1 x)} -> typing g2 (s x) (Some?.v (g1 x))
+
+(* Substitution preserves typing
+   Strongest possible statement; suggested by Steven SchÃ¤fer *)
+let rec substitution (#g1:env) 
+                     (#e:exp)
+                     (#t:typ)
+                     (#r:bool)
+                     (s:sub r)
+                     (#g2:env)
+                     (h1:typing g1 e t)
+                     (hs:subst_typing s g1 g2)
+   : Tot (typing g2 (subst s e) t)
+         (decreases %[bool_order (EVar? e); bool_order r; e])
+   = match h1 with
+   | TyVar x -> hs x
+   | TyLam tlam hbody ->
+     let hs'' : subst_typing (sub_inc) g2 (extend tlam g2) =
+       fun x -> TyVar (x+1) in
+     let hs' : subst_typing (sub_elam s) (extend tlam g1) (extend tlam g2) =
+       fun y -> if y = 0 then TyVar y
+             else substitution sub_inc (hs (y - 1)) hs''
+     in TyLam tlam (substitution (sub_elam s) hbody hs')
+      | TyApp hfun harg -> TyApp (substitution s hfun hs) (substitution s harg hs)
+   | TyUnit -> TyUnit
+   | TyZero -> TyZero
+   | TySucc h1 -> TySucc (substitution s h1 hs)
+   | TyNRec h1 h2 h3 -> TyNRec (substitution s h1 hs) (substitution s h2 hs) (substitution s h3 hs)
+   | TyInl t2 h1 -> 
+     let EInl e' = e in
+     let hs' : typing g2 (EInl (subst s e')) t = TyInl t2 (substitution s h1 hs) in
+     assert (subst s e == EInl (subst s e'));
+     hs'
+   | TyInr t1 h1 -> 
+     let EInr e' = e in
+     let hs' : typing g2 (EInr (subst s e')) t = TyInr t1 (substitution s h1 hs) in
+     assert (subst s e == EInr (subst s e'));
+     hs'
+   | TyCase h1 h2 h3 -> TyCase (substitution s h1 hs) (substitution s h2 hs) (substitution s h3 hs)
+   | TyFst h1 -> TyFst (substitution s h1 hs)
+   | TySnd h1 -> TySnd (substitution s h1 hs)
+   | TyPair h1 h2 -> TyPair (substitution s h1 hs) (substitution s h2 hs)
+
+(* Substitution for beta reduction
+   Now just a special case of substitution lemma *)
+let substitution_beta #e #v #t_x #t #g 
+                      (h1:typing g v t_x)
+                      (h2:typing (extend t_x g) e t)
+  : typing g (subst (sub_beta v) e) t
+  = let hs : subst_typing (sub_beta v) (extend t_x g) g =
+        fun y -> if y = 0 then h1 else TyVar (y-1) in
+    substitution (sub_beta v) h2 hs
+
+
+(* Type preservation *)
+let rec preservation_step #e #e' #g #t (ht:typing g e t) (hs:step e e') 
+  : typing g e' t
+  =  match hs with
+     | SBeta tx e1' e2' -> 
+          let TyApp h1 h2 = ht in
+          substitution_beta h2 (TyLam?.hbody h1)
+     | SApp1 e2' hs1   -> 
+          let TyApp h1 h2 = ht in
+          TyApp (preservation_step h1 hs1) h2
+     | SApp2 e1' hs2   -> 
+          let TyApp h1 h2 = ht in
+          TyApp h1 (preservation_step h2 hs2)
+     | SSucc e' hs1    -> 
+          let TySucc h1 = ht in
+          TySucc (preservation_step h1 hs1)
+     | SNRecV _ _ hs1 ->
+          let TyNRec h1 h2 h3 = ht in
+          TyNRec (preservation_step h1 hs1) h2 h3
+     | SNRec0 _ _ ->
+          let TyNRec h1 h2 h3 = ht in
+          h2
+     | SNRecIter _ _ _ ->
+          let TyNRec h1 h2 h3 = ht in
+          let TySucc h1' = h1 in
+          TyNRec h1' (TyApp h3 h2) h3
+     | SInl _ hs1     -> 
+          let TyInl t2 h1 = ht in
+          TyInl t2 (preservation_step h1 hs1)
+     | SInr _ hs1     -> 
+          let TyInr t1 h1 = ht in
+          TyInr t1 (preservation_step h1 hs1)
+     | SCase _ _ hs1 -> 
+          let TyCase h1 h2 h3 = ht in
+          TyCase (preservation_step h1 hs1) h2 h3
+     | SCaseInl _ _ _ -> 
+          let TyCase h1 h2 h3 = ht in
+          let TyInl _ h1' = h1 in
+          TyApp h2 h1'
+     | SCaseInr _ _ _ -> 
+          let TyCase h1 h2 h3 = ht in
+          let TyInr _ h1' = h1 in
+          TyApp h3 h1'
+     | SFst0 hs1 -> 
+          let TyFst h1 = ht in
+          TyFst (preservation_step h1 hs1)
+     | SFst _ _ -> 
+          let TyFst h1 = ht in
+          let TyPair h1' _ = h1 in
+          h1'
+     | SSnd0 hs1 -> 
+          let TySnd h1 = ht in
+          TySnd (preservation_step h1 hs1)
+     | SSnd _ _ -> 
+          let TySnd h1 = ht in
+          let TyPair _ h1' = h1 in
+          h1'
+     | SPair1 hs1 _ ->
+          let TyPair h1 h2 = ht in
+          TyPair (preservation_step h1 hs1) h2
+     | SPair2 _ hs2 ->
+          let TyPair h1 h2 = ht in
+          TyPair h1 (preservation_step h2 hs2)
+
+(** Phil Wadler: Progress + Preservation = Evaluation. **)
+let rec eval (#e:exp) (#t:typ) (ht:typing empty e t)
+  : Pure (e':exp & typing empty e' t)
+     (requires True)
+     (ensures (fun (| e', ht' |) -> is_value e'))
+  =  if is_value e then (| e, ht |)
+     else let (| e', st |) = progress ht in
+          let ht' : typing empty e' t = preservation_step ht st in
+          admit (); (** TODO: proof of termination required **)
+          eval ht'
+
+(** *** Elaboration of types and expressions to F* *)
+
+open FStar.Ghost
+open FStar.UInt32
+let convert (n : nat) : u32 = if n < 65535 then (uint_to_t n <: u32) else 0ul
+
+type file_descr = int
+
+let rec elab_typ (t:typ) : Type =
+  match t with
+  | TArr t1 t2 -> (elab_typ t1) -> Tot (elab_typ t2)
+  | TUnit -> unit
+  | TNat -> nat
+  | TSum t1 t2 -> either (elab_typ t1) (elab_typ t2)
+  | TPair t1 t2 -> (elab_typ t1) * (elab_typ t2)
+
+type venv (g:env) = x:var{Some? (g x)} -> elab_typ (Some?.v (g x))
+
+let vempty : venv empty = fun _ -> assert false
+
+let vextend #t (x:elab_typ t) (#g:env) (ve:venv g) : venv (extend t g) =
+  fun y -> if y = 0 then x else ve (y-1)
+
+let cast_TArr #t1 #t2 (h : (elab_typ t1 -> Tot (elab_typ t2))) : elab_typ (TArr t1 t2) = h
+
+open FStar.List.Tot
+
+let rec elab_exp (#g:env) (#e:exp) (#t:typ) (h:typing g e t) (ve:venv g)
+  : Tot (elab_typ t) (decreases e) =
+  match e with
+  | EUnit -> ()
+  | EZero -> 0
+  | ESucc e ->
+       let TySucc h1 = h in
+       assert (t == TNat);
+       let v = elab_exp h1 ve in
+       v
+  | ENRec e1 e2 e3 ->
+       let TyNRec h1 h2 h3 = h in
+       let v1 = elab_exp h1 ve in
+       let v2 : elab_typ t = elab_exp h2 ve in
+       let v3 : elab_typ (TArr t t) = elab_exp h3 ve in
+       let rec f (n : nat) : Tot (elab_typ t) =
+         if n = 0 then v2 else f (n - 1) in
+       f v1
+  | EInl e ->
+       let TyInl #_ #_ #t1 #t2 h1 = h in
+       let v = elab_exp h1 ve in
+       Inl #(elab_typ t1) #(elab_typ t2) v
+  | EInr e ->
+       let TyInr #_ #_ #t1 #t2 h1 = h in
+       let v = elab_exp h1 ve in
+       Inr #(elab_typ t1) #(elab_typ t2) v
+  | ECase e1 e2 e3 ->
+       let TyCase #_ #_ #_ #_ #t1 #t2 #t3 h1 h2 h3 = h in
+       let v1 = elab_exp h1 ve in
+       let v2 = elab_exp h2 ve in
+       let v3 = elab_exp h3 ve in
+       (match v1 with | Inl x -> v2 x | Inr y -> v3 y)
+  | EVar x -> ve x
+  | ELam t1 e1 ->
+       let TyLam t1' #_ #t2 h1 = h in
+       assert (t1' == t1);
+       assert (t == TArr t1 t2);
+       let w : elab_typ t1 -> Tot (elab_typ t2) =
+         (fun x -> elab_exp h1 (vextend x ve)) in
+       cast_TArr w
+  | EApp e1 e2 ->
+       let TyApp #_ #_ #_ #t1 #t2 h1 h2 = h in
+       assert ((elab_typ t) == (elab_typ t2));
+       (* TODO: Should we change the order here, first evaluate argument? *)
+       let v1 : elab_typ (TArr t1 t2) = elab_exp h1 ve in
+       let v2 : elab_typ t1 = elab_exp h2 ve in
+       v1 v2
+  | EFst e ->
+       let TyFst #_ #_ #t1 #t2 h1 = h in
+       let v = elab_exp h1 ve in
+       fst #(elab_typ t1) #(elab_typ t2) v
+  | ESnd e ->
+       let TySnd #_ #_ #t1 #t2 h1 = h in
+       let v = elab_exp h1 ve in
+       snd #(elab_typ t1) #(elab_typ t2) v
+  | EPair e1 e2 ->
+       let TyPair #_ #_ #_ #t1 #t2 h1 h2 = h in
+       let v1 = elab_exp h1 ve in
+       let v2 = elab_exp h2 ve in
+       (v1, v2)
+
+(** ** Semantics **)
+let sem #t (#e:exp) (hte:typing empty e t) : elab_typ t = 
+     let (| e', hte' |) = eval hte in
+     elab_exp hte' vempty
+
+type wholeS = (unit -> Tot nat)
+val behS : wholeS -> nat
+let behS ws = ws ()
+
+type wholeT = wt:exp & typing empty wt (TArr TUnit TNat)
+
+val behT : wt:wholeT -> nat 
+let behT (| ew, htw |) = sem (TyApp htw TyUnit)
+
+type rel = 
+  #ty:typ -> 
+  elab_typ ty ->             (** F* value **)
+  #e:exp ->                  (** STLC value **)
+  typing empty e ty -> 
+  Type0
+
+let rel_whole (r:rel) (ws:wholeS) (wt:wholeT) : Type0 =
+  ws `r` (dsnd wt) ==> behS ws == behT wt
+
+val naive_rel : rel
+let rec naive_rel #ty fst_e hte =
+  let (| stlc_e, hte |) = eval hte in
+  match hte with
+  | TyLam tv #_ #t' _ -> 
+    let fst_f : elab_typ tv -> elab_typ t' = fst_e in
+    forall (v:exp) (htv:typing empty v tv). 
+      let fst_v : elab_typ tv = elab_exp htv vempty in
+      let happ : typing empty (EApp stlc_e v) t' = TyApp hte htv in
+      (fst_v `naive_rel` htv) <==> ((fst_f fst_v) `naive_rel` happ)
+  | TyUnit -> fst_e == ()
+  | TyZero -> fst_e == 0
+  | TySucc hte' -> fst_e > 0 /\ (fst_e-1) `naive_rel` hte'
+  | TyInl #_ #_ #t1 t2 ht1 ->
+    let fst_sum : either (elab_typ t1) (elab_typ t2) = fst_e in
+    Inl? fst_sum /\ (Inl?.v fst_sum `naive_rel` ht1)
+  | TyInr #_ #_ t1 #t2 ht2 ->
+    let fst_sum : either (elab_typ t1) (elab_typ t2) = fst_e in
+    Inr? fst_sum /\ (Inr?.v fst_sum `naive_rel` ht2)
+  | TyPair #_ #_ #_ #t1 #t2 ht1 ht2 ->
+    let fst_pair : (elab_typ t1 * elab_typ t2) = fst_e in
+    let (fst_fst, fst_snd) = fst_pair in
+    (fst_fst `naive_rel` ht1) /\ (fst_snd `naive_rel` ht2)
+
+let naive_rel_implies_c ws wt : Lemma (rel_whole naive_rel ws wt) = 
+  let (| ew, htw |) = wt in
+  introduce 
+    ws `naive_rel` (dsnd wt)
+  ==> 
+    behS ws == behT wt
+  with _. begin
+    let (| ew', htw' |) = eval (dsnd wt) in
+    assert (TyLam? htw');
+    let htapp : typing empty (EApp ew' EUnit) TNat = TyApp htw' TyUnit in
+    assert (() `naive_rel` TyUnit);
+    assert ((ws ()) `naive_rel` htapp);
+    let (| ev, htv |) = eval htapp in
+    match htv with
+    | TyZero -> begin
+      calc (==) {
+        behS ws;
+        == { _ by (tadmit ()) }
+        elab_exp (dsnd (eval (TyApp (dsnd (eval htw)) TyUnit))) vempty;
+        == { _ by (tadmit ()) }
+        behT wt;
+      }
+    end
+    | TySucc htapp' -> admit ()
+  end

--- a/tests/bug-reports/Bug3207b.fst
+++ b/tests/bug-reports/Bug3207b.fst
@@ -1,0 +1,9 @@
+module Bug3207b
+
+open FStar.List.Tot
+
+type t (i : list int) = | Mk of int
+
+#set-options "--no_smt"
+ 
+let f #l (x : t l) : t ([] @ l) = x

--- a/tests/bug-reports/Bug3207c.fst
+++ b/tests/bug-reports/Bug3207c.fst
@@ -1,0 +1,245 @@
+module Bug3207c
+
+(* Minimization of Bug3207.fst *)
+
+open FStar.Tactics
+open FStar.Constructive
+open FStar.Classical
+open FStar.FunctionalExtensionality
+
+(* Constructive-style progress and preservation proof for STLC with
+   strong reduction, using deBruijn indices and parallel substitution. *)
+
+type typ =
+  | TArr    : typ -> typ -> typ
+  | TSum    : typ -> typ -> typ
+  | TPair   : typ -> typ -> typ
+  | TUnit   : typ
+  | TNat    : typ
+
+type var = nat
+
+open FStar.Bytes
+
+type exp =
+  | EVar         : var -> exp
+  | EApp         : exp -> exp -> exp
+  | ELam         : typ -> exp -> exp
+  | EUnit        : exp
+  | EZero        : exp
+  | ESucc        : v:exp -> exp
+  | ENRec        : exp -> exp -> exp -> exp
+  | EInl         : v:exp -> exp
+  | EInr         : v:exp -> exp
+  | ECase        : exp -> exp -> exp -> exp
+  | EFst         : exp -> exp
+  | ESnd         : exp -> exp
+  | EPair        : fst:exp -> snd:exp -> exp
+
+
+(* Type system; as inductive relation (not strictly necessary for STLC) *)
+
+type env = var -> Tot (option typ)
+
+val empty : env
+let empty _ = None
+
+(* we only need extend at 0 *)
+val extend : typ -> env -> Tot env
+let extend t g y = if y = 0 then Some t
+                   else g (y-1)
+
+noeq type typing : env -> exp -> typ -> Type =
+  | TyVar : #g:env ->
+             x:var{Some? (g x)} ->
+             typing g (EVar x) (Some?.v (g x))
+  | TyLam : #g :env ->
+             t :typ ->
+            #e1:exp ->
+            #t':typ ->
+            $hbody:typing (extend t g) e1 t' ->
+                   typing g (ELam t e1) (TArr t t')
+  | TyApp : #g:env ->
+            #e1:exp ->
+            #e2:exp ->
+            #t11:typ ->
+            #t12:typ ->
+            $h1:typing g e1 (TArr t11 t12) ->
+            $h2:typing g e2 t11 ->
+                typing g (EApp e1 e2) t12
+  | TyUnit : #g:env ->
+             typing g EUnit TUnit
+  | TyZero : #g:env ->
+             typing g EZero TNat
+  | TySucc : #g:env ->
+             #e:exp ->
+             $h1:typing g e TNat ->
+                 typing g (ESucc e) TNat
+  | TyNRec : #g:env ->
+             #e1:exp ->
+             #e2:exp ->
+             #e3:exp ->
+             #t1:typ ->
+             $h1:typing g e1 TNat ->
+             $h2:typing g e2 t1 ->
+             $h3:typing g e3 (TArr t1 t1) ->
+                 typing g (ENRec e1 e2 e3) t1
+  | TyInl  : #g:env ->
+             #e:exp ->
+             #t1:typ ->
+             t2:typ ->
+             $h1:typing g e t1 ->
+                 typing g (EInl e) (TSum t1 t2)
+  | TyInr  : #g:env ->
+             #e:exp ->
+             t1:typ ->
+             #t2:typ ->
+             $h1:typing g e t2 ->
+                 typing g (EInr e) (TSum t1 t2)
+  | TyCase : #g:env ->
+             #e1:exp ->
+             #e2:exp ->
+             #e3:exp ->
+             #t1:typ ->
+             #t2:typ ->
+             #t3:typ ->
+             $h1:typing g e1 (TSum t1 t2) ->
+             $h2:typing g e2 (TArr t1 t3) ->
+             $h3:typing g e3 (TArr t2 t3) ->
+                 typing g (ECase e1 e2 e3) t3
+  | TyFst         : #g:env ->
+                    #e:exp ->
+                    #t1:typ ->
+                    #t2:typ ->
+                    $h1:typing g e (TPair t1 t2) ->
+                        typing g (EFst e) t1
+  | TySnd         : #g:env ->
+                    #e:exp ->
+                    #t1:typ ->
+                    #t2:typ ->
+                    $h1:typing g e (TPair t1 t2) ->
+                        typing g (ESnd e) t2
+  | TyPair        : #g:env ->
+                    #e1:exp ->
+                    #e2:exp ->
+                    #t1:typ ->
+                    #t2:typ ->
+                    $h1:typing g e1 t1 ->
+                    $h2:typing g e2 t2 ->
+                        typing g (EPair e1 e2) (TPair t1 t2)
+
+(* Parallel substitution operation `subst` *)
+let sub (renaming:bool) = 
+    f:(var -> exp){ renaming <==> (forall x. EVar? (f x)) }
+
+let bool_order (b:bool) = if b then 0 else 1
+
+let sub_inc 
+  : sub true
+  = fun y -> EVar (y+1)
+
+let is_var (e:exp) : int = if EVar? e then 0 else 1
+
+let rec subst (#r:bool)
+              (s:sub r)
+              (e:exp)
+  : Tot (e':exp { r ==> (EVar? e <==> EVar? e') })
+        (decreases %[bool_order (EVar? e); 
+                     bool_order r;
+                     1;
+                     e])
+  = match e with
+  | EVar x -> s x
+  | ELam t e1 -> ELam t (subst (sub_elam s) e1)
+  | EApp e1 e2 -> EApp (subst s e1) (subst s e2)
+  | EUnit -> EUnit
+  | EZero -> EZero
+  | ESucc e -> ESucc (subst s e)
+  | ENRec e1 e2 e3 -> ENRec (subst s e1) (subst s e2) (subst s e3)
+  | EInl e -> EInl (subst s e)
+  | EInr e -> EInr (subst s e)
+  | ECase e1 e2 e3 -> ECase (subst s e1) (subst s e2) (subst s e3)
+  | EFst e -> EFst (subst s e)
+  | ESnd e -> ESnd (subst s e)
+  | EPair e1 e2 -> EPair (subst s e1) (subst s e2)
+
+and sub_elam (#r:bool) (s:sub r) 
+  : Tot (sub r)
+        (decreases %[1;
+                     bool_order r;
+                     0;
+                     EVar 0])
+  = let f : var -> exp = 
+      fun y ->
+        if y=0
+        then EVar y
+        else subst sub_inc (s (y - 1))
+    in
+    introduce not r ==> (exists x. ~ (EVar? (f x)))
+    with not_r. 
+      eliminate exists y. ~ (EVar? (s y))
+      returns (exists x. ~ (EVar? (f x)))
+      with (not_evar_sy:squash (~(EVar? (s y)))). 
+        introduce exists x. ~(EVar? (f x))
+        with (y + 1)
+        and ()
+    ;
+    f
+
+let sub_beta (e:exp)
+  : sub (EVar? e)
+  = let f = 
+      fun (y:var) ->
+        if y = 0 then e      (* substitute *)
+        else (EVar (y-1))    (* shift -1 *)
+    in
+    if not (EVar? e)
+    then introduce exists (x:var). ~(EVar? (f x))
+         with 0 and ();
+    f
+
+(* Small-step operational semantics; strong / full-beta reduction is
+   non-deterministic, so necessarily as inductive relation *)
+
+type step : exp -> exp -> Type =
+
+let rec is_value (e:exp) : bool = 
+     ELam? e || 
+     EUnit? e || 
+     EZero? e || 
+     (ESucc? e && is_value (ESucc?.v e)) || 
+     (EInl? e && is_value (EInl?.v e)) ||
+     (EInr? e && is_value (EInr?.v e)) || 
+     (EPair? e && is_value (EPair?.fst e) && is_value (EPair?.snd e) )
+
+let progress (#e:exp { ~(is_value e) })
+                 (#t:typ)
+                 (h:typing empty e t)
+  : e':exp & step e e'
+  =  magic()
+
+(* Typing of substitutions (very easy, actually) *)
+
+(* Type preservation *)
+let rec preservation_step #e #e' #g #t (ht:typing g e t) (hs:step e e') 
+  : typing g e' t
+  =  magic()
+  
+(** Phil Wadler: Progress + Preservation = Evaluation. **)
+let rec eval (#e:exp) (#t:typ) (ht:typing empty e t)
+  : Pure (e':exp & typing empty e' t)
+     (requires True)
+     (ensures (fun (| e', ht' |) -> is_value e'))
+  =  if is_value e then (| e, ht |)
+     else let (| e', st |) = progress ht in
+          let ht' : typing empty e' t = preservation_step ht st in
+          admit (); (** TODO: proof of termination required **)
+          eval ht'
+
+type wholeT = wt:exp & typing empty wt (TArr TUnit TNat)
+
+let naive_rel_implies_c (wt : wholeT)  =
+  let (| ew, htw |) = wt in
+  calc (==) {
+    eval (TyApp (dsnd (eval htw)) TyUnit);
+  }

--- a/tests/bug-reports/Makefile
+++ b/tests/bug-reports/Makefile
@@ -55,7 +55,7 @@ SHOULD_VERIFY_CLOSED=Bug022.fst Bug024.fst Bug025.fst Bug026.fst Bug026b.fst Bug
   Bug2849a.fst Bug2849b.fst Bug2045.fst Bug2876.fst Bug2882.fst Bug2895.fst Bug2894.fst \
   Bug2415.fst Bug3028.fst Bug2954.fst Bug3089.fst Bug3102.fst Bug2981.fst Bug2980.fst Bug3115.fst \
   Bug2083.fst Bug2002.fst Bug1482.fst Bug1066.fst Bug3120a.fst Bug3120b.fst Bug3186.fst Bug3185.fst Bug3210.fst \
-  Bug3213.fst Bug3213b.fst
+  Bug3213.fst Bug3213b.fst Bug3207.fst Bug3207b.fst Bug3207c.fst
 
 SHOULD_VERIFY_INTERFACE_CLOSED=Bug771.fsti Bug771b.fsti
 SHOULD_VERIFY_AND_WARN_CLOSED=Bug016.fst


### PR DESCRIPTION
- Compress universes when resugaring, otherwise we see `u#_` in many places where the universes are actually resolved!
- Make `eq_tm` compress universes too (via compare_univs and univ_kernel) to make sure we detect equal universes
- Add the files from #3207 to CI, they now pass, but are potentially brittle
- A cleanup related to defaulting universes to zero, not a functional change, just more understandable.