### PR TITLE
Tactics: if dump_on_failure is true, do not add Tactic failed prefix

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_Tactics_Interpreter.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Interpreter.ml
@@ -1102,9 +1102,12 @@ let run_unembedded_tactic_on_ps :
                      let uu___2 =
                        let uu___3 =
                          let uu___4 =
-                           let uu___5 =
-                             FStar_Pprint.doc_of_string "Tactic failed" in
-                           [uu___5] in
+                           if ps3.FStar_Tactics_Types.dump_on_failure
+                           then
+                             let uu___5 =
+                               FStar_Pprint.doc_of_string "Tactic failed" in
+                             [uu___5]
+                           else [] in
                          let uu___5 = texn_to_doc e in
                          FStar_Compiler_List.op_At uu___4 uu___5 in
                        (FStar_Errors_Codes.Fatal_UserTacticFailure, uu___3) in

--- a/ocaml/fstar-lib/generated/FStar_Tactics_V2_Basic.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_V2_Basic.ml
@@ -12334,20 +12334,25 @@ let (log_issues :
          (fun ps ->
             let ps = Obj.magic ps in
             let is1 =
-              FStar_Compiler_List.map
-                (fun i ->
-                   let uu___ =
-                     let uu___1 =
-                       FStar_Errors_Msg.text "Tactic logged issue:" in
-                     uu___1 :: (i.FStar_Errors.issue_msg) in
-                   {
-                     FStar_Errors.issue_msg = uu___;
-                     FStar_Errors.issue_level = (i.FStar_Errors.issue_level);
-                     FStar_Errors.issue_range = (i.FStar_Errors.issue_range);
-                     FStar_Errors.issue_number =
-                       (i.FStar_Errors.issue_number);
-                     FStar_Errors.issue_ctx = (i.FStar_Errors.issue_ctx)
-                   }) is in
+              if ps.FStar_Tactics_Types.dump_on_failure
+              then
+                FStar_Compiler_List.map
+                  (fun i ->
+                     let uu___ =
+                       let uu___1 =
+                         FStar_Errors_Msg.text "Tactic logged issue:" in
+                       uu___1 :: (i.FStar_Errors.issue_msg) in
+                     {
+                       FStar_Errors.issue_msg = uu___;
+                       FStar_Errors.issue_level =
+                         (i.FStar_Errors.issue_level);
+                       FStar_Errors.issue_range =
+                         (i.FStar_Errors.issue_range);
+                       FStar_Errors.issue_number =
+                         (i.FStar_Errors.issue_number);
+                       FStar_Errors.issue_ctx = (i.FStar_Errors.issue_ctx)
+                     }) is
+              else is in
             FStar_Errors.add_issues is1;
             Obj.magic
               (FStar_Class_Monad.return FStar_Tactics_Monad.monad_tac ()

--- a/src/tactics/FStar.Tactics.Interpreter.fst
+++ b/src/tactics/FStar.Tactics.Interpreter.fst
@@ -388,7 +388,7 @@ let run_unembedded_tactic_on_ps
         in
         let open FStar.Pprint in
         Err.raise_error_doc (Err.Fatal_UserTacticFailure, (
-                              [doc_of_string "Tactic failed"]
+                              (if ps.dump_on_failure then [doc_of_string "Tactic failed"] else [])
                               @ texn_to_doc e)
                             )
                           rng

--- a/src/tactics/FStar.Tactics.V2.Basic.fst
+++ b/src/tactics/FStar.Tactics.V2.Basic.fst
@@ -2765,9 +2765,14 @@ let resolve_name (e:env) (n:list string) =
 let log_issues (is : list Errors.issue) : tac unit =
   let open FStar.Errors in
   let! ps = get in
-  (* Prepend an error component *)
-  let is = is |>
-     List.map (fun i -> { i with issue_msg = (Errors.text "Tactic logged issue:")::i.issue_msg })
+  (* Prepend an error component, unless the tactic handles its own errors. *)
+  let is =
+    if ps.dump_on_failure
+    then
+      is |>
+      List.map (fun i -> { i with issue_msg = (Errors.text "Tactic logged issue:")::i.issue_msg })
+    else
+      is
   in
   add_issues is;
   return ()

--- a/tests/error-messages/Bug1918.fst.expected
+++ b/tests/error-messages/Bug1918.fst.expected
@@ -1,6 +1,5 @@
 >> Got issues: [
 * Error 228 at Bug1918.fst(11,13-11,14):
-  - Tactic failed
   - Typeclass resolution failed
   - Could not solve constraint Bug1918.mon
   - See also FStar.Tactics.Typeclasses.fst(293,6-297,7)


### PR DESCRIPTION
For tactics that handle their own errors, i.e. those which call `set_dump_on_failure false`, do not a "Tactic failed" prefix. This includes tcresolve and the pulse checker.