### PR TITLE
A tweak to typeclass resolution: allow for "higher-order" resolution

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_Tactics_Typeclasses.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Typeclasses.ml
@@ -148,6 +148,90 @@ let rec first :
                  (Obj.repr
                     (FStar_Tactics_V2_Derived.or_else (fun uu___ -> f x)
                        (fun uu___ -> first f xs)))) uu___1 uu___
+let rec (maybe_intros : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
+  fun uu___ ->
+    FStar_Tactics_Effect.tac_bind
+      (FStar_Sealed.seal
+         (Obj.magic
+            (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
+               (Prims.of_int (85)) (Prims.of_int (10)) (Prims.of_int (85))
+               (Prims.of_int (21)))))
+      (FStar_Sealed.seal
+         (Obj.magic
+            (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
+               (Prims.of_int (86)) (Prims.of_int (2)) (Prims.of_int (90))
+               (Prims.of_int (11)))))
+      (Obj.magic (FStar_Tactics_V2_Derived.cur_goal ()))
+      (fun uu___1 ->
+         (fun g ->
+            Obj.magic
+              (FStar_Tactics_Effect.tac_bind
+                 (FStar_Sealed.seal
+                    (Obj.magic
+                       (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
+                          (Prims.of_int (86)) (Prims.of_int (8))
+                          (Prims.of_int (86)) (Prims.of_int (17)))))
+                 (FStar_Sealed.seal
+                    (Obj.magic
+                       (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
+                          (Prims.of_int (86)) (Prims.of_int (2))
+                          (Prims.of_int (90)) (Prims.of_int (11)))))
+                 (Obj.magic (FStar_Tactics_NamedView.inspect g))
+                 (fun uu___1 ->
+                    (fun uu___1 ->
+                       match uu___1 with
+                       | FStar_Tactics_NamedView.Tv_Arrow (uu___2, uu___3) ->
+                           Obj.magic
+                             (Obj.repr
+                                (FStar_Tactics_Effect.tac_bind
+                                   (FStar_Sealed.seal
+                                      (Obj.magic
+                                         (FStar_Range.mk_range
+                                            "FStar.Tactics.Typeclasses.fst"
+                                            (Prims.of_int (88))
+                                            (Prims.of_int (4))
+                                            (Prims.of_int (88))
+                                            (Prims.of_int (21)))))
+                                   (FStar_Sealed.seal
+                                      (Obj.magic
+                                         (FStar_Range.mk_range
+                                            "FStar.Tactics.Typeclasses.fst"
+                                            (Prims.of_int (89))
+                                            (Prims.of_int (4))
+                                            (Prims.of_int (89))
+                                            (Prims.of_int (19)))))
+                                   (Obj.magic
+                                      (FStar_Tactics_Effect.tac_bind
+                                         (FStar_Sealed.seal
+                                            (Obj.magic
+                                               (FStar_Range.mk_range
+                                                  "FStar.Tactics.Typeclasses.fst"
+                                                  (Prims.of_int (88))
+                                                  (Prims.of_int (11))
+                                                  (Prims.of_int (88))
+                                                  (Prims.of_int (21)))))
+                                         (FStar_Sealed.seal
+                                            (Obj.magic
+                                               (FStar_Range.mk_range
+                                                  "FStar.Tactics.Typeclasses.fst"
+                                                  (Prims.of_int (88))
+                                                  (Prims.of_int (4))
+                                                  (Prims.of_int (88))
+                                                  (Prims.of_int (21)))))
+                                         (Obj.magic
+                                            (FStar_Tactics_V2_Builtins.intro
+                                               ()))
+                                         (fun uu___4 ->
+                                            FStar_Tactics_Effect.lift_div_tac
+                                              (fun uu___5 -> ()))))
+                                   (fun uu___4 ->
+                                      (fun uu___4 ->
+                                         Obj.magic (maybe_intros ())) uu___4)))
+                       | uu___2 ->
+                           Obj.magic
+                             (Obj.repr
+                                (FStar_Tactics_Effect.lift_div_tac
+                                   (fun uu___3 -> ())))) uu___1))) uu___1)
 let rec (tcresolve' :
   FStar_Tactics_NamedView.term Prims.list ->
     FStar_Reflection_Types.fv Prims.list ->
@@ -160,13 +244,13 @@ let rec (tcresolve' :
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-                   (Prims.of_int (96)) (Prims.of_int (4)) (Prims.of_int (97))
-                   (Prims.of_int (18)))))
+                   (Prims.of_int (105)) (Prims.of_int (4))
+                   (Prims.of_int (106)) (Prims.of_int (18)))))
           (FStar_Sealed.seal
              (Obj.magic
                 (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-                   (Prims.of_int (98)) (Prims.of_int (4))
-                   (Prims.of_int (118)) (Prims.of_int (34)))))
+                   (Prims.of_int (107)) (Prims.of_int (4))
+                   (Prims.of_int (128)) (Prims.of_int (34)))))
           (if fuel <= Prims.int_zero
            then FStar_Tactics_Effect.raise NoInst
            else FStar_Tactics_Effect.lift_div_tac (fun uu___1 -> ()))
@@ -178,14 +262,14 @@ let rec (tcresolve' :
                         (Obj.magic
                            (FStar_Range.mk_range
                               "FStar.Tactics.Typeclasses.fst"
-                              (Prims.of_int (98)) (Prims.of_int (4))
-                              (Prims.of_int (98)) (Prims.of_int (52)))))
+                              (Prims.of_int (107)) (Prims.of_int (4))
+                              (Prims.of_int (107)) (Prims.of_int (52)))))
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range
                               "FStar.Tactics.Typeclasses.fst"
-                              (Prims.of_int (98)) (Prims.of_int (53))
-                              (Prims.of_int (118)) (Prims.of_int (34)))))
+                              (Prims.of_int (109)) (Prims.of_int (4))
+                              (Prims.of_int (128)) (Prims.of_int (34)))))
                      (Obj.magic
                         (debug
                            (fun uu___1 ->
@@ -204,169 +288,207 @@ let rec (tcresolve' :
                                    (Obj.magic
                                       (FStar_Range.mk_range
                                          "FStar.Tactics.Typeclasses.fst"
-                                         (Prims.of_int (100))
-                                         (Prims.of_int (12))
-                                         (Prims.of_int (100))
-                                         (Prims.of_int (23)))))
+                                         (Prims.of_int (109))
+                                         (Prims.of_int (4))
+                                         (Prims.of_int (109))
+                                         (Prims.of_int (18)))))
                                 (FStar_Sealed.seal
                                    (Obj.magic
                                       (FStar_Range.mk_range
                                          "FStar.Tactics.Typeclasses.fst"
-                                         (Prims.of_int (103))
-                                         (Prims.of_int (4))
-                                         (Prims.of_int (118))
+                                         (Prims.of_int (109))
+                                         (Prims.of_int (19))
+                                         (Prims.of_int (128))
                                          (Prims.of_int (34)))))
-                                (Obj.magic
-                                   (FStar_Tactics_V2_Derived.cur_goal ()))
+                                (Obj.magic (maybe_intros ()))
                                 (fun uu___2 ->
-                                   (fun g ->
+                                   (fun uu___2 ->
                                       Obj.magic
                                         (FStar_Tactics_Effect.tac_bind
                                            (FStar_Sealed.seal
                                               (Obj.magic
                                                  (FStar_Range.mk_range
                                                     "FStar.Tactics.Typeclasses.fst"
-                                                    (Prims.of_int (103))
-                                                    (Prims.of_int (4))
-                                                    (Prims.of_int (106))
-                                                    (Prims.of_int (5)))))
+                                                    (Prims.of_int (110))
+                                                    (Prims.of_int (12))
+                                                    (Prims.of_int (110))
+                                                    (Prims.of_int (23)))))
                                            (FStar_Sealed.seal
                                               (Obj.magic
                                                  (FStar_Range.mk_range
                                                     "FStar.Tactics.Typeclasses.fst"
-                                                    (Prims.of_int (108))
+                                                    (Prims.of_int (113))
                                                     (Prims.of_int (4))
-                                                    (Prims.of_int (118))
+                                                    (Prims.of_int (128))
                                                     (Prims.of_int (34)))))
-                                           (if
-                                              FStar_List_Tot_Base.existsb
-                                                (FStar_Reflection_V2_TermEq.term_eq
-                                                   g) seen
-                                            then
-                                              Obj.magic
-                                                (Obj.repr
-                                                   (FStar_Tactics_Effect.tac_bind
-                                                      (FStar_Sealed.seal
-                                                         (Obj.magic
-                                                            (FStar_Range.mk_range
-                                                               "FStar.Tactics.Typeclasses.fst"
-                                                               (Prims.of_int (104))
-                                                               (Prims.of_int (6))
-                                                               (Prims.of_int (104))
-                                                               (Prims.of_int (30)))))
-                                                      (FStar_Sealed.seal
-                                                         (Obj.magic
-                                                            (FStar_Range.mk_range
-                                                               "FStar.Tactics.Typeclasses.fst"
-                                                               (Prims.of_int (105))
-                                                               (Prims.of_int (6))
-                                                               (Prims.of_int (105))
-                                                               (Prims.of_int (18)))))
-                                                      (Obj.magic
-                                                         (debug
-                                                            (fun uu___2 ->
-                                                               (fun uu___2 ->
-                                                                  Obj.magic
-                                                                    (
-                                                                    FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___3 ->
-                                                                    "loop")))
-                                                                 uu___2)))
-                                                      (fun uu___2 ->
-                                                         FStar_Tactics_Effect.raise
-                                                           NoInst)))
-                                            else
-                                              Obj.magic
-                                                (Obj.repr
-                                                   (FStar_Tactics_Effect.lift_div_tac
-                                                      (fun uu___3 -> ()))))
-                                           (fun uu___2 ->
-                                              (fun uu___2 ->
+                                           (Obj.magic
+                                              (FStar_Tactics_V2_Derived.cur_goal
+                                                 ()))
+                                           (fun uu___3 ->
+                                              (fun g ->
                                                  Obj.magic
                                                    (FStar_Tactics_Effect.tac_bind
                                                       (FStar_Sealed.seal
                                                          (Obj.magic
                                                             (FStar_Range.mk_range
                                                                "FStar.Tactics.Typeclasses.fst"
-                                                               (Prims.of_int (108))
-                                                               (Prims.of_int (10))
-                                                               (Prims.of_int (108))
-                                                               (Prims.of_int (19)))))
+                                                               (Prims.of_int (113))
+                                                               (Prims.of_int (4))
+                                                               (Prims.of_int (116))
+                                                               (Prims.of_int (5)))))
                                                       (FStar_Sealed.seal
                                                          (Obj.magic
                                                             (FStar_Range.mk_range
                                                                "FStar.Tactics.Typeclasses.fst"
-                                                               (Prims.of_int (108))
-                                                               (Prims.of_int (4))
                                                                (Prims.of_int (118))
+                                                               (Prims.of_int (4))
+                                                               (Prims.of_int (128))
                                                                (Prims.of_int (34)))))
-                                                      (Obj.magic (head_of g))
+                                                      (if
+                                                         FStar_List_Tot_Base.existsb
+                                                           (FStar_Reflection_V2_TermEq.term_eq
+                                                              g) seen
+                                                       then
+                                                         Obj.magic
+                                                           (Obj.repr
+                                                              (FStar_Tactics_Effect.tac_bind
+                                                                 (FStar_Sealed.seal
+                                                                    (
+                                                                    Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.Typeclasses.fst"
+                                                                    (Prims.of_int (114))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (114))
+                                                                    (Prims.of_int (30)))))
+                                                                 (FStar_Sealed.seal
+                                                                    (
+                                                                    Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.Typeclasses.fst"
+                                                                    (Prims.of_int (115))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (115))
+                                                                    (Prims.of_int (18)))))
+                                                                 (Obj.magic
+                                                                    (
+                                                                    debug
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___4 ->
+                                                                    "loop")))
+                                                                    uu___3)))
+                                                                 (fun uu___3
+                                                                    ->
+                                                                    FStar_Tactics_Effect.raise
+                                                                    NoInst)))
+                                                       else
+                                                         Obj.magic
+                                                           (Obj.repr
+                                                              (FStar_Tactics_Effect.lift_div_tac
+                                                                 (fun uu___4
+                                                                    -> ()))))
                                                       (fun uu___3 ->
                                                          (fun uu___3 ->
-                                                            match uu___3 with
-                                                            | FStar_Pervasives_Native.None
-                                                                ->
-                                                                Obj.magic
-                                                                  (FStar_Tactics_Effect.tac_bind
+                                                            Obj.magic
+                                                              (FStar_Tactics_Effect.tac_bind
+                                                                 (FStar_Sealed.seal
+                                                                    (
+                                                                    Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.Typeclasses.fst"
+                                                                    (Prims.of_int (118))
+                                                                    (Prims.of_int (10))
+                                                                    (Prims.of_int (118))
+                                                                    (Prims.of_int (19)))))
+                                                                 (FStar_Sealed.seal
+                                                                    (
+                                                                    Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.Typeclasses.fst"
+                                                                    (Prims.of_int (118))
+                                                                    (Prims.of_int (4))
+                                                                    (Prims.of_int (128))
+                                                                    (Prims.of_int (34)))))
+                                                                 (Obj.magic
+                                                                    (
+                                                                    head_of g))
+                                                                 (fun uu___4
+                                                                    ->
+                                                                    (fun
+                                                                    uu___4 ->
+                                                                    match uu___4
+                                                                    with
+                                                                    | 
+                                                                    FStar_Pervasives_Native.None
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (110))
+                                                                    (Prims.of_int (120))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (110))
+                                                                    (Prims.of_int (120))
                                                                     (Prims.of_int (61)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (111))
+                                                                    (Prims.of_int (121))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (111))
+                                                                    (Prims.of_int (121))
                                                                     (Prims.of_int (18)))))
                                                                     (Obj.magic
                                                                     (debug
                                                                     (fun
-                                                                    uu___4 ->
+                                                                    uu___5 ->
                                                                     (fun
-                                                                    uu___4 ->
+                                                                    uu___5 ->
                                                                     Obj.magic
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___5 ->
+                                                                    uu___6 ->
                                                                     "goal does not look like a typeclass")))
-                                                                    uu___4)))
+                                                                    uu___5)))
                                                                     (fun
-                                                                    uu___4 ->
+                                                                    uu___5 ->
                                                                     FStar_Tactics_Effect.raise
                                                                     NoInst))
-                                                            | FStar_Pervasives_Native.Some
-                                                                head_fv ->
-                                                                Obj.magic
-                                                                  (FStar_Tactics_Effect.tac_bind
+                                                                    | 
+                                                                    FStar_Pervasives_Native.Some
+                                                                    head_fv
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (115))
+                                                                    (Prims.of_int (125))
                                                                     (Prims.of_int (17))
-                                                                    (Prims.of_int (115))
+                                                                    (Prims.of_int (125))
                                                                     (Prims.of_int (26)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (116))
+                                                                    (Prims.of_int (126))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (118))
+                                                                    (Prims.of_int (128))
                                                                     (Prims.of_int (34)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___4 ->
+                                                                    uu___5 ->
                                                                     g :: seen))
                                                                     (fun
-                                                                    uu___4 ->
+                                                                    uu___5 ->
                                                                     (fun
                                                                     seen1 ->
                                                                     Obj.magic
@@ -379,8 +501,9 @@ let rec (tcresolve' :
                                                                     head_fv
                                                                     seen1 glb
                                                                     fuel)))
+                                                                    uu___5)))
                                                                     uu___4)))
-                                                           uu___3))) uu___2)))
+                                                           uu___3))) uu___3)))
                                      uu___2))) uu___1))) uu___)
 and (local :
   FStar_Reflection_Types.fv ->
@@ -397,27 +520,27 @@ and (local :
               (FStar_Sealed.seal
                  (Obj.magic
                     (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-                       (Prims.of_int (121)) (Prims.of_int (13))
-                       (Prims.of_int (121)) (Prims.of_int (37)))))
+                       (Prims.of_int (131)) (Prims.of_int (13))
+                       (Prims.of_int (131)) (Prims.of_int (37)))))
               (FStar_Sealed.seal
                  (Obj.magic
                     (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-                       (Prims.of_int (122)) (Prims.of_int (4))
-                       (Prims.of_int (124)) (Prims.of_int (12)))))
+                       (Prims.of_int (132)) (Prims.of_int (4))
+                       (Prims.of_int (134)) (Prims.of_int (12)))))
               (Obj.magic
                  (FStar_Tactics_Effect.tac_bind
                     (FStar_Sealed.seal
                        (Obj.magic
                           (FStar_Range.mk_range
                              "FStar.Tactics.Typeclasses.fst"
-                             (Prims.of_int (121)) (Prims.of_int (25))
-                             (Prims.of_int (121)) (Prims.of_int (37)))))
+                             (Prims.of_int (131)) (Prims.of_int (25))
+                             (Prims.of_int (131)) (Prims.of_int (37)))))
                     (FStar_Sealed.seal
                        (Obj.magic
                           (FStar_Range.mk_range
                              "FStar.Tactics.Typeclasses.fst"
-                             (Prims.of_int (121)) (Prims.of_int (13))
-                             (Prims.of_int (121)) (Prims.of_int (37)))))
+                             (Prims.of_int (131)) (Prims.of_int (13))
+                             (Prims.of_int (131)) (Prims.of_int (37)))))
                     (Obj.magic (FStar_Tactics_V2_Derived.cur_env ()))
                     (fun uu___1 ->
                        FStar_Tactics_Effect.lift_div_tac
@@ -452,28 +575,28 @@ and (global :
                       (Obj.magic
                          (FStar_Range.mk_range
                             "FStar.Tactics.Typeclasses.fst"
-                            (Prims.of_int (128)) (Prims.of_int (24))
-                            (Prims.of_int (128)) (Prims.of_int (58)))))
+                            (Prims.of_int (138)) (Prims.of_int (24))
+                            (Prims.of_int (138)) (Prims.of_int (58)))))
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range
                             "FStar.Tactics.Typeclasses.fst"
-                            (Prims.of_int (129)) (Prims.of_int (14))
-                            (Prims.of_int (129)) (Prims.of_int (67)))))
+                            (Prims.of_int (139)) (Prims.of_int (14))
+                            (Prims.of_int (139)) (Prims.of_int (67)))))
                    (Obj.magic
                       (FStar_Tactics_Effect.tac_bind
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range
                                   "FStar.Tactics.Typeclasses.fst"
-                                  (Prims.of_int (128)) (Prims.of_int (27))
-                                  (Prims.of_int (128)) (Prims.of_int (38)))))
+                                  (Prims.of_int (138)) (Prims.of_int (27))
+                                  (Prims.of_int (138)) (Prims.of_int (38)))))
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range
                                   "FStar.Tactics.Typeclasses.fst"
-                                  (Prims.of_int (128)) (Prims.of_int (24))
-                                  (Prims.of_int (128)) (Prims.of_int (58)))))
+                                  (Prims.of_int (138)) (Prims.of_int (24))
+                                  (Prims.of_int (138)) (Prims.of_int (58)))))
                          (Obj.magic (FStar_Tactics_V2_Derived.cur_env ()))
                          (fun uu___1 ->
                             (fun uu___1 ->
@@ -508,165 +631,129 @@ and (trywith :
                 (FStar_Sealed.seal
                    (Obj.magic
                       (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-                         (Prims.of_int (133)) (Prims.of_int (4))
-                         (Prims.of_int (133)) (Prims.of_int (51)))))
+                         (Prims.of_int (144)) (Prims.of_int (10))
+                         (Prims.of_int (144)) (Prims.of_int (31)))))
                 (FStar_Sealed.seal
                    (Obj.magic
                       (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-                         (Prims.of_int (134)) (Prims.of_int (4))
-                         (Prims.of_int (148)) (Prims.of_int (7)))))
+                         (Prims.of_int (144)) (Prims.of_int (4))
+                         (Prims.of_int (158)) (Prims.of_int (7)))))
                 (Obj.magic
-                   (debug
+                   (FStar_Tactics_Effect.tac_bind
+                      (FStar_Sealed.seal
+                         (Obj.magic
+                            (FStar_Range.mk_range
+                               "FStar.Tactics.Typeclasses.fst"
+                               (Prims.of_int (144)) (Prims.of_int (18))
+                               (Prims.of_int (144)) (Prims.of_int (31)))))
+                      (FStar_Sealed.seal
+                         (Obj.magic
+                            (FStar_Range.mk_range
+                               "FStar.Tactics.Typeclasses.fst"
+                               (Prims.of_int (144)) (Prims.of_int (10))
+                               (Prims.of_int (144)) (Prims.of_int (31)))))
+                      (Obj.magic (res_typ typ))
                       (fun uu___ ->
-                         FStar_Tactics_Effect.tac_bind
-                           (FStar_Sealed.seal
-                              (Obj.magic
-                                 (FStar_Range.mk_range
-                                    "FStar.Tactics.Typeclasses.fst"
-                                    (Prims.of_int (133)) (Prims.of_int (34))
-                                    (Prims.of_int (133)) (Prims.of_int (50)))))
-                           (FStar_Sealed.seal
-                              (Obj.magic
-                                 (FStar_Range.mk_range "prims.fst"
-                                    (Prims.of_int (590)) (Prims.of_int (19))
-                                    (Prims.of_int (590)) (Prims.of_int (31)))))
-                           (Obj.magic
-                              (FStar_Tactics_V2_Builtins.term_to_string t))
-                           (fun uu___1 ->
-                              FStar_Tactics_Effect.lift_div_tac
-                                (fun uu___2 -> Prims.strcat "trywith " uu___1)))))
+                         (fun uu___ -> Obj.magic (head_of uu___)) uu___)))
                 (fun uu___ ->
                    (fun uu___ ->
-                      Obj.magic
-                        (FStar_Tactics_Effect.tac_bind
-                           (FStar_Sealed.seal
-                              (Obj.magic
-                                 (FStar_Range.mk_range
-                                    "FStar.Tactics.Typeclasses.fst"
-                                    (Prims.of_int (134)) (Prims.of_int (10))
-                                    (Prims.of_int (134)) (Prims.of_int (31)))))
-                           (FStar_Sealed.seal
-                              (Obj.magic
-                                 (FStar_Range.mk_range
-                                    "FStar.Tactics.Typeclasses.fst"
-                                    (Prims.of_int (134)) (Prims.of_int (4))
-                                    (Prims.of_int (148)) (Prims.of_int (7)))))
-                           (Obj.magic
-                              (FStar_Tactics_Effect.tac_bind
-                                 (FStar_Sealed.seal
-                                    (Obj.magic
-                                       (FStar_Range.mk_range
-                                          "FStar.Tactics.Typeclasses.fst"
-                                          (Prims.of_int (134))
-                                          (Prims.of_int (18))
-                                          (Prims.of_int (134))
-                                          (Prims.of_int (31)))))
-                                 (FStar_Sealed.seal
-                                    (Obj.magic
-                                       (FStar_Range.mk_range
-                                          "FStar.Tactics.Typeclasses.fst"
-                                          (Prims.of_int (134))
-                                          (Prims.of_int (10))
-                                          (Prims.of_int (134))
-                                          (Prims.of_int (31)))))
-                                 (Obj.magic (res_typ typ))
-                                 (fun uu___1 ->
-                                    (fun uu___1 -> Obj.magic (head_of uu___1))
-                                      uu___1)))
-                           (fun uu___1 ->
-                              (fun uu___1 ->
-                                 match uu___1 with
-                                 | FStar_Pervasives_Native.None ->
-                                     Obj.magic
-                                       (FStar_Tactics_Effect.tac_bind
-                                          (FStar_Sealed.seal
+                      match uu___ with
+                      | FStar_Pervasives_Native.None ->
+                          Obj.magic
+                            (Obj.repr
+                               (FStar_Tactics_Effect.tac_bind
+                                  (FStar_Sealed.seal
+                                     (Obj.magic
+                                        (FStar_Range.mk_range
+                                           "FStar.Tactics.Typeclasses.fst"
+                                           (Prims.of_int (146))
+                                           (Prims.of_int (6))
+                                           (Prims.of_int (146))
+                                           (Prims.of_int (104)))))
+                                  (FStar_Sealed.seal
+                                     (Obj.magic
+                                        (FStar_Range.mk_range
+                                           "FStar.Tactics.Typeclasses.fst"
+                                           (Prims.of_int (147))
+                                           (Prims.of_int (6))
+                                           (Prims.of_int (147))
+                                           (Prims.of_int (18)))))
+                                  (Obj.magic
+                                     (debug
+                                        (fun uu___1 ->
+                                           FStar_Tactics_Effect.tac_bind
+                                             (FStar_Sealed.seal
+                                                (Obj.magic
+                                                   (FStar_Range.mk_range
+                                                      "FStar.Tactics.Typeclasses.fst"
+                                                      (Prims.of_int (146))
+                                                      (Prims.of_int (53))
+                                                      (Prims.of_int (146))
+                                                      (Prims.of_int (103)))))
+                                             (FStar_Sealed.seal
+                                                (Obj.magic
+                                                   (FStar_Range.mk_range
+                                                      "prims.fst"
+                                                      (Prims.of_int (590))
+                                                      (Prims.of_int (19))
+                                                      (Prims.of_int (590))
+                                                      (Prims.of_int (31)))))
                                              (Obj.magic
-                                                (FStar_Range.mk_range
-                                                   "FStar.Tactics.Typeclasses.fst"
-                                                   (Prims.of_int (136))
-                                                   (Prims.of_int (6))
-                                                   (Prims.of_int (136))
-                                                   (Prims.of_int (104)))))
-                                          (FStar_Sealed.seal
-                                             (Obj.magic
-                                                (FStar_Range.mk_range
-                                                   "FStar.Tactics.Typeclasses.fst"
-                                                   (Prims.of_int (137))
-                                                   (Prims.of_int (6))
-                                                   (Prims.of_int (137))
-                                                   (Prims.of_int (18)))))
-                                          (Obj.magic
-                                             (debug
-                                                (fun uu___2 ->
-                                                   FStar_Tactics_Effect.tac_bind
-                                                     (FStar_Sealed.seal
-                                                        (Obj.magic
-                                                           (FStar_Range.mk_range
-                                                              "FStar.Tactics.Typeclasses.fst"
-                                                              (Prims.of_int (136))
-                                                              (Prims.of_int (53))
-                                                              (Prims.of_int (136))
-                                                              (Prims.of_int (103)))))
-                                                     (FStar_Sealed.seal
-                                                        (Obj.magic
-                                                           (FStar_Range.mk_range
-                                                              "prims.fst"
-                                                              (Prims.of_int (590))
-                                                              (Prims.of_int (19))
-                                                              (Prims.of_int (590))
-                                                              (Prims.of_int (31)))))
-                                                     (Obj.magic
-                                                        (FStar_Tactics_Effect.tac_bind
-                                                           (FStar_Sealed.seal
-                                                              (Obj.magic
-                                                                 (FStar_Range.mk_range
+                                                (FStar_Tactics_Effect.tac_bind
+                                                   (FStar_Sealed.seal
+                                                      (Obj.magic
+                                                         (FStar_Range.mk_range
+                                                            "FStar.Tactics.Typeclasses.fst"
+                                                            (Prims.of_int (146))
+                                                            (Prims.of_int (53))
+                                                            (Prims.of_int (146))
+                                                            (Prims.of_int (69)))))
+                                                   (FStar_Sealed.seal
+                                                      (Obj.magic
+                                                         (FStar_Range.mk_range
+                                                            "FStar.Tactics.Typeclasses.fst"
+                                                            (Prims.of_int (146))
+                                                            (Prims.of_int (53))
+                                                            (Prims.of_int (146))
+                                                            (Prims.of_int (103)))))
+                                                   (Obj.magic
+                                                      (FStar_Tactics_V2_Builtins.term_to_string
+                                                         t))
+                                                   (fun uu___2 ->
+                                                      (fun uu___2 ->
+                                                         Obj.magic
+                                                           (FStar_Tactics_Effect.tac_bind
+                                                              (FStar_Sealed.seal
+                                                                 (Obj.magic
+                                                                    (
+                                                                    FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (136))
-                                                                    (Prims.of_int (53))
-                                                                    (Prims.of_int (136))
-                                                                    (Prims.of_int (69)))))
-                                                           (FStar_Sealed.seal
-                                                              (Obj.magic
-                                                                 (FStar_Range.mk_range
-                                                                    "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (136))
-                                                                    (Prims.of_int (53))
-                                                                    (Prims.of_int (136))
-                                                                    (Prims.of_int (103)))))
-                                                           (Obj.magic
-                                                              (FStar_Tactics_V2_Builtins.term_to_string
-                                                                 t))
-                                                           (fun uu___3 ->
-                                                              (fun uu___3 ->
-                                                                 Obj.magic
-                                                                   (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (136))
+                                                                    (Prims.of_int (146))
                                                                     (Prims.of_int (72))
-                                                                    (Prims.of_int (136))
+                                                                    (Prims.of_int (146))
                                                                     (Prims.of_int (103)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
+                                                              (FStar_Sealed.seal
+                                                                 (Obj.magic
+                                                                    (
+                                                                    FStar_Range.mk_range
                                                                     "prims.fst"
                                                                     (Prims.of_int (590))
                                                                     (Prims.of_int (19))
                                                                     (Prims.of_int (590))
                                                                     (Prims.of_int (31)))))
-                                                                    (Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
+                                                              (Obj.magic
+                                                                 (FStar_Tactics_Effect.tac_bind
+                                                                    (
+                                                                    FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (136))
+                                                                    (Prims.of_int (146))
                                                                     (Prims.of_int (85))
-                                                                    (Prims.of_int (136))
+                                                                    (Prims.of_int (146))
                                                                     (Prims.of_int (103)))))
-                                                                    (FStar_Sealed.seal
+                                                                    (
+                                                                    FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
@@ -674,285 +761,165 @@ and (trywith :
                                                                     (Prims.of_int (19))
                                                                     (Prims.of_int (590))
                                                                     (Prims.of_int (31)))))
-                                                                    (Obj.magic
+                                                                    (
+                                                                    Obj.magic
                                                                     (FStar_Tactics_V2_Builtins.term_to_string
                                                                     typ))
-                                                                    (fun
-                                                                    uu___4 ->
+                                                                    (
+                                                                    fun
+                                                                    uu___3 ->
                                                                     FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___5 ->
+                                                                    uu___4 ->
                                                                     Prims.strcat
                                                                     "    typ="
-                                                                    uu___4))))
-                                                                    (fun
+                                                                    uu___3))))
+                                                              (fun uu___3 ->
+                                                                 FStar_Tactics_Effect.lift_div_tac
+                                                                   (fun
                                                                     uu___4 ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___5 ->
                                                                     Prims.strcat
-                                                                    uu___3
-                                                                    uu___4))))
-                                                                uu___3)))
-                                                     (fun uu___3 ->
-                                                        FStar_Tactics_Effect.lift_div_tac
-                                                          (fun uu___4 ->
-                                                             Prims.strcat
-                                                               "no head for typ of this? "
-                                                               uu___3)))))
-                                          (fun uu___2 ->
-                                             FStar_Tactics_Effect.raise
-                                               NoInst))
-                                 | FStar_Pervasives_Native.Some fv' ->
-                                     if fv_eq fv' head_fv
-                                     then
-                                       Obj.magic
-                                         (FStar_Tactics_Effect.tac_bind
-                                            (FStar_Sealed.seal
-                                               (Obj.magic
-                                                  (FStar_Range.mk_range
-                                                     "FStar.Tactics.Typeclasses.fst"
-                                                     (Prims.of_int (141))
-                                                     (Prims.of_int (8))
-                                                     (Prims.of_int (141))
-                                                     (Prims.of_int (84)))))
-                                            (FStar_Sealed.seal
-                                               (Obj.magic
-                                                  (FStar_Range.mk_range
-                                                     "FStar.Tactics.Typeclasses.fst"
-                                                     (Prims.of_int (142))
-                                                     (Prims.of_int (8))
-                                                     (Prims.of_int (144))
-                                                     (Prims.of_int (39)))))
-                                            (Obj.magic
-                                               (debug
+                                                                    uu___2
+                                                                    uu___3))))
+                                                        uu___2)))
+                                             (fun uu___2 ->
+                                                FStar_Tactics_Effect.lift_div_tac
+                                                  (fun uu___3 ->
+                                                     Prims.strcat
+                                                       "no head for typ of this? "
+                                                       uu___2)))))
+                                  (fun uu___1 ->
+                                     FStar_Tactics_Effect.raise NoInst)))
+                      | FStar_Pervasives_Native.Some fv' ->
+                          Obj.magic
+                            (Obj.repr
+                               (if fv_eq fv' head_fv
+                                then
+                                  Obj.repr
+                                    (FStar_Tactics_Effect.tac_bind
+                                       (FStar_Sealed.seal
+                                          (Obj.magic
+                                             (FStar_Range.mk_range
+                                                "FStar.Tactics.Typeclasses.fst"
+                                                (Prims.of_int (151))
+                                                (Prims.of_int (8))
+                                                (Prims.of_int (151))
+                                                (Prims.of_int (84)))))
+                                       (FStar_Sealed.seal
+                                          (Obj.magic
+                                             (FStar_Range.mk_range
+                                                "FStar.Tactics.Typeclasses.fst"
+                                                (Prims.of_int (152))
+                                                (Prims.of_int (8))
+                                                (Prims.of_int (154))
+                                                (Prims.of_int (39)))))
+                                       (Obj.magic
+                                          (debug
+                                             (fun uu___1 ->
+                                                FStar_Tactics_Effect.tac_bind
+                                                  (FStar_Sealed.seal
+                                                     (Obj.magic
+                                                        (FStar_Range.mk_range
+                                                           "FStar.Tactics.Typeclasses.fst"
+                                                           (Prims.of_int (151))
+                                                           (Prims.of_int (67))
+                                                           (Prims.of_int (151))
+                                                           (Prims.of_int (83)))))
+                                                  (FStar_Sealed.seal
+                                                     (Obj.magic
+                                                        (FStar_Range.mk_range
+                                                           "prims.fst"
+                                                           (Prims.of_int (590))
+                                                           (Prims.of_int (19))
+                                                           (Prims.of_int (590))
+                                                           (Prims.of_int (31)))))
+                                                  (Obj.magic
+                                                     (FStar_Tactics_V2_Builtins.term_to_string
+                                                        t))
+                                                  (fun uu___2 ->
+                                                     FStar_Tactics_Effect.lift_div_tac
+                                                       (fun uu___3 ->
+                                                          Prims.strcat
+                                                            "Trying to apply hypothesis/instance: "
+                                                            uu___2)))))
+                                       (fun uu___1 ->
+                                          (fun uu___1 ->
+                                             Obj.magic
+                                               (FStar_Tactics_V2_Derived.seq
+                                                  (fun uu___2 ->
+                                                     FStar_Tactics_V2_Derived.apply_noinst
+                                                       t)
                                                   (fun uu___2 ->
                                                      FStar_Tactics_Effect.tac_bind
                                                        (FStar_Sealed.seal
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "FStar.Tactics.Typeclasses.fst"
-                                                                (Prims.of_int (141))
-                                                                (Prims.of_int (67))
-                                                                (Prims.of_int (141))
-                                                                (Prims.of_int (83)))))
+                                                                (Prims.of_int (153))
+                                                                (Prims.of_int (10))
+                                                                (Prims.of_int (153))
+                                                                (Prims.of_int (69)))))
                                                        (FStar_Sealed.seal
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
-                                                                "prims.fst"
-                                                                (Prims.of_int (590))
-                                                                (Prims.of_int (19))
-                                                                (Prims.of_int (590))
-                                                                (Prims.of_int (31)))))
+                                                                "FStar.Tactics.Typeclasses.fst"
+                                                                (Prims.of_int (154))
+                                                                (Prims.of_int (10))
+                                                                (Prims.of_int (154))
+                                                                (Prims.of_int (38)))))
                                                        (Obj.magic
-                                                          (FStar_Tactics_V2_Builtins.term_to_string
-                                                             t))
-                                                       (fun uu___3 ->
-                                                          FStar_Tactics_Effect.lift_div_tac
-                                                            (fun uu___4 ->
-                                                               Prims.strcat
-                                                                 "Trying to apply hypothesis/instance: "
-                                                                 uu___3)))))
-                                            (fun uu___2 ->
-                                               (fun uu___2 ->
-                                                  Obj.magic
-                                                    (FStar_Tactics_V2_Derived.seq
-                                                       (fun uu___3 ->
-                                                          FStar_Tactics_V2_Derived.apply_noinst
-                                                            t)
-                                                       (fun uu___3 ->
-                                                          FStar_Tactics_Effect.tac_bind
-                                                            (FStar_Sealed.seal
-                                                               (Obj.magic
-                                                                  (FStar_Range.mk_range
-                                                                    "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (143))
-                                                                    (Prims.of_int (10))
-                                                                    (Prims.of_int (143))
-                                                                    (Prims.of_int (69)))))
-                                                            (FStar_Sealed.seal
-                                                               (Obj.magic
-                                                                  (FStar_Range.mk_range
-                                                                    "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (144))
-                                                                    (Prims.of_int (10))
-                                                                    (Prims.of_int (144))
-                                                                    (Prims.of_int (38)))))
-                                                            (Obj.magic
-                                                               (debug
-                                                                  (fun uu___4
-                                                                    ->
-                                                                    FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
+                                                          (debug
+                                                             (fun uu___3 ->
+                                                                FStar_Tactics_Effect.tac_bind
+                                                                  (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (143))
+                                                                    (Prims.of_int (153))
                                                                     (Prims.of_int (27))
-                                                                    (Prims.of_int (143))
+                                                                    (Prims.of_int (153))
                                                                     (Prims.of_int (38)))))
-                                                                    (FStar_Sealed.seal
+                                                                  (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (143))
+                                                                    (Prims.of_int (153))
                                                                     (Prims.of_int (40))
-                                                                    (Prims.of_int (143))
+                                                                    (Prims.of_int (153))
                                                                     (Prims.of_int (68)))))
-                                                                    (Obj.magic
+                                                                  (Obj.magic
                                                                     (FStar_Tactics_V2_Builtins.dump
                                                                     "next"))
-                                                                    (fun
-                                                                    uu___5 ->
+                                                                  (fun uu___4
+                                                                    ->
                                                                     FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___6 ->
+                                                                    uu___5 ->
                                                                     "apply seems to have worked")))))
-                                                            (fun uu___4 ->
-                                                               (fun uu___4 ->
-                                                                  Obj.magic
-                                                                    (
-                                                                    tcresolve'
-                                                                    seen glb
-                                                                    (fuel -
+                                                       (fun uu___3 ->
+                                                          (fun uu___3 ->
+                                                             Obj.magic
+                                                               (tcresolve'
+                                                                  seen glb
+                                                                  (fuel -
                                                                     Prims.int_one)))
-                                                                 uu___4))))
-                                                 uu___2))
-                                     else
-                                       Obj.magic
-                                         (FStar_Tactics_Effect.tac_bind
-                                            (FStar_Sealed.seal
-                                               (Obj.magic
-                                                  (FStar_Range.mk_range
-                                                     "FStar.Tactics.Typeclasses.fst"
-                                                     (Prims.of_int (146))
-                                                     (Prims.of_int (8))
-                                                     (Prims.of_int (146))
-                                                     (Prims.of_int (96)))))
-                                            (FStar_Sealed.seal
-                                               (Obj.magic
-                                                  (FStar_Range.mk_range
-                                                     "FStar.Tactics.Typeclasses.fst"
-                                                     (Prims.of_int (147))
-                                                     (Prims.of_int (8))
-                                                     (Prims.of_int (147))
-                                                     (Prims.of_int (20)))))
-                                            (Obj.magic
-                                               (debug
-                                                  (fun uu___3 ->
-                                                     (fun uu___3 ->
-                                                        Obj.magic
-                                                          (FStar_Tactics_Effect.lift_div_tac
-                                                             (fun uu___4 ->
-                                                                Prims.strcat
-                                                                  "different class: "
-                                                                  (Prims.strcat
-                                                                    (FStar_Reflection_V2_Derived.fv_to_string
-                                                                    fv')
-                                                                    (Prims.strcat
-                                                                    " <> "
-                                                                    (FStar_Reflection_V2_Derived.fv_to_string
-                                                                    head_fv))))))
-                                                       uu___3)))
-                                            (fun uu___3 ->
-                                               FStar_Tactics_Effect.raise
-                                                 NoInst))) uu___1))) uu___)
-let rec (maybe_intros : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
-  fun uu___ ->
-    FStar_Tactics_Effect.tac_bind
-      (FStar_Sealed.seal
-         (Obj.magic
-            (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-               (Prims.of_int (152)) (Prims.of_int (10)) (Prims.of_int (152))
-               (Prims.of_int (21)))))
-      (FStar_Sealed.seal
-         (Obj.magic
-            (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-               (Prims.of_int (153)) (Prims.of_int (2)) (Prims.of_int (157))
-               (Prims.of_int (11)))))
-      (Obj.magic (FStar_Tactics_V2_Derived.cur_goal ()))
-      (fun uu___1 ->
-         (fun g ->
-            Obj.magic
-              (FStar_Tactics_Effect.tac_bind
-                 (FStar_Sealed.seal
-                    (Obj.magic
-                       (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-                          (Prims.of_int (153)) (Prims.of_int (8))
-                          (Prims.of_int (153)) (Prims.of_int (17)))))
-                 (FStar_Sealed.seal
-                    (Obj.magic
-                       (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-                          (Prims.of_int (153)) (Prims.of_int (2))
-                          (Prims.of_int (157)) (Prims.of_int (11)))))
-                 (Obj.magic (FStar_Tactics_NamedView.inspect g))
-                 (fun uu___1 ->
-                    (fun uu___1 ->
-                       match uu___1 with
-                       | FStar_Tactics_NamedView.Tv_Arrow (uu___2, uu___3) ->
-                           Obj.magic
-                             (Obj.repr
-                                (FStar_Tactics_Effect.tac_bind
-                                   (FStar_Sealed.seal
-                                      (Obj.magic
-                                         (FStar_Range.mk_range
-                                            "FStar.Tactics.Typeclasses.fst"
-                                            (Prims.of_int (155))
-                                            (Prims.of_int (4))
-                                            (Prims.of_int (155))
-                                            (Prims.of_int (21)))))
-                                   (FStar_Sealed.seal
-                                      (Obj.magic
-                                         (FStar_Range.mk_range
-                                            "FStar.Tactics.Typeclasses.fst"
-                                            (Prims.of_int (156))
-                                            (Prims.of_int (4))
-                                            (Prims.of_int (156))
-                                            (Prims.of_int (19)))))
-                                   (Obj.magic
-                                      (FStar_Tactics_Effect.tac_bind
-                                         (FStar_Sealed.seal
-                                            (Obj.magic
-                                               (FStar_Range.mk_range
-                                                  "FStar.Tactics.Typeclasses.fst"
-                                                  (Prims.of_int (155))
-                                                  (Prims.of_int (11))
-                                                  (Prims.of_int (155))
-                                                  (Prims.of_int (21)))))
-                                         (FStar_Sealed.seal
-                                            (Obj.magic
-                                               (FStar_Range.mk_range
-                                                  "FStar.Tactics.Typeclasses.fst"
-                                                  (Prims.of_int (155))
-                                                  (Prims.of_int (4))
-                                                  (Prims.of_int (155))
-                                                  (Prims.of_int (21)))))
-                                         (Obj.magic
-                                            (FStar_Tactics_V2_Builtins.intro
-                                               ()))
-                                         (fun uu___4 ->
-                                            FStar_Tactics_Effect.lift_div_tac
-                                              (fun uu___5 -> ()))))
-                                   (fun uu___4 ->
-                                      (fun uu___4 ->
-                                         Obj.magic (maybe_intros ())) uu___4)))
-                       | uu___2 ->
-                           Obj.magic
-                             (Obj.repr
-                                (FStar_Tactics_Effect.lift_div_tac
-                                   (fun uu___3 -> ())))) uu___1))) uu___1)
+                                                            uu___3)))) uu___1))
+                                else
+                                  Obj.repr
+                                    (FStar_Tactics_Effect.raise NoInst))))
+                     uu___)
 let (tcresolve : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
   fun uu___ ->
     FStar_Tactics_Effect.tac_bind
       (FStar_Sealed.seal
          (Obj.magic
             (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-               (Prims.of_int (161)) (Prims.of_int (4)) (Prims.of_int (161))
+               (Prims.of_int (162)) (Prims.of_int (4)) (Prims.of_int (162))
                (Prims.of_int (54)))))
       (FStar_Sealed.seal
          (Obj.magic
             (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-               (Prims.of_int (161)) (Prims.of_int (55)) (Prims.of_int (185))
+               (Prims.of_int (162)) (Prims.of_int (55)) (Prims.of_int (186))
                (Prims.of_int (18)))))
       (Obj.magic
          (debug
@@ -961,13 +928,13 @@ let (tcresolve : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                  (FStar_Sealed.seal
                     (Obj.magic
                        (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-                          (Prims.of_int (161)) (Prims.of_int (21))
-                          (Prims.of_int (161)) (Prims.of_int (28)))))
+                          (Prims.of_int (162)) (Prims.of_int (21))
+                          (Prims.of_int (162)) (Prims.of_int (28)))))
                  (FStar_Sealed.seal
                     (Obj.magic
                        (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-                          (Prims.of_int (161)) (Prims.of_int (30))
-                          (Prims.of_int (161)) (Prims.of_int (53)))))
+                          (Prims.of_int (162)) (Prims.of_int (30))
+                          (Prims.of_int (162)) (Prims.of_int (53)))))
                  (Obj.magic (FStar_Tactics_V2_Builtins.dump ""))
                  (fun uu___2 ->
                     FStar_Tactics_Effect.lift_div_tac
@@ -979,13 +946,13 @@ let (tcresolve : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                  (FStar_Sealed.seal
                     (Obj.magic
                        (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-                          (Prims.of_int (166)) (Prims.of_int (12))
-                          (Prims.of_int (166)) (Prims.of_int (26)))))
+                          (Prims.of_int (167)) (Prims.of_int (12))
+                          (Prims.of_int (167)) (Prims.of_int (26)))))
                  (FStar_Sealed.seal
                     (Obj.magic
                        (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-                          (Prims.of_int (167)) (Prims.of_int (4))
-                          (Prims.of_int (185)) (Prims.of_int (18)))))
+                          (Prims.of_int (168)) (Prims.of_int (4))
+                          (Prims.of_int (186)) (Prims.of_int (18)))))
                  (Obj.magic (FStar_Tactics_V2_Derived.cur_witness ()))
                  (fun uu___2 ->
                     (fun w ->
@@ -995,14 +962,14 @@ let (tcresolve : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                (Obj.magic
                                   (FStar_Range.mk_range
                                      "FStar.Tactics.Typeclasses.fst"
-                                     (Prims.of_int (167)) (Prims.of_int (4))
-                                     (Prims.of_int (167)) (Prims.of_int (19)))))
+                                     (Prims.of_int (168)) (Prims.of_int (4))
+                                     (Prims.of_int (168)) (Prims.of_int (19)))))
                             (FStar_Sealed.seal
                                (Obj.magic
                                   (FStar_Range.mk_range
                                      "FStar.Tactics.Typeclasses.fst"
-                                     (Prims.of_int (167)) (Prims.of_int (20))
-                                     (Prims.of_int (185)) (Prims.of_int (18)))))
+                                     (Prims.of_int (168)) (Prims.of_int (20))
+                                     (Prims.of_int (186)) (Prims.of_int (18)))))
                             (Obj.magic (maybe_intros ()))
                             (fun uu___2 ->
                                (fun uu___2 ->
@@ -1012,17 +979,17 @@ let (tcresolve : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                           (Obj.magic
                                              (FStar_Range.mk_range
                                                 "FStar.Tactics.Typeclasses.fst"
-                                                (Prims.of_int (172))
+                                                (Prims.of_int (173))
                                                 (Prims.of_int (14))
-                                                (Prims.of_int (172))
+                                                (Prims.of_int (173))
                                                 (Prims.of_int (52)))))
                                        (FStar_Sealed.seal
                                           (Obj.magic
                                              (FStar_Range.mk_range
                                                 "FStar.Tactics.Typeclasses.fst"
-                                                (Prims.of_int (173))
+                                                (Prims.of_int (174))
                                                 (Prims.of_int (4))
-                                                (Prims.of_int (185))
+                                                (Prims.of_int (186))
                                                 (Prims.of_int (18)))))
                                        (Obj.magic
                                           (FStar_Tactics_Effect.tac_bind
@@ -1030,17 +997,17 @@ let (tcresolve : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "FStar.Tactics.Typeclasses.fst"
-                                                      (Prims.of_int (172))
+                                                      (Prims.of_int (173))
                                                       (Prims.of_int (40))
-                                                      (Prims.of_int (172))
+                                                      (Prims.of_int (173))
                                                       (Prims.of_int (52)))))
                                              (FStar_Sealed.seal
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "FStar.Tactics.Typeclasses.fst"
-                                                      (Prims.of_int (172))
+                                                      (Prims.of_int (173))
                                                       (Prims.of_int (14))
-                                                      (Prims.of_int (172))
+                                                      (Prims.of_int (173))
                                                       (Prims.of_int (52)))))
                                              (Obj.magic
                                                 (FStar_Tactics_V2_Derived.cur_env
@@ -1069,17 +1036,17 @@ let (tcresolve : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                               (Obj.magic
                                                                  (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (174))
+                                                                    (Prims.of_int (175))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (174))
+                                                                    (Prims.of_int (175))
                                                                     (Prims.of_int (26)))))
                                                            (FStar_Sealed.seal
                                                               (Obj.magic
                                                                  (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (175))
+                                                                    (Prims.of_int (176))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (175))
+                                                                    (Prims.of_int (176))
                                                                     (Prims.of_int (59)))))
                                                            (Obj.magic
                                                               (tcresolve' []
@@ -1096,9 +1063,9 @@ let (tcresolve : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (175))
+                                                                    (Prims.of_int (176))
                                                                     (Prims.of_int (42))
-                                                                    (Prims.of_int (175))
+                                                                    (Prims.of_int (176))
                                                                     (Prims.of_int (58)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -1132,18 +1099,18 @@ let (tcresolve : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (179))
+                                                                    (Prims.of_int (180))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (182))
+                                                                    (Prims.of_int (183))
                                                                     (Prims.of_int (7)))))
                                                                     (
                                                                     FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (179))
+                                                                    (Prims.of_int (180))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (182))
+                                                                    (Prims.of_int (183))
                                                                     (Prims.of_int (7)))))
                                                                     (
                                                                     Obj.magic
@@ -1152,17 +1119,17 @@ let (tcresolve : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (180))
-                                                                    (Prims.of_int (8))
                                                                     (Prims.of_int (181))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (182))
                                                                     (Prims.of_int (59)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (179))
+                                                                    (Prims.of_int (180))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (182))
+                                                                    (Prims.of_int (183))
                                                                     (Prims.of_int (7)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1170,17 +1137,17 @@ let (tcresolve : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (181))
+                                                                    (Prims.of_int (182))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (181))
+                                                                    (Prims.of_int (182))
                                                                     (Prims.of_int (59)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (180))
-                                                                    (Prims.of_int (8))
                                                                     (Prims.of_int (181))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (182))
                                                                     (Prims.of_int (59)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1188,17 +1155,17 @@ let (tcresolve : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (181))
+                                                                    (Prims.of_int (182))
                                                                     (Prims.of_int (28))
-                                                                    (Prims.of_int (181))
+                                                                    (Prims.of_int (182))
                                                                     (Prims.of_int (58)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (181))
+                                                                    (Prims.of_int (182))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (181))
+                                                                    (Prims.of_int (182))
                                                                     (Prims.of_int (59)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1206,17 +1173,17 @@ let (tcresolve : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (181))
+                                                                    (Prims.of_int (182))
                                                                     (Prims.of_int (44))
-                                                                    (Prims.of_int (181))
+                                                                    (Prims.of_int (182))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (181))
+                                                                    (Prims.of_int (182))
                                                                     (Prims.of_int (28))
-                                                                    (Prims.of_int (181))
+                                                                    (Prims.of_int (182))
                                                                     (Prims.of_int (58)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Derived.cur_goal
@@ -1310,8 +1277,8 @@ let rec (mk_abs :
                           (Obj.magic
                              (FStar_Range.mk_range
                                 "FStar.Tactics.Typeclasses.fst"
-                                (Prims.of_int (194)) (Prims.of_int (20))
-                                (Prims.of_int (194)) (Prims.of_int (47)))))
+                                (Prims.of_int (195)) (Prims.of_int (20))
+                                (Prims.of_int (195)) (Prims.of_int (47)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "dummy" Prims.int_zero
@@ -1322,17 +1289,17 @@ let rec (mk_abs :
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "FStar.Tactics.Typeclasses.fst"
-                                      (Prims.of_int (194))
+                                      (Prims.of_int (195))
                                       (Prims.of_int (30))
-                                      (Prims.of_int (194))
+                                      (Prims.of_int (195))
                                       (Prims.of_int (46)))))
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "FStar.Tactics.Typeclasses.fst"
-                                      (Prims.of_int (194))
+                                      (Prims.of_int (195))
                                       (Prims.of_int (20))
-                                      (Prims.of_int (194))
+                                      (Prims.of_int (195))
                                       (Prims.of_int (47)))))
                              (Obj.magic (mk_abs bs1 body))
                              (fun uu___ ->
@@ -1391,12 +1358,12 @@ let (mk_class :
       (FStar_Sealed.seal
          (Obj.magic
             (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-               (Prims.of_int (218)) (Prims.of_int (13)) (Prims.of_int (218))
+               (Prims.of_int (219)) (Prims.of_int (13)) (Prims.of_int (219))
                (Prims.of_int (26)))))
       (FStar_Sealed.seal
          (Obj.magic
             (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-               (Prims.of_int (218)) (Prims.of_int (29)) (Prims.of_int (308))
+               (Prims.of_int (219)) (Prims.of_int (29)) (Prims.of_int (309))
                (Prims.of_int (5)))))
       (FStar_Tactics_Effect.lift_div_tac
          (fun uu___ -> FStar_Reflection_V2_Builtins.explode_qn nm))
@@ -1407,27 +1374,27 @@ let (mk_class :
                  (FStar_Sealed.seal
                     (Obj.magic
                        (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-                          (Prims.of_int (219)) (Prims.of_int (12))
-                          (Prims.of_int (219)) (Prims.of_int (38)))))
+                          (Prims.of_int (220)) (Prims.of_int (12))
+                          (Prims.of_int (220)) (Prims.of_int (38)))))
                  (FStar_Sealed.seal
                     (Obj.magic
                        (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-                          (Prims.of_int (220)) (Prims.of_int (4))
-                          (Prims.of_int (308)) (Prims.of_int (5)))))
+                          (Prims.of_int (221)) (Prims.of_int (4))
+                          (Prims.of_int (309)) (Prims.of_int (5)))))
                  (Obj.magic
                     (FStar_Tactics_Effect.tac_bind
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range
                                 "FStar.Tactics.Typeclasses.fst"
-                                (Prims.of_int (219)) (Prims.of_int (23))
-                                (Prims.of_int (219)) (Prims.of_int (35)))))
+                                (Prims.of_int (220)) (Prims.of_int (23))
+                                (Prims.of_int (220)) (Prims.of_int (35)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range
                                 "FStar.Tactics.Typeclasses.fst"
-                                (Prims.of_int (219)) (Prims.of_int (12))
-                                (Prims.of_int (219)) (Prims.of_int (38)))))
+                                (Prims.of_int (220)) (Prims.of_int (12))
+                                (Prims.of_int (220)) (Prims.of_int (38)))))
                        (Obj.magic (FStar_Tactics_V2_Builtins.top_env ()))
                        (fun uu___ ->
                           FStar_Tactics_Effect.lift_div_tac
@@ -1442,14 +1409,14 @@ let (mk_class :
                                (Obj.magic
                                   (FStar_Range.mk_range
                                      "FStar.Tactics.Typeclasses.fst"
-                                     (Prims.of_int (220)) (Prims.of_int (4))
-                                     (Prims.of_int (220)) (Prims.of_int (19)))))
+                                     (Prims.of_int (221)) (Prims.of_int (4))
+                                     (Prims.of_int (221)) (Prims.of_int (19)))))
                             (FStar_Sealed.seal
                                (Obj.magic
                                   (FStar_Range.mk_range
                                      "FStar.Tactics.Typeclasses.fst"
-                                     (Prims.of_int (220)) (Prims.of_int (20))
-                                     (Prims.of_int (308)) (Prims.of_int (5)))))
+                                     (Prims.of_int (221)) (Prims.of_int (20))
+                                     (Prims.of_int (309)) (Prims.of_int (5)))))
                             (Obj.magic
                                (FStar_Tactics_V2_Derived.guard
                                   (FStar_Pervasives_Native.uu___is_Some r)))
@@ -1461,17 +1428,17 @@ let (mk_class :
                                           (Obj.magic
                                              (FStar_Range.mk_range
                                                 "FStar.Tactics.Typeclasses.fst"
-                                                (Prims.of_int (221))
+                                                (Prims.of_int (222))
                                                 (Prims.of_int (18))
-                                                (Prims.of_int (221))
+                                                (Prims.of_int (222))
                                                 (Prims.of_int (19)))))
                                        (FStar_Sealed.seal
                                           (Obj.magic
                                              (FStar_Range.mk_range
                                                 "FStar.Tactics.Typeclasses.fst"
-                                                (Prims.of_int (220))
+                                                (Prims.of_int (221))
                                                 (Prims.of_int (20))
-                                                (Prims.of_int (308))
+                                                (Prims.of_int (309))
                                                 (Prims.of_int (5)))))
                                        (FStar_Tactics_Effect.lift_div_tac
                                           (fun uu___1 -> r))
@@ -1486,17 +1453,17 @@ let (mk_class :
                                                          (Obj.magic
                                                             (FStar_Range.mk_range
                                                                "FStar.Tactics.Typeclasses.fst"
-                                                               (Prims.of_int (222))
+                                                               (Prims.of_int (223))
                                                                (Prims.of_int (23))
-                                                               (Prims.of_int (222))
+                                                               (Prims.of_int (223))
                                                                (Prims.of_int (115)))))
                                                       (FStar_Sealed.seal
                                                          (Obj.magic
                                                             (FStar_Range.mk_range
                                                                "FStar.Tactics.Typeclasses.fst"
-                                                               (Prims.of_int (222))
+                                                               (Prims.of_int (223))
                                                                (Prims.of_int (118))
-                                                               (Prims.of_int (308))
+                                                               (Prims.of_int (309))
                                                                (Prims.of_int (5)))))
                                                       (FStar_Tactics_Effect.lift_div_tac
                                                          (fun uu___2 ->
@@ -1521,18 +1488,18 @@ let (mk_class :
                                                                     Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (223))
+                                                                    (Prims.of_int (224))
                                                                     (Prims.of_int (13))
-                                                                    (Prims.of_int (223))
+                                                                    (Prims.of_int (224))
                                                                     (Prims.of_int (30)))))
                                                                  (FStar_Sealed.seal
                                                                     (
                                                                     Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (224))
+                                                                    (Prims.of_int (225))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (308))
+                                                                    (Prims.of_int (309))
                                                                     (Prims.of_int (5)))))
                                                                  (Obj.magic
                                                                     (
@@ -1548,17 +1515,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (224))
+                                                                    (Prims.of_int (225))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (224))
+                                                                    (Prims.of_int (225))
                                                                     (Prims.of_int (28)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (224))
+                                                                    (Prims.of_int (225))
                                                                     (Prims.of_int (29))
-                                                                    (Prims.of_int (308))
+                                                                    (Prims.of_int (309))
                                                                     (Prims.of_int (5)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Derived.guard
@@ -1574,17 +1541,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (225))
+                                                                    (Prims.of_int (226))
                                                                     (Prims.of_int (63))
-                                                                    (Prims.of_int (225))
+                                                                    (Prims.of_int (226))
                                                                     (Prims.of_int (65)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (224))
+                                                                    (Prims.of_int (225))
                                                                     (Prims.of_int (29))
-                                                                    (Prims.of_int (308))
+                                                                    (Prims.of_int (309))
                                                                     (Prims.of_int (5)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1616,17 +1583,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (226))
+                                                                    (Prims.of_int (227))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (226))
+                                                                    (Prims.of_int (227))
                                                                     (Prims.of_int (87)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (227))
+                                                                    (Prims.of_int (228))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (308))
+                                                                    (Prims.of_int (309))
                                                                     (Prims.of_int (5)))))
                                                                     (Obj.magic
                                                                     (debug
@@ -1637,9 +1604,9 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (226))
+                                                                    (Prims.of_int (227))
                                                                     (Prims.of_int (35))
-                                                                    (Prims.of_int (226))
+                                                                    (Prims.of_int (227))
                                                                     (Prims.of_int (86)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -1671,17 +1638,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (227))
+                                                                    (Prims.of_int (228))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (227))
+                                                                    (Prims.of_int (228))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (228))
+                                                                    (Prims.of_int (229))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (308))
+                                                                    (Prims.of_int (309))
                                                                     (Prims.of_int (5)))))
                                                                     (Obj.magic
                                                                     (debug
@@ -1708,17 +1675,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (228))
+                                                                    (Prims.of_int (229))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (228))
+                                                                    (Prims.of_int (229))
                                                                     (Prims.of_int (59)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (228))
+                                                                    (Prims.of_int (229))
                                                                     (Prims.of_int (60))
-                                                                    (Prims.of_int (308))
+                                                                    (Prims.of_int (309))
                                                                     (Prims.of_int (5)))))
                                                                     (Obj.magic
                                                                     (debug
@@ -1729,9 +1696,9 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (228))
+                                                                    (Prims.of_int (229))
                                                                     (Prims.of_int (40))
-                                                                    (Prims.of_int (228))
+                                                                    (Prims.of_int (229))
                                                                     (Prims.of_int (58)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -1762,17 +1729,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (229))
+                                                                    (Prims.of_int (230))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (229))
+                                                                    (Prims.of_int (230))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (231))
+                                                                    (Prims.of_int (232))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (308))
+                                                                    (Prims.of_int (309))
                                                                     (Prims.of_int (5)))))
                                                                     (Obj.magic
                                                                     (last
@@ -1788,17 +1755,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (231))
+                                                                    (Prims.of_int (232))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (231))
+                                                                    (Prims.of_int (232))
                                                                     (Prims.of_int (30)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (231))
+                                                                    (Prims.of_int (232))
                                                                     (Prims.of_int (31))
-                                                                    (Prims.of_int (308))
+                                                                    (Prims.of_int (309))
                                                                     (Prims.of_int (5)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Derived.guard
@@ -1815,17 +1782,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (232))
+                                                                    (Prims.of_int (233))
                                                                     (Prims.of_int (25))
-                                                                    (Prims.of_int (232))
+                                                                    (Prims.of_int (233))
                                                                     (Prims.of_int (30)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (231))
+                                                                    (Prims.of_int (232))
                                                                     (Prims.of_int (31))
-                                                                    (Prims.of_int (308))
+                                                                    (Prims.of_int (309))
                                                                     (Prims.of_int (5)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1847,17 +1814,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (233))
+                                                                    (Prims.of_int (234))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (233))
+                                                                    (Prims.of_int (234))
                                                                     (Prims.of_int (87)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (233))
+                                                                    (Prims.of_int (234))
                                                                     (Prims.of_int (88))
-                                                                    (Prims.of_int (308))
+                                                                    (Prims.of_int (309))
                                                                     (Prims.of_int (5)))))
                                                                     (Obj.magic
                                                                     (debug
@@ -1868,9 +1835,9 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (233))
+                                                                    (Prims.of_int (234))
                                                                     (Prims.of_int (35))
-                                                                    (Prims.of_int (233))
+                                                                    (Prims.of_int (234))
                                                                     (Prims.of_int (86)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -1886,9 +1853,9 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (233))
+                                                                    (Prims.of_int (234))
                                                                     (Prims.of_int (55))
-                                                                    (Prims.of_int (233))
+                                                                    (Prims.of_int (234))
                                                                     (Prims.of_int (86)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -1904,9 +1871,9 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (233))
+                                                                    (Prims.of_int (234))
                                                                     (Prims.of_int (69))
-                                                                    (Prims.of_int (233))
+                                                                    (Prims.of_int (234))
                                                                     (Prims.of_int (86)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -1960,17 +1927,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (234))
+                                                                    (Prims.of_int (235))
                                                                     (Prims.of_int (18))
-                                                                    (Prims.of_int (234))
+                                                                    (Prims.of_int (235))
                                                                     (Prims.of_int (35)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (233))
+                                                                    (Prims.of_int (234))
                                                                     (Prims.of_int (88))
-                                                                    (Prims.of_int (308))
+                                                                    (Prims.of_int (309))
                                                                     (Prims.of_int (5)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_SyntaxHelpers.collect_arr_bs
@@ -1992,17 +1959,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (235))
+                                                                    (Prims.of_int (236))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (235))
+                                                                    (Prims.of_int (236))
                                                                     (Prims.of_int (28)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (236))
+                                                                    (Prims.of_int (237))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (308))
+                                                                    (Prims.of_int (309))
                                                                     (Prims.of_int (5)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2021,17 +1988,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (236))
+                                                                    (Prims.of_int (237))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (236))
+                                                                    (Prims.of_int (237))
                                                                     (Prims.of_int (22)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (236))
+                                                                    (Prims.of_int (237))
                                                                     (Prims.of_int (23))
-                                                                    (Prims.of_int (308))
+                                                                    (Prims.of_int (309))
                                                                     (Prims.of_int (5)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Derived.guard
@@ -2049,17 +2016,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (237))
+                                                                    (Prims.of_int (238))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (237))
+                                                                    (Prims.of_int (238))
                                                                     (Prims.of_int (23)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (236))
+                                                                    (Prims.of_int (237))
                                                                     (Prims.of_int (23))
-                                                                    (Prims.of_int (308))
+                                                                    (Prims.of_int (309))
                                                                     (Prims.of_int (5)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2082,17 +2049,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (239))
+                                                                    (Prims.of_int (240))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (239))
+                                                                    (Prims.of_int (240))
                                                                     (Prims.of_int (87)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (240))
+                                                                    (Prims.of_int (241))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (308))
+                                                                    (Prims.of_int (309))
                                                                     (Prims.of_int (5)))))
                                                                     (Obj.magic
                                                                     (debug
@@ -2104,9 +2071,9 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (239))
+                                                                    (Prims.of_int (240))
                                                                     (Prims.of_int (35))
-                                                                    (Prims.of_int (239))
+                                                                    (Prims.of_int (240))
                                                                     (Prims.of_int (86)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -2142,17 +2109,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (240))
+                                                                    (Prims.of_int (241))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (240))
+                                                                    (Prims.of_int (241))
                                                                     (Prims.of_int (81)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (241))
+                                                                    (Prims.of_int (242))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (308))
+                                                                    (Prims.of_int (309))
                                                                     (Prims.of_int (5)))))
                                                                     (Obj.magic
                                                                     (debug
@@ -2185,17 +2152,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (241))
+                                                                    (Prims.of_int (242))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (241))
+                                                                    (Prims.of_int (242))
                                                                     (Prims.of_int (76)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (242))
+                                                                    (Prims.of_int (243))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (308))
+                                                                    (Prims.of_int (309))
                                                                     (Prims.of_int (5)))))
                                                                     (Obj.magic
                                                                     (debug
@@ -2228,17 +2195,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (242))
+                                                                    (Prims.of_int (243))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (242))
+                                                                    (Prims.of_int (243))
                                                                     (Prims.of_int (51)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (242))
+                                                                    (Prims.of_int (243))
                                                                     (Prims.of_int (52))
-                                                                    (Prims.of_int (308))
+                                                                    (Prims.of_int (309))
                                                                     (Prims.of_int (5)))))
                                                                     (Obj.magic
                                                                     (debug
@@ -2250,9 +2217,9 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (242))
+                                                                    (Prims.of_int (243))
                                                                     (Prims.of_int (32))
-                                                                    (Prims.of_int (242))
+                                                                    (Prims.of_int (243))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -2287,17 +2254,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (246))
+                                                                    (Prims.of_int (247))
                                                                     (Prims.of_int (24))
-                                                                    (Prims.of_int (246))
+                                                                    (Prims.of_int (247))
                                                                     (Prims.of_int (61)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (249))
+                                                                    (Prims.of_int (250))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (308))
+                                                                    (Prims.of_int (309))
                                                                     (Prims.of_int (5)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2321,17 +2288,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (251))
+                                                                    (Prims.of_int (252))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (251))
+                                                                    (Prims.of_int (252))
                                                                     (Prims.of_int (30)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (252))
+                                                                    (Prims.of_int (253))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (307))
+                                                                    (Prims.of_int (308))
                                                                     (Prims.of_int (8)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Derived.name_of_binder
@@ -2346,17 +2313,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (252))
+                                                                    (Prims.of_int (253))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (252))
+                                                                    (Prims.of_int (253))
                                                                     (Prims.of_int (48)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (252))
+                                                                    (Prims.of_int (253))
                                                                     (Prims.of_int (49))
-                                                                    (Prims.of_int (307))
+                                                                    (Prims.of_int (308))
                                                                     (Prims.of_int (8)))))
                                                                     (Obj.magic
                                                                     (debug
@@ -2387,17 +2354,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (253))
+                                                                    (Prims.of_int (254))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (253))
+                                                                    (Prims.of_int (254))
                                                                     (Prims.of_int (28)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (253))
+                                                                    (Prims.of_int (254))
                                                                     (Prims.of_int (31))
-                                                                    (Prims.of_int (307))
+                                                                    (Prims.of_int (308))
                                                                     (Prims.of_int (8)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Derived.cur_module
@@ -2413,17 +2380,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (254))
+                                                                    (Prims.of_int (255))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (254))
+                                                                    (Prims.of_int (255))
                                                                     (Prims.of_int (34)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (254))
+                                                                    (Prims.of_int (255))
                                                                     (Prims.of_int (37))
-                                                                    (Prims.of_int (307))
+                                                                    (Prims.of_int (308))
                                                                     (Prims.of_int (8)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2444,17 +2411,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (255))
+                                                                    (Prims.of_int (256))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (255))
+                                                                    (Prims.of_int (256))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (255))
+                                                                    (Prims.of_int (256))
                                                                     (Prims.of_int (41))
-                                                                    (Prims.of_int (307))
+                                                                    (Prims.of_int (308))
                                                                     (Prims.of_int (8)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Derived.fresh_namedv_named
@@ -2470,17 +2437,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (256))
+                                                                    (Prims.of_int (257))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (256))
+                                                                    (Prims.of_int (257))
                                                                     (Prims.of_int (28)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (256))
+                                                                    (Prims.of_int (257))
                                                                     (Prims.of_int (31))
-                                                                    (Prims.of_int (307))
+                                                                    (Prims.of_int (308))
                                                                     (Prims.of_int (8)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2504,17 +2471,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (258))
+                                                                    (Prims.of_int (259))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (263))
                                                                     (Prims.of_int (20)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (263))
+                                                                    (Prims.of_int (264))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (307))
+                                                                    (Prims.of_int (308))
                                                                     (Prims.of_int (8)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2522,17 +2489,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (260))
+                                                                    (Prims.of_int (261))
                                                                     (Prims.of_int (17))
-                                                                    (Prims.of_int (260))
+                                                                    (Prims.of_int (261))
                                                                     (Prims.of_int (24)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (258))
+                                                                    (Prims.of_int (259))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (263))
                                                                     (Prims.of_int (20)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Builtins.fresh
@@ -2571,17 +2538,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (264))
+                                                                    (Prims.of_int (265))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (264))
+                                                                    (Prims.of_int (265))
                                                                     (Prims.of_int (48)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (264))
+                                                                    (Prims.of_int (265))
                                                                     (Prims.of_int (51))
-                                                                    (Prims.of_int (307))
+                                                                    (Prims.of_int (308))
                                                                     (Prims.of_int (8)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2589,17 +2556,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (264))
+                                                                    (Prims.of_int (265))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (264))
+                                                                    (Prims.of_int (265))
                                                                     (Prims.of_int (35)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (264))
+                                                                    (Prims.of_int (265))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (264))
+                                                                    (Prims.of_int (265))
                                                                     (Prims.of_int (48)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Derived.cur_module
@@ -2628,17 +2595,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (265))
+                                                                    (Prims.of_int (266))
                                                                     (Prims.of_int (17))
-                                                                    (Prims.of_int (265))
+                                                                    (Prims.of_int (266))
                                                                     (Prims.of_int (51)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (265))
+                                                                    (Prims.of_int (266))
                                                                     (Prims.of_int (54))
-                                                                    (Prims.of_int (307))
+                                                                    (Prims.of_int (308))
                                                                     (Prims.of_int (8)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2659,17 +2626,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (268))
+                                                                    (Prims.of_int (269))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (273))
+                                                                    (Prims.of_int (274))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (274))
+                                                                    (Prims.of_int (275))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (307))
+                                                                    (Prims.of_int (308))
                                                                     (Prims.of_int (8)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2677,17 +2644,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (268))
+                                                                    (Prims.of_int (269))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (268))
+                                                                    (Prims.of_int (269))
                                                                     (Prims.of_int (47)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (268))
+                                                                    (Prims.of_int (269))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (273))
+                                                                    (Prims.of_int (274))
                                                                     (Prims.of_int (50)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2695,17 +2662,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (268))
+                                                                    (Prims.of_int (269))
                                                                     (Prims.of_int (25))
-                                                                    (Prims.of_int (268))
+                                                                    (Prims.of_int (269))
                                                                     (Prims.of_int (37)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (268))
+                                                                    (Prims.of_int (269))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (268))
+                                                                    (Prims.of_int (269))
                                                                     (Prims.of_int (47)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Builtins.top_env
@@ -2745,17 +2712,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (271))
+                                                                    (Prims.of_int (272))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (271))
+                                                                    (Prims.of_int (272))
                                                                     (Prims.of_int (33)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (271))
+                                                                    (Prims.of_int (272))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (273))
+                                                                    (Prims.of_int (274))
                                                                     (Prims.of_int (50)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_NamedView.inspect_sigelt
@@ -2802,17 +2769,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (277))
+                                                                    (Prims.of_int (278))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (284))
+                                                                    (Prims.of_int (285))
                                                                     (Prims.of_int (37)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (285))
+                                                                    (Prims.of_int (286))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (307))
+                                                                    (Prims.of_int (308))
                                                                     (Prims.of_int (8)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2820,17 +2787,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (278))
+                                                                    (Prims.of_int (279))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (278))
+                                                                    (Prims.of_int (279))
                                                                     (Prims.of_int (51)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (277))
+                                                                    (Prims.of_int (278))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (284))
+                                                                    (Prims.of_int (285))
                                                                     (Prims.of_int (37)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_SyntaxHelpers.collect_arr_bs
@@ -2852,17 +2819,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (279))
+                                                                    (Prims.of_int (280))
                                                                     (Prims.of_int (21))
-                                                                    (Prims.of_int (279))
+                                                                    (Prims.of_int (280))
                                                                     (Prims.of_int (75)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (278))
+                                                                    (Prims.of_int (279))
                                                                     (Prims.of_int (54))
-                                                                    (Prims.of_int (284))
+                                                                    (Prims.of_int (285))
                                                                     (Prims.of_int (37)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2901,17 +2868,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (283))
+                                                                    (Prims.of_int (284))
                                                                     (Prims.of_int (21))
-                                                                    (Prims.of_int (283))
+                                                                    (Prims.of_int (284))
                                                                     (Prims.of_int (43)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (284))
+                                                                    (Prims.of_int (285))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (284))
+                                                                    (Prims.of_int (285))
                                                                     (Prims.of_int (37)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2945,17 +2912,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (286))
+                                                                    (Prims.of_int (287))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (293))
+                                                                    (Prims.of_int (294))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (295))
+                                                                    (Prims.of_int (296))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (307))
+                                                                    (Prims.of_int (308))
                                                                     (Prims.of_int (8)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2963,17 +2930,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (287))
+                                                                    (Prims.of_int (288))
                                                                     (Prims.of_int (23))
-                                                                    (Prims.of_int (287))
+                                                                    (Prims.of_int (288))
                                                                     (Prims.of_int (49)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (286))
+                                                                    (Prims.of_int (287))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (293))
+                                                                    (Prims.of_int (294))
                                                                     (Prims.of_int (38)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_SyntaxHelpers.collect_abs
@@ -2995,17 +2962,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (288))
+                                                                    (Prims.of_int (289))
                                                                     (Prims.of_int (21))
-                                                                    (Prims.of_int (288))
+                                                                    (Prims.of_int (289))
                                                                     (Prims.of_int (75)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (287))
+                                                                    (Prims.of_int (288))
                                                                     (Prims.of_int (52))
-                                                                    (Prims.of_int (293))
+                                                                    (Prims.of_int (294))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3044,17 +3011,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (292))
+                                                                    (Prims.of_int (293))
                                                                     (Prims.of_int (21))
-                                                                    (Prims.of_int (292))
+                                                                    (Prims.of_int (293))
                                                                     (Prims.of_int (43)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (293))
+                                                                    (Prims.of_int (294))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (293))
+                                                                    (Prims.of_int (294))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3088,17 +3055,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (295))
+                                                                    (Prims.of_int (296))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (295))
+                                                                    (Prims.of_int (296))
                                                                     (Prims.of_int (53)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (296))
+                                                                    (Prims.of_int (297))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (307))
+                                                                    (Prims.of_int (308))
                                                                     (Prims.of_int (8)))))
                                                                     (Obj.magic
                                                                     (debug
@@ -3110,9 +3077,9 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (295))
+                                                                    (Prims.of_int (296))
                                                                     (Prims.of_int (34))
-                                                                    (Prims.of_int (295))
+                                                                    (Prims.of_int (296))
                                                                     (Prims.of_int (52)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -3147,17 +3114,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (296))
+                                                                    (Prims.of_int (297))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (296))
+                                                                    (Prims.of_int (297))
                                                                     (Prims.of_int (52)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (296))
+                                                                    (Prims.of_int (297))
                                                                     (Prims.of_int (53))
-                                                                    (Prims.of_int (307))
+                                                                    (Prims.of_int (308))
                                                                     (Prims.of_int (8)))))
                                                                     (Obj.magic
                                                                     (debug
@@ -3169,9 +3136,9 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (296))
+                                                                    (Prims.of_int (297))
                                                                     (Prims.of_int (34))
-                                                                    (Prims.of_int (296))
+                                                                    (Prims.of_int (297))
                                                                     (Prims.of_int (51)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -3206,17 +3173,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (298))
+                                                                    (Prims.of_int (299))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (298))
+                                                                    (Prims.of_int (299))
                                                                     (Prims.of_int (24)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (298))
+                                                                    (Prims.of_int (299))
                                                                     (Prims.of_int (27))
-                                                                    (Prims.of_int (307))
+                                                                    (Prims.of_int (308))
                                                                     (Prims.of_int (8)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3233,17 +3200,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (299))
+                                                                    (Prims.of_int (300))
                                                                     (Prims.of_int (23))
-                                                                    (Prims.of_int (299))
+                                                                    (Prims.of_int (300))
                                                                     (Prims.of_int (26)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (299))
+                                                                    (Prims.of_int (300))
                                                                     (Prims.of_int (29))
-                                                                    (Prims.of_int (307))
+                                                                    (Prims.of_int (308))
                                                                     (Prims.of_int (8)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3260,17 +3227,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (300))
+                                                                    (Prims.of_int (301))
                                                                     (Prims.of_int (21))
-                                                                    (Prims.of_int (300))
+                                                                    (Prims.of_int (301))
                                                                     (Prims.of_int (24)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (300))
+                                                                    (Prims.of_int (301))
                                                                     (Prims.of_int (27))
-                                                                    (Prims.of_int (307))
+                                                                    (Prims.of_int (308))
                                                                     (Prims.of_int (8)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3287,17 +3254,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (302))
+                                                                    (Prims.of_int (303))
                                                                     (Prims.of_int (17))
-                                                                    (Prims.of_int (302))
+                                                                    (Prims.of_int (303))
                                                                     (Prims.of_int (70)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (302))
+                                                                    (Prims.of_int (303))
                                                                     (Prims.of_int (75))
-                                                                    (Prims.of_int (307))
+                                                                    (Prims.of_int (308))
                                                                     (Prims.of_int (8)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3325,17 +3292,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (303))
+                                                                    (Prims.of_int (304))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (303))
+                                                                    (Prims.of_int (304))
                                                                     (Prims.of_int (59)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (305))
+                                                                    (Prims.of_int (306))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (305))
+                                                                    (Prims.of_int (306))
                                                                     (Prims.of_int (42)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_NamedView.pack_sigelt

--- a/tests/error-messages/Bug1918.fst.expected
+++ b/tests/error-messages/Bug1918.fst.expected
@@ -1,5 +1,5 @@
 proof-state: State dump @ depth 0 (at the time of failure):
-Location: FStar.Tactics.Typeclasses.fst(179,6-182,7)
+Location: FStar.Tactics.Typeclasses.fst(180,6-183,7)
 Goal 1/1:
  |- _ : Bug1918.mon
 
@@ -7,7 +7,7 @@ Goal 1/1:
 * Error 228 at Bug1918.fst(11,13-11,14):
   - Tactic failed
   - Could not solve constraint Bug1918.mon
-  - See also FStar.Tactics.Typeclasses.fst(179,6-182,7)
+  - See also FStar.Tactics.Typeclasses.fst(180,6-183,7)
 
 >>]
 Verified module: Bug1918

--- a/tests/typeclasses/Higher.fst
+++ b/tests/typeclasses/Higher.fst
@@ -1,0 +1,41 @@
+module Higher
+
+open FStar.Tactics.Typeclasses
+
+noeq
+type code =
+  | Eq : int -> int -> code
+  | ForallInt : (int -> code) -> code
+
+let rec interp (c : code) : prop =
+  match c with
+  | Eq x y -> x == y
+  | ForallInt p -> forall (x:int). interp (p x)
+
+class codeable (p : prop) = {
+  code_of : code;
+  pf : squash (interp code_of <==> p);
+}
+
+instance codeable_eq (x y : int) : codeable (x == y) = {
+  code_of = Eq x y;
+  pf = ();
+}
+
+instance codeable_forall
+  (p : int -> prop)
+  (d : (x:int) -> codeable (p x))
+: codeable (forall (x:int). p x) = {
+  code_of = ForallInt (fun x -> code_of #(p x) #(d x));
+  pf = ();
+}
+
+let encode (p : prop) {| codeable p |} : code = code_of #p
+
+let test0 = encode (1 == 1)
+let _ = assert (test0 == Eq 1 1)
+
+(* This example only works if the typeclass tactic introduces arrows,
+as there is an intermediate goal for the `d` of `codeable_forall` *)
+let test1 = encode (forall (x:int). x == x)
+let _ = assert_norm (test1 == ForallInt (fun x -> Eq x x))

--- a/ulib/FStar.Tactics.Typeclasses.fst
+++ b/ulib/FStar.Tactics.Typeclasses.fst
@@ -80,6 +80,15 @@ let rec first (f : 'a -> Tac 'b) (l : list 'a) : Tac 'b =
     | [] -> raise NoInst
     | x::xs -> (fun () -> f x) `or_else` (fun () -> first f xs)
 
+private
+let rec maybe_intros () : Tac unit =
+  let g = cur_goal () in
+  match inspect g with
+  | Tv_Arrow _ _ ->
+    ignore (intro ());
+    maybe_intros ()
+  | _ -> ()
+
 (*
  tcresolve': the main typeclass instantiation function.
 
@@ -97,6 +106,7 @@ let rec tcresolve' (seen : list term) (glb : list fv) (fuel : int) : Tac unit =
       raise NoInst;
     debug (fun () -> "fuel = " ^ string_of_int fuel);
 
+    maybe_intros();
     let g = cur_goal () in
 
     (* Try to detect loops *)
@@ -130,7 +140,7 @@ and global (head_fv : fv) (seen : list term) (glb : list fv) (fuel : int) () : T
           glb
 
 and trywith (head_fv : fv) (seen:list term) (glb : list fv) (fuel:int) (t typ : term) : Tac unit =
-    debug (fun () -> "trywith " ^ term_to_string t);
+    //debug (fun () -> "trywith " ^ term_to_string t);
     match head_of (res_typ typ) with
     | None ->
       debug (fun () -> "no head for typ of this? " ^ term_to_string t ^ "    typ=" ^ term_to_string typ);
@@ -143,18 +153,9 @@ and trywith (head_fv : fv) (seen:list term) (glb : list fv) (fuel:int) (t typ : 
           debug (fun () -> dump "next"; "apply seems to have worked");
           tcresolve' seen glb (fuel-1))
       ) else (
-        debug (fun () -> "different class: " ^ fv_to_string fv' ^ " <> " ^ fv_to_string head_fv);
+        //debug (fun () -> "different class: " ^ fv_to_string fv' ^ " <> " ^ fv_to_string head_fv);
         raise NoInst
       )
-
-private
-let rec maybe_intros () : Tac unit =
-  let g = cur_goal () in
-  match inspect g with
-  | Tv_Arrow _ _ ->
-    ignore (intro ());
-    maybe_intros ()
-  | _ -> ()
 
 [@@plugin]
 let tcresolve () : Tac unit =


### PR DESCRIPTION
This allows to define instances such as this one:
```fstar
instance codeable_forall
  (p : int -> prop)
  (d : (x:int) -> codeable (p x))
: codeable (forall (x:int). p x) = {
  code_of = ForallInt (fun x -> code_of #(p x) #(d x));
  pf = ();
}
```
which would previously not work as the `d` argument cannot be resolved as it is, but needs an intro instead. The tactic will now unconditionally introduce arrows. If this proves inconvenient, we could consider using an attribute to mark the arguments for which this should be done.

I think this can also be encoded by using a separate class for each arity, but it seems like a reasonable thing to do everywhere.