### PR TITLE
Adding attributes to type parameters in ML AST

### DIFF
--- a/ocaml/fstar-lib/FStar_Extraction_ML_PrintML.ml
+++ b/ocaml/fstar-lib/FStar_Extraction_ML_PrintML.ml
@@ -391,7 +391,7 @@ and build_binding (toplevel: bool) (lb: mllb): value_binding =
       | None -> None
       | Some ts ->
            if lb.print_typ && toplevel
-           then let vars = List.map mk1 (fst ts) in
+           then let vars = List.map mk1 (ty_param_names (fst ts)) in
                 let ty = snd ts in
                 Some (build_core_type ~annots:vars ty)
            else None
@@ -460,7 +460,7 @@ let build_one_tydecl ({tydecl_name=x;
   let ptype_name = match mangle_opt with
     | Some y -> mk_sym y
     | None -> mk_sym x in
-  let ptype_params = Some (map (fun sym -> Typ.mk (Ptyp_var (mk_typ_name sym)), (NoVariance, NoInjectivity)) tparams) in
+  let ptype_params = Some (map (fun sym -> Typ.mk (Ptyp_var (mk_typ_name sym)), (NoVariance, NoInjectivity)) (ty_param_names tparams)) in
   let (ptype_manifest: core_type option) =
     BatOption.map_default build_ty_manifest None body |> add_deriving_const attrs in
   let ptype_kind =  Some (BatOption.map_default build_ty_kind Ptype_abstract body) in

--- a/ocaml/fstar-lib/generated/FStar_Extraction_Krml.ml
+++ b/ocaml/fstar-lib/generated/FStar_Extraction_Krml.ml
@@ -2729,7 +2729,14 @@ let (translate_type_decl' :
           let name2 = ((env1.module_name), name1) in
           let env2 =
             FStar_Compiler_List.fold_left
-              (fun env3 -> fun name3 -> extend_t env3 name3) env1 args in
+              (fun env3 ->
+                 fun uu___1 ->
+                   match uu___1 with
+                   | {
+                       FStar_Extraction_ML_Syntax.ty_param_name =
+                         ty_param_name;
+                       FStar_Extraction_ML_Syntax.ty_param_attrs = uu___2;_}
+                       -> extend_t env3 ty_param_name) env1 args in
           if
             assumed &&
               (FStar_Compiler_List.mem FStar_Extraction_ML_Syntax.CAbstract
@@ -2763,7 +2770,14 @@ let (translate_type_decl' :
           let name2 = ((env1.module_name), name1) in
           let env2 =
             FStar_Compiler_List.fold_left
-              (fun env3 -> fun name3 -> extend_t env3 name3) env1 args in
+              (fun env3 ->
+                 fun uu___2 ->
+                   match uu___2 with
+                   | {
+                       FStar_Extraction_ML_Syntax.ty_param_name =
+                         ty_param_name;
+                       FStar_Extraction_ML_Syntax.ty_param_attrs = uu___3;_}
+                       -> extend_t env3 ty_param_name) env1 args in
           let uu___2 =
             let uu___3 =
               let uu___4 = translate_flags flags in
@@ -2790,7 +2804,9 @@ let (translate_type_decl' :
           ->
           let name2 = ((env1.module_name), name1) in
           let flags1 = translate_flags flags in
-          let env2 = FStar_Compiler_List.fold_left extend_t env1 args in
+          let env2 =
+            let uu___2 = FStar_Extraction_ML_Syntax.ty_param_names args in
+            FStar_Compiler_List.fold_left extend_t env1 uu___2 in
           let uu___2 =
             let uu___3 =
               let uu___4 =
@@ -2903,8 +2919,9 @@ let (translate_let' :
                  then extend env1 name1
                  else env1 in
                let env3 =
+                 let uu___6 = FStar_Extraction_ML_Syntax.ty_param_names tvars in
                  FStar_Compiler_List.fold_left
-                   (fun env4 -> fun name2 -> extend_t env4 name2) env2 tvars in
+                   (fun env4 -> fun name2 -> extend_t env4 name2) env2 uu___6 in
                let rec find_return_type eff i uu___6 =
                  match uu___6 with
                  | FStar_Extraction_ML_Syntax.MLTY_Fun (uu___7, eff1, t) when
@@ -2987,8 +3004,9 @@ let (translate_let' :
             else
               (let meta1 = translate_flags meta in
                let env2 =
+                 let uu___4 = FStar_Extraction_ML_Syntax.ty_param_names tvars in
                  FStar_Compiler_List.fold_left
-                   (fun env3 -> fun name2 -> extend_t env3 name2) env1 tvars in
+                   (fun env3 -> fun name2 -> extend_t env3 name2) env1 uu___4 in
                let t1 = translate_type env2 t in
                let name2 = ((env2.module_name), name1) in
                try
@@ -3034,12 +3052,15 @@ let (translate_let' :
               FStar_Errors.log_issue FStar_Compiler_Range_Type.dummyRange
                 uu___6);
              (match ts with
-              | FStar_Pervasives_Native.Some (idents, t) ->
+              | FStar_Pervasives_Native.Some (tps, t) ->
                   let uu___7 =
+                    let uu___8 =
+                      FStar_Extraction_ML_Syntax.ty_param_names tps in
+                    FStar_Compiler_String.concat ", " uu___8 in
+                  let uu___8 =
                     FStar_Extraction_ML_Code.string_of_mlty ([], "") t in
                   FStar_Compiler_Util.print2
-                    "Type scheme is: forall %s. %s\n"
-                    (FStar_Compiler_String.concat ", " idents) uu___7
+                    "Type scheme is: forall %s. %s\n" uu___7 uu___8
               | FStar_Pervasives_Native.None -> ());
              FStar_Pervasives_Native.None)
 type translate_let_t =
@@ -3135,7 +3156,7 @@ let (translate : FStar_Extraction_ML_Syntax.mllib -> file Prims.list) =
                      "Unable to translate module: %s because:\n  %s\n" m_name
                      uu___3);
                   FStar_Pervasives_Native.None)) modules
-let (uu___1700 : unit) =
+let (uu___1702 : unit) =
   register_post_translate_type_without_decay translate_type_without_decay';
   register_post_translate_type translate_type';
   register_post_translate_type_decl translate_type_decl';

--- a/ocaml/fstar-lib/generated/FStar_Extraction_ML_Code.ml
+++ b/ocaml/fstar-lib/generated/FStar_Extraction_ML_Code.ml
@@ -1071,12 +1071,15 @@ and (doc_of_lets :
                                   (min_op_prec, NonAssoc) ty in
                               let vars =
                                 let uu___8 =
+                                  let uu___9 =
+                                    FStar_Extraction_ML_Syntax.ty_param_names
+                                      vs in
                                   FStar_Compiler_List.map
                                     (fun x ->
                                        doc_of_mltype currentModule
                                          (min_op_prec, NonAssoc)
                                          (FStar_Extraction_ML_Syntax.MLTY_Var
-                                            x)) vs in
+                                            x)) uu___9 in
                                 reduce1 uu___8 in
                               reduce1 [text ":"; vars; text "."; ty1])
                        else text "") in
@@ -1136,12 +1139,14 @@ let (doc_of_mltydecl :
               | FStar_Pervasives_Native.None -> x
               | FStar_Pervasives_Native.Some y -> y in
             let tparams1 =
-              match tparams with
+              let tparams2 =
+                FStar_Extraction_ML_Syntax.ty_param_names tparams in
+              match tparams2 with
               | [] -> empty
               | x2::[] -> text x2
               | uu___3 ->
                   let doc1 =
-                    FStar_Compiler_List.map (fun x2 -> text x2) tparams in
+                    FStar_Compiler_List.map (fun x2 -> text x2) tparams2 in
                   let uu___4 = combine (text ", ") doc1 in parens uu___4 in
             let forbody body1 =
               match body1 with

--- a/ocaml/fstar-lib/generated/FStar_Extraction_ML_Modul.ml
+++ b/ocaml/fstar-lib/generated/FStar_Extraction_ML_Modul.ml
@@ -325,7 +325,7 @@ let (extract_metadata :
 let (binders_as_mlty_binders :
   FStar_Extraction_ML_UEnv.uenv ->
     FStar_Syntax_Syntax.binder Prims.list ->
-      (FStar_Extraction_ML_UEnv.uenv * FStar_Extraction_ML_Syntax.mlident
+      (FStar_Extraction_ML_UEnv.uenv * FStar_Extraction_ML_Syntax.ty_param
         Prims.list))
   =
   fun env ->
@@ -337,15 +337,27 @@ let (binders_as_mlty_binders :
              | { FStar_Syntax_Syntax.binder_bv = bv;
                  FStar_Syntax_Syntax.binder_qual = uu___1;
                  FStar_Syntax_Syntax.binder_positivity = uu___2;
-                 FStar_Syntax_Syntax.binder_attrs = uu___3;_} ->
+                 FStar_Syntax_Syntax.binder_attrs = binder_attrs;_} ->
                  let env2 = FStar_Extraction_ML_UEnv.extend_ty env1 bv false in
-                 let name =
-                   let uu___4 = FStar_Extraction_ML_UEnv.lookup_bv env2 bv in
-                   match uu___4 with
+                 let ty_param_name =
+                   let uu___3 = FStar_Extraction_ML_UEnv.lookup_bv env2 bv in
+                   match uu___3 with
                    | FStar_Pervasives.Inl ty ->
                        ty.FStar_Extraction_ML_UEnv.ty_b_name
-                   | uu___5 -> FStar_Compiler_Effect.failwith "Impossible" in
-                 (env2, name)) env bs
+                   | uu___4 -> FStar_Compiler_Effect.failwith "Impossible" in
+                 let ty_param_attrs =
+                   FStar_Compiler_List.map
+                     (fun attr ->
+                        let uu___3 =
+                          FStar_Extraction_ML_Term.term_as_mlexpr env2 attr in
+                        match uu___3 with | (e, uu___4, uu___5) -> e)
+                     binder_attrs in
+                 (env2,
+                   {
+                     FStar_Extraction_ML_Syntax.ty_param_name = ty_param_name;
+                     FStar_Extraction_ML_Syntax.ty_param_attrs =
+                       ty_param_attrs
+                   })) env bs
 type data_constructor =
   {
   dname: FStar_Ident.lident ;
@@ -1290,11 +1302,13 @@ let (extract_reifiable_effect :
                                  (FStar_Pervasives_Native.snd tysc) in
                              FStar_Compiler_Util.print1
                                "Extracted action type: %s\n" uu___9);
-                            FStar_Compiler_List.iter
-                              (fun x ->
-                                 FStar_Compiler_Util.print1
-                                   "and binders: %s\n" x)
-                              (FStar_Pervasives_Native.fst tysc))
+                            (let uu___9 =
+                               FStar_Extraction_ML_Syntax.ty_param_names
+                                 (FStar_Pervasives_Native.fst tysc) in
+                             FStar_Compiler_List.iter
+                               (fun x ->
+                                  FStar_Compiler_Util.print1
+                                    "and binders: %s\n" x) uu___9))
                          else ());
                         (let uu___7 = extend_iface a_lid a_nm exp exp_b in
                          match uu___7 with
@@ -1968,8 +1982,15 @@ let (extract_bundle :
                             (fun i ->
                                fun uu___5 ->
                                  let uu___6 =
-                                   FStar_Compiler_Util.string_of_int i in
-                                 Prims.strcat "'dummyV" uu___6) indices in
+                                   let uu___7 =
+                                     FStar_Compiler_Util.string_of_int i in
+                                   Prims.strcat "'dummyV" uu___7 in
+                                 {
+                                   FStar_Extraction_ML_Syntax.ty_param_name =
+                                     uu___6;
+                                   FStar_Extraction_ML_Syntax.ty_param_attrs
+                                     = []
+                                 }) indices in
                         FStar_Compiler_List.append vars uu___4 in
                       let uu___4 =
                         let uu___5 =

--- a/ocaml/fstar-lib/generated/FStar_Extraction_ML_RemoveUnusedParameters.ml
+++ b/ocaml/fstar-lib/generated/FStar_Extraction_ML_RemoveUnusedParameters.ml
@@ -273,10 +273,10 @@ let (elim_tydef :
   env_t ->
     Prims.string ->
       FStar_Extraction_ML_Syntax.meta Prims.list ->
-        Prims.string Prims.list ->
+        FStar_Extraction_ML_Syntax.ty_param Prims.list ->
           FStar_Extraction_ML_Syntax.mlty ->
             (env_t * (Prims.string * FStar_Extraction_ML_Syntax.meta
-              Prims.list * Prims.string Prims.list *
+              Prims.list * FStar_Extraction_ML_Syntax.ty_param Prims.list *
               FStar_Extraction_ML_Syntax.mlty)))
   =
   fun env ->
@@ -321,9 +321,11 @@ let (elim_tydef :
             let uu___ =
               FStar_Compiler_List.fold_left
                 (fun uu___1 ->
-                   fun p ->
+                   fun param ->
                      match uu___1 with
                      | (i, params, entry1) ->
+                         let p =
+                           param.FStar_Extraction_ML_Syntax.ty_param_name in
                          let uu___2 =
                            FStar_Compiler_Set.mem FStar_Class_Ord.ord_string
                              p freevars in
@@ -340,8 +342,8 @@ let (elim_tydef :
                                    uu___5) in
                                FStar_Errors.log_issue range_of_tydef uu___4)
                             else ();
-                            ((i + Prims.int_one), (p :: params), (Retain ::
-                              entry1)))
+                            ((i + Prims.int_one), (param :: params), (Retain
+                              :: entry1)))
                          else
                            if (can_eliminate i) || (must_eliminate i)
                            then
@@ -372,9 +374,9 @@ let (elim_tydef :
                                   FStar_Errors.log_issue range uu___7);
                                  FStar_Compiler_Effect.raise Drop_tydef)
                               else
-                                ((i + Prims.int_one), (p :: params), (Retain
-                                  :: entry1)))) (Prims.int_zero, [], [])
-                parameters in
+                                ((i + Prims.int_one), (param :: params),
+                                  (Retain :: entry1))))
+                (Prims.int_zero, [], []) parameters in
             match uu___ with
             | (uu___1, parameters1, entry1) ->
                 let uu___2 =

--- a/ocaml/fstar-lib/generated/FStar_Extraction_ML_Term.ml
+++ b/ocaml/fstar-lib/generated/FStar_Extraction_ML_Term.ml
@@ -2171,7 +2171,7 @@ let (maybe_promote_effect :
             (FStar_Extraction_ML_Syntax.ml_unit,
               FStar_Extraction_ML_Syntax.E_PURE)
         | uu___ -> (ml_e, tag)
-let (extract_lb_sig :
+let rec (extract_lb_sig :
   FStar_Extraction_ML_UEnv.uenv ->
     FStar_Syntax_Syntax.letbindings ->
       (FStar_Syntax_Syntax.lbname * FStar_Extraction_ML_Syntax.e_tag *
@@ -2234,6 +2234,37 @@ let (extract_lb_sig :
                              let lbdef1 =
                                let uu___7 = normalize_abs lbdef in
                                FStar_Syntax_Util.unmeta uu___7 in
+                             let tbinders_as_ty_params env =
+                               FStar_Compiler_List.map
+                                 (fun uu___7 ->
+                                    match uu___7 with
+                                    | { FStar_Syntax_Syntax.binder_bv = x;
+                                        FStar_Syntax_Syntax.binder_qual =
+                                          uu___8;
+                                        FStar_Syntax_Syntax.binder_positivity
+                                          = uu___9;
+                                        FStar_Syntax_Syntax.binder_attrs =
+                                          binder_attrs;_}
+                                        ->
+                                        let uu___10 =
+                                          let uu___11 =
+                                            FStar_Extraction_ML_UEnv.lookup_ty
+                                              env x in
+                                          uu___11.FStar_Extraction_ML_UEnv.ty_b_name in
+                                        let uu___11 =
+                                          FStar_Compiler_List.map
+                                            (fun attr ->
+                                               let uu___12 =
+                                                 term_as_mlexpr g attr in
+                                               match uu___12 with
+                                               | (e, uu___13, uu___14) -> e)
+                                            binder_attrs in
+                                        {
+                                          FStar_Extraction_ML_Syntax.ty_param_name
+                                            = uu___10;
+                                          FStar_Extraction_ML_Syntax.ty_param_attrs
+                                            = uu___11
+                                        }) in
                              (match lbdef1.FStar_Syntax_Syntax.n with
                               | FStar_Syntax_Syntax.Tm_abs
                                   { FStar_Syntax_Syntax.bs = bs2;
@@ -2313,23 +2344,7 @@ let (extract_lb_sig :
                                                   expected_source_ty in
                                               let polytype =
                                                 let uu___9 =
-                                                  FStar_Compiler_List.map
-                                                    (fun uu___10 ->
-                                                       match uu___10 with
-                                                       | {
-                                                           FStar_Syntax_Syntax.binder_bv
-                                                             = x;
-                                                           FStar_Syntax_Syntax.binder_qual
-                                                             = uu___11;
-                                                           FStar_Syntax_Syntax.binder_positivity
-                                                             = uu___12;
-                                                           FStar_Syntax_Syntax.binder_attrs
-                                                             = uu___13;_}
-                                                           ->
-                                                           let uu___14 =
-                                                             FStar_Extraction_ML_UEnv.lookup_ty
-                                                               env x in
-                                                           uu___14.FStar_Extraction_ML_UEnv.ty_b_name)
+                                                  tbinders_as_ty_params env
                                                     targs in
                                                 (uu___9, expected_t) in
                                               let add_unit =
@@ -2387,24 +2402,7 @@ let (extract_lb_sig :
                                   let expected_t = term_as_mlty env tbody in
                                   let polytype =
                                     let uu___8 =
-                                      FStar_Compiler_List.map
-                                        (fun uu___9 ->
-                                           match uu___9 with
-                                           | {
-                                               FStar_Syntax_Syntax.binder_bv
-                                                 = x;
-                                               FStar_Syntax_Syntax.binder_qual
-                                                 = uu___10;
-                                               FStar_Syntax_Syntax.binder_positivity
-                                                 = uu___11;
-                                               FStar_Syntax_Syntax.binder_attrs
-                                                 = uu___12;_}
-                                               ->
-                                               let uu___13 =
-                                                 FStar_Extraction_ML_UEnv.lookup_ty
-                                                   env x in
-                                               uu___13.FStar_Extraction_ML_UEnv.ty_b_name)
-                                        tbinders in
+                                      tbinders_as_ty_params env tbinders in
                                     (uu___8, expected_t) in
                                   let args =
                                     FStar_Compiler_List.map
@@ -2455,24 +2453,7 @@ let (extract_lb_sig :
                                   let expected_t = term_as_mlty env tbody in
                                   let polytype =
                                     let uu___8 =
-                                      FStar_Compiler_List.map
-                                        (fun uu___9 ->
-                                           match uu___9 with
-                                           | {
-                                               FStar_Syntax_Syntax.binder_bv
-                                                 = x;
-                                               FStar_Syntax_Syntax.binder_qual
-                                                 = uu___10;
-                                               FStar_Syntax_Syntax.binder_positivity
-                                                 = uu___11;
-                                               FStar_Syntax_Syntax.binder_attrs
-                                                 = uu___12;_}
-                                               ->
-                                               let uu___13 =
-                                                 FStar_Extraction_ML_UEnv.lookup_ty
-                                                   env x in
-                                               uu___13.FStar_Extraction_ML_UEnv.ty_b_name)
-                                        tbinders in
+                                      tbinders_as_ty_params env tbinders in
                                     (uu___8, expected_t) in
                                   let args =
                                     FStar_Compiler_List.map
@@ -2523,24 +2504,7 @@ let (extract_lb_sig :
                                   let expected_t = term_as_mlty env tbody in
                                   let polytype =
                                     let uu___8 =
-                                      FStar_Compiler_List.map
-                                        (fun uu___9 ->
-                                           match uu___9 with
-                                           | {
-                                               FStar_Syntax_Syntax.binder_bv
-                                                 = x;
-                                               FStar_Syntax_Syntax.binder_qual
-                                                 = uu___10;
-                                               FStar_Syntax_Syntax.binder_positivity
-                                                 = uu___11;
-                                               FStar_Syntax_Syntax.binder_attrs
-                                                 = uu___12;_}
-                                               ->
-                                               let uu___13 =
-                                                 FStar_Extraction_ML_UEnv.lookup_ty
-                                                   env x in
-                                               uu___13.FStar_Extraction_ML_UEnv.ty_b_name)
-                                        tbinders in
+                                      tbinders_as_ty_params env tbinders in
                                     (uu___8, expected_t) in
                                   let args =
                                     FStar_Compiler_List.map
@@ -2574,7 +2538,7 @@ let (extract_lb_sig :
                | uu___5 -> no_gen ()) in
       FStar_Compiler_List.map maybe_generalize
         (FStar_Pervasives_Native.snd lbs)
-let (extract_lb_iface :
+and (extract_lb_iface :
   FStar_Extraction_ML_UEnv.uenv ->
     FStar_Syntax_Syntax.letbindings ->
       (FStar_Extraction_ML_UEnv.uenv * (FStar_Syntax_Syntax.fv *
@@ -2602,7 +2566,7 @@ let (extract_lb_iface :
                         let uu___4 = FStar_Compiler_Util.right lbname in
                         (uu___4, exp_binding) in
                       (env1, uu___3))) g lbs1
-let rec (check_term_as_mlexpr :
+and (check_term_as_mlexpr :
   FStar_Extraction_ML_UEnv.uenv ->
     FStar_Syntax_Syntax.term ->
       FStar_Extraction_ML_Syntax.e_tag ->

--- a/ocaml/fstar-lib/generated/FStar_Extraction_ML_UEnv.ml
+++ b/ocaml/fstar-lib/generated/FStar_Extraction_ML_UEnv.ml
@@ -819,7 +819,10 @@ let (extend_fv :
             | [] -> true in
           let tySchemeIsClosed tys =
             let uu___ = mltyFvars (FStar_Pervasives_Native.snd tys) in
-            subsetMlidents uu___ (FStar_Pervasives_Native.fst tys) in
+            let uu___1 =
+              FStar_Extraction_ML_Syntax.ty_param_names
+                (FStar_Pervasives_Native.fst tys) in
+            subsetMlidents uu___ uu___1 in
           let uu___ = tySchemeIsClosed t_x in
           if uu___
           then
@@ -1137,7 +1140,10 @@ let (new_uenv : FStar_TypeChecker_Env.env -> uenv) =
       } in
     let a = "'a" in
     let failwith_ty =
-      ([a],
+      ([{
+          FStar_Extraction_ML_Syntax.ty_param_name = a;
+          FStar_Extraction_ML_Syntax.ty_param_attrs = []
+        }],
         (FStar_Extraction_ML_Syntax.MLTY_Fun
            ((FStar_Extraction_ML_Syntax.MLTY_Named
                ([], (["Prims"], "string"))),

--- a/ocaml/fstar-lib/generated/FStar_Extraction_ML_Util.ml
+++ b/ocaml/fstar-lib/generated/FStar_Extraction_ML_Util.ml
@@ -186,11 +186,15 @@ let (try_subst :
           then FStar_Pervasives_Native.None
           else
             (let uu___2 =
-               let uu___3 = FStar_Compiler_List.zip formals args in
+               let uu___3 =
+                 let uu___4 =
+                   FStar_Extraction_ML_Syntax.ty_param_names formals in
+                 FStar_Compiler_List.zip uu___4 args in
                subst_aux uu___3 t in
              FStar_Pervasives_Native.Some uu___2)
 let (subst :
-  (FStar_Extraction_ML_Syntax.mlidents * FStar_Extraction_ML_Syntax.mlty) ->
+  (FStar_Extraction_ML_Syntax.ty_param Prims.list *
+    FStar_Extraction_ML_Syntax.mlty) ->
     FStar_Extraction_ML_Syntax.mlty Prims.list ->
       FStar_Extraction_ML_Syntax.mlty)
   =

--- a/src/extraction/FStar.Extraction.ML.Code.fst
+++ b/src/extraction/FStar.Extraction.ML.Code.fst
@@ -629,7 +629,9 @@ and doc_of_lets (currentModule : mlsymbol) (rec_, top_level, lets) =
                       reduce1 [text ":"; ty]
                     | Some (vs, ty) ->
                       let ty = doc_of_mltype currentModule (min_op_prec, NonAssoc) ty in
-                      let vars = vs |> List.map (fun x -> doc_of_mltype currentModule (min_op_prec, NonAssoc) (MLTY_Var x)) |>  reduce1  in
+                      let vars = vs |> ty_param_names
+                                    |> List.map (fun x -> doc_of_mltype currentModule (min_op_prec, NonAssoc) (MLTY_Var x))
+                                    |>  reduce1  in
                       reduce1 [text ":"; vars; text "."; ty]
             else text "" in
         reduce1 [text name; reduce1 ids; ty_annot; text "="; e] in
@@ -658,6 +660,7 @@ let doc_of_mltydecl (currentModule : mlsymbol) (decls : mltydecl) =
                 | None -> x
                 | Some y -> y in
         let tparams =
+            let tparams = ty_param_names tparams in
             match tparams with
             | []  -> empty
             | [x] -> text x

--- a/src/extraction/FStar.Extraction.ML.RemoveUnusedParameters.fst
+++ b/src/extraction/FStar.Extraction.ML.RemoveUnusedParameters.fst
@@ -204,7 +204,8 @@ let elim_tydef (env:env_t) name metadata parameters mlty
     let freevars = freevars_of_mlty mlty in
     let _, parameters, entry =
         List.fold_left
-          (fun (i, params, entry) p ->
+          (fun (i, params, entry) param ->
+             let p = param.ty_param_name in
              if Set.mem p freevars
              then begin
                if must_eliminate i
@@ -215,7 +216,7 @@ let elim_tydef (env:env_t) name metadata parameters mlty
                     "Expected parameter %s of %s to be unused in its definition and eliminated"
                       p name)
                end;
-               i+1, p::params, Retain::entry
+               i+1, param::params, Retain::entry
              end
              else begin
                if can_eliminate i //there's no val
@@ -240,7 +241,7 @@ let elim_tydef (env:env_t) name metadata parameters mlty
                         name
                         (string_of_int i));
                     raise Drop_tydef
-               else i+1, p::params, Retain::entry
+               else i+1, param::params, Retain::entry
              end)
           (0, [], [])
           parameters

--- a/src/extraction/FStar.Extraction.ML.UEnv.fst
+++ b/src/extraction/FStar.Extraction.ML.UEnv.fst
@@ -484,7 +484,7 @@ let extend_fv (g:uenv) (x:fv) (t_x:mltyscheme) (add_unit:bool)
       | [] -> true
     in
     let tySchemeIsClosed (tys : mltyscheme) : bool =
-      subsetMlidents  (mltyFvars (snd tys)) (fst tys)
+      subsetMlidents  (mltyFvars (snd tys)) (tys |> fst |> ty_param_names)
     in
     if tySchemeIsClosed t_x
     then
@@ -631,7 +631,8 @@ let new_uenv (e:TypeChecker.Env.env)
     (* We handle [failwith] specially, extracting it to OCaml's 'failwith'
        rather than FStar.Compiler.Effect.failwith. Not sure this is necessary *)
     let a = "'a" in
-    let failwith_ty = ([a], MLTY_Fun(MLTY_Named([], (["Prims"], "string")), E_IMPURE, MLTY_Var a)) in
+    let failwith_ty = ([{ty_param_name=a; ty_param_attrs=[]}],
+                        MLTY_Fun(MLTY_Named([], (["Prims"], "string")), E_IMPURE, MLTY_Var a)) in
     let g, _, _ =
         extend_lb env (Inr (lid_as_fv (Const.failwith_lid()) None)) tun failwith_ty false
     in

--- a/src/extraction/FStar.Extraction.ML.Util.fst
+++ b/src/extraction/FStar.Extraction.ML.Util.fst
@@ -128,7 +128,7 @@ let rec subst_aux (subst:list (mlident * mlty)) (t:mlty)  : mlty =
 let try_subst ((formals, t):mltyscheme) (args:list mlty) : option mlty =
     if List.length formals <> List.length args
     then None
-    else Some (subst_aux (List.zip formals args) t)
+    else Some (subst_aux (List.zip (ty_param_names formals) args) t)
 
 let subst ts args =
     match try_subst ts args with

--- a/src/extraction/FStar.Extraction.ML.Util.fsti
+++ b/src/extraction/FStar.Extraction.ML.Util.fsti
@@ -28,7 +28,7 @@ val mk_range_mle : mlexpr
 val mlconst_of_const : p:Range.range -> c:Const.sconst -> mlconstant
 val mlexpr_of_const : p:Range.range -> c:Const.sconst -> mlexpr'
 val mlexpr_of_range : r:Range.range -> mlexpr'
-val subst : mlidents * mlty -> args:list mlty -> mlty
+val subst : list ty_param * mlty -> args:list mlty -> mlty
 val udelta_unfold : g:UEnv.uenv -> _arg1:mlty -> option mlty
 val eff_leq : f:e_tag -> f':e_tag -> bool
 val eff_to_string : _arg1:e_tag -> string


### PR DESCRIPTION
This makes writing generic bounds in Pulse code easier. It needs patches in steel and pulse, will push them after merging the PR.