### PR TITLE
Tactics.TypeRepr: add a tactic to translate inductives to a sums of products

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_Syntax_Resugar.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Resugar.ml
@@ -90,10 +90,11 @@ let rec (universe_to_int :
   =
   fun n ->
     fun u ->
-      match u with
+      let uu___ = FStar_Syntax_Subst.compress_univ u in
+      match uu___ with
       | FStar_Syntax_Syntax.U_succ u1 ->
           universe_to_int (n + Prims.int_one) u1
-      | uu___ -> (n, u)
+      | uu___1 -> (n, u)
 let (universe_to_string : FStar_Ident.ident Prims.list -> Prims.string) =
   fun univs ->
     let uu___ = FStar_Options.print_universes () in
@@ -110,73 +111,73 @@ let rec (resugar_universe :
   fun u ->
     fun r ->
       let mk a r1 = FStar_Parser_AST.mk_term a r1 FStar_Parser_AST.Un in
-      let uu___ = FStar_Syntax_Subst.compress_univ u in
-      match uu___ with
+      let u1 = FStar_Syntax_Subst.compress_univ u in
+      match u1 with
       | FStar_Syntax_Syntax.U_zero ->
           mk
             (FStar_Parser_AST.Const
                (FStar_Const.Const_int ("0", FStar_Pervasives_Native.None))) r
-      | FStar_Syntax_Syntax.U_succ uu___1 ->
-          let uu___2 = universe_to_int Prims.int_zero u in
-          (match uu___2 with
-           | (n, u1) ->
-               (match u1 with
+      | FStar_Syntax_Syntax.U_succ uu___ ->
+          let uu___1 = universe_to_int Prims.int_zero u1 in
+          (match uu___1 with
+           | (n, u2) ->
+               (match u2 with
                 | FStar_Syntax_Syntax.U_zero ->
+                    let uu___2 =
+                      let uu___3 =
+                        let uu___4 =
+                          let uu___5 = FStar_Compiler_Util.string_of_int n in
+                          (uu___5, FStar_Pervasives_Native.None) in
+                        FStar_Const.Const_int uu___4 in
+                      FStar_Parser_AST.Const uu___3 in
+                    mk uu___2 r
+                | uu___2 ->
+                    let e1 =
+                      let uu___3 =
+                        let uu___4 =
+                          let uu___5 =
+                            let uu___6 = FStar_Compiler_Util.string_of_int n in
+                            (uu___6, FStar_Pervasives_Native.None) in
+                          FStar_Const.Const_int uu___5 in
+                        FStar_Parser_AST.Const uu___4 in
+                      mk uu___3 r in
+                    let e2 = resugar_universe u2 r in
                     let uu___3 =
                       let uu___4 =
-                        let uu___5 =
-                          let uu___6 = FStar_Compiler_Util.string_of_int n in
-                          (uu___6, FStar_Pervasives_Native.None) in
-                        FStar_Const.Const_int uu___5 in
-                      FStar_Parser_AST.Const uu___4 in
-                    mk uu___3 r
-                | uu___3 ->
-                    let e1 =
-                      let uu___4 =
-                        let uu___5 =
-                          let uu___6 =
-                            let uu___7 = FStar_Compiler_Util.string_of_int n in
-                            (uu___7, FStar_Pervasives_Native.None) in
-                          FStar_Const.Const_int uu___6 in
-                        FStar_Parser_AST.Const uu___5 in
-                      mk uu___4 r in
-                    let e2 = resugar_universe u1 r in
-                    let uu___4 =
-                      let uu___5 =
-                        let uu___6 = FStar_Ident.id_of_text "+" in
-                        (uu___6, [e1; e2]) in
-                      FStar_Parser_AST.Op uu___5 in
-                    mk uu___4 r))
+                        let uu___5 = FStar_Ident.id_of_text "+" in
+                        (uu___5, [e1; e2]) in
+                      FStar_Parser_AST.Op uu___4 in
+                    mk uu___3 r))
       | FStar_Syntax_Syntax.U_max l ->
           (match l with
            | [] ->
                FStar_Compiler_Effect.failwith
                  "Impossible: U_max without arguments"
-           | uu___1 ->
+           | uu___ ->
                let t =
-                 let uu___2 =
-                   let uu___3 = FStar_Ident.lid_of_path ["max"] r in
-                   FStar_Parser_AST.Var uu___3 in
-                 mk uu___2 r in
+                 let uu___1 =
+                   let uu___2 = FStar_Ident.lid_of_path ["max"] r in
+                   FStar_Parser_AST.Var uu___2 in
+                 mk uu___1 r in
                FStar_Compiler_List.fold_left
                  (fun acc ->
                     fun x ->
-                      let uu___2 =
-                        let uu___3 =
-                          let uu___4 = resugar_universe x r in
-                          (acc, uu___4, FStar_Parser_AST.Nothing) in
-                        FStar_Parser_AST.App uu___3 in
-                      mk uu___2 r) t l)
-      | FStar_Syntax_Syntax.U_name u1 -> mk (FStar_Parser_AST.Uvar u1) r
-      | FStar_Syntax_Syntax.U_unif uu___1 -> mk FStar_Parser_AST.Wild r
+                      let uu___1 =
+                        let uu___2 =
+                          let uu___3 = resugar_universe x r in
+                          (acc, uu___3, FStar_Parser_AST.Nothing) in
+                        FStar_Parser_AST.App uu___2 in
+                      mk uu___1 r) t l)
+      | FStar_Syntax_Syntax.U_name u2 -> mk (FStar_Parser_AST.Uvar u2) r
+      | FStar_Syntax_Syntax.U_unif uu___ -> mk FStar_Parser_AST.Wild r
       | FStar_Syntax_Syntax.U_bvar x ->
           let id =
-            let uu___1 =
-              let uu___2 =
-                let uu___3 = FStar_Compiler_Util.string_of_int x in
-                FStar_Compiler_Util.strcat "uu__univ_bvar_" uu___3 in
-              (uu___2, r) in
-            FStar_Ident.mk_ident uu___1 in
+            let uu___ =
+              let uu___1 =
+                let uu___2 = FStar_Compiler_Util.string_of_int x in
+                FStar_Compiler_Util.strcat "uu__univ_bvar_" uu___2 in
+              (uu___1, r) in
+            FStar_Ident.mk_ident uu___ in
           mk (FStar_Parser_AST.Uvar id) r
       | FStar_Syntax_Syntax.U_unknown -> mk FStar_Parser_AST.Wild r
 let (resugar_universe' :

--- a/ocaml/fstar-lib/generated/FStar_Tactics_TypeRepr.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_TypeRepr.ml
@@ -1,0 +1,2369 @@
+open Prims
+let (empty_elim : Prims.empty -> unit -> Obj.t) =
+  fun uu___1 ->
+    fun uu___ ->
+      (fun e -> fun a -> Obj.magic (failwith "unreachable")) uu___1 uu___
+let (add_suffix :
+  Prims.string -> FStar_Reflection_Types.name -> FStar_Reflection_Types.name)
+  =
+  fun s ->
+    fun nm ->
+      FStar_Reflection_V2_Builtins.explode_qn
+        (Prims.strcat (FStar_Reflection_V2_Builtins.implode_qn nm) s)
+let (unitv_ : FStar_Tactics_NamedView.term) =
+  FStar_Reflection_V2_Builtins.pack_ln
+    (FStar_Reflection_V2_Data.Tv_Const FStar_Reflection_V2_Data.C_Unit)
+let (unitt_ : FStar_Tactics_NamedView.term) =
+  FStar_Reflection_V2_Builtins.pack_ln
+    (FStar_Reflection_V2_Data.Tv_FVar
+       (FStar_Reflection_V2_Builtins.pack_fv ["Prims"; "unit"]))
+let (empty_ : FStar_Tactics_NamedView.term) =
+  FStar_Reflection_V2_Builtins.pack_ln
+    (FStar_Reflection_V2_Data.Tv_FVar
+       (FStar_Reflection_V2_Builtins.pack_fv ["Prims"; "empty"]))
+let (either_ :
+  FStar_Tactics_NamedView.term ->
+    FStar_Tactics_NamedView.term -> FStar_Tactics_NamedView.term)
+  =
+  fun a ->
+    fun b ->
+      FStar_Reflection_V2_Builtins.pack_ln
+        (FStar_Reflection_V2_Data.Tv_App
+           ((FStar_Reflection_V2_Builtins.pack_ln
+               (FStar_Reflection_V2_Data.Tv_App
+                  ((FStar_Reflection_V2_Builtins.pack_ln
+                      (FStar_Reflection_V2_Data.Tv_FVar
+                         (FStar_Reflection_V2_Builtins.pack_fv
+                            ["FStar"; "Pervasives"; "either"]))),
+                    (a, FStar_Reflection_V2_Data.Q_Explicit)))),
+             (b, FStar_Reflection_V2_Data.Q_Explicit)))
+let (tuple2_ :
+  FStar_Tactics_NamedView.term ->
+    FStar_Tactics_NamedView.term -> FStar_Tactics_NamedView.term)
+  =
+  fun a ->
+    fun b ->
+      FStar_Reflection_V2_Builtins.pack_ln
+        (FStar_Reflection_V2_Data.Tv_App
+           ((FStar_Reflection_V2_Builtins.pack_ln
+               (FStar_Reflection_V2_Data.Tv_App
+                  ((FStar_Reflection_V2_Builtins.pack_ln
+                      (FStar_Reflection_V2_Data.Tv_FVar
+                         (FStar_Reflection_V2_Builtins.pack_fv
+                            ["FStar"; "Pervasives"; "Native"; "tuple2"]))),
+                    (a, FStar_Reflection_V2_Data.Q_Explicit)))),
+             (b, FStar_Reflection_V2_Data.Q_Explicit)))
+let (mktuple2_ :
+  FStar_Tactics_NamedView.term ->
+    FStar_Tactics_NamedView.term -> FStar_Tactics_NamedView.term)
+  =
+  fun a ->
+    fun b ->
+      FStar_Reflection_V2_Builtins.pack_ln
+        (FStar_Reflection_V2_Data.Tv_App
+           ((FStar_Reflection_V2_Builtins.pack_ln
+               (FStar_Reflection_V2_Data.Tv_App
+                  ((FStar_Reflection_V2_Builtins.pack_ln
+                      (FStar_Reflection_V2_Data.Tv_FVar
+                         (FStar_Reflection_V2_Builtins.pack_fv
+                            ["FStar"; "Pervasives"; "Native"; "Mktuple2"]))),
+                    (a, FStar_Reflection_V2_Data.Q_Explicit)))),
+             (b, FStar_Reflection_V2_Data.Q_Explicit)))
+let (get_inductive_typ :
+  Prims.string ->
+    (FStar_Tactics_NamedView.sigelt_view, unit) FStar_Tactics_Effect.tac_repr)
+  =
+  fun nm ->
+    FStar_Tactics_Effect.tac_bind
+      (FStar_Sealed.seal
+         (Obj.magic
+            (FStar_Range.mk_range "FStar.Tactics.TypeRepr.fst"
+               (Prims.of_int (18)) (Prims.of_int (10)) (Prims.of_int (18))
+               (Prims.of_int (20)))))
+      (FStar_Sealed.seal
+         (Obj.magic
+            (FStar_Range.mk_range "FStar.Tactics.TypeRepr.fst"
+               (Prims.of_int (18)) (Prims.of_int (23)) (Prims.of_int (27))
+               (Prims.of_int (48)))))
+      (Obj.magic (FStar_Tactics_V2_Builtins.top_env ()))
+      (fun uu___ ->
+         (fun e ->
+            Obj.magic
+              (FStar_Tactics_Effect.tac_bind
+                 (FStar_Sealed.seal
+                    (Obj.magic
+                       (FStar_Range.mk_range "FStar.Tactics.TypeRepr.fst"
+                          (Prims.of_int (19)) (Prims.of_int (11))
+                          (Prims.of_int (19)) (Prims.of_int (39)))))
+                 (FStar_Sealed.seal
+                    (Obj.magic
+                       (FStar_Range.mk_range "FStar.Tactics.TypeRepr.fst"
+                          (Prims.of_int (20)) (Prims.of_int (2))
+                          (Prims.of_int (27)) (Prims.of_int (48)))))
+                 (FStar_Tactics_Effect.lift_div_tac
+                    (fun uu___ ->
+                       FStar_Reflection_V2_Builtins.lookup_typ e
+                         (FStar_Reflection_V2_Builtins.explode_qn nm)))
+                 (fun uu___ ->
+                    (fun se ->
+                       match se with
+                       | FStar_Pervasives_Native.None ->
+                           Obj.magic
+                             (Obj.repr
+                                (FStar_Tactics_V2_Derived.fail
+                                   "ctors_of_typ: type not found"))
+                       | FStar_Pervasives_Native.Some se1 ->
+                           Obj.magic
+                             (Obj.repr
+                                (FStar_Tactics_Effect.tac_bind
+                                   (FStar_Sealed.seal
+                                      (Obj.magic
+                                         (FStar_Range.mk_range
+                                            "FStar.Tactics.TypeRepr.fst"
+                                            (Prims.of_int (23))
+                                            (Prims.of_int (14))
+                                            (Prims.of_int (23))
+                                            (Prims.of_int (31)))))
+                                   (FStar_Sealed.seal
+                                      (Obj.magic
+                                         (FStar_Range.mk_range
+                                            "FStar.Tactics.TypeRepr.fst"
+                                            (Prims.of_int (24))
+                                            (Prims.of_int (4))
+                                            (Prims.of_int (27))
+                                            (Prims.of_int (48)))))
+                                   (Obj.magic
+                                      (FStar_Tactics_NamedView.inspect_sigelt
+                                         se1))
+                                   (fun sev ->
+                                      if
+                                        FStar_Tactics_NamedView.uu___is_Sg_Inductive
+                                          sev
+                                      then
+                                        FStar_Tactics_Effect.lift_div_tac
+                                          (fun uu___ -> sev)
+                                      else
+                                        FStar_Tactics_V2_Derived.fail
+                                          "ctors_of_typ: not an inductive type"))))
+                      uu___))) uu___)
+let (alg_ctor :
+  FStar_Reflection_Types.typ ->
+    (FStar_Reflection_Types.typ, unit) FStar_Tactics_Effect.tac_repr)
+  =
+  fun ty ->
+    FStar_Tactics_Effect.tac_bind
+      (FStar_Sealed.seal
+         (Obj.magic
+            (FStar_Range.mk_range "FStar.Tactics.TypeRepr.fst"
+               (Prims.of_int (30)) (Prims.of_int (15)) (Prims.of_int (30))
+               (Prims.of_int (29)))))
+      (FStar_Sealed.seal
+         (Obj.magic
+            (FStar_Range.mk_range "FStar.Tactics.TypeRepr.fst"
+               (Prims.of_int (29)) (Prims.of_int (35)) (Prims.of_int (31))
+               (Prims.of_int (67)))))
+      (Obj.magic (FStar_Tactics_V2_SyntaxHelpers.collect_arr ty))
+      (fun uu___ ->
+         (fun uu___ ->
+            match uu___ with
+            | (tys, c) ->
+                Obj.magic
+                  (FStar_Tactics_Util.fold_right
+                     (fun uu___2 ->
+                        fun uu___1 ->
+                          (fun ty1 ->
+                             fun acc ->
+                               Obj.magic
+                                 (FStar_Tactics_Effect.lift_div_tac
+                                    (fun uu___1 -> tuple2_ ty1 acc))) uu___2
+                            uu___1) tys unitt_)) uu___)
+let (generate_repr_typ :
+  FStar_Tactics_NamedView.binders ->
+    FStar_Reflection_V2_Data.ctor Prims.list ->
+      (FStar_Reflection_Types.typ, unit) FStar_Tactics_Effect.tac_repr)
+  =
+  fun params ->
+    fun ctors ->
+      FStar_Tactics_Effect.tac_bind
+        (FStar_Sealed.seal
+           (Obj.magic
+              (FStar_Range.mk_range "FStar.Tactics.TypeRepr.fst"
+                 (Prims.of_int (35)) (Prims.of_int (18)) (Prims.of_int (35))
+                 (Prims.of_int (61)))))
+        (FStar_Sealed.seal
+           (Obj.magic
+              (FStar_Range.mk_range "FStar.Tactics.TypeRepr.fst"
+                 (Prims.of_int (35)) (Prims.of_int (64)) (Prims.of_int (38))
+                 (Prims.of_int (17)))))
+        (Obj.magic
+           (FStar_Tactics_Util.map
+              (fun uu___ -> match uu___ with | (uu___1, ty) -> alg_ctor ty)
+              ctors))
+        (fun uu___ ->
+           (fun ctor_typs ->
+              Obj.magic
+                (FStar_Tactics_Effect.tac_bind
+                   (FStar_Sealed.seal
+                      (Obj.magic
+                         (FStar_Range.mk_range "FStar.Tactics.TypeRepr.fst"
+                            (Prims.of_int (37)) (Prims.of_int (4))
+                            (Prims.of_int (37)) (Prims.of_int (67)))))
+                   (FStar_Sealed.seal
+                      (Obj.magic
+                         (FStar_Range.mk_range "FStar.Tactics.TypeRepr.fst"
+                            (Prims.of_int (36)) (Prims.of_int (6))
+                            (Prims.of_int (36)) (Prims.of_int (21)))))
+                   (Obj.magic
+                      (FStar_Tactics_Util.fold_right
+                         (fun uu___1 ->
+                            fun uu___ ->
+                              (fun ty ->
+                                 fun acc ->
+                                   Obj.magic
+                                     (FStar_Tactics_Effect.lift_div_tac
+                                        (fun uu___ -> either_ ty acc)))
+                                uu___1 uu___) ctor_typs empty_))
+                   (fun alternative_typ ->
+                      FStar_Tactics_Effect.lift_div_tac
+                        (fun uu___ -> alternative_typ)))) uu___)
+let _ =
+  FStar_Tactics_Native.register_tactic
+    "FStar.Tactics.TypeRepr.generate_repr_typ" (Prims.of_int (3))
+    (fun psc ->
+       fun ncb ->
+         fun us ->
+           fun args ->
+             FStar_Tactics_InterpFuns.mk_tactic_interpretation_2
+               "FStar.Tactics.TypeRepr.generate_repr_typ (plugin)"
+               (FStar_Tactics_Native.from_tactic_2 generate_repr_typ)
+               (FStar_Syntax_Embeddings.e_list
+                  FStar_Tactics_NamedView.e_binder)
+               (FStar_Syntax_Embeddings.e_list
+                  (FStar_Syntax_Embeddings.e_tuple2
+                     (FStar_Syntax_Embeddings.e_list
+                        FStar_Syntax_Embeddings.e_string)
+                     FStar_Reflection_V2_Embeddings.e_term))
+               FStar_Reflection_V2_Embeddings.e_term psc ncb us args)
+let (generate_down : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
+  fun uu___ ->
+    FStar_Tactics_Effect.tac_bind
+      (FStar_Sealed.seal
+         (Obj.magic
+            (FStar_Range.mk_range "FStar.Tactics.TypeRepr.fst"
+               (Prims.of_int (43)) (Prims.of_int (10)) (Prims.of_int (43))
+               (Prims.of_int (18)))))
+      (FStar_Sealed.seal
+         (Obj.magic
+            (FStar_Range.mk_range "FStar.Tactics.TypeRepr.fst"
+               (Prims.of_int (43)) (Prims.of_int (21)) (Prims.of_int (52))
+               (Prims.of_int (3)))))
+      (Obj.magic (FStar_Tactics_V2_Builtins.intro ()))
+      (fun uu___1 ->
+         (fun b ->
+            Obj.magic
+              (FStar_Tactics_Effect.tac_bind
+                 (FStar_Sealed.seal
+                    (Obj.magic
+                       (FStar_Range.mk_range "FStar.Tactics.TypeRepr.fst"
+                          (Prims.of_int (44)) (Prims.of_int (14))
+                          (Prims.of_int (44)) (Prims.of_int (26)))))
+                 (FStar_Sealed.seal
+                    (Obj.magic
+                       (FStar_Range.mk_range "FStar.Tactics.TypeRepr.fst"
+                          (Prims.of_int (45)) (Prims.of_int (2))
+                          (Prims.of_int (52)) (Prims.of_int (3)))))
+                 (Obj.magic
+                    (FStar_Tactics_V2_Builtins.t_destruct
+                       (FStar_Tactics_V2_SyntaxCoercions.binding_to_term b)))
+                 (fun uu___1 ->
+                    (fun cases ->
+                       Obj.magic
+                         (FStar_Tactics_Util.iteri
+                            (fun i ->
+                               fun uu___1 ->
+                                 match uu___1 with
+                                 | (c, n) ->
+                                     FStar_Tactics_Effect.tac_bind
+                                       (FStar_Sealed.seal
+                                          (Obj.magic
+                                             (FStar_Range.mk_range
+                                                "FStar.Tactics.TypeRepr.fst"
+                                                (Prims.of_int (46))
+                                                (Prims.of_int (13))
+                                                (Prims.of_int (46))
+                                                (Prims.of_int (42)))))
+                                       (FStar_Sealed.seal
+                                          (Obj.magic
+                                             (FStar_Range.mk_range
+                                                "FStar.Tactics.TypeRepr.fst"
+                                                (Prims.of_int (46))
+                                                (Prims.of_int (45))
+                                                (Prims.of_int (51))
+                                                (Prims.of_int (13)))))
+                                       (Obj.magic
+                                          (FStar_Tactics_Util.repeatn n
+                                             (fun uu___2 ->
+                                                FStar_Tactics_V2_Builtins.intro
+                                                  ())))
+                                       (fun uu___2 ->
+                                          (fun bs ->
+                                             Obj.magic
+                                               (FStar_Tactics_Effect.tac_bind
+                                                  (FStar_Sealed.seal
+                                                     (Obj.magic
+                                                        (FStar_Range.mk_range
+                                                           "FStar.Tactics.TypeRepr.fst"
+                                                           (Prims.of_int (47))
+                                                           (Prims.of_int (16))
+                                                           (Prims.of_int (47))
+                                                           (Prims.of_int (24)))))
+                                                  (FStar_Sealed.seal
+                                                     (Obj.magic
+                                                        (FStar_Range.mk_range
+                                                           "FStar.Tactics.TypeRepr.fst"
+                                                           (Prims.of_int (47))
+                                                           (Prims.of_int (27))
+                                                           (Prims.of_int (51))
+                                                           (Prims.of_int (13)))))
+                                                  (Obj.magic
+                                                     (FStar_Tactics_V2_Builtins.intro
+                                                        ()))
+                                                  (fun uu___2 ->
+                                                     (fun _b_eq ->
+                                                        Obj.magic
+                                                          (FStar_Tactics_Effect.tac_bind
+                                                             (FStar_Sealed.seal
+                                                                (Obj.magic
+                                                                   (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (48))
+                                                                    (Prims.of_int (14))
+                                                                    (Prims.of_int (48))
+                                                                    (Prims.of_int (80)))))
+                                                             (FStar_Sealed.seal
+                                                                (Obj.magic
+                                                                   (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (48))
+                                                                    (Prims.of_int (83))
+                                                                    (Prims.of_int (51))
+                                                                    (Prims.of_int (13)))))
+                                                             (Obj.magic
+                                                                (FStar_Tactics_Util.fold_right
+                                                                   (fun
+                                                                    uu___3 ->
+                                                                    fun
+                                                                    uu___2 ->
+                                                                    (fun b1
+                                                                    ->
+                                                                    fun acc
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    mktuple2_
+                                                                    (FStar_Tactics_V2_SyntaxCoercions.binding_to_term
+                                                                    b1) acc)))
+                                                                    uu___3
+                                                                    uu___2)
+                                                                   bs unitv_))
+                                                             (fun uu___2 ->
+                                                                (fun sol ->
+                                                                   Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (49))
+                                                                    (Prims.of_int (12))
+                                                                    (Prims.of_int (49))
+                                                                    (Prims.of_int (45)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (50))
+                                                                    (Prims.of_int (4))
+                                                                    (Prims.of_int (51))
+                                                                    (Prims.of_int (13)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Util.repeatn
+                                                                    i
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    FStar_Tactics_V2_Derived.apply
+                                                                    (FStar_Reflection_V2_Builtins.pack_ln
+                                                                    (FStar_Reflection_V2_Data.Tv_FVar
+                                                                    (FStar_Reflection_V2_Builtins.pack_fv
+                                                                    ["FStar";
+                                                                    "Pervasives";
+                                                                    "Inr"]))))))
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (50))
+                                                                    (Prims.of_int (4))
+                                                                    (Prims.of_int (50))
+                                                                    (Prims.of_int (16)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (51))
+                                                                    (Prims.of_int (4))
+                                                                    (Prims.of_int (51))
+                                                                    (Prims.of_int (13)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_V2_Derived.apply
+                                                                    (FStar_Reflection_V2_Builtins.pack_ln
+                                                                    (FStar_Reflection_V2_Data.Tv_FVar
+                                                                    (FStar_Reflection_V2_Builtins.pack_fv
+                                                                    ["FStar";
+                                                                    "Pervasives";
+                                                                    "Inl"])))))
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_V2_Derived.exact
+                                                                    sol))
+                                                                    uu___3)))
+                                                                    uu___2)))
+                                                                  uu___2)))
+                                                       uu___2))) uu___2))
+                            cases)) uu___1))) uu___1)
+let _ =
+  FStar_Tactics_Native.register_tactic "FStar.Tactics.TypeRepr.generate_down"
+    (Prims.of_int (2))
+    (fun psc ->
+       fun ncb ->
+         fun us ->
+           fun args ->
+             FStar_Tactics_InterpFuns.mk_tactic_interpretation_1
+               "FStar.Tactics.TypeRepr.generate_down (plugin)"
+               (FStar_Tactics_Native.from_tactic_1 generate_down)
+               FStar_Syntax_Embeddings.e_unit FStar_Syntax_Embeddings.e_unit
+               psc ncb us args)
+let rec (get_apply_tuple :
+  FStar_Tactics_NamedView.binding ->
+    (FStar_Tactics_NamedView.binding Prims.list, unit)
+      FStar_Tactics_Effect.tac_repr)
+  =
+  fun b ->
+    FStar_Tactics_Effect.tac_bind
+      (FStar_Sealed.seal
+         (Obj.magic
+            (FStar_Range.mk_range "FStar.Tactics.TypeRepr.fst"
+               (Prims.of_int (55)) (Prims.of_int (17)) (Prims.of_int (55))
+               (Prims.of_int (35)))))
+      (FStar_Sealed.seal
+         (Obj.magic
+            (FStar_Range.mk_range "FStar.Tactics.TypeRepr.fst"
+               (Prims.of_int (54)) (Prims.of_int (58)) (Prims.of_int (74))
+               (Prims.of_int (69)))))
+      (Obj.magic
+         (FStar_Tactics_V2_SyntaxHelpers.collect_app
+            b.FStar_Reflection_V2_Data.sort3))
+      (fun uu___ ->
+         (fun uu___ ->
+            match uu___ with
+            | (hd, args) ->
+                Obj.magic
+                  (FStar_Tactics_Effect.tac_bind
+                     (FStar_Sealed.seal
+                        (Obj.magic
+                           (FStar_Range.mk_range "FStar.Tactics.TypeRepr.fst"
+                              (Prims.of_int (56)) (Prims.of_int (8))
+                              (Prims.of_int (56)) (Prims.of_int (24)))))
+                     (FStar_Sealed.seal
+                        (Obj.magic
+                           (FStar_Range.mk_range "FStar.Tactics.TypeRepr.fst"
+                              (Prims.of_int (56)) (Prims.of_int (2))
+                              (Prims.of_int (74)) (Prims.of_int (69)))))
+                     (Obj.magic
+                        (FStar_Tactics_Effect.tac_bind
+                           (FStar_Sealed.seal
+                              (Obj.magic
+                                 (FStar_Range.mk_range
+                                    "FStar.Tactics.TypeRepr.fst"
+                                    (Prims.of_int (56)) (Prims.of_int (8))
+                                    (Prims.of_int (56)) (Prims.of_int (18)))))
+                           (FStar_Sealed.seal
+                              (Obj.magic
+                                 (FStar_Range.mk_range
+                                    "FStar.Tactics.TypeRepr.fst"
+                                    (Prims.of_int (56)) (Prims.of_int (8))
+                                    (Prims.of_int (56)) (Prims.of_int (24)))))
+                           (Obj.magic (FStar_Tactics_NamedView.inspect hd))
+                           (fun uu___1 ->
+                              FStar_Tactics_Effect.lift_div_tac
+                                (fun uu___2 -> (uu___1, args)))))
+                     (fun uu___1 ->
+                        (fun uu___1 ->
+                           match uu___1 with
+                           | (FStar_Tactics_NamedView.Tv_UInst (fv, uu___2),
+                              b1::b2::[]) ->
+                               Obj.magic
+                                 (Obj.repr
+                                    (if
+                                       (FStar_Reflection_V2_Builtins.inspect_fv
+                                          fv)
+                                         =
+                                         ["FStar";
+                                         "Pervasives";
+                                         "Native";
+                                         "tuple2"]
+                                     then
+                                       FStar_Tactics_Effect.tac_bind
+                                         (FStar_Sealed.seal
+                                            (Obj.magic
+                                               (FStar_Range.mk_range
+                                                  "FStar.Tactics.TypeRepr.fst"
+                                                  (Prims.of_int (60))
+                                                  (Prims.of_int (18))
+                                                  (Prims.of_int (60))
+                                                  (Prims.of_int (30)))))
+                                         (FStar_Sealed.seal
+                                            (Obj.magic
+                                               (FStar_Range.mk_range
+                                                  "FStar.Tactics.TypeRepr.fst"
+                                                  (Prims.of_int (61))
+                                                  (Prims.of_int (6))
+                                                  (Prims.of_int (65))
+                                                  (Prims.of_int (30)))))
+                                         (Obj.magic
+                                            (FStar_Tactics_V2_Builtins.t_destruct
+                                               (FStar_Tactics_V2_SyntaxCoercions.binding_to_term
+                                                  b)))
+                                         (fun uu___3 ->
+                                            (fun cases ->
+                                               Obj.magic
+                                                 (FStar_Tactics_Effect.tac_bind
+                                                    (FStar_Sealed.seal
+                                                       (Obj.magic
+                                                          (FStar_Range.mk_range
+                                                             "FStar.Tactics.TypeRepr.fst"
+                                                             (Prims.of_int (61))
+                                                             (Prims.of_int (6))
+                                                             (Prims.of_int (61))
+                                                             (Prims.of_int (136)))))
+                                                    (FStar_Sealed.seal
+                                                       (Obj.magic
+                                                          (FStar_Range.mk_range
+                                                             "FStar.Tactics.TypeRepr.fst"
+                                                             (Prims.of_int (61))
+                                                             (Prims.of_int (137))
+                                                             (Prims.of_int (65))
+                                                             (Prims.of_int (30)))))
+                                                    (Obj.magic
+                                                       (FStar_Tactics_V2_Derived.guard
+                                                          ((((FStar_List_Tot_Base.length
+                                                                cases)
+                                                               =
+                                                               Prims.int_one)
+                                                              &&
+                                                              ((FStar_Reflection_V2_Builtins.inspect_fv
+                                                                  (FStar_Pervasives_Native.fst
+                                                                    (FStar_List_Tot_Base.hd
+                                                                    cases)))
+                                                                 =
+                                                                 ["FStar";
+                                                                 "Pervasives";
+                                                                 "Native";
+                                                                 "Mktuple2"]))
+                                                             &&
+                                                             ((FStar_Pervasives_Native.snd
+                                                                 (FStar_List_Tot_Base.hd
+                                                                    cases))
+                                                                =
+                                                                (Prims.of_int (2))))))
+                                                    (fun uu___3 ->
+                                                       (fun uu___3 ->
+                                                          Obj.magic
+                                                            (FStar_Tactics_Effect.tac_bind
+                                                               (FStar_Sealed.seal
+                                                                  (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (62))
+                                                                    (Prims.of_int (15))
+                                                                    (Prims.of_int (62))
+                                                                    (Prims.of_int (23)))))
+                                                               (FStar_Sealed.seal
+                                                                  (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (62))
+                                                                    (Prims.of_int (26))
+                                                                    (Prims.of_int (65))
+                                                                    (Prims.of_int (30)))))
+                                                               (Obj.magic
+                                                                  (FStar_Tactics_V2_Builtins.intro
+                                                                    ()))
+                                                               (fun uu___4 ->
+                                                                  (fun b11 ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (63))
+                                                                    (Prims.of_int (15))
+                                                                    (Prims.of_int (63))
+                                                                    (Prims.of_int (23)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (63))
+                                                                    (Prims.of_int (26))
+                                                                    (Prims.of_int (65))
+                                                                    (Prims.of_int (30)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_V2_Builtins.intro
+                                                                    ()))
+                                                                    (fun
+                                                                    uu___4 ->
+                                                                    (fun b21
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (64))
+                                                                    (Prims.of_int (16))
+                                                                    (Prims.of_int (64))
+                                                                    (Prims.of_int (24)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (65))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (65))
+                                                                    (Prims.of_int (30)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_V2_Builtins.intro
+                                                                    ()))
+                                                                    (fun
+                                                                    uu___4 ->
+                                                                    (fun _eq
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (65))
+                                                                    (Prims.of_int (12))
+                                                                    (Prims.of_int (65))
+                                                                    (Prims.of_int (30)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (65))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (65))
+                                                                    (Prims.of_int (30)))))
+                                                                    (Obj.magic
+                                                                    (get_apply_tuple
+                                                                    b21))
+                                                                    (fun
+                                                                    uu___4 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___5 ->
+                                                                    b11 ::
+                                                                    uu___4))))
+                                                                    uu___4)))
+                                                                    uu___4)))
+                                                                    uu___4)))
+                                                         uu___3))) uu___3)
+                                     else
+                                       FStar_Tactics_Effect.tac_bind
+                                         (FStar_Sealed.seal
+                                            (Obj.magic
+                                               (FStar_Range.mk_range
+                                                  "FStar.Tactics.TypeRepr.fst"
+                                                  (Prims.of_int (67))
+                                                  (Prims.of_int (11))
+                                                  (Prims.of_int (67))
+                                                  (Prims.of_int (71)))))
+                                         (FStar_Sealed.seal
+                                            (Obj.magic
+                                               (FStar_Range.mk_range
+                                                  "FStar.Tactics.TypeRepr.fst"
+                                                  (Prims.of_int (67))
+                                                  (Prims.of_int (6))
+                                                  (Prims.of_int (67))
+                                                  (Prims.of_int (71)))))
+                                         (Obj.magic
+                                            (FStar_Tactics_Effect.tac_bind
+                                               (FStar_Sealed.seal
+                                                  (Obj.magic
+                                                     (FStar_Range.mk_range
+                                                        "FStar.Tactics.TypeRepr.fst"
+                                                        (Prims.of_int (67))
+                                                        (Prims.of_int (49))
+                                                        (Prims.of_int (67))
+                                                        (Prims.of_int (70)))))
+                                               (FStar_Sealed.seal
+                                                  (Obj.magic
+                                                     (FStar_Range.mk_range
+                                                        "prims.fst"
+                                                        (Prims.of_int (590))
+                                                        (Prims.of_int (19))
+                                                        (Prims.of_int (590))
+                                                        (Prims.of_int (31)))))
+                                               (Obj.magic
+                                                  (FStar_Tactics_V2_Builtins.term_to_string
+                                                     b.FStar_Reflection_V2_Data.sort3))
+                                               (fun uu___4 ->
+                                                  FStar_Tactics_Effect.lift_div_tac
+                                                    (fun uu___5 ->
+                                                       Prims.strcat
+                                                         "unexpected term in apply_tuple: "
+                                                         uu___4))))
+                                         (fun uu___4 ->
+                                            FStar_Tactics_V2_Derived.fail
+                                              uu___4)))
+                           | (FStar_Tactics_NamedView.Tv_FVar fv, b1::b2::[])
+                               ->
+                               Obj.magic
+                                 (Obj.repr
+                                    (if
+                                       (FStar_Reflection_V2_Builtins.inspect_fv
+                                          fv)
+                                         =
+                                         ["FStar";
+                                         "Pervasives";
+                                         "Native";
+                                         "tuple2"]
+                                     then
+                                       FStar_Tactics_Effect.tac_bind
+                                         (FStar_Sealed.seal
+                                            (Obj.magic
+                                               (FStar_Range.mk_range
+                                                  "FStar.Tactics.TypeRepr.fst"
+                                                  (Prims.of_int (60))
+                                                  (Prims.of_int (18))
+                                                  (Prims.of_int (60))
+                                                  (Prims.of_int (30)))))
+                                         (FStar_Sealed.seal
+                                            (Obj.magic
+                                               (FStar_Range.mk_range
+                                                  "FStar.Tactics.TypeRepr.fst"
+                                                  (Prims.of_int (61))
+                                                  (Prims.of_int (6))
+                                                  (Prims.of_int (65))
+                                                  (Prims.of_int (30)))))
+                                         (Obj.magic
+                                            (FStar_Tactics_V2_Builtins.t_destruct
+                                               (FStar_Tactics_V2_SyntaxCoercions.binding_to_term
+                                                  b)))
+                                         (fun uu___2 ->
+                                            (fun cases ->
+                                               Obj.magic
+                                                 (FStar_Tactics_Effect.tac_bind
+                                                    (FStar_Sealed.seal
+                                                       (Obj.magic
+                                                          (FStar_Range.mk_range
+                                                             "FStar.Tactics.TypeRepr.fst"
+                                                             (Prims.of_int (61))
+                                                             (Prims.of_int (6))
+                                                             (Prims.of_int (61))
+                                                             (Prims.of_int (136)))))
+                                                    (FStar_Sealed.seal
+                                                       (Obj.magic
+                                                          (FStar_Range.mk_range
+                                                             "FStar.Tactics.TypeRepr.fst"
+                                                             (Prims.of_int (61))
+                                                             (Prims.of_int (137))
+                                                             (Prims.of_int (65))
+                                                             (Prims.of_int (30)))))
+                                                    (Obj.magic
+                                                       (FStar_Tactics_V2_Derived.guard
+                                                          ((((FStar_List_Tot_Base.length
+                                                                cases)
+                                                               =
+                                                               Prims.int_one)
+                                                              &&
+                                                              ((FStar_Reflection_V2_Builtins.inspect_fv
+                                                                  (FStar_Pervasives_Native.fst
+                                                                    (FStar_List_Tot_Base.hd
+                                                                    cases)))
+                                                                 =
+                                                                 ["FStar";
+                                                                 "Pervasives";
+                                                                 "Native";
+                                                                 "Mktuple2"]))
+                                                             &&
+                                                             ((FStar_Pervasives_Native.snd
+                                                                 (FStar_List_Tot_Base.hd
+                                                                    cases))
+                                                                =
+                                                                (Prims.of_int (2))))))
+                                                    (fun uu___2 ->
+                                                       (fun uu___2 ->
+                                                          Obj.magic
+                                                            (FStar_Tactics_Effect.tac_bind
+                                                               (FStar_Sealed.seal
+                                                                  (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (62))
+                                                                    (Prims.of_int (15))
+                                                                    (Prims.of_int (62))
+                                                                    (Prims.of_int (23)))))
+                                                               (FStar_Sealed.seal
+                                                                  (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (62))
+                                                                    (Prims.of_int (26))
+                                                                    (Prims.of_int (65))
+                                                                    (Prims.of_int (30)))))
+                                                               (Obj.magic
+                                                                  (FStar_Tactics_V2_Builtins.intro
+                                                                    ()))
+                                                               (fun uu___3 ->
+                                                                  (fun b11 ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (63))
+                                                                    (Prims.of_int (15))
+                                                                    (Prims.of_int (63))
+                                                                    (Prims.of_int (23)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (63))
+                                                                    (Prims.of_int (26))
+                                                                    (Prims.of_int (65))
+                                                                    (Prims.of_int (30)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_V2_Builtins.intro
+                                                                    ()))
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    (fun b21
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (64))
+                                                                    (Prims.of_int (16))
+                                                                    (Prims.of_int (64))
+                                                                    (Prims.of_int (24)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (65))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (65))
+                                                                    (Prims.of_int (30)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_V2_Builtins.intro
+                                                                    ()))
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    (fun _eq
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (65))
+                                                                    (Prims.of_int (12))
+                                                                    (Prims.of_int (65))
+                                                                    (Prims.of_int (30)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (65))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (65))
+                                                                    (Prims.of_int (30)))))
+                                                                    (Obj.magic
+                                                                    (get_apply_tuple
+                                                                    b21))
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___4 ->
+                                                                    b11 ::
+                                                                    uu___3))))
+                                                                    uu___3)))
+                                                                    uu___3)))
+                                                                    uu___3)))
+                                                         uu___2))) uu___2)
+                                     else
+                                       FStar_Tactics_Effect.tac_bind
+                                         (FStar_Sealed.seal
+                                            (Obj.magic
+                                               (FStar_Range.mk_range
+                                                  "FStar.Tactics.TypeRepr.fst"
+                                                  (Prims.of_int (67))
+                                                  (Prims.of_int (11))
+                                                  (Prims.of_int (67))
+                                                  (Prims.of_int (71)))))
+                                         (FStar_Sealed.seal
+                                            (Obj.magic
+                                               (FStar_Range.mk_range
+                                                  "FStar.Tactics.TypeRepr.fst"
+                                                  (Prims.of_int (67))
+                                                  (Prims.of_int (6))
+                                                  (Prims.of_int (67))
+                                                  (Prims.of_int (71)))))
+                                         (Obj.magic
+                                            (FStar_Tactics_Effect.tac_bind
+                                               (FStar_Sealed.seal
+                                                  (Obj.magic
+                                                     (FStar_Range.mk_range
+                                                        "FStar.Tactics.TypeRepr.fst"
+                                                        (Prims.of_int (67))
+                                                        (Prims.of_int (49))
+                                                        (Prims.of_int (67))
+                                                        (Prims.of_int (70)))))
+                                               (FStar_Sealed.seal
+                                                  (Obj.magic
+                                                     (FStar_Range.mk_range
+                                                        "prims.fst"
+                                                        (Prims.of_int (590))
+                                                        (Prims.of_int (19))
+                                                        (Prims.of_int (590))
+                                                        (Prims.of_int (31)))))
+                                               (Obj.magic
+                                                  (FStar_Tactics_V2_Builtins.term_to_string
+                                                     b.FStar_Reflection_V2_Data.sort3))
+                                               (fun uu___3 ->
+                                                  FStar_Tactics_Effect.lift_div_tac
+                                                    (fun uu___4 ->
+                                                       Prims.strcat
+                                                         "unexpected term in apply_tuple: "
+                                                         uu___3))))
+                                         (fun uu___3 ->
+                                            FStar_Tactics_V2_Derived.fail
+                                              uu___3)))
+                           | (FStar_Tactics_NamedView.Tv_FVar fv, []) ->
+                               Obj.magic
+                                 (Obj.repr
+                                    (if
+                                       (FStar_Reflection_V2_Builtins.inspect_fv
+                                          fv)
+                                         = ["Prims"; "unit"]
+                                     then
+                                       Obj.repr
+                                         (FStar_Tactics_Effect.lift_div_tac
+                                            (fun uu___2 -> []))
+                                     else
+                                       Obj.repr
+                                         (FStar_Tactics_Effect.tac_bind
+                                            (FStar_Sealed.seal
+                                               (Obj.magic
+                                                  (FStar_Range.mk_range
+                                                     "FStar.Tactics.TypeRepr.fst"
+                                                     (Prims.of_int (72))
+                                                     (Prims.of_int (11))
+                                                     (Prims.of_int (72))
+                                                     (Prims.of_int (71)))))
+                                            (FStar_Sealed.seal
+                                               (Obj.magic
+                                                  (FStar_Range.mk_range
+                                                     "FStar.Tactics.TypeRepr.fst"
+                                                     (Prims.of_int (72))
+                                                     (Prims.of_int (6))
+                                                     (Prims.of_int (72))
+                                                     (Prims.of_int (71)))))
+                                            (Obj.magic
+                                               (FStar_Tactics_Effect.tac_bind
+                                                  (FStar_Sealed.seal
+                                                     (Obj.magic
+                                                        (FStar_Range.mk_range
+                                                           "FStar.Tactics.TypeRepr.fst"
+                                                           (Prims.of_int (72))
+                                                           (Prims.of_int (49))
+                                                           (Prims.of_int (72))
+                                                           (Prims.of_int (70)))))
+                                                  (FStar_Sealed.seal
+                                                     (Obj.magic
+                                                        (FStar_Range.mk_range
+                                                           "prims.fst"
+                                                           (Prims.of_int (590))
+                                                           (Prims.of_int (19))
+                                                           (Prims.of_int (590))
+                                                           (Prims.of_int (31)))))
+                                                  (Obj.magic
+                                                     (FStar_Tactics_V2_Builtins.term_to_string
+                                                        b.FStar_Reflection_V2_Data.sort3))
+                                                  (fun uu___3 ->
+                                                     FStar_Tactics_Effect.lift_div_tac
+                                                       (fun uu___4 ->
+                                                          Prims.strcat
+                                                            "unexpected term in apply_tuple: "
+                                                            uu___3))))
+                                            (fun uu___3 ->
+                                               FStar_Tactics_V2_Derived.fail
+                                                 uu___3))))
+                           | uu___2 ->
+                               Obj.magic
+                                 (Obj.repr
+                                    (FStar_Tactics_Effect.tac_bind
+                                       (FStar_Sealed.seal
+                                          (Obj.magic
+                                             (FStar_Range.mk_range
+                                                "FStar.Tactics.TypeRepr.fst"
+                                                (Prims.of_int (74))
+                                                (Prims.of_int (9))
+                                                (Prims.of_int (74))
+                                                (Prims.of_int (69)))))
+                                       (FStar_Sealed.seal
+                                          (Obj.magic
+                                             (FStar_Range.mk_range
+                                                "FStar.Tactics.TypeRepr.fst"
+                                                (Prims.of_int (74))
+                                                (Prims.of_int (4))
+                                                (Prims.of_int (74))
+                                                (Prims.of_int (69)))))
+                                       (Obj.magic
+                                          (FStar_Tactics_Effect.tac_bind
+                                             (FStar_Sealed.seal
+                                                (Obj.magic
+                                                   (FStar_Range.mk_range
+                                                      "FStar.Tactics.TypeRepr.fst"
+                                                      (Prims.of_int (74))
+                                                      (Prims.of_int (47))
+                                                      (Prims.of_int (74))
+                                                      (Prims.of_int (68)))))
+                                             (FStar_Sealed.seal
+                                                (Obj.magic
+                                                   (FStar_Range.mk_range
+                                                      "prims.fst"
+                                                      (Prims.of_int (590))
+                                                      (Prims.of_int (19))
+                                                      (Prims.of_int (590))
+                                                      (Prims.of_int (31)))))
+                                             (Obj.magic
+                                                (FStar_Tactics_V2_Builtins.term_to_string
+                                                   b.FStar_Reflection_V2_Data.sort3))
+                                             (fun uu___3 ->
+                                                FStar_Tactics_Effect.lift_div_tac
+                                                  (fun uu___4 ->
+                                                     Prims.strcat
+                                                       "unexpected term in apply_tuple: "
+                                                       uu___3))))
+                                       (fun uu___3 ->
+                                          FStar_Tactics_V2_Derived.fail
+                                            uu___3)))) uu___1))) uu___)
+let rec (generate_up_aux :
+  FStar_Reflection_V2_Data.ctor Prims.list ->
+    FStar_Tactics_NamedView.binding ->
+      (unit, unit) FStar_Tactics_Effect.tac_repr)
+  =
+  fun ctors ->
+    fun b ->
+      match ctors with
+      | [] ->
+          FStar_Tactics_Effect.tac_bind
+            (FStar_Sealed.seal
+               (Obj.magic
+                  (FStar_Range.mk_range "FStar.Tactics.TypeRepr.fst"
+                     (Prims.of_int (82)) (Prims.of_int (4))
+                     (Prims.of_int (82)) (Prims.of_int (23)))))
+            (FStar_Sealed.seal
+               (Obj.magic
+                  (FStar_Range.mk_range "FStar.Tactics.TypeRepr.fst"
+                     (Prims.of_int (83)) (Prims.of_int (4))
+                     (Prims.of_int (83)) (Prims.of_int (11)))))
+            (Obj.magic
+               (FStar_Tactics_V2_Derived.apply
+                  (FStar_Reflection_V2_Builtins.pack_ln
+                     (FStar_Reflection_V2_Data.Tv_FVar
+                        (FStar_Reflection_V2_Builtins.pack_fv
+                           ["FStar"; "Tactics"; "TypeRepr"; "empty_elim"])))))
+            (fun uu___ ->
+               (fun uu___ ->
+                  Obj.magic
+                    (FStar_Tactics_V2_Derived.exact
+                       (FStar_Tactics_V2_SyntaxCoercions.binding_to_term b)))
+                 uu___)
+      | c::cs ->
+          FStar_Tactics_Effect.tac_bind
+            (FStar_Sealed.seal
+               (Obj.magic
+                  (FStar_Range.mk_range "FStar.Tactics.TypeRepr.fst"
+                     (Prims.of_int (85)) (Prims.of_int (16))
+                     (Prims.of_int (85)) (Prims.of_int (28)))))
+            (FStar_Sealed.seal
+               (Obj.magic
+                  (FStar_Range.mk_range "FStar.Tactics.TypeRepr.fst"
+                     (Prims.of_int (86)) (Prims.of_int (4))
+                     (Prims.of_int (99)) (Prims.of_int (24)))))
+            (Obj.magic
+               (FStar_Tactics_V2_Builtins.t_destruct
+                  (FStar_Tactics_V2_SyntaxCoercions.binding_to_term b)))
+            (fun uu___ ->
+               (fun cases ->
+                  Obj.magic
+                    (FStar_Tactics_Effect.tac_bind
+                       (FStar_Sealed.seal
+                          (Obj.magic
+                             (FStar_Range.mk_range
+                                "FStar.Tactics.TypeRepr.fst"
+                                (Prims.of_int (86)) (Prims.of_int (4))
+                                (Prims.of_int (87)) (Prims.of_int (49)))))
+                       (FStar_Sealed.seal
+                          (Obj.magic
+                             (FStar_Range.mk_range
+                                "FStar.Tactics.TypeRepr.fst"
+                                (Prims.of_int (88)) (Prims.of_int (4))
+                                (Prims.of_int (99)) (Prims.of_int (24)))))
+                       (if
+                          (FStar_List_Tot_Base.length cases) <>
+                            (Prims.of_int (2))
+                        then
+                          FStar_Tactics_V2_Derived.fail
+                            "generate_up_aux: expected Inl/Inr???"
+                        else
+                          FStar_Tactics_Effect.lift_div_tac
+                            (fun uu___1 -> ()))
+                       (fun uu___ ->
+                          (fun uu___ ->
+                             Obj.magic
+                               (FStar_Tactics_Effect.tac_bind
+                                  (FStar_Sealed.seal
+                                     (Obj.magic
+                                        (FStar_Range.mk_range
+                                           "FStar.Tactics.TypeRepr.fst"
+                                           (Prims.of_int (88))
+                                           (Prims.of_int (4))
+                                           (Prims.of_int (96))
+                                           (Prims.of_int (5)))))
+                                  (FStar_Sealed.seal
+                                     (Obj.magic
+                                        (FStar_Range.mk_range
+                                           "FStar.Tactics.TypeRepr.fst"
+                                           (Prims.of_int (96))
+                                           (Prims.of_int (6))
+                                           (Prims.of_int (99))
+                                           (Prims.of_int (24)))))
+                                  (Obj.magic
+                                     (FStar_Tactics_V2_Derived.focus
+                                        (fun uu___1 ->
+                                           FStar_Tactics_Effect.tac_bind
+                                             (FStar_Sealed.seal
+                                                (Obj.magic
+                                                   (FStar_Range.mk_range
+                                                      "FStar.Tactics.TypeRepr.fst"
+                                                      (Prims.of_int (89))
+                                                      (Prims.of_int (15))
+                                                      (Prims.of_int (89))
+                                                      (Prims.of_int (23)))))
+                                             (FStar_Sealed.seal
+                                                (Obj.magic
+                                                   (FStar_Range.mk_range
+                                                      "FStar.Tactics.TypeRepr.fst"
+                                                      (Prims.of_int (89))
+                                                      (Prims.of_int (26))
+                                                      (Prims.of_int (95))
+                                                      (Prims.of_int (11)))))
+                                             (Obj.magic
+                                                (FStar_Tactics_V2_Builtins.intro
+                                                   ()))
+                                             (fun uu___2 ->
+                                                (fun b' ->
+                                                   Obj.magic
+                                                     (FStar_Tactics_Effect.tac_bind
+                                                        (FStar_Sealed.seal
+                                                           (Obj.magic
+                                                              (FStar_Range.mk_range
+                                                                 "FStar.Tactics.TypeRepr.fst"
+                                                                 (Prims.of_int (90))
+                                                                 (Prims.of_int (16))
+                                                                 (Prims.of_int (90))
+                                                                 (Prims.of_int (24)))))
+                                                        (FStar_Sealed.seal
+                                                           (Obj.magic
+                                                              (FStar_Range.mk_range
+                                                                 "FStar.Tactics.TypeRepr.fst"
+                                                                 (Prims.of_int (90))
+                                                                 (Prims.of_int (27))
+                                                                 (Prims.of_int (95))
+                                                                 (Prims.of_int (11)))))
+                                                        (Obj.magic
+                                                           (FStar_Tactics_V2_Builtins.intro
+                                                              ()))
+                                                        (fun uu___2 ->
+                                                           (fun _eq ->
+                                                              Obj.magic
+                                                                (FStar_Tactics_Effect.tac_bind
+                                                                   (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (91))
+                                                                    (Prims.of_int (19))
+                                                                    (Prims.of_int (91))
+                                                                    (Prims.of_int (24)))))
+                                                                   (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (91))
+                                                                    (Prims.of_int (27))
+                                                                    (Prims.of_int (95))
+                                                                    (Prims.of_int (11)))))
+                                                                   (FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    FStar_Pervasives_Native.fst
+                                                                    c))
+                                                                   (fun
+                                                                    uu___2 ->
+                                                                    (fun
+                                                                    c_name ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (92))
+                                                                    (Prims.of_int (17))
+                                                                    (Prims.of_int (92))
+                                                                    (Prims.of_int (35)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (93))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (95))
+                                                                    (Prims.of_int (11)))))
+                                                                    (Obj.magic
+                                                                    (get_apply_tuple
+                                                                    b'))
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    (fun args
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (93))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (93))
+                                                                    (Prims.of_int (45)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (94))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (95))
+                                                                    (Prims.of_int (11)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_V2_Derived.apply
+                                                                    (FStar_Tactics_NamedView.pack
+                                                                    (FStar_Tactics_NamedView.Tv_FVar
+                                                                    (FStar_Reflection_V2_Builtins.pack_fv
+                                                                    c_name)))))
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (94))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (94))
+                                                                    (Prims.of_int (49)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (95))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (95))
+                                                                    (Prims.of_int (11)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Util.iter
+                                                                    (fun b1
+                                                                    ->
+                                                                    FStar_Tactics_V2_Derived.exact
+                                                                    (FStar_Tactics_V2_SyntaxCoercions.binding_to_term
+                                                                    b1)) args))
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    (fun
+                                                                    uu___3 ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_V2_Derived.qed
+                                                                    ()))
+                                                                    uu___3)))
+                                                                    uu___2)))
+                                                                    uu___2)))
+                                                                    uu___2)))
+                                                             uu___2))) uu___2))))
+                                  (fun uu___1 ->
+                                     (fun uu___1 ->
+                                        Obj.magic
+                                          (FStar_Tactics_Effect.tac_bind
+                                             (FStar_Sealed.seal
+                                                (Obj.magic
+                                                   (FStar_Range.mk_range
+                                                      "FStar.Tactics.TypeRepr.fst"
+                                                      (Prims.of_int (97))
+                                                      (Prims.of_int (12))
+                                                      (Prims.of_int (97))
+                                                      (Prims.of_int (20)))))
+                                             (FStar_Sealed.seal
+                                                (Obj.magic
+                                                   (FStar_Range.mk_range
+                                                      "FStar.Tactics.TypeRepr.fst"
+                                                      (Prims.of_int (97))
+                                                      (Prims.of_int (23))
+                                                      (Prims.of_int (99))
+                                                      (Prims.of_int (24)))))
+                                             (Obj.magic
+                                                (FStar_Tactics_V2_Builtins.intro
+                                                   ()))
+                                             (fun uu___2 ->
+                                                (fun b1 ->
+                                                   Obj.magic
+                                                     (FStar_Tactics_Effect.tac_bind
+                                                        (FStar_Sealed.seal
+                                                           (Obj.magic
+                                                              (FStar_Range.mk_range
+                                                                 "FStar.Tactics.TypeRepr.fst"
+                                                                 (Prims.of_int (98))
+                                                                 (Prims.of_int (14))
+                                                                 (Prims.of_int (98))
+                                                                 (Prims.of_int (22)))))
+                                                        (FStar_Sealed.seal
+                                                           (Obj.magic
+                                                              (FStar_Range.mk_range
+                                                                 "FStar.Tactics.TypeRepr.fst"
+                                                                 (Prims.of_int (99))
+                                                                 (Prims.of_int (4))
+                                                                 (Prims.of_int (99))
+                                                                 (Prims.of_int (24)))))
+                                                        (Obj.magic
+                                                           (FStar_Tactics_V2_Builtins.intro
+                                                              ()))
+                                                        (fun uu___2 ->
+                                                           (fun _eq ->
+                                                              Obj.magic
+                                                                (generate_up_aux
+                                                                   cs b1))
+                                                             uu___2))) uu___2)))
+                                       uu___1))) uu___))) uu___)
+let (generate_up :
+  Prims.string -> unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
+  fun nm ->
+    fun uu___ ->
+      FStar_Tactics_Effect.tac_bind
+        (FStar_Sealed.seal
+           (Obj.magic
+              (FStar_Range.mk_range "FStar.Tactics.TypeRepr.fst"
+                 (Prims.of_int (104)) (Prims.of_int (29))
+                 (Prims.of_int (104)) (Prims.of_int (49)))))
+        (FStar_Sealed.seal
+           (Obj.magic
+              (FStar_Range.mk_range "FStar.Tactics.TypeRepr.fst"
+                 (Prims.of_int (103)) (Prims.of_int (43))
+                 (Prims.of_int (106)) (Prims.of_int (25)))))
+        (Obj.magic (get_inductive_typ nm))
+        (fun uu___1 ->
+           (fun uu___1 ->
+              match uu___1 with
+              | FStar_Tactics_NamedView.Sg_Inductive
+                  { FStar_Tactics_NamedView.nm = uu___2;
+                    FStar_Tactics_NamedView.univs1 = uu___3;
+                    FStar_Tactics_NamedView.params = uu___4;
+                    FStar_Tactics_NamedView.typ = uu___5;
+                    FStar_Tactics_NamedView.ctors = ctors;_}
+                  ->
+                  Obj.magic
+                    (FStar_Tactics_Effect.tac_bind
+                       (FStar_Sealed.seal
+                          (Obj.magic
+                             (FStar_Range.mk_range
+                                "FStar.Tactics.TypeRepr.fst"
+                                (Prims.of_int (105)) (Prims.of_int (10))
+                                (Prims.of_int (105)) (Prims.of_int (18)))))
+                       (FStar_Sealed.seal
+                          (Obj.magic
+                             (FStar_Range.mk_range
+                                "FStar.Tactics.TypeRepr.fst"
+                                (Prims.of_int (106)) (Prims.of_int (2))
+                                (Prims.of_int (106)) (Prims.of_int (25)))))
+                       (Obj.magic (FStar_Tactics_V2_Builtins.intro ()))
+                       (fun uu___6 ->
+                          (fun b -> Obj.magic (generate_up_aux ctors b))
+                            uu___6))) uu___1)
+let _ =
+  FStar_Tactics_Native.register_tactic "FStar.Tactics.TypeRepr.generate_up"
+    (Prims.of_int (3))
+    (fun psc ->
+       fun ncb ->
+         fun us ->
+           fun args ->
+             FStar_Tactics_InterpFuns.mk_tactic_interpretation_2
+               "FStar.Tactics.TypeRepr.generate_up (plugin)"
+               (FStar_Tactics_Native.from_tactic_2 generate_up)
+               FStar_Syntax_Embeddings.e_string
+               FStar_Syntax_Embeddings.e_unit FStar_Syntax_Embeddings.e_unit
+               psc ncb us args)
+let (make_implicits :
+  FStar_Tactics_NamedView.binders -> FStar_Tactics_NamedView.binders) =
+  fun bs ->
+    FStar_List_Tot_Base.map
+      (fun b ->
+         match b.FStar_Tactics_NamedView.qual with
+         | FStar_Reflection_V2_Data.Q_Explicit ->
+             {
+               FStar_Tactics_NamedView.uniq =
+                 (b.FStar_Tactics_NamedView.uniq);
+               FStar_Tactics_NamedView.ppname =
+                 (b.FStar_Tactics_NamedView.ppname);
+               FStar_Tactics_NamedView.sort =
+                 (b.FStar_Tactics_NamedView.sort);
+               FStar_Tactics_NamedView.qual =
+                 FStar_Reflection_V2_Data.Q_Implicit;
+               FStar_Tactics_NamedView.attrs =
+                 (b.FStar_Tactics_NamedView.attrs)
+             }
+         | uu___ -> b) bs
+let (binder_to_argv :
+  FStar_Tactics_NamedView.binder -> FStar_Reflection_V2_Data.argv) =
+  fun b ->
+    ((FStar_Tactics_V2_SyntaxCoercions.binder_to_term b),
+      (b.FStar_Tactics_NamedView.qual))
+let (generate_all :
+  FStar_Reflection_Types.name ->
+    FStar_Tactics_NamedView.binders ->
+      FStar_Reflection_V2_Data.ctor Prims.list ->
+        (FStar_Reflection_Types.decls, unit) FStar_Tactics_Effect.tac_repr)
+  =
+  fun nm ->
+    fun params ->
+      fun ctors ->
+        FStar_Tactics_Effect.tac_bind
+          (FStar_Sealed.seal
+             (Obj.magic
+                (FStar_Range.mk_range "FStar.Tactics.TypeRepr.fst"
+                   (Prims.of_int (119)) (Prims.of_int (17))
+                   (Prims.of_int (119)) (Prims.of_int (38)))))
+          (FStar_Sealed.seal
+             (Obj.magic
+                (FStar_Range.mk_range "FStar.Tactics.TypeRepr.fst"
+                   (Prims.of_int (119)) (Prims.of_int (41))
+                   (Prims.of_int (165)) (Prims.of_int (27)))))
+          (FStar_Tactics_Effect.lift_div_tac
+             (fun uu___ -> make_implicits params))
+          (fun uu___ ->
+             (fun params_i ->
+                Obj.magic
+                  (FStar_Tactics_Effect.tac_bind
+                     (FStar_Sealed.seal
+                        (Obj.magic
+                           (FStar_Range.mk_range "FStar.Tactics.TypeRepr.fst"
+                              (Prims.of_int (120)) (Prims.of_int (15))
+                              (Prims.of_int (120)) (Prims.of_int (88)))))
+                     (FStar_Sealed.seal
+                        (Obj.magic
+                           (FStar_Range.mk_range "FStar.Tactics.TypeRepr.fst"
+                              (Prims.of_int (120)) (Prims.of_int (91))
+                              (Prims.of_int (165)) (Prims.of_int (27)))))
+                     (FStar_Tactics_Effect.lift_div_tac
+                        (fun uu___ ->
+                           FStar_Reflection_V2_Derived.mk_app
+                             (FStar_Tactics_NamedView.pack
+                                (FStar_Tactics_NamedView.Tv_FVar
+                                   (FStar_Reflection_V2_Builtins.pack_fv nm)))
+                             (FStar_List_Tot_Base.map binder_to_argv params)))
+                     (fun uu___ ->
+                        (fun t ->
+                           Obj.magic
+                             (FStar_Tactics_Effect.tac_bind
+                                (FStar_Sealed.seal
+                                   (Obj.magic
+                                      (FStar_Range.mk_range
+                                         "FStar.Tactics.TypeRepr.fst"
+                                         (Prims.of_int (121))
+                                         (Prims.of_int (15))
+                                         (Prims.of_int (121))
+                                         (Prims.of_int (45)))))
+                                (FStar_Sealed.seal
+                                   (Obj.magic
+                                      (FStar_Range.mk_range
+                                         "FStar.Tactics.TypeRepr.fst"
+                                         (Prims.of_int (121))
+                                         (Prims.of_int (48))
+                                         (Prims.of_int (165))
+                                         (Prims.of_int (27)))))
+                                (Obj.magic (generate_repr_typ params ctors))
+                                (fun uu___ ->
+                                   (fun t_repr ->
+                                      Obj.magic
+                                        (FStar_Tactics_Effect.tac_bind
+                                           (FStar_Sealed.seal
+                                              (Obj.magic
+                                                 (FStar_Range.mk_range
+                                                    "FStar.Tactics.TypeRepr.fst"
+                                                    (Prims.of_int (122))
+                                                    (Prims.of_int (16))
+                                                    (Prims.of_int (130))
+                                                    (Prims.of_int (3)))))
+                                           (FStar_Sealed.seal
+                                              (Obj.magic
+                                                 (FStar_Range.mk_range
+                                                    "FStar.Tactics.TypeRepr.fst"
+                                                    (Prims.of_int (131))
+                                                    (Prims.of_int (4))
+                                                    (Prims.of_int (165))
+                                                    (Prims.of_int (27)))))
+                                           (Obj.magic
+                                              (FStar_Tactics_Effect.tac_bind
+                                                 (FStar_Sealed.seal
+                                                    (Obj.magic
+                                                       (FStar_Range.mk_range
+                                                          "FStar.Tactics.TypeRepr.fst"
+                                                          (Prims.of_int (122))
+                                                          (Prims.of_int (31))
+                                                          (Prims.of_int (130))
+                                                          (Prims.of_int (3)))))
+                                                 (FStar_Sealed.seal
+                                                    (Obj.magic
+                                                       (FStar_Range.mk_range
+                                                          "FStar.Tactics.TypeRepr.fst"
+                                                          (Prims.of_int (122))
+                                                          (Prims.of_int (16))
+                                                          (Prims.of_int (130))
+                                                          (Prims.of_int (3)))))
+                                                 (Obj.magic
+                                                    (FStar_Tactics_Effect.tac_bind
+                                                       (FStar_Sealed.seal
+                                                          (Obj.magic
+                                                             (FStar_Range.mk_range
+                                                                "FStar.Tactics.TypeRepr.fst"
+                                                                (Prims.of_int (123))
+                                                                (Prims.of_int (4))
+                                                                (Prims.of_int (129))
+                                                                (Prims.of_int (6)))))
+                                                       (FStar_Sealed.seal
+                                                          (Obj.magic
+                                                             (FStar_Range.mk_range
+                                                                "FStar.Tactics.TypeRepr.fst"
+                                                                (Prims.of_int (122))
+                                                                (Prims.of_int (31))
+                                                                (Prims.of_int (130))
+                                                                (Prims.of_int (3)))))
+                                                       (Obj.magic
+                                                          (FStar_Tactics_Effect.tac_bind
+                                                             (FStar_Sealed.seal
+                                                                (Obj.magic
+                                                                   (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (124))
+                                                                    (Prims.of_int (10))
+                                                                    (Prims.of_int (129))
+                                                                    (Prims.of_int (6)))))
+                                                             (FStar_Sealed.seal
+                                                                (Obj.magic
+                                                                   (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (123))
+                                                                    (Prims.of_int (4))
+                                                                    (Prims.of_int (129))
+                                                                    (Prims.of_int (6)))))
+                                                             (Obj.magic
+                                                                (FStar_Tactics_Effect.tac_bind
+                                                                   (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (125))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (128))
+                                                                    (Prims.of_int (36)))))
+                                                                   (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (124))
+                                                                    (Prims.of_int (10))
+                                                                    (Prims.of_int (129))
+                                                                    (Prims.of_int (6)))))
+                                                                   (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (127))
+                                                                    (Prims.of_int (15))
+                                                                    (Prims.of_int (127))
+                                                                    (Prims.of_int (47)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (125))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (128))
+                                                                    (Prims.of_int (36)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_V2_SyntaxHelpers.mk_arr
+                                                                    params
+                                                                    (FStar_Reflection_V2_Data.C_Total
+                                                                    (FStar_Reflection_V2_Builtins.pack_ln
+                                                                    (FStar_Reflection_V2_Data.Tv_Type
+                                                                    (FStar_Reflection_V2_Builtins.pack_universe
+                                                                    FStar_Reflection_V2_Data.Uv_Unk))))))
+                                                                    (fun
+                                                                    uu___ ->
+                                                                    (fun
+                                                                    uu___ ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (128))
+                                                                    (Prims.of_int (15))
+                                                                    (Prims.of_int (128))
+                                                                    (Prims.of_int (35)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (125))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (128))
+                                                                    (Prims.of_int (36)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_V2_Derived.mk_abs
+                                                                    params
+                                                                    t_repr))
+                                                                    (fun
+                                                                    uu___1 ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___2 ->
+                                                                    {
+                                                                    FStar_Tactics_NamedView.lb_fv
+                                                                    =
+                                                                    (FStar_Reflection_V2_Builtins.pack_fv
+                                                                    (add_suffix
+                                                                    "_repr"
+                                                                    nm));
+                                                                    FStar_Tactics_NamedView.lb_us
+                                                                    = [];
+                                                                    FStar_Tactics_NamedView.lb_typ
+                                                                    = uu___;
+                                                                    FStar_Tactics_NamedView.lb_def
+                                                                    = uu___1
+                                                                    }))))
+                                                                    uu___)))
+                                                                   (fun uu___
+                                                                    ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___1 ->
+                                                                    [uu___]))))
+                                                             (fun uu___ ->
+                                                                FStar_Tactics_Effect.lift_div_tac
+                                                                  (fun uu___1
+                                                                    ->
+                                                                    {
+                                                                    FStar_Tactics_NamedView.isrec
+                                                                    = false;
+                                                                    FStar_Tactics_NamedView.lbs
+                                                                    = uu___
+                                                                    }))))
+                                                       (fun uu___ ->
+                                                          FStar_Tactics_Effect.lift_div_tac
+                                                            (fun uu___1 ->
+                                                               FStar_Tactics_NamedView.Sg_Let
+                                                                 uu___))))
+                                                 (fun uu___ ->
+                                                    (fun uu___ ->
+                                                       Obj.magic
+                                                         (FStar_Tactics_NamedView.pack_sigelt
+                                                            uu___)) uu___)))
+                                           (fun uu___ ->
+                                              (fun se_repr ->
+                                                 Obj.magic
+                                                   (FStar_Tactics_Effect.tac_bind
+                                                      (FStar_Sealed.seal
+                                                         (Obj.magic
+                                                            (FStar_Range.mk_range
+                                                               "FStar.Tactics.TypeRepr.fst"
+                                                               (Prims.of_int (134))
+                                                               (Prims.of_int (4))
+                                                               (Prims.of_int (134))
+                                                               (Prims.of_int (30)))))
+                                                      (FStar_Sealed.seal
+                                                         (Obj.magic
+                                                            (FStar_Range.mk_range
+                                                               "FStar.Tactics.TypeRepr.fst"
+                                                               (Prims.of_int (135))
+                                                               (Prims.of_int (4))
+                                                               (Prims.of_int (165))
+                                                               (Prims.of_int (27)))))
+                                                      (FStar_Tactics_Effect.lift_div_tac
+                                                         (fun uu___ ->
+                                                            FStar_Reflection_V2_Builtins.pack_ln
+                                                              (FStar_Reflection_V2_Data.Tv_App
+                                                                 ((FStar_Reflection_V2_Builtins.pack_ln
+                                                                    (FStar_Reflection_V2_Data.Tv_FVar
+                                                                    (FStar_Reflection_V2_Builtins.pack_fv
+                                                                    ["FStar";
+                                                                    "Tactics";
+                                                                    "Effect";
+                                                                    "synth_by_tactic"]))),
+                                                                   ((FStar_Reflection_V2_Builtins.pack_ln
+                                                                    (FStar_Reflection_V2_Data.Tv_Abs
+                                                                    ((FStar_Reflection_V2_Builtins.pack_binder
+                                                                    {
+                                                                    FStar_Reflection_V2_Data.sort2
+                                                                    =
+                                                                    (FStar_Reflection_V2_Builtins.pack_ln
+                                                                    FStar_Reflection_V2_Data.Tv_Unknown);
+                                                                    FStar_Reflection_V2_Data.qual
+                                                                    =
+                                                                    FStar_Reflection_V2_Data.Q_Explicit;
+                                                                    FStar_Reflection_V2_Data.attrs
+                                                                    = [];
+                                                                    FStar_Reflection_V2_Data.ppname2
+                                                                    =
+                                                                    (FStar_Sealed.seal
+                                                                    "uu___")
+                                                                    }),
+                                                                    (FStar_Reflection_V2_Builtins.pack_ln
+                                                                    (FStar_Reflection_V2_Data.Tv_App
+                                                                    ((FStar_Reflection_V2_Builtins.pack_ln
+                                                                    (FStar_Reflection_V2_Data.Tv_FVar
+                                                                    (FStar_Reflection_V2_Builtins.pack_fv
+                                                                    ["FStar";
+                                                                    "Tactics";
+                                                                    "TypeRepr";
+                                                                    "generate_down"]))),
+                                                                    ((FStar_Reflection_V2_Builtins.pack_ln
+                                                                    (FStar_Reflection_V2_Data.Tv_Const
+                                                                    FStar_Reflection_V2_Data.C_Unit)),
+                                                                    FStar_Reflection_V2_Data.Q_Explicit))))))),
+                                                                    FStar_Reflection_V2_Data.Q_Explicit)))))
+                                                      (fun uu___ ->
+                                                         (fun down_def ->
+                                                            Obj.magic
+                                                              (FStar_Tactics_Effect.tac_bind
+                                                                 (FStar_Sealed.seal
+                                                                    (
+                                                                    Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (136))
+                                                                    (Prims.of_int (17))
+                                                                    (Prims.of_int (136))
+                                                                    (Prims.of_int (41)))))
+                                                                 (FStar_Sealed.seal
+                                                                    (
+                                                                    Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (136))
+                                                                    (Prims.of_int (44))
+                                                                    (Prims.of_int (165))
+                                                                    (Prims.of_int (27)))))
+                                                                 (Obj.magic
+                                                                    (
+                                                                    FStar_Tactics_V2_Derived.mk_abs
+                                                                    params_i
+                                                                    down_def))
+                                                                 (fun uu___
+                                                                    ->
+                                                                    (fun
+                                                                    down_def1
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (137))
+                                                                    (Prims.of_int (15))
+                                                                    (Prims.of_int (147))
+                                                                    (Prims.of_int (3)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (148))
+                                                                    (Prims.of_int (4))
+                                                                    (Prims.of_int (165))
+                                                                    (Prims.of_int (27)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (138))
+                                                                    (Prims.of_int (12))
+                                                                    (Prims.of_int (138))
+                                                                    (Prims.of_int (26)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (139))
+                                                                    (Prims.of_int (4))
+                                                                    (Prims.of_int (147))
+                                                                    (Prims.of_int (3)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_V2_Derived.fresh_binder
+                                                                    t))
+                                                                    (fun
+                                                                    uu___ ->
+                                                                    (fun b ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (139))
+                                                                    (Prims.of_int (19))
+                                                                    (Prims.of_int (147))
+                                                                    (Prims.of_int (3)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (139))
+                                                                    (Prims.of_int (4))
+                                                                    (Prims.of_int (147))
+                                                                    (Prims.of_int (3)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (140))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (146))
+                                                                    (Prims.of_int (8)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (139))
+                                                                    (Prims.of_int (19))
+                                                                    (Prims.of_int (147))
+                                                                    (Prims.of_int (3)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (141))
+                                                                    (Prims.of_int (12))
+                                                                    (Prims.of_int (146))
+                                                                    (Prims.of_int (8)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (140))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (146))
+                                                                    (Prims.of_int (8)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (142))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (145))
+                                                                    (Prims.of_int (26)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (141))
+                                                                    (Prims.of_int (12))
+                                                                    (Prims.of_int (146))
+                                                                    (Prims.of_int (8)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (144))
+                                                                    (Prims.of_int (17))
+                                                                    (Prims.of_int (144))
+                                                                    (Prims.of_int (67)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (142))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (145))
+                                                                    (Prims.of_int (26)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_V2_SyntaxHelpers.mk_tot_arr
+                                                                    params_i
+                                                                    (FStar_Tactics_NamedView.pack
+                                                                    (FStar_Tactics_NamedView.Tv_Arrow
+                                                                    (b,
+                                                                    (FStar_Reflection_V2_Data.C_Total
+                                                                    t_repr))))))
+                                                                    (fun
+                                                                    uu___ ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___1 ->
+                                                                    {
+                                                                    FStar_Tactics_NamedView.lb_fv
+                                                                    =
+                                                                    (FStar_Reflection_V2_Builtins.pack_fv
+                                                                    (add_suffix
+                                                                    "_down"
+                                                                    nm));
+                                                                    FStar_Tactics_NamedView.lb_us
+                                                                    = [];
+                                                                    FStar_Tactics_NamedView.lb_typ
+                                                                    = uu___;
+                                                                    FStar_Tactics_NamedView.lb_def
+                                                                    =
+                                                                    down_def1
+                                                                    }))))
+                                                                    (fun
+                                                                    uu___ ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___1 ->
+                                                                    [uu___]))))
+                                                                    (fun
+                                                                    uu___ ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___1 ->
+                                                                    {
+                                                                    FStar_Tactics_NamedView.isrec
+                                                                    = false;
+                                                                    FStar_Tactics_NamedView.lbs
+                                                                    = uu___
+                                                                    }))))
+                                                                    (fun
+                                                                    uu___ ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___1 ->
+                                                                    FStar_Tactics_NamedView.Sg_Let
+                                                                    uu___))))
+                                                                    (fun
+                                                                    uu___ ->
+                                                                    (fun
+                                                                    uu___ ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_NamedView.pack_sigelt
+                                                                    uu___))
+                                                                    uu___)))
+                                                                    uu___)))
+                                                                    (fun
+                                                                    uu___ ->
+                                                                    (fun
+                                                                    se_down
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (150))
+                                                                    (Prims.of_int (4))
+                                                                    (Prims.of_int (150))
+                                                                    (Prims.of_int (77)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (151))
+                                                                    (Prims.of_int (4))
+                                                                    (Prims.of_int (165))
+                                                                    (Prims.of_int (27)))))
+                                                                    (FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___ ->
+                                                                    FStar_Reflection_V2_Builtins.pack_ln
+                                                                    (FStar_Reflection_V2_Data.Tv_App
+                                                                    ((FStar_Reflection_V2_Builtins.pack_ln
+                                                                    (FStar_Reflection_V2_Data.Tv_FVar
+                                                                    (FStar_Reflection_V2_Builtins.pack_fv
+                                                                    ["FStar";
+                                                                    "Tactics";
+                                                                    "Effect";
+                                                                    "synth_by_tactic"]))),
+                                                                    ((FStar_Reflection_V2_Builtins.pack_ln
+                                                                    (FStar_Reflection_V2_Data.Tv_Abs
+                                                                    ((FStar_Reflection_V2_Builtins.pack_binder
+                                                                    {
+                                                                    FStar_Reflection_V2_Data.sort2
+                                                                    =
+                                                                    (FStar_Reflection_V2_Builtins.pack_ln
+                                                                    FStar_Reflection_V2_Data.Tv_Unknown);
+                                                                    FStar_Reflection_V2_Data.qual
+                                                                    =
+                                                                    FStar_Reflection_V2_Data.Q_Explicit;
+                                                                    FStar_Reflection_V2_Data.attrs
+                                                                    = [];
+                                                                    FStar_Reflection_V2_Data.ppname2
+                                                                    =
+                                                                    (FStar_Sealed.seal
+                                                                    "uu___")
+                                                                    }),
+                                                                    (FStar_Reflection_V2_Builtins.pack_ln
+                                                                    (FStar_Reflection_V2_Data.Tv_App
+                                                                    ((FStar_Reflection_V2_Builtins.pack_ln
+                                                                    (FStar_Reflection_V2_Data.Tv_App
+                                                                    ((FStar_Reflection_V2_Builtins.pack_ln
+                                                                    (FStar_Reflection_V2_Data.Tv_FVar
+                                                                    (FStar_Reflection_V2_Builtins.pack_fv
+                                                                    ["FStar";
+                                                                    "Tactics";
+                                                                    "TypeRepr";
+                                                                    "generate_up"]))),
+                                                                    ((FStar_Tactics_NamedView.pack
+                                                                    (FStar_Tactics_NamedView.Tv_Const
+                                                                    (FStar_Reflection_V2_Data.C_String
+                                                                    (FStar_Reflection_V2_Builtins.implode_qn
+                                                                    nm)))),
+                                                                    FStar_Reflection_V2_Data.Q_Explicit)))),
+                                                                    ((FStar_Reflection_V2_Builtins.pack_ln
+                                                                    (FStar_Reflection_V2_Data.Tv_Const
+                                                                    FStar_Reflection_V2_Data.C_Unit)),
+                                                                    FStar_Reflection_V2_Data.Q_Explicit))))))),
+                                                                    FStar_Reflection_V2_Data.Q_Explicit)))))
+                                                                    (fun
+                                                                    uu___ ->
+                                                                    (fun
+                                                                    up_def ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (152))
+                                                                    (Prims.of_int (15))
+                                                                    (Prims.of_int (152))
+                                                                    (Prims.of_int (37)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (152))
+                                                                    (Prims.of_int (40))
+                                                                    (Prims.of_int (165))
+                                                                    (Prims.of_int (27)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_V2_Derived.mk_abs
+                                                                    params_i
+                                                                    up_def))
+                                                                    (fun
+                                                                    uu___ ->
+                                                                    (fun
+                                                                    up_def1
+                                                                    ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (153))
+                                                                    (Prims.of_int (13))
+                                                                    (Prims.of_int (163))
+                                                                    (Prims.of_int (3)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (165))
+                                                                    (Prims.of_int (2))
+                                                                    (Prims.of_int (165))
+                                                                    (Prims.of_int (27)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (154))
+                                                                    (Prims.of_int (12))
+                                                                    (Prims.of_int (154))
+                                                                    (Prims.of_int (31)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (155))
+                                                                    (Prims.of_int (4))
+                                                                    (Prims.of_int (163))
+                                                                    (Prims.of_int (3)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_V2_Derived.fresh_binder
+                                                                    t_repr))
+                                                                    (fun
+                                                                    uu___ ->
+                                                                    (fun b ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (155))
+                                                                    (Prims.of_int (19))
+                                                                    (Prims.of_int (163))
+                                                                    (Prims.of_int (3)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (155))
+                                                                    (Prims.of_int (4))
+                                                                    (Prims.of_int (163))
+                                                                    (Prims.of_int (3)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (156))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (162))
+                                                                    (Prims.of_int (8)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (155))
+                                                                    (Prims.of_int (19))
+                                                                    (Prims.of_int (163))
+                                                                    (Prims.of_int (3)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (157))
+                                                                    (Prims.of_int (12))
+                                                                    (Prims.of_int (162))
+                                                                    (Prims.of_int (8)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (156))
+                                                                    (Prims.of_int (6))
+                                                                    (Prims.of_int (162))
+                                                                    (Prims.of_int (8)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (158))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (161))
+                                                                    (Prims.of_int (24)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (157))
+                                                                    (Prims.of_int (12))
+                                                                    (Prims.of_int (162))
+                                                                    (Prims.of_int (8)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_Effect.tac_bind
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (160))
+                                                                    (Prims.of_int (17))
+                                                                    (Prims.of_int (160))
+                                                                    (Prims.of_int (62)))))
+                                                                    (FStar_Sealed.seal
+                                                                    (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.TypeRepr.fst"
+                                                                    (Prims.of_int (158))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (161))
+                                                                    (Prims.of_int (24)))))
+                                                                    (Obj.magic
+                                                                    (FStar_Tactics_V2_SyntaxHelpers.mk_tot_arr
+                                                                    params_i
+                                                                    (FStar_Tactics_NamedView.pack
+                                                                    (FStar_Tactics_NamedView.Tv_Arrow
+                                                                    (b,
+                                                                    (FStar_Reflection_V2_Data.C_Total
+                                                                    t))))))
+                                                                    (fun
+                                                                    uu___ ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___1 ->
+                                                                    {
+                                                                    FStar_Tactics_NamedView.lb_fv
+                                                                    =
+                                                                    (FStar_Reflection_V2_Builtins.pack_fv
+                                                                    (add_suffix
+                                                                    "_up" nm));
+                                                                    FStar_Tactics_NamedView.lb_us
+                                                                    = [];
+                                                                    FStar_Tactics_NamedView.lb_typ
+                                                                    = uu___;
+                                                                    FStar_Tactics_NamedView.lb_def
+                                                                    = up_def1
+                                                                    }))))
+                                                                    (fun
+                                                                    uu___ ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___1 ->
+                                                                    [uu___]))))
+                                                                    (fun
+                                                                    uu___ ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___1 ->
+                                                                    {
+                                                                    FStar_Tactics_NamedView.isrec
+                                                                    = false;
+                                                                    FStar_Tactics_NamedView.lbs
+                                                                    = uu___
+                                                                    }))))
+                                                                    (fun
+                                                                    uu___ ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___1 ->
+                                                                    FStar_Tactics_NamedView.Sg_Let
+                                                                    uu___))))
+                                                                    (fun
+                                                                    uu___ ->
+                                                                    (fun
+                                                                    uu___ ->
+                                                                    Obj.magic
+                                                                    (FStar_Tactics_NamedView.pack_sigelt
+                                                                    uu___))
+                                                                    uu___)))
+                                                                    uu___)))
+                                                                    (fun
+                                                                    se_up ->
+                                                                    FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___ ->
+                                                                    [se_repr;
+                                                                    se_down;
+                                                                    se_up]))))
+                                                                    uu___)))
+                                                                    uu___)))
+                                                                    uu___)))
+                                                                    uu___)))
+                                                           uu___))) uu___)))
+                                     uu___))) uu___))) uu___)
+let (entry :
+  Prims.string ->
+    (FStar_Reflection_Types.decls, unit) FStar_Tactics_Effect.tac_repr)
+  =
+  fun nm ->
+    FStar_Tactics_Effect.tac_bind
+      (FStar_Sealed.seal
+         (Obj.magic
+            (FStar_Range.mk_range "FStar.Tactics.TypeRepr.fst"
+               (Prims.of_int (169)) (Prims.of_int (41)) (Prims.of_int (169))
+               (Prims.of_int (61)))))
+      (FStar_Sealed.seal
+         (Obj.magic
+            (FStar_Range.mk_range "FStar.Tactics.TypeRepr.fst"
+               (Prims.of_int (168)) (Prims.of_int (37)) (Prims.of_int (170))
+               (Prims.of_int (30))))) (Obj.magic (get_inductive_typ nm))
+      (fun uu___ ->
+         (fun uu___ ->
+            match uu___ with
+            | FStar_Tactics_NamedView.Sg_Inductive
+                { FStar_Tactics_NamedView.nm = nm1;
+                  FStar_Tactics_NamedView.univs1 = uu___1;
+                  FStar_Tactics_NamedView.params = params;
+                  FStar_Tactics_NamedView.typ = uu___2;
+                  FStar_Tactics_NamedView.ctors = ctors;_}
+                -> Obj.magic (generate_all nm1 params ctors)) uu___)
+let _ =
+  FStar_Tactics_Native.register_tactic "FStar.Tactics.TypeRepr.entry"
+    (Prims.of_int (2))
+    (fun psc ->
+       fun ncb ->
+         fun us ->
+           fun args ->
+             FStar_Tactics_InterpFuns.mk_tactic_interpretation_1
+               "FStar.Tactics.TypeRepr.entry (plugin)"
+               (FStar_Tactics_Native.from_tactic_1 entry)
+               FStar_Syntax_Embeddings.e_string
+               (FStar_Syntax_Embeddings.e_list
+                  FStar_Reflection_V2_Embeddings.e_sigelt) psc ncb us args)

--- a/src/syntax/FStar.Syntax.Resugar.fst
+++ b/src/syntax/FStar.Syntax.Resugar.fst
@@ -84,7 +84,7 @@ let label s t =
   else A.mk_term (A.Labeled (t,s,true)) t.range A.Un
 
 let rec universe_to_int n u =
-  match u with
+  match Subst.compress_univ u with
     | U_succ u -> universe_to_int (n+1) u
     | _ -> (n, u)
 
@@ -98,7 +98,8 @@ let rec resugar_universe (u:S.universe) r: A.term =
       //augment `a` an Unknown level (the level is unimportant ... we should maybe remove it altogether)
       A.mk_term a r A.Un
   in
-  begin match Subst.compress_univ u with
+  let u = Subst.compress_univ u in
+  begin match u with
     | U_zero ->
       mk (A.Const(Const_int ("0", None))) r
 

--- a/tests/tactics/Test.TypeRepr.fst
+++ b/tests/tactics/Test.TypeRepr.fst
@@ -1,0 +1,17 @@
+module Test.TypeRepr
+
+open FStar.Tactics.V2
+module TypeRepr = FStar.Tactics.TypeRepr
+
+type test1 (a:Type0) : Type u#123 =
+  | A of a
+  | B : bool -> int -> test1 a
+  | C : int -> string -> list bool -> test1 a
+  | D : int -> (int & bool) -> test1 a
+
+%splice[test1_repr; test1_down; test1_up] (TypeRepr.entry (`%test1))
+
+let _ = assert (forall a (x:test1 a). test1_up (test1_down x) == x)
+
+[@@expect_failure] // fuel limitation
+let _ = assert (forall a (x:test1_repr a). test1_down (test1_up x) == x)

--- a/ulib/FStar.Tactics.TypeRepr.fst
+++ b/ulib/FStar.Tactics.TypeRepr.fst
@@ -1,0 +1,170 @@
+module FStar.Tactics.TypeRepr
+
+//#set-options "--print_implicits --print_full_names --print_universes"
+
+open FStar.Tactics.V2
+
+let add_suffix (s:string) (nm:name) : name =
+  explode_qn (implode_qn nm ^ s)
+
+let unitv_                 : term = `()
+let unitt_                 : term = `(unit)
+let empty_                 : term = `(empty)
+let either_ (a b : term)   : term = `(either (`#a) (`#b))
+let tuple2_ (a b : term)   : term = `(tuple2 (`#a) (`#b))
+let mktuple2_ (a b : term) : term = `(Mktuple2 (`#a) (`#b))
+
+let get_inductive_typ (nm:string) : Tac (se:sigelt_view{Sg_Inductive? se}) =
+  let e = top_env () in
+  let se = lookup_typ e (explode_qn nm) in
+  match se with
+  | None -> fail "ctors_of_typ: type not found"
+  | Some se ->
+    let sev = inspect_sigelt se in
+    if Sg_Inductive? sev then
+      sev
+    else
+      fail "ctors_of_typ: not an inductive type"
+
+let alg_ctor (ty : typ) : Tac typ =
+  let tys, c = collect_arr ty in
+  Tactics.Util.fold_right (fun ty acc -> tuple2_ ty acc) tys unitt_
+
+[@@plugin]
+let generate_repr_typ (params : binders) (ctors : list ctor)  : Tac typ =
+  let ctor_typs = Util.map (fun (_, ty) -> alg_ctor ty) ctors in
+  let alternative_typ =
+    Util.fold_right (fun ty acc -> either_ ty acc) ctor_typs empty_ in
+  alternative_typ
+
+(* Expects a goal of type [t -> t_repr] *)
+[@@plugin]
+let generate_down () : Tac unit =
+  let b = intro () in
+  let cases = t_destruct b in
+  cases |> Util.iteri #(fv & nat) (fun i (c, n) ->
+    let bs = repeatn n (fun _ -> intro ()) in
+    let _b_eq = intro () in
+    let sol = Util.fold_right (fun (b:binding) acc -> mktuple2_ b acc) bs unitv_ in
+    let _ = repeatn i (fun _ -> apply (`Inr)) in
+    apply (`Inl);
+    exact sol
+  )
+
+let rec get_apply_tuple (b:binding) : Tac (list binding) =
+  let hd, args = collect_app b.sort in
+  match inspect hd, args with
+  | Tv_UInst fv _, [b1; b2]
+  | Tv_FVar fv, [b1; b2] ->
+    if inspect_fv fv = explode_qn (`%tuple2) then
+      let cases = t_destruct b in
+      guard (List.Tot.length cases = 1 && inspect_fv (fst (List.Tot.hd cases)) = explode_qn (`%Mktuple2) && snd (List.Tot.hd cases) = 2);
+      let b1 = intro () in
+      let b2 = intro () in
+      let _eq = intro () in
+      b1 :: get_apply_tuple b2
+    else
+      fail ("unexpected term in apply_tuple: " ^ term_to_string b.sort)
+  | Tv_FVar fv, [] ->
+    if inspect_fv fv = explode_qn (`%unit) then
+      []
+    else
+      fail ("unexpected term in apply_tuple: " ^ term_to_string b.sort)
+  | _ ->
+    fail ("unexpected term in apply_tuple: " ^ term_to_string b.sort)
+
+(* Expects a goal of type [t_repr -> t] *)
+
+let rec generate_up_aux (ctors : list ctor) (b:binding) : Tac unit =
+  match ctors with
+  | [] ->
+    (* b must have type empty, it's the finisher for the cases *)
+    apply (`empty_elim);
+    exact b
+  | c::cs ->
+    let cases = t_destruct b in
+    if List.Tot.length cases <> 2 then
+      fail "generate_up_aux: expected Inl/Inr???";
+    focus (fun () ->
+      let b' = intro () in
+      let _eq = intro () in
+      let c_name = fst c in
+      let args = get_apply_tuple b' in
+      apply (pack (Tv_FVar (pack_fv c_name)));
+      Util.iter (fun (b:binding) -> exact b) args;
+      qed()
+    );
+    let b = intro () in
+    let _eq = intro () in
+    generate_up_aux cs b
+
+(* Expects a goal of type [t_repr -> t] *)
+[@@plugin]
+let generate_up (nm:string) () : Tac unit =
+  let Sg_Inductive {ctors} = get_inductive_typ nm in
+  let b = intro () in
+  generate_up_aux ctors b
+
+let make_implicits (bs : binders) : binders =
+  bs |> List.Tot.map (fun b ->
+    match b.qual with
+    | Q_Explicit -> { b with qual = Q_Implicit }
+    | _ -> b
+  )
+
+let binder_to_argv (b:binder) : argv =
+  (binder_to_term b, b.qual)
+
+let generate_all (nm:name) (params:binders) (ctors : list ctor) : Tac decls =
+  let params_i = make_implicits params in
+  let t =      mk_app (pack (Tv_FVar (pack_fv nm))) (List.Tot.map binder_to_argv params) in
+  let t_repr = generate_repr_typ params ctors in
+  let se_repr = pack_sigelt <| Sg_Let {
+    isrec = false;
+    lbs = [{
+      lb_fv = pack_fv (add_suffix "_repr" nm);
+      lb_us = [];
+      lb_typ = mk_arr params <| C_Total (`Type);
+      lb_def = mk_abs params t_repr;
+    }]
+  }
+  in
+  
+  let down_def =
+    `(_ by (generate_down ()))
+  in
+  let down_def = mk_abs params_i down_def in
+  let se_down =
+    let b = fresh_binder t in
+    pack_sigelt <| Sg_Let {
+      isrec = false;
+      lbs = [{
+        lb_fv = pack_fv (add_suffix "_down" nm);
+        lb_us = [];
+        lb_typ = mk_tot_arr params_i <| Tv_Arrow b (C_Total t_repr);
+        lb_def = down_def;
+      }]
+  }
+  in
+  let up_def =
+    `(_ by (generate_up (`#(pack (Tv_Const (C_String (implode_qn nm))))) ()))
+  in
+  let up_def = mk_abs params_i up_def in
+  let se_up =
+    let b = fresh_binder t_repr in
+    pack_sigelt <| Sg_Let {
+      isrec = false;
+      lbs = [{
+        lb_fv = pack_fv (add_suffix "_up" nm);
+        lb_us = [];
+        lb_typ = mk_tot_arr params_i <| Tv_Arrow b (C_Total t);
+        lb_def = up_def;
+      }]
+  }
+  in
+  [se_repr; se_down; se_up]
+
+[@@plugin]
+let entry (nm : string) : Tac decls =
+  let Sg_Inductive {params; nm; ctors} = get_inductive_typ nm in
+  generate_all nm params ctors

--- a/ulib/FStar.Tactics.TypeRepr.fsti
+++ b/ulib/FStar.Tactics.TypeRepr.fsti
@@ -1,0 +1,21 @@
+module FStar.Tactics.TypeRepr
+
+open FStar.Tactics.V2
+
+private
+let empty_elim (e:empty) (#a:Type) : a = match e with
+
+(* Do not use directly. *)
+[@@plugin]
+val generate_repr_typ (params : binders) (ctors : list ctor)  : Tac typ
+
+(* Do not use directly. *)
+[@@plugin]
+val generate_down () : Tac unit
+
+(* Do not use directly. *)
+[@@plugin]
+val generate_up (nm:string) () : Tac unit
+
+[@@plugin]
+val entry (nm : string) : Tac decls


### PR DESCRIPTION
cc @tahina-pro 

The tactic will always finish the sum with an `empty`, and finish each product with a `unit`, for uniformity.

I didn't add an automatic proof of the bijection yet, but one of the directions (`up (down x) == x`) should be always provable by SMT I think.