### PR TITLE
Functional dependencies for typeclasses

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_Tactics_Typeclasses.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Typeclasses.ml
@@ -67,11 +67,19 @@ let (__proj__Mkst_t__item__fuel : st_t -> Prims.int) =
 type tc_goal =
   {
   g: FStar_Tactics_NamedView.term ;
-  head_fv: FStar_Reflection_Types.fv }
+  head_fv: FStar_Reflection_Types.fv ;
+  args_and_uvars: (FStar_Reflection_V2_Data.argv * Prims.bool) Prims.list }
 let (__proj__Mktc_goal__item__g : tc_goal -> FStar_Tactics_NamedView.term) =
-  fun projectee -> match projectee with | { g; head_fv;_} -> g
+  fun projectee ->
+    match projectee with | { g; head_fv; args_and_uvars;_} -> g
 let (__proj__Mktc_goal__item__head_fv : tc_goal -> FStar_Reflection_Types.fv)
-  = fun projectee -> match projectee with | { g; head_fv;_} -> head_fv
+  =
+  fun projectee ->
+    match projectee with | { g; head_fv; args_and_uvars;_} -> head_fv
+let (__proj__Mktc_goal__item__args_and_uvars :
+  tc_goal -> (FStar_Reflection_V2_Data.argv * Prims.bool) Prims.list) =
+  fun projectee ->
+    match projectee with | { g; head_fv; args_and_uvars;_} -> args_and_uvars
 let (fv_eq :
   FStar_Reflection_Types.fv -> FStar_Reflection_Types.fv -> Prims.bool) =
   fun fv1 ->
@@ -88,12 +96,12 @@ let rec (head_of :
       (FStar_Sealed.seal
          (Obj.magic
             (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-               (Prims.of_int (71)) (Prims.of_int (8)) (Prims.of_int (71))
+               (Prims.of_int (76)) (Prims.of_int (8)) (Prims.of_int (76))
                (Prims.of_int (17)))))
       (FStar_Sealed.seal
          (Obj.magic
             (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-               (Prims.of_int (71)) (Prims.of_int (2)) (Prims.of_int (75))
+               (Prims.of_int (76)) (Prims.of_int (2)) (Prims.of_int (80))
                (Prims.of_int (13)))))
       (Obj.magic (FStar_Tactics_NamedView.inspect t))
       (fun uu___ ->
@@ -116,6 +124,55 @@ let rec (head_of :
                   (Obj.repr
                      (FStar_Tactics_Effect.lift_div_tac
                         (fun uu___1 -> FStar_Pervasives_Native.None)))) uu___)
+let (hua :
+  FStar_Tactics_NamedView.term ->
+    ((FStar_Reflection_Types.fv * FStar_Reflection_V2_Data.universes *
+       FStar_Reflection_V2_Data.argv Prims.list)
+       FStar_Pervasives_Native.option,
+      unit) FStar_Tactics_Effect.tac_repr)
+  =
+  fun t ->
+    FStar_Tactics_Effect.tac_bind
+      (FStar_Sealed.seal
+         (Obj.magic
+            (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
+               (Prims.of_int (83)) (Prims.of_int (17)) (Prims.of_int (83))
+               (Prims.of_int (30)))))
+      (FStar_Sealed.seal
+         (Obj.magic
+            (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
+               (Prims.of_int (82)) (Prims.of_int (62)) (Prims.of_int (87))
+               (Prims.of_int (13)))))
+      (Obj.magic (FStar_Tactics_V2_SyntaxHelpers.collect_app t))
+      (fun uu___ ->
+         (fun uu___ ->
+            match uu___ with
+            | (hd, args) ->
+                Obj.magic
+                  (FStar_Tactics_Effect.tac_bind
+                     (FStar_Sealed.seal
+                        (Obj.magic
+                           (FStar_Range.mk_range
+                              "FStar.Tactics.Typeclasses.fst"
+                              (Prims.of_int (84)) (Prims.of_int (8))
+                              (Prims.of_int (84)) (Prims.of_int (18)))))
+                     (FStar_Sealed.seal
+                        (Obj.magic
+                           (FStar_Range.mk_range
+                              "FStar.Tactics.Typeclasses.fst"
+                              (Prims.of_int (84)) (Prims.of_int (2))
+                              (Prims.of_int (87)) (Prims.of_int (13)))))
+                     (Obj.magic (FStar_Tactics_NamedView.inspect hd))
+                     (fun uu___1 ->
+                        FStar_Tactics_Effect.lift_div_tac
+                          (fun uu___2 ->
+                             match uu___1 with
+                             | FStar_Tactics_NamedView.Tv_FVar fv ->
+                                 FStar_Pervasives_Native.Some (fv, [], args)
+                             | FStar_Tactics_NamedView.Tv_UInst (fv, us) ->
+                                 FStar_Pervasives_Native.Some (fv, us, args)
+                             | uu___3 -> FStar_Pervasives_Native.None))))
+           uu___)
 let rec (res_typ :
   FStar_Tactics_NamedView.term ->
     (FStar_Tactics_NamedView.term, unit) FStar_Tactics_Effect.tac_repr)
@@ -125,12 +182,12 @@ let rec (res_typ :
       (FStar_Sealed.seal
          (Obj.magic
             (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-               (Prims.of_int (78)) (Prims.of_int (8)) (Prims.of_int (78))
+               (Prims.of_int (90)) (Prims.of_int (8)) (Prims.of_int (90))
                (Prims.of_int (17)))))
       (FStar_Sealed.seal
          (Obj.magic
             (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-               (Prims.of_int (78)) (Prims.of_int (2)) (Prims.of_int (84))
+               (Prims.of_int (90)) (Prims.of_int (2)) (Prims.of_int (96))
                (Prims.of_int (10)))))
       (Obj.magic (FStar_Tactics_NamedView.inspect t))
       (fun uu___ ->
@@ -176,12 +233,12 @@ let rec (maybe_intros : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
       (FStar_Sealed.seal
          (Obj.magic
             (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-               (Prims.of_int (99)) (Prims.of_int (10)) (Prims.of_int (99))
+               (Prims.of_int (111)) (Prims.of_int (10)) (Prims.of_int (111))
                (Prims.of_int (21)))))
       (FStar_Sealed.seal
          (Obj.magic
             (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-               (Prims.of_int (100)) (Prims.of_int (2)) (Prims.of_int (104))
+               (Prims.of_int (112)) (Prims.of_int (2)) (Prims.of_int (116))
                (Prims.of_int (11)))))
       (Obj.magic (FStar_Tactics_V2_Derived.cur_goal ()))
       (fun uu___1 ->
@@ -191,13 +248,13 @@ let rec (maybe_intros : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                  (FStar_Sealed.seal
                     (Obj.magic
                        (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-                          (Prims.of_int (100)) (Prims.of_int (8))
-                          (Prims.of_int (100)) (Prims.of_int (17)))))
+                          (Prims.of_int (112)) (Prims.of_int (8))
+                          (Prims.of_int (112)) (Prims.of_int (17)))))
                  (FStar_Sealed.seal
                     (Obj.magic
                        (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-                          (Prims.of_int (100)) (Prims.of_int (2))
-                          (Prims.of_int (104)) (Prims.of_int (11)))))
+                          (Prims.of_int (112)) (Prims.of_int (2))
+                          (Prims.of_int (116)) (Prims.of_int (11)))))
                  (Obj.magic (FStar_Tactics_NamedView.inspect g))
                  (fun uu___1 ->
                     (fun uu___1 ->
@@ -210,17 +267,17 @@ let rec (maybe_intros : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                       (Obj.magic
                                          (FStar_Range.mk_range
                                             "FStar.Tactics.Typeclasses.fst"
-                                            (Prims.of_int (102))
+                                            (Prims.of_int (114))
                                             (Prims.of_int (4))
-                                            (Prims.of_int (102))
+                                            (Prims.of_int (114))
                                             (Prims.of_int (21)))))
                                    (FStar_Sealed.seal
                                       (Obj.magic
                                          (FStar_Range.mk_range
                                             "FStar.Tactics.Typeclasses.fst"
-                                            (Prims.of_int (103))
+                                            (Prims.of_int (115))
                                             (Prims.of_int (4))
-                                            (Prims.of_int (103))
+                                            (Prims.of_int (115))
                                             (Prims.of_int (19)))))
                                    (Obj.magic
                                       (FStar_Tactics_Effect.tac_bind
@@ -228,17 +285,17 @@ let rec (maybe_intros : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                             (Obj.magic
                                                (FStar_Range.mk_range
                                                   "FStar.Tactics.Typeclasses.fst"
-                                                  (Prims.of_int (102))
+                                                  (Prims.of_int (114))
                                                   (Prims.of_int (11))
-                                                  (Prims.of_int (102))
+                                                  (Prims.of_int (114))
                                                   (Prims.of_int (21)))))
                                          (FStar_Sealed.seal
                                             (Obj.magic
                                                (FStar_Range.mk_range
                                                   "FStar.Tactics.Typeclasses.fst"
-                                                  (Prims.of_int (102))
+                                                  (Prims.of_int (114))
                                                   (Prims.of_int (4))
-                                                  (Prims.of_int (102))
+                                                  (Prims.of_int (114))
                                                   (Prims.of_int (21)))))
                                          (Obj.magic
                                             (FStar_Tactics_V2_Builtins.intro
@@ -266,331 +323,856 @@ let (sigelt_name :
     | FStar_Reflection_V2_Data.Sg_Val (nm, uu___, uu___1) ->
         [FStar_Reflection_V2_Builtins.pack_fv nm]
     | uu___ -> []
-let (trywith :
-  st_t ->
-    tc_goal ->
-      FStar_Reflection_Types.sigelt FStar_Pervasives_Native.option ->
-        FStar_Tactics_NamedView.term ->
-          FStar_Tactics_NamedView.term ->
-            (st_t -> (unit, unit) FStar_Tactics_Effect.tac_repr) ->
-              (unit, unit) FStar_Tactics_Effect.tac_repr)
+let (unembed_int :
+  FStar_Tactics_NamedView.term ->
+    (Prims.int FStar_Pervasives_Native.option, unit)
+      FStar_Tactics_Effect.tac_repr)
   =
-  fun st ->
-    fun g ->
-      fun uu___ ->
-        fun t ->
-          fun typ ->
-            fun k ->
-              FStar_Tactics_Effect.tac_bind
-                (FStar_Sealed.seal
-                   (Obj.magic
-                      (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-                         (Prims.of_int (117)) (Prims.of_int (10))
-                         (Prims.of_int (117)) (Prims.of_int (31)))))
-                (FStar_Sealed.seal
-                   (Obj.magic
-                      (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-                         (Prims.of_int (117)) (Prims.of_int (4))
-                         (Prims.of_int (130)) (Prims.of_int (13)))))
-                (Obj.magic
-                   (FStar_Tactics_Effect.tac_bind
-                      (FStar_Sealed.seal
-                         (Obj.magic
-                            (FStar_Range.mk_range
-                               "FStar.Tactics.Typeclasses.fst"
-                               (Prims.of_int (117)) (Prims.of_int (18))
-                               (Prims.of_int (117)) (Prims.of_int (31)))))
-                      (FStar_Sealed.seal
-                         (Obj.magic
-                            (FStar_Range.mk_range
-                               "FStar.Tactics.Typeclasses.fst"
-                               (Prims.of_int (117)) (Prims.of_int (10))
-                               (Prims.of_int (117)) (Prims.of_int (31)))))
-                      (Obj.magic (res_typ typ))
-                      (fun uu___1 ->
-                         (fun uu___1 -> Obj.magic (head_of uu___1)) uu___1)))
-                (fun uu___1 ->
-                   (fun uu___1 ->
-                      match uu___1 with
-                      | FStar_Pervasives_Native.None ->
-                          Obj.magic
+  fun uu___ ->
+    (fun t ->
+       Obj.magic
+         (FStar_Tactics_Effect.lift_div_tac
+            (fun uu___ ->
+               match FStar_Reflection_V2_Builtins.inspect_ln t with
+               | FStar_Reflection_V2_Data.Tv_Const
+                   (FStar_Reflection_V2_Data.C_Int i) ->
+                   FStar_Pervasives_Native.Some i
+               | uu___1 -> FStar_Pervasives_Native.None))) uu___
+let rec unembed_list :
+  'a .
+    (FStar_Tactics_NamedView.term ->
+       ('a FStar_Pervasives_Native.option, unit)
+         FStar_Tactics_Effect.tac_repr)
+      ->
+      FStar_Tactics_NamedView.term ->
+        ('a Prims.list FStar_Pervasives_Native.option, unit)
+          FStar_Tactics_Effect.tac_repr
+  =
+  fun u ->
+    fun t ->
+      FStar_Tactics_Effect.tac_bind
+        (FStar_Sealed.seal
+           (Obj.magic
+              (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
+                 (Prims.of_int (135)) (Prims.of_int (8)) (Prims.of_int (135))
+                 (Prims.of_int (13)))))
+        (FStar_Sealed.seal
+           (Obj.magic
+              (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
+                 (Prims.of_int (135)) (Prims.of_int (2)) (Prims.of_int (149))
+                 (Prims.of_int (8))))) (Obj.magic (hua t))
+        (fun uu___ ->
+           (fun uu___ ->
+              match uu___ with
+              | FStar_Pervasives_Native.Some
+                  (fv, uu___1,
+                   (ty, FStar_Reflection_V2_Data.Q_Implicit)::(hd,
+                                                               FStar_Reflection_V2_Data.Q_Explicit)::
+                   (tl, FStar_Reflection_V2_Data.Q_Explicit)::[])
+                  ->
+                  Obj.magic
+                    (Obj.repr
+                       (if
+                          (FStar_Reflection_V2_Builtins.implode_qn
+                             (FStar_Reflection_V2_Builtins.inspect_fv fv))
+                            = "Prims.Cons"
+                        then
+                          Obj.repr
                             (FStar_Tactics_Effect.tac_bind
                                (FStar_Sealed.seal
                                   (Obj.magic
                                      (FStar_Range.mk_range
                                         "FStar.Tactics.Typeclasses.fst"
-                                        (Prims.of_int (119))
-                                        (Prims.of_int (6))
-                                        (Prims.of_int (119))
-                                        (Prims.of_int (104)))))
+                                        (Prims.of_int (138))
+                                        (Prims.of_int (12))
+                                        (Prims.of_int (138))
+                                        (Prims.of_int (35)))))
                                (FStar_Sealed.seal
                                   (Obj.magic
                                      (FStar_Range.mk_range
                                         "FStar.Tactics.Typeclasses.fst"
-                                        (Prims.of_int (120))
+                                        (Prims.of_int (138))
                                         (Prims.of_int (6))
-                                        (Prims.of_int (120))
-                                        (Prims.of_int (18)))))
+                                        (Prims.of_int (140))
+                                        (Prims.of_int (17)))))
                                (Obj.magic
-                                  (debug
+                                  (FStar_Tactics_Effect.tac_bind
+                                     (FStar_Sealed.seal
+                                        (Obj.magic
+                                           (FStar_Range.mk_range
+                                              "FStar.Tactics.Typeclasses.fst"
+                                              (Prims.of_int (138))
+                                              (Prims.of_int (12))
+                                              (Prims.of_int (138))
+                                              (Prims.of_int (16)))))
+                                     (FStar_Sealed.seal
+                                        (Obj.magic
+                                           (FStar_Range.mk_range
+                                              "FStar.Tactics.Typeclasses.fst"
+                                              (Prims.of_int (138))
+                                              (Prims.of_int (12))
+                                              (Prims.of_int (138))
+                                              (Prims.of_int (35)))))
+                                     (Obj.magic (u hd))
                                      (fun uu___2 ->
-                                        FStar_Tactics_Effect.tac_bind
-                                          (FStar_Sealed.seal
-                                             (Obj.magic
-                                                (FStar_Range.mk_range
-                                                   "FStar.Tactics.Typeclasses.fst"
-                                                   (Prims.of_int (119))
-                                                   (Prims.of_int (53))
-                                                   (Prims.of_int (119))
-                                                   (Prims.of_int (103)))))
-                                          (FStar_Sealed.seal
-                                             (Obj.magic
-                                                (FStar_Range.mk_range
-                                                   "prims.fst"
-                                                   (Prims.of_int (590))
-                                                   (Prims.of_int (19))
-                                                   (Prims.of_int (590))
-                                                   (Prims.of_int (31)))))
-                                          (Obj.magic
+                                        (fun uu___2 ->
+                                           Obj.magic
                                              (FStar_Tactics_Effect.tac_bind
                                                 (FStar_Sealed.seal
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "FStar.Tactics.Typeclasses.fst"
-                                                         (Prims.of_int (119))
-                                                         (Prims.of_int (53))
-                                                         (Prims.of_int (119))
-                                                         (Prims.of_int (69)))))
+                                                         (Prims.of_int (138))
+                                                         (Prims.of_int (18))
+                                                         (Prims.of_int (138))
+                                                         (Prims.of_int (35)))))
                                                 (FStar_Sealed.seal
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "FStar.Tactics.Typeclasses.fst"
-                                                         (Prims.of_int (119))
-                                                         (Prims.of_int (53))
-                                                         (Prims.of_int (119))
-                                                         (Prims.of_int (103)))))
+                                                         (Prims.of_int (138))
+                                                         (Prims.of_int (12))
+                                                         (Prims.of_int (138))
+                                                         (Prims.of_int (35)))))
                                                 (Obj.magic
-                                                   (FStar_Tactics_V2_Builtins.term_to_string
-                                                      t))
+                                                   (unembed_list u tl))
                                                 (fun uu___3 ->
-                                                   (fun uu___3 ->
-                                                      Obj.magic
-                                                        (FStar_Tactics_Effect.tac_bind
-                                                           (FStar_Sealed.seal
-                                                              (Obj.magic
-                                                                 (FStar_Range.mk_range
-                                                                    "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (119))
-                                                                    (Prims.of_int (72))
-                                                                    (Prims.of_int (119))
-                                                                    (Prims.of_int (103)))))
-                                                           (FStar_Sealed.seal
-                                                              (Obj.magic
-                                                                 (FStar_Range.mk_range
-                                                                    "prims.fst"
-                                                                    (Prims.of_int (590))
-                                                                    (Prims.of_int (19))
-                                                                    (Prims.of_int (590))
-                                                                    (Prims.of_int (31)))))
-                                                           (Obj.magic
-                                                              (FStar_Tactics_Effect.tac_bind
-                                                                 (FStar_Sealed.seal
-                                                                    (
-                                                                    Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (119))
-                                                                    (Prims.of_int (85))
-                                                                    (Prims.of_int (119))
-                                                                    (Prims.of_int (103)))))
-                                                                 (FStar_Sealed.seal
-                                                                    (
-                                                                    Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "prims.fst"
-                                                                    (Prims.of_int (590))
-                                                                    (Prims.of_int (19))
-                                                                    (Prims.of_int (590))
-                                                                    (Prims.of_int (31)))))
-                                                                 (Obj.magic
-                                                                    (
-                                                                    FStar_Tactics_V2_Builtins.term_to_string
-                                                                    typ))
-                                                                 (fun uu___4
-                                                                    ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___5 ->
-                                                                    Prims.strcat
-                                                                    "    typ="
-                                                                    uu___4))))
-                                                           (fun uu___4 ->
-                                                              FStar_Tactics_Effect.lift_div_tac
-                                                                (fun uu___5
-                                                                   ->
-                                                                   Prims.strcat
-                                                                    uu___3
-                                                                    uu___4))))
-                                                     uu___3)))
-                                          (fun uu___3 ->
-                                             FStar_Tactics_Effect.lift_div_tac
-                                               (fun uu___4 ->
-                                                  Prims.strcat
-                                                    "no head for typ of this? "
-                                                    uu___3)))))
+                                                   FStar_Tactics_Effect.lift_div_tac
+                                                     (fun uu___4 ->
+                                                        (uu___2, uu___3)))))
+                                          uu___2)))
                                (fun uu___2 ->
-                                  FStar_Tactics_Effect.raise NoInst))
-                      | FStar_Pervasives_Native.Some fv' ->
-                          Obj.magic
-                            (FStar_Tactics_Effect.tac_bind
-                               (FStar_Sealed.seal
-                                  (Obj.magic
-                                     (FStar_Range.mk_range
-                                        "FStar.Tactics.Typeclasses.fst"
-                                        (Prims.of_int (122))
-                                        (Prims.of_int (6))
-                                        (Prims.of_int (123))
-                                        (Prims.of_int (20)))))
-                               (FStar_Sealed.seal
-                                  (Obj.magic
-                                     (FStar_Range.mk_range
-                                        "FStar.Tactics.Typeclasses.fst"
-                                        (Prims.of_int (124))
-                                        (Prims.of_int (6))
-                                        (Prims.of_int (130))
-                                        (Prims.of_int (13)))))
-                               (if Prims.op_Negation (fv_eq fv' g.head_fv)
-                                then FStar_Tactics_Effect.raise NoInst
-                                else
                                   FStar_Tactics_Effect.lift_div_tac
-                                    (fun uu___3 -> ()))
-                               (fun uu___2 ->
-                                  (fun uu___2 ->
-                                     Obj.magic
+                                    (fun uu___3 ->
+                                       match uu___2 with
+                                       | (FStar_Pervasives_Native.Some hd1,
+                                          FStar_Pervasives_Native.Some tl1)
+                                           ->
+                                           FStar_Pervasives_Native.Some (hd1
+                                             :: tl1)
+                                       | uu___4 ->
+                                           FStar_Pervasives_Native.None)))
+                        else
+                          Obj.repr
+                            (FStar_Tactics_Effect.lift_div_tac
+                               (fun uu___3 -> FStar_Pervasives_Native.None))))
+              | FStar_Pervasives_Native.Some
+                  (fv, uu___1, (ty, FStar_Reflection_V2_Data.Q_Implicit)::[])
+                  ->
+                  Obj.magic
+                    (Obj.repr
+                       (FStar_Tactics_Effect.lift_div_tac
+                          (fun uu___2 ->
+                             if
+                               (FStar_Reflection_V2_Builtins.implode_qn
+                                  (FStar_Reflection_V2_Builtins.inspect_fv fv))
+                                 = "Prims.Nil"
+                             then FStar_Pervasives_Native.Some []
+                             else FStar_Pervasives_Native.None)))
+              | uu___1 ->
+                  Obj.magic
+                    (Obj.repr
+                       (FStar_Tactics_Effect.lift_div_tac
+                          (fun uu___2 -> FStar_Pervasives_Native.None))))
+             uu___)
+let (extract_fundep :
+  FStar_Reflection_Types.sigelt ->
+    (Prims.int Prims.list FStar_Pervasives_Native.option, unit)
+      FStar_Tactics_Effect.tac_repr)
+  =
+  fun se ->
+    FStar_Tactics_Effect.tac_bind
+      (FStar_Sealed.seal
+         (Obj.magic
+            (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
+               (Prims.of_int (152)) (Prims.of_int (14)) (Prims.of_int (152))
+               (Prims.of_int (29)))))
+      (FStar_Sealed.seal
+         (Obj.magic
+            (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
+               (Prims.of_int (152)) (Prims.of_int (32)) (Prims.of_int (166))
+               (Prims.of_int (13)))))
+      (FStar_Tactics_Effect.lift_div_tac
+         (fun uu___ -> FStar_Reflection_V2_Builtins.sigelt_attrs se))
+      (fun uu___ ->
+         (fun attrs ->
+            let rec aux uu___ =
+              (fun attrs1 ->
+                 match attrs1 with
+                 | [] ->
+                     Obj.magic
+                       (Obj.repr
+                          (FStar_Tactics_Effect.lift_div_tac
+                             (fun uu___ -> FStar_Pervasives_Native.None)))
+                 | attr::attrs' ->
+                     Obj.magic
+                       (Obj.repr
+                          (FStar_Tactics_Effect.tac_bind
+                             (FStar_Sealed.seal
+                                (Obj.magic
+                                   (FStar_Range.mk_range
+                                      "FStar.Tactics.Typeclasses.fst"
+                                      (Prims.of_int (157))
+                                      (Prims.of_int (12))
+                                      (Prims.of_int (157))
+                                      (Prims.of_int (28)))))
+                             (FStar_Sealed.seal
+                                (Obj.magic
+                                   (FStar_Range.mk_range
+                                      "FStar.Tactics.Typeclasses.fst"
+                                      (Prims.of_int (157))
+                                      (Prims.of_int (12))
+                                      (Prims.of_int (157))
+                                      (Prims.of_int (28)))))
+                             (Obj.magic
+                                (FStar_Tactics_V2_SyntaxHelpers.collect_app
+                                   attr))
+                             (fun uu___ ->
+                                (fun uu___ ->
+                                   match uu___ with
+                                   | (hd,
+                                      (a0,
+                                       FStar_Reflection_V2_Data.Q_Explicit)::[])
+                                       ->
+                                       if
+                                         FStar_Reflection_V2_TermEq.term_eq
+                                           hd
+                                           (FStar_Reflection_V2_Builtins.pack_ln
+                                              (FStar_Reflection_V2_Data.Tv_FVar
+                                                 (FStar_Reflection_V2_Builtins.pack_fv
+                                                    ["FStar";
+                                                    "Tactics";
+                                                    "Typeclasses";
+                                                    "fundeps"])))
+                                       then
+                                         Obj.magic
+                                           (unembed_list unembed_int a0)
+                                       else Obj.magic (aux attrs')
+                                   | uu___1 -> Obj.magic (aux attrs')) uu___))))
+                uu___ in
+            Obj.magic (aux attrs)) uu___)
+let (trywith :
+  st_t ->
+    tc_goal ->
+      FStar_Tactics_NamedView.term ->
+        FStar_Tactics_NamedView.term ->
+          (st_t -> (unit, unit) FStar_Tactics_Effect.tac_repr) ->
+            (unit, unit) FStar_Tactics_Effect.tac_repr)
+  =
+  fun st ->
+    fun g ->
+      fun t ->
+        fun typ ->
+          fun k ->
+            FStar_Tactics_Effect.tac_bind
+              (FStar_Sealed.seal
+                 (Obj.magic
+                    (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
+                       (Prims.of_int (170)) (Prims.of_int (15))
+                       (Prims.of_int (170)) (Prims.of_int (60)))))
+              (FStar_Sealed.seal
+                 (Obj.magic
+                    (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
+                       (Prims.of_int (170)) (Prims.of_int (63))
+                       (Prims.of_int (204)) (Prims.of_int (13)))))
+              (Obj.magic
+                 (FStar_Tactics_Effect.tac_bind
+                    (FStar_Sealed.seal
+                       (Obj.magic
+                          (FStar_Range.mk_range
+                             "FStar.Tactics.Typeclasses.fst"
+                             (Prims.of_int (170)) (Prims.of_int (26))
+                             (Prims.of_int (170)) (Prims.of_int (37)))))
+                    (FStar_Sealed.seal
+                       (Obj.magic
+                          (FStar_Range.mk_range
+                             "FStar.Tactics.Typeclasses.fst"
+                             (Prims.of_int (170)) (Prims.of_int (15))
+                             (Prims.of_int (170)) (Prims.of_int (60)))))
+                    (Obj.magic (FStar_Tactics_V2_Derived.cur_env ()))
+                    (fun uu___ ->
+                       FStar_Tactics_Effect.lift_div_tac
+                         (fun uu___1 ->
+                            FStar_Reflection_V2_Builtins.lookup_typ uu___
+                              (FStar_Reflection_V2_Builtins.inspect_fv
+                                 g.head_fv)))))
+              (fun uu___ ->
+                 (fun c_se ->
+                    Obj.magic
+                      (FStar_Tactics_Effect.tac_bind
+                         (FStar_Sealed.seal
+                            (Obj.magic
+                               (FStar_Range.mk_range
+                                  "FStar.Tactics.Typeclasses.fst"
+                                  (Prims.of_int (172)) (Prims.of_int (6))
+                                  (Prims.of_int (175)) (Prims.of_int (20)))))
+                         (FStar_Sealed.seal
+                            (Obj.magic
+                               (FStar_Range.mk_range
+                                  "FStar.Tactics.Typeclasses.fst"
+                                  (Prims.of_int (176)) (Prims.of_int (6))
+                                  (Prims.of_int (204)) (Prims.of_int (13)))))
+                         (match c_se with
+                          | FStar_Pervasives_Native.Some se ->
+                              Obj.magic (Obj.repr (extract_fundep se))
+                          | FStar_Pervasives_Native.None ->
+                              Obj.magic
+                                (Obj.repr
+                                   (FStar_Tactics_Effect.lift_div_tac
+                                      (fun uu___ ->
+                                         FStar_Pervasives_Native.None))))
+                         (fun uu___ ->
+                            (fun fundeps ->
+                               Obj.magic
+                                 (FStar_Tactics_Effect.tac_bind
+                                    (FStar_Sealed.seal
+                                       (Obj.magic
+                                          (FStar_Range.mk_range
+                                             "FStar.Tactics.Typeclasses.fst"
+                                             (Prims.of_int (179))
+                                             (Prims.of_int (26))
+                                             (Prims.of_int (179))
+                                             (Prims.of_int (122)))))
+                                    (FStar_Sealed.seal
+                                       (Obj.magic
+                                          (FStar_Range.mk_range
+                                             "FStar.Tactics.Typeclasses.fst"
+                                             (Prims.of_int (182))
+                                             (Prims.of_int (4))
+                                             (Prims.of_int (204))
+                                             (Prims.of_int (13)))))
+                                    (Obj.magic
                                        (FStar_Tactics_Effect.tac_bind
                                           (FStar_Sealed.seal
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "FStar.Tactics.Typeclasses.fst"
-                                                   (Prims.of_int (124))
-                                                   (Prims.of_int (6))
-                                                   (Prims.of_int (124))
-                                                   (Prims.of_int (82)))))
+                                                   (Prims.of_int (179))
+                                                   (Prims.of_int (26))
+                                                   (Prims.of_int (179))
+                                                   (Prims.of_int (102)))))
                                           (FStar_Sealed.seal
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "FStar.Tactics.Typeclasses.fst"
-                                                   (Prims.of_int (125))
-                                                   (Prims.of_int (6))
-                                                   (Prims.of_int (130))
-                                                   (Prims.of_int (13)))))
+                                                   (Prims.of_int (179))
+                                                   (Prims.of_int (26))
+                                                   (Prims.of_int (179))
+                                                   (Prims.of_int (122)))))
                                           (Obj.magic
-                                             (debug
-                                                (fun uu___3 ->
-                                                   FStar_Tactics_Effect.tac_bind
+                                             (FStar_Tactics_Util.mapi
+                                                (fun uu___1 ->
+                                                   fun uu___ ->
+                                                     (fun i ->
+                                                        fun uu___ ->
+                                                          Obj.magic
+                                                            (FStar_Tactics_Effect.lift_div_tac
+                                                               (fun uu___1 ->
+                                                                  match uu___
+                                                                  with
+                                                                  | (uu___2,
+                                                                    b) ->
+                                                                    if b
+                                                                    then [i]
+                                                                    else [])))
+                                                       uu___1 uu___)
+                                                g.args_and_uvars))
+                                          (fun uu___ ->
+                                             FStar_Tactics_Effect.lift_div_tac
+                                               (fun uu___1 ->
+                                                  FStar_List_Tot_Base.flatten
+                                                    uu___))))
+                                    (fun uu___ ->
+                                       (fun unresolved_args ->
+                                          Obj.magic
+                                            (FStar_Tactics_Effect.tac_bind
+                                               (FStar_Sealed.seal
+                                                  (Obj.magic
+                                                     (FStar_Range.mk_range
+                                                        "FStar.Tactics.Typeclasses.fst"
+                                                        (Prims.of_int (182))
+                                                        (Prims.of_int (10))
+                                                        (Prims.of_int (182))
+                                                        (Prims.of_int (31)))))
+                                               (FStar_Sealed.seal
+                                                  (Obj.magic
+                                                     (FStar_Range.mk_range
+                                                        "FStar.Tactics.Typeclasses.fst"
+                                                        (Prims.of_int (182))
+                                                        (Prims.of_int (4))
+                                                        (Prims.of_int (204))
+                                                        (Prims.of_int (13)))))
+                                               (Obj.magic
+                                                  (FStar_Tactics_Effect.tac_bind
                                                      (FStar_Sealed.seal
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "FStar.Tactics.Typeclasses.fst"
-                                                              (Prims.of_int (124))
-                                                              (Prims.of_int (65))
-                                                              (Prims.of_int (124))
-                                                              (Prims.of_int (81)))))
+                                                              (Prims.of_int (182))
+                                                              (Prims.of_int (18))
+                                                              (Prims.of_int (182))
+                                                              (Prims.of_int (31)))))
                                                      (FStar_Sealed.seal
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
-                                                              "prims.fst"
-                                                              (Prims.of_int (590))
-                                                              (Prims.of_int (19))
-                                                              (Prims.of_int (590))
+                                                              "FStar.Tactics.Typeclasses.fst"
+                                                              (Prims.of_int (182))
+                                                              (Prims.of_int (10))
+                                                              (Prims.of_int (182))
                                                               (Prims.of_int (31)))))
-                                                     (Obj.magic
-                                                        (FStar_Tactics_V2_Builtins.term_to_string
-                                                           t))
-                                                     (fun uu___4 ->
-                                                        FStar_Tactics_Effect.lift_div_tac
-                                                          (fun uu___5 ->
-                                                             Prims.strcat
-                                                               "Trying to apply hypothesis/instance: "
-                                                               uu___4)))))
-                                          (fun uu___3 ->
-                                             (fun uu___3 ->
-                                                Obj.magic
-                                                  (FStar_Tactics_V2_Derived.seq
-                                                     (fun uu___4 ->
-                                                        FStar_Tactics_V2_Derived.apply_noinst
-                                                          t)
-                                                     (fun uu___4 ->
-                                                        FStar_Tactics_Effect.tac_bind
-                                                          (FStar_Sealed.seal
-                                                             (Obj.magic
-                                                                (FStar_Range.mk_range
-                                                                   "FStar.Tactics.Typeclasses.fst"
-                                                                   (Prims.of_int (128))
-                                                                   (Prims.of_int (8))
-                                                                   (Prims.of_int (128))
-                                                                   (Prims.of_int (67)))))
-                                                          (FStar_Sealed.seal
-                                                             (Obj.magic
-                                                                (FStar_Range.mk_range
-                                                                   "FStar.Tactics.Typeclasses.fst"
-                                                                   (Prims.of_int (128))
-                                                                   (Prims.of_int (68))
-                                                                   (Prims.of_int (130))
-                                                                   (Prims.of_int (12)))))
-                                                          (Obj.magic
-                                                             (debug
-                                                                (fun uu___5
-                                                                   ->
-                                                                   FStar_Tactics_Effect.tac_bind
+                                                     (Obj.magic (res_typ typ))
+                                                     (fun uu___ ->
+                                                        (fun uu___ ->
+                                                           Obj.magic
+                                                             (head_of uu___))
+                                                          uu___)))
+                                               (fun uu___ ->
+                                                  (fun uu___ ->
+                                                     match uu___ with
+                                                     | FStar_Pervasives_Native.None
+                                                         ->
+                                                         Obj.magic
+                                                           (FStar_Tactics_Effect.tac_bind
+                                                              (FStar_Sealed.seal
+                                                                 (Obj.magic
+                                                                    (
+                                                                    FStar_Range.mk_range
+                                                                    "FStar.Tactics.Typeclasses.fst"
+                                                                    (Prims.of_int (184))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (184))
+                                                                    (Prims.of_int (104)))))
+                                                              (FStar_Sealed.seal
+                                                                 (Obj.magic
+                                                                    (
+                                                                    FStar_Range.mk_range
+                                                                    "FStar.Tactics.Typeclasses.fst"
+                                                                    (Prims.of_int (185))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (185))
+                                                                    (Prims.of_int (18)))))
+                                                              (Obj.magic
+                                                                 (debug
+                                                                    (
+                                                                    fun
+                                                                    uu___1 ->
+                                                                    FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (128))
-                                                                    (Prims.of_int (25))
-                                                                    (Prims.of_int (128))
+                                                                    (Prims.of_int (184))
+                                                                    (Prims.of_int (53))
+                                                                    (Prims.of_int (184))
+                                                                    (Prims.of_int (103)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "prims.fst"
+                                                                    (Prims.of_int (590))
+                                                                    (Prims.of_int (19))
+                                                                    (Prims.of_int (590))
+                                                                    (Prims.of_int (31)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.Typeclasses.fst"
+                                                                    (Prims.of_int (184))
+                                                                    (Prims.of_int (53))
+                                                                    (Prims.of_int (184))
+                                                                    (Prims.of_int (69)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.Typeclasses.fst"
+                                                                    (Prims.of_int (184))
+                                                                    (Prims.of_int (53))
+                                                                    (Prims.of_int (184))
+                                                                    (Prims.of_int (103)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_V2_Builtins.term_to_string
+                                                                    t))
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.Typeclasses.fst"
+                                                                    (Prims.of_int (184))
+                                                                    (Prims.of_int (72))
+                                                                    (Prims.of_int (184))
+                                                                    (Prims.of_int (103)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "prims.fst"
+                                                                    (Prims.of_int (590))
+                                                                    (Prims.of_int (19))
+                                                                    (Prims.of_int (590))
+                                                                    (Prims.of_int (31)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.Typeclasses.fst"
+                                                                    (Prims.of_int (184))
+                                                                    (Prims.of_int (85))
+                                                                    (Prims.of_int (184))
+                                                                    (Prims.of_int (103)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "prims.fst"
+                                                                    (Prims.of_int (590))
+                                                                    (Prims.of_int (19))
+                                                                    (Prims.of_int (590))
+                                                                    (Prims.of_int (31)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_V2_Builtins.term_to_string
+                                                                    typ))
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___4 ->
+                                                                    Prims.strcat
+                                                                    "    typ="
+                                                                    uu___3))))
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___4 ->
+                                                                    Prims.strcat
+                                                                    uu___2
+                                                                    uu___3))))
+                                                                    uu___2)))
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    Prims.strcat
+                                                                    "no head for typ of this? "
+                                                                    uu___2)))))
+                                                              (fun uu___1 ->
+                                                                 FStar_Tactics_Effect.raise
+                                                                   NoInst))
+                                                     | FStar_Pervasives_Native.Some
+                                                         fv' ->
+                                                         Obj.magic
+                                                           (FStar_Tactics_Effect.tac_bind
+                                                              (FStar_Sealed.seal
+                                                                 (Obj.magic
+                                                                    (
+                                                                    FStar_Range.mk_range
+                                                                    "FStar.Tactics.Typeclasses.fst"
+                                                                    (Prims.of_int (187))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (188))
+                                                                    (Prims.of_int (20)))))
+                                                              (FStar_Sealed.seal
+                                                                 (Obj.magic
+                                                                    (
+                                                                    FStar_Range.mk_range
+                                                                    "FStar.Tactics.Typeclasses.fst"
+                                                                    (Prims.of_int (189))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (204))
+                                                                    (Prims.of_int (13)))))
+                                                              (if
+                                                                 Prims.op_Negation
+                                                                   (fv_eq fv'
+                                                                    g.head_fv)
+                                                               then
+                                                                 FStar_Tactics_Effect.raise
+                                                                   NoInst
+                                                               else
+                                                                 FStar_Tactics_Effect.lift_div_tac
+                                                                   (fun
+                                                                    uu___2 ->
+                                                                    ()))
+                                                              (fun uu___1 ->
+                                                                 (fun uu___1
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.Typeclasses.fst"
+                                                                    (Prims.of_int (189))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (189))
+                                                                    (Prims.of_int (82)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.Typeclasses.fst"
+                                                                    (Prims.of_int (190))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (204))
+                                                                    (Prims.of_int (13)))))
+                                                                    (Obj.magic
+                                                                    (debug
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.Typeclasses.fst"
+                                                                    (Prims.of_int (189))
+                                                                    (Prims.of_int (65))
+                                                                    (Prims.of_int (189))
+                                                                    (Prims.of_int (81)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "prims.fst"
+                                                                    (Prims.of_int (590))
+                                                                    (Prims.of_int (19))
+                                                                    (Prims.of_int (590))
+                                                                    (Prims.of_int (31)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_V2_Builtins.term_to_string
+                                                                    t))
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___4 ->
+                                                                    Prims.strcat
+                                                                    "Trying to apply hypothesis/instance: "
+                                                                    uu___3)))))
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_V2_Derived.seq
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    if
+                                                                    (Prims.uu___is_Cons
+                                                                    unresolved_args)
+                                                                    &&
+                                                                    (FStar_Pervasives_Native.uu___is_None
+                                                                    fundeps)
+                                                                    then
+                                                                    Obj.magic
+                                                                    (Obj.repr
+                                                                    (FStar_Tactics_V2_Derived.fail
+                                                                    "Will not continue as there are unresolved args (and no fundeps)"))
+                                                                    else
+                                                                    Obj.magic
+                                                                    (Obj.repr
+                                                                    (if
+                                                                    (Prims.uu___is_Cons
+                                                                    unresolved_args)
+                                                                    &&
+                                                                    (FStar_Pervasives_Native.uu___is_Some
+                                                                    fundeps)
+                                                                    then
+                                                                    FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.Typeclasses.fst"
+                                                                    (Prims.of_int (194))
+                                                                    (Prims.of_int (29))
+                                                                    (Prims.of_int (194))
                                                                     (Prims.of_int (36)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (128))
+                                                                    (Prims.of_int (193))
+                                                                    (Prims.of_int (60))
+                                                                    (Prims.of_int (198))
+                                                                    (Prims.of_int (9)))))
+                                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___5 ->
+                                                                    fundeps))
+                                                                    (fun
+                                                                    uu___5 ->
+                                                                    (fun
+                                                                    uu___5 ->
+                                                                    match uu___5
+                                                                    with
+                                                                    | 
+                                                                    FStar_Pervasives_Native.Some
+                                                                    fundeps1
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.Typeclasses.fst"
+                                                                    (Prims.of_int (195))
+                                                                    (Prims.of_int (10))
+                                                                    (Prims.of_int (195))
+                                                                    (Prims.of_int (46)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.Typeclasses.fst"
+                                                                    (Prims.of_int (195))
+                                                                    (Prims.of_int (47))
+                                                                    (Prims.of_int (197))
+                                                                    (Prims.of_int (54)))))
+                                                                    (Obj.magic
+                                                                    (debug
+                                                                    (fun
+                                                                    uu___6 ->
+                                                                    (fun
+                                                                    uu___6 ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___7 ->
+                                                                    "checking fundeps")))
+                                                                    uu___6)))
+                                                                    (fun
+                                                                    uu___6 ->
+                                                                    (fun
+                                                                    uu___6 ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.Typeclasses.fst"
+                                                                    (Prims.of_int (196))
+                                                                    (Prims.of_int (25))
+                                                                    (Prims.of_int (196))
+                                                                    (Prims.of_int (91)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.Typeclasses.fst"
+                                                                    (Prims.of_int (197))
+                                                                    (Prims.of_int (10))
+                                                                    (Prims.of_int (197))
+                                                                    (Prims.of_int (54)))))
+                                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___7 ->
+                                                                    FStar_List_Tot_Base.for_all
+                                                                    (fun i ->
+                                                                    FStar_List_Tot_Base.mem
+                                                                    i
+                                                                    fundeps1)
+                                                                    unresolved_args))
+                                                                    (fun
+                                                                    uu___7 ->
+                                                                    (fun
+                                                                    all_good
+                                                                    ->
+                                                                    if
+                                                                    all_good
+                                                                    then
+                                                                    Obj.magic
+                                                                    (Obj.repr
+                                                                    (FStar_Tactics_V2_Derived.apply
+                                                                    t))
+                                                                    else
+                                                                    Obj.magic
+                                                                    (Obj.repr
+                                                                    (FStar_Tactics_V2_Derived.fail
+                                                                    "fundeps")))
+                                                                    uu___7)))
+                                                                    uu___6)))
+                                                                    uu___5)
+                                                                    else
+                                                                    FStar_Tactics_V2_Derived.apply_noinst
+                                                                    t)))
+                                                                    uu___3)
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.Typeclasses.fst"
+                                                                    (Prims.of_int (202))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (202))
+                                                                    (Prims.of_int (67)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.Typeclasses.fst"
+                                                                    (Prims.of_int (202))
+                                                                    (Prims.of_int (68))
+                                                                    (Prims.of_int (204))
+                                                                    (Prims.of_int (12)))))
+                                                                    (Obj.magic
+                                                                    (debug
+                                                                    (fun
+                                                                    uu___4 ->
+                                                                    FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.Typeclasses.fst"
+                                                                    (Prims.of_int (202))
+                                                                    (Prims.of_int (25))
+                                                                    (Prims.of_int (202))
+                                                                    (Prims.of_int (36)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.Typeclasses.fst"
+                                                                    (Prims.of_int (202))
                                                                     (Prims.of_int (38))
-                                                                    (Prims.of_int (128))
+                                                                    (Prims.of_int (202))
                                                                     (Prims.of_int (66)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Builtins.dump
                                                                     "next"))
                                                                     (fun
-                                                                    uu___6 ->
+                                                                    uu___5 ->
                                                                     FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___7 ->
+                                                                    uu___6 ->
                                                                     "apply seems to have worked")))))
-                                                          (fun uu___5 ->
-                                                             (fun uu___5 ->
-                                                                Obj.magic
-                                                                  (FStar_Tactics_Effect.tac_bind
+                                                                    (fun
+                                                                    uu___4 ->
+                                                                    (fun
+                                                                    uu___4 ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (129))
+                                                                    (Prims.of_int (203))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (129))
+                                                                    (Prims.of_int (203))
                                                                     (Prims.of_int (45)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (130))
+                                                                    (Prims.of_int (204))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (130))
+                                                                    (Prims.of_int (204))
                                                                     (Prims.of_int (12)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
-                                                                    uu___6 ->
+                                                                    uu___5 ->
                                                                     {
                                                                     seen =
                                                                     (st.seen);
@@ -602,14 +1184,17 @@ let (trywith :
                                                                     Prims.int_one)
                                                                     }))
                                                                     (fun
-                                                                    uu___6 ->
+                                                                    uu___5 ->
                                                                     (fun st1
                                                                     ->
                                                                     Obj.magic
                                                                     (k st1))
-                                                                    uu___6)))
-                                                               uu___5))))
-                                               uu___3))) uu___2))) uu___1)
+                                                                    uu___5)))
+                                                                    uu___4))))
+                                                                    uu___2)))
+                                                                   uu___1)))
+                                                    uu___))) uu___))) uu___)))
+                   uu___)
 let (local :
   st_t ->
     tc_goal ->
@@ -624,13 +1209,13 @@ let (local :
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-                     (Prims.of_int (133)) (Prims.of_int (4))
-                     (Prims.of_int (133)) (Prims.of_int (59)))))
+                     (Prims.of_int (207)) (Prims.of_int (4))
+                     (Prims.of_int (207)) (Prims.of_int (59)))))
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-                     (Prims.of_int (133)) (Prims.of_int (60))
-                     (Prims.of_int (137)) (Prims.of_int (12)))))
+                     (Prims.of_int (207)) (Prims.of_int (60))
+                     (Prims.of_int (211)) (Prims.of_int (12)))))
             (Obj.magic
                (debug
                   (fun uu___1 ->
@@ -639,8 +1224,8 @@ let (local :
                           (Obj.magic
                              (FStar_Range.mk_range
                                 "FStar.Tactics.Typeclasses.fst"
-                                (Prims.of_int (133)) (Prims.of_int (40))
-                                (Prims.of_int (133)) (Prims.of_int (58)))))
+                                (Prims.of_int (207)) (Prims.of_int (40))
+                                (Prims.of_int (207)) (Prims.of_int (58)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "prims.fst"
@@ -660,31 +1245,31 @@ let (local :
                           (Obj.magic
                              (FStar_Range.mk_range
                                 "FStar.Tactics.Typeclasses.fst"
-                                (Prims.of_int (134)) (Prims.of_int (13))
-                                (Prims.of_int (134)) (Prims.of_int (37)))))
+                                (Prims.of_int (208)) (Prims.of_int (13))
+                                (Prims.of_int (208)) (Prims.of_int (37)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range
                                 "FStar.Tactics.Typeclasses.fst"
-                                (Prims.of_int (135)) (Prims.of_int (4))
-                                (Prims.of_int (137)) (Prims.of_int (12)))))
+                                (Prims.of_int (209)) (Prims.of_int (4))
+                                (Prims.of_int (211)) (Prims.of_int (12)))))
                        (Obj.magic
                           (FStar_Tactics_Effect.tac_bind
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "FStar.Tactics.Typeclasses.fst"
-                                      (Prims.of_int (134))
+                                      (Prims.of_int (208))
                                       (Prims.of_int (25))
-                                      (Prims.of_int (134))
+                                      (Prims.of_int (208))
                                       (Prims.of_int (37)))))
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "FStar.Tactics.Typeclasses.fst"
-                                      (Prims.of_int (134))
+                                      (Prims.of_int (208))
                                       (Prims.of_int (13))
-                                      (Prims.of_int (134))
+                                      (Prims.of_int (208))
                                       (Prims.of_int (37)))))
                              (Obj.magic (FStar_Tactics_V2_Derived.cur_env ()))
                              (fun uu___2 ->
@@ -698,7 +1283,6 @@ let (local :
                                (first
                                   (fun b ->
                                      trywith st g
-                                       FStar_Pervasives_Native.None
                                        (FStar_Tactics_NamedView.pack
                                           (FStar_Tactics_NamedView.Tv_Var
                                              (FStar_Tactics_V2_SyntaxCoercions.binding_to_namedv
@@ -719,13 +1303,13 @@ let (global :
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-                     (Prims.of_int (140)) (Prims.of_int (4))
-                     (Prims.of_int (140)) (Prims.of_int (60)))))
+                     (Prims.of_int (214)) (Prims.of_int (4))
+                     (Prims.of_int (214)) (Prims.of_int (60)))))
             (FStar_Sealed.seal
                (Obj.magic
                   (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-                     (Prims.of_int (141)) (Prims.of_int (4))
-                     (Prims.of_int (144)) (Prims.of_int (16)))))
+                     (Prims.of_int (215)) (Prims.of_int (4))
+                     (Prims.of_int (218)) (Prims.of_int (16)))))
             (Obj.magic
                (debug
                   (fun uu___1 ->
@@ -734,8 +1318,8 @@ let (global :
                           (Obj.magic
                              (FStar_Range.mk_range
                                 "FStar.Tactics.Typeclasses.fst"
-                                (Prims.of_int (140)) (Prims.of_int (41))
-                                (Prims.of_int (140)) (Prims.of_int (59)))))
+                                (Prims.of_int (214)) (Prims.of_int (41))
+                                (Prims.of_int (214)) (Prims.of_int (59)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "prims.fst"
@@ -759,35 +1343,35 @@ let (global :
                                    (Obj.magic
                                       (FStar_Range.mk_range
                                          "FStar.Tactics.Typeclasses.fst"
-                                         (Prims.of_int (142))
+                                         (Prims.of_int (216))
                                          (Prims.of_int (24))
-                                         (Prims.of_int (142))
+                                         (Prims.of_int (216))
                                          (Prims.of_int (58)))))
                                 (FStar_Sealed.seal
                                    (Obj.magic
                                       (FStar_Range.mk_range
                                          "FStar.Tactics.Typeclasses.fst"
-                                         (Prims.of_int (143))
+                                         (Prims.of_int (217))
                                          (Prims.of_int (14))
-                                         (Prims.of_int (143))
-                                         (Prims.of_int (62)))))
+                                         (Prims.of_int (217))
+                                         (Prims.of_int (52)))))
                                 (Obj.magic
                                    (FStar_Tactics_Effect.tac_bind
                                       (FStar_Sealed.seal
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "FStar.Tactics.Typeclasses.fst"
-                                               (Prims.of_int (142))
+                                               (Prims.of_int (216))
                                                (Prims.of_int (27))
-                                               (Prims.of_int (142))
+                                               (Prims.of_int (216))
                                                (Prims.of_int (38)))))
                                       (FStar_Sealed.seal
                                          (Obj.magic
                                             (FStar_Range.mk_range
                                                "FStar.Tactics.Typeclasses.fst"
-                                               (Prims.of_int (142))
+                                               (Prims.of_int (216))
                                                (Prims.of_int (24))
-                                               (Prims.of_int (142))
+                                               (Prims.of_int (216))
                                                (Prims.of_int (58)))))
                                       (Obj.magic
                                          (FStar_Tactics_V2_Derived.cur_env ()))
@@ -803,7 +1387,6 @@ let (global :
                                    (fun typ ->
                                       Obj.magic
                                         (trywith st g
-                                           (FStar_Pervasives_Native.Some se)
                                            (FStar_Tactics_NamedView.pack
                                               (FStar_Tactics_NamedView.Tv_FVar
                                                  fv)) typ k)) uu___3)) 
@@ -814,12 +1397,12 @@ let rec (tcresolve' : st_t -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
       (FStar_Sealed.seal
          (Obj.magic
             (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-               (Prims.of_int (158)) (Prims.of_int (4)) (Prims.of_int (159))
+               (Prims.of_int (232)) (Prims.of_int (4)) (Prims.of_int (233))
                (Prims.of_int (18)))))
       (FStar_Sealed.seal
          (Obj.magic
             (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-               (Prims.of_int (160)) (Prims.of_int (4)) (Prims.of_int (180))
+               (Prims.of_int (234)) (Prims.of_int (4)) (Prims.of_int (255))
                (Prims.of_int (60)))))
       (if st.fuel <= Prims.int_zero
        then FStar_Tactics_Effect.raise NoInst
@@ -831,13 +1414,13 @@ let rec (tcresolve' : st_t -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                  (FStar_Sealed.seal
                     (Obj.magic
                        (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-                          (Prims.of_int (160)) (Prims.of_int (4))
-                          (Prims.of_int (160)) (Prims.of_int (55)))))
+                          (Prims.of_int (234)) (Prims.of_int (4))
+                          (Prims.of_int (234)) (Prims.of_int (55)))))
                  (FStar_Sealed.seal
                     (Obj.magic
                        (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-                          (Prims.of_int (162)) (Prims.of_int (4))
-                          (Prims.of_int (180)) (Prims.of_int (60)))))
+                          (Prims.of_int (236)) (Prims.of_int (4))
+                          (Prims.of_int (255)) (Prims.of_int (60)))))
                  (Obj.magic
                     (debug
                        (fun uu___1 ->
@@ -856,14 +1439,14 @@ let rec (tcresolve' : st_t -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                (Obj.magic
                                   (FStar_Range.mk_range
                                      "FStar.Tactics.Typeclasses.fst"
-                                     (Prims.of_int (162)) (Prims.of_int (4))
-                                     (Prims.of_int (162)) (Prims.of_int (18)))))
+                                     (Prims.of_int (236)) (Prims.of_int (4))
+                                     (Prims.of_int (236)) (Prims.of_int (18)))))
                             (FStar_Sealed.seal
                                (Obj.magic
                                   (FStar_Range.mk_range
                                      "FStar.Tactics.Typeclasses.fst"
-                                     (Prims.of_int (162)) (Prims.of_int (19))
-                                     (Prims.of_int (180)) (Prims.of_int (60)))))
+                                     (Prims.of_int (236)) (Prims.of_int (19))
+                                     (Prims.of_int (255)) (Prims.of_int (60)))))
                             (Obj.magic (maybe_intros ()))
                             (fun uu___2 ->
                                (fun uu___2 ->
@@ -873,17 +1456,17 @@ let rec (tcresolve' : st_t -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                           (Obj.magic
                                              (FStar_Range.mk_range
                                                 "FStar.Tactics.Typeclasses.fst"
-                                                (Prims.of_int (163))
+                                                (Prims.of_int (237))
                                                 (Prims.of_int (12))
-                                                (Prims.of_int (163))
+                                                (Prims.of_int (237))
                                                 (Prims.of_int (23)))))
                                        (FStar_Sealed.seal
                                           (Obj.magic
                                              (FStar_Range.mk_range
                                                 "FStar.Tactics.Typeclasses.fst"
-                                                (Prims.of_int (166))
+                                                (Prims.of_int (240))
                                                 (Prims.of_int (4))
-                                                (Prims.of_int (180))
+                                                (Prims.of_int (255))
                                                 (Prims.of_int (60)))))
                                        (Obj.magic
                                           (FStar_Tactics_V2_Derived.cur_goal
@@ -896,17 +1479,17 @@ let rec (tcresolve' : st_t -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                      (Obj.magic
                                                         (FStar_Range.mk_range
                                                            "FStar.Tactics.Typeclasses.fst"
-                                                           (Prims.of_int (166))
+                                                           (Prims.of_int (240))
                                                            (Prims.of_int (4))
-                                                           (Prims.of_int (169))
+                                                           (Prims.of_int (243))
                                                            (Prims.of_int (5)))))
                                                   (FStar_Sealed.seal
                                                      (Obj.magic
                                                         (FStar_Range.mk_range
                                                            "FStar.Tactics.Typeclasses.fst"
-                                                           (Prims.of_int (171))
+                                                           (Prims.of_int (245))
                                                            (Prims.of_int (4))
-                                                           (Prims.of_int (180))
+                                                           (Prims.of_int (255))
                                                            (Prims.of_int (60)))))
                                                   (if
                                                      FStar_List_Tot_Base.existsb
@@ -920,17 +1503,17 @@ let rec (tcresolve' : st_t -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                                 (Obj.magic
                                                                    (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (167))
+                                                                    (Prims.of_int (241))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (167))
+                                                                    (Prims.of_int (241))
                                                                     (Prims.of_int (30)))))
                                                              (FStar_Sealed.seal
                                                                 (Obj.magic
                                                                    (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (168))
+                                                                    (Prims.of_int (242))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (168))
+                                                                    (Prims.of_int (242))
                                                                     (Prims.of_int (18)))))
                                                              (Obj.magic
                                                                 (debug
@@ -961,20 +1544,20 @@ let rec (tcresolve' : st_t -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                                 (Obj.magic
                                                                    (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (171))
+                                                                    (Prims.of_int (245))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (171))
-                                                                    (Prims.of_int (19)))))
+                                                                    (Prims.of_int (245))
+                                                                    (Prims.of_int (15)))))
                                                              (FStar_Sealed.seal
                                                                 (Obj.magic
                                                                    (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (171))
+                                                                    (Prims.of_int (245))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (180))
+                                                                    (Prims.of_int (255))
                                                                     (Prims.of_int (60)))))
                                                              (Obj.magic
-                                                                (head_of g))
+                                                                (hua g))
                                                              (fun uu___4 ->
                                                                 (fun uu___4
                                                                    ->
@@ -989,17 +1572,17 @@ let rec (tcresolve' : st_t -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (173))
+                                                                    (Prims.of_int (247))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (173))
+                                                                    (Prims.of_int (247))
                                                                     (Prims.of_int (61)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (174))
+                                                                    (Prims.of_int (248))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (174))
+                                                                    (Prims.of_int (248))
                                                                     (Prims.of_int (18)))))
                                                                     (Obj.magic
                                                                     (debug
@@ -1019,7 +1602,8 @@ let rec (tcresolve' : st_t -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                                     NoInst))
                                                                    | 
                                                                    FStar_Pervasives_Native.Some
-                                                                    head_fv
+                                                                    (head_fv,
+                                                                    us, args)
                                                                     ->
                                                                     Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1027,17 +1611,101 @@ let rec (tcresolve' : st_t -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (178))
+                                                                    (Prims.of_int (251))
+                                                                    (Prims.of_int (27))
+                                                                    (Prims.of_int (251))
+                                                                    (Prims.of_int (89)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.Typeclasses.fst"
+                                                                    (Prims.of_int (251))
+                                                                    (Prims.of_int (92))
+                                                                    (Prims.of_int (255))
+                                                                    (Prims.of_int (60)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Util.map
+                                                                    (fun
+                                                                    uu___5 ->
+                                                                    match uu___5
+                                                                    with
+                                                                    | 
+                                                                    (a, q) ->
+                                                                    FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.Typeclasses.fst"
+                                                                    (Prims.of_int (251))
+                                                                    (Prims.of_int (67))
+                                                                    (Prims.of_int (251))
+                                                                    (Prims.of_int (88)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.Typeclasses.fst"
+                                                                    (Prims.of_int (251))
+                                                                    (Prims.of_int (59))
+                                                                    (Prims.of_int (251))
+                                                                    (Prims.of_int (88)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.Typeclasses.fst"
+                                                                    (Prims.of_int (251))
+                                                                    (Prims.of_int (73))
+                                                                    (Prims.of_int (251))
+                                                                    (Prims.of_int (88)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.Typeclasses.fst"
+                                                                    (Prims.of_int (251))
+                                                                    (Prims.of_int (67))
+                                                                    (Prims.of_int (251))
+                                                                    (Prims.of_int (88)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_V2_Builtins.free_uvars
+                                                                    a))
+                                                                    (fun
+                                                                    uu___6 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___7 ->
+                                                                    Prims.uu___is_Cons
+                                                                    uu___6))))
+                                                                    (fun
+                                                                    uu___6 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___7 ->
+                                                                    ((a, q),
+                                                                    uu___6))))
+                                                                    args))
+                                                                    (fun
+                                                                    uu___5 ->
+                                                                    (fun
+                                                                    args_and_uvars
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.Typeclasses.fst"
+                                                                    (Prims.of_int (253))
                                                                     (Prims.of_int (17))
-                                                                    (Prims.of_int (178))
+                                                                    (Prims.of_int (253))
                                                                     (Prims.of_int (44)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (178))
+                                                                    (Prims.of_int (253))
                                                                     (Prims.of_int (49))
-                                                                    (Prims.of_int (180))
+                                                                    (Prims.of_int (255))
                                                                     (Prims.of_int (60)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1061,24 +1729,25 @@ let rec (tcresolve' : st_t -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (179))
+                                                                    (Prims.of_int (254))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (179))
-                                                                    (Prims.of_int (41)))))
+                                                                    (Prims.of_int (254))
+                                                                    (Prims.of_int (73)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (180))
+                                                                    (Prims.of_int (255))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (180))
+                                                                    (Prims.of_int (255))
                                                                     (Prims.of_int (60)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
                                                                     uu___5 ->
                                                                     {
                                                                     g;
-                                                                    head_fv
+                                                                    head_fv;
+                                                                    args_and_uvars
                                                                     }))
                                                                     (fun
                                                                     uu___5 ->
@@ -1092,6 +1761,7 @@ let rec (tcresolve' : st_t -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                                     (global
                                                                     st1 g1
                                                                     tcresolve')))
+                                                                    uu___5)))
                                                                     uu___5)))
                                                                     uu___5)))
                                                                   uu___4)))
@@ -1119,14 +1789,14 @@ let rec concatMap :
                           (Obj.magic
                              (FStar_Range.mk_range
                                 "FStar.Tactics.Typeclasses.fst"
-                                (Prims.of_int (185)) (Prims.of_int (13))
-                                (Prims.of_int (185)) (Prims.of_int (16)))))
+                                (Prims.of_int (260)) (Prims.of_int (13))
+                                (Prims.of_int (260)) (Prims.of_int (16)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range
                                 "FStar.Tactics.Typeclasses.fst"
-                                (Prims.of_int (185)) (Prims.of_int (13))
-                                (Prims.of_int (185)) (Prims.of_int (33)))))
+                                (Prims.of_int (260)) (Prims.of_int (13))
+                                (Prims.of_int (260)) (Prims.of_int (33)))))
                        (Obj.magic (f x))
                        (fun uu___ ->
                           (fun uu___ ->
@@ -1136,17 +1806,17 @@ let rec concatMap :
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "FStar.Tactics.Typeclasses.fst"
-                                           (Prims.of_int (185))
+                                           (Prims.of_int (260))
                                            (Prims.of_int (19))
-                                           (Prims.of_int (185))
+                                           (Prims.of_int (260))
                                            (Prims.of_int (33)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "FStar.Tactics.Typeclasses.fst"
-                                           (Prims.of_int (185))
+                                           (Prims.of_int (260))
                                            (Prims.of_int (13))
-                                           (Prims.of_int (185))
+                                           (Prims.of_int (260))
                                            (Prims.of_int (33)))))
                                   (Obj.magic (concatMap f xs))
                                   (fun uu___1 ->
@@ -1159,12 +1829,12 @@ let (tcresolve : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
       (FStar_Sealed.seal
          (Obj.magic
             (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-               (Prims.of_int (189)) (Prims.of_int (4)) (Prims.of_int (189))
+               (Prims.of_int (264)) (Prims.of_int (4)) (Prims.of_int (264))
                (Prims.of_int (54)))))
       (FStar_Sealed.seal
          (Obj.magic
             (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-               (Prims.of_int (189)) (Prims.of_int (55)) (Prims.of_int (219))
+               (Prims.of_int (264)) (Prims.of_int (55)) (Prims.of_int (295))
                (Prims.of_int (18)))))
       (Obj.magic
          (debug
@@ -1173,13 +1843,13 @@ let (tcresolve : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                  (FStar_Sealed.seal
                     (Obj.magic
                        (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-                          (Prims.of_int (189)) (Prims.of_int (21))
-                          (Prims.of_int (189)) (Prims.of_int (28)))))
+                          (Prims.of_int (264)) (Prims.of_int (21))
+                          (Prims.of_int (264)) (Prims.of_int (28)))))
                  (FStar_Sealed.seal
                     (Obj.magic
                        (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-                          (Prims.of_int (189)) (Prims.of_int (30))
-                          (Prims.of_int (189)) (Prims.of_int (53)))))
+                          (Prims.of_int (264)) (Prims.of_int (30))
+                          (Prims.of_int (264)) (Prims.of_int (53)))))
                  (Obj.magic (FStar_Tactics_V2_Builtins.dump ""))
                  (fun uu___2 ->
                     FStar_Tactics_Effect.lift_div_tac
@@ -1191,13 +1861,13 @@ let (tcresolve : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                  (FStar_Sealed.seal
                     (Obj.magic
                        (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-                          (Prims.of_int (190)) (Prims.of_int (12))
-                          (Prims.of_int (190)) (Prims.of_int (26)))))
+                          (Prims.of_int (265)) (Prims.of_int (12))
+                          (Prims.of_int (265)) (Prims.of_int (26)))))
                  (FStar_Sealed.seal
                     (Obj.magic
                        (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-                          (Prims.of_int (193)) (Prims.of_int (4))
-                          (Prims.of_int (219)) (Prims.of_int (18)))))
+                          (Prims.of_int (268)) (Prims.of_int (4))
+                          (Prims.of_int (295)) (Prims.of_int (18)))))
                  (Obj.magic (FStar_Tactics_V2_Derived.cur_witness ()))
                  (fun uu___2 ->
                     (fun w ->
@@ -1207,14 +1877,14 @@ let (tcresolve : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                (Obj.magic
                                   (FStar_Range.mk_range
                                      "FStar.Tactics.Typeclasses.fst"
-                                     (Prims.of_int (193)) (Prims.of_int (4))
-                                     (Prims.of_int (193)) (Prims.of_int (19)))))
+                                     (Prims.of_int (268)) (Prims.of_int (4))
+                                     (Prims.of_int (268)) (Prims.of_int (19)))))
                             (FStar_Sealed.seal
                                (Obj.magic
                                   (FStar_Range.mk_range
                                      "FStar.Tactics.Typeclasses.fst"
-                                     (Prims.of_int (193)) (Prims.of_int (20))
-                                     (Prims.of_int (219)) (Prims.of_int (18)))))
+                                     (Prims.of_int (268)) (Prims.of_int (20))
+                                     (Prims.of_int (295)) (Prims.of_int (18)))))
                             (Obj.magic (maybe_intros ()))
                             (fun uu___2 ->
                                (fun uu___2 ->
@@ -1224,17 +1894,17 @@ let (tcresolve : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                           (Obj.magic
                                              (FStar_Range.mk_range
                                                 "FStar.Tactics.Typeclasses.fst"
-                                                (Prims.of_int (198))
+                                                (Prims.of_int (273))
                                                 (Prims.of_int (14))
-                                                (Prims.of_int (198))
+                                                (Prims.of_int (273))
                                                 (Prims.of_int (56)))))
                                        (FStar_Sealed.seal
                                           (Obj.magic
                                              (FStar_Range.mk_range
                                                 "FStar.Tactics.Typeclasses.fst"
-                                                (Prims.of_int (198))
+                                                (Prims.of_int (273))
                                                 (Prims.of_int (59))
-                                                (Prims.of_int (219))
+                                                (Prims.of_int (295))
                                                 (Prims.of_int (18)))))
                                        (Obj.magic
                                           (FStar_Tactics_Effect.tac_bind
@@ -1242,17 +1912,17 @@ let (tcresolve : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "FStar.Tactics.Typeclasses.fst"
-                                                      (Prims.of_int (198))
+                                                      (Prims.of_int (273))
                                                       (Prims.of_int (44))
-                                                      (Prims.of_int (198))
+                                                      (Prims.of_int (273))
                                                       (Prims.of_int (56)))))
                                              (FStar_Sealed.seal
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "FStar.Tactics.Typeclasses.fst"
-                                                      (Prims.of_int (198))
+                                                      (Prims.of_int (273))
                                                       (Prims.of_int (14))
-                                                      (Prims.of_int (198))
+                                                      (Prims.of_int (273))
                                                       (Prims.of_int (56)))))
                                              (Obj.magic
                                                 (FStar_Tactics_V2_Derived.cur_env
@@ -1277,17 +1947,17 @@ let (tcresolve : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                      (Obj.magic
                                                         (FStar_Range.mk_range
                                                            "FStar.Tactics.Typeclasses.fst"
-                                                           (Prims.of_int (199))
+                                                           (Prims.of_int (274))
                                                            (Prims.of_int (14))
-                                                           (Prims.of_int (200))
-                                                           (Prims.of_int (65)))))
+                                                           (Prims.of_int (276))
+                                                           (Prims.of_int (5)))))
                                                   (FStar_Sealed.seal
                                                      (Obj.magic
                                                         (FStar_Range.mk_range
                                                            "FStar.Tactics.Typeclasses.fst"
-                                                           (Prims.of_int (201))
+                                                           (Prims.of_int (277))
                                                            (Prims.of_int (6))
-                                                           (Prims.of_int (219))
+                                                           (Prims.of_int (295))
                                                            (Prims.of_int (18)))))
                                                   (Obj.magic
                                                      (concatMap
@@ -1312,17 +1982,17 @@ let (tcresolve : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                                 (Obj.magic
                                                                    (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (203))
+                                                                    (Prims.of_int (279))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (205))
+                                                                    (Prims.of_int (281))
                                                                     (Prims.of_int (16)))))
                                                              (FStar_Sealed.seal
                                                                 (Obj.magic
                                                                    (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (207))
+                                                                    (Prims.of_int (283))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (219))
+                                                                    (Prims.of_int (295))
                                                                     (Prims.of_int (18)))))
                                                              (FStar_Tactics_Effect.lift_div_tac
                                                                 (fun uu___3
@@ -1349,17 +2019,17 @@ let (tcresolve : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (208))
+                                                                    (Prims.of_int (284))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (208))
+                                                                    (Prims.of_int (284))
                                                                     (Prims.of_int (20)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (209))
+                                                                    (Prims.of_int (285))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (209))
+                                                                    (Prims.of_int (285))
                                                                     (Prims.of_int (59)))))
                                                                     (Obj.magic
                                                                     (tcresolve'
@@ -1377,9 +2047,9 @@ let (tcresolve : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (209))
+                                                                    (Prims.of_int (285))
                                                                     (Prims.of_int (42))
-                                                                    (Prims.of_int (209))
+                                                                    (Prims.of_int (285))
                                                                     (Prims.of_int (58)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -1416,17 +2086,17 @@ let (tcresolve : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (213))
+                                                                    (Prims.of_int (289))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (216))
+                                                                    (Prims.of_int (292))
                                                                     (Prims.of_int (7)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (213))
+                                                                    (Prims.of_int (289))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (216))
+                                                                    (Prims.of_int (292))
                                                                     (Prims.of_int (7)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1434,17 +2104,17 @@ let (tcresolve : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (214))
+                                                                    (Prims.of_int (290))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (215))
+                                                                    (Prims.of_int (291))
                                                                     (Prims.of_int (59)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (213))
+                                                                    (Prims.of_int (289))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (216))
+                                                                    (Prims.of_int (292))
                                                                     (Prims.of_int (7)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1452,17 +2122,17 @@ let (tcresolve : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (215))
+                                                                    (Prims.of_int (291))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (215))
+                                                                    (Prims.of_int (291))
                                                                     (Prims.of_int (59)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (214))
+                                                                    (Prims.of_int (290))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (215))
+                                                                    (Prims.of_int (291))
                                                                     (Prims.of_int (59)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1470,17 +2140,17 @@ let (tcresolve : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (215))
+                                                                    (Prims.of_int (291))
                                                                     (Prims.of_int (28))
-                                                                    (Prims.of_int (215))
+                                                                    (Prims.of_int (291))
                                                                     (Prims.of_int (58)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (215))
+                                                                    (Prims.of_int (291))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (215))
+                                                                    (Prims.of_int (291))
                                                                     (Prims.of_int (59)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1488,17 +2158,17 @@ let (tcresolve : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (215))
+                                                                    (Prims.of_int (291))
                                                                     (Prims.of_int (44))
-                                                                    (Prims.of_int (215))
+                                                                    (Prims.of_int (291))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (215))
+                                                                    (Prims.of_int (291))
                                                                     (Prims.of_int (28))
-                                                                    (Prims.of_int (215))
+                                                                    (Prims.of_int (291))
                                                                     (Prims.of_int (58)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Derived.cur_goal
@@ -1595,8 +2265,8 @@ let rec (mk_abs :
                           (Obj.magic
                              (FStar_Range.mk_range
                                 "FStar.Tactics.Typeclasses.fst"
-                                (Prims.of_int (228)) (Prims.of_int (20))
-                                (Prims.of_int (228)) (Prims.of_int (47)))))
+                                (Prims.of_int (304)) (Prims.of_int (20))
+                                (Prims.of_int (304)) (Prims.of_int (47)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "dummy" Prims.int_zero
@@ -1607,17 +2277,17 @@ let rec (mk_abs :
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "FStar.Tactics.Typeclasses.fst"
-                                      (Prims.of_int (228))
+                                      (Prims.of_int (304))
                                       (Prims.of_int (30))
-                                      (Prims.of_int (228))
+                                      (Prims.of_int (304))
                                       (Prims.of_int (46)))))
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "FStar.Tactics.Typeclasses.fst"
-                                      (Prims.of_int (228))
+                                      (Prims.of_int (304))
                                       (Prims.of_int (20))
-                                      (Prims.of_int (228))
+                                      (Prims.of_int (304))
                                       (Prims.of_int (47)))))
                              (Obj.magic (mk_abs bs1 body))
                              (fun uu___ ->
@@ -1676,12 +2346,12 @@ let (mk_class :
       (FStar_Sealed.seal
          (Obj.magic
             (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-               (Prims.of_int (252)) (Prims.of_int (13)) (Prims.of_int (252))
+               (Prims.of_int (328)) (Prims.of_int (13)) (Prims.of_int (328))
                (Prims.of_int (26)))))
       (FStar_Sealed.seal
          (Obj.magic
             (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-               (Prims.of_int (252)) (Prims.of_int (29)) (Prims.of_int (342))
+               (Prims.of_int (328)) (Prims.of_int (29)) (Prims.of_int (418))
                (Prims.of_int (5)))))
       (FStar_Tactics_Effect.lift_div_tac
          (fun uu___ -> FStar_Reflection_V2_Builtins.explode_qn nm))
@@ -1692,27 +2362,27 @@ let (mk_class :
                  (FStar_Sealed.seal
                     (Obj.magic
                        (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-                          (Prims.of_int (253)) (Prims.of_int (12))
-                          (Prims.of_int (253)) (Prims.of_int (38)))))
+                          (Prims.of_int (329)) (Prims.of_int (12))
+                          (Prims.of_int (329)) (Prims.of_int (38)))))
                  (FStar_Sealed.seal
                     (Obj.magic
                        (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-                          (Prims.of_int (254)) (Prims.of_int (4))
-                          (Prims.of_int (342)) (Prims.of_int (5)))))
+                          (Prims.of_int (330)) (Prims.of_int (4))
+                          (Prims.of_int (418)) (Prims.of_int (5)))))
                  (Obj.magic
                     (FStar_Tactics_Effect.tac_bind
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range
                                 "FStar.Tactics.Typeclasses.fst"
-                                (Prims.of_int (253)) (Prims.of_int (23))
-                                (Prims.of_int (253)) (Prims.of_int (35)))))
+                                (Prims.of_int (329)) (Prims.of_int (23))
+                                (Prims.of_int (329)) (Prims.of_int (35)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range
                                 "FStar.Tactics.Typeclasses.fst"
-                                (Prims.of_int (253)) (Prims.of_int (12))
-                                (Prims.of_int (253)) (Prims.of_int (38)))))
+                                (Prims.of_int (329)) (Prims.of_int (12))
+                                (Prims.of_int (329)) (Prims.of_int (38)))))
                        (Obj.magic (FStar_Tactics_V2_Builtins.top_env ()))
                        (fun uu___ ->
                           FStar_Tactics_Effect.lift_div_tac
@@ -1727,14 +2397,14 @@ let (mk_class :
                                (Obj.magic
                                   (FStar_Range.mk_range
                                      "FStar.Tactics.Typeclasses.fst"
-                                     (Prims.of_int (254)) (Prims.of_int (4))
-                                     (Prims.of_int (254)) (Prims.of_int (19)))))
+                                     (Prims.of_int (330)) (Prims.of_int (4))
+                                     (Prims.of_int (330)) (Prims.of_int (19)))))
                             (FStar_Sealed.seal
                                (Obj.magic
                                   (FStar_Range.mk_range
                                      "FStar.Tactics.Typeclasses.fst"
-                                     (Prims.of_int (254)) (Prims.of_int (20))
-                                     (Prims.of_int (342)) (Prims.of_int (5)))))
+                                     (Prims.of_int (330)) (Prims.of_int (20))
+                                     (Prims.of_int (418)) (Prims.of_int (5)))))
                             (Obj.magic
                                (FStar_Tactics_V2_Derived.guard
                                   (FStar_Pervasives_Native.uu___is_Some r)))
@@ -1746,17 +2416,17 @@ let (mk_class :
                                           (Obj.magic
                                              (FStar_Range.mk_range
                                                 "FStar.Tactics.Typeclasses.fst"
-                                                (Prims.of_int (255))
+                                                (Prims.of_int (331))
                                                 (Prims.of_int (18))
-                                                (Prims.of_int (255))
+                                                (Prims.of_int (331))
                                                 (Prims.of_int (19)))))
                                        (FStar_Sealed.seal
                                           (Obj.magic
                                              (FStar_Range.mk_range
                                                 "FStar.Tactics.Typeclasses.fst"
-                                                (Prims.of_int (254))
+                                                (Prims.of_int (330))
                                                 (Prims.of_int (20))
-                                                (Prims.of_int (342))
+                                                (Prims.of_int (418))
                                                 (Prims.of_int (5)))))
                                        (FStar_Tactics_Effect.lift_div_tac
                                           (fun uu___1 -> r))
@@ -1771,17 +2441,17 @@ let (mk_class :
                                                          (Obj.magic
                                                             (FStar_Range.mk_range
                                                                "FStar.Tactics.Typeclasses.fst"
-                                                               (Prims.of_int (256))
+                                                               (Prims.of_int (332))
                                                                (Prims.of_int (23))
-                                                               (Prims.of_int (256))
+                                                               (Prims.of_int (332))
                                                                (Prims.of_int (115)))))
                                                       (FStar_Sealed.seal
                                                          (Obj.magic
                                                             (FStar_Range.mk_range
                                                                "FStar.Tactics.Typeclasses.fst"
-                                                               (Prims.of_int (256))
+                                                               (Prims.of_int (332))
                                                                (Prims.of_int (118))
-                                                               (Prims.of_int (342))
+                                                               (Prims.of_int (418))
                                                                (Prims.of_int (5)))))
                                                       (FStar_Tactics_Effect.lift_div_tac
                                                          (fun uu___2 ->
@@ -1806,18 +2476,18 @@ let (mk_class :
                                                                     Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (257))
+                                                                    (Prims.of_int (333))
                                                                     (Prims.of_int (13))
-                                                                    (Prims.of_int (257))
+                                                                    (Prims.of_int (333))
                                                                     (Prims.of_int (30)))))
                                                                  (FStar_Sealed.seal
                                                                     (
                                                                     Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (258))
+                                                                    (Prims.of_int (334))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (342))
+                                                                    (Prims.of_int (418))
                                                                     (Prims.of_int (5)))))
                                                                  (Obj.magic
                                                                     (
@@ -1833,17 +2503,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (258))
+                                                                    (Prims.of_int (334))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (258))
+                                                                    (Prims.of_int (334))
                                                                     (Prims.of_int (28)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (258))
+                                                                    (Prims.of_int (334))
                                                                     (Prims.of_int (29))
-                                                                    (Prims.of_int (342))
+                                                                    (Prims.of_int (418))
                                                                     (Prims.of_int (5)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Derived.guard
@@ -1859,17 +2529,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (259))
+                                                                    (Prims.of_int (335))
                                                                     (Prims.of_int (63))
-                                                                    (Prims.of_int (259))
+                                                                    (Prims.of_int (335))
                                                                     (Prims.of_int (65)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (258))
+                                                                    (Prims.of_int (334))
                                                                     (Prims.of_int (29))
-                                                                    (Prims.of_int (342))
+                                                                    (Prims.of_int (418))
                                                                     (Prims.of_int (5)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -1901,17 +2571,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (260))
+                                                                    (Prims.of_int (336))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (260))
+                                                                    (Prims.of_int (336))
                                                                     (Prims.of_int (87)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (261))
+                                                                    (Prims.of_int (337))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (342))
+                                                                    (Prims.of_int (418))
                                                                     (Prims.of_int (5)))))
                                                                     (Obj.magic
                                                                     (debug
@@ -1922,9 +2592,9 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (260))
+                                                                    (Prims.of_int (336))
                                                                     (Prims.of_int (35))
-                                                                    (Prims.of_int (260))
+                                                                    (Prims.of_int (336))
                                                                     (Prims.of_int (86)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -1956,17 +2626,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (261))
+                                                                    (Prims.of_int (337))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (261))
+                                                                    (Prims.of_int (337))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (338))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (342))
+                                                                    (Prims.of_int (418))
                                                                     (Prims.of_int (5)))))
                                                                     (Obj.magic
                                                                     (debug
@@ -1993,17 +2663,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (338))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (338))
                                                                     (Prims.of_int (59)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (338))
                                                                     (Prims.of_int (60))
-                                                                    (Prims.of_int (342))
+                                                                    (Prims.of_int (418))
                                                                     (Prims.of_int (5)))))
                                                                     (Obj.magic
                                                                     (debug
@@ -2014,9 +2684,9 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (338))
                                                                     (Prims.of_int (40))
-                                                                    (Prims.of_int (262))
+                                                                    (Prims.of_int (338))
                                                                     (Prims.of_int (58)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -2047,17 +2717,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (263))
+                                                                    (Prims.of_int (339))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (263))
+                                                                    (Prims.of_int (339))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (265))
+                                                                    (Prims.of_int (341))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (342))
+                                                                    (Prims.of_int (418))
                                                                     (Prims.of_int (5)))))
                                                                     (Obj.magic
                                                                     (last
@@ -2073,17 +2743,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (265))
+                                                                    (Prims.of_int (341))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (265))
+                                                                    (Prims.of_int (341))
                                                                     (Prims.of_int (30)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (265))
+                                                                    (Prims.of_int (341))
                                                                     (Prims.of_int (31))
-                                                                    (Prims.of_int (342))
+                                                                    (Prims.of_int (418))
                                                                     (Prims.of_int (5)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Derived.guard
@@ -2100,17 +2770,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (266))
+                                                                    (Prims.of_int (342))
                                                                     (Prims.of_int (25))
-                                                                    (Prims.of_int (266))
+                                                                    (Prims.of_int (342))
                                                                     (Prims.of_int (30)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (265))
+                                                                    (Prims.of_int (341))
                                                                     (Prims.of_int (31))
-                                                                    (Prims.of_int (342))
+                                                                    (Prims.of_int (418))
                                                                     (Prims.of_int (5)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2132,17 +2802,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (267))
+                                                                    (Prims.of_int (343))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (267))
+                                                                    (Prims.of_int (343))
                                                                     (Prims.of_int (87)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (267))
+                                                                    (Prims.of_int (343))
                                                                     (Prims.of_int (88))
-                                                                    (Prims.of_int (342))
+                                                                    (Prims.of_int (418))
                                                                     (Prims.of_int (5)))))
                                                                     (Obj.magic
                                                                     (debug
@@ -2153,9 +2823,9 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (267))
+                                                                    (Prims.of_int (343))
                                                                     (Prims.of_int (35))
-                                                                    (Prims.of_int (267))
+                                                                    (Prims.of_int (343))
                                                                     (Prims.of_int (86)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -2171,9 +2841,9 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (267))
+                                                                    (Prims.of_int (343))
                                                                     (Prims.of_int (55))
-                                                                    (Prims.of_int (267))
+                                                                    (Prims.of_int (343))
                                                                     (Prims.of_int (86)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -2189,9 +2859,9 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (267))
+                                                                    (Prims.of_int (343))
                                                                     (Prims.of_int (69))
-                                                                    (Prims.of_int (267))
+                                                                    (Prims.of_int (343))
                                                                     (Prims.of_int (86)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -2245,17 +2915,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (268))
+                                                                    (Prims.of_int (344))
                                                                     (Prims.of_int (18))
-                                                                    (Prims.of_int (268))
+                                                                    (Prims.of_int (344))
                                                                     (Prims.of_int (35)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (267))
+                                                                    (Prims.of_int (343))
                                                                     (Prims.of_int (88))
-                                                                    (Prims.of_int (342))
+                                                                    (Prims.of_int (418))
                                                                     (Prims.of_int (5)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_SyntaxHelpers.collect_arr_bs
@@ -2277,17 +2947,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (269))
+                                                                    (Prims.of_int (345))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (269))
+                                                                    (Prims.of_int (345))
                                                                     (Prims.of_int (28)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (270))
+                                                                    (Prims.of_int (346))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (342))
+                                                                    (Prims.of_int (418))
                                                                     (Prims.of_int (5)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2306,17 +2976,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (270))
+                                                                    (Prims.of_int (346))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (270))
+                                                                    (Prims.of_int (346))
                                                                     (Prims.of_int (22)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (270))
+                                                                    (Prims.of_int (346))
                                                                     (Prims.of_int (23))
-                                                                    (Prims.of_int (342))
+                                                                    (Prims.of_int (418))
                                                                     (Prims.of_int (5)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Derived.guard
@@ -2334,17 +3004,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (271))
+                                                                    (Prims.of_int (347))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (271))
+                                                                    (Prims.of_int (347))
                                                                     (Prims.of_int (23)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (270))
+                                                                    (Prims.of_int (346))
                                                                     (Prims.of_int (23))
-                                                                    (Prims.of_int (342))
+                                                                    (Prims.of_int (418))
                                                                     (Prims.of_int (5)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2367,17 +3037,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (273))
+                                                                    (Prims.of_int (349))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (273))
+                                                                    (Prims.of_int (349))
                                                                     (Prims.of_int (87)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (274))
+                                                                    (Prims.of_int (350))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (342))
+                                                                    (Prims.of_int (418))
                                                                     (Prims.of_int (5)))))
                                                                     (Obj.magic
                                                                     (debug
@@ -2389,9 +3059,9 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (273))
+                                                                    (Prims.of_int (349))
                                                                     (Prims.of_int (35))
-                                                                    (Prims.of_int (273))
+                                                                    (Prims.of_int (349))
                                                                     (Prims.of_int (86)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -2427,17 +3097,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (274))
+                                                                    (Prims.of_int (350))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (274))
+                                                                    (Prims.of_int (350))
                                                                     (Prims.of_int (81)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (275))
+                                                                    (Prims.of_int (351))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (342))
+                                                                    (Prims.of_int (418))
                                                                     (Prims.of_int (5)))))
                                                                     (Obj.magic
                                                                     (debug
@@ -2470,17 +3140,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (275))
+                                                                    (Prims.of_int (351))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (275))
+                                                                    (Prims.of_int (351))
                                                                     (Prims.of_int (76)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (276))
+                                                                    (Prims.of_int (352))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (342))
+                                                                    (Prims.of_int (418))
                                                                     (Prims.of_int (5)))))
                                                                     (Obj.magic
                                                                     (debug
@@ -2513,17 +3183,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (276))
+                                                                    (Prims.of_int (352))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (276))
+                                                                    (Prims.of_int (352))
                                                                     (Prims.of_int (51)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (276))
+                                                                    (Prims.of_int (352))
                                                                     (Prims.of_int (52))
-                                                                    (Prims.of_int (342))
+                                                                    (Prims.of_int (418))
                                                                     (Prims.of_int (5)))))
                                                                     (Obj.magic
                                                                     (debug
@@ -2535,9 +3205,9 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (276))
+                                                                    (Prims.of_int (352))
                                                                     (Prims.of_int (32))
-                                                                    (Prims.of_int (276))
+                                                                    (Prims.of_int (352))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -2572,17 +3242,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (280))
+                                                                    (Prims.of_int (356))
                                                                     (Prims.of_int (24))
-                                                                    (Prims.of_int (280))
+                                                                    (Prims.of_int (356))
                                                                     (Prims.of_int (61)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (283))
+                                                                    (Prims.of_int (359))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (342))
+                                                                    (Prims.of_int (418))
                                                                     (Prims.of_int (5)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2606,17 +3276,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (285))
+                                                                    (Prims.of_int (361))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (285))
+                                                                    (Prims.of_int (361))
                                                                     (Prims.of_int (30)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (286))
+                                                                    (Prims.of_int (362))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (341))
+                                                                    (Prims.of_int (417))
                                                                     (Prims.of_int (8)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Derived.name_of_binder
@@ -2631,17 +3301,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (286))
+                                                                    (Prims.of_int (362))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (286))
+                                                                    (Prims.of_int (362))
                                                                     (Prims.of_int (48)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (286))
+                                                                    (Prims.of_int (362))
                                                                     (Prims.of_int (49))
-                                                                    (Prims.of_int (341))
+                                                                    (Prims.of_int (417))
                                                                     (Prims.of_int (8)))))
                                                                     (Obj.magic
                                                                     (debug
@@ -2672,17 +3342,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (287))
+                                                                    (Prims.of_int (363))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (287))
+                                                                    (Prims.of_int (363))
                                                                     (Prims.of_int (28)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (287))
+                                                                    (Prims.of_int (363))
                                                                     (Prims.of_int (31))
-                                                                    (Prims.of_int (341))
+                                                                    (Prims.of_int (417))
                                                                     (Prims.of_int (8)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Derived.cur_module
@@ -2698,17 +3368,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (288))
+                                                                    (Prims.of_int (364))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (288))
+                                                                    (Prims.of_int (364))
                                                                     (Prims.of_int (34)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (288))
+                                                                    (Prims.of_int (364))
                                                                     (Prims.of_int (37))
-                                                                    (Prims.of_int (341))
+                                                                    (Prims.of_int (417))
                                                                     (Prims.of_int (8)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2729,17 +3399,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (289))
+                                                                    (Prims.of_int (365))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (289))
+                                                                    (Prims.of_int (365))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (289))
+                                                                    (Prims.of_int (365))
                                                                     (Prims.of_int (41))
-                                                                    (Prims.of_int (341))
+                                                                    (Prims.of_int (417))
                                                                     (Prims.of_int (8)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Derived.fresh_namedv_named
@@ -2755,17 +3425,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (290))
+                                                                    (Prims.of_int (366))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (290))
+                                                                    (Prims.of_int (366))
                                                                     (Prims.of_int (28)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (290))
+                                                                    (Prims.of_int (366))
                                                                     (Prims.of_int (31))
-                                                                    (Prims.of_int (341))
+                                                                    (Prims.of_int (417))
                                                                     (Prims.of_int (8)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2789,17 +3459,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (292))
+                                                                    (Prims.of_int (368))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (296))
+                                                                    (Prims.of_int (372))
                                                                     (Prims.of_int (20)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (297))
+                                                                    (Prims.of_int (373))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (341))
+                                                                    (Prims.of_int (417))
                                                                     (Prims.of_int (8)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2807,17 +3477,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (294))
+                                                                    (Prims.of_int (370))
                                                                     (Prims.of_int (17))
-                                                                    (Prims.of_int (294))
+                                                                    (Prims.of_int (370))
                                                                     (Prims.of_int (24)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (292))
+                                                                    (Prims.of_int (368))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (296))
+                                                                    (Prims.of_int (372))
                                                                     (Prims.of_int (20)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Builtins.fresh
@@ -2856,17 +3526,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (298))
+                                                                    (Prims.of_int (374))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (298))
+                                                                    (Prims.of_int (374))
                                                                     (Prims.of_int (48)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (298))
+                                                                    (Prims.of_int (374))
                                                                     (Prims.of_int (51))
-                                                                    (Prims.of_int (341))
+                                                                    (Prims.of_int (417))
                                                                     (Prims.of_int (8)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2874,17 +3544,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (298))
+                                                                    (Prims.of_int (374))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (298))
+                                                                    (Prims.of_int (374))
                                                                     (Prims.of_int (35)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (298))
+                                                                    (Prims.of_int (374))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (298))
+                                                                    (Prims.of_int (374))
                                                                     (Prims.of_int (48)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Derived.cur_module
@@ -2913,17 +3583,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (299))
+                                                                    (Prims.of_int (375))
                                                                     (Prims.of_int (17))
-                                                                    (Prims.of_int (299))
+                                                                    (Prims.of_int (375))
                                                                     (Prims.of_int (51)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (299))
+                                                                    (Prims.of_int (375))
                                                                     (Prims.of_int (54))
-                                                                    (Prims.of_int (341))
+                                                                    (Prims.of_int (417))
                                                                     (Prims.of_int (8)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2944,17 +3614,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (302))
+                                                                    (Prims.of_int (378))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (307))
+                                                                    (Prims.of_int (383))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (308))
+                                                                    (Prims.of_int (384))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (341))
+                                                                    (Prims.of_int (417))
                                                                     (Prims.of_int (8)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2962,17 +3632,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (302))
+                                                                    (Prims.of_int (378))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (302))
+                                                                    (Prims.of_int (378))
                                                                     (Prims.of_int (47)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (302))
+                                                                    (Prims.of_int (378))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (307))
+                                                                    (Prims.of_int (383))
                                                                     (Prims.of_int (50)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2980,17 +3650,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (302))
+                                                                    (Prims.of_int (378))
                                                                     (Prims.of_int (25))
-                                                                    (Prims.of_int (302))
+                                                                    (Prims.of_int (378))
                                                                     (Prims.of_int (37)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (302))
+                                                                    (Prims.of_int (378))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (302))
+                                                                    (Prims.of_int (378))
                                                                     (Prims.of_int (47)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Builtins.top_env
@@ -3030,17 +3700,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (305))
+                                                                    (Prims.of_int (381))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (305))
+                                                                    (Prims.of_int (381))
                                                                     (Prims.of_int (33)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (305))
+                                                                    (Prims.of_int (381))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (307))
+                                                                    (Prims.of_int (383))
                                                                     (Prims.of_int (50)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_NamedView.inspect_sigelt
@@ -3087,17 +3757,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (311))
+                                                                    (Prims.of_int (387))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (318))
+                                                                    (Prims.of_int (394))
                                                                     (Prims.of_int (37)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (319))
+                                                                    (Prims.of_int (395))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (341))
+                                                                    (Prims.of_int (417))
                                                                     (Prims.of_int (8)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -3105,17 +3775,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (312))
+                                                                    (Prims.of_int (388))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (312))
+                                                                    (Prims.of_int (388))
                                                                     (Prims.of_int (51)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (311))
+                                                                    (Prims.of_int (387))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (318))
+                                                                    (Prims.of_int (394))
                                                                     (Prims.of_int (37)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_SyntaxHelpers.collect_arr_bs
@@ -3137,17 +3807,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (313))
+                                                                    (Prims.of_int (389))
                                                                     (Prims.of_int (21))
-                                                                    (Prims.of_int (313))
+                                                                    (Prims.of_int (389))
                                                                     (Prims.of_int (75)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (312))
+                                                                    (Prims.of_int (388))
                                                                     (Prims.of_int (54))
-                                                                    (Prims.of_int (318))
+                                                                    (Prims.of_int (394))
                                                                     (Prims.of_int (37)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3186,17 +3856,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (317))
+                                                                    (Prims.of_int (393))
                                                                     (Prims.of_int (21))
-                                                                    (Prims.of_int (317))
+                                                                    (Prims.of_int (393))
                                                                     (Prims.of_int (43)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (318))
+                                                                    (Prims.of_int (394))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (318))
+                                                                    (Prims.of_int (394))
                                                                     (Prims.of_int (37)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3230,17 +3900,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (320))
+                                                                    (Prims.of_int (396))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (327))
+                                                                    (Prims.of_int (403))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (329))
+                                                                    (Prims.of_int (405))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (341))
+                                                                    (Prims.of_int (417))
                                                                     (Prims.of_int (8)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -3248,17 +3918,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (321))
+                                                                    (Prims.of_int (397))
                                                                     (Prims.of_int (23))
-                                                                    (Prims.of_int (321))
+                                                                    (Prims.of_int (397))
                                                                     (Prims.of_int (49)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (320))
+                                                                    (Prims.of_int (396))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (327))
+                                                                    (Prims.of_int (403))
                                                                     (Prims.of_int (38)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_SyntaxHelpers.collect_abs
@@ -3280,17 +3950,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (322))
+                                                                    (Prims.of_int (398))
                                                                     (Prims.of_int (21))
-                                                                    (Prims.of_int (322))
+                                                                    (Prims.of_int (398))
                                                                     (Prims.of_int (75)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (321))
+                                                                    (Prims.of_int (397))
                                                                     (Prims.of_int (52))
-                                                                    (Prims.of_int (327))
+                                                                    (Prims.of_int (403))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3329,17 +3999,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (326))
+                                                                    (Prims.of_int (402))
                                                                     (Prims.of_int (21))
-                                                                    (Prims.of_int (326))
+                                                                    (Prims.of_int (402))
                                                                     (Prims.of_int (43)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (327))
+                                                                    (Prims.of_int (403))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (327))
+                                                                    (Prims.of_int (403))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3373,17 +4043,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (329))
+                                                                    (Prims.of_int (405))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (329))
+                                                                    (Prims.of_int (405))
                                                                     (Prims.of_int (53)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (330))
+                                                                    (Prims.of_int (406))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (341))
+                                                                    (Prims.of_int (417))
                                                                     (Prims.of_int (8)))))
                                                                     (Obj.magic
                                                                     (debug
@@ -3395,9 +4065,9 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (329))
+                                                                    (Prims.of_int (405))
                                                                     (Prims.of_int (34))
-                                                                    (Prims.of_int (329))
+                                                                    (Prims.of_int (405))
                                                                     (Prims.of_int (52)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -3432,17 +4102,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (330))
+                                                                    (Prims.of_int (406))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (330))
+                                                                    (Prims.of_int (406))
                                                                     (Prims.of_int (52)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (330))
+                                                                    (Prims.of_int (406))
                                                                     (Prims.of_int (53))
-                                                                    (Prims.of_int (341))
+                                                                    (Prims.of_int (417))
                                                                     (Prims.of_int (8)))))
                                                                     (Obj.magic
                                                                     (debug
@@ -3454,9 +4124,9 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (330))
+                                                                    (Prims.of_int (406))
                                                                     (Prims.of_int (34))
-                                                                    (Prims.of_int (330))
+                                                                    (Prims.of_int (406))
                                                                     (Prims.of_int (51)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -3491,17 +4161,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (332))
+                                                                    (Prims.of_int (408))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (332))
+                                                                    (Prims.of_int (408))
                                                                     (Prims.of_int (24)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (332))
+                                                                    (Prims.of_int (408))
                                                                     (Prims.of_int (27))
-                                                                    (Prims.of_int (341))
+                                                                    (Prims.of_int (417))
                                                                     (Prims.of_int (8)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3518,17 +4188,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (333))
+                                                                    (Prims.of_int (409))
                                                                     (Prims.of_int (23))
-                                                                    (Prims.of_int (333))
+                                                                    (Prims.of_int (409))
                                                                     (Prims.of_int (26)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (333))
+                                                                    (Prims.of_int (409))
                                                                     (Prims.of_int (29))
-                                                                    (Prims.of_int (341))
+                                                                    (Prims.of_int (417))
                                                                     (Prims.of_int (8)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3545,17 +4215,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (334))
+                                                                    (Prims.of_int (410))
                                                                     (Prims.of_int (21))
-                                                                    (Prims.of_int (334))
+                                                                    (Prims.of_int (410))
                                                                     (Prims.of_int (24)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (334))
+                                                                    (Prims.of_int (410))
                                                                     (Prims.of_int (27))
-                                                                    (Prims.of_int (341))
+                                                                    (Prims.of_int (417))
                                                                     (Prims.of_int (8)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3572,17 +4242,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (336))
+                                                                    (Prims.of_int (412))
                                                                     (Prims.of_int (17))
-                                                                    (Prims.of_int (336))
+                                                                    (Prims.of_int (412))
                                                                     (Prims.of_int (70)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (336))
+                                                                    (Prims.of_int (412))
                                                                     (Prims.of_int (75))
-                                                                    (Prims.of_int (341))
+                                                                    (Prims.of_int (417))
                                                                     (Prims.of_int (8)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3610,17 +4280,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (337))
+                                                                    (Prims.of_int (413))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (337))
+                                                                    (Prims.of_int (413))
                                                                     (Prims.of_int (59)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (339))
+                                                                    (Prims.of_int (415))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (339))
+                                                                    (Prims.of_int (415))
                                                                     (Prims.of_int (42)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_NamedView.pack_sigelt

--- a/tests/error-messages/Bug1918.fst.expected
+++ b/tests/error-messages/Bug1918.fst.expected
@@ -1,5 +1,5 @@
 proof-state: State dump @ depth 0 (at the time of failure):
-Location: FStar.Tactics.Typeclasses.fst(213,6-216,7)
+Location: FStar.Tactics.Typeclasses.fst(289,6-292,7)
 Goal 1/1:
  |- _ : Bug1918.mon
 
@@ -7,7 +7,7 @@ Goal 1/1:
 * Error 228 at Bug1918.fst(11,13-11,14):
   - Tactic failed
   - Could not solve constraint Bug1918.mon
-  - See also FStar.Tactics.Typeclasses.fst(213,6-216,7)
+  - See also FStar.Tactics.Typeclasses.fst(289,6-292,7)
 
 >>]
 Verified module: Bug1918

--- a/tests/error-messages/Bug2021.fst.expected
+++ b/tests/error-messages/Bug2021.fst.expected
@@ -36,8 +36,8 @@
 
 >>]
 >> Got issues: [
-* Error 66 at Bug2021.fst(37,13-37,14):
-  - Failed to resolve implicit argument ?11
+* Error 66 at Bug2021.fst(37,13-37,17):
+  - Failed to resolve implicit argument ?13
     of type Prims.int
     introduced for Instantiating implicit argument in application
   - See also Bug2021.fst(36,11-36,12)

--- a/tests/typeclasses/Fundeps.fst
+++ b/tests/typeclasses/Fundeps.fst
@@ -1,0 +1,17 @@
+module Fundeps
+
+[@@Tactics.Typeclasses.fundeps [0]]
+class setlike (e:Type) (s:Type) = {
+  empty : s;
+  add : e -> s -> s;
+  remove : e -> s -> s;
+  contains : e -> s -> bool;
+  size : s -> int;
+}
+
+assume val set (a:Type) : Type
+
+assume
+instance val setlike_set (a:Type) : setlike a (set a)
+
+let test (s : set int) = size s

--- a/ulib/FStar.Tactics.Typeclasses.fst
+++ b/ulib/FStar.Tactics.Typeclasses.fst
@@ -41,6 +41,10 @@ let tcclass : unit = ()
 irreducible
 let tcinstance : unit = ()
 
+(* Functional dependencies of a class. *)
+irreducible
+let fundeps (_ : list int) : unit = ()
+
 (* The attribute that marks class fields
    to signal that no method should be generated for them *)
 irreducible
@@ -57,6 +61,7 @@ noeq
 type tc_goal = {
   g : term;
   head_fv : fv;
+  args_and_uvars : list (argv & bool);
 }
 
 val fv_eq : fv -> fv -> Tot bool
@@ -73,6 +78,13 @@ let rec head_of (t:term) : Tac (option fv) =
   | Tv_UInst fv _ -> Some fv
   | Tv_App h _ -> head_of h
   | v -> None
+
+let hua (t:term) : Tac (option (fv & universes & list argv)) =
+  let hd, args = collect_app t in
+  match inspect hd with
+  | Tv_FVar fv -> Some (fv, [], args)
+  | Tv_UInst fv us -> Some (fv, us, args)
+  | _ -> None
 
 let rec res_typ (t:term) : Tac term =
   match inspect t with
@@ -113,7 +125,60 @@ let sigelt_name (se:sigelt) : list fv =
   | Stubs.Reflection.V2.Data.Sg_Val nm _ _ -> [pack_fv nm]
   | _ -> []
 
-let trywith (st:st_t) (g:tc_goal) (_:option sigelt) (t typ : term) (k : st_t -> Tac unit) : Tac unit =
+(* Would be nice to define an unembedding class here.. but it's circular. *)
+let unembed_int (t:term) : Tac (option int) =
+  match inspect_ln t with
+  | R.Tv_Const (C_Int i) -> Some i
+  | _ -> None
+
+let rec unembed_list (#a:Type) (u : term -> Tac (option a)) (t:term) : Tac (option (list a)) =
+  match hua t with
+  | Some (fv, _, [(ty, Q_Implicit); (hd, Q_Explicit); (tl, Q_Explicit)]) ->
+    if implode_qn (inspect_fv fv) = `%Prims.Cons then
+      match u hd, unembed_list u tl with
+      | Some hd, Some tl -> Some (hd::tl)
+      | _ -> None
+    else
+      None
+  | Some (fv, _, [(ty, Q_Implicit)]) ->
+    if implode_qn (inspect_fv fv) = `%Prims.Nil then
+      Some []
+    else
+      None
+  | _ ->
+    None
+
+let extract_fundep (se : sigelt) : Tac (option (list int)) =
+  let attrs = sigelt_attrs se in
+  let rec aux (attrs : list term) : Tac (option (list int)) =
+    match attrs with
+    | [] -> None
+    | attr::attrs' ->
+      match collect_app attr with
+      | hd, [(a0, Q_Explicit)] ->
+        if FStar.Reflection.V2.TermEq.term_eq hd (`fundeps) then (
+          unembed_list unembed_int a0
+        ) else
+          aux attrs'
+      | _ ->
+        aux attrs'
+    in
+    aux attrs
+
+let trywith (st:st_t) (g:tc_goal) (t typ : term) (k : st_t -> Tac unit) : Tac unit =
+    (* Class sigelt *)
+    let c_se = lookup_typ (cur_env()) (inspect_fv g.head_fv) in
+    let fundeps =
+      match c_se with
+      | Some se ->
+        extract_fundep se
+      | None -> None
+    in
+    // print ("head_fv = " ^ fv_to_string g.head_fv);
+    // print ("fundeps = " ^ Util.string_of_option (Util.string_of_list (fun i -> string_of_int i)) fundeps);
+    let unresolved_args = g.args_and_uvars |> Util.mapi (fun i (_, b) -> if b then [i <: int] else []) |> List.Tot.flatten in
+    // print ("unresolved_args = " ^ Util.string_of_list (fun i -> string_of_int i) unresolved_args);
+
     match head_of (res_typ typ) with
     | None ->
       debug (fun () -> "no head for typ of this? " ^ term_to_string t ^ "    typ=" ^ term_to_string typ);
@@ -123,7 +188,16 @@ let trywith (st:st_t) (g:tc_goal) (_:option sigelt) (t typ : term) (k : st_t -> 
         raise NoInst; // class mismatch, would be better to not even get here
       debug (fun () -> "Trying to apply hypothesis/instance: " ^ term_to_string t);
       (fun () ->
+        if Cons? unresolved_args && None? fundeps then
+          fail "Will not continue as there are unresolved args (and no fundeps)"
+        else if Cons? unresolved_args && Some? fundeps then (
+          let Some fundeps = fundeps in
+          debug (fun () -> "checking fundeps");
+          let all_good = List.Tot.for_all (fun i -> List.Tot.mem i fundeps) unresolved_args in
+          if all_good then apply t else fail "fundeps"
+        ) else (
           apply_noinst t
+        )
       ) `seq` (fun () ->
         debug (fun () -> dump "next"; "apply seems to have worked");
         let st = { st with fuel = st.fuel - 1 } in
@@ -133,14 +207,14 @@ let local (st:st_t) (g:tc_goal) (k : st_t -> Tac unit) () : Tac unit =
     debug (fun () -> "local, goal = " ^ term_to_string g.g);
     let bs = vars_of_env (cur_env ()) in
     first (fun (b:binding) ->
-              trywith st g None (pack (Tv_Var b)) b.sort k)
+              trywith st g (pack (Tv_Var b)) b.sort k)
           bs
 
 let global (st:st_t) (g:tc_goal) (k : st_t -> Tac unit) () : Tac unit =
     debug (fun () -> "global, goal = " ^ term_to_string g.g);
     first (fun (se, fv) ->
               let typ = tc (cur_env()) (pack (Tv_FVar fv)) in // FIXME: a bit slow.. but at least it's a simple fvar
-              trywith st g (Some se) (pack (Tv_FVar fv)) typ k)
+              trywith st g (pack (Tv_FVar fv)) typ k)
           st.glb
 
 (*
@@ -168,15 +242,16 @@ let rec tcresolve' (st:st_t) : Tac unit =
       raise NoInst
     );
 
-    match head_of g with
+    match hua g with
     | None ->
       debug (fun () -> "Goal does not look like a typeclass");
       raise NoInst
 
-    | Some head_fv ->
+    | Some (head_fv, us, args) ->
+      let args_and_uvars = args |> Util.map (fun (a, q) -> (a, q), Cons? (free_uvars a )) in
       (* ^ Maybe should check is this really is a class too? *)
       let st = { st with seen = g :: st.seen } in
-      let g = { g = g; head_fv = head_fv; } in
+      let g = { g = g; head_fv = head_fv; args_and_uvars = args_and_uvars } in
       local st g tcresolve' `or_else` global st g tcresolve'
 
 let rec concatMap (f : 'a -> Tac (list 'b)) (l : list 'a) : Tac (list 'b) =
@@ -197,7 +272,8 @@ let tcresolve () : Tac unit =
     // stored.
     let glb = lookup_attr_ses (`tcinstance) (cur_env ()) in
     let glb = glb |> concatMap (fun se ->
-              sigelt_name se |> concatMap (fun fv -> [(se, fv)]))
+              sigelt_name se |> concatMap (fun fv -> [(se, fv)])
+    )
     in
     let st0 = {
       seen = [];

--- a/ulib/FStar.Tactics.Typeclasses.fsti
+++ b/ulib/FStar.Tactics.Typeclasses.fsti
@@ -24,6 +24,14 @@ val tcclass : unit
 (* The attribute that marks instances *)
 val tcinstance : unit
 
+(* Functional dependencies of a class. It takes an int list
+representing the arguments of the class (starting from 0, both explicit
+and implicit alike) that are dependent on the rest. When trying to apply
+an instance, if the fundeps are unresolved (i.e. contain uvars) but the
+other arguments do not, we will apply the instance and instantiate the
+fundeps. *)
+val fundeps : list int -> unit
+
 (* The attribute that marks class fields
    to signal that no method should be generated for them *)
 val no_method : unit


### PR DESCRIPTION
This PR implements a simple flavor of functional dependencies for typeclasses. A class definition can now be annotated with the `fundeps` attribute, providing a list of the class arguments that are functionally dependent on the rest. For instance, the following definition represents a class of set-like types `s` over elements type `e`.
```fstar
[@@Tactics.Typeclasses.fundep [0]]
class setlike (e:Type) (s:Type) = {
  empty         : unit -> s;
  singleton     : e -> s;
  is_empty      : s -> bool;
  add           : e -> s -> s;
  [...]
}
```
The fundep attribute is indicating the the 0th argument (`e`) is determined from all other arguments (the complement of the ones listed in the fundep, in this case `s`).

Assuming we have an instance `setlike a (Set.set a)`, this allows one to write something like `is_empty (add 1 (empty ())`. That would previously fail, since `is_empty` being called on a `Set.set int`, but nothing is constraining `e` to be `int`. For example we could also have `instance setlike bool (Set.set int)`, though of course that's not the intention.

This change allows the tcresolve to instantiate some uvars in the goal (something we've been prohibiting so far, see #3134, #3130, #2591). I am now allowing this, only for `tcresolve`, since I made `tcresolve` aware of uvars and it should *not* instantiate uvars willy-nilly, it will only ever instantiate the uvars in the fundeps of a goal.

There is currently no check for the instances actually respecting the dependencies... so if the user states a functional dependency and does not respect it, some unexpected behavior may occur. This is basically an overlap check which we do not do for non-fundep classes either.

cc @TWal who may find this interesting.

