### PR TITLE
Making Reals erasable, and providing a reflection API for real literals

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_Extraction_ML_Term.ml
+++ b/ocaml/fstar-lib/generated/FStar_Extraction_ML_Term.ml
@@ -2931,18 +2931,26 @@ and (term_as_mlexpr' :
            -> term_as_mlexpr g t1
        | FStar_Syntax_Syntax.Tm_uinst (t1, uu___1) -> term_as_mlexpr g t1
        | FStar_Syntax_Syntax.Tm_constant c ->
+           let tcenv = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
            let uu___1 =
-             let uu___2 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
-             FStar_TypeChecker_TcTerm.typeof_tot_or_gtot_term uu___2 t true in
+             FStar_TypeChecker_TcTerm.typeof_tot_or_gtot_term tcenv t true in
            (match uu___1 with
             | (uu___2, ty, uu___3) ->
-                let ml_ty = term_as_mlty g ty in
                 let uu___4 =
-                  let uu___5 =
-                    FStar_Extraction_ML_Util.mlexpr_of_const
-                      t.FStar_Syntax_Syntax.pos c in
-                  FStar_Extraction_ML_Syntax.with_ty ml_ty uu___5 in
-                (uu___4, FStar_Extraction_ML_Syntax.E_PURE, ml_ty))
+                  FStar_TypeChecker_Util.must_erase_for_extraction tcenv ty in
+                if uu___4
+                then
+                  (FStar_Extraction_ML_Syntax.ml_unit,
+                    FStar_Extraction_ML_Syntax.E_PURE,
+                    FStar_Extraction_ML_Syntax.MLTY_Erased)
+                else
+                  (let ml_ty = term_as_mlty g ty in
+                   let uu___6 =
+                     let uu___7 =
+                       FStar_Extraction_ML_Util.mlexpr_of_const
+                         t.FStar_Syntax_Syntax.pos c in
+                     FStar_Extraction_ML_Syntax.with_ty ml_ty uu___7 in
+                   (uu___6, FStar_Extraction_ML_Syntax.E_PURE, ml_ty)))
        | FStar_Syntax_Syntax.Tm_name uu___1 ->
            let uu___2 = is_type g t in
            if uu___2

--- a/ocaml/fstar-lib/generated/FStar_Extraction_ML_Util.ml
+++ b/ocaml/fstar-lib/generated/FStar_Extraction_ML_Util.ml
@@ -18,9 +18,6 @@ let (mk_range_mle : FStar_Extraction_ML_Syntax.mlexpr) =
 let (dummy_range_mle : FStar_Extraction_ML_Syntax.mlexpr) =
   FStar_Extraction_ML_Syntax.with_ty FStar_Extraction_ML_Syntax.MLTY_Top
     (FStar_Extraction_ML_Syntax.MLE_Name (["FStar"; "Range"], "dummyRange"))
-let (fstar_real_of_string : FStar_Extraction_ML_Syntax.mlexpr) =
-  FStar_Extraction_ML_Syntax.with_ty FStar_Extraction_ML_Syntax.MLTY_Top
-    (FStar_Extraction_ML_Syntax.MLE_Name (["FStar"; "Real"], "of_string"))
 let (mlconst_of_const' :
   FStar_Const.sconst -> FStar_Extraction_ML_Syntax.mlconstant) =
   fun sctt ->
@@ -130,13 +127,6 @@ let (mlexpr_of_const :
     fun c ->
       match c with
       | FStar_Const.Const_range r -> mlexpr_of_range r
-      | FStar_Const.Const_real s ->
-          let str = mlconst_of_const p (FStar_Const.Const_string (s, p)) in
-          FStar_Extraction_ML_Syntax.MLE_App
-            (fstar_real_of_string,
-              [FStar_Extraction_ML_Syntax.with_ty
-                 FStar_Extraction_ML_Syntax.ml_string_ty
-                 (FStar_Extraction_ML_Syntax.MLE_Const str)])
       | uu___ ->
           let uu___1 = mlconst_of_const p c in
           FStar_Extraction_ML_Syntax.MLE_Const uu___1

--- a/ocaml/fstar-lib/generated/FStar_Parser_Const.ml
+++ b/ocaml/fstar-lib/generated/FStar_Parser_Const.ml
@@ -155,6 +155,7 @@ let (op_Negation : FStar_Ident.lident) = pconst "op_Negation"
 let (subtype_of_lid : FStar_Ident.lident) = pconst "subtype_of"
 let (real_const : Prims.string -> FStar_Ident.lident) =
   fun s -> p2l ["FStar"; "Real"; s]
+let (real_op_EQ : FStar_Ident.lident) = real_const "op_Equals_Dot"
 let (real_op_LT : FStar_Ident.lident) = real_const "op_Less_Dot"
 let (real_op_LTE : FStar_Ident.lident) = real_const "op_Less_Equals_Dot"
 let (real_op_GT : FStar_Ident.lident) = real_const "op_Greater_Dot"

--- a/ocaml/fstar-lib/generated/FStar_Parser_Dep.ml
+++ b/ocaml/fstar-lib/generated/FStar_Parser_Dep.ml
@@ -1459,6 +1459,13 @@ let (collect_one :
                      (false, uu___4) in
                    P_dep uu___3 in
                  add_to_parsing_data uu___2
+             | FStar_Const.Const_real uu___2 ->
+                 let uu___3 =
+                   let uu___4 =
+                     let uu___5 = FStar_Ident.lid_of_str "fstar.real" in
+                     (false, uu___5) in
+                   P_dep uu___4 in
+                 add_to_parsing_data uu___3
              | uu___2 -> ()
            and collect_term' uu___1 =
              match uu___1 with

--- a/ocaml/fstar-lib/generated/FStar_Real_Old.ml
+++ b/ocaml/fstar-lib/generated/FStar_Real_Old.ml
@@ -1,0 +1,6 @@
+open Prims
+type real = unit
+
+
+
+

--- a/ocaml/fstar-lib/generated/FStar_Reflection_V2_Builtins.ml
+++ b/ocaml/fstar-lib/generated/FStar_Reflection_V2_Builtins.ml
@@ -118,6 +118,7 @@ let (inspect_const :
     | FStar_Const.Const_reflect l ->
         let uu___ = FStar_Ident.path_of_lid l in
         FStar_Reflection_V2_Data.C_Reflect uu___
+    | FStar_Const.Const_real s -> FStar_Reflection_V2_Data.C_Real s
     | uu___ ->
         let uu___1 =
           let uu___2 = FStar_Syntax_Print.const_to_string c in
@@ -443,6 +444,7 @@ let (pack_const :
         let uu___ =
           FStar_Ident.lid_of_path ns FStar_Compiler_Range_Type.dummyRange in
         FStar_Const.Const_reflect uu___
+    | FStar_Reflection_V2_Data.C_Real r -> FStar_Const.Const_real r
 let rec (pack_pat :
   FStar_Reflection_V2_Data.pattern -> FStar_Syntax_Syntax.pat) =
   fun p ->

--- a/ocaml/fstar-lib/generated/FStar_Reflection_V2_Compare.ml
+++ b/ocaml/fstar-lib/generated/FStar_Reflection_V2_Compare.ml
@@ -42,6 +42,10 @@ let (compare_const :
           -> FStar_Order.Eq
       | (FStar_Reflection_V2_Data.C_Reflect l1,
          FStar_Reflection_V2_Data.C_Reflect l2) -> compare_name l1 l2
+      | (FStar_Reflection_V2_Data.C_Real r1, FStar_Reflection_V2_Data.C_Real
+         r2) ->
+          FStar_Order.order_from_int
+            (FStar_Reflection_V2_Builtins.compare_string r1 r2)
       | (FStar_Reflection_V2_Data.C_Unit, uu___) -> FStar_Order.Lt
       | (uu___, FStar_Reflection_V2_Data.C_Unit) -> FStar_Order.Gt
       | (FStar_Reflection_V2_Data.C_Int uu___, uu___1) -> FStar_Order.Lt
@@ -58,6 +62,8 @@ let (compare_const :
       | (uu___, FStar_Reflection_V2_Data.C_Reify) -> FStar_Order.Gt
       | (FStar_Reflection_V2_Data.C_Reflect uu___, uu___1) -> FStar_Order.Lt
       | (uu___, FStar_Reflection_V2_Data.C_Reflect uu___1) -> FStar_Order.Gt
+      | (FStar_Reflection_V2_Data.C_Real uu___, uu___1) -> FStar_Order.Lt
+      | (uu___, FStar_Reflection_V2_Data.C_Real uu___1) -> FStar_Order.Gt
 let (compare_ident :
   FStar_Reflection_Types.ident ->
     FStar_Reflection_Types.ident -> FStar_Order.order)

--- a/ocaml/fstar-lib/generated/FStar_Reflection_V2_Data.ml
+++ b/ocaml/fstar-lib/generated/FStar_Reflection_V2_Data.ml
@@ -17,6 +17,7 @@ type vconst =
   | C_Range of FStar_Compiler_Range_Type.range 
   | C_Reify 
   | C_Reflect of name 
+  | C_Real of Prims.string 
 let (uu___is_C_Unit : vconst -> Prims.bool) =
   fun projectee -> match projectee with | C_Unit -> true | uu___ -> false
 let (uu___is_C_Int : vconst -> Prims.bool) =
@@ -43,6 +44,10 @@ let (uu___is_C_Reflect : vconst -> Prims.bool) =
     match projectee with | C_Reflect _0 -> true | uu___ -> false
 let (__proj__C_Reflect__item___0 : vconst -> name) =
   fun projectee -> match projectee with | C_Reflect _0 -> _0
+let (uu___is_C_Real : vconst -> Prims.bool) =
+  fun projectee -> match projectee with | C_Real _0 -> true | uu___ -> false
+let (__proj__C_Real__item___0 : vconst -> Prims.string) =
+  fun projectee -> match projectee with | C_Real _0 -> _0
 type universes = FStar_Syntax_Syntax.universe Prims.list
 type pattern =
   | Pat_Constant of vconst 

--- a/ocaml/fstar-lib/generated/FStar_Reflection_V2_TermEq.ml
+++ b/ocaml/fstar-lib/generated/FStar_Reflection_V2_TermEq.ml
@@ -233,6 +233,8 @@ let (const_cmp : FStar_Reflection_V2_Data.vconst comparator_for) =
       | (FStar_Reflection_V2_Data.C_Reflect n1,
          FStar_Reflection_V2_Data.C_Reflect n2) ->
           Obj.magic (Obj.repr (eq_cmp n1 n2))
+      | (FStar_Reflection_V2_Data.C_Real s1, FStar_Reflection_V2_Data.C_Real
+         s2) -> Obj.magic (Obj.repr (eq_cmp s1 s2))
       | uu___ -> Obj.magic (Obj.repr Neq)
 let (ctxu_cmp : FStar_Reflection_Types.ctx_uvar_and_subst comparator_for) =
   fun uu___ -> fun uu___1 -> Unknown
@@ -474,6 +476,7 @@ and (pat_arg_cmp :
 type 'r defined = unit
 type ('uuuuu, 'uuuuu1, 'f, 'l1, 'l2) def2 = unit
 type 'u faithful_univ = Obj.t
+type 'c faithful_const = unit
 type 't faithful = Obj.t
 type 'a faithful_arg = Obj.t
 type 'q faithful_qual = Obj.t

--- a/ocaml/fstar-lib/generated/FStar_SMTEncoding_Encode.ml
+++ b/ocaml/fstar-lib/generated/FStar_SMTEncoding_Encode.ml
@@ -59,6 +59,29 @@ let (__proj__Mkprims_t__item__mk :
 let (__proj__Mkprims_t__item__is :
   prims_t -> FStar_Ident.lident -> Prims.bool) =
   fun projectee -> match projectee with | { mk; is;_} -> is
+type defn_rel_type =
+  | Eq 
+  | ValidIff 
+let (uu___is_Eq : defn_rel_type -> Prims.bool) =
+  fun projectee -> match projectee with | Eq -> true | uu___ -> false
+let (uu___is_ValidIff : defn_rel_type -> Prims.bool) =
+  fun projectee -> match projectee with | ValidIff -> true | uu___ -> false
+let (rel_type_f :
+  defn_rel_type ->
+    (FStar_SMTEncoding_Term.term * FStar_SMTEncoding_Term.term) ->
+      FStar_SMTEncoding_Term.term)
+  =
+  fun uu___ ->
+    match uu___ with
+    | Eq -> FStar_SMTEncoding_Util.mkEq
+    | ValidIff ->
+        (fun uu___1 ->
+           match uu___1 with
+           | (x, y) ->
+               let uu___2 =
+                 let uu___3 = FStar_SMTEncoding_Term.mk_Valid x in
+                 (uu___3, y) in
+               FStar_SMTEncoding_Util.mkEq uu___2)
 let (prims : prims_t) =
   let module_name = "Prims" in
   let uu___ =
@@ -76,7 +99,7 @@ let (prims : prims_t) =
                FStar_SMTEncoding_Term.Term_sort in
            (match uu___2 with
             | (ysym, y) ->
-                let quant vars body rng x1 =
+                let quant rel vars body rng x1 =
                   let xname_decl =
                     let uu___3 =
                       let uu___4 =
@@ -147,6 +170,7 @@ let (prims : prims_t) =
                                  (uu___5, app1, vars2))
                         ([tot_fun_axiom_for_x], xtok1, []) all_vars_but_one in
                     match uu___3 with | (axioms, uu___4, uu___5) -> axioms in
+                  let rel_body = rel_type_f rel (xapp, body) in
                   let uu___3 =
                     let uu___4 =
                       let uu___5 =
@@ -154,11 +178,8 @@ let (prims : prims_t) =
                           let uu___7 =
                             let uu___8 =
                               let uu___9 =
-                                let uu___10 =
-                                  let uu___11 =
-                                    FStar_SMTEncoding_Util.mkEq (xapp, body) in
-                                  ([[xapp]], vars, uu___11) in
-                                FStar_SMTEncoding_Term.mkForall rng uu___10 in
+                                FStar_SMTEncoding_Term.mkForall rng
+                                  ([[xapp]], vars, rel_body) in
                               (uu___9, FStar_Pervasives_Native.None,
                                 (Prims.strcat "primitive_" x1)) in
                             FStar_SMTEncoding_Util.mkAssume uu___8 in
@@ -203,7 +224,7 @@ let (prims : prims_t) =
                       let uu___5 =
                         let uu___6 = FStar_SMTEncoding_Util.mkEq (x, y) in
                         FStar_SMTEncoding_Term.boxBool uu___6 in
-                      quant axy uu___5 in
+                      quant Eq axy uu___5 in
                     (FStar_Parser_Const.op_Eq, uu___4) in
                   let uu___4 =
                     let uu___5 =
@@ -213,7 +234,7 @@ let (prims : prims_t) =
                             let uu___9 = FStar_SMTEncoding_Util.mkEq (x, y) in
                             FStar_SMTEncoding_Util.mkNot uu___9 in
                           FStar_SMTEncoding_Term.boxBool uu___8 in
-                        quant axy uu___7 in
+                        quant Eq axy uu___7 in
                       (FStar_Parser_Const.op_notEq, uu___6) in
                     let uu___6 =
                       let uu___7 =
@@ -228,7 +249,7 @@ let (prims : prims_t) =
                                 (uu___12, uu___13) in
                               FStar_SMTEncoding_Util.mkAnd uu___11 in
                             FStar_SMTEncoding_Term.boxBool uu___10 in
-                          quant xy uu___9 in
+                          quant Eq xy uu___9 in
                         (FStar_Parser_Const.op_And, uu___8) in
                       let uu___8 =
                         let uu___9 =
@@ -243,7 +264,7 @@ let (prims : prims_t) =
                                   (uu___14, uu___15) in
                                 FStar_SMTEncoding_Util.mkOr uu___13 in
                               FStar_SMTEncoding_Term.boxBool uu___12 in
-                            quant xy uu___11 in
+                            quant Eq xy uu___11 in
                           (FStar_Parser_Const.op_Or, uu___10) in
                         let uu___10 =
                           let uu___11 =
@@ -254,7 +275,7 @@ let (prims : prims_t) =
                                     FStar_SMTEncoding_Term.unboxBool x in
                                   FStar_SMTEncoding_Util.mkNot uu___15 in
                                 FStar_SMTEncoding_Term.boxBool uu___14 in
-                              quant qx uu___13 in
+                              quant Eq qx uu___13 in
                             (FStar_Parser_Const.op_Negation, uu___12) in
                           let uu___12 =
                             let uu___13 =
@@ -269,7 +290,7 @@ let (prims : prims_t) =
                                       (uu___18, uu___19) in
                                     FStar_SMTEncoding_Util.mkLT uu___17 in
                                   FStar_SMTEncoding_Term.boxBool uu___16 in
-                                quant xy uu___15 in
+                                quant Eq xy uu___15 in
                               (FStar_Parser_Const.op_LT, uu___14) in
                             let uu___14 =
                               let uu___15 =
@@ -284,7 +305,7 @@ let (prims : prims_t) =
                                         (uu___20, uu___21) in
                                       FStar_SMTEncoding_Util.mkLTE uu___19 in
                                     FStar_SMTEncoding_Term.boxBool uu___18 in
-                                  quant xy uu___17 in
+                                  quant Eq xy uu___17 in
                                 (FStar_Parser_Const.op_LTE, uu___16) in
                               let uu___16 =
                                 let uu___17 =
@@ -299,7 +320,7 @@ let (prims : prims_t) =
                                           (uu___22, uu___23) in
                                         FStar_SMTEncoding_Util.mkGT uu___21 in
                                       FStar_SMTEncoding_Term.boxBool uu___20 in
-                                    quant xy uu___19 in
+                                    quant Eq xy uu___19 in
                                   (FStar_Parser_Const.op_GT, uu___18) in
                                 let uu___18 =
                                   let uu___19 =
@@ -318,7 +339,7 @@ let (prims : prims_t) =
                                             uu___23 in
                                         FStar_SMTEncoding_Term.boxBool
                                           uu___22 in
-                                      quant xy uu___21 in
+                                      quant Eq xy uu___21 in
                                     (FStar_Parser_Const.op_GTE, uu___20) in
                                   let uu___20 =
                                     let uu___21 =
@@ -337,7 +358,7 @@ let (prims : prims_t) =
                                               uu___25 in
                                           FStar_SMTEncoding_Term.boxInt
                                             uu___24 in
-                                        quant xy uu___23 in
+                                        quant Eq xy uu___23 in
                                       (FStar_Parser_Const.op_Subtraction,
                                         uu___22) in
                                     let uu___22 =
@@ -352,7 +373,7 @@ let (prims : prims_t) =
                                                 uu___27 in
                                             FStar_SMTEncoding_Term.boxInt
                                               uu___26 in
-                                          quant qx uu___25 in
+                                          quant Eq qx uu___25 in
                                         (FStar_Parser_Const.op_Minus,
                                           uu___24) in
                                       let uu___24 =
@@ -372,7 +393,7 @@ let (prims : prims_t) =
                                                   uu___29 in
                                               FStar_SMTEncoding_Term.boxInt
                                                 uu___28 in
-                                            quant xy uu___27 in
+                                            quant Eq xy uu___27 in
                                           (FStar_Parser_Const.op_Addition,
                                             uu___26) in
                                         let uu___26 =
@@ -392,7 +413,7 @@ let (prims : prims_t) =
                                                     uu___31 in
                                                 FStar_SMTEncoding_Term.boxInt
                                                   uu___30 in
-                                              quant xy uu___29 in
+                                              quant Eq xy uu___29 in
                                             (FStar_Parser_Const.op_Multiply,
                                               uu___28) in
                                           let uu___28 =
@@ -412,7 +433,7 @@ let (prims : prims_t) =
                                                       uu___33 in
                                                   FStar_SMTEncoding_Term.boxInt
                                                     uu___32 in
-                                                quant xy uu___31 in
+                                                quant Eq xy uu___31 in
                                               (FStar_Parser_Const.op_Division,
                                                 uu___30) in
                                             let uu___30 =
@@ -432,7 +453,7 @@ let (prims : prims_t) =
                                                         uu___35 in
                                                     FStar_SMTEncoding_Term.boxInt
                                                       uu___34 in
-                                                  quant xy uu___33 in
+                                                  quant Eq xy uu___33 in
                                                 (FStar_Parser_Const.op_Modulus,
                                                   uu___32) in
                                               let uu___32 =
@@ -441,18 +462,15 @@ let (prims : prims_t) =
                                                     let uu___35 =
                                                       let uu___36 =
                                                         let uu___37 =
-                                                          let uu___38 =
-                                                            FStar_SMTEncoding_Term.unboxReal
-                                                              x in
-                                                          let uu___39 =
-                                                            FStar_SMTEncoding_Term.unboxReal
-                                                              y in
-                                                          (uu___38, uu___39) in
-                                                        FStar_SMTEncoding_Util.mkLT
-                                                          uu___37 in
-                                                      FStar_SMTEncoding_Term.boxBool
+                                                          FStar_SMTEncoding_Term.unboxReal
+                                                            x in
+                                                        let uu___38 =
+                                                          FStar_SMTEncoding_Term.unboxReal
+                                                            y in
+                                                        (uu___37, uu___38) in
+                                                      FStar_SMTEncoding_Util.mkLT
                                                         uu___36 in
-                                                    quant xy uu___35 in
+                                                    quant ValidIff xy uu___35 in
                                                   (FStar_Parser_Const.real_op_LT,
                                                     uu___34) in
                                                 let uu___34 =
@@ -461,19 +479,16 @@ let (prims : prims_t) =
                                                       let uu___37 =
                                                         let uu___38 =
                                                           let uu___39 =
-                                                            let uu___40 =
-                                                              FStar_SMTEncoding_Term.unboxReal
-                                                                x in
-                                                            let uu___41 =
-                                                              FStar_SMTEncoding_Term.unboxReal
-                                                                y in
-                                                            (uu___40,
-                                                              uu___41) in
-                                                          FStar_SMTEncoding_Util.mkLTE
-                                                            uu___39 in
-                                                        FStar_SMTEncoding_Term.boxBool
+                                                            FStar_SMTEncoding_Term.unboxReal
+                                                              x in
+                                                          let uu___40 =
+                                                            FStar_SMTEncoding_Term.unboxReal
+                                                              y in
+                                                          (uu___39, uu___40) in
+                                                        FStar_SMTEncoding_Util.mkLTE
                                                           uu___38 in
-                                                      quant xy uu___37 in
+                                                      quant ValidIff xy
+                                                        uu___37 in
                                                     (FStar_Parser_Const.real_op_LTE,
                                                       uu___36) in
                                                   let uu___36 =
@@ -482,19 +497,17 @@ let (prims : prims_t) =
                                                         let uu___39 =
                                                           let uu___40 =
                                                             let uu___41 =
-                                                              let uu___42 =
-                                                                FStar_SMTEncoding_Term.unboxReal
-                                                                  x in
-                                                              let uu___43 =
-                                                                FStar_SMTEncoding_Term.unboxReal
-                                                                  y in
-                                                              (uu___42,
-                                                                uu___43) in
-                                                            FStar_SMTEncoding_Util.mkGT
-                                                              uu___41 in
-                                                          FStar_SMTEncoding_Term.boxBool
+                                                              FStar_SMTEncoding_Term.unboxReal
+                                                                x in
+                                                            let uu___42 =
+                                                              FStar_SMTEncoding_Term.unboxReal
+                                                                y in
+                                                            (uu___41,
+                                                              uu___42) in
+                                                          FStar_SMTEncoding_Util.mkGT
                                                             uu___40 in
-                                                        quant xy uu___39 in
+                                                        quant ValidIff xy
+                                                          uu___39 in
                                                       (FStar_Parser_Const.real_op_GT,
                                                         uu___38) in
                                                     let uu___38 =
@@ -503,19 +516,17 @@ let (prims : prims_t) =
                                                           let uu___41 =
                                                             let uu___42 =
                                                               let uu___43 =
-                                                                let uu___44 =
-                                                                  FStar_SMTEncoding_Term.unboxReal
-                                                                    x in
-                                                                let uu___45 =
-                                                                  FStar_SMTEncoding_Term.unboxReal
-                                                                    y in
-                                                                (uu___44,
-                                                                  uu___45) in
-                                                              FStar_SMTEncoding_Util.mkGTE
-                                                                uu___43 in
-                                                            FStar_SMTEncoding_Term.boxBool
+                                                                FStar_SMTEncoding_Term.unboxReal
+                                                                  x in
+                                                              let uu___44 =
+                                                                FStar_SMTEncoding_Term.unboxReal
+                                                                  y in
+                                                              (uu___43,
+                                                                uu___44) in
+                                                            FStar_SMTEncoding_Util.mkGTE
                                                               uu___42 in
-                                                          quant xy uu___41 in
+                                                          quant ValidIff xy
+                                                            uu___41 in
                                                         (FStar_Parser_Const.real_op_GTE,
                                                           uu___40) in
                                                       let uu___40 =
@@ -538,7 +549,8 @@ let (prims : prims_t) =
                                                                   uu___45 in
                                                               FStar_SMTEncoding_Term.boxReal
                                                                 uu___44 in
-                                                            quant xy uu___43 in
+                                                            quant Eq xy
+                                                              uu___43 in
                                                           (FStar_Parser_Const.real_op_Subtraction,
                                                             uu___42) in
                                                         let uu___42 =
@@ -562,7 +574,7 @@ let (prims : prims_t) =
                                                                     uu___47 in
                                                                 FStar_SMTEncoding_Term.boxReal
                                                                   uu___46 in
-                                                              quant xy
+                                                              quant Eq xy
                                                                 uu___45 in
                                                             (FStar_Parser_Const.real_op_Addition,
                                                               uu___44) in
@@ -588,7 +600,7 @@ let (prims : prims_t) =
                                                                     uu___49 in
                                                                   FStar_SMTEncoding_Term.boxReal
                                                                     uu___48 in
-                                                                quant xy
+                                                                quant Eq xy
                                                                   uu___47 in
                                                               (FStar_Parser_Const.real_op_Multiply,
                                                                 uu___46) in
@@ -615,7 +627,7 @@ let (prims : prims_t) =
                                                                     uu___51 in
                                                                     FStar_SMTEncoding_Term.boxReal
                                                                     uu___50 in
-                                                                  quant xy
+                                                                  quant Eq xy
                                                                     uu___49 in
                                                                 (FStar_Parser_Const.real_op_Division,
                                                                   uu___48) in
@@ -636,7 +648,8 @@ let (prims : prims_t) =
                                                                     FStar_Compiler_Range_Type.dummyRange in
                                                                     FStar_SMTEncoding_Term.boxReal
                                                                     uu___52 in
-                                                                    quant qx
+                                                                    quant Eq
+                                                                    qx
                                                                     uu___51 in
                                                                   (FStar_Parser_Const.real_of_int,
                                                                     uu___50) in

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Print.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Print.ml
@@ -2130,4 +2130,6 @@ and (const_to_ast_string :
                | FStar_Reflection_V2_Data.C_Reify -> "C_Reify"
                | FStar_Reflection_V2_Data.C_Reflect name ->
                    Prims.strcat "C_Reflect "
-                     (FStar_Reflection_V2_Builtins.implode_qn name)))) uu___
+                     (FStar_Reflection_V2_Builtins.implode_qn name)
+               | FStar_Reflection_V2_Data.C_Real r ->
+                   Prims.strcat "C_Real \"" (Prims.strcat r "\"")))) uu___

--- a/src/extraction/FStar.Extraction.ML.Util.fst
+++ b/src/extraction/FStar.Extraction.ML.Util.fst
@@ -56,10 +56,10 @@ let mlconst_of_const' (sctt : sconst) =
   | Const_effect       -> failwith "Unsupported constant"
 
   | Const_range _
-  | Const_unit         -> MLC_Unit
-  | Const_char   c     -> MLC_Char  c
-  | Const_int    (s, i)-> MLC_Int   (s, i)
-  | Const_bool   b     -> MLC_Bool  b
+  | Const_unit          -> MLC_Unit
+  | Const_char   c      -> MLC_Char  c
+  | Const_int    (s, i) -> MLC_Int   (s, i)
+  | Const_bool   b      -> MLC_Bool  b
   | Const_string (s, _) -> MLC_String (s)
 
   | Const_range_of

--- a/src/extraction/FStar.Extraction.ML.Util.fst
+++ b/src/extraction/FStar.Extraction.ML.Util.fst
@@ -49,7 +49,6 @@ let pruneNones (l : list (option 'a)) : list 'a =
 
 let mk_range_mle = with_ty MLTY_Top <| MLE_Name (["FStar"; "Range"], "mk_range")
 let dummy_range_mle = with_ty MLTY_Top <| MLE_Name (["FStar"; "Range"], "dummyRange")
-let fstar_real_of_string = with_ty MLTY_Top <| MLE_Name (["FStar";"Real"], "of_string")
 
 (* private *)
 let mlconst_of_const' (sctt : sconst) =
@@ -106,10 +105,6 @@ let mlexpr_of_const (p:Range.range) (c:sconst) : mlexpr' =
     match c with
     | Const_range r ->
         mlexpr_of_range r
-
-    | Const_real s ->
-        let str = mlconst_of_const p (Const_string(s, p)) in
-        MLE_App(fstar_real_of_string, [with_ty ml_string_ty <| MLE_Const str])
 
     | _ ->
         MLE_Const (mlconst_of_const p c)

--- a/src/parser/FStar.Parser.Const.fst
+++ b/src/parser/FStar.Parser.Const.fst
@@ -188,6 +188,7 @@ let op_Negation        = pconst "op_Negation"
 let subtype_of_lid     = pconst "subtype_of"
 
 let real_const  s        = p2l ["FStar";"Real";s]
+let real_op_EQ           = real_const "op_Equals_Dot"
 let real_op_LT           = real_const "op_Less_Dot"
 let real_op_LTE          = real_const "op_Less_Equals_Dot"
 let real_op_GT           = real_const "op_Greater_Dot"

--- a/src/parser/FStar.Parser.Dep.fst
+++ b/src/parser/FStar.Parser.Dep.fst
@@ -914,6 +914,8 @@ let collect_one
         | Const_range_of
         | Const_set_range_of ->
             add_to_parsing_data (P_dep (false, ("fstar.range" |> Ident.lid_of_str)))
+        | Const_real _ ->
+            add_to_parsing_data (P_dep (false, ("fstar.real" |> Ident.lid_of_str)))
         | _ ->
             ()
 

--- a/src/reflection/FStar.Reflection.V2.Builtins.fst
+++ b/src/reflection/FStar.Reflection.V2.Builtins.fst
@@ -155,6 +155,7 @@ let inspect_const (c:sconst) : vconst =
     | FStar.Const.Const_range r -> C_Range r
     | FStar.Const.Const_reify _ -> C_Reify
     | FStar.Const.Const_reflect l -> C_Reflect (Ident.path_of_lid l)
+    | FStar.Const.Const_real s -> C_Real s
     | _ -> failwith (BU.format1 "unknown constant: %s" (Print.const_to_string c))
 
 let inspect_universe u =
@@ -361,6 +362,7 @@ let pack_const (c:vconst) : sconst =
     | C_Range  r     -> C.Const_range r
     | C_Reify        -> C.Const_reify None
     | C_Reflect ns   -> C.Const_reflect (Ident.lid_of_path ns Range.dummyRange)
+    | C_Real r       -> C.Const_real r
 
 let rec pack_pat p : S.pat =
   let wrap v = {v=v;p=Range.dummyRange} in

--- a/src/reflection/FStar.Reflection.V2.Data.fsti
+++ b/src/reflection/FStar.Reflection.V2.Data.fsti
@@ -54,6 +54,7 @@ type vconst =
     | C_Range of Range.range
     | C_Reify
     | C_Reflect of name
+    | C_Real of string (* Real literals are represented as a string e.g. "1.2" *)
 
 type universes = list universe
 

--- a/src/smtencoding/FStar.SMTEncoding.Encode.fst
+++ b/src/smtencoding/FStar.SMTEncoding.Encode.fst
@@ -138,6 +138,7 @@ let prims =
         (Const.op_Division,    (quant xy  (boxInt  <| mkDiv(unboxInt x, unboxInt y))));
         (Const.op_Modulus,     (quant xy  (boxInt  <| mkMod(unboxInt x, unboxInt y))));
         //real ops
+        (Const.real_op_EQ,          (quant xy  (boxBool <| mkEq(unboxReal x, unboxReal y))));
         (Const.real_op_LT,          (quant xy  (boxBool <| mkLT(unboxReal x, unboxReal y))));
         (Const.real_op_LTE,         (quant xy  (boxBool <| mkLTE(unboxReal x, unboxReal y))));
         (Const.real_op_GT,          (quant xy  (boxBool <| mkGT(unboxReal x, unboxReal y))));

--- a/tests/micro-benchmarks/Test.Real.fst
+++ b/tests/micro-benchmarks/Test.Real.fst
@@ -1,0 +1,61 @@
+module Test.Real
+
+open FStar.Real
+
+#push-options "--smtencoding.elim_box true --smtencoding.l_arith_repr native --smtencoding.nl_arith_repr native"
+let n_over_n2 (n:real{n =!= 0.0R /\ n*.n =!= 0.0R}) = assert (n /. (n *. n) == 1.0R /. n)
+#pop-options
+
+let test = assert (two >. one)
+let test1 = assert (one =. 1.0R)
+
+let test_lt1 = assert (1.0R <. 2.0R)
+let test_lt2 = assert (~ (1.0R <. 1.0R))
+let test_lt3 = assert (~ (2.0R <. 1.0R))
+
+let test_le1 = assert (1.0R <=. 2.0R)
+let test_le2 = assert (1.0R <=. 1.0R)
+let test_le3 = assert (~ (2.0R <=. 1.0R))
+
+let test_gt1 = assert (~ (1.0R >. 2.0R))
+let test_gt2 = assert (~ (1.0R >. 1.0R))
+let test_gt3 = assert (2.0R >. 1.0R)
+
+let test_ge1 = assert (~ (1.0R >=. 2.0R))
+let test_ge2 = assert (1.0R >=. 1.0R)
+let test_ge3 = assert (2.0R >=. 1.0R)
+
+let test_add_eq = assert (1.0R +. 1.0R =. 2.0R)
+let test_add_eq' = assert (1.0R +. 3.0R =. 4.0R)
+let test_add_lt = assert (1.0R +. 1.0R <. 3.0R)
+
+let test_mul_eq = assert (2.0R *. 2.0R =. 4.0R)
+let test_mul_lt = assert (2.0R *. 2.0R <. 5.0R)
+
+let test_div_eq = assert (8.0R /. 2.0R =. 4.0R)
+let test_div_lt = assert (8.0R /. 2.0R <. 5.0R)
+
+let test_sqrt_2_mul = assert (sqrt_2 *. sqrt_2 =. 2.0R)
+// let test_sqrt_2_add = assert (sqrt_2 +. sqrt_2 >. 2.0R) // Fails
+#push-options "--smtencoding.elim_box true --smtencoding.l_arith_repr native --smtencoding.nl_arith_repr native"
+let test_sqrt_2_scale = assert (1.0R /. sqrt_2 == sqrt_2 /. 2.0R)
+#pop-options
+
+// Common identities
+let add_id_l = assert (forall n. 0.0R +. n =. n)
+let add_id_r = assert (forall n. n +. 0.0R =. n)
+
+let mul_nil_l = assert (forall n. 0.0R *. n =. 0.0R)
+let mul_nil_r = assert (forall n. n *. 0.0R =. 0.0R)
+
+let mul_id_l = assert (forall n. 1.0R *. n =. n)
+let mul_id_r = assert (forall n. n *. 1.0R =. n)
+
+let add_comm = assert (forall x y. x +. y =. y +.x)
+let add_assoc = assert (forall x y z. ((x +. y) +.z) =. (x +. (y +. z)))
+
+let mul_comm = assert (forall x y. x *. y =. y *.x)
+#push-options "--smtencoding.elim_box true --smtencoding.l_arith_repr native --smtencoding.nl_arith_repr native"
+let mul_assoc = assert (forall x y z. ((x *. y) *.z) =. (x *. (y *. z)))
+let mul_dist = assert (forall x y z. x *. (y +. z) =. (x *. y) +. (x *.z))
+#pop-options

--- a/tests/micro-benchmarks/Test.Real.fst
+++ b/tests/micro-benchmarks/Test.Real.fst
@@ -36,7 +36,18 @@ let test_div_eq = assert (8.0R /. 2.0R == 4.0R)
 let test_div_lt = assert (8.0R /. 2.0R <. 5.0R)
 
 let test_sqrt_2_mul = assert (sqrt_2 *. sqrt_2 == 2.0R)
-// let test_sqrt_2_add = assert (sqrt_2 +. sqrt_2 >. 2.0R) // Fails
+
+[@@expect_failure] // should hopefully work...
+let test_sqrt_2_add = assert (sqrt_2 >. 1.0R)
+
+let test_sqrt_2_add_explicit =
+  (* A bit of SMT wrestling can prove it *)
+  let mlem (x y : (r:real{r >=. 0.0R})) : Lemma (requires x*.x >. y*.y) (ensures x >. y) =
+    ()
+  in
+  mlem sqrt_2 1.0R;
+  assert (sqrt_2 >. 1.0R)
+
 #push-options "--smtencoding.elim_box true --smtencoding.l_arith_repr native --smtencoding.nl_arith_repr native"
 let test_sqrt_2_scale = assert (1.0R /. sqrt_2 == sqrt_2 /. 2.0R)
 #pop-options

--- a/tests/micro-benchmarks/Test.Real.fst
+++ b/tests/micro-benchmarks/Test.Real.fst
@@ -7,7 +7,7 @@ let n_over_n2 (n:real{n =!= 0.0R /\ n*.n =!= 0.0R}) = assert (n /. (n *. n) == 1
 #pop-options
 
 let test = assert (two >. one)
-let test1 = assert (one =. 1.0R)
+let test1 = assert (one == 1.0R)
 
 let test_lt1 = assert (1.0R <. 2.0R)
 let test_lt2 = assert (~ (1.0R <. 1.0R))
@@ -25,37 +25,37 @@ let test_ge1 = assert (~ (1.0R >=. 2.0R))
 let test_ge2 = assert (1.0R >=. 1.0R)
 let test_ge3 = assert (2.0R >=. 1.0R)
 
-let test_add_eq = assert (1.0R +. 1.0R =. 2.0R)
-let test_add_eq' = assert (1.0R +. 3.0R =. 4.0R)
+let test_add_eq = assert (1.0R +. 1.0R == 2.0R)
+let test_add_eq' = assert (1.0R +. 3.0R == 4.0R)
 let test_add_lt = assert (1.0R +. 1.0R <. 3.0R)
 
-let test_mul_eq = assert (2.0R *. 2.0R =. 4.0R)
+let test_mul_eq = assert (2.0R *. 2.0R == 4.0R)
 let test_mul_lt = assert (2.0R *. 2.0R <. 5.0R)
 
-let test_div_eq = assert (8.0R /. 2.0R =. 4.0R)
+let test_div_eq = assert (8.0R /. 2.0R == 4.0R)
 let test_div_lt = assert (8.0R /. 2.0R <. 5.0R)
 
-let test_sqrt_2_mul = assert (sqrt_2 *. sqrt_2 =. 2.0R)
+let test_sqrt_2_mul = assert (sqrt_2 *. sqrt_2 == 2.0R)
 // let test_sqrt_2_add = assert (sqrt_2 +. sqrt_2 >. 2.0R) // Fails
 #push-options "--smtencoding.elim_box true --smtencoding.l_arith_repr native --smtencoding.nl_arith_repr native"
 let test_sqrt_2_scale = assert (1.0R /. sqrt_2 == sqrt_2 /. 2.0R)
 #pop-options
 
 // Common identities
-let add_id_l = assert (forall n. 0.0R +. n =. n)
-let add_id_r = assert (forall n. n +. 0.0R =. n)
+let add_id_l = assert (forall n. 0.0R +. n == n)
+let add_id_r = assert (forall n. n +. 0.0R == n)
 
-let mul_nil_l = assert (forall n. 0.0R *. n =. 0.0R)
-let mul_nil_r = assert (forall n. n *. 0.0R =. 0.0R)
+let mul_nil_l = assert (forall n. 0.0R *. n == 0.0R)
+let mul_nil_r = assert (forall n. n *. 0.0R == 0.0R)
 
-let mul_id_l = assert (forall n. 1.0R *. n =. n)
-let mul_id_r = assert (forall n. n *. 1.0R =. n)
+let mul_id_l = assert (forall n. 1.0R *. n == n)
+let mul_id_r = assert (forall n. n *. 1.0R == n)
 
-let add_comm = assert (forall x y. x +. y =. y +.x)
-let add_assoc = assert (forall x y z. ((x +. y) +.z) =. (x +. (y +. z)))
+let add_comm = assert (forall x y. x +. y == y +.x)
+let add_assoc = assert (forall x y z. ((x +. y) +.z) == (x +. (y +. z)))
 
-let mul_comm = assert (forall x y. x *. y =. y *.x)
+let mul_comm = assert (forall x y. x *. y == y *.x)
 #push-options "--smtencoding.elim_box true --smtencoding.l_arith_repr native --smtencoding.nl_arith_repr native"
-let mul_assoc = assert (forall x y z. ((x *. y) *.z) =. (x *. (y *. z)))
-let mul_dist = assert (forall x y z. x *. (y +. z) =. (x *. y) +. (x *.z))
+let mul_assoc = assert (forall x y z. ((x *. y) *.z) == (x *. (y *. z)))
+let mul_dist = assert (forall x y z. x *. (y +. z) == (x *. y) +. (x *.z))
 #pop-options

--- a/ulib/FStar.Real.Old.fst
+++ b/ulib/FStar.Real.Old.fst
@@ -1,0 +1,70 @@
+(* This module is DEPRECATED. Use FStar.Real instead. *)
+module FStar.Real.Old
+
+module SEM = FStar.StrongExcludedMiddle
+
+let of_string = admit()
+// We cannot really implement this. The old implementation
+// had no execution behavior for it nor assumed any facts.
+
+let (=.)  x y = SEM.strong_excluded_middle (x == y)
+let (<>.) x y = SEM.strong_excluded_middle (x =!= y)
+let (>.)  x y = SEM.strong_excluded_middle (x >. y)
+let (>=.) x y = SEM.strong_excluded_middle (x >=. y)
+let (<.)  x y = SEM.strong_excluded_middle (x <. y)
+let (<=.) x y = SEM.strong_excluded_middle (x <=. y)
+
+#reset-options "--smtencoding.elim_box true --smtencoding.l_arith_repr native --smtencoding.nl_arith_repr native"
+
+let n_over_n2 (n:real{n <>. 0.0R /\ n*.n <>. 0.0R}) =
+  assert (n /. (n *. n) == 1.0R /. n)
+
+let test = assert (two >. one)
+let test1 = assert (one =. 1.0R)
+
+let test_lt1 = assert (1.0R <. 2.0R)
+let test_lt2 = assert (~ (1.0R <. 1.0R))
+let test_lt3 = assert (~ (2.0R <. 1.0R))
+
+let test_le1 = assert (1.0R <=. 2.0R)
+let test_le2 = assert (1.0R <=. 1.0R)
+let test_le3 = assert (~ (2.0R <=. 1.0R))
+
+let test_gt1 = assert (~ (1.0R >. 2.0R))
+let test_gt2 = assert (~ (1.0R >. 1.0R))
+let test_gt3 = assert (2.0R >. 1.0R)
+
+let test_ge1 = assert (~ (1.0R >=. 2.0R))
+let test_ge2 = assert (1.0R >=. 1.0R)
+let test_ge3 = assert (2.0R >=. 1.0R)
+
+let test_add_eq = assert (1.0R +. 1.0R =. 2.0R)
+let test_add_eq' = assert (1.0R +. 3.0R =. 4.0R)
+let test_add_lt = assert (1.0R +. 1.0R <. 3.0R)
+
+let test_mul_eq = assert (2.0R *. 2.0R =. 4.0R)
+let test_mul_lt = assert (2.0R *. 2.0R <. 5.0R)
+
+let test_div_eq = assert (8.0R /. 2.0R =. 4.0R)
+let test_div_lt = assert (8.0R /. 2.0R <. 5.0R)
+
+let test_sqrt_2_mul = assert (sqrt_2 *. sqrt_2 == 2.0R)
+//let test_sqrt_2_add = assert (sqrt_2 +. sqrt_2 >. 2.0R) // Fails
+let test_sqrt_2_scale = assert (1.0R /. sqrt_2 =. sqrt_2 /. 2.0R)
+
+// Common identities
+let add_id_l = assert (forall n. 0.0R +. n =. n)
+let add_id_r = assert (forall n. n +. 0.0R =. n)
+
+let mul_nil_l = assert (forall n. 0.0R *. n =. 0.0R)
+let mul_nil_r = assert (forall n. n *. 0.0R =. 0.0R)
+
+let mul_id_l = assert (forall n. 1.0R *. n =. n)
+let mul_id_r = assert (forall n. n *. 1.0R =. n)
+
+let add_comm = assert (forall x y. x +. y =. y +.x)
+let add_assoc = assert (forall x y z. ((x +. y) +.z) =. (x +. (y +. z)))
+
+let mul_comm = assert (forall x y. x *. y =. y *.x)
+let mul_assoc = assert (forall x y z. ((x *. y) *.z) =. (x *. (y *. z)))
+let mul_dist = assert (forall x y z. x *. (y +. z) =. (x *. y) +. (x *.z))

--- a/ulib/FStar.Real.Old.fsti
+++ b/ulib/FStar.Real.Old.fsti
@@ -1,0 +1,48 @@
+(*
+   Copyright 2008-2019 Microsoft Research
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*)
+module FStar.Real.Old
+
+(* This module is DEPRECATED. Use FStar.Real instead. *)
+
+open FStar.Real
+module R = FStar.Real
+
+let real = R.real
+let of_int = R.of_int
+
+(**
+  Used to extract real constants; this function is
+  uninterpreted logically. i.e., 1.1R is extracted to
+  [of_string "1.1"]
+  *)
+val of_string: string -> Tot real
+
+unfold let ( +. ) : real -> real -> Tot real                = R.op_Plus_Dot
+unfold let ( -. ) : real -> real -> Tot real                = R.op_Subtraction_Dot
+unfold let ( *. ) : real -> real -> Tot real                = R.op_Star_Dot
+unfold let ( /. ) : real -> d:real{d <> 0.0R} -> Tot real   = R.op_Slash_Dot
+
+(* Assuming ghost decidable equality, but it is not eqtype. *)
+val ( =.  ) (x y : real) : GTot (b:bool{b <==> x == y})
+val ( >.  ) (x y : real) : GTot (b:bool{b <==> R.op_Greater_Dot x y})
+val ( >=. ) (x y : real) : GTot (b:bool{b <==> R.op_Greater_Equals_Dot x y})
+val ( <.  ) (x y : real) : GTot (b:bool{b <==> R.op_Less_Dot x y})
+val ( <=. ) (x y : real) : GTot (b:bool{b <==> R.op_Less_Equals_Dot x y})
+
+unfold let zero   = R.zero
+unfold let one    = R.one
+unfold let two    = R.two
+unfold let sqrt_2 = R.sqrt_2

--- a/ulib/FStar.Real.fsti
+++ b/ulib/FStar.Real.fsti
@@ -25,7 +25,7 @@ module FStar.Real
 
   This is only a logical model of the reals. There is no extraction
   for them, as they are an erasable type. Any operation that can observe
-  a real (comparisons, to_string, etc) must be Ghost.
+  a real (comparisons, to_string, etc) must be Ghost or a proposition.
 *)
 
 [@@erasable]
@@ -40,13 +40,11 @@ val ( -. ) : real -> real -> Tot real
 val ( *. ) : real -> real -> Tot real
 val ( /. ) : real -> d:real{d =!= 0.0R} -> Tot real
 
-val ( =.  ) : real -> real -> GTot bool
+val ( >.  ) : real -> real -> prop
+val ( >=. ) : real -> real -> prop
 
-val ( >.  ) : real -> real -> GTot bool
-val ( >=. ) : real -> real -> GTot bool
-
-val ( <.  ) : real -> real -> GTot bool
-val ( <=. ) : real -> real -> GTot bool
+val ( <.  ) : real -> real -> prop
+val ( <=. ) : real -> real -> prop
 
 let zero : real = of_int 0
 let one  : real = of_int 1

--- a/ulib/FStar.Real.fsti
+++ b/ulib/FStar.Real.fsti
@@ -33,13 +33,6 @@ val real : Type0
 
 val of_int : int -> Tot real
 
-(**
-  Used to extract real constants; this function is
-  uninterpreted logically. i.e., 1.1R is extracted to
-  [of_string "1.1"]
-  *)
-val of_string: string -> Tot real
-
 val to_string: real -> GTot string
 
 val ( +. ) : real -> real -> Tot real

--- a/ulib/FStar.Real.fsti
+++ b/ulib/FStar.Real.fsti
@@ -22,9 +22,14 @@ module FStar.Real
 
   All these operations are mapped to the corresponding primitives
   in Z3's theory of real arithmetic.
+
+  This is only a logical model of the reals. There is no extraction
+  for them, as they are an erasable type. Any operation that can observe
+  a real (comparisons, to_string, etc) must be Ghost.
 *)
 
-val real : eqtype
+[@@erasable]
+val real : Type0
 
 val of_int : int -> Tot real
 
@@ -35,73 +40,22 @@ val of_int : int -> Tot real
   *)
 val of_string: string -> Tot real
 
+val to_string: real -> GTot string
+
 val ( +. ) : real -> real -> Tot real
 val ( -. ) : real -> real -> Tot real
 val ( *. ) : real -> real -> Tot real
-val ( /. ) : real -> d:real{d <> 0.0R} -> Tot real
+val ( /. ) : real -> d:real{d =!= 0.0R} -> Tot real
 
-val ( >.  ) : real -> real -> Tot bool
-val ( >=. ) : real -> real -> Tot bool
+val ( =.  ) : real -> real -> GTot bool
 
-val ( <.  ) : real -> real -> Tot bool
-val ( <=. ) : real -> real -> Tot bool
+val ( >.  ) : real -> real -> GTot bool
+val ( >=. ) : real -> real -> GTot bool
 
-#reset-options "--smtencoding.elim_box true --smtencoding.l_arith_repr native --smtencoding.nl_arith_repr native"
-//Tests
+val ( <.  ) : real -> real -> GTot bool
+val ( <=. ) : real -> real -> GTot bool
+
 let zero : real = of_int 0
-let one : real = of_int 1
-let two : real = of_int 2
-
-val sqrt_2 : r:real{r *. r = two}
-
-let n_over_n2 (n:real{n <> 0.0R /\ n*.n <> 0.0R}) = assert (n /. (n *. n) == 1.0R /. n)
-
-let test = assert (two >. one)
-let test1 = assert (one = 1.0R)
-
-let test_lt1 = assert (1.0R <. 2.0R)
-let test_lt2 = assert (~ (1.0R <. 1.0R))
-let test_lt3 = assert (~ (2.0R <. 1.0R))
-
-let test_le1 = assert (1.0R <=. 2.0R)
-let test_le2 = assert (1.0R <=. 1.0R)
-let test_le3 = assert (~ (2.0R <=. 1.0R))
-
-let test_gt1 = assert (~ (1.0R >. 2.0R))
-let test_gt2 = assert (~ (1.0R >. 1.0R))
-let test_gt3 = assert (2.0R >. 1.0R)
-
-let test_ge1 = assert (~ (1.0R >=. 2.0R))
-let test_ge2 = assert (1.0R >=. 1.0R)
-let test_ge3 = assert (2.0R >=. 1.0R)
-
-let test_add_eq = assert (1.0R +. 1.0R = 2.0R)
-let test_add_eq' = assert (1.0R +. 3.0R = 4.0R)
-let test_add_lt = assert (1.0R +. 1.0R <. 3.0R)
-
-let test_mul_eq = assert (2.0R *. 2.0R = 4.0R)
-let test_mul_lt = assert (2.0R *. 2.0R <. 5.0R)
-
-let test_div_eq = assert (8.0R /. 2.0R = 4.0R)
-let test_div_lt = assert (8.0R /. 2.0R <. 5.0R)
-
-let test_sqrt_2_mul = assert (sqrt_2 *. sqrt_2 = 2.0R)
-//let test_sqrt_2_add = assert (sqrt_2 +. sqrt_2 >. 2.0R) // Fails
-let test_sqrt_2_scale = assert (1.0R /. sqrt_2 = sqrt_2 /. 2.0R)
-
-// Common identities
-let add_id_l = assert (forall n. 0.0R +. n = n)
-let add_id_r = assert (forall n. n +. 0.0R = n)
-
-let mul_nil_l = assert (forall n. 0.0R *. n = 0.0R)
-let mul_nil_r = assert (forall n. n *. 0.0R = 0.0R)
-
-let mul_id_l = assert (forall n. 1.0R *. n = n)
-let mul_id_r = assert (forall n. n *. 1.0R = n)
-
-let add_comm = assert (forall x y. x +. y = y +.x)
-let add_assoc = assert (forall x y z. ((x +. y) +.z) = (x +. (y +. z)))
-
-let mul_comm = assert (forall x y. x *. y = y *.x)
-let mul_assoc = assert (forall x y z. ((x *. y) *.z) = (x *. (y *. z)))
-let mul_dist = assert (forall x y z. x *. (y +. z) = (x *. y) +. (x *.z))
+let one  : real = of_int 1
+let two  : real = of_int 2
+val sqrt_2 : r:real{r *. r == two}

--- a/ulib/FStar.Real.fsti
+++ b/ulib/FStar.Real.fsti
@@ -49,4 +49,4 @@ val ( <=. ) : real -> real -> prop
 let zero : real = of_int 0
 let one  : real = of_int 1
 let two  : real = of_int 2
-val sqrt_2 : r:real{r *. r == two}
+val sqrt_2 : r:real{r >=. 0.0R /\ r *. r == two}

--- a/ulib/FStar.Real.fsti
+++ b/ulib/FStar.Real.fsti
@@ -25,15 +25,13 @@ module FStar.Real
 
   This is only a logical model of the reals. There is no extraction
   for them, as they are an erasable type. Any operation that can observe
-  a real (comparisons, to_string, etc) must be Ghost or a proposition.
+  a real (comparisons, etc) must be Ghost or a proposition.
 *)
 
 [@@erasable]
 val real : Type0
 
 val of_int : int -> Tot real
-
-val to_string: real -> GTot string
 
 val ( +. ) : real -> real -> Tot real
 val ( -. ) : real -> real -> Tot real

--- a/ulib/FStar.Reflection.V2.Compare.fst
+++ b/ulib/FStar.Reflection.V2.Compare.fst
@@ -37,6 +37,7 @@ let compare_const (c1 c2 : vconst) : order =
     | C_Range r1, C_Range r2 -> Eq
     | C_Reify, C_Reify -> Eq
     | C_Reflect l1, C_Reflect l2 -> compare_name l1 l2
+    | C_Real r1, C_Real r2 -> order_from_int (compare_string r1 r2)
     | C_Unit,  _ -> Lt       | _, C_Unit  -> Gt
     | C_Int _, _ -> Lt       | _, C_Int _ -> Gt
     | C_True,  _ -> Lt       | _, C_True  -> Gt
@@ -45,6 +46,7 @@ let compare_const (c1 c2 : vconst) : order =
     | C_Range _, _ -> Lt     | _, C_Range _ -> Gt
     | C_Reify, _ -> Lt       | _, C_Reify -> Gt
     | C_Reflect _, _ -> Lt   | _, C_Reflect _ -> Gt
+    | C_Real _, _ -> Lt      | _ , C_Real _ -> Gt
 
 let compare_ident (i1 i2:ident) : order =
   let nm1, _ = inspect_ident i1 in

--- a/ulib/FStar.Reflection.V2.TermEq.fst
+++ b/ulib/FStar.Reflection.V2.TermEq.fst
@@ -223,6 +223,7 @@ let const_cmp c1 c2 =
   | C_Range r1, C_Range r2 -> range_cmp r1 r2
   | C_Reify, C_Reify -> Eq
   | C_Reflect n1, C_Reflect n2 -> eq_cmp n1 n2
+  | C_Real s1, C_Real s2 -> eq_cmp s1 s2
   | _ -> Neq
 
 (* TODO. Or seal...? *)
@@ -452,14 +453,21 @@ and univ_faithful_lemma_list #b (u1 u2 : b) (us1 : list universe{us1 << u1}) (us
     ;
     defined_list_dec u1 u2 univ_cmp us1 us2
 
+(* Just a placeholder for now *)
+val faithful_const : vconst -> Type0
+let faithful_const c = True
+
 val faithful : term -> Type0
 let rec faithful t =
   match inspect_ln t with
   | Tv_Var _
   | Tv_BVar _
   | Tv_FVar _
-  | Tv_Unknown
-  | Tv_Const _ -> True
+  | Tv_Unknown ->
+    True
+
+  | Tv_Const c ->
+    faithful_const c
 
   | Tv_UInst f us ->
     allP t faithful_univ us
@@ -519,7 +527,7 @@ and faithful_branch (b : branch) : Type0 =
 
 and faithful_pattern (p : pattern) : Type0 =
   match p with
-  | Pat_Constant _ -> True
+  | Pat_Constant c -> faithful_const c
   | Pat_Cons head univs subpats ->
     optP p (allP p faithful_univ) univs
      /\ allP p faithful_pattern_arg subpats

--- a/ulib/FStar.Stubs.Reflection.V2.Data.fsti
+++ b/ulib/FStar.Stubs.Reflection.V2.Data.fsti
@@ -33,6 +33,7 @@ type vconst =
   | C_Range     : range -> vconst
   | C_Reify     : vconst
   | C_Reflect   : name -> vconst
+  | C_Real      : string -> vconst (* Real literals are represented as a string e.g. "1.2" *)
   (* TODO: complete *)
 
 type universes = list universe

--- a/ulib/FStar.Tactics.Print.fst
+++ b/ulib/FStar.Tactics.Print.fst
@@ -108,3 +108,4 @@ and const_to_ast_string (c:vconst) : Tac string =
   | C_Range _ -> "C_Range _"
   | C_Reify -> "C_Reify"
   | C_Reflect name -> "C_Reflect " ^ implode_qn name
+  | C_Real r -> "C_Real \"" ^ r ^ "\""


### PR DESCRIPTION
Our FStar.Real module did not make much sense, in that it supported decidable operations (like equality) over arbitrary reals, and a total `of_string` operation to make a real from a string (although this was uninterpreted logically, so not unsound, but it also did not have a runtime implementation).

This PR makes the `real` type erasable, and removes the `of_string` operation and the extraction rules for reals (which would never be triggered now).

It also adds them to the vconst view that Meta-F* exposes.