### PR TITLE
Tactics: add a primitive to spawn a subinvocation of the engine

### DIFF
--- a/ocaml/fstar-lib/FStar_Tactics_V2_Builtins.ml
+++ b/ocaml/fstar-lib/FStar_Tactics_V2_Builtins.ml
@@ -173,3 +173,7 @@ let ctrl_rewrite
     (t2 : unit -> unit __tac)
   : unit __tac
   = from_tac_3 "ctrl_rewrite" CTRW.ctrl_rewrite d (to_tac_1 t1) (to_tac_0 (t2 ()))
+
+let call_subtac g (t : unit -> unit __tac) u ty =
+  let t = to_tac_1 t () in
+  from_tac_4 "B.call_subtac" B.call_subtac g t u ty

--- a/ocaml/fstar-lib/generated/FStar_Reflection_Typing.ml
+++ b/ocaml/fstar-lib/generated/FStar_Reflection_Typing.ml
@@ -1874,3 +1874,10 @@ let (mk_unchecked_let :
                                    FStar_Reflection_V2_Data.lb_typ = ty;
                                    FStar_Reflection_V2_Data.lb_def = tm
                                  }]))), FStar_Pervasives_Native.None)))
+let (typing_to_token :
+  FStar_Reflection_Types.env ->
+    FStar_Reflection_Types.term ->
+      comp_typ ->
+        (unit, unit, unit) typing ->
+          (unit, unit, unit) FStar_Tactics_Types.typing_token)
+  = fun g -> fun e -> fun c -> fun uu___ -> Prims.magic ()

--- a/ocaml/fstar-lib/generated/FStar_Tactics_CtrlRewrite.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_CtrlRewrite.ml
@@ -226,8 +226,7 @@ let (__do_rewrite :
                                       "do_rewrite.lhs") in
                              let uu___4 =
                                let uu___5 =
-                                 FStar_Tactics_V2_Basic.goal_typedness_deps
-                                   g0 in
+                                 FStar_Tactics_Monad.goal_typedness_deps g0 in
                                FStar_Tactics_Monad.new_uvar "do_rewrite.rhs"
                                  env typ should_check uu___5 (rangeof g0) in
                              Obj.magic
@@ -285,7 +284,7 @@ let (__do_rewrite :
                                                                     uu___9 in
                                                                   let uu___10
                                                                     =
-                                                                    FStar_Tactics_V2_Basic.focus
+                                                                    FStar_Tactics_Monad.focus
                                                                     rewriter in
                                                                   Obj.magic
                                                                     (
@@ -1628,7 +1627,7 @@ let (ctrl_rewrite :
                                                                     Obj.magic
                                                                     uu___9 in
                                                                     let g1 =
-                                                                    FStar_Tactics_V2_Basic.goal_with_type
+                                                                    FStar_Tactics_Monad.goal_with_type
                                                                     g gt' in
                                                                     Obj.magic
                                                                     (FStar_Tactics_Monad.add_goals

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Interpreter.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Interpreter.ml
@@ -585,6 +585,475 @@ let (report_implicits :
                         uu___3) in
                     FStar_Errors.log_issue rng uu___2)) is;
       FStar_Errors.stop_if_err ()
+let run_unembedded_tactic_on_ps :
+  'a 'b .
+    FStar_Compiler_Range_Type.range ->
+      FStar_Compiler_Range_Type.range ->
+        Prims.bool ->
+          'a ->
+            ('a -> 'b FStar_Tactics_Monad.tac) ->
+              FStar_Tactics_Types.proofstate ->
+                (FStar_Tactics_Types.goal Prims.list * 'b)
+  =
+  fun rng_call ->
+    fun rng_goal ->
+      fun background ->
+        fun arg ->
+          fun tau ->
+            fun ps ->
+              let ps1 =
+                {
+                  FStar_Tactics_Types.main_context =
+                    (let uu___ = ps.FStar_Tactics_Types.main_context in
+                     {
+                       FStar_TypeChecker_Env.solver =
+                         (uu___.FStar_TypeChecker_Env.solver);
+                       FStar_TypeChecker_Env.range =
+                         (uu___.FStar_TypeChecker_Env.range);
+                       FStar_TypeChecker_Env.curmodule =
+                         (uu___.FStar_TypeChecker_Env.curmodule);
+                       FStar_TypeChecker_Env.gamma =
+                         (uu___.FStar_TypeChecker_Env.gamma);
+                       FStar_TypeChecker_Env.gamma_sig =
+                         (uu___.FStar_TypeChecker_Env.gamma_sig);
+                       FStar_TypeChecker_Env.gamma_cache =
+                         (uu___.FStar_TypeChecker_Env.gamma_cache);
+                       FStar_TypeChecker_Env.modules =
+                         (uu___.FStar_TypeChecker_Env.modules);
+                       FStar_TypeChecker_Env.expected_typ =
+                         (uu___.FStar_TypeChecker_Env.expected_typ);
+                       FStar_TypeChecker_Env.sigtab =
+                         (uu___.FStar_TypeChecker_Env.sigtab);
+                       FStar_TypeChecker_Env.attrtab =
+                         (uu___.FStar_TypeChecker_Env.attrtab);
+                       FStar_TypeChecker_Env.instantiate_imp =
+                         (uu___.FStar_TypeChecker_Env.instantiate_imp);
+                       FStar_TypeChecker_Env.effects =
+                         (uu___.FStar_TypeChecker_Env.effects);
+                       FStar_TypeChecker_Env.generalize =
+                         (uu___.FStar_TypeChecker_Env.generalize);
+                       FStar_TypeChecker_Env.letrecs =
+                         (uu___.FStar_TypeChecker_Env.letrecs);
+                       FStar_TypeChecker_Env.top_level =
+                         (uu___.FStar_TypeChecker_Env.top_level);
+                       FStar_TypeChecker_Env.check_uvars =
+                         (uu___.FStar_TypeChecker_Env.check_uvars);
+                       FStar_TypeChecker_Env.use_eq_strict =
+                         (uu___.FStar_TypeChecker_Env.use_eq_strict);
+                       FStar_TypeChecker_Env.is_iface =
+                         (uu___.FStar_TypeChecker_Env.is_iface);
+                       FStar_TypeChecker_Env.admit =
+                         (uu___.FStar_TypeChecker_Env.admit);
+                       FStar_TypeChecker_Env.lax =
+                         (uu___.FStar_TypeChecker_Env.lax);
+                       FStar_TypeChecker_Env.lax_universes =
+                         (uu___.FStar_TypeChecker_Env.lax_universes);
+                       FStar_TypeChecker_Env.phase1 =
+                         (uu___.FStar_TypeChecker_Env.phase1);
+                       FStar_TypeChecker_Env.failhard =
+                         (uu___.FStar_TypeChecker_Env.failhard);
+                       FStar_TypeChecker_Env.nosynth =
+                         (uu___.FStar_TypeChecker_Env.nosynth);
+                       FStar_TypeChecker_Env.uvar_subtyping =
+                         (uu___.FStar_TypeChecker_Env.uvar_subtyping);
+                       FStar_TypeChecker_Env.intactics = true;
+                       FStar_TypeChecker_Env.nocoerce =
+                         (uu___.FStar_TypeChecker_Env.nocoerce);
+                       FStar_TypeChecker_Env.tc_term =
+                         (uu___.FStar_TypeChecker_Env.tc_term);
+                       FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
+                         (uu___.FStar_TypeChecker_Env.typeof_tot_or_gtot_term);
+                       FStar_TypeChecker_Env.universe_of =
+                         (uu___.FStar_TypeChecker_Env.universe_of);
+                       FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
+                         =
+                         (uu___.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                       FStar_TypeChecker_Env.teq_nosmt_force =
+                         (uu___.FStar_TypeChecker_Env.teq_nosmt_force);
+                       FStar_TypeChecker_Env.subtype_nosmt_force =
+                         (uu___.FStar_TypeChecker_Env.subtype_nosmt_force);
+                       FStar_TypeChecker_Env.qtbl_name_and_index =
+                         (uu___.FStar_TypeChecker_Env.qtbl_name_and_index);
+                       FStar_TypeChecker_Env.normalized_eff_names =
+                         (uu___.FStar_TypeChecker_Env.normalized_eff_names);
+                       FStar_TypeChecker_Env.fv_delta_depths =
+                         (uu___.FStar_TypeChecker_Env.fv_delta_depths);
+                       FStar_TypeChecker_Env.proof_ns =
+                         (uu___.FStar_TypeChecker_Env.proof_ns);
+                       FStar_TypeChecker_Env.synth_hook =
+                         (uu___.FStar_TypeChecker_Env.synth_hook);
+                       FStar_TypeChecker_Env.try_solve_implicits_hook =
+                         (uu___.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                       FStar_TypeChecker_Env.splice =
+                         (uu___.FStar_TypeChecker_Env.splice);
+                       FStar_TypeChecker_Env.mpreprocess =
+                         (uu___.FStar_TypeChecker_Env.mpreprocess);
+                       FStar_TypeChecker_Env.postprocess =
+                         (uu___.FStar_TypeChecker_Env.postprocess);
+                       FStar_TypeChecker_Env.identifier_info =
+                         (uu___.FStar_TypeChecker_Env.identifier_info);
+                       FStar_TypeChecker_Env.tc_hooks =
+                         (uu___.FStar_TypeChecker_Env.tc_hooks);
+                       FStar_TypeChecker_Env.dsenv =
+                         (uu___.FStar_TypeChecker_Env.dsenv);
+                       FStar_TypeChecker_Env.nbe =
+                         (uu___.FStar_TypeChecker_Env.nbe);
+                       FStar_TypeChecker_Env.strict_args_tab =
+                         (uu___.FStar_TypeChecker_Env.strict_args_tab);
+                       FStar_TypeChecker_Env.erasable_types_tab =
+                         (uu___.FStar_TypeChecker_Env.erasable_types_tab);
+                       FStar_TypeChecker_Env.enable_defer_to_tac =
+                         (uu___.FStar_TypeChecker_Env.enable_defer_to_tac);
+                       FStar_TypeChecker_Env.unif_allow_ref_guards =
+                         (uu___.FStar_TypeChecker_Env.unif_allow_ref_guards);
+                       FStar_TypeChecker_Env.erase_erasable_args =
+                         (uu___.FStar_TypeChecker_Env.erase_erasable_args);
+                       FStar_TypeChecker_Env.core_check =
+                         (uu___.FStar_TypeChecker_Env.core_check)
+                     });
+                  FStar_Tactics_Types.all_implicits =
+                    (ps.FStar_Tactics_Types.all_implicits);
+                  FStar_Tactics_Types.goals = (ps.FStar_Tactics_Types.goals);
+                  FStar_Tactics_Types.smt_goals =
+                    (ps.FStar_Tactics_Types.smt_goals);
+                  FStar_Tactics_Types.depth = (ps.FStar_Tactics_Types.depth);
+                  FStar_Tactics_Types.__dump =
+                    (ps.FStar_Tactics_Types.__dump);
+                  FStar_Tactics_Types.psc = (ps.FStar_Tactics_Types.psc);
+                  FStar_Tactics_Types.entry_range =
+                    (ps.FStar_Tactics_Types.entry_range);
+                  FStar_Tactics_Types.guard_policy =
+                    (ps.FStar_Tactics_Types.guard_policy);
+                  FStar_Tactics_Types.freshness =
+                    (ps.FStar_Tactics_Types.freshness);
+                  FStar_Tactics_Types.tac_verb_dbg =
+                    (ps.FStar_Tactics_Types.tac_verb_dbg);
+                  FStar_Tactics_Types.local_state =
+                    (ps.FStar_Tactics_Types.local_state);
+                  FStar_Tactics_Types.urgency =
+                    (ps.FStar_Tactics_Types.urgency)
+                } in
+              let ps2 =
+                {
+                  FStar_Tactics_Types.main_context =
+                    (let uu___ = ps1.FStar_Tactics_Types.main_context in
+                     {
+                       FStar_TypeChecker_Env.solver =
+                         (uu___.FStar_TypeChecker_Env.solver);
+                       FStar_TypeChecker_Env.range = rng_goal;
+                       FStar_TypeChecker_Env.curmodule =
+                         (uu___.FStar_TypeChecker_Env.curmodule);
+                       FStar_TypeChecker_Env.gamma =
+                         (uu___.FStar_TypeChecker_Env.gamma);
+                       FStar_TypeChecker_Env.gamma_sig =
+                         (uu___.FStar_TypeChecker_Env.gamma_sig);
+                       FStar_TypeChecker_Env.gamma_cache =
+                         (uu___.FStar_TypeChecker_Env.gamma_cache);
+                       FStar_TypeChecker_Env.modules =
+                         (uu___.FStar_TypeChecker_Env.modules);
+                       FStar_TypeChecker_Env.expected_typ =
+                         (uu___.FStar_TypeChecker_Env.expected_typ);
+                       FStar_TypeChecker_Env.sigtab =
+                         (uu___.FStar_TypeChecker_Env.sigtab);
+                       FStar_TypeChecker_Env.attrtab =
+                         (uu___.FStar_TypeChecker_Env.attrtab);
+                       FStar_TypeChecker_Env.instantiate_imp =
+                         (uu___.FStar_TypeChecker_Env.instantiate_imp);
+                       FStar_TypeChecker_Env.effects =
+                         (uu___.FStar_TypeChecker_Env.effects);
+                       FStar_TypeChecker_Env.generalize =
+                         (uu___.FStar_TypeChecker_Env.generalize);
+                       FStar_TypeChecker_Env.letrecs =
+                         (uu___.FStar_TypeChecker_Env.letrecs);
+                       FStar_TypeChecker_Env.top_level =
+                         (uu___.FStar_TypeChecker_Env.top_level);
+                       FStar_TypeChecker_Env.check_uvars =
+                         (uu___.FStar_TypeChecker_Env.check_uvars);
+                       FStar_TypeChecker_Env.use_eq_strict =
+                         (uu___.FStar_TypeChecker_Env.use_eq_strict);
+                       FStar_TypeChecker_Env.is_iface =
+                         (uu___.FStar_TypeChecker_Env.is_iface);
+                       FStar_TypeChecker_Env.admit =
+                         (uu___.FStar_TypeChecker_Env.admit);
+                       FStar_TypeChecker_Env.lax =
+                         (uu___.FStar_TypeChecker_Env.lax);
+                       FStar_TypeChecker_Env.lax_universes =
+                         (uu___.FStar_TypeChecker_Env.lax_universes);
+                       FStar_TypeChecker_Env.phase1 =
+                         (uu___.FStar_TypeChecker_Env.phase1);
+                       FStar_TypeChecker_Env.failhard =
+                         (uu___.FStar_TypeChecker_Env.failhard);
+                       FStar_TypeChecker_Env.nosynth =
+                         (uu___.FStar_TypeChecker_Env.nosynth);
+                       FStar_TypeChecker_Env.uvar_subtyping =
+                         (uu___.FStar_TypeChecker_Env.uvar_subtyping);
+                       FStar_TypeChecker_Env.intactics =
+                         (uu___.FStar_TypeChecker_Env.intactics);
+                       FStar_TypeChecker_Env.nocoerce =
+                         (uu___.FStar_TypeChecker_Env.nocoerce);
+                       FStar_TypeChecker_Env.tc_term =
+                         (uu___.FStar_TypeChecker_Env.tc_term);
+                       FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
+                         (uu___.FStar_TypeChecker_Env.typeof_tot_or_gtot_term);
+                       FStar_TypeChecker_Env.universe_of =
+                         (uu___.FStar_TypeChecker_Env.universe_of);
+                       FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
+                         =
+                         (uu___.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                       FStar_TypeChecker_Env.teq_nosmt_force =
+                         (uu___.FStar_TypeChecker_Env.teq_nosmt_force);
+                       FStar_TypeChecker_Env.subtype_nosmt_force =
+                         (uu___.FStar_TypeChecker_Env.subtype_nosmt_force);
+                       FStar_TypeChecker_Env.qtbl_name_and_index =
+                         (uu___.FStar_TypeChecker_Env.qtbl_name_and_index);
+                       FStar_TypeChecker_Env.normalized_eff_names =
+                         (uu___.FStar_TypeChecker_Env.normalized_eff_names);
+                       FStar_TypeChecker_Env.fv_delta_depths =
+                         (uu___.FStar_TypeChecker_Env.fv_delta_depths);
+                       FStar_TypeChecker_Env.proof_ns =
+                         (uu___.FStar_TypeChecker_Env.proof_ns);
+                       FStar_TypeChecker_Env.synth_hook =
+                         (uu___.FStar_TypeChecker_Env.synth_hook);
+                       FStar_TypeChecker_Env.try_solve_implicits_hook =
+                         (uu___.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                       FStar_TypeChecker_Env.splice =
+                         (uu___.FStar_TypeChecker_Env.splice);
+                       FStar_TypeChecker_Env.mpreprocess =
+                         (uu___.FStar_TypeChecker_Env.mpreprocess);
+                       FStar_TypeChecker_Env.postprocess =
+                         (uu___.FStar_TypeChecker_Env.postprocess);
+                       FStar_TypeChecker_Env.identifier_info =
+                         (uu___.FStar_TypeChecker_Env.identifier_info);
+                       FStar_TypeChecker_Env.tc_hooks =
+                         (uu___.FStar_TypeChecker_Env.tc_hooks);
+                       FStar_TypeChecker_Env.dsenv =
+                         (uu___.FStar_TypeChecker_Env.dsenv);
+                       FStar_TypeChecker_Env.nbe =
+                         (uu___.FStar_TypeChecker_Env.nbe);
+                       FStar_TypeChecker_Env.strict_args_tab =
+                         (uu___.FStar_TypeChecker_Env.strict_args_tab);
+                       FStar_TypeChecker_Env.erasable_types_tab =
+                         (uu___.FStar_TypeChecker_Env.erasable_types_tab);
+                       FStar_TypeChecker_Env.enable_defer_to_tac =
+                         (uu___.FStar_TypeChecker_Env.enable_defer_to_tac);
+                       FStar_TypeChecker_Env.unif_allow_ref_guards =
+                         (uu___.FStar_TypeChecker_Env.unif_allow_ref_guards);
+                       FStar_TypeChecker_Env.erase_erasable_args =
+                         (uu___.FStar_TypeChecker_Env.erase_erasable_args);
+                       FStar_TypeChecker_Env.core_check =
+                         (uu___.FStar_TypeChecker_Env.core_check)
+                     });
+                  FStar_Tactics_Types.all_implicits =
+                    (ps1.FStar_Tactics_Types.all_implicits);
+                  FStar_Tactics_Types.goals = (ps1.FStar_Tactics_Types.goals);
+                  FStar_Tactics_Types.smt_goals =
+                    (ps1.FStar_Tactics_Types.smt_goals);
+                  FStar_Tactics_Types.depth = (ps1.FStar_Tactics_Types.depth);
+                  FStar_Tactics_Types.__dump =
+                    (ps1.FStar_Tactics_Types.__dump);
+                  FStar_Tactics_Types.psc = (ps1.FStar_Tactics_Types.psc);
+                  FStar_Tactics_Types.entry_range =
+                    (ps1.FStar_Tactics_Types.entry_range);
+                  FStar_Tactics_Types.guard_policy =
+                    (ps1.FStar_Tactics_Types.guard_policy);
+                  FStar_Tactics_Types.freshness =
+                    (ps1.FStar_Tactics_Types.freshness);
+                  FStar_Tactics_Types.tac_verb_dbg =
+                    (ps1.FStar_Tactics_Types.tac_verb_dbg);
+                  FStar_Tactics_Types.local_state =
+                    (ps1.FStar_Tactics_Types.local_state);
+                  FStar_Tactics_Types.urgency =
+                    (ps1.FStar_Tactics_Types.urgency)
+                } in
+              let env = ps2.FStar_Tactics_Types.main_context in
+              let res =
+                let uu___ =
+                  let uu___1 =
+                    let uu___2 =
+                      FStar_TypeChecker_Env.current_module
+                        ps2.FStar_Tactics_Types.main_context in
+                    FStar_Ident.string_of_lid uu___2 in
+                  FStar_Pervasives_Native.Some uu___1 in
+                FStar_Profiling.profile
+                  (fun uu___1 ->
+                     let uu___2 = tau arg in
+                     FStar_Tactics_Monad.run_safe uu___2 ps2) uu___
+                  "FStar.Tactics.Interpreter.run_safe" in
+              (let uu___1 = FStar_Compiler_Effect.op_Bang tacdbg in
+               if uu___1 then FStar_Compiler_Util.print_string "}\n" else ());
+              (match res with
+               | FStar_Tactics_Result.Success (ret, ps3) ->
+                   ((let uu___2 = FStar_Compiler_Effect.op_Bang tacdbg in
+                     if uu___2
+                     then
+                       FStar_Tactics_Printing.do_dump_proofstate ps3
+                         "at the finish line"
+                     else ());
+                    (let remaining_smt_goals =
+                       FStar_Compiler_List.op_At
+                         ps3.FStar_Tactics_Types.goals
+                         ps3.FStar_Tactics_Types.smt_goals in
+                     FStar_Compiler_List.iter
+                       (fun g ->
+                          FStar_Tactics_Monad.mark_goal_implicit_already_checked
+                            g;
+                          (let uu___4 = FStar_Tactics_Monad.is_irrelevant g in
+                           if uu___4
+                           then
+                             ((let uu___6 =
+                                 FStar_Compiler_Effect.op_Bang tacdbg in
+                               if uu___6
+                               then
+                                 let uu___7 =
+                                   let uu___8 =
+                                     FStar_Tactics_Types.goal_witness g in
+                                   FStar_Class_Show.show
+                                     FStar_Syntax_Print.showable_term uu___8 in
+                                 FStar_Compiler_Util.print1
+                                   "Assigning irrelevant goal %s\n" uu___7
+                               else ());
+                              (let uu___6 =
+                                 let uu___7 = FStar_Tactics_Types.goal_env g in
+                                 let uu___8 =
+                                   FStar_Tactics_Types.goal_witness g in
+                                 FStar_TypeChecker_Rel.teq_nosmt_force uu___7
+                                   uu___8 FStar_Syntax_Util.exp_unit in
+                               if uu___6
+                               then ()
+                               else
+                                 (let uu___8 =
+                                    let uu___9 =
+                                      let uu___10 =
+                                        FStar_Tactics_Types.goal_witness g in
+                                      FStar_Class_Show.show
+                                        FStar_Syntax_Print.showable_term
+                                        uu___10 in
+                                    FStar_Compiler_Util.format1
+                                      "Irrelevant tactic witness does not unify with (): %s"
+                                      uu___9 in
+                                  FStar_Compiler_Effect.failwith uu___8)))
+                           else ())) remaining_smt_goals;
+                     FStar_Errors.with_ctx
+                       "While checking implicits left by a tactic"
+                       (fun uu___4 ->
+                          (let uu___6 = FStar_Compiler_Effect.op_Bang tacdbg in
+                           if uu___6
+                           then
+                             let uu___7 =
+                               (FStar_Common.string_of_list ())
+                                 (fun imp ->
+                                    FStar_Class_Show.show
+                                      FStar_Syntax_Print.showable_ctxu
+                                      imp.FStar_TypeChecker_Common.imp_uvar)
+                                 ps3.FStar_Tactics_Types.all_implicits in
+                             FStar_Compiler_Util.print1
+                               "About to check tactic implicits: %s\n" uu___7
+                           else ());
+                          (let g =
+                             {
+                               FStar_TypeChecker_Common.guard_f =
+                                 (FStar_TypeChecker_Env.trivial_guard.FStar_TypeChecker_Common.guard_f);
+                               FStar_TypeChecker_Common.deferred_to_tac =
+                                 (FStar_TypeChecker_Env.trivial_guard.FStar_TypeChecker_Common.deferred_to_tac);
+                               FStar_TypeChecker_Common.deferred =
+                                 (FStar_TypeChecker_Env.trivial_guard.FStar_TypeChecker_Common.deferred);
+                               FStar_TypeChecker_Common.univ_ineqs =
+                                 (FStar_TypeChecker_Env.trivial_guard.FStar_TypeChecker_Common.univ_ineqs);
+                               FStar_TypeChecker_Common.implicits =
+                                 (ps3.FStar_Tactics_Types.all_implicits)
+                             } in
+                           let g1 =
+                             FStar_TypeChecker_Rel.solve_deferred_constraints
+                               env g in
+                           (let uu___7 = FStar_Compiler_Effect.op_Bang tacdbg in
+                            if uu___7
+                            then
+                              let uu___8 =
+                                FStar_Class_Show.show
+                                  (FStar_Class_Show.printableshow
+                                     FStar_Class_Printable.printable_nat)
+                                  (FStar_Compiler_List.length
+                                     ps3.FStar_Tactics_Types.all_implicits) in
+                              let uu___9 =
+                                FStar_Class_Show.show
+                                  (FStar_Class_Show.show_list
+                                     FStar_TypeChecker_Common.show_implicit)
+                                  ps3.FStar_Tactics_Types.all_implicits in
+                              FStar_Compiler_Util.print2
+                                "Checked %s implicits (1): %s\n" uu___8
+                                uu___9
+                            else ());
+                           (let tagged_implicits =
+                              FStar_TypeChecker_Rel.resolve_implicits_tac env
+                                g1 in
+                            (let uu___8 =
+                               FStar_Compiler_Effect.op_Bang tacdbg in
+                             if uu___8
+                             then
+                               let uu___9 =
+                                 FStar_Class_Show.show
+                                   (FStar_Class_Show.printableshow
+                                      FStar_Class_Printable.printable_nat)
+                                   (FStar_Compiler_List.length
+                                      ps3.FStar_Tactics_Types.all_implicits) in
+                               let uu___10 =
+                                 FStar_Class_Show.show
+                                   (FStar_Class_Show.show_list
+                                      FStar_TypeChecker_Common.show_implicit)
+                                   ps3.FStar_Tactics_Types.all_implicits in
+                               FStar_Compiler_Util.print2
+                                 "Checked %s implicits (2): %s\n" uu___9
+                                 uu___10
+                             else ());
+                            report_implicits rng_goal tagged_implicits)));
+                     (remaining_smt_goals, ret)))
+               | FStar_Tactics_Result.Failed
+                   (FStar_Errors.Error (code, msg, rng, ctx), ps3) ->
+                   let msg1 =
+                     let uu___1 = FStar_Pprint.doc_of_string "Tactic failed" in
+                     uu___1 :: msg in
+                   FStar_Compiler_Effect.raise
+                     (FStar_Errors.Error (code, msg1, rng, ctx))
+               | FStar_Tactics_Result.Failed
+                   (FStar_Errors.Err (code, msg, ctx), ps3) ->
+                   let msg1 =
+                     let uu___1 = FStar_Pprint.doc_of_string "Tactic failed" in
+                     uu___1 :: msg in
+                   FStar_Compiler_Effect.raise
+                     (FStar_Errors.Err (code, msg1, ctx))
+               | FStar_Tactics_Result.Failed (e, ps3) ->
+                   (FStar_Tactics_Printing.do_dump_proofstate ps3
+                      "at the time of failure";
+                    (let texn_to_string e1 =
+                       match e1 with
+                       | FStar_Tactics_Common.TacticFailure s ->
+                           Prims.strcat "\"" (Prims.strcat s "\"")
+                       | FStar_Tactics_Common.EExn t ->
+                           let uu___2 =
+                             FStar_Class_Show.show
+                               FStar_Syntax_Print.showable_term t in
+                           Prims.strcat "Uncaught exception: " uu___2
+                       | e2 -> FStar_Compiler_Effect.raise e2 in
+                     let rng =
+                       if background
+                       then
+                         match ps3.FStar_Tactics_Types.goals with
+                         | g::uu___2 ->
+                             (g.FStar_Tactics_Types.goal_ctx_uvar).FStar_Syntax_Syntax.ctx_uvar_range
+                         | uu___2 -> rng_call
+                       else ps3.FStar_Tactics_Types.entry_range in
+                     let uu___2 =
+                       let uu___3 =
+                         let uu___4 =
+                           FStar_Pprint.doc_of_string "Tactic failed" in
+                         let uu___5 =
+                           let uu___6 =
+                             let uu___7 = texn_to_string e in
+                             FStar_Pprint.doc_of_string uu___7 in
+                           [uu___6] in
+                         uu___4 :: uu___5 in
+                       (FStar_Errors_Codes.Fatal_UserTacticFailure, uu___3) in
+                     FStar_Errors.raise_error_doc uu___2 rng)))
 let run_tactic_on_ps' :
   'a 'b .
     FStar_Compiler_Range_Type.range ->
@@ -607,277 +1076,7 @@ let run_tactic_on_ps' :
               fun tactic ->
                 fun tactic_already_typed ->
                   fun ps ->
-                    let ps1 =
-                      {
-                        FStar_Tactics_Types.main_context =
-                          (let uu___ = ps.FStar_Tactics_Types.main_context in
-                           {
-                             FStar_TypeChecker_Env.solver =
-                               (uu___.FStar_TypeChecker_Env.solver);
-                             FStar_TypeChecker_Env.range =
-                               (uu___.FStar_TypeChecker_Env.range);
-                             FStar_TypeChecker_Env.curmodule =
-                               (uu___.FStar_TypeChecker_Env.curmodule);
-                             FStar_TypeChecker_Env.gamma =
-                               (uu___.FStar_TypeChecker_Env.gamma);
-                             FStar_TypeChecker_Env.gamma_sig =
-                               (uu___.FStar_TypeChecker_Env.gamma_sig);
-                             FStar_TypeChecker_Env.gamma_cache =
-                               (uu___.FStar_TypeChecker_Env.gamma_cache);
-                             FStar_TypeChecker_Env.modules =
-                               (uu___.FStar_TypeChecker_Env.modules);
-                             FStar_TypeChecker_Env.expected_typ =
-                               (uu___.FStar_TypeChecker_Env.expected_typ);
-                             FStar_TypeChecker_Env.sigtab =
-                               (uu___.FStar_TypeChecker_Env.sigtab);
-                             FStar_TypeChecker_Env.attrtab =
-                               (uu___.FStar_TypeChecker_Env.attrtab);
-                             FStar_TypeChecker_Env.instantiate_imp =
-                               (uu___.FStar_TypeChecker_Env.instantiate_imp);
-                             FStar_TypeChecker_Env.effects =
-                               (uu___.FStar_TypeChecker_Env.effects);
-                             FStar_TypeChecker_Env.generalize =
-                               (uu___.FStar_TypeChecker_Env.generalize);
-                             FStar_TypeChecker_Env.letrecs =
-                               (uu___.FStar_TypeChecker_Env.letrecs);
-                             FStar_TypeChecker_Env.top_level =
-                               (uu___.FStar_TypeChecker_Env.top_level);
-                             FStar_TypeChecker_Env.check_uvars =
-                               (uu___.FStar_TypeChecker_Env.check_uvars);
-                             FStar_TypeChecker_Env.use_eq_strict =
-                               (uu___.FStar_TypeChecker_Env.use_eq_strict);
-                             FStar_TypeChecker_Env.is_iface =
-                               (uu___.FStar_TypeChecker_Env.is_iface);
-                             FStar_TypeChecker_Env.admit =
-                               (uu___.FStar_TypeChecker_Env.admit);
-                             FStar_TypeChecker_Env.lax =
-                               (uu___.FStar_TypeChecker_Env.lax);
-                             FStar_TypeChecker_Env.lax_universes =
-                               (uu___.FStar_TypeChecker_Env.lax_universes);
-                             FStar_TypeChecker_Env.phase1 =
-                               (uu___.FStar_TypeChecker_Env.phase1);
-                             FStar_TypeChecker_Env.failhard =
-                               (uu___.FStar_TypeChecker_Env.failhard);
-                             FStar_TypeChecker_Env.nosynth =
-                               (uu___.FStar_TypeChecker_Env.nosynth);
-                             FStar_TypeChecker_Env.uvar_subtyping =
-                               (uu___.FStar_TypeChecker_Env.uvar_subtyping);
-                             FStar_TypeChecker_Env.intactics = true;
-                             FStar_TypeChecker_Env.nocoerce =
-                               (uu___.FStar_TypeChecker_Env.nocoerce);
-                             FStar_TypeChecker_Env.tc_term =
-                               (uu___.FStar_TypeChecker_Env.tc_term);
-                             FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
-                               (uu___.FStar_TypeChecker_Env.typeof_tot_or_gtot_term);
-                             FStar_TypeChecker_Env.universe_of =
-                               (uu___.FStar_TypeChecker_Env.universe_of);
-                             FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
-                               =
-                               (uu___.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
-                             FStar_TypeChecker_Env.teq_nosmt_force =
-                               (uu___.FStar_TypeChecker_Env.teq_nosmt_force);
-                             FStar_TypeChecker_Env.subtype_nosmt_force =
-                               (uu___.FStar_TypeChecker_Env.subtype_nosmt_force);
-                             FStar_TypeChecker_Env.qtbl_name_and_index =
-                               (uu___.FStar_TypeChecker_Env.qtbl_name_and_index);
-                             FStar_TypeChecker_Env.normalized_eff_names =
-                               (uu___.FStar_TypeChecker_Env.normalized_eff_names);
-                             FStar_TypeChecker_Env.fv_delta_depths =
-                               (uu___.FStar_TypeChecker_Env.fv_delta_depths);
-                             FStar_TypeChecker_Env.proof_ns =
-                               (uu___.FStar_TypeChecker_Env.proof_ns);
-                             FStar_TypeChecker_Env.synth_hook =
-                               (uu___.FStar_TypeChecker_Env.synth_hook);
-                             FStar_TypeChecker_Env.try_solve_implicits_hook =
-                               (uu___.FStar_TypeChecker_Env.try_solve_implicits_hook);
-                             FStar_TypeChecker_Env.splice =
-                               (uu___.FStar_TypeChecker_Env.splice);
-                             FStar_TypeChecker_Env.mpreprocess =
-                               (uu___.FStar_TypeChecker_Env.mpreprocess);
-                             FStar_TypeChecker_Env.postprocess =
-                               (uu___.FStar_TypeChecker_Env.postprocess);
-                             FStar_TypeChecker_Env.identifier_info =
-                               (uu___.FStar_TypeChecker_Env.identifier_info);
-                             FStar_TypeChecker_Env.tc_hooks =
-                               (uu___.FStar_TypeChecker_Env.tc_hooks);
-                             FStar_TypeChecker_Env.dsenv =
-                               (uu___.FStar_TypeChecker_Env.dsenv);
-                             FStar_TypeChecker_Env.nbe =
-                               (uu___.FStar_TypeChecker_Env.nbe);
-                             FStar_TypeChecker_Env.strict_args_tab =
-                               (uu___.FStar_TypeChecker_Env.strict_args_tab);
-                             FStar_TypeChecker_Env.erasable_types_tab =
-                               (uu___.FStar_TypeChecker_Env.erasable_types_tab);
-                             FStar_TypeChecker_Env.enable_defer_to_tac =
-                               (uu___.FStar_TypeChecker_Env.enable_defer_to_tac);
-                             FStar_TypeChecker_Env.unif_allow_ref_guards =
-                               (uu___.FStar_TypeChecker_Env.unif_allow_ref_guards);
-                             FStar_TypeChecker_Env.erase_erasable_args =
-                               (uu___.FStar_TypeChecker_Env.erase_erasable_args);
-                             FStar_TypeChecker_Env.core_check =
-                               (uu___.FStar_TypeChecker_Env.core_check)
-                           });
-                        FStar_Tactics_Types.all_implicits =
-                          (ps.FStar_Tactics_Types.all_implicits);
-                        FStar_Tactics_Types.goals =
-                          (ps.FStar_Tactics_Types.goals);
-                        FStar_Tactics_Types.smt_goals =
-                          (ps.FStar_Tactics_Types.smt_goals);
-                        FStar_Tactics_Types.depth =
-                          (ps.FStar_Tactics_Types.depth);
-                        FStar_Tactics_Types.__dump =
-                          (ps.FStar_Tactics_Types.__dump);
-                        FStar_Tactics_Types.psc =
-                          (ps.FStar_Tactics_Types.psc);
-                        FStar_Tactics_Types.entry_range =
-                          (ps.FStar_Tactics_Types.entry_range);
-                        FStar_Tactics_Types.guard_policy =
-                          (ps.FStar_Tactics_Types.guard_policy);
-                        FStar_Tactics_Types.freshness =
-                          (ps.FStar_Tactics_Types.freshness);
-                        FStar_Tactics_Types.tac_verb_dbg =
-                          (ps.FStar_Tactics_Types.tac_verb_dbg);
-                        FStar_Tactics_Types.local_state =
-                          (ps.FStar_Tactics_Types.local_state);
-                        FStar_Tactics_Types.urgency =
-                          (ps.FStar_Tactics_Types.urgency)
-                      } in
-                    let ps2 =
-                      {
-                        FStar_Tactics_Types.main_context =
-                          (let uu___ = ps1.FStar_Tactics_Types.main_context in
-                           {
-                             FStar_TypeChecker_Env.solver =
-                               (uu___.FStar_TypeChecker_Env.solver);
-                             FStar_TypeChecker_Env.range = rng_goal;
-                             FStar_TypeChecker_Env.curmodule =
-                               (uu___.FStar_TypeChecker_Env.curmodule);
-                             FStar_TypeChecker_Env.gamma =
-                               (uu___.FStar_TypeChecker_Env.gamma);
-                             FStar_TypeChecker_Env.gamma_sig =
-                               (uu___.FStar_TypeChecker_Env.gamma_sig);
-                             FStar_TypeChecker_Env.gamma_cache =
-                               (uu___.FStar_TypeChecker_Env.gamma_cache);
-                             FStar_TypeChecker_Env.modules =
-                               (uu___.FStar_TypeChecker_Env.modules);
-                             FStar_TypeChecker_Env.expected_typ =
-                               (uu___.FStar_TypeChecker_Env.expected_typ);
-                             FStar_TypeChecker_Env.sigtab =
-                               (uu___.FStar_TypeChecker_Env.sigtab);
-                             FStar_TypeChecker_Env.attrtab =
-                               (uu___.FStar_TypeChecker_Env.attrtab);
-                             FStar_TypeChecker_Env.instantiate_imp =
-                               (uu___.FStar_TypeChecker_Env.instantiate_imp);
-                             FStar_TypeChecker_Env.effects =
-                               (uu___.FStar_TypeChecker_Env.effects);
-                             FStar_TypeChecker_Env.generalize =
-                               (uu___.FStar_TypeChecker_Env.generalize);
-                             FStar_TypeChecker_Env.letrecs =
-                               (uu___.FStar_TypeChecker_Env.letrecs);
-                             FStar_TypeChecker_Env.top_level =
-                               (uu___.FStar_TypeChecker_Env.top_level);
-                             FStar_TypeChecker_Env.check_uvars =
-                               (uu___.FStar_TypeChecker_Env.check_uvars);
-                             FStar_TypeChecker_Env.use_eq_strict =
-                               (uu___.FStar_TypeChecker_Env.use_eq_strict);
-                             FStar_TypeChecker_Env.is_iface =
-                               (uu___.FStar_TypeChecker_Env.is_iface);
-                             FStar_TypeChecker_Env.admit =
-                               (uu___.FStar_TypeChecker_Env.admit);
-                             FStar_TypeChecker_Env.lax =
-                               (uu___.FStar_TypeChecker_Env.lax);
-                             FStar_TypeChecker_Env.lax_universes =
-                               (uu___.FStar_TypeChecker_Env.lax_universes);
-                             FStar_TypeChecker_Env.phase1 =
-                               (uu___.FStar_TypeChecker_Env.phase1);
-                             FStar_TypeChecker_Env.failhard =
-                               (uu___.FStar_TypeChecker_Env.failhard);
-                             FStar_TypeChecker_Env.nosynth =
-                               (uu___.FStar_TypeChecker_Env.nosynth);
-                             FStar_TypeChecker_Env.uvar_subtyping =
-                               (uu___.FStar_TypeChecker_Env.uvar_subtyping);
-                             FStar_TypeChecker_Env.intactics =
-                               (uu___.FStar_TypeChecker_Env.intactics);
-                             FStar_TypeChecker_Env.nocoerce =
-                               (uu___.FStar_TypeChecker_Env.nocoerce);
-                             FStar_TypeChecker_Env.tc_term =
-                               (uu___.FStar_TypeChecker_Env.tc_term);
-                             FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
-                               (uu___.FStar_TypeChecker_Env.typeof_tot_or_gtot_term);
-                             FStar_TypeChecker_Env.universe_of =
-                               (uu___.FStar_TypeChecker_Env.universe_of);
-                             FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
-                               =
-                               (uu___.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
-                             FStar_TypeChecker_Env.teq_nosmt_force =
-                               (uu___.FStar_TypeChecker_Env.teq_nosmt_force);
-                             FStar_TypeChecker_Env.subtype_nosmt_force =
-                               (uu___.FStar_TypeChecker_Env.subtype_nosmt_force);
-                             FStar_TypeChecker_Env.qtbl_name_and_index =
-                               (uu___.FStar_TypeChecker_Env.qtbl_name_and_index);
-                             FStar_TypeChecker_Env.normalized_eff_names =
-                               (uu___.FStar_TypeChecker_Env.normalized_eff_names);
-                             FStar_TypeChecker_Env.fv_delta_depths =
-                               (uu___.FStar_TypeChecker_Env.fv_delta_depths);
-                             FStar_TypeChecker_Env.proof_ns =
-                               (uu___.FStar_TypeChecker_Env.proof_ns);
-                             FStar_TypeChecker_Env.synth_hook =
-                               (uu___.FStar_TypeChecker_Env.synth_hook);
-                             FStar_TypeChecker_Env.try_solve_implicits_hook =
-                               (uu___.FStar_TypeChecker_Env.try_solve_implicits_hook);
-                             FStar_TypeChecker_Env.splice =
-                               (uu___.FStar_TypeChecker_Env.splice);
-                             FStar_TypeChecker_Env.mpreprocess =
-                               (uu___.FStar_TypeChecker_Env.mpreprocess);
-                             FStar_TypeChecker_Env.postprocess =
-                               (uu___.FStar_TypeChecker_Env.postprocess);
-                             FStar_TypeChecker_Env.identifier_info =
-                               (uu___.FStar_TypeChecker_Env.identifier_info);
-                             FStar_TypeChecker_Env.tc_hooks =
-                               (uu___.FStar_TypeChecker_Env.tc_hooks);
-                             FStar_TypeChecker_Env.dsenv =
-                               (uu___.FStar_TypeChecker_Env.dsenv);
-                             FStar_TypeChecker_Env.nbe =
-                               (uu___.FStar_TypeChecker_Env.nbe);
-                             FStar_TypeChecker_Env.strict_args_tab =
-                               (uu___.FStar_TypeChecker_Env.strict_args_tab);
-                             FStar_TypeChecker_Env.erasable_types_tab =
-                               (uu___.FStar_TypeChecker_Env.erasable_types_tab);
-                             FStar_TypeChecker_Env.enable_defer_to_tac =
-                               (uu___.FStar_TypeChecker_Env.enable_defer_to_tac);
-                             FStar_TypeChecker_Env.unif_allow_ref_guards =
-                               (uu___.FStar_TypeChecker_Env.unif_allow_ref_guards);
-                             FStar_TypeChecker_Env.erase_erasable_args =
-                               (uu___.FStar_TypeChecker_Env.erase_erasable_args);
-                             FStar_TypeChecker_Env.core_check =
-                               (uu___.FStar_TypeChecker_Env.core_check)
-                           });
-                        FStar_Tactics_Types.all_implicits =
-                          (ps1.FStar_Tactics_Types.all_implicits);
-                        FStar_Tactics_Types.goals =
-                          (ps1.FStar_Tactics_Types.goals);
-                        FStar_Tactics_Types.smt_goals =
-                          (ps1.FStar_Tactics_Types.smt_goals);
-                        FStar_Tactics_Types.depth =
-                          (ps1.FStar_Tactics_Types.depth);
-                        FStar_Tactics_Types.__dump =
-                          (ps1.FStar_Tactics_Types.__dump);
-                        FStar_Tactics_Types.psc =
-                          (ps1.FStar_Tactics_Types.psc);
-                        FStar_Tactics_Types.entry_range =
-                          (ps1.FStar_Tactics_Types.entry_range);
-                        FStar_Tactics_Types.guard_policy =
-                          (ps1.FStar_Tactics_Types.guard_policy);
-                        FStar_Tactics_Types.freshness =
-                          (ps1.FStar_Tactics_Types.freshness);
-                        FStar_Tactics_Types.tac_verb_dbg =
-                          (ps1.FStar_Tactics_Types.tac_verb_dbg);
-                        FStar_Tactics_Types.local_state =
-                          (ps1.FStar_Tactics_Types.local_state);
-                        FStar_Tactics_Types.urgency =
-                          (ps1.FStar_Tactics_Types.urgency)
-                      } in
-                    let env = ps2.FStar_Tactics_Types.main_context in
+                    let env = ps.FStar_Tactics_Types.main_context in
                     (let uu___1 = FStar_Compiler_Effect.op_Bang tacdbg in
                      if uu___1
                      then
@@ -914,214 +1113,8 @@ let run_tactic_on_ps' :
                      (let tau =
                         unembed_tactic_1 e_arg e_res tactic
                           FStar_Syntax_Embeddings_Base.id_norm_cb in
-                      let res =
-                        let uu___4 =
-                          let uu___5 =
-                            let uu___6 =
-                              FStar_TypeChecker_Env.current_module
-                                ps2.FStar_Tactics_Types.main_context in
-                            FStar_Ident.string_of_lid uu___6 in
-                          FStar_Pervasives_Native.Some uu___5 in
-                        FStar_Profiling.profile
-                          (fun uu___5 ->
-                             let uu___6 = tau arg in
-                             FStar_Tactics_Monad.run_safe uu___6 ps2) uu___4
-                          "FStar.Tactics.Interpreter.run_safe" in
-                      (let uu___5 = FStar_Compiler_Effect.op_Bang tacdbg in
-                       if uu___5
-                       then FStar_Compiler_Util.print_string "}\n"
-                       else ());
-                      (match res with
-                       | FStar_Tactics_Result.Success (ret, ps3) ->
-                           ((let uu___6 =
-                               FStar_Compiler_Effect.op_Bang tacdbg in
-                             if uu___6
-                             then
-                               FStar_Tactics_Printing.do_dump_proofstate ps3
-                                 "at the finish line"
-                             else ());
-                            (let remaining_smt_goals =
-                               FStar_Compiler_List.op_At
-                                 ps3.FStar_Tactics_Types.goals
-                                 ps3.FStar_Tactics_Types.smt_goals in
-                             FStar_Compiler_List.iter
-                               (fun g1 ->
-                                  FStar_Tactics_V2_Basic.mark_goal_implicit_already_checked
-                                    g1;
-                                  (let uu___8 =
-                                     FStar_Tactics_V2_Basic.is_irrelevant g1 in
-                                   if uu___8
-                                   then
-                                     ((let uu___10 =
-                                         FStar_Compiler_Effect.op_Bang tacdbg in
-                                       if uu___10
-                                       then
-                                         let uu___11 =
-                                           let uu___12 =
-                                             FStar_Tactics_Types.goal_witness
-                                               g1 in
-                                           FStar_Class_Show.show
-                                             FStar_Syntax_Print.showable_term
-                                             uu___12 in
-                                         FStar_Compiler_Util.print1
-                                           "Assigning irrelevant goal %s\n"
-                                           uu___11
-                                       else ());
-                                      (let uu___10 =
-                                         let uu___11 =
-                                           FStar_Tactics_Types.goal_env g1 in
-                                         let uu___12 =
-                                           FStar_Tactics_Types.goal_witness
-                                             g1 in
-                                         FStar_TypeChecker_Rel.teq_nosmt_force
-                                           uu___11 uu___12
-                                           FStar_Syntax_Util.exp_unit in
-                                       if uu___10
-                                       then ()
-                                       else
-                                         (let uu___12 =
-                                            let uu___13 =
-                                              let uu___14 =
-                                                FStar_Tactics_Types.goal_witness
-                                                  g1 in
-                                              FStar_Class_Show.show
-                                                FStar_Syntax_Print.showable_term
-                                                uu___14 in
-                                            FStar_Compiler_Util.format1
-                                              "Irrelevant tactic witness does not unify with (): %s"
-                                              uu___13 in
-                                          FStar_Compiler_Effect.failwith
-                                            uu___12)))
-                                   else ())) remaining_smt_goals;
-                             FStar_Errors.with_ctx
-                               "While checking implicits left by a tactic"
-                               (fun uu___8 ->
-                                  (let uu___10 =
-                                     FStar_Compiler_Effect.op_Bang tacdbg in
-                                   if uu___10
-                                   then
-                                     let uu___11 =
-                                       (FStar_Common.string_of_list ())
-                                         (fun imp ->
-                                            FStar_Class_Show.show
-                                              FStar_Syntax_Print.showable_ctxu
-                                              imp.FStar_TypeChecker_Common.imp_uvar)
-                                         ps3.FStar_Tactics_Types.all_implicits in
-                                     FStar_Compiler_Util.print1
-                                       "About to check tactic implicits: %s\n"
-                                       uu___11
-                                   else ());
-                                  (let g1 =
-                                     {
-                                       FStar_TypeChecker_Common.guard_f =
-                                         (FStar_TypeChecker_Env.trivial_guard.FStar_TypeChecker_Common.guard_f);
-                                       FStar_TypeChecker_Common.deferred_to_tac
-                                         =
-                                         (FStar_TypeChecker_Env.trivial_guard.FStar_TypeChecker_Common.deferred_to_tac);
-                                       FStar_TypeChecker_Common.deferred =
-                                         (FStar_TypeChecker_Env.trivial_guard.FStar_TypeChecker_Common.deferred);
-                                       FStar_TypeChecker_Common.univ_ineqs =
-                                         (FStar_TypeChecker_Env.trivial_guard.FStar_TypeChecker_Common.univ_ineqs);
-                                       FStar_TypeChecker_Common.implicits =
-                                         (ps3.FStar_Tactics_Types.all_implicits)
-                                     } in
-                                   let g2 =
-                                     FStar_TypeChecker_Rel.solve_deferred_constraints
-                                       env g1 in
-                                   (let uu___11 =
-                                      FStar_Compiler_Effect.op_Bang tacdbg in
-                                    if uu___11
-                                    then
-                                      let uu___12 =
-                                        FStar_Class_Show.show
-                                          (FStar_Class_Show.printableshow
-                                             FStar_Class_Printable.printable_nat)
-                                          (FStar_Compiler_List.length
-                                             ps3.FStar_Tactics_Types.all_implicits) in
-                                      let uu___13 =
-                                        FStar_Class_Show.show
-                                          (FStar_Class_Show.show_list
-                                             FStar_TypeChecker_Common.show_implicit)
-                                          ps3.FStar_Tactics_Types.all_implicits in
-                                      FStar_Compiler_Util.print2
-                                        "Checked %s implicits (1): %s\n"
-                                        uu___12 uu___13
-                                    else ());
-                                   (let tagged_implicits =
-                                      FStar_TypeChecker_Rel.resolve_implicits_tac
-                                        env g2 in
-                                    (let uu___12 =
-                                       FStar_Compiler_Effect.op_Bang tacdbg in
-                                     if uu___12
-                                     then
-                                       let uu___13 =
-                                         FStar_Class_Show.show
-                                           (FStar_Class_Show.printableshow
-                                              FStar_Class_Printable.printable_nat)
-                                           (FStar_Compiler_List.length
-                                              ps3.FStar_Tactics_Types.all_implicits) in
-                                       let uu___14 =
-                                         FStar_Class_Show.show
-                                           (FStar_Class_Show.show_list
-                                              FStar_TypeChecker_Common.show_implicit)
-                                           ps3.FStar_Tactics_Types.all_implicits in
-                                       FStar_Compiler_Util.print2
-                                         "Checked %s implicits (2): %s\n"
-                                         uu___13 uu___14
-                                     else ());
-                                    report_implicits rng_goal
-                                      tagged_implicits)));
-                             (remaining_smt_goals, ret)))
-                       | FStar_Tactics_Result.Failed
-                           (FStar_Errors.Error (code, msg, rng, ctx), ps3) ->
-                           let msg1 =
-                             let uu___5 =
-                               FStar_Pprint.doc_of_string "Tactic failed" in
-                             uu___5 :: msg in
-                           FStar_Compiler_Effect.raise
-                             (FStar_Errors.Error (code, msg1, rng, ctx))
-                       | FStar_Tactics_Result.Failed
-                           (FStar_Errors.Err (code, msg, ctx), ps3) ->
-                           let msg1 =
-                             let uu___5 =
-                               FStar_Pprint.doc_of_string "Tactic failed" in
-                             uu___5 :: msg in
-                           FStar_Compiler_Effect.raise
-                             (FStar_Errors.Err (code, msg1, ctx))
-                       | FStar_Tactics_Result.Failed (e, ps3) ->
-                           (FStar_Tactics_Printing.do_dump_proofstate ps3
-                              "at the time of failure";
-                            (let texn_to_string e1 =
-                               match e1 with
-                               | FStar_Tactics_Common.TacticFailure s ->
-                                   Prims.strcat "\"" (Prims.strcat s "\"")
-                               | FStar_Tactics_Common.EExn t ->
-                                   let uu___6 =
-                                     FStar_Class_Show.show
-                                       FStar_Syntax_Print.showable_term t in
-                                   Prims.strcat "Uncaught exception: " uu___6
-                               | e2 -> FStar_Compiler_Effect.raise e2 in
-                             let rng =
-                               if background
-                               then
-                                 match ps3.FStar_Tactics_Types.goals with
-                                 | g1::uu___6 ->
-                                     (g1.FStar_Tactics_Types.goal_ctx_uvar).FStar_Syntax_Syntax.ctx_uvar_range
-                                 | uu___6 -> rng_call
-                               else ps3.FStar_Tactics_Types.entry_range in
-                             let uu___6 =
-                               let uu___7 =
-                                 let uu___8 =
-                                   FStar_Pprint.doc_of_string "Tactic failed" in
-                                 let uu___9 =
-                                   let uu___10 =
-                                     let uu___11 = texn_to_string e in
-                                     FStar_Pprint.doc_of_string uu___11 in
-                                   [uu___10] in
-                                 uu___8 :: uu___9 in
-                               (FStar_Errors_Codes.Fatal_UserTacticFailure,
-                                 uu___7) in
-                             FStar_Errors.raise_error_doc uu___6 rng)))))
+                      run_unembedded_tactic_on_ps rng_call rng_goal
+                        background arg tau ps))
 let run_tactic_on_ps :
   'a 'b .
     FStar_Compiler_Range_Type.range ->

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Monad.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Monad.ml
@@ -991,3 +991,357 @@ let (compress_implicits : unit tac) =
            FStar_Tactics_Types.urgency = (ps.FStar_Tactics_Types.urgency)
          } in
        set ps')
+let (get_phi :
+  FStar_Tactics_Types.goal ->
+    FStar_Syntax_Syntax.term FStar_Pervasives_Native.option)
+  =
+  fun g ->
+    let uu___ =
+      let uu___1 = FStar_Tactics_Types.goal_env g in
+      let uu___2 = FStar_Tactics_Types.goal_type g in
+      FStar_TypeChecker_Normalize.unfold_whnf uu___1 uu___2 in
+    FStar_Syntax_Util.un_squash uu___
+let (is_irrelevant : FStar_Tactics_Types.goal -> Prims.bool) =
+  fun g -> let uu___ = get_phi g in FStar_Compiler_Option.isSome uu___
+let (goal_typedness_deps :
+  FStar_Tactics_Types.goal -> FStar_Syntax_Syntax.ctx_uvar Prims.list) =
+  fun g ->
+    FStar_Syntax_Util.ctx_uvar_typedness_deps
+      g.FStar_Tactics_Types.goal_ctx_uvar
+let (set_uvar_expected_typ :
+  FStar_Syntax_Syntax.ctx_uvar -> FStar_Syntax_Syntax.typ -> unit) =
+  fun u ->
+    fun t ->
+      let dec =
+        FStar_Syntax_Unionfind.find_decoration
+          u.FStar_Syntax_Syntax.ctx_uvar_head in
+      FStar_Syntax_Unionfind.change_decoration
+        u.FStar_Syntax_Syntax.ctx_uvar_head
+        {
+          FStar_Syntax_Syntax.uvar_decoration_typ = t;
+          FStar_Syntax_Syntax.uvar_decoration_typedness_depends_on =
+            (dec.FStar_Syntax_Syntax.uvar_decoration_typedness_depends_on);
+          FStar_Syntax_Syntax.uvar_decoration_should_check =
+            (dec.FStar_Syntax_Syntax.uvar_decoration_should_check)
+        }
+let (mark_uvar_with_should_check_tag :
+  FStar_Syntax_Syntax.ctx_uvar ->
+    FStar_Syntax_Syntax.should_check_uvar -> unit)
+  =
+  fun u ->
+    fun sc ->
+      let dec =
+        FStar_Syntax_Unionfind.find_decoration
+          u.FStar_Syntax_Syntax.ctx_uvar_head in
+      FStar_Syntax_Unionfind.change_decoration
+        u.FStar_Syntax_Syntax.ctx_uvar_head
+        {
+          FStar_Syntax_Syntax.uvar_decoration_typ =
+            (dec.FStar_Syntax_Syntax.uvar_decoration_typ);
+          FStar_Syntax_Syntax.uvar_decoration_typedness_depends_on =
+            (dec.FStar_Syntax_Syntax.uvar_decoration_typedness_depends_on);
+          FStar_Syntax_Syntax.uvar_decoration_should_check = sc
+        }
+let (mark_uvar_as_already_checked : FStar_Syntax_Syntax.ctx_uvar -> unit) =
+  fun u ->
+    mark_uvar_with_should_check_tag u FStar_Syntax_Syntax.Already_checked
+let (mark_goal_implicit_already_checked : FStar_Tactics_Types.goal -> unit) =
+  fun g -> mark_uvar_as_already_checked g.FStar_Tactics_Types.goal_ctx_uvar
+let (goal_with_type :
+  FStar_Tactics_Types.goal ->
+    FStar_Syntax_Syntax.typ -> FStar_Tactics_Types.goal)
+  =
+  fun g ->
+    fun t ->
+      let u = g.FStar_Tactics_Types.goal_ctx_uvar in
+      set_uvar_expected_typ u t; g
+let divide : 'a 'b . FStar_BigInt.t -> 'a tac -> 'b tac -> ('a * 'b) tac =
+  fun uu___2 ->
+    fun uu___1 ->
+      fun uu___ ->
+        (fun n ->
+           fun l ->
+             fun r ->
+               Obj.magic
+                 (FStar_Class_Monad.op_let_Bang monad_tac () ()
+                    (Obj.magic get)
+                    (fun uu___ ->
+                       (fun p ->
+                          let p = Obj.magic p in
+                          let uu___ =
+                            try
+                              (fun uu___1 ->
+                                 (fun uu___1 ->
+                                    match () with
+                                    | () ->
+                                        let uu___2 =
+                                          let uu___3 =
+                                            FStar_BigInt.to_int_fs n in
+                                          FStar_Compiler_List.splitAt uu___3
+                                            p.FStar_Tactics_Types.goals in
+                                        Obj.magic
+                                          (FStar_Class_Monad.return monad_tac
+                                             () (Obj.magic uu___2))) uu___1)
+                                ()
+                            with | uu___1 -> fail "divide: not enough goals" in
+                          Obj.magic
+                            (FStar_Class_Monad.op_let_Bang monad_tac () ()
+                               (Obj.magic uu___)
+                               (fun uu___1 ->
+                                  (fun uu___1 ->
+                                     let uu___1 = Obj.magic uu___1 in
+                                     match uu___1 with
+                                     | (lgs, rgs) ->
+                                         let lp =
+                                           {
+                                             FStar_Tactics_Types.main_context
+                                               =
+                                               (p.FStar_Tactics_Types.main_context);
+                                             FStar_Tactics_Types.all_implicits
+                                               =
+                                               (p.FStar_Tactics_Types.all_implicits);
+                                             FStar_Tactics_Types.goals = lgs;
+                                             FStar_Tactics_Types.smt_goals =
+                                               [];
+                                             FStar_Tactics_Types.depth =
+                                               (p.FStar_Tactics_Types.depth);
+                                             FStar_Tactics_Types.__dump =
+                                               (p.FStar_Tactics_Types.__dump);
+                                             FStar_Tactics_Types.psc =
+                                               (p.FStar_Tactics_Types.psc);
+                                             FStar_Tactics_Types.entry_range
+                                               =
+                                               (p.FStar_Tactics_Types.entry_range);
+                                             FStar_Tactics_Types.guard_policy
+                                               =
+                                               (p.FStar_Tactics_Types.guard_policy);
+                                             FStar_Tactics_Types.freshness =
+                                               (p.FStar_Tactics_Types.freshness);
+                                             FStar_Tactics_Types.tac_verb_dbg
+                                               =
+                                               (p.FStar_Tactics_Types.tac_verb_dbg);
+                                             FStar_Tactics_Types.local_state
+                                               =
+                                               (p.FStar_Tactics_Types.local_state);
+                                             FStar_Tactics_Types.urgency =
+                                               (p.FStar_Tactics_Types.urgency)
+                                           } in
+                                         let uu___2 = set lp in
+                                         Obj.magic
+                                           (FStar_Class_Monad.op_let_Bang
+                                              monad_tac () () uu___2
+                                              (fun uu___3 ->
+                                                 (fun uu___3 ->
+                                                    let uu___3 =
+                                                      Obj.magic uu___3 in
+                                                    Obj.magic
+                                                      (FStar_Class_Monad.op_let_Bang
+                                                         monad_tac () ()
+                                                         (Obj.magic l)
+                                                         (fun uu___4 ->
+                                                            (fun a1 ->
+                                                               let a1 =
+                                                                 Obj.magic a1 in
+                                                               Obj.magic
+                                                                 (FStar_Class_Monad.op_let_Bang
+                                                                    monad_tac
+                                                                    () ()
+                                                                    (
+                                                                    Obj.magic
+                                                                    get)
+                                                                    (
+                                                                    fun
+                                                                    uu___4 ->
+                                                                    (fun lp'
+                                                                    ->
+                                                                    let lp' =
+                                                                    Obj.magic
+                                                                    lp' in
+                                                                    let rp =
+                                                                    {
+                                                                    FStar_Tactics_Types.main_context
+                                                                    =
+                                                                    (lp'.FStar_Tactics_Types.main_context);
+                                                                    FStar_Tactics_Types.all_implicits
+                                                                    =
+                                                                    (lp'.FStar_Tactics_Types.all_implicits);
+                                                                    FStar_Tactics_Types.goals
+                                                                    = rgs;
+                                                                    FStar_Tactics_Types.smt_goals
+                                                                    = [];
+                                                                    FStar_Tactics_Types.depth
+                                                                    =
+                                                                    (lp'.FStar_Tactics_Types.depth);
+                                                                    FStar_Tactics_Types.__dump
+                                                                    =
+                                                                    (lp'.FStar_Tactics_Types.__dump);
+                                                                    FStar_Tactics_Types.psc
+                                                                    =
+                                                                    (lp'.FStar_Tactics_Types.psc);
+                                                                    FStar_Tactics_Types.entry_range
+                                                                    =
+                                                                    (lp'.FStar_Tactics_Types.entry_range);
+                                                                    FStar_Tactics_Types.guard_policy
+                                                                    =
+                                                                    (lp'.FStar_Tactics_Types.guard_policy);
+                                                                    FStar_Tactics_Types.freshness
+                                                                    =
+                                                                    (lp'.FStar_Tactics_Types.freshness);
+                                                                    FStar_Tactics_Types.tac_verb_dbg
+                                                                    =
+                                                                    (lp'.FStar_Tactics_Types.tac_verb_dbg);
+                                                                    FStar_Tactics_Types.local_state
+                                                                    =
+                                                                    (lp'.FStar_Tactics_Types.local_state);
+                                                                    FStar_Tactics_Types.urgency
+                                                                    =
+                                                                    (lp'.FStar_Tactics_Types.urgency)
+                                                                    } in
+                                                                    let uu___4
+                                                                    = set rp in
+                                                                    Obj.magic
+                                                                    (FStar_Class_Monad.op_let_Bang
+                                                                    monad_tac
+                                                                    () ()
+                                                                    uu___4
+                                                                    (fun
+                                                                    uu___5 ->
+                                                                    (fun
+                                                                    uu___5 ->
+                                                                    let uu___5
+                                                                    =
+                                                                    Obj.magic
+                                                                    uu___5 in
+                                                                    Obj.magic
+                                                                    (FStar_Class_Monad.op_let_Bang
+                                                                    monad_tac
+                                                                    () ()
+                                                                    (Obj.magic
+                                                                    r)
+                                                                    (fun
+                                                                    uu___6 ->
+                                                                    (fun b1
+                                                                    ->
+                                                                    let b1 =
+                                                                    Obj.magic
+                                                                    b1 in
+                                                                    Obj.magic
+                                                                    (FStar_Class_Monad.op_let_Bang
+                                                                    monad_tac
+                                                                    () ()
+                                                                    (Obj.magic
+                                                                    get)
+                                                                    (fun
+                                                                    uu___6 ->
+                                                                    (fun rp'
+                                                                    ->
+                                                                    let rp' =
+                                                                    Obj.magic
+                                                                    rp' in
+                                                                    let p' =
+                                                                    {
+                                                                    FStar_Tactics_Types.main_context
+                                                                    =
+                                                                    (rp'.FStar_Tactics_Types.main_context);
+                                                                    FStar_Tactics_Types.all_implicits
+                                                                    =
+                                                                    (rp'.FStar_Tactics_Types.all_implicits);
+                                                                    FStar_Tactics_Types.goals
+                                                                    =
+                                                                    (FStar_Compiler_List.op_At
+                                                                    lp'.FStar_Tactics_Types.goals
+                                                                    rp'.FStar_Tactics_Types.goals);
+                                                                    FStar_Tactics_Types.smt_goals
+                                                                    =
+                                                                    (FStar_Compiler_List.op_At
+                                                                    lp'.FStar_Tactics_Types.smt_goals
+                                                                    (FStar_Compiler_List.op_At
+                                                                    rp'.FStar_Tactics_Types.smt_goals
+                                                                    p.FStar_Tactics_Types.smt_goals));
+                                                                    FStar_Tactics_Types.depth
+                                                                    =
+                                                                    (rp'.FStar_Tactics_Types.depth);
+                                                                    FStar_Tactics_Types.__dump
+                                                                    =
+                                                                    (rp'.FStar_Tactics_Types.__dump);
+                                                                    FStar_Tactics_Types.psc
+                                                                    =
+                                                                    (rp'.FStar_Tactics_Types.psc);
+                                                                    FStar_Tactics_Types.entry_range
+                                                                    =
+                                                                    (rp'.FStar_Tactics_Types.entry_range);
+                                                                    FStar_Tactics_Types.guard_policy
+                                                                    =
+                                                                    (rp'.FStar_Tactics_Types.guard_policy);
+                                                                    FStar_Tactics_Types.freshness
+                                                                    =
+                                                                    (rp'.FStar_Tactics_Types.freshness);
+                                                                    FStar_Tactics_Types.tac_verb_dbg
+                                                                    =
+                                                                    (rp'.FStar_Tactics_Types.tac_verb_dbg);
+                                                                    FStar_Tactics_Types.local_state
+                                                                    =
+                                                                    (rp'.FStar_Tactics_Types.local_state);
+                                                                    FStar_Tactics_Types.urgency
+                                                                    =
+                                                                    (rp'.FStar_Tactics_Types.urgency)
+                                                                    } in
+                                                                    let uu___6
+                                                                    = set p' in
+                                                                    Obj.magic
+                                                                    (FStar_Class_Monad.op_let_Bang
+                                                                    monad_tac
+                                                                    () ()
+                                                                    uu___6
+                                                                    (fun
+                                                                    uu___7 ->
+                                                                    (fun
+                                                                    uu___7 ->
+                                                                    let uu___7
+                                                                    =
+                                                                    Obj.magic
+                                                                    uu___7 in
+                                                                    Obj.magic
+                                                                    (FStar_Class_Monad.op_let_Bang
+                                                                    monad_tac
+                                                                    () ()
+                                                                    remove_solved_goals
+                                                                    (fun
+                                                                    uu___8 ->
+                                                                    (fun
+                                                                    uu___8 ->
+                                                                    let uu___8
+                                                                    =
+                                                                    Obj.magic
+                                                                    uu___8 in
+                                                                    Obj.magic
+                                                                    (FStar_Class_Monad.return
+                                                                    monad_tac
+                                                                    ()
+                                                                    (Obj.magic
+                                                                    (a1, b1))))
+                                                                    uu___8)))
+                                                                    uu___7)))
+                                                                    uu___6)))
+                                                                    uu___6)))
+                                                                    uu___5)))
+                                                                    uu___4)))
+                                                              uu___4)))
+                                                   uu___3))) uu___1))) uu___)))
+          uu___2 uu___1 uu___
+let focus : 'a . 'a tac -> 'a tac =
+  fun uu___ ->
+    (fun f ->
+       let uu___ =
+         let uu___1 = FStar_Class_Monad.return monad_tac () (Obj.repr ()) in
+         divide FStar_BigInt.one f uu___1 in
+       Obj.magic
+         (FStar_Class_Monad.op_let_Bang monad_tac () () (Obj.magic uu___)
+            (fun uu___1 ->
+               (fun uu___1 ->
+                  let uu___1 = Obj.magic uu___1 in
+                  match uu___1 with
+                  | (a1, uu___2) ->
+                      Obj.magic
+                        (FStar_Class_Monad.return monad_tac () (Obj.magic a1)))
+                 uu___1))) uu___

--- a/ocaml/fstar-lib/generated/FStar_Tactics_V2_Primops.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_V2_Primops.ml
@@ -1805,7 +1805,45 @@ let (ops : FStar_TypeChecker_Primops_Base.primitive_step Prims.list) =
                                                                     FStar_TypeChecker_NBETerm.e_unit
                                                                     FStar_Tactics_V2_Basic.log_issues
                                                                     FStar_Tactics_V2_Basic.log_issues in
-                                                                    [uu___212] in
+                                                                    let uu___213
+                                                                    =
+                                                                    let uu___214
+                                                                    =
+                                                                    let uu___215
+                                                                    =
+                                                                    FStar_Tactics_Interpreter.e_tactic_thunk
+                                                                    FStar_Syntax_Embeddings.e_unit in
+                                                                    let uu___216
+                                                                    =
+                                                                    FStar_Tactics_Interpreter.e_tactic_nbe_thunk
+                                                                    FStar_TypeChecker_NBETerm.e_unit in
+                                                                    FStar_Tactics_InterpFuns.mk_tac_step_4
+                                                                    Prims.int_zero
+                                                                    "call_subtac"
+                                                                    FStar_Reflection_V2_Embeddings.e_env
+                                                                    uu___215
+                                                                    FStar_Reflection_V2_Embeddings.e_universe
+                                                                    uu___2
+                                                                    (FStar_Syntax_Embeddings.e_tuple2
+                                                                    (FStar_Syntax_Embeddings.e_option
+                                                                    uu___2)
+                                                                    (FStar_Syntax_Embeddings.e_list
+                                                                    FStar_Syntax_Embeddings.e_issue))
+                                                                    FStar_Reflection_V2_NBEEmbeddings.e_env
+                                                                    uu___216
+                                                                    FStar_Reflection_V2_NBEEmbeddings.e_universe
+                                                                    FStar_Reflection_V2_NBEEmbeddings.e_attribute
+                                                                    (FStar_TypeChecker_NBETerm.e_tuple2
+                                                                    (FStar_TypeChecker_NBETerm.e_option
+                                                                    FStar_Reflection_V2_NBEEmbeddings.e_attribute)
+                                                                    (FStar_TypeChecker_NBETerm.e_list
+                                                                    FStar_TypeChecker_NBETerm.e_issue))
+                                                                    FStar_Tactics_V2_Basic.call_subtac
+                                                                    FStar_Tactics_V2_Basic.call_subtac in
+                                                                    [uu___214] in
+                                                                    uu___212
+                                                                    ::
+                                                                    uu___213 in
                                                                     uu___210
                                                                     ::
                                                                     uu___211 in

--- a/src/tactics/FStar.Tactics.CtrlRewrite.fst
+++ b/src/tactics/FStar.Tactics.CtrlRewrite.fst
@@ -114,7 +114,7 @@ let __do_rewrite
     let! ut, uvar_t =
       new_uvar "do_rewrite.rhs" env typ 
                should_check
-               (FStar.Tactics.V2.Basic.goal_typedness_deps g0)
+               (goal_typedness_deps g0)
                (rangeof g0)
     in
     if_verbose (fun () ->
@@ -127,7 +127,7 @@ let __do_rewrite
                       (U.mk_eq2 (env.universe_of env typ) typ tm ut)
                       None ;!
     (* v1 and v2 match *)
-    FStar.Tactics.V2.Basic.focus rewriter ;!
+    focus rewriter ;!
     // Try to get rid of all the unification lambdas
     let ut = N.reduce_uvar_solutions env ut in
     if_verbose (fun () ->
@@ -437,6 +437,6 @@ let ctrl_rewrite
         BU.print1 "ctrl_rewrite seems to have succeded with %s\n" (show gt')) ;!
 
     push_goals gs ;!
-    let g = V2.Basic.goal_with_type g gt' in
+    let g = goal_with_type g gt' in
     add_goals [g]
     )

--- a/src/tactics/FStar.Tactics.Interpreter.fst
+++ b/src/tactics/FStar.Tactics.Interpreter.fst
@@ -283,15 +283,12 @@ let report_implicits rng (is : TcRel.tagged_implicits) : unit =
                              (show ty)));
   Err.stop_if_err ()
 
-let run_tactic_on_ps'
+let run_unembedded_tactic_on_ps
   (rng_call : Range.range)
   (rng_goal : Range.range)
   (background : bool)
-  (e_arg : embedding 'a)
   (arg : 'a)
-  (e_res : embedding 'b)
-  (tactic:term)
-  (tactic_already_typed:bool)
+  (tau: 'a -> tac 'b)
   (ps:proofstate)
   : list goal // remaining goals
   * 'b // return value
@@ -299,27 +296,6 @@ let run_tactic_on_ps'
     let ps = { ps with main_context = { ps.main_context with intactics = true } } in
     let ps = { ps with main_context = { ps.main_context with range = rng_goal } } in
     let env = ps.main_context in
-    if !tacdbg then
-        BU.print2 "Typechecking tactic: (%s) (already_typed: %s) {\n"
-          (show tactic)
-          (show tactic_already_typed);
-
-    (* Do NOT use the returned tactic, the typechecker is not idempotent and
-     * will mess up the monadic lifts. We're just making sure it's well-typed
-     * so it won't get stuck. c.f #1307 *)
-    let g =
-      if tactic_already_typed
-      then Env.trivial_guard
-      else let _, _, g = TcTerm.tc_tactic (type_of e_arg) (type_of e_res) env tactic in
-           g in
-
-    if !tacdbg then
-        BU.print_string "}\n";
-
-    TcRel.force_trivial_guard env g;
-    Err.stop_if_err ();
-    let tau = unembed_tactic_1 e_arg e_res tactic FStar.Syntax.Embeddings.id_norm_cb in
-
     (* if !tacdbg then *)
     (*     BU.print1 "Running tactic with goal = (%s) {\n" (show typ); *)
     let res =
@@ -409,6 +385,46 @@ let run_tactic_on_ps'
                              doc_of_string (texn_to_string e);
                             ])
                           rng
+
+let run_tactic_on_ps'
+  (rng_call : Range.range)
+  (rng_goal : Range.range)
+  (background : bool)
+  (e_arg : embedding 'a)
+  (arg : 'a)
+  (e_res : embedding 'b)
+  (tactic:term)
+  (tactic_already_typed:bool)
+  (ps:proofstate)
+  : list goal // remaining goals
+  * 'b // return value
+  =
+    let env = ps.main_context in
+    if !tacdbg then
+        BU.print2 "Typechecking tactic: (%s) (already_typed: %s) {\n"
+          (show tactic)
+          (show tactic_already_typed);
+
+    (* Do NOT use the returned tactic, the typechecker is not idempotent and
+     * will mess up the monadic lifts. We're just making sure it's well-typed
+     * so it won't get stuck. c.f #1307 *)
+    let g =
+      if tactic_already_typed
+      then Env.trivial_guard
+      else let _, _, g = TcTerm.tc_tactic (type_of e_arg) (type_of e_res) env tactic in
+           g
+    in
+
+    if !tacdbg then
+        BU.print_string "}\n";
+
+    TcRel.force_trivial_guard env g;
+    Err.stop_if_err ();
+    let tau = unembed_tactic_1 e_arg e_res tactic FStar.Syntax.Embeddings.id_norm_cb in
+
+    run_unembedded_tactic_on_ps
+        rng_call rng_goal background
+        arg tau ps
 
 let run_tactic_on_ps
           (rng_call : Range.range)

--- a/src/tactics/FStar.Tactics.Interpreter.fst
+++ b/src/tactics/FStar.Tactics.Interpreter.fst
@@ -33,7 +33,6 @@ open FStar.Tactics.Result
 open FStar.Tactics.Types
 open FStar.Tactics.Printing
 open FStar.Tactics.Monad
-open FStar.Tactics.V2.Basic
 open FStar.Tactics.CtrlRewrite
 open FStar.Tactics.Native
 open FStar.Tactics.Common
@@ -342,7 +341,7 @@ let run_tactic_on_ps'
         let remaining_smt_goals = ps.goals@ps.smt_goals in
         List.iter
           (fun g ->
-            FStar.Tactics.V2.Basic.mark_goal_implicit_already_checked g;//all of these will be fed to SMT anyway
+            mark_goal_implicit_already_checked g;//all of these will be fed to SMT anyway
             if is_irrelevant g
             then (
               if !tacdbg then BU.print1 "Assigning irrelevant goal %s\n" (show (goal_witness g));

--- a/src/tactics/FStar.Tactics.Interpreter.fsti
+++ b/src/tactics/FStar.Tactics.Interpreter.fsti
@@ -22,6 +22,17 @@ open FStar.Syntax.Embeddings
 open FStar.Tactics.Types
 module Env = FStar.TypeChecker.Env
 
+(* Run a `tac` *)
+val run_unembedded_tactic_on_ps :
+    range -> (* position on the tactic call *)
+    range -> (* position for the goal *)
+    bool ->  (* whether this call is in the "background", like resolve_implicits *)
+    'a ->
+    ('a -> Monad.tac 'b) -> (* a term representing an `'a -> tac 'b` *)
+    proofstate ->  (* proofstate *)
+    list goal * 'b (* goals and return value *)
+
+(* Run a term of type `a -> Tac b` *)
 val run_tactic_on_ps :
     range -> (* position on the tactic call *)
     range -> (* position for the goal *)

--- a/src/tactics/FStar.Tactics.Monad.fsti
+++ b/src/tactics/FStar.Tactics.Monad.fsti
@@ -149,3 +149,16 @@ val mk_tac : (proofstate -> __result 'a) -> tac 'a
 
 (* inform the core of a well-typed goal *)
 val register_goal (g:goal) : unit
+
+val divide (n:BigInt.t) (l : tac 'a) (r : tac 'b) : tac ('a * 'b)
+val focus (f:tac 'a) : tac 'a
+
+(* Internal utilities *)
+val get_phi : goal -> option term
+val is_irrelevant : goal -> bool
+val goal_typedness_deps : goal -> list ctx_uvar
+val set_uvar_expected_typ (u:ctx_uvar) (t:typ) : unit
+val mark_uvar_with_should_check_tag (u:ctx_uvar) (sc:should_check_uvar) : unit
+val mark_uvar_as_already_checked (u:ctx_uvar) : unit
+val mark_goal_implicit_already_checked (g:goal) : unit
+val goal_with_type : goal -> typ -> goal

--- a/src/tactics/FStar.Tactics.V2.Basic.fst
+++ b/src/tactics/FStar.Tactics.V2.Basic.fst
@@ -61,11 +61,6 @@ module PO     = FStar.TypeChecker.Primops
 open FStar.Class.Show
 open FStar.Class.Monad
 
-(* Internal, repeated from V2 too. Could be in Types, but that
-constrains dependencies and F* claims a cycle. *)
-let get_phi (g:goal) : option term = U.un_squash (N.unfold_whnf (goal_env g) (goal_type g))
-let is_irrelevant (g:goal) : bool = Option.isSome (get_phi g)
-
 let compress (t:term) : tac term =
   return ();!
   return (SS.compress t)
@@ -114,30 +109,6 @@ let whnf e t = N.unfold_whnf e t
  * term_to_string, we don't want to cause normalization with debug
  * flags. *)
 let tts = N.term_to_string
-
-let set_uvar_expected_typ (u:ctx_uvar) (t:typ)
-  : unit
-  = let dec = UF.find_decoration u.ctx_uvar_head in
-    UF.change_decoration u.ctx_uvar_head ({dec with uvar_decoration_typ = t })
-
-let mark_uvar_with_should_check_tag (u:ctx_uvar) (sc:should_check_uvar)
-  : unit
-  = let dec = UF.find_decoration u.ctx_uvar_head in
-    UF.change_decoration u.ctx_uvar_head ({dec with uvar_decoration_should_check = sc })
-
-let mark_uvar_as_already_checked (u:ctx_uvar)
-  : unit
-  = mark_uvar_with_should_check_tag u Already_checked
-
-let mark_goal_implicit_already_checked (g:goal)
-  : unit
-  = mark_uvar_as_already_checked g.goal_ctx_uvar
-
-let goal_with_type g t
-  : goal
-  = let u = g.goal_ctx_uvar in
-    set_uvar_expected_typ u t;
-    g
 
 let bnorm_goal g = goal_with_type g (bnorm (goal_env g) (goal_type g))
 
@@ -666,33 +637,6 @@ let tc (e : env) (t : term) : tac typ = wrap_err "tc" <| (
   return (U.comp_result c)
 )
 
-let divide (n:Z.t) (l : tac 'a) (r : tac 'b) : tac ('a * 'b) =
-  let! p = get in
-  let! lgs, rgs =
-    try return (List.splitAt (Z.to_int_fs n) p.goals) with
-    | _ -> fail "divide: not enough goals"
-  in
-  let lp = { p with goals = lgs; smt_goals = [] } in
-  set lp;!
-  let! a = l in
-  let! lp' = get in
-  let rp = { lp' with goals = rgs; smt_goals = [] } in
-  set rp;!
-  let! b = r in
-  let! rp' = get in
-  let p' = { rp' with goals = lp'.goals @ rp'.goals;
-                      smt_goals = lp'.smt_goals @ rp'.smt_goals @ p.smt_goals }
-  in
-  set p';!
-  remove_solved_goals;!
-  return (a, b)
-
-(* focus: runs f on the current goal only, and then restores all the goals *)
-(* There is a user defined version as well, we just use this one internally, but can't mark it as private *)
-let focus (f:tac 'a) : tac 'a =
-    let! (a, _) = divide Z.one f (return ()) in
-    return a
-
 (* Applies t to each of the current goals
       fails if t fails on any of the goals
       collects each result in the output list *)
@@ -713,7 +657,6 @@ let seq (t1:tac unit) (t2:tac unit) : tac unit =
   focus (t1 ;! map t2 ;! return ())
 
 let should_check_goal_uvar (g:goal) = U.ctx_uvar_should_check g.goal_ctx_uvar
-let goal_typedness_deps (g:goal) = U.ctx_uvar_typedness_deps g.goal_ctx_uvar
 
 let bnorm_and_replace g = replace_cur (bnorm_goal g)
 

--- a/src/tactics/FStar.Tactics.V2.Basic.fsti
+++ b/src/tactics/FStar.Tactics.V2.Basic.fsti
@@ -144,3 +144,5 @@ val push_open_namespace               : env -> list string -> tac env
 val push_module_abbrev                : env -> string -> list string -> tac env
 val resolve_name                      : env -> list string -> tac (option (either bv fv))
 val log_issues                        : list Errors.issue -> tac unit
+
+val call_subtac                       : env -> tac unit -> universe -> typ -> tac (option term & issues)

--- a/src/tactics/FStar.Tactics.V2.Basic.fsti
+++ b/src/tactics/FStar.Tactics.V2.Basic.fsti
@@ -37,18 +37,11 @@ module TcComm = FStar.TypeChecker.Common
 module Core   = FStar.TypeChecker.Core
 module RD     = FStar.Reflection.V2.Data
 
-(* Internal utilities *)
-val is_irrelevant : goal -> bool
-val goal_typedness_deps : goal -> list ctx_uvar
-
 val proofstate_of_goals : Range.range -> env -> list goal -> list implicit -> proofstate
 (* Returns proofstate and uvar for main witness *)
 val proofstate_of_goal_ty : Range.range -> env -> typ -> proofstate * term
 
 val proofstate_of_all_implicits: Range.range -> env -> implicits -> proofstate * term
-
-(* Helper *)
-val focus                  : tac 'a -> tac 'a
 
 (* Metaprogramming primitives (not all of them).
  * Documented in `ulib/FStar.Tactics.Builtins.fst` *)
@@ -106,8 +99,6 @@ val lset                   : typ -> string -> term -> tac unit
 val curms                  : unit -> tac Z.t
 val set_urgency            : Z.t -> tac unit
 val t_commute_applied_match : unit -> tac unit
-val goal_with_type : goal -> typ -> goal
-val mark_goal_implicit_already_checked : goal -> unit
 val string_to_term         : env -> string -> tac term
 val push_bv_dsenv          : env -> string -> tac (env * RD.binding)
 val term_to_string         : term -> tac string

--- a/src/tactics/FStar.Tactics.V2.Primops.fst
+++ b/src/tactics/FStar.Tactics.V2.Primops.fst
@@ -267,4 +267,8 @@ let ops = [
     #_ #_ #(NBET.e_option (NBET.e_either NRE.e_bv solve))
     resolve_name resolve_name;
   mk_tac_step_1 0 "log_issues" log_issues log_issues;
+  mk_tac_step_4 0 "call_subtac"
+    #_ #(TI.e_tactic_thunk e_unit) #_ #_ #_
+    #_ #(TI.e_tactic_nbe_thunk NBET.e_unit) #_ #_ #_
+    call_subtac call_subtac;
 ]

--- a/tests/tactics/CallSubtac.fst
+++ b/tests/tactics/CallSubtac.fst
@@ -1,0 +1,33 @@
+module CallSubtac
+
+open FStar.Tactics.V2
+
+class cc (a:Type) = {
+  dummy : a -> a;
+}
+
+instance cc_int : cc int = {
+  dummy = (fun x -> x);
+}
+
+instance cc_bool : cc bool = {
+  dummy = (fun x -> x);
+}
+
+instance cc_list (a:Type) (_ : cc a) : cc (list a) = {
+  dummy = (fun x -> x);
+}
+
+let must #a (r : ret_t a) : Tac a =
+  match r with
+  | Some x, _ -> x
+  | _ -> fail "must failed"
+
+let test1 () = assert True by (
+  let g = cur_env () in
+  let goal = `(cc (list (list int))) in
+  let goal, _ = must <| tc_term g goal in
+  let u = must <| universe_of g goal in
+  let w = must <| call_subtac g FStar.Tactics.Typeclasses.tcresolve u goal in
+  dump ("witness = " ^ term_to_string w)
+)

--- a/ulib/FStar.Stubs.Tactics.V2.Builtins.fsti
+++ b/ulib/FStar.Stubs.Tactics.V2.Builtins.fsti
@@ -583,3 +583,10 @@ val resolve_name (g:env) (n:name)
 
 val log_issues (issues:list FStar.Issue.issue)
   : Tac unit
+
+(* Reentrancy: a metaprogram can spawn a sub-metaprogram to
+solve a goal, starting from a clean state, and obtain the witness
+that solves it. *)
+val call_subtac (g:env) (t : unit -> Tac unit) (u:universe)
+                (goal_ty : term{typing_token g goal_ty (E_Total, pack_ln (Tv_Type u))})
+  : Tac (ret_t (w:term{typing_token g w (E_Total, goal_ty)}))

--- a/ulib/experimental/FStar.Reflection.Typing.fst
+++ b/ulib/experimental/FStar.Reflection.Typing.fst
@@ -969,3 +969,5 @@ let mkif
     [[]; []]
     (MC_Tok g scrutinee bool_ty _ _ (Squash.return_squash (if_complete_match g scrutinee)))
     (brty ())
+
+let typing_to_token (#g:env) (#e:term) (#c:comp_typ) (_ : typing g e c) = magic()

--- a/ulib/experimental/FStar.Reflection.Typing.fsti
+++ b/ulib/experimental/FStar.Reflection.Typing.fsti
@@ -1843,3 +1843,11 @@ let mk_unchecked_let (g:R.env) (nm:string) (tm:R.term) (ty:R.typ) : T.Tac (sigel
   let lb = R.pack_lb ({ lb_fv = fv; lb_us = []; lb_typ = ty; lb_def = tm }) in
   let se = R.pack_sigelt (R.Sg_Let false [lb]) in
   ( false, se, None )
+
+(* Turn a typing derivation into a token. This is useful
+to call primitives that require a proof of typing, like
+`call_subtac`, since they do not take derivations nor can
+they even be mentioned in that module due to dependencies.
+Probably the right thing to do is refactor and avoid this, though. *)
+val typing_to_token (#g:env) (#e:term) (#c:comp_typ)
+  : typing g e c -> T.typing_token g e c


### PR DESCRIPTION
... and obtain a proof of typing for the generated witness.

This allows to easily reuse metaprograms that work to solve a goal as metaprograms that create proofs of typing. In particular, we can use this is Pulse to call the typeclass resolution tactic and create well-typed dictionaries for constraints, that do not have to be rechecked by Pulse or F*.

Reusing `tcresolve` is othewise not straightforward, as it is very much oriented to working in the proofstate and has no knowledge of typing reflection.