### PR TITLE
Add missing case in lidents_of_term

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_Parser_AST_Util.ml
+++ b/ocaml/fstar-lib/generated/FStar_Parser_AST_Util.ml
@@ -752,6 +752,7 @@ and (lidents_of_term' :
         FStar_Compiler_List.op_At uu___ uu___1
     | FStar_Parser_AST.QForall (bs, _pats, t1) -> lidents_of_term t1
     | FStar_Parser_AST.QExists (bs, _pats, t1) -> lidents_of_term t1
+    | FStar_Parser_AST.QuantOp (i, bs, pats, t1) -> lidents_of_term t1
     | FStar_Parser_AST.Refine (b, t1) -> lidents_of_term t1
     | FStar_Parser_AST.NamedTyp (i, t1) -> lidents_of_term t1
     | FStar_Parser_AST.Paren t1 -> lidents_of_term t1

--- a/src/parser/FStar.Parser.AST.Util.fst
+++ b/src/parser/FStar.Parser.AST.Util.fst
@@ -599,6 +599,7 @@ and lidents_of_term' (t:term')
   | Sum (ts, t) -> concat_map (function Inl b -> lidents_of_binder b | Inr t -> lidents_of_term t) ts @ lidents_of_term t
   | QForall (bs, _pats, t) -> lidents_of_term t
   | QExists (bs, _pats, t) -> lidents_of_term t
+  | QuantOp (i, bs, pats, t) -> lidents_of_term t
   | Refine (b, t) -> lidents_of_term t
   | NamedTyp (i, t) -> lidents_of_term t
   | Paren t -> lidents_of_term t


### PR DESCRIPTION
This caused the IDE server to crash on some files in pulse.