### PR TITLE
Syntax/SMT: Structure SMT errors (and Meta_labeled)

### DIFF
--- a/examples/miniparse/MiniParse.fst.config.json
+++ b/examples/miniparse/MiniParse.fst.config.json
@@ -1,0 +1,7 @@
+{
+  "fstar_exe": "fstar.exe",
+  "options": [
+  ],
+  "include_dirs": [
+  ]
+}

--- a/ocaml/fstar-lib/generated/FStar_Compiler_RBSet.ml
+++ b/ocaml/fstar-lib/generated/FStar_Compiler_RBSet.ml
@@ -215,3 +215,14 @@ let setlike_rbset :
       FStar_Class_Setlike.from_list = (from_list uu___);
       FStar_Class_Setlike.addn = (addn uu___)
     }
+let showable_rbset :
+  'a . 'a FStar_Class_Show.showable -> 'a t FStar_Class_Show.showable =
+  fun uu___ ->
+    {
+      FStar_Class_Show.show =
+        (fun s ->
+           let uu___1 =
+             let uu___2 = elems s in
+             FStar_Class_Show.show (FStar_Class_Show.show_list uu___) uu___2 in
+           Prims.strcat "RBSet " uu___1)
+    }

--- a/ocaml/fstar-lib/generated/FStar_SMTEncoding_EncodeTerm.ml
+++ b/ocaml/fstar-lib/generated/FStar_SMTEncoding_EncodeTerm.ml
@@ -3695,27 +3695,38 @@ and (encode_formula :
                   | (FStar_Pervasives_Native.Some r1,
                      FStar_Pervasives_Native.Some s) ->
                       let phi3 =
-                        FStar_Syntax_Syntax.mk
-                          (FStar_Syntax_Syntax.Tm_meta
-                             {
-                               FStar_Syntax_Syntax.tm2 = phi2;
-                               FStar_Syntax_Syntax.meta =
-                                 (FStar_Syntax_Syntax.Meta_labeled
-                                    (s, r1, false))
-                             }) r1 in
+                        let uu___4 =
+                          let uu___5 =
+                            let uu___6 =
+                              let uu___7 =
+                                let uu___8 = FStar_Errors_Msg.mkmsg s in
+                                (uu___8, r1, false) in
+                              FStar_Syntax_Syntax.Meta_labeled uu___7 in
+                            {
+                              FStar_Syntax_Syntax.tm2 = phi2;
+                              FStar_Syntax_Syntax.meta = uu___6
+                            } in
+                          FStar_Syntax_Syntax.Tm_meta uu___5 in
+                        FStar_Syntax_Syntax.mk uu___4 r1 in
                       fallback phi3
                   | (FStar_Pervasives_Native.None,
                      FStar_Pervasives_Native.Some s) ->
                       let phi3 =
-                        FStar_Syntax_Syntax.mk
-                          (FStar_Syntax_Syntax.Tm_meta
-                             {
-                               FStar_Syntax_Syntax.tm2 = phi2;
-                               FStar_Syntax_Syntax.meta =
-                                 (FStar_Syntax_Syntax.Meta_labeled
-                                    (s, (phi2.FStar_Syntax_Syntax.pos),
-                                      false))
-                             }) phi2.FStar_Syntax_Syntax.pos in
+                        let uu___4 =
+                          let uu___5 =
+                            let uu___6 =
+                              let uu___7 =
+                                let uu___8 = FStar_Errors_Msg.mkmsg s in
+                                (uu___8, (phi2.FStar_Syntax_Syntax.pos),
+                                  false) in
+                              FStar_Syntax_Syntax.Meta_labeled uu___7 in
+                            {
+                              FStar_Syntax_Syntax.tm2 = phi2;
+                              FStar_Syntax_Syntax.meta = uu___6
+                            } in
+                          FStar_Syntax_Syntax.Tm_meta uu___5 in
+                        FStar_Syntax_Syntax.mk uu___4
+                          phi2.FStar_Syntax_Syntax.pos in
                       fallback phi3
                   | uu___4 -> fallback phi2)
              | (FStar_Syntax_Syntax.Tm_fvar fv, (t, uu___)::[]) when

--- a/ocaml/fstar-lib/generated/FStar_SMTEncoding_ErrorReporting.ml
+++ b/ocaml/fstar-lib/generated/FStar_SMTEncoding_ErrorReporting.ml
@@ -11,7 +11,7 @@ let (__proj__Not_a_wp_implication__item__uu___ : Prims.exn -> Prims.string) =
   fun projectee -> match projectee with | Not_a_wp_implication uu___ -> uu___
 let (sort_labels :
   (FStar_SMTEncoding_Term.error_label * Prims.bool) Prims.list ->
-    ((FStar_SMTEncoding_Term.fv * Prims.string *
+    ((FStar_SMTEncoding_Term.fv * FStar_Errors_Msg.error_message *
       FStar_Compiler_Range_Type.range) * Prims.bool) Prims.list)
   =
   fun l ->
@@ -23,7 +23,7 @@ let (sort_labels :
                -> FStar_Compiler_Range_Ops.compare r1 r2) l
 let (remove_dups :
   labels ->
-    (FStar_SMTEncoding_Term.fv * Prims.string *
+    (FStar_SMTEncoding_Term.fv * FStar_Errors_Msg.error_message *
       FStar_Compiler_Range_Type.range) Prims.list)
   =
   fun l ->
@@ -40,7 +40,7 @@ type ranges =
 let (__ctr : Prims.int FStar_Compiler_Effect.ref) =
   FStar_Compiler_Util.mk_ref Prims.int_zero
 let (fresh_label :
-  Prims.string ->
+  FStar_Errors_Msg.error_message ->
     FStar_Compiler_Range_Type.range ->
       FStar_SMTEncoding_Term.term -> (label * FStar_SMTEncoding_Term.term))
   =
@@ -104,17 +104,23 @@ let (label_goals :
           FStar_Compiler_Util.for_some is_guard_free (conjuncts lhs) in
         let uu___ =
           match use_env_msg with
-          | FStar_Pervasives_Native.None -> (false, "")
+          | FStar_Pervasives_Native.None -> (false, FStar_Pprint.empty)
           | FStar_Pervasives_Native.Some f ->
-              let uu___1 = f () in (true, uu___1) in
+              let uu___1 =
+                let uu___2 = f () in FStar_Pprint.doc_of_string uu___2 in
+              (true, uu___1) in
         match uu___ with
         | (flag, msg_prefix) ->
             let fresh_label1 msg1 ropt rng t =
               let msg2 =
                 if flag
                 then
-                  Prims.strcat "Failed to verify implicit argument: "
-                    (Prims.strcat msg_prefix (Prims.strcat " :: " msg1))
+                  let uu___1 =
+                    let uu___2 =
+                      FStar_Errors_Msg.text
+                        "Failed to verify implicit argument: " in
+                    FStar_Pprint.op_Hat_Hat uu___2 msg_prefix in
+                  uu___1 :: msg1
                 else msg1 in
               let rng1 =
                 match ropt with
@@ -138,8 +144,9 @@ let (label_goals :
               | FStar_SMTEncoding_Term.Real uu___1 -> (labels1, q1)
               | FStar_SMTEncoding_Term.LblPos uu___1 ->
                   FStar_Compiler_Effect.failwith "Impossible"
-              | FStar_SMTEncoding_Term.Labeled
-                  (arg, "Could not prove post-condition", label_range) ->
+              | FStar_SMTEncoding_Term.Labeled (arg, d::[], label_range) when
+                  let uu___1 = FStar_Errors_Msg.renderdoc d in
+                  uu___1 = "Could not prove post-condition" ->
                   let fallback debug_msg =
                     aux default_msg
                       (FStar_Pervasives_Native.Some label_range)
@@ -233,8 +240,10 @@ let (label_goals :
                                                       if uu___7
                                                       then
                                                         let uu___8 =
-                                                          aux
-                                                            "Could not prove post-condition"
+                                                          let uu___9 =
+                                                            FStar_Errors_Msg.mkmsg
+                                                              "Could not prove post-condition" in
+                                                          aux uu___9
                                                             FStar_Pervasives_Native.None
                                                             (FStar_Pervasives_Native.Some
                                                                post_name)
@@ -744,8 +753,9 @@ let (label_goals :
                            q1.FStar_SMTEncoding_Term.rng in
                        (labels2, uu___2)) in
             (FStar_Compiler_Effect.op_Colon_Equals __ctr Prims.int_zero;
-             aux "Assertion failed" FStar_Pervasives_Native.None
-               FStar_Pervasives_Native.None [] q)
+             (let uu___2 = FStar_Errors_Msg.mkmsg "Assertion failed" in
+              aux uu___2 FStar_Pervasives_Native.None
+                FStar_Pervasives_Native.None [] q))
 let (detail_errors :
   Prims.bool ->
     FStar_TypeChecker_Env.env ->
@@ -785,21 +795,32 @@ let (detail_errors :
                 else
                   if hint_replay
                   then
-                    FStar_Errors.log_issue r
-                      (FStar_Errors_Codes.Warning_HintFailedToReplayProof,
-                        (Prims.strcat
-                           "Hint failed to replay this sub-proof: " msg1))
+                    (let uu___3 =
+                       let uu___4 =
+                         let uu___5 =
+                           FStar_Errors_Msg.text
+                             "Hint failed to replay this sub-proof" in
+                         uu___5 :: msg1 in
+                       (FStar_Errors_Codes.Warning_HintFailedToReplayProof,
+                         uu___4) in
+                     FStar_Errors.log_issue_doc r uu___3)
                   else
                     (let uu___4 =
                        let uu___5 =
                          let uu___6 =
-                           FStar_Compiler_Range_Ops.string_of_range r in
-                         FStar_Compiler_Util.format2
-                           "XX: proof obligation at %s failed\n\t%s\n" uu___6
-                           msg1 in
+                           let uu___7 =
+                             let uu___8 =
+                               let uu___9 =
+                                 FStar_Class_Show.show
+                                   FStar_Compiler_Range_Ops.show_range r in
+                               FStar_Compiler_Util.format1
+                                 "XX: proof obligation at %s failed." uu___9 in
+                             FStar_Errors_Msg.text uu___8 in
+                           [uu___7] in
+                         FStar_Compiler_List.op_At uu___6 msg1 in
                        (FStar_Errors_Codes.Error_ProofObligationFailed,
                          uu___5) in
-                     FStar_Errors.log_issue r uu___4) in
+                     FStar_Errors.log_issue_doc r uu___4) in
           let elim labs =
             FStar_Compiler_List.map
               (fun uu___ ->

--- a/ocaml/fstar-lib/generated/FStar_SMTEncoding_Solver.ml
+++ b/ocaml/fstar-lib/generated/FStar_SMTEncoding_Solver.ml
@@ -631,10 +631,9 @@ let (query_errors :
                      (fun uu___3 ->
                         match uu___3 with
                         | (uu___4, x, y) ->
-                            let uu___5 = FStar_Errors_Msg.mkmsg x in
-                            let uu___6 = FStar_Errors.get_ctx () in
-                            (FStar_Errors_Codes.Error_Z3SolverError, uu___5,
-                              y, uu___6)) error_labels in
+                            let uu___5 = FStar_Errors.get_ctx () in
+                            (FStar_Errors_Codes.Error_Z3SolverError, x, y,
+                              uu___5)) error_labels in
                  {
                    error_reason = msg;
                    error_fuel = (settings.query_fuel);
@@ -821,9 +820,8 @@ let (errors_to_report :
         | (FStar_Pervasives_Native.None, (uu___1, msg, rng)::[]) ->
             let uu___2 =
               let uu___3 =
-                let uu___4 = FStar_Errors_Msg.mkmsg msg in
-                let uu___5 = FStar_Errors.get_ctx () in
-                (FStar_Errors_Codes.Error_Z3SolverError, uu___4, rng, uu___5) in
+                let uu___4 = FStar_Errors.get_ctx () in
+                (FStar_Errors_Codes.Error_Z3SolverError, msg, rng, uu___4) in
               [uu___3] in
             FStar_TypeChecker_Err.errors_smt_detail settings.query_env uu___2
               recovery_failed_msg
@@ -840,10 +838,14 @@ let (errors_to_report :
                        ("", FStar_SMTEncoding_Term.dummy_sort) in
                    let msg =
                      let uu___3 =
-                       FStar_Syntax_Print.term_to_string settings.query_term in
-                     FStar_Compiler_Util.format1
-                       "Failed to prove the following goal, although it appears to be trivial: %s"
-                       uu___3 in
+                       let uu___4 =
+                         FStar_Errors_Msg.text
+                           "Failed to prove the following goal, although it appears to be trivial:" in
+                       let uu___5 =
+                         FStar_Class_PP.pp FStar_Syntax_Print.pretty_term
+                           settings.query_term in
+                       FStar_Pprint.op_Hat_Slash_Hat uu___4 uu___5 in
+                     [uu___3] in
                    let range =
                      FStar_TypeChecker_Env.get_range settings.query_env in
                    [(dummy_fv, msg, range)]
@@ -870,10 +872,9 @@ let (errors_to_report :
                     | (uu___4, msg, rng) ->
                         let uu___5 =
                           let uu___6 =
-                            let uu___7 = FStar_Errors_Msg.mkmsg msg in
-                            let uu___8 = FStar_Errors.get_ctx () in
-                            (FStar_Errors_Codes.Error_Z3SolverError, uu___7,
-                              rng, uu___8) in
+                            let uu___7 = FStar_Errors.get_ctx () in
+                            (FStar_Errors_Codes.Error_Z3SolverError, msg,
+                              rng, uu___7) in
                           [uu___6] in
                         FStar_TypeChecker_Err.errors_smt_detail
                           settings.query_env uu___5 recovery_failed_msg)
@@ -1140,13 +1141,17 @@ let (query_info : query_settings -> FStar_SMTEncoding_Z3.z3result -> unit) =
                     (fun uu___5 ->
                        match uu___5 with
                        | (uu___6, msg, range1) ->
-                           let tag1 =
+                           let msg1 =
                              if used_hint settings
-                             then "(Hint-replay failed): "
-                             else "" in
-                           FStar_Errors.log_issue range1
+                             then
+                               let uu___7 =
+                                 FStar_Pprint.doc_of_string
+                                   "Hint-replay failed" in
+                               uu___7 :: msg
+                             else msg in
+                           FStar_Errors.log_issue_doc range1
                              (FStar_Errors_Codes.Warning_HitReplayFailed,
-                               (Prims.strcat tag1 msg))) errs))
+                               msg1)) errs))
       else ()
 let (store_hint : FStar_Compiler_Hints.hint -> unit) =
   fun hint ->

--- a/ocaml/fstar-lib/generated/FStar_SMTEncoding_Term.ml
+++ b/ocaml/fstar-lib/generated/FStar_SMTEncoding_Term.ml
@@ -166,7 +166,8 @@ type term' =
   | Quant of (qop * term Prims.list Prims.list * Prims.int
   FStar_Pervasives_Native.option * sort Prims.list * term) 
   | Let of (term Prims.list * term) 
-  | Labeled of (term * Prims.string * FStar_Compiler_Range_Type.range) 
+  | Labeled of (term * FStar_Errors_Msg.error_message *
+  FStar_Compiler_Range_Type.range) 
   | LblPos of (term * Prims.string) 
 and term =
   {
@@ -213,8 +214,9 @@ let (__proj__Let__item___0 : term' -> (term Prims.list * term)) =
 let (uu___is_Labeled : term' -> Prims.bool) =
   fun projectee -> match projectee with | Labeled _0 -> true | uu___ -> false
 let (__proj__Labeled__item___0 :
-  term' -> (term * Prims.string * FStar_Compiler_Range_Type.range)) =
-  fun projectee -> match projectee with | Labeled _0 -> _0
+  term' ->
+    (term * FStar_Errors_Msg.error_message * FStar_Compiler_Range_Type.range))
+  = fun projectee -> match projectee with | Labeled _0 -> _0
 let (uu___is_LblPos : term' -> Prims.bool) =
   fun projectee -> match projectee with | LblPos _0 -> true | uu___ -> false
 let (__proj__LblPos__item___0 : term' -> (term * Prims.string)) =
@@ -523,7 +525,8 @@ let (fv_sort : fv -> sort) =
 let (fv_force : fv -> Prims.bool) =
   fun x ->
     let uu___ = x in match uu___ with | FV (uu___1, uu___2, force) -> force
-type error_label = (fv * Prims.string * FStar_Compiler_Range_Type.range)
+type error_label =
+  (fv * FStar_Errors_Msg.error_message * FStar_Compiler_Range_Type.range)
 type error_labels = error_label Prims.list
 let (fv_eq : fv -> fv -> Prims.bool) =
   fun x ->
@@ -665,8 +668,9 @@ let rec (hash_of_term' : term' -> Prims.string) =
     | Labeled (t1, r1, r2) ->
         let uu___ = hash_of_term t1 in
         let uu___1 =
-          let uu___2 = FStar_Compiler_Range_Ops.string_of_range r2 in
-          Prims.strcat r1 uu___2 in
+          let uu___2 = FStar_Errors_Msg.rendermsg r1 in
+          let uu___3 = FStar_Compiler_Range_Ops.string_of_range r2 in
+          Prims.strcat uu___2 uu___3 in
         Prims.strcat uu___ uu___1
     | LblPos (t1, r) ->
         let uu___ =
@@ -1089,8 +1093,9 @@ let rec (print_smt_term : term -> Prims.string) =
         let uu___1 = print_smt_term_list l in
         FStar_Compiler_Util.format2 "(%s %s)" uu___ uu___1
     | Labeled (t1, r1, r2) ->
-        let uu___ = print_smt_term t1 in
-        FStar_Compiler_Util.format2 "(Labeled '%s' %s)" r1 uu___
+        let uu___ = FStar_Errors_Msg.rendermsg r1 in
+        let uu___1 = print_smt_term t1 in
+        FStar_Compiler_Util.format2 "(Labeled '%s' %s)" uu___ uu___1
     | LblPos (t1, s) ->
         let uu___ = print_smt_term t1 in
         FStar_Compiler_Util.format2 "(LblPos %s %s)" s uu___

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Free.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Free.ml
@@ -109,17 +109,41 @@ let op_At_At :
           xs ys
 let (no_free_vars : free_vars_and_fvars) =
   let uu___ =
+    let uu___1 =
+      Obj.magic
+        (FStar_Class_Setlike.empty ()
+           (Obj.magic
+              (FStar_Compiler_FlatSet.setlike_flat_set
+                 FStar_Syntax_Syntax.ord_bv)) ()) in
+    let uu___2 =
+      Obj.magic
+        (FStar_Class_Setlike.empty ()
+           (Obj.magic (FStar_Compiler_FlatSet.setlike_flat_set ord_ctx_uvar))
+           ()) in
+    let uu___3 =
+      Obj.magic
+        (FStar_Class_Setlike.empty ()
+           (Obj.magic (FStar_Compiler_FlatSet.setlike_flat_set ord_univ_uvar))
+           ()) in
+    let uu___4 =
+      Obj.magic
+        (FStar_Class_Setlike.empty ()
+           (Obj.magic
+              (FStar_Compiler_FlatSet.setlike_flat_set
+                 FStar_Syntax_Syntax.ord_ident)) ()) in
+    {
+      FStar_Syntax_Syntax.free_names = uu___1;
+      FStar_Syntax_Syntax.free_uvars = uu___2;
+      FStar_Syntax_Syntax.free_univs = uu___3;
+      FStar_Syntax_Syntax.free_univ_names = uu___4
+    } in
+  let uu___1 =
     Obj.magic
       (FStar_Class_Setlike.empty ()
          (Obj.magic
             (FStar_Compiler_RBSet.setlike_rbset FStar_Syntax_Syntax.ord_fv))
          ()) in
-  ({
-     FStar_Syntax_Syntax.free_names = [];
-     FStar_Syntax_Syntax.free_uvars = [];
-     FStar_Syntax_Syntax.free_univs = [];
-     FStar_Syntax_Syntax.free_univ_names = []
-   }, uu___)
+  (uu___, uu___1)
 let (singleton_fvar : FStar_Syntax_Syntax.fv -> free_vars_and_fvars) =
   fun fv ->
     let uu___ =
@@ -142,64 +166,94 @@ let (singleton_bv :
       FStar_Compiler_RBSet.t))
   =
   fun x ->
-    ((let uu___ = FStar_Pervasives_Native.fst no_free_vars in
+    let uu___ =
+      let uu___1 = FStar_Pervasives_Native.fst no_free_vars in
+      let uu___2 =
+        Obj.magic
+          (FStar_Class_Setlike.singleton ()
+             (Obj.magic
+                (FStar_Compiler_FlatSet.setlike_flat_set
+                   FStar_Syntax_Syntax.ord_bv)) x) in
       {
-        FStar_Syntax_Syntax.free_names = [x];
+        FStar_Syntax_Syntax.free_names = uu___2;
         FStar_Syntax_Syntax.free_uvars =
-          (uu___.FStar_Syntax_Syntax.free_uvars);
+          (uu___1.FStar_Syntax_Syntax.free_uvars);
         FStar_Syntax_Syntax.free_univs =
-          (uu___.FStar_Syntax_Syntax.free_univs);
+          (uu___1.FStar_Syntax_Syntax.free_univs);
         FStar_Syntax_Syntax.free_univ_names =
-          (uu___.FStar_Syntax_Syntax.free_univ_names)
-      }), (FStar_Pervasives_Native.snd no_free_vars))
+          (uu___1.FStar_Syntax_Syntax.free_univ_names)
+      } in
+    (uu___, (FStar_Pervasives_Native.snd no_free_vars))
 let (singleton_uv :
   FStar_Syntax_Syntax.ctx_uvar ->
     (FStar_Syntax_Syntax.free_vars * FStar_Ident.lident
       FStar_Compiler_RBSet.t))
   =
   fun x ->
-    ((let uu___ = FStar_Pervasives_Native.fst no_free_vars in
+    let uu___ =
+      let uu___1 = FStar_Pervasives_Native.fst no_free_vars in
+      let uu___2 =
+        Obj.magic
+          (FStar_Class_Setlike.singleton ()
+             (Obj.magic
+                (FStar_Compiler_FlatSet.setlike_flat_set ord_ctx_uvar)) x) in
       {
         FStar_Syntax_Syntax.free_names =
-          (uu___.FStar_Syntax_Syntax.free_names);
-        FStar_Syntax_Syntax.free_uvars = [x];
+          (uu___1.FStar_Syntax_Syntax.free_names);
+        FStar_Syntax_Syntax.free_uvars = uu___2;
         FStar_Syntax_Syntax.free_univs =
-          (uu___.FStar_Syntax_Syntax.free_univs);
+          (uu___1.FStar_Syntax_Syntax.free_univs);
         FStar_Syntax_Syntax.free_univ_names =
-          (uu___.FStar_Syntax_Syntax.free_univ_names)
-      }), (FStar_Pervasives_Native.snd no_free_vars))
+          (uu___1.FStar_Syntax_Syntax.free_univ_names)
+      } in
+    (uu___, (FStar_Pervasives_Native.snd no_free_vars))
 let (singleton_univ :
   FStar_Syntax_Syntax.universe_uvar ->
     (FStar_Syntax_Syntax.free_vars * FStar_Ident.lident
       FStar_Compiler_RBSet.t))
   =
   fun x ->
-    ((let uu___ = FStar_Pervasives_Native.fst no_free_vars in
+    let uu___ =
+      let uu___1 = FStar_Pervasives_Native.fst no_free_vars in
+      let uu___2 =
+        Obj.magic
+          (FStar_Class_Setlike.singleton ()
+             (Obj.magic
+                (FStar_Compiler_FlatSet.setlike_flat_set ord_univ_uvar)) x) in
       {
         FStar_Syntax_Syntax.free_names =
-          (uu___.FStar_Syntax_Syntax.free_names);
+          (uu___1.FStar_Syntax_Syntax.free_names);
         FStar_Syntax_Syntax.free_uvars =
-          (uu___.FStar_Syntax_Syntax.free_uvars);
-        FStar_Syntax_Syntax.free_univs = [x];
+          (uu___1.FStar_Syntax_Syntax.free_uvars);
+        FStar_Syntax_Syntax.free_univs = uu___2;
         FStar_Syntax_Syntax.free_univ_names =
-          (uu___.FStar_Syntax_Syntax.free_univ_names)
-      }), (FStar_Pervasives_Native.snd no_free_vars))
+          (uu___1.FStar_Syntax_Syntax.free_univ_names)
+      } in
+    (uu___, (FStar_Pervasives_Native.snd no_free_vars))
 let (singleton_univ_name :
   FStar_Syntax_Syntax.univ_name ->
     (FStar_Syntax_Syntax.free_vars * FStar_Ident.lident
       FStar_Compiler_RBSet.t))
   =
   fun x ->
-    ((let uu___ = FStar_Pervasives_Native.fst no_free_vars in
+    let uu___ =
+      let uu___1 = FStar_Pervasives_Native.fst no_free_vars in
+      let uu___2 =
+        Obj.magic
+          (FStar_Class_Setlike.singleton ()
+             (Obj.magic
+                (FStar_Compiler_FlatSet.setlike_flat_set
+                   FStar_Syntax_Syntax.ord_ident)) x) in
       {
         FStar_Syntax_Syntax.free_names =
-          (uu___.FStar_Syntax_Syntax.free_names);
+          (uu___1.FStar_Syntax_Syntax.free_names);
         FStar_Syntax_Syntax.free_uvars =
-          (uu___.FStar_Syntax_Syntax.free_uvars);
+          (uu___1.FStar_Syntax_Syntax.free_uvars);
         FStar_Syntax_Syntax.free_univs =
-          (uu___.FStar_Syntax_Syntax.free_univs);
-        FStar_Syntax_Syntax.free_univ_names = [x]
-      }), (FStar_Pervasives_Native.snd no_free_vars))
+          (uu___1.FStar_Syntax_Syntax.free_univs);
+        FStar_Syntax_Syntax.free_univ_names = uu___2
+      } in
+    (uu___, (FStar_Pervasives_Native.snd no_free_vars))
 let (union :
   free_vars_and_fvars ->
     free_vars_and_fvars ->
@@ -210,21 +264,43 @@ let (union :
     fun f2 ->
       let uu___ =
         let uu___1 =
-          op_At_At FStar_Syntax_Syntax.deq_bv
-            (FStar_Pervasives_Native.fst f1).FStar_Syntax_Syntax.free_names
-            (FStar_Pervasives_Native.fst f2).FStar_Syntax_Syntax.free_names in
+          Obj.magic
+            (FStar_Class_Setlike.union ()
+               (Obj.magic
+                  (FStar_Compiler_FlatSet.setlike_flat_set
+                     FStar_Syntax_Syntax.ord_bv))
+               (Obj.magic
+                  (FStar_Pervasives_Native.fst f1).FStar_Syntax_Syntax.free_names)
+               (Obj.magic
+                  (FStar_Pervasives_Native.fst f2).FStar_Syntax_Syntax.free_names)) in
         let uu___2 =
-          op_At_At deq_ctx_uvar
-            (FStar_Pervasives_Native.fst f1).FStar_Syntax_Syntax.free_uvars
-            (FStar_Pervasives_Native.fst f2).FStar_Syntax_Syntax.free_uvars in
+          Obj.magic
+            (FStar_Class_Setlike.union ()
+               (Obj.magic
+                  (FStar_Compiler_FlatSet.setlike_flat_set ord_ctx_uvar))
+               (Obj.magic
+                  (FStar_Pervasives_Native.fst f1).FStar_Syntax_Syntax.free_uvars)
+               (Obj.magic
+                  (FStar_Pervasives_Native.fst f2).FStar_Syntax_Syntax.free_uvars)) in
         let uu___3 =
-          op_At_At deq_univ_uvar
-            (FStar_Pervasives_Native.fst f1).FStar_Syntax_Syntax.free_univs
-            (FStar_Pervasives_Native.fst f2).FStar_Syntax_Syntax.free_univs in
+          Obj.magic
+            (FStar_Class_Setlike.union ()
+               (Obj.magic
+                  (FStar_Compiler_FlatSet.setlike_flat_set ord_univ_uvar))
+               (Obj.magic
+                  (FStar_Pervasives_Native.fst f1).FStar_Syntax_Syntax.free_univs)
+               (Obj.magic
+                  (FStar_Pervasives_Native.fst f2).FStar_Syntax_Syntax.free_univs)) in
         let uu___4 =
-          op_At_At FStar_Syntax_Syntax.deq_univ_name
-            (FStar_Pervasives_Native.fst f1).FStar_Syntax_Syntax.free_univ_names
-            (FStar_Pervasives_Native.fst f2).FStar_Syntax_Syntax.free_univ_names in
+          Obj.magic
+            (FStar_Class_Setlike.union ()
+               (Obj.magic
+                  (FStar_Compiler_FlatSet.setlike_flat_set
+                     FStar_Syntax_Syntax.ord_ident))
+               (Obj.magic
+                  (FStar_Pervasives_Native.fst f1).FStar_Syntax_Syntax.free_univ_names)
+               (Obj.magic
+                  (FStar_Pervasives_Native.fst f2).FStar_Syntax_Syntax.free_univ_names)) in
         {
           FStar_Syntax_Syntax.free_names = uu___1;
           FStar_Syntax_Syntax.free_uvars = uu___2;
@@ -267,13 +343,14 @@ let rec (free_names_and_uvs' :
           FStar_Compiler_Effect.failwith "Impossible"
       | FStar_Syntax_Syntax.Tm_name x -> singleton_bv x
       | FStar_Syntax_Syntax.Tm_uvar (uv, (s, uu___)) ->
-          let uu___1 =
+          let uu___1 = singleton_uv uv in
+          let uu___2 =
             if use_cache = Full
             then
-              let uu___2 = ctx_uvar_typ uv in
-              free_names_and_uvars uu___2 use_cache
+              let uu___3 = ctx_uvar_typ uv in
+              free_names_and_uvars uu___3 use_cache
             else no_free_vars in
-          union (singleton_uv uv) uu___1
+          union uu___1 uu___2
       | FStar_Syntax_Syntax.Tm_type u -> free_univs u
       | FStar_Syntax_Syntax.Tm_bvar uu___ -> no_free_vars
       | FStar_Syntax_Syntax.Tm_fvar fv -> singleton_fvar fv
@@ -563,100 +640,69 @@ and (should_invalidate_cache :
   fun n ->
     fun use_cache ->
       ((use_cache <> Def) ||
-         (FStar_Compiler_Util.for_some
+         (FStar_Class_Setlike.for_any ()
+            (Obj.magic (FStar_Compiler_FlatSet.setlike_flat_set ord_ctx_uvar))
             (fun u ->
                let uu___ =
                  FStar_Syntax_Unionfind.find
                    u.FStar_Syntax_Syntax.ctx_uvar_head in
                match uu___ with
                | FStar_Pervasives_Native.Some uu___1 -> true
-               | uu___1 -> false) n.FStar_Syntax_Syntax.free_uvars))
+               | uu___1 -> false)
+            (Obj.magic n.FStar_Syntax_Syntax.free_uvars)))
         ||
-        (FStar_Compiler_Util.for_some
+        (FStar_Class_Setlike.for_any ()
+           (Obj.magic (FStar_Compiler_FlatSet.setlike_flat_set ord_univ_uvar))
            (fun u ->
               let uu___ = FStar_Syntax_Unionfind.univ_find u in
               match uu___ with
               | FStar_Pervasives_Native.Some uu___1 -> true
               | FStar_Pervasives_Native.None -> false)
-           n.FStar_Syntax_Syntax.free_univs)
+           (Obj.magic n.FStar_Syntax_Syntax.free_univs))
 let (names :
   FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.bv FStar_Compiler_FlatSet.t)
   =
-  fun uu___ ->
-    (fun t ->
-       let uu___ =
-         let uu___1 =
-           let uu___2 = free_names_and_uvars t Def in
-           FStar_Pervasives_Native.fst uu___2 in
-         uu___1.FStar_Syntax_Syntax.free_names in
-       Obj.magic
-         (FStar_Class_Setlike.from_list ()
-            (Obj.magic
-               (FStar_Compiler_FlatSet.setlike_flat_set
-                  FStar_Syntax_Syntax.ord_bv)) uu___)) uu___
+  fun t ->
+    let uu___ =
+      let uu___1 = free_names_and_uvars t Def in
+      FStar_Pervasives_Native.fst uu___1 in
+    uu___.FStar_Syntax_Syntax.free_names
 let (uvars :
   FStar_Syntax_Syntax.term ->
     FStar_Syntax_Syntax.ctx_uvar FStar_Compiler_FlatSet.t)
   =
-  fun uu___ ->
-    (fun t ->
-       let uu___ =
-         let uu___1 =
-           let uu___2 = free_names_and_uvars t Def in
-           FStar_Pervasives_Native.fst uu___2 in
-         uu___1.FStar_Syntax_Syntax.free_uvars in
-       Obj.magic
-         (FStar_Class_Setlike.from_list ()
-            (Obj.magic (FStar_Compiler_FlatSet.setlike_flat_set ord_ctx_uvar))
-            uu___)) uu___
+  fun t ->
+    let uu___ =
+      let uu___1 = free_names_and_uvars t Def in
+      FStar_Pervasives_Native.fst uu___1 in
+    uu___.FStar_Syntax_Syntax.free_uvars
 let (univs :
   FStar_Syntax_Syntax.term ->
     FStar_Syntax_Syntax.universe_uvar FStar_Compiler_FlatSet.t)
   =
-  fun uu___ ->
-    (fun t ->
-       let uu___ =
-         let uu___1 =
-           let uu___2 = free_names_and_uvars t Def in
-           FStar_Pervasives_Native.fst uu___2 in
-         uu___1.FStar_Syntax_Syntax.free_univs in
-       Obj.magic
-         (FStar_Class_Setlike.from_list ()
-            (Obj.magic
-               (FStar_Compiler_FlatSet.setlike_flat_set ord_univ_uvar)) uu___))
-      uu___
+  fun t ->
+    let uu___ =
+      let uu___1 = free_names_and_uvars t Def in
+      FStar_Pervasives_Native.fst uu___1 in
+    uu___.FStar_Syntax_Syntax.free_univs
 let (univnames :
   FStar_Syntax_Syntax.term ->
     FStar_Syntax_Syntax.univ_name FStar_Compiler_FlatSet.t)
   =
-  fun uu___ ->
-    (fun t ->
-       let uu___ =
-         let uu___1 =
-           let uu___2 = free_names_and_uvars t Def in
-           FStar_Pervasives_Native.fst uu___2 in
-         uu___1.FStar_Syntax_Syntax.free_univ_names in
-       Obj.magic
-         (FStar_Class_Setlike.from_list ()
-            (Obj.magic
-               (FStar_Compiler_FlatSet.setlike_flat_set
-                  FStar_Syntax_Syntax.ord_ident)) uu___)) uu___
+  fun t ->
+    let uu___ =
+      let uu___1 = free_names_and_uvars t Def in
+      FStar_Pervasives_Native.fst uu___1 in
+    uu___.FStar_Syntax_Syntax.free_univ_names
 let (univnames_comp :
   FStar_Syntax_Syntax.comp ->
     FStar_Syntax_Syntax.univ_name FStar_Compiler_FlatSet.t)
   =
-  fun uu___ ->
-    (fun c ->
-       let uu___ =
-         let uu___1 =
-           let uu___2 = free_names_and_uvars_comp c Def in
-           FStar_Pervasives_Native.fst uu___2 in
-         uu___1.FStar_Syntax_Syntax.free_univ_names in
-       Obj.magic
-         (FStar_Class_Setlike.from_list ()
-            (Obj.magic
-               (FStar_Compiler_FlatSet.setlike_flat_set
-                  FStar_Syntax_Syntax.ord_ident)) uu___)) uu___
+  fun c ->
+    let uu___ =
+      let uu___1 = free_names_and_uvars_comp c Def in
+      FStar_Pervasives_Native.fst uu___1 in
+    uu___.FStar_Syntax_Syntax.free_univ_names
 let (fvars :
   FStar_Syntax_Syntax.term -> FStar_Ident.lident FStar_Compiler_RBSet.t) =
   fun t ->
@@ -666,45 +712,26 @@ let (names_of_binders :
   FStar_Syntax_Syntax.binders ->
     FStar_Syntax_Syntax.bv FStar_Compiler_FlatSet.t)
   =
-  fun uu___ ->
-    (fun bs ->
-       let uu___ =
-         let uu___1 =
-           let uu___2 = free_names_and_uvars_binders bs Def in
-           FStar_Pervasives_Native.fst uu___2 in
-         uu___1.FStar_Syntax_Syntax.free_names in
-       Obj.magic
-         (FStar_Class_Setlike.from_list ()
-            (Obj.magic
-               (FStar_Compiler_FlatSet.setlike_flat_set
-                  FStar_Syntax_Syntax.ord_bv)) uu___)) uu___
+  fun bs ->
+    let uu___ =
+      let uu___1 = free_names_and_uvars_binders bs Def in
+      FStar_Pervasives_Native.fst uu___1 in
+    uu___.FStar_Syntax_Syntax.free_names
 let (uvars_uncached :
   FStar_Syntax_Syntax.term ->
     FStar_Syntax_Syntax.ctx_uvar FStar_Compiler_FlatSet.t)
   =
-  fun uu___ ->
-    (fun t ->
-       let uu___ =
-         let uu___1 =
-           let uu___2 = free_names_and_uvars t NoCache in
-           FStar_Pervasives_Native.fst uu___2 in
-         uu___1.FStar_Syntax_Syntax.free_uvars in
-       Obj.magic
-         (FStar_Class_Setlike.from_list ()
-            (Obj.magic (FStar_Compiler_FlatSet.setlike_flat_set ord_ctx_uvar))
-            uu___)) uu___
+  fun t ->
+    let uu___ =
+      let uu___1 = free_names_and_uvars t NoCache in
+      FStar_Pervasives_Native.fst uu___1 in
+    uu___.FStar_Syntax_Syntax.free_uvars
 let (uvars_full :
   FStar_Syntax_Syntax.term ->
     FStar_Syntax_Syntax.ctx_uvar FStar_Compiler_FlatSet.t)
   =
-  fun uu___ ->
-    (fun t ->
-       let uu___ =
-         let uu___1 =
-           let uu___2 = free_names_and_uvars t Full in
-           FStar_Pervasives_Native.fst uu___2 in
-         uu___1.FStar_Syntax_Syntax.free_uvars in
-       Obj.magic
-         (FStar_Class_Setlike.from_list ()
-            (Obj.magic (FStar_Compiler_FlatSet.setlike_flat_set ord_ctx_uvar))
-            uu___)) uu___
+  fun t ->
+    let uu___ =
+      let uu___1 = free_names_and_uvars t Full in
+      FStar_Pervasives_Native.fst uu___1 in
+    uu___.FStar_Syntax_Syntax.free_uvars

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Hash.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Hash.ml
@@ -83,6 +83,15 @@ let hash_option :
             let uu___1 = FStar_Hash.of_int (Prims.of_int (1249)) in
             ret uu___1 in
           let uu___1 = h o1 in mix uu___ uu___1
+let (hash_doc : FStar_Pprint.document -> FStar_Hash.hash_code mm) =
+  fun d ->
+    let uu___ =
+      FStar_Pprint.pretty_string (FStar_Compiler_Util.float_of_string "1.0")
+        (Prims.of_int (80)) d in
+    of_string uu___
+let (hash_doc_list :
+  FStar_Pprint.document Prims.list -> FStar_Hash.hash_code mm) =
+  fun ds -> hash_list hash_doc ds
 let hash_pair :
   'a 'b .
     ('a -> FStar_Hash.hash_code mm) ->
@@ -579,7 +588,7 @@ and (hash_meta : FStar_Syntax_Syntax.metadata -> FStar_Hash.hash_code mm) =
         let uu___1 =
           let uu___2 = of_int (Prims.of_int (1031)) in
           let uu___3 =
-            let uu___4 = of_string s in
+            let uu___4 = hash_doc_list s in
             let uu___5 =
               let uu___6 =
                 let uu___7 = FStar_Compiler_Range_Ops.string_of_range r in

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Print.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Print.ml
@@ -417,10 +417,11 @@ and (term_to_string : FStar_Syntax_Syntax.term -> Prims.string) =
                  FStar_Syntax_Syntax.meta = FStar_Syntax_Syntax.Meta_labeled
                    (l, r, b);_}
                ->
-               let uu___3 = FStar_Compiler_Range_Ops.string_of_range r in
-               let uu___4 = term_to_string t in
-               FStar_Compiler_Util.format3 "Meta_labeled(%s, %s){%s}" l
-                 uu___3 uu___4
+               let uu___3 = FStar_Errors_Msg.rendermsg l in
+               let uu___4 = FStar_Compiler_Range_Ops.string_of_range r in
+               let uu___5 = term_to_string t in
+               FStar_Compiler_Util.format3 "Meta_labeled(%s, %s){%s}" uu___3
+                 uu___4 uu___5
            | FStar_Syntax_Syntax.Tm_meta
                { FStar_Syntax_Syntax.tm2 = t;
                  FStar_Syntax_Syntax.meta = FStar_Syntax_Syntax.Meta_named l;_}
@@ -1111,8 +1112,9 @@ and (metadata_to_string : FStar_Syntax_Syntax.metadata -> Prims.string) =
         let uu___1 = sli lid in
         FStar_Compiler_Util.format1 "{Meta_named %s}" uu___1
     | FStar_Syntax_Syntax.Meta_labeled (l, r, uu___1) ->
-        let uu___2 = FStar_Compiler_Range_Ops.string_of_range r in
-        FStar_Compiler_Util.format2 "{Meta_labeled (%s, %s)}" l uu___2
+        let uu___2 = FStar_Errors_Msg.rendermsg l in
+        let uu___3 = FStar_Compiler_Range_Ops.string_of_range r in
+        FStar_Compiler_Util.format2 "{Meta_labeled (%s, %s)}" uu___2 uu___3
     | FStar_Syntax_Syntax.Meta_desugared msi -> "{Meta_desugared}"
     | FStar_Syntax_Syntax.Meta_monadic (m, t) ->
         let uu___1 = sli m in

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Resugar.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Resugar.ml
@@ -1035,9 +1035,13 @@ let rec (resugar_term' :
                                   | FStar_Syntax_Syntax.Meta_labeled
                                       (s, r, p) ->
                                       let uu___9 =
-                                        mk
-                                          (FStar_Parser_AST.Labeled
-                                             (body3, s, p)) in
+                                        let uu___10 =
+                                          let uu___11 =
+                                            let uu___12 =
+                                              FStar_Errors_Msg.rendermsg s in
+                                            (body3, uu___12, p) in
+                                          FStar_Parser_AST.Labeled uu___11 in
+                                        mk uu___10 in
                                       ([], uu___9)
                                   | uu___9 ->
                                       FStar_Compiler_Effect.failwith

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Syntax.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Syntax.ml
@@ -381,10 +381,10 @@ and fv = {
   fv_qual: fv_qual FStar_Pervasives_Native.option }
 and free_vars =
   {
-  free_names: bv Prims.list ;
-  free_uvars: ctx_uvar Prims.list ;
-  free_univs: universe_uvar Prims.list ;
-  free_univ_names: univ_name Prims.list }
+  free_names: bv FStar_Compiler_FlatSet.t ;
+  free_uvars: ctx_uvar FStar_Compiler_FlatSet.t ;
+  free_univs: universe_uvar FStar_Compiler_FlatSet.t ;
+  free_univ_names: univ_name FStar_Compiler_FlatSet.t }
 and residual_comp =
   {
   residual_effect: FStar_Ident.lident ;
@@ -973,22 +973,23 @@ let (__proj__Mkfv__item__fv_qual :
   fv -> fv_qual FStar_Pervasives_Native.option) =
   fun projectee ->
     match projectee with | { fv_name; fv_qual = fv_qual1;_} -> fv_qual1
-let (__proj__Mkfree_vars__item__free_names : free_vars -> bv Prims.list) =
+let (__proj__Mkfree_vars__item__free_names :
+  free_vars -> bv FStar_Compiler_FlatSet.t) =
   fun projectee ->
     match projectee with
     | { free_names; free_uvars; free_univs; free_univ_names;_} -> free_names
 let (__proj__Mkfree_vars__item__free_uvars :
-  free_vars -> ctx_uvar Prims.list) =
+  free_vars -> ctx_uvar FStar_Compiler_FlatSet.t) =
   fun projectee ->
     match projectee with
     | { free_names; free_uvars; free_univs; free_univ_names;_} -> free_uvars
 let (__proj__Mkfree_vars__item__free_univs :
-  free_vars -> universe_uvar Prims.list) =
+  free_vars -> universe_uvar FStar_Compiler_FlatSet.t) =
   fun projectee ->
     match projectee with
     | { free_names; free_uvars; free_univs; free_univ_names;_} -> free_univs
 let (__proj__Mkfree_vars__item__free_univ_names :
-  free_vars -> univ_name Prims.list) =
+  free_vars -> univ_name FStar_Compiler_FlatSet.t) =
   fun projectee ->
     match projectee with
     | { free_names; free_uvars; free_univs; free_univ_names;_} ->

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Syntax.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Syntax.ml
@@ -337,8 +337,8 @@ and metadata =
   | Meta_pattern of (term' syntax Prims.list * (term' syntax * arg_qualifier
   FStar_Pervasives_Native.option) Prims.list Prims.list) 
   | Meta_named of FStar_Ident.lident 
-  | Meta_labeled of (Prims.string * FStar_Compiler_Range_Type.range *
-  Prims.bool) 
+  | Meta_labeled of (FStar_Pprint.document Prims.list *
+  FStar_Compiler_Range_Type.range * Prims.bool) 
   | Meta_desugared of meta_source_info 
   | Meta_monadic of (monad_name * term' syntax) 
   | Meta_monadic_lift of (monad_name * monad_name * term' syntax) 
@@ -847,7 +847,9 @@ let (uu___is_Meta_labeled : metadata -> Prims.bool) =
   fun projectee ->
     match projectee with | Meta_labeled _0 -> true | uu___ -> false
 let (__proj__Meta_labeled__item___0 :
-  metadata -> (Prims.string * FStar_Compiler_Range_Type.range * Prims.bool))
+  metadata ->
+    (FStar_Pprint.document Prims.list * FStar_Compiler_Range_Type.range *
+      Prims.bool))
   = fun projectee -> match projectee with | Meta_labeled _0 -> _0
 let (uu___is_Meta_desugared : metadata -> Prims.bool) =
   fun projectee ->

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Hooks.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Hooks.ml
@@ -649,26 +649,31 @@ let (preprocess :
                                 (let label =
                                    let uu___7 =
                                      let uu___8 =
-                                       FStar_Class_Show.show
-                                         (FStar_Class_Show.printableshow
-                                            FStar_Class_Printable.printable_int)
-                                         n in
+                                       FStar_Pprint.doc_of_string
+                                         "Could not prove goal #" in
                                      let uu___9 =
                                        let uu___10 =
-                                         let uu___11 =
-                                           FStar_Tactics_Types.get_label g in
-                                         uu___11 = "" in
-                                       if uu___10
-                                       then ""
-                                       else
-                                         (let uu___12 =
-                                            let uu___13 =
-                                              FStar_Tactics_Types.get_label g in
-                                            Prims.strcat uu___13 ")" in
-                                          Prims.strcat " (" uu___12) in
-                                     Prims.strcat uu___8 uu___9 in
-                                   Prims.strcat "Could not prove goal #"
-                                     uu___7 in
+                                         FStar_Class_PP.pp
+                                           FStar_Class_PP.pp_int n in
+                                       let uu___11 =
+                                         let uu___12 =
+                                           let uu___13 =
+                                             FStar_Tactics_Types.get_label g in
+                                           uu___13 = "" in
+                                         if uu___12
+                                         then FStar_Pprint.empty
+                                         else
+                                           (let uu___14 =
+                                              let uu___15 =
+                                                FStar_Tactics_Types.get_label
+                                                  g in
+                                              FStar_Pprint.doc_of_string
+                                                uu___15 in
+                                            FStar_Pprint.parens uu___14) in
+                                       FStar_Pprint.op_Hat_Slash_Hat uu___10
+                                         uu___11 in
+                                     FStar_Pprint.op_Hat_Hat uu___8 uu___9 in
+                                   [uu___7] in
                                  let gt' =
                                    let uu___7 =
                                      FStar_Tactics_Types.goal_range g in
@@ -695,7 +700,7 @@ let (preprocess :
                       (did_anything, uu___7)))))
 let rec (traverse_for_spinoff :
   pol ->
-    (Prims.string * FStar_Compiler_Range_Type.range)
+    (FStar_Pprint.document Prims.list * FStar_Compiler_Range_Type.range)
       FStar_Pervasives_Native.option ->
       FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.term -> tres)
   =
@@ -716,8 +721,9 @@ let rec (traverse_for_spinoff :
                     FStar_Compiler_Range_Ops.string_of_def_range rng in
                   let uu___2 =
                     FStar_Compiler_Range_Ops.string_of_use_range rng in
+                  let uu___3 = FStar_Errors_Msg.rendermsg msg in
                   FStar_Compiler_Util.format3 "(%s,%s) : %s" uu___1 uu___2
-                    msg in
+                    uu___3 in
             if debug
             then
               (let uu___1 =

--- a/ocaml/fstar-lib/generated/FStar_ToSyntax_ToSyntax.ml
+++ b/ocaml/fstar-lib/generated/FStar_ToSyntax_ToSyntax.ml
@@ -6005,14 +6005,19 @@ and (desugar_formula :
       match uu___ with
       | FStar_Parser_AST.Labeled (f1, l, p) ->
           let f2 = desugar_formula env f1 in
-          mk
-            (FStar_Syntax_Syntax.Tm_meta
-               {
-                 FStar_Syntax_Syntax.tm2 = f2;
-                 FStar_Syntax_Syntax.meta =
-                   (FStar_Syntax_Syntax.Meta_labeled
-                      (l, (f2.FStar_Syntax_Syntax.pos), p))
-               })
+          let uu___1 =
+            let uu___2 =
+              let uu___3 =
+                let uu___4 =
+                  let uu___5 = FStar_Errors_Msg.mkmsg l in
+                  (uu___5, (f2.FStar_Syntax_Syntax.pos), p) in
+                FStar_Syntax_Syntax.Meta_labeled uu___4 in
+              {
+                FStar_Syntax_Syntax.tm2 = f2;
+                FStar_Syntax_Syntax.meta = uu___3
+              } in
+            FStar_Syntax_Syntax.Tm_meta uu___2 in
+          mk uu___1
       | FStar_Parser_AST.QForall ([], uu___1, uu___2) ->
           FStar_Compiler_Effect.failwith
             "Impossible: Quantifier without binders"

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Err.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Err.ml
@@ -219,23 +219,36 @@ let (err_msg_comp_strings :
       fun c2 ->
         print_discrepancy (FStar_TypeChecker_Normalize.comp_to_string env) c1
           c2
-let (exhaustiveness_check : Prims.string) = "Patterns are incomplete"
+let (exhaustiveness_check : FStar_Pprint.document Prims.list) =
+  let uu___ = FStar_Errors_Msg.text "Patterns are incomplete" in [uu___]
 let (subtyping_failed :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.typ ->
-      FStar_Syntax_Syntax.typ -> unit -> Prims.string)
+      FStar_Syntax_Syntax.typ -> unit -> FStar_Errors_Msg.error_message)
   =
   fun env ->
     fun t1 ->
       fun t2 ->
         fun uu___ ->
-          let uu___1 = err_msg_type_strings env t1 t2 in
-          match uu___1 with
-          | (s1, s2) ->
-              FStar_Compiler_Util.format2
-                "Subtyping check failed; expected type %s; got type %s" s2 s1
-let (ill_kinded_type : Prims.string) = "Ill-kinded type"
-let (totality_check : Prims.string) = "This term may not terminate"
+          let ppt = FStar_TypeChecker_Normalize.term_to_doc env in
+          let uu___1 = FStar_Errors_Msg.text "Subtyping check failed" in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 =
+                let uu___5 = FStar_Errors_Msg.text "Expected type" in
+                let uu___6 = ppt t2 in
+                FStar_Pprint.prefix (Prims.of_int (2)) Prims.int_one uu___5
+                  uu___6 in
+              let uu___5 =
+                let uu___6 = FStar_Errors_Msg.text "got type" in
+                let uu___7 = ppt t1 in
+                FStar_Pprint.prefix (Prims.of_int (2)) Prims.int_one uu___6
+                  uu___7 in
+              FStar_Pprint.op_Hat_Slash_Hat uu___4 uu___5 in
+            [uu___3] in
+          uu___1 :: uu___2
+let (ill_kinded_type : FStar_Errors_Msg.error_message) =
+  FStar_Errors_Msg.mkmsg "Ill-kinded type"
 let (unexpected_signature_for_monad :
   FStar_TypeChecker_Env.env ->
     FStar_Ident.lident ->

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_TcInductive.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_TcInductive.ml
@@ -1299,10 +1299,27 @@ let (optimized_haseq_soundness_for_data :
                          ((b.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort).FStar_Syntax_Syntax.pos in
                        let haseq_b1 =
                          let uu___2 =
-                           let uu___3 = FStar_Ident.string_of_lid ty_lid in
-                           FStar_Compiler_Util.format1
-                             "Failed to prove that the type '%s' supports decidable equality because of this argument; add either the 'noeq' or 'unopteq' qualifier"
-                             uu___3 in
+                           let uu___3 =
+                             let uu___4 =
+                               FStar_Errors_Msg.text
+                                 "Failed to prove that the type" in
+                             let uu___5 =
+                               let uu___6 =
+                                 let uu___7 =
+                                   FStar_Class_PP.pp
+                                     FStar_Ident.pretty_lident ty_lid in
+                                 FStar_Pprint.squotes uu___7 in
+                               let uu___7 =
+                                 FStar_Errors_Msg.text
+                                   "supports decidable equality because of this argument." in
+                               FStar_Pprint.op_Hat_Slash_Hat uu___6 uu___7 in
+                             FStar_Pprint.op_Hat_Slash_Hat uu___4 uu___5 in
+                           let uu___4 =
+                             let uu___5 =
+                               FStar_Errors_Msg.text
+                                 "Add either the 'noeq' or 'unopteq' qualifier" in
+                             [uu___5] in
+                           uu___3 :: uu___4 in
                          FStar_TypeChecker_Util.label uu___2 sort_range
                            haseq_b in
                        FStar_Syntax_Util.mk_conj t haseq_b1)

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_TcTerm.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_TcTerm.ml
@@ -809,9 +809,11 @@ let (check_expected_effect :
                                       let g1 =
                                         let uu___10 =
                                           FStar_TypeChecker_Env.get_range env in
+                                        let uu___11 =
+                                          FStar_Errors_Msg.mkmsg
+                                            "Could not prove post-condition" in
                                         FStar_TypeChecker_Util.label_guard
-                                          uu___10
-                                          "Could not prove post-condition" g in
+                                          uu___10 uu___11 g in
                                       ((let uu___11 =
                                           FStar_TypeChecker_Env.debug env
                                             FStar_Options.Medium in
@@ -1606,9 +1608,10 @@ let (guard_letrecs :
                              FStar_TypeChecker_Env.push_binders env1 formals1 in
                            mk_precedes env2 dec previous_dec in
                          let precedes1 =
-                           FStar_TypeChecker_Util.label
-                             "Could not prove termination of this recursive call"
-                             r precedes in
+                           let uu___3 =
+                             FStar_Errors_Msg.mkmsg
+                               "Could not prove termination of this recursive call" in
+                           FStar_TypeChecker_Util.label uu___3 r precedes in
                          let uu___3 = FStar_Compiler_Util.prefix formals1 in
                          match uu___3 with
                          | (bs,
@@ -2639,8 +2642,7 @@ and (tc_maybe_toplevel_term :
                              FStar_TypeChecker_Util.strengthen_precondition
                                (FStar_Pervasives_Native.Some
                                   (fun uu___9 ->
-                                     FStar_Compiler_Util.return_all
-                                       FStar_TypeChecker_Err.ill_kinded_type))
+                                     FStar_TypeChecker_Err.ill_kinded_type))
                                uu___8 e2 c f in
                            (match uu___7 with
                             | (c1, f1) ->
@@ -6067,10 +6069,12 @@ and (tc_abs_check_binders :
                                 | (t, uu___8, g1_env) ->
                                     let g2_env =
                                       let label_guard g =
+                                        let uu___9 =
+                                          FStar_Errors_Msg.mkmsg
+                                            "Type annotation on parameter incompatible with the expected type" in
                                         FStar_TypeChecker_Util.label_guard
                                           (hd.FStar_Syntax_Syntax.sort).FStar_Syntax_Syntax.pos
-                                          "Type annotation on parameter incompatible with the expected type"
-                                          g in
+                                          uu___9 g in
                                       let uu___9 =
                                         FStar_TypeChecker_Rel.teq_nosmt env1
                                           t expected_t in
@@ -10699,7 +10703,8 @@ and (check_inner_let :
                              FStar_TypeChecker_Util.strengthen_precondition
                                (FStar_Pervasives_Native.Some
                                   (fun uu___7 ->
-                                     "folding guard g2 of e2 in the lcomp"))
+                                     FStar_Errors_Msg.mkmsg
+                                       "folding guard g2 of e2 in the lcomp"))
                                env_x e22 c2 g2 in
                            (match uu___6 with | (c21, g21) -> (e22, c21, g21)) in
                      (match uu___4 with

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Util.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Util.ml
@@ -861,7 +861,7 @@ let (mk_wp_return :
                else ());
               c
 let (label :
-  Prims.string ->
+  FStar_Pprint.document Prims.list ->
     FStar_Compiler_Range_Type.range ->
       FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ)
   =
@@ -877,7 +877,8 @@ let (label :
              }) f.FStar_Syntax_Syntax.pos
 let (label_opt :
   FStar_TypeChecker_Env.env ->
-    (unit -> Prims.string) FStar_Pervasives_Native.option ->
+    (unit -> FStar_Pprint.document Prims.list) FStar_Pervasives_Native.option
+      ->
       FStar_Compiler_Range_Type.range ->
         FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ)
   =
@@ -896,7 +897,7 @@ let (label_opt :
               else (let uu___2 = reason1 () in label uu___2 r f)
 let (label_guard :
   FStar_Compiler_Range_Type.range ->
-    Prims.string ->
+    FStar_Pprint.document Prims.list ->
       FStar_TypeChecker_Env.guard_t -> FStar_TypeChecker_Env.guard_t)
   =
   fun r ->
@@ -2794,7 +2795,8 @@ let (mk_bind :
                                       (c, uu___5)))))
 let (strengthen_comp :
   FStar_TypeChecker_Env.env ->
-    (unit -> Prims.string) FStar_Pervasives_Native.option ->
+    (unit -> FStar_Pprint.document Prims.list) FStar_Pervasives_Native.option
+      ->
       FStar_Syntax_Syntax.comp ->
         FStar_Syntax_Syntax.formula ->
           FStar_Syntax_Syntax.cflag Prims.list ->
@@ -2982,7 +2984,8 @@ let (weaken_precondition :
           lc.FStar_TypeChecker_Common.eff_name
           lc.FStar_TypeChecker_Common.res_typ uu___ weaken
 let (strengthen_precondition :
-  (unit -> Prims.string) FStar_Pervasives_Native.option ->
+  (unit -> FStar_Pprint.document Prims.list) FStar_Pervasives_Native.option
+    ->
     FStar_TypeChecker_Env.env ->
       FStar_Syntax_Syntax.term ->
         FStar_TypeChecker_Common.lcomp ->

--- a/src/data/FStar.Compiler.RBSet.fst
+++ b/src/data/FStar.Compiler.RBSet.fst
@@ -167,3 +167,7 @@ instance setlike_rbset (a:Type) (_ : ord a) : Tot (setlike a (rbset a)) = {
     from_list = from_list;
     addn = addn;
 }
+
+instance showable_rbset (a:Type) (_ : showable a) : Tot (showable (rbset a)) = {
+  show = (fun s -> "RBSet " ^ show (elems s));
+}

--- a/src/data/FStar.Compiler.RBSet.fsti
+++ b/src/data/FStar.Compiler.RBSet.fsti
@@ -30,3 +30,6 @@ type t = rbset
 
 instance
 val setlike_rbset (a:Type0) (_ : ord a) : Tot (setlike a (t a))
+
+instance
+val showable_rbset (a:Type0) (_ : showable a) : Tot (showable (t a))

--- a/src/smtencoding/FStar.SMTEncoding.EncodeTerm.fst
+++ b/src/smtencoding/FStar.SMTEncoding.EncodeTerm.fst
@@ -1593,15 +1593,17 @@ and encode_formula (phi:typ) (env:env_t) : (term * decls_t)  = (* expects phi to
               encode_formula phi env
 
             | Tm_fvar fv, [(r, _); (msg, _); (phi, _)] when S.fv_eq_lid fv Const.labeled_lid -> //interpret (labeled r msg t) as Tm_meta(t, Meta_labeled(msg, r, false)
+              (* NB: below we use Errors.mkmsg since FStar.Range.labeled takes a string, but
+                 the Meta_labeled node needs a list of docs (Errors.error_message). *)
               begin match SE.try_unembed r SE.id_norm_cb,
                           SE.try_unembed msg SE.id_norm_cb with
               | Some r, Some s ->
-                let phi = S.mk (Tm_meta {tm=phi; meta=Meta_labeled(s, r, false)}) r in
+                let phi = S.mk (Tm_meta {tm=phi; meta=Meta_labeled(Errors.mkmsg s, r, false)}) r in
                 fallback phi
 
               (* If we could not unembed the position, still use the string *)
               | None, Some s ->
-                let phi = S.mk (Tm_meta {tm=phi; meta=Meta_labeled(s, phi.pos, false)}) phi.pos in
+                let phi = S.mk (Tm_meta {tm=phi; meta=Meta_labeled(Errors.mkmsg s, phi.pos, false)}) phi.pos in
                 fallback phi
 
               | _ ->

--- a/src/smtencoding/FStar.SMTEncoding.Solver.fst
+++ b/src/smtencoding/FStar.SMTEncoding.Solver.fst
@@ -321,7 +321,7 @@ let query_errors settings z3result =
             error_messages =
                error_labels |>
                List.map (fun (_, x, y) -> Errors.Error_Z3SolverError,
-                                          Errors.mkmsg x,
+                                          x,
                                           y,
                                           Errors.get_ctx ()) // FIXME: leaking abstraction
         }
@@ -442,7 +442,7 @@ let errors_to_report (tried_recovery : bool) (settings : query_settings) : list 
           //we have a unique label already; just report it
           FStar.TypeChecker.Err.errors_smt_detail
                      settings.query_env
-                     [(Error_Z3SolverError, mkmsg msg, rng, get_ctx())]
+                     [(Error_Z3SolverError, msg, rng, get_ctx())]
                      recovery_failed_msg
 
         | None, _ ->
@@ -461,9 +461,10 @@ let errors_to_report (tried_recovery : bool) (settings : query_settings) : list 
                   //with no labeled sub-goals and so no error location to report.
                   //So, print the source location and the query term itself
                   let dummy_fv = Term.mk_fv ("", dummy_sort) in
-                  let msg =
-                    BU.format1 "Failed to prove the following goal, although it appears to be trivial: %s"
-                               (Print.term_to_string settings.query_term)
+                  let msg = [
+                    Errors.Msg.text "Failed to prove the following goal, although it appears to be trivial:"
+                      ^/^ pp settings.query_term;
+                  ]
                   in
                   let range = Env.get_range settings.query_env in
                   [dummy_fv, msg, range]
@@ -490,7 +491,7 @@ let errors_to_report (tried_recovery : bool) (settings : query_settings) : list 
                  List.collect (fun (_, msg, rng) ->
                    FStar.TypeChecker.Err.errors_smt_detail
                      settings.query_env
-                     [(Error_Z3SolverError, mkmsg msg, rng, get_ctx())]
+                     [(Error_Z3SolverError, msg, rng, get_ctx())]
                      recovery_failed_msg
                      )
             )
@@ -670,8 +671,8 @@ let query_info settings z3result =
              ];
         if Options.print_z3_statistics () then process_unsat_core core;
         errs |> List.iter (fun (_, msg, range) ->
-            let tag = if used_hint settings then "(Hint-replay failed): " else "" in
-            FStar.Errors.log_issue range (FStar.Errors.Warning_HitReplayFailed, (tag ^ msg)))
+            let msg = if used_hint settings then Pprint.doc_of_string "Hint-replay failed" :: msg else msg in
+            FStar.Errors.log_issue_doc range (FStar.Errors.Warning_HitReplayFailed, msg))
     end
 
 //caller must ensure that the recorded_hints is already initiailized

--- a/src/smtencoding/FStar.SMTEncoding.Term.fst
+++ b/src/smtencoding/FStar.SMTEncoding.Term.fst
@@ -233,7 +233,7 @@ let rec hash_of_term' t = match t with
   | BoundV i  -> "@"^string_of_int i
   | FreeV x   -> fv_name x ^ ":" ^ strSort (fv_sort x) //Question: Why is the sort part of the hash?
   | App(op, tms) -> "("^(op_to_string op)^(List.map hash_of_term tms |> String.concat " ")^")"
-  | Labeled(t, r1, r2) -> hash_of_term t ^ r1 ^ (Range.string_of_range r2)
+  | Labeled(t, r1, r2) -> hash_of_term t ^ Errors.Msg.rendermsg r1 ^ (Range.string_of_range r2)
   | LblPos(t, r) -> "(! " ^hash_of_term t^ " :lblpos " ^r^ ")"
   | Quant(qop, pats, wopt, sorts, body) ->
       "("
@@ -431,7 +431,7 @@ let check_pattern_ok (t:term) : option term =
   | BoundV  n               -> BU.format1 "(BoundV %s)" (BU.string_of_int n)
   | FreeV  fv               -> BU.format1 "(FreeV %s)" (fv_name fv)
   | App (op, l)             -> BU.format2 "(%s %s)" (op_to_string op) (print_smt_term_list l)
-  | Labeled(t, r1, r2)      -> BU.format2 "(Labeled '%s' %s)" r1 (print_smt_term t)
+  | Labeled(t, r1, r2)      -> BU.format2 "(Labeled '%s' %s)" (Errors.Msg.rendermsg r1) (print_smt_term t)
   | LblPos(t, s)            -> BU.format2 "(LblPos %s %s)" s (print_smt_term t)
   | Quant (qop, l, _, _, t) -> BU.format3 "(%s %s %s)" (qop_to_string qop) (print_smt_term_list_list l) (print_smt_term t)
   | Let (es, body) -> BU.format2 "(let %s %s)" (print_smt_term_list es) (print_smt_term body)

--- a/src/smtencoding/FStar.SMTEncoding.Term.fsti
+++ b/src/smtencoding/FStar.SMTEncoding.Term.fsti
@@ -84,8 +84,8 @@ type term' =
   | App        of op  * list term
   | Quant      of qop * list (list pat) * option int * list sort * term
   | Let        of list term * term
-  | Labeled    of term * string * Range.range
-  | LblPos     of term * string
+  | Labeled    of term * Errors.error_message * Range.range
+  | LblPos     of term * string // FIXME: this case is unused
 and pat  = term
 and term = {tm:term'; freevars:S.memo fvs; rng:Range.range}
 and fv = | FV of string * sort * bool (* bool iff variable must be forced/unthunked *)
@@ -190,7 +190,7 @@ val mk_decls_trivial: list decl -> decls_t
  *)
 val decls_list_of: decls_t -> list decl
 
-type error_label = (fv * string * Range.range)
+type error_label = (fv * Errors.error_message * Range.range)
 type error_labels = list error_label
 
 val escape: string -> string

--- a/src/syntax/FStar.Syntax.Free.fsti
+++ b/src/syntax/FStar.Syntax.Free.fsti
@@ -23,16 +23,19 @@ open FStar.Compiler.FlatSet
 open FStar.Syntax
 open FStar.Syntax.Syntax
 
-val names: term -> FlatSet.t bv
-val uvars: term -> FlatSet.t ctx_uvar
-val univs: term -> FlatSet.t universe_uvar
-val univnames: term -> FlatSet.t univ_name
-val univnames_comp: comp -> FlatSet.t univ_name
-val fvars: term -> RBSet.t Ident.lident
-val names_of_binders: binders -> FlatSet.t bv
+val names            : term -> FlatSet.t bv
+val names_of_binders : binders -> FlatSet.t bv
 
-val uvars_uncached: term -> FlatSet.t ctx_uvar
-val uvars_full: term -> FlatSet.t ctx_uvar
+val fvars            : term -> RBSet.t Ident.lident
+
+val uvars            : term -> FlatSet.t ctx_uvar
+val uvars_uncached   : term -> FlatSet.t ctx_uvar
+val uvars_full       : term -> FlatSet.t ctx_uvar
+
+val univs            : term -> FlatSet.t universe_uvar
+
+val univnames        : term -> FlatSet.t univ_name
+val univnames_comp   : comp -> FlatSet.t univ_name
 
 (* Bad place for these instances. But they cannot be instance
 Syntax.Syntax since they reference the UF graph. *)

--- a/src/syntax/FStar.Syntax.Hash.fst
+++ b/src/syntax/FStar.Syntax.Hash.fst
@@ -73,12 +73,17 @@ let mix_list_lit = mix_list
 
 let hash_list (h:'a -> mm H.hash_code) (ts:list 'a) : mm H.hash_code = mix_list (List.map h ts)
 
-
 let hash_option (h:'a -> mm H.hash_code) (o:option 'a) : mm H.hash_code =
   match o with
   | None -> ret (H.of_int 1237)
   | Some o -> mix (ret (H.of_int 1249)) (h o)
 
+// hash the string.
+let hash_doc (d : Pprint.document) : mm H.hash_code =
+  of_string (Pprint.pretty_string (float_of_string "1.0") 80 d)
+
+let hash_doc_list (ds : list Pprint.document) : mm H.hash_code =
+  hash_list hash_doc ds
 
 let hash_pair (h:'a -> mm H.hash_code) (i:'b -> mm H.hash_code) (x:('a * 'b))
   : mm H.hash_code
@@ -298,7 +303,7 @@ and hash_meta m =
   | Meta_labeled (s, r, _) ->
     mix_list_lit
       [ of_int 1031;
-        of_string s;
+        hash_doc_list s;
         of_string (Range.string_of_range r) ]
   | Meta_desugared msi ->
     mix_list_lit

--- a/src/syntax/FStar.Syntax.Print.fst
+++ b/src/syntax/FStar.Syntax.Print.fst
@@ -249,7 +249,7 @@ and term_to_string x =
       | Tm_meta {tm=t; meta=Meta_monadic_lift(m0, m1, t')} -> U.format4 ("(MetaMonadicLift-{%s : %s -> %s} %s)") (term_to_string t') (sli m0) (sli m1) (term_to_string t)
 
       | Tm_meta {tm=t; meta=Meta_labeled(l,r,b)} ->
-        U.format3 "Meta_labeled(%s, %s){%s}" l (Range.string_of_range r) (term_to_string t)
+        U.format3 "Meta_labeled(%s, %s){%s}" (Errors.Msg.rendermsg l) (Range.string_of_range r) (term_to_string t)
 
       | Tm_meta {tm=t; meta=Meta_named(l)} ->
         U.format3 "Meta_named(%s, %s){%s}" (lid_to_string l) (Range.string_of_range t.pos) (term_to_string t)
@@ -559,7 +559,7 @@ and metadata_to_string = function
         U.format1 "{Meta_named %s}" (sli lid)
 
     | Meta_labeled (l, r, _) ->
-        U.format2 "{Meta_labeled (%s, %s)}" l (Range.string_of_range r)
+        U.format2 "{Meta_labeled (%s, %s)}" (Errors.Msg.rendermsg l) (Range.string_of_range r)
 
     | Meta_desugared msi ->
         "{Meta_desugared}"

--- a/src/syntax/FStar.Syntax.Resugar.fst
+++ b/src/syntax/FStar.Syntax.Resugar.fst
@@ -593,7 +593,7 @@ let rec resugar_term' (env: DsEnv.env) (t : S.term) : A.term =
                         body
                       | Meta_labeled (s, r, p) ->
                         // this case can occur in typechecker when a failure is wrapped in meta_labeled
-                        [], mk (A.Labeled (body, s, p))
+                        [], mk (A.Labeled (body, Errors.Msg.rendermsg s, p))
                       | _ -> failwith "wrong pattern format for QForall/QExists"
                     in
                     pats, body

--- a/src/syntax/FStar.Syntax.Syntax.fsti
+++ b/src/syntax/FStar.Syntax.Syntax.fsti
@@ -327,7 +327,7 @@ and cflag =                                                      (* flags applic
 and metadata =
   | Meta_pattern       of list term * list args                  (* Patterns for SMT quantifier instantiation; the first arg instantiation *)
   | Meta_named         of lident                                 (* Useful for pretty printing to keep the type abbreviation around *)
-  | Meta_labeled       of string * Range.range * bool            (* Sub-terms in a VC are labeled with error messages to be reported, used in SMT encoding *)
+  | Meta_labeled       of list Pprint.document * Range.range * bool (* Sub-terms in a VC are labeled with error messages to be reported, used in SMT encoding *)
   | Meta_desugared     of meta_source_info                       (* Node tagged with some information about source term before desugaring *)
   | Meta_monadic       of monad_name * typ                       (* Annotation on a Tm_app or Tm_let node in case it is monadic for m not in {Pure, Ghost, Div} *)
                                                                  (* Contains the name of the monadic effect and  the type of the subterm *)

--- a/src/syntax/FStar.Syntax.Syntax.fsti
+++ b/src/syntax/FStar.Syntax.Syntax.fsti
@@ -379,10 +379,10 @@ and fv = {
     fv_qual :option fv_qual
 }
 and free_vars = {
-    free_names:list bv;
-    free_uvars:list ctx_uvar;
-    free_univs:list universe_uvar;
-    free_univ_names:list univ_name; //fifo
+    free_names      : FlatSet.t bv;
+    free_uvars      : uvars;
+    free_univs      : FlatSet.t universe_uvar;
+    free_univ_names : FlatSet.t univ_name; //fifo
 }
 
 (* Residual of a computation type after typechecking *)

--- a/src/tosyntax/FStar.ToSyntax.ToSyntax.fst
+++ b/src/tosyntax/FStar.ToSyntax.ToSyntax.fst
@@ -2630,7 +2630,8 @@ and desugar_formula env (f:term) : S.term =
   match (unparen f).tm with
     | Labeled(f, l, p) ->
       let f = desugar_formula env f in
-      mk <| Tm_meta {tm=f; meta=Meta_labeled(l, f.pos, p)}
+      // GM: I don't think this case really happens?
+      mk <| Tm_meta {tm=f; meta=Meta_labeled(Errors.Msg.mkmsg l, f.pos, p)}
 
     | QForall([], _, _)
     | QExists([], _, _)

--- a/src/typechecker/FStar.TypeChecker.TcInductive.fst
+++ b/src/typechecker/FStar.TypeChecker.TcInductive.fst
@@ -412,8 +412,14 @@ let optimized_haseq_soundness_for_data (ty_lid:lident) (data:sigelt) (usubst:lis
       let haseq_b = mk_Tm_app U.t_haseq [S.as_arg b.binder_bv.sort] Range.dummyRange in
       //label the haseq predicate so that we get a proper error message if the assertion fails
       let sort_range = b.binder_bv.sort.pos in
+      let open FStar.Errors.Msg in
+      let open FStar.Pprint in
+      let open FStar.Class.PP in
       let haseq_b = TcUtil.label
-                    (BU.format1 "Failed to prove that the type '%s' supports decidable equality because of this argument; add either the 'noeq' or 'unopteq' qualifier" (string_of_lid ty_lid))
+                    [
+                      text "Failed to prove that the type" ^/^ squotes (pp ty_lid) ^/^ text "supports decidable equality because of this argument.";
+                      text "Add either the 'noeq' or 'unopteq' qualifier";
+                    ]
                     sort_range
                     haseq_b
       in

--- a/src/typechecker/FStar.TypeChecker.Util.fst
+++ b/src/typechecker/FStar.TypeChecker.Util.fst
@@ -1302,7 +1302,7 @@ let mk_bind env
       else mk_wp_bind env m ct1 b ct2 flags r1, Env.trivial_guard in
     c, Env.conj_guard g_lift g_bind
 
-let strengthen_comp env (reason:option (unit -> string)) (c:comp) (f:formula) flags : comp * guard_t =
+let strengthen_comp env (reason:option (unit -> list Pprint.document)) (c:comp) (f:formula) flags : comp * guard_t =
     if env.lax || Env.too_early_in_prims env
     then c, Env.trivial_guard
     else let r = Env.get_range env in
@@ -1415,7 +1415,7 @@ let weaken_precondition env lc (f:guard_formula) : lcomp =
   TcComm.mk_lcomp lc.eff_name lc.res_typ (weaken_flags lc.cflags) weaken
 
 let strengthen_precondition
-            (reason:option (unit -> string))
+            (reason:option (unit -> list Pprint.document))
             env
             (e_for_debugging_only:term)
             (lc:lcomp)

--- a/src/typechecker/FStar.TypeChecker.Util.fsti
+++ b/src/typechecker/FStar.TypeChecker.Util.fsti
@@ -98,7 +98,7 @@ val bind_cases: env -> typ -> list (typ * lident * list cflag * (bool -> lcomp))
  *)
 val weaken_result_typ: env -> term -> lcomp -> typ -> bool -> term * lcomp * guard_t
 
-val strengthen_precondition: (option (unit -> string) -> env -> term -> lcomp -> guard_t -> lcomp*guard_t)
+val strengthen_precondition: (option (unit -> list Pprint.document) -> env -> term -> lcomp -> guard_t -> lcomp*guard_t)
 val weaken_guard: guard_formula -> guard_formula -> guard_formula
 val weaken_precondition: env -> lcomp -> guard_formula -> lcomp
 val maybe_assume_result_eq_pure_term: env -> term -> lcomp -> lcomp
@@ -132,8 +132,8 @@ val check_top_level: env -> guard_t -> lcomp -> bool*comp
 val maybe_coerce_lc : env -> term -> lcomp -> typ -> term * lcomp * guard_t
 
 //misc.
-val label: string -> Range.range -> typ -> typ
-val label_guard: Range.range -> string -> guard_t -> guard_t
+val label: list Pprint.document -> Range.range -> typ -> typ
+val label_guard: Range.range -> list Pprint.document -> guard_t -> guard_t
 val short_circuit: term -> args -> guard_formula
 val short_circuit_head: term -> bool
 val maybe_add_implicit_binders: env -> binders -> binders

--- a/tests/error-messages/ArrowRanges.fst.expected
+++ b/tests/error-messages/ArrowRanges.fst.expected
@@ -1,6 +1,7 @@
 >> Got issues: [
 * Error 19 at ArrowRanges.fst(4,30-4,39):
-  - Subtyping check failed; expected type Prims.eqtype; got type Type0
+  - Subtyping check failed
+  - Expected type Prims.eqtype got type Type0
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
   - See also prims.fst(52,23-52,30)
@@ -8,7 +9,10 @@
 >>]
 >> Got issues: [
 * Error 19 at ArrowRanges.fst(8,10-8,28):
-  - Failed to prove that the type 'ArrowRanges.ppof' supports decidable equality because of this argument; add either the 'noeq' or 'unopteq' qualifier
+  - Failed to prove that the type
+    'ArrowRanges.ppof'
+    supports decidable equality because of this argument.
+  - Add either the 'noeq' or 'unopteq' qualifier
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
   - See also ArrowRanges.fst(7,0-11,1)

--- a/tests/error-messages/Calc.fst.expected
+++ b/tests/error-messages/Calc.fst.expected
@@ -33,7 +33,8 @@
 >>]
 >> Got issues: [
 * Error 19 at Calc.fst(51,6-51,8):
-  - Subtyping check failed; expected type Prims.squash (1 == 2); got type Prims.unit
+  - Subtyping check failed
+  - Expected type Prims.squash (1 == 2) got type Prims.unit
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
   - See also Calc.fst(51,3-51,5)
@@ -41,7 +42,8 @@
 >>]
 >> Got issues: [
 * Error 19 at Calc.fst(65,6-65,8):
-  - Subtyping check failed; expected type Prims.squash (2 == 3); got type Prims.unit
+  - Subtyping check failed
+  - Expected type Prims.squash (2 == 3) got type Prims.unit
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
   - See also Calc.fst(65,3-65,5)
@@ -49,7 +51,8 @@
 >>]
 >> Got issues: [
 * Error 19 at Calc.fst(79,6-79,8):
-  - Subtyping check failed; expected type Prims.squash (3 == 4); got type Prims.unit
+  - Subtyping check failed
+  - Expected type Prims.squash (3 == 4) got type Prims.unit
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
   - See also Calc.fst(79,3-79,5)
@@ -57,7 +60,8 @@
 >>]
 >> Got issues: [
 * Error 19 at Calc.fst(93,42-93,44):
-  - Subtyping check failed; expected type Prims.squash q; got type Prims.unit
+  - Subtyping check failed
+  - Expected type Prims.squash q got type Prims.unit
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
   - See also Calc.fst(91,20-91,21)
@@ -65,7 +69,8 @@
 >>]
 >> Got issues: [
 * Error 19 at Calc.fst(100,10-100,12):
-  - Subtyping check failed; expected type Prims.squash q; got type Prims.unit
+  - Subtyping check failed
+  - Expected type Prims.squash q got type Prims.unit
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
   - See also Calc.fst(101,4-101,5)

--- a/tests/error-messages/Coercions.fst.expected
+++ b/tests/error-messages/Coercions.fst.expected
@@ -10,7 +10,8 @@
 >>]
 >> Got issues: [
 * Error 19 at Coercions.fst(71,4-71,8):
-  - Subtyping check failed; expected type Prims.nat; got type Prims.int
+  - Subtyping check failed
+  - Expected type Prims.nat got type Prims.int
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
   - See also prims.fst(659,18-659,24)
@@ -18,7 +19,8 @@
 >>]
 >> Got issues: [
 * Error 19 at Coercions.fst(74,49-74,57):
-  - Subtyping check failed; expected type Prims.nat; got type Prims.int
+  - Subtyping check failed
+  - Expected type Prims.nat got type Prims.int
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
   - See also prims.fst(659,18-659,24)
@@ -26,7 +28,8 @@
 >>]
 >> Got issues: [
 * Error 19 at Coercions.fst(76,55-76,56):
-  - Subtyping check failed; expected type Prims.nat; got type Prims.int
+  - Subtyping check failed
+  - Expected type Prims.nat got type Prims.int
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
   - See also prims.fst(659,18-659,24)
@@ -34,7 +37,8 @@
 >>]
 >> Got issues: [
 * Error 19 at Coercions.fst(78,50-78,51):
-  - Subtyping check failed; expected type Prims.nat; got type Prims.int
+  - Subtyping check failed
+  - Expected type Prims.nat got type Prims.int
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
   - See also prims.fst(659,18-659,24)
@@ -42,7 +46,8 @@
 >>]
 >> Got issues: [
 * Error 19 at Coercions.fst(80,51-80,52):
-  - Subtyping check failed; expected type Prims.nat; got type Prims.int
+  - Subtyping check failed
+  - Expected type Prims.nat got type Prims.int
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
   - See also prims.fst(659,18-659,24)

--- a/tests/error-messages/Inference.fst.expected
+++ b/tests/error-messages/Inference.fst.expected
@@ -1,12 +1,14 @@
 >> Got issues: [
 * Error 19 at Inference.fst(20,14-20,15):
-  - Subtyping check failed; expected type Prims.eqtype; got type Type0
+  - Subtyping check failed
+  - Expected type Prims.eqtype got type Type0
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
   - See also prims.fst(52,23-52,30)
 
 * Error 19 at Inference.fst(20,14-20,15):
-  - Subtyping check failed; expected type Prims.eqtype; got type Type0
+  - Subtyping check failed
+  - Expected type Prims.eqtype got type Type0
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
   - See also prims.fst(52,23-52,30)

--- a/tests/error-messages/NegativeTests.BST.fst.expected
+++ b/tests/error-messages/NegativeTests.BST.fst.expected
@@ -1,8 +1,12 @@
 >> Got issues: [
 * Error 19 at NegativeTests.BST.fst(37,38-37,42):
-  - Subtyping check failed; expected type right:
-    FStar.Pervasives.Native.option (tree 2)
-      {0 <= 1 /\ 1 <= 2 /\ None? right == (1 = 2) /\ None? FStar.Pervasives.Native.None == (1 = 0)}; got type FStar.Pervasives.Native.option (tree 2)
+  - Subtyping check failed
+  - Expected type
+      right:
+      FStar.Pervasives.Native.option (tree 2)
+        { 0 <= 1 /\ 1 <= 2 /\ None? right == (1 = 2) /\
+          None? FStar.Pervasives.Native.None == (1 = 0) }
+    got type FStar.Pervasives.Native.option (tree 2)
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
   - See also NegativeTests.BST.fst(27,36-27,58)
@@ -10,10 +14,13 @@
 >>]
 >> Got issues: [
 * Error 19 at NegativeTests.BST.fst(40,61-40,65):
-  - Subtyping check failed; expected type right:
-    FStar.Pervasives.Native.option (tree (l + 1))
-      { l <= l /\ l <= l + 1 /\ None? right == (l = l + 1) /\
-        None? (FStar.Pervasives.Native.Some t) == (l = l) }; got type FStar.Pervasives.Native.option (tree (l + 1))
+  - Subtyping check failed
+  - Expected type
+      right:
+      FStar.Pervasives.Native.option (tree (l + 1))
+        { l <= l /\ l <= l + 1 /\ None? right == (l = l + 1) /\
+          None? (FStar.Pervasives.Native.Some t) == (l = l) }
+    got type FStar.Pervasives.Native.option (tree (l + 1))
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
   - See also NegativeTests.BST.fst(27,36-27,58)
@@ -21,10 +28,13 @@
 >>]
 >> Got issues: [
 * Error 19 at NegativeTests.BST.fst(43,78-43,87):
-  - Subtyping check failed; expected type right:
-    FStar.Pervasives.Native.option (tree (l + 1))
-      { l <= l + 1 /\ l + 1 <= l + 1 /\ None? right == (l + 1 = l + 1) /\
-        None? (FStar.Pervasives.Native.Some t1) == (l + 1 = l) }; got type FStar.Pervasives.Native.option (tree (l + 1))
+  - Subtyping check failed
+  - Expected type
+      right:
+      FStar.Pervasives.Native.option (tree (l + 1))
+        { l <= l + 1 /\ l + 1 <= l + 1 /\ None? right == (l + 1 = l + 1) /\
+          None? (FStar.Pervasives.Native.Some t1) == (l + 1 = l) }
+    got type FStar.Pervasives.Native.option (tree (l + 1))
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
   - See also NegativeTests.BST.fst(27,36-27,58)

--- a/tests/error-messages/NegativeTests.Bug260.fst.expected
+++ b/tests/error-messages/NegativeTests.Bug260.fst.expected
@@ -1,6 +1,7 @@
 >> Got issues: [
 * Error 19 at NegativeTests.Bug260.fst(26,12-26,19):
-  - Subtyping check failed; expected type validity (S (S t)); got type validity (S t)
+  - Subtyping check failed
+  - Expected type validity (S (S t)) got type validity (S t)
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
   - See also NegativeTests.Bug260.fst(23,37-26,9)

--- a/tests/error-messages/NegativeTests.Neg.fst.expected
+++ b/tests/error-messages/NegativeTests.Neg.fst.expected
@@ -1,6 +1,7 @@
 >> Got issues: [
 * Error 19 at NegativeTests.Neg.fst(20,8-20,10):
-  - Subtyping check failed; expected type Prims.nat; got type Prims.int
+  - Subtyping check failed
+  - Expected type Prims.nat got type Prims.int
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
   - See also prims.fst(659,18-659,24)
@@ -8,7 +9,8 @@
 >>]
 >> Got issues: [
 * Error 19 at NegativeTests.Neg.fst(24,8-24,10):
-  - Subtyping check failed; expected type Prims.nat; got type Prims.int
+  - Subtyping check failed
+  - Expected type Prims.nat got type Prims.int
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
   - See also prims.fst(659,18-659,24)
@@ -46,7 +48,9 @@
 >>]
 >> Got issues: [
 * Error 19 at NegativeTests.Neg.fst(46,30-46,31):
-  - Subtyping check failed; expected type _: FStar.Pervasives.Native.option 'a {Some? _}; got type FStar.Pervasives.Native.option 'a
+  - Subtyping check failed
+  - Expected type _: FStar.Pervasives.Native.option 'a {Some? _}
+    got type FStar.Pervasives.Native.option 'a
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
   - See also FStar.Pervasives.Native.fst(33,4-33,8)
@@ -54,7 +58,9 @@
 >>]
 >> Got issues: [
 * Error 19 at NegativeTests.Neg.fst(50,45-50,47):
-  - Subtyping check failed; expected type _: FStar.Pervasives.result Prims.int {V? _}; got type FStar.Pervasives.result Prims.int
+  - Subtyping check failed
+  - Expected type _: FStar.Pervasives.result Prims.int {V? _}
+    got type FStar.Pervasives.result Prims.int
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
   - See also FStar.Pervasives.fsti(519,4-519,5)
@@ -62,7 +68,8 @@
 >>]
 >> Got issues: [
 * Error 19 at NegativeTests.Neg.fst(55,25-55,26):
-  - Subtyping check failed; expected type Prims.nat; got type Prims.int
+  - Subtyping check failed
+  - Expected type Prims.nat got type Prims.int
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
   - See also prims.fst(659,18-659,24)

--- a/tests/error-messages/NegativeTests.ShortCircuiting.fst.expected
+++ b/tests/error-messages/NegativeTests.ShortCircuiting.fst.expected
@@ -1,6 +1,7 @@
 >> Got issues: [
 * Error 19 at NegativeTests.ShortCircuiting.fst(21,16-21,33):
-  - Subtyping check failed; expected type b: Prims.bool{bad_p b}; got type Prims.bool
+  - Subtyping check failed
+  - Expected type b: Prims.bool{bad_p b} got type Prims.bool
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
   - See also NegativeTests.ShortCircuiting.fst(19,31-19,38)

--- a/tests/error-messages/NegativeTests.ZZImplicitFalse.fst.expected
+++ b/tests/error-messages/NegativeTests.ZZImplicitFalse.fst.expected
@@ -1,6 +1,7 @@
 >> Got issues: [
 * Error 19 at NegativeTests.ZZImplicitFalse.fst(20,27-20,28):
-  - Subtyping check failed; expected type Prims.l_False; got type Prims.unit
+  - Subtyping check failed
+  - Expected type Prims.l_False got type Prims.unit
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
   - See also prims.fst(138,29-138,34)

--- a/tests/error-messages/PatAnnot.fst.expected
+++ b/tests/error-messages/PatAnnot.fst.expected
@@ -1,6 +1,7 @@
 >> Got issues: [
 * Error 19 at PatAnnot.fst(25,8-25,9):
-  - Subtyping check failed; expected type Prims.squash Prims.l_False; got type Prims.unit
+  - Subtyping check failed
+  - Expected type Prims.squash Prims.l_False got type Prims.unit
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
   - See also PatAnnot.fst(25,19-25,24)
@@ -24,7 +25,8 @@
 >>]
 >> Got issues: [
 * Error 19 at PatAnnot.fst(39,10-39,12):
-  - Subtyping check failed; expected type Prims.squash Prims.l_False; got type Prims.unit
+  - Subtyping check failed
+  - Expected type Prims.squash Prims.l_False got type Prims.unit
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
   - See also PatAnnot.fst(40,26-40,31)
@@ -32,7 +34,8 @@
 >>]
 >> Got issues: [
 * Error 19 at PatAnnot.fst(46,10-46,11):
-  - Subtyping check failed; expected type Prims.nat; got type Prims.int
+  - Subtyping check failed
+  - Expected type Prims.nat got type Prims.int
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
   - See also prims.fst(659,18-659,24)

--- a/tests/error-messages/Test.FunctionalExtensionality.fst.expected
+++ b/tests/error-messages/Test.FunctionalExtensionality.fst.expected
@@ -1,6 +1,7 @@
 >> Got issues: [
 * Error 19 at Test.FunctionalExtensionality.fst(36,49-36,50):
-  - Subtyping check failed; expected type Prims.nat ^-> Prims.int; got type Prims.int ^-> Prims.int
+  - Subtyping check failed
+  - Expected type Prims.nat ^-> Prims.int got type Prims.int ^-> Prims.int
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
   - See also FStar.FunctionalExtensionality.fsti(102,60-102,77)
@@ -16,7 +17,8 @@
 >>]
 >> Got issues: [
 * Error 19 at Test.FunctionalExtensionality.fst(92,36-92,47):
-  - Subtyping check failed; expected type _: Prims.int -> Prims.int; got type Prims.nat ^-> Prims.int
+  - Subtyping check failed
+  - Expected type _: Prims.int -> Prims.int got type Prims.nat ^-> Prims.int
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
   - See also prims.fst(659,18-659,24)
@@ -24,7 +26,8 @@
 >>]
 >> Got issues: [
 * Error 19 at Test.FunctionalExtensionality.fst(142,57-142,58):
-  - Subtyping check failed; expected type Prims.int ^-> Prims.int; got type Prims.int ^-> Prims.nat
+  - Subtyping check failed
+  - Expected type Prims.int ^-> Prims.int got type Prims.int ^-> Prims.nat
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
   - See also FStar.FunctionalExtensionality.fsti(102,60-102,77)

--- a/tests/error-messages/TestErrorLocations.fst.expected
+++ b/tests/error-messages/TestErrorLocations.fst.expected
@@ -30,7 +30,8 @@
 >>]
 >> Got issues: [
 * Error 19 at TestErrorLocations.fst(43,20-43,21):
-  - Subtyping check failed; expected type Prims.nat; got type Prims.int
+  - Subtyping check failed
+  - Expected type Prims.nat got type Prims.int
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
   - See also prims.fst(659,18-659,24)
@@ -62,7 +63,8 @@
 >>]
 >> Got issues: [
 * Error 19 at TestErrorLocations.fst(66,27-66,28):
-  - Subtyping check failed; expected type Prims.nat; got type Prims.int
+  - Subtyping check failed
+  - Expected type Prims.nat got type Prims.int
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
   - See also prims.fst(659,18-659,24)
@@ -70,7 +72,8 @@
 >>]
 >> Got issues: [
 * Error 19 at TestErrorLocations.fst(70,25-70,34):
-  - Subtyping check failed; expected type Type0; got type Type0
+  - Subtyping check failed
+  - Expected type Type0 got type Type0
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
   - See also TestErrorLocations.fst(68,52-68,66)
@@ -78,7 +81,9 @@
 >>]
 >> Got issues: [
 * Error 19 at TestErrorLocations.fst(89,20-89,36):
-  - Subtyping check failed; expected type Prims.squash (exists (x: Prims.nat). x = 0); got type Prims.unit
+  - Subtyping check failed
+  - Expected type Prims.squash (exists (x: Prims.nat). x = 0)
+    got type Prims.unit
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
   - See also FStar.Classical.Sugar.fsti(66,22-66,41)
@@ -86,14 +91,17 @@
 >>]
 >> Got issues: [
 * Error 19 at TestErrorLocations.fst(97,28-97,33):
-  - Subtyping check failed; expected type Prims.squash (forall (x: Prims.nat). x = 0); got type Prims.unit
+  - Subtyping check failed
+  - Expected type Prims.squash (forall (x: Prims.nat). x = 0)
+    got type Prims.unit
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
 
 >>]
 >> Got issues: [
 * Error 19 at TestErrorLocations.fst(102,12-102,13):
-  - Subtyping check failed; expected type Prims.squash (p /\ q); got type Prims.unit
+  - Subtyping check failed
+  - Expected type Prims.squash (p /\ q) got type Prims.unit
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
   - See also TestErrorLocations.fst(101,19-101,20)
@@ -101,7 +109,8 @@
 >>]
 >> Got issues: [
 * Error 19 at TestErrorLocations.fst(108,17-108,18):
-  - Subtyping check failed; expected type Prims.squash (p /\ q); got type Prims.unit
+  - Subtyping check failed
+  - Expected type Prims.squash (p /\ q) got type Prims.unit
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
   - See also TestErrorLocations.fst(107,21-107,22)
@@ -109,7 +118,8 @@
 >>]
 >> Got issues: [
 * Error 19 at TestErrorLocations.fst(114,12-114,18):
-  - Subtyping check failed; expected type Prims.squash (p \/ q); got type Prims.unit
+  - Subtyping check failed
+  - Expected type Prims.squash (p \/ q) got type Prims.unit
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
   - See also FStar.Classical.Sugar.fsti(88,21-88,31)

--- a/tests/error-messages/TestHasEq.fst.expected
+++ b/tests/error-messages/TestHasEq.fst.expected
@@ -1,6 +1,9 @@
 >> Got issues: [
 * Error 19 at TestHasEq.fst(58,10-58,11):
-  - Failed to prove that the type 'TestHasEq.t3' supports decidable equality because of this argument; add either the 'noeq' or 'unopteq' qualifier
+  - Failed to prove that the type
+    'TestHasEq.t3'
+    supports decidable equality because of this argument.
+  - Add either the 'noeq' or 'unopteq' qualifier
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
   - See also TestHasEq.fst(57,0-58,19)
@@ -8,7 +11,8 @@
 >>]
 >> Got issues: [
 * Error 19 at TestHasEq.fst(84,10-84,70):
-  - Subtyping check failed; expected type Prims.eqtype; got type Type0
+  - Subtyping check failed
+  - Expected type Prims.eqtype got type Type0
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
   - See also TestHasEq.fst(84,12-84,22)

--- a/tests/ide/emacs/backtracking.refinements.out.expected
+++ b/tests/ide/emacs/backtracking.refinements.out.expected
@@ -16,15 +16,15 @@
 {"kind": "response", "query-id": "15", "response": [{"level": "error", "message": "  - Syntax error\n", "number": 168, "ranges": [{"beg": [3, 15], "end": [3, 15], "fname": "<input>"}]}], "status": "success"}
 {"kind": "response", "query-id": "16", "response": [{"level": "error", "message": "  - Syntax error\n", "number": 168, "ranges": [{"beg": [3, 15], "end": [3, 15], "fname": "<input>"}]}], "status": "success"}
 {"kind": "response", "query-id": "17", "response": [], "status": "success"}
-{"kind": "response", "query-id": "18", "response": [{"level": "error", "message": "  - Subtyping check failed; expected type a: nat{a > 2}; got type int\n  - The SMT solver could not prove the query. Use --query_stats for more\n    details.\n  - See also <input>(3,14-3,19)\n", "number": 19, "ranges": [{"beg": [3, 23], "end": [3, 24], "fname": "<input>"}, {"beg": [3, 14], "end": [3, 19], "fname": "<input>"}]}], "status": "failure"}
+{"kind": "response", "query-id": "18", "response": [{"level": "error", "message": "  - Subtyping check failed\n  - Expected type a: nat{a > 2} got type int\n  - The SMT solver could not prove the query. Use --query_stats for more\n    details.\n  - See also <input>(3,14-3,19)\n", "number": 19, "ranges": [{"beg": [3, 23], "end": [3, 24], "fname": "<input>"}, {"beg": [3, 14], "end": [3, 19], "fname": "<input>"}]}], "status": "failure"}
 {"kind": "response", "query-id": "19", "response": [], "status": "success"}
 {"kind": "response", "query-id": "20", "response": [], "status": "success"}
-{"kind": "response", "query-id": "21", "response": [{"level": "error", "message": "  - Subtyping check failed; expected type a: nat{a > 1}; got type int\n  - The SMT solver could not prove the query. Use --query_stats for more\n    details.\n  - See also <input>(3,14-3,19)\n", "number": 19, "ranges": [{"beg": [3, 23], "end": [3, 24], "fname": "<input>"}, {"beg": [3, 14], "end": [3, 19], "fname": "<input>"}]}], "status": "failure"}
+{"kind": "response", "query-id": "21", "response": [{"level": "error", "message": "  - Subtyping check failed\n  - Expected type a: nat{a > 1} got type int\n  - The SMT solver could not prove the query. Use --query_stats for more\n    details.\n  - See also <input>(3,14-3,19)\n", "number": 19, "ranges": [{"beg": [3, 23], "end": [3, 24], "fname": "<input>"}, {"beg": [3, 14], "end": [3, 19], "fname": "<input>"}]}], "status": "failure"}
 {"kind": "response", "query-id": "22", "response": [], "status": "success"}
 {"kind": "response", "query-id": "23", "response": [], "status": "success"}
 {"kind": "response", "query-id": "24", "response": null, "status": "success"}
 {"kind": "response", "query-id": "25", "response": [], "status": "success"}
-{"kind": "response", "query-id": "26", "response": [{"level": "error", "message": "  - Subtyping check failed; expected type a: nat{a > 0}; got type int\n  - The SMT solver could not prove the query. Use --query_stats for more\n    details.\n  - See also <input>(3,14-3,19)\n", "number": 19, "ranges": [{"beg": [3, 23], "end": [3, 25], "fname": "<input>"}, {"beg": [3, 14], "end": [3, 19], "fname": "<input>"}]}], "status": "failure"}
+{"kind": "response", "query-id": "26", "response": [{"level": "error", "message": "  - Subtyping check failed\n  - Expected type a: nat{a > 0} got type int\n  - The SMT solver could not prove the query. Use --query_stats for more\n    details.\n  - See also <input>(3,14-3,19)\n", "number": 19, "ranges": [{"beg": [3, 23], "end": [3, 25], "fname": "<input>"}, {"beg": [3, 14], "end": [3, 19], "fname": "<input>"}]}], "status": "failure"}
 {"kind": "response", "query-id": "27", "response": [], "status": "success"}
 {"kind": "response", "query-id": "28", "response": [], "status": "success"}
 {"kind": "response", "query-id": "29", "response": [], "status": "success"}
@@ -43,7 +43,7 @@
 {"kind": "response", "query-id": "42", "response": [], "status": "success"}
 {"kind": "response", "query-id": "43", "response": [], "status": "success"}
 {"kind": "response", "query-id": "44", "response": [], "status": "success"}
-{"kind": "response", "query-id": "45", "response": [{"level": "error", "message": "  - Subtyping check failed; expected type b: nat{b > 1}; got type int\n  - The SMT solver could not prove the query. Use --query_stats for more\n    details.\n  - See also <input>(5,13-5,18)\n", "number": 19, "ranges": [{"beg": [5, 22], "end": [5, 31], "fname": "<input>"}, {"beg": [5, 13], "end": [5, 18], "fname": "<input>"}]}], "status": "failure"}
+{"kind": "response", "query-id": "45", "response": [{"level": "error", "message": "  - Subtyping check failed\n  - Expected type b: nat{b > 1} got type int\n  - The SMT solver could not prove the query. Use --query_stats for more\n    details.\n  - See also <input>(5,13-5,18)\n", "number": 19, "ranges": [{"beg": [5, 22], "end": [5, 31], "fname": "<input>"}, {"beg": [5, 13], "end": [5, 18], "fname": "<input>"}]}], "status": "failure"}
 {"kind": "response", "query-id": "46", "response": [], "status": "success"}
 {"kind": "response", "query-id": "47", "response": [], "status": "success"}
 {"kind": "response", "query-id": "48", "response": [], "status": "success"}
@@ -53,7 +53,7 @@
 {"kind": "response", "query-id": "52", "response": [], "status": "success"}
 {"kind": "response", "query-id": "53", "response": null, "status": "success"}
 {"kind": "response", "query-id": "54", "response": [], "status": "success"}
-{"kind": "response", "query-id": "55", "response": [{"level": "error", "message": "  - Subtyping check failed; expected type b: nat{b > 1}; got type int\n  - The SMT solver could not prove the query. Use --query_stats for more\n    details.\n  - See also <input>(5,13-5,18)\n", "number": 19, "ranges": [{"beg": [5, 22], "end": [5, 31], "fname": "<input>"}, {"beg": [5, 13], "end": [5, 18], "fname": "<input>"}]}], "status": "failure"}
+{"kind": "response", "query-id": "55", "response": [{"level": "error", "message": "  - Subtyping check failed\n  - Expected type b: nat{b > 1} got type int\n  - The SMT solver could not prove the query. Use --query_stats for more\n    details.\n  - See also <input>(5,13-5,18)\n", "number": 19, "ranges": [{"beg": [5, 22], "end": [5, 31], "fname": "<input>"}, {"beg": [5, 13], "end": [5, 18], "fname": "<input>"}]}], "status": "failure"}
 {"kind": "response", "query-id": "56", "response": null, "status": "success"}
 {"kind": "response", "query-id": "57", "response": [], "status": "success"}
 {"kind": "response", "query-id": "58", "response": [], "status": "success"}
@@ -61,12 +61,12 @@
 {"kind": "response", "query-id": "60", "response": null, "status": "success"}
 {"kind": "response", "query-id": "61", "response": null, "status": "success"}
 {"kind": "response", "query-id": "62", "response": [], "status": "success"}
-{"kind": "response", "query-id": "63", "response": [{"level": "error", "message": "  - Subtyping check failed; expected type a: nat{a > 0}; got type int\n  - The SMT solver could not prove the query. Use --query_stats for more\n    details.\n  - See also <input>(3,14-3,19)\n", "number": 19, "ranges": [{"beg": [3, 23], "end": [3, 25], "fname": "<input>"}, {"beg": [3, 14], "end": [3, 19], "fname": "<input>"}]}], "status": "failure"}
+{"kind": "response", "query-id": "63", "response": [{"level": "error", "message": "  - Subtyping check failed\n  - Expected type a: nat{a > 0} got type int\n  - The SMT solver could not prove the query. Use --query_stats for more\n    details.\n  - See also <input>(3,14-3,19)\n", "number": 19, "ranges": [{"beg": [3, 23], "end": [3, 25], "fname": "<input>"}, {"beg": [3, 14], "end": [3, 19], "fname": "<input>"}]}], "status": "failure"}
 {"kind": "response", "query-id": "64", "response": [], "status": "success"}
-{"kind": "response", "query-id": "65", "response": [{"level": "error", "message": "  - Subtyping check failed; expected type a: nat{a > 0}; got type int\n  - The SMT solver could not prove the query. Use --query_stats for more\n    details.\n  - See also <input>(3,14-3,19)\n", "number": 19, "ranges": [{"beg": [3, 23], "end": [3, 24], "fname": "<input>"}, {"beg": [3, 14], "end": [3, 19], "fname": "<input>"}]}], "status": "failure"}
+{"kind": "response", "query-id": "65", "response": [{"level": "error", "message": "  - Subtyping check failed\n  - Expected type a: nat{a > 0} got type int\n  - The SMT solver could not prove the query. Use --query_stats for more\n    details.\n  - See also <input>(3,14-3,19)\n", "number": 19, "ranges": [{"beg": [3, 23], "end": [3, 24], "fname": "<input>"}, {"beg": [3, 14], "end": [3, 19], "fname": "<input>"}]}], "status": "failure"}
 {"kind": "response", "query-id": "66", "response": [], "status": "success"}
 {"kind": "response", "query-id": "67", "response": [], "status": "success"}
-{"kind": "response", "query-id": "68", "response": [{"level": "error", "message": "  - Subtyping check failed; expected type b: nat{b > 1}; got type int\n  - The SMT solver could not prove the query. Use --query_stats for more\n    details.\n  - See also <input>(5,13-5,18)\n", "number": 19, "ranges": [{"beg": [5, 22], "end": [5, 31], "fname": "<input>"}, {"beg": [5, 13], "end": [5, 18], "fname": "<input>"}]}], "status": "failure"}
+{"kind": "response", "query-id": "68", "response": [{"level": "error", "message": "  - Subtyping check failed\n  - Expected type b: nat{b > 1} got type int\n  - The SMT solver could not prove the query. Use --query_stats for more\n    details.\n  - See also <input>(5,13-5,18)\n", "number": 19, "ranges": [{"beg": [5, 22], "end": [5, 31], "fname": "<input>"}, {"beg": [5, 13], "end": [5, 18], "fname": "<input>"}]}], "status": "failure"}
 {"kind": "response", "query-id": "69", "response": null, "status": "success"}
 {"kind": "response", "query-id": "70", "response": [], "status": "success"}
 {"kind": "response", "query-id": "71", "response": [], "status": "success"}

--- a/tests/ide/emacs/integration.push-pop.out.expected
+++ b/tests/ide/emacs/integration.push-pop.out.expected
@@ -78,17 +78,17 @@
 {"kind": "response", "query-id": "80", "response": [], "status": "success"}
 {"kind": "response", "query-id": "91", "response": [{"level": "error", "message": "  - Syntax error\n", "number": 168, "ranges": [{"beg": [12, 0], "end": [12, 0], "fname": "<input>"}]}], "status": "success"}
 {"kind": "response", "query-id": "98", "response": [], "status": "success"}
-{"kind": "response", "query-id": "101", "response": [{"level": "error", "message": "  - Subtyping check failed; expected type nat; got type int\n  - The SMT solver could not prove the query. Use --query_stats for more\n    details.\n  - See also prims.fst(659,18-659,24)\n", "number": 19, "ranges": [{"beg": [11, 15], "end": [11, 17], "fname": "<input>"}, {"beg": [659, 18], "end": [659, 24], "fname": "prims.fst"}]}], "status": "failure"}
+{"kind": "response", "query-id": "101", "response": [{"level": "error", "message": "  - Subtyping check failed\n  - Expected type nat got type int\n  - The SMT solver could not prove the query. Use --query_stats for more\n    details.\n  - See also prims.fst(659,18-659,24)\n", "number": 19, "ranges": [{"beg": [11, 15], "end": [11, 17], "fname": "<input>"}, {"beg": [659, 18], "end": [659, 24], "fname": "prims.fst"}]}], "status": "failure"}
 {"kind": "response", "query-id": "107", "response": [], "status": "success"}
 {"kind": "response", "query-id": "108", "response": [], "status": "success"}
 {"kind": "response", "query-id": "112", "response": null, "status": "success"}
 {"kind": "response", "query-id": "114", "response": [], "status": "success"}
-{"kind": "response", "query-id": "116", "response": [{"level": "error", "message": "  - Subtyping check failed; expected type nat; got type int\n  - The SMT solver could not prove the query. Use --query_stats for more\n    details.\n  - See also prims.fst(659,18-659,24)\n", "number": 19, "ranges": [{"beg": [11, 15], "end": [11, 17], "fname": "<input>"}, {"beg": [659, 18], "end": [659, 24], "fname": "prims.fst"}]}], "status": "failure"}
+{"kind": "response", "query-id": "116", "response": [{"level": "error", "message": "  - Subtyping check failed\n  - Expected type nat got type int\n  - The SMT solver could not prove the query. Use --query_stats for more\n    details.\n  - See also prims.fst(659,18-659,24)\n", "number": 19, "ranges": [{"beg": [11, 15], "end": [11, 17], "fname": "<input>"}, {"beg": [659, 18], "end": [659, 24], "fname": "prims.fst"}]}], "status": "failure"}
 {"kind": "response", "query-id": "118", "response": [], "status": "success"}
 {"kind": "response", "query-id": "119", "response": [], "status": "success"}
 {"kind": "response", "query-id": "122", "response": null, "status": "success"}
 {"kind": "response", "query-id": "124", "response": [], "status": "success"}
-{"kind": "response", "query-id": "126", "response": [{"level": "error", "message": "  - Subtyping check failed; expected type nat; got type int\n  - The SMT solver could not prove the query. Use --query_stats for more\n    details.\n  - See also prims.fst(659,18-659,24)\n", "number": 19, "ranges": [{"beg": [11, 15], "end": [11, 17], "fname": "<input>"}, {"beg": [659, 18], "end": [659, 24], "fname": "prims.fst"}]}], "status": "failure"}
+{"kind": "response", "query-id": "126", "response": [{"level": "error", "message": "  - Subtyping check failed\n  - Expected type nat got type int\n  - The SMT solver could not prove the query. Use --query_stats for more\n    details.\n  - See also prims.fst(659,18-659,24)\n", "number": 19, "ranges": [{"beg": [11, 15], "end": [11, 17], "fname": "<input>"}, {"beg": [659, 18], "end": [659, 24], "fname": "prims.fst"}]}], "status": "failure"}
 {"kind": "response", "query-id": "128", "response": [], "status": "success"}
 {"kind": "response", "query-id": "130", "response": [], "status": "success"}
 {"kind": "response", "query-id": "133", "response": [], "status": "success"}
@@ -106,7 +106,7 @@
 {"kind": "response", "query-id": "191", "response": null, "status": "success"}
 {"kind": "response", "query-id": "192", "response": null, "status": "success"}
 {"kind": "response", "query-id": "194", "response": [], "status": "success"}
-{"kind": "response", "query-id": "198", "response": [{"level": "error", "message": "  - Subtyping check failed; expected type nat; got type int\n  - The SMT solver could not prove the query. Use --query_stats for more\n    details.\n  - See also prims.fst(659,18-659,24)\n", "number": 19, "ranges": [{"beg": [11, 15], "end": [11, 17], "fname": "<input>"}, {"beg": [659, 18], "end": [659, 24], "fname": "prims.fst"}]}], "status": "failure"}
+{"kind": "response", "query-id": "198", "response": [{"level": "error", "message": "  - Subtyping check failed\n  - Expected type nat got type int\n  - The SMT solver could not prove the query. Use --query_stats for more\n    details.\n  - See also prims.fst(659,18-659,24)\n", "number": 19, "ranges": [{"beg": [11, 15], "end": [11, 17], "fname": "<input>"}, {"beg": [659, 18], "end": [659, 24], "fname": "prims.fst"}]}], "status": "failure"}
 {"kind": "response", "query-id": "200", "response": [], "status": "success"}
 {"kind": "response", "query-id": "204", "response": [], "status": "success"}
 {"kind": "response", "query-id": "205", "response": [{"level": "error", "message": "  - Assertion failed\n  - The SMT solver could not prove the query. Use --query_stats for more\n    details.\n  - See also <input>(13,15-13,23)\n", "number": 19, "ranges": [{"beg": [13, 8], "end": [13, 14], "fname": "<input>"}, {"beg": [13, 15], "end": [13, 23], "fname": "<input>"}]}], "status": "failure"}

--- a/tests/ide/emacs/number.interface-violation-and-fix.out.expected
+++ b/tests/ide/emacs/number.interface-violation-and-fix.out.expected
@@ -1,7 +1,7 @@
 {"kind": "protocol-info", "rest": "[...]"}
 {"kind": "response", "query-id": "1", "response": null, "status": "success"}
 {"kind": "response", "query-id": "2", "response": [], "status": "success"}
-{"kind": "response", "query-id": "3", "response": [{"level": "error", "message": "  - Subtyping check failed; expected type a: int{a > 0}; got type int\n  - The SMT solver could not prove the query. Use --query_stats for more\n    details.\n  - See also number.fsti(18,14-18,19)\n", "number": 19, "ranges": [{"beg": [3, 8], "end": [3, 10], "fname": "<input>"}, {"beg": [18, 14], "end": [18, 19], "fname": "number.fsti"}]}], "status": "failure"}
+{"kind": "response", "query-id": "3", "response": [{"level": "error", "message": "  - Subtyping check failed\n  - Expected type a: int{a > 0} got type int\n  - The SMT solver could not prove the query. Use --query_stats for more\n    details.\n  - See also number.fsti(18,14-18,19)\n", "number": 19, "ranges": [{"beg": [3, 8], "end": [3, 10], "fname": "<input>"}, {"beg": [18, 14], "end": [18, 19], "fname": "number.fsti"}]}], "status": "failure"}
 {"kind": "response", "query-id": "4", "response": null, "status": "success"}
 {"kind": "response", "query-id": "5", "response": null, "status": "success"}
 {"kind": "response", "query-id": "6", "response": [], "status": "success"}

--- a/tests/ide/emacs/number.interface-violation.out.expected
+++ b/tests/ide/emacs/number.interface-violation.out.expected
@@ -1,4 +1,4 @@
 {"kind": "protocol-info", "rest": "[...]"}
 {"kind": "response", "query-id": "1", "response": null, "status": "success"}
 {"kind": "response", "query-id": "2", "response": [], "status": "success"}
-{"kind": "response", "query-id": "3", "response": [{"level": "error", "message": "  - Subtyping check failed; expected type a: int{a > 0}; got type int\n  - The SMT solver could not prove the query. Use --query_stats for more\n    details.\n  - See also number.fsti(18,14-18,19)\n", "number": 19, "ranges": [{"beg": [3, 8], "end": [3, 10], "fname": "<input>"}, {"beg": [18, 14], "end": [18, 19], "fname": "number.fsti"}]}], "status": "failure"}
+{"kind": "response", "query-id": "3", "response": [{"level": "error", "message": "  - Subtyping check failed\n  - Expected type a: int{a > 0} got type int\n  - The SMT solver could not prove the query. Use --query_stats for more\n    details.\n  - See also number.fsti(18,14-18,19)\n", "number": 19, "ranges": [{"beg": [3, 8], "end": [3, 10], "fname": "<input>"}, {"beg": [18, 14], "end": [18, 19], "fname": "number.fsti"}]}], "status": "failure"}


### PR DESCRIPTION
The whole family of SMT errors was limited to using strings. This patch allows them to use structured errors like everywhere else.