### PR TITLE
Fixing #3224

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_Tactics_V2_Basic.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_V2_Basic.ml
@@ -11954,7 +11954,8 @@ let (refl_maybe_relate_after_unfolding :
                              dbg_refl g1
                                (fun uu___4 ->
                                   let uu___5 =
-                                    FStar_TypeChecker_Core.side_to_string s in
+                                    FStar_Class_Show.show
+                                      FStar_TypeChecker_Core.showable_side s in
                                   FStar_Compiler_Util.format1
                                     "} returning side: %s\n" uu___5);
                              (s, [])))))

--- a/src/tactics/FStar.Tactics.V2.Basic.fst
+++ b/src/tactics/FStar.Tactics.V2.Basic.fst
@@ -2758,8 +2758,7 @@ let refl_maybe_relate_after_unfolding (g:env) (t0 t1:typ)
              (show t1));
          let s = Core.maybe_relate_after_unfolding g t0 t1 in
          dbg_refl g (fun _ ->
-           BU.format1 "} returning side: %s\n"
-             (Core.side_to_string s));
+           BU.format1 "} returning side: %s\n" (show s));
          s, [])
   else return (None, [unexpected_uvars_issue (Env.get_range g)])
 

--- a/src/typechecker/FStar.TypeChecker.Core.fst
+++ b/src/typechecker/FStar.TypeChecker.Core.fst
@@ -1513,7 +1513,7 @@ and do_check (g:env) (e:term)
               (weaken
                  this_path_condition
                  (let! eff_br, tbr = check "branch" g' b in
-                  let expect_tbr = Subst.subst [NT(as_x.binder_bv, e)] returns_ty in
+                  let expect_tbr = Subst.subst [NT(as_x.binder_bv, sc)] returns_ty in
                   let rel =
                     if eq
                     then EQUALITY

--- a/src/typechecker/FStar.TypeChecker.Core.fst
+++ b/src/typechecker/FStar.TypeChecker.Core.fst
@@ -1157,7 +1157,7 @@ and check_relation_comp (g:env) rel (c0 c1:comp)
         )
       )
 
-    | Some (E_Total, t0), Some (_, t1)
+    | Some (E_Total, t0), Some (_, t1) // why is this right? what about EQUALITY?
     | Some (E_Ghost, t0), Some (E_Ghost, t1) ->
       check_relation g rel t0 t1
 

--- a/src/typechecker/FStar.TypeChecker.Core.fsti
+++ b/src/typechecker/FStar.TypeChecker.Core.fsti
@@ -21,7 +21,7 @@ type side =
   | Both
   | Neither
 
-val side_to_string : side -> string
+instance val showable_side : Class.Show.showable side
 
 val maybe_relate_after_unfolding (g:Env.env) (t0 t1:term) : side
 

--- a/tests/bug-reports/Bug3224a.fst
+++ b/tests/bug-reports/Bug3224a.fst
@@ -1,0 +1,28 @@
+module Bug3224a
+
+open FStar.Tactics.V2
+
+noeq
+type vcode = {
+    t : Type u#2;
+    up : t -> int;
+}
+
+let x = true
+let tt : term = `(Mkvcode?.up)
+
+let _ = assert True by (
+  let g = cur_env () in
+  set_guard_policy SMTSync;
+  // ^ for some reason this is needed for this example to
+  // work, but the important bit is that it does not overflow
+  // the stack and crash.
+  let u = check_equiv g tt (`(match x with | true -> Mkvcode?.up)) in
+  match u with
+  | Some u, _ ->
+    dump "ok"
+  | _, [] ->
+    dump "fail and no issue?"
+  | _, i::is ->
+    dump (FStar.Issue.render_issue i)
+)

--- a/tests/bug-reports/Bug3224b.fst
+++ b/tests/bug-reports/Bug3224b.fst
@@ -1,0 +1,21 @@
+module Bug3224b
+
+open FStar.Tactics.V2
+
+noeq
+type vcode = {
+    t : Type u#2;
+    up : t -> int;
+}
+
+let _ = assert True by (
+  let g = cur_env () in
+  let u = tc_term g (`(fun projectee -> match projectee as proj_ret returns Mkvcode?.t proj_ret -> int with | Mkvcode t up -> up)) in
+  match u with
+  | Some u, _ ->
+    dump "ok"
+  | _, [] ->
+    dump "fail and no issue?"
+  | _, i::is ->
+    dump (FStar.Issue.render_issue i)
+)

--- a/tests/bug-reports/Makefile
+++ b/tests/bug-reports/Makefile
@@ -55,7 +55,7 @@ SHOULD_VERIFY_CLOSED=Bug022.fst Bug024.fst Bug025.fst Bug026.fst Bug026b.fst Bug
   Bug2849a.fst Bug2849b.fst Bug2045.fst Bug2876.fst Bug2882.fst Bug2895.fst Bug2894.fst \
   Bug2415.fst Bug3028.fst Bug2954.fst Bug3089.fst Bug3102.fst Bug2981.fst Bug2980.fst Bug3115.fst \
   Bug2083.fst Bug2002.fst Bug1482.fst Bug1066.fst Bug3120a.fst Bug3120b.fst Bug3186.fst Bug3185.fst Bug3210.fst \
-  Bug3213.fst Bug3213b.fst Bug3207.fst Bug3207b.fst Bug3207c.fst Bug2155.fst
+  Bug3213.fst Bug3213b.fst Bug3207.fst Bug3207b.fst Bug3207c.fst Bug2155.fst Bug3224a.fst Bug3224b.fst
 
 SHOULD_VERIFY_INTERFACE_CLOSED=Bug771.fsti Bug771b.fsti
 SHOULD_VERIFY_AND_WARN_CLOSED=Bug016.fst


### PR DESCRIPTION
The core typechecker had a bug in handling returns annotations on matches, which could cause it to go into a loop and stack overflow. It was just an oversight in substituting the annotation with the full match expression, instead of the scrutinee, most likely just a typo.