### PR TITLE
Fixing CI

### DIFF
--- a/.docker/base.Dockerfile
+++ b/.docker/base.Dockerfile
@@ -23,7 +23,6 @@ RUN apt-get -y --no-install-recommends install vim emacs
 # Base dependencies: opam
 # CI dependencies: jq (to identify F* branch)
 # python3 (for interactive tests)
-# libicu (for .NET, cf. https://aka.ms/dotnet-missing-libicu )
 RUN apt-get install -y --no-install-recommends \
       jq \
       bc \
@@ -35,7 +34,6 @@ RUN apt-get install -y --no-install-recommends \
       sudo \
       python3 \
       python-is-python3 \
-      libicu70 \
       opam \
       && apt-get clean -y
 

--- a/.docker/base.Dockerfile
+++ b/.docker/base.Dockerfile
@@ -9,7 +9,8 @@
 # will NOT use this file.
 
 # We always try to build against the most current ubuntu image.
-FROM ubuntu:latest
+# FIXME: Broken with 24.04, fixing it to 23.10 so we can keep working
+FROM ubuntu:23.10
 
 RUN apt-get update
 


### PR DESCRIPTION
First remove libicu from install invocation: It seems to flow into the dependencies automatically. Plus, this now broke after the version in the Ubuntu repos became 74 instead of 70.

Also, fix the Ubuntu version to 23.10 instead of `latest`. We fail to install z3 via OPAM in 24.04 since python3-distutils does not exist any more, apparently.