### PR TITLE
SizeT: make SizeT.t a new type

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_PtrdiffT.ml
+++ b/ocaml/fstar-lib/generated/FStar_PtrdiffT.ml
@@ -4,7 +4,7 @@ type 'x fits = unit
 let (v : t -> Prims.int) = fun x -> FStar_Int64.v x
 let (int_to_t : Prims.int -> t) = fun x -> FStar_Int64.int_to_t x
 let (ptrdifft_to_sizet : t -> FStar_SizeT.t) =
-  fun x -> FStar_Int_Cast.int64_to_uint64 x
+  fun x -> FStar_SizeT.Sz (FStar_Int_Cast.int64_to_uint64 x)
 let (add : t -> t -> t) = fun x -> fun y -> FStar_Int64.add x y
 let (div : t -> t -> t) = fun x -> fun y -> FStar_Int64.div x y
 let (rem : t -> t -> t) = fun x -> fun y -> FStar_Int64.rem x y

--- a/ocaml/fstar-lib/generated/FStar_SizeT.ml
+++ b/ocaml/fstar-lib/generated/FStar_SizeT.ml
@@ -1,8 +1,12 @@
 open Prims
-type t = FStar_UInt64.t
+type t =
+  | Sz of FStar_UInt64.t 
+let (uu___is_Sz : t -> Prims.bool) = fun projectee -> true
+let (__proj__Sz__item__x : t -> FStar_UInt64.t) =
+  fun projectee -> match projectee with | Sz x -> x
 type 'x fits = unit
-let (v : t -> Prims.nat) = fun x -> FStar_UInt64.v x
-let (uint_to_t : Prims.nat -> t) = fun x -> FStar_UInt64.uint_to_t x
+let (v : t -> Prims.nat) = fun x -> FStar_UInt64.v (__proj__Sz__item__x x)
+let (uint_to_t : Prims.nat -> t) = fun x -> Sz (FStar_UInt64.uint_to_t x)
 type fits_u32 = unit
 type fits_u64 = unit
 let (uint16_to_sizet : FStar_UInt16.t -> t) =
@@ -12,17 +16,41 @@ let (uint32_to_sizet : FStar_UInt32.t -> t) =
 let (uint64_to_sizet : FStar_UInt64.t -> t) =
   fun x -> uint_to_t (FStar_UInt64.v x)
 let (sizet_to_uint32 : t -> FStar_UInt32.t) =
-  fun x -> FStar_Int_Cast.uint64_to_uint32 x
-let (add : t -> t -> t) = fun x -> fun y -> FStar_UInt64.add x y
-let (sub : t -> t -> t) = fun x -> fun y -> FStar_UInt64.sub x y
-let (mul : t -> t -> t) = fun x -> fun y -> FStar_UInt64.mul x y
+  fun x -> FStar_Int_Cast.uint64_to_uint32 (__proj__Sz__item__x x)
+let (add : t -> t -> t) =
+  fun x ->
+    fun y ->
+      Sz (FStar_UInt64.add (__proj__Sz__item__x x) (__proj__Sz__item__x y))
+let (sub : t -> t -> t) =
+  fun x ->
+    fun y ->
+      Sz (FStar_UInt64.sub (__proj__Sz__item__x x) (__proj__Sz__item__x y))
+let (mul : t -> t -> t) =
+  fun x ->
+    fun y ->
+      Sz (FStar_UInt64.mul (__proj__Sz__item__x x) (__proj__Sz__item__x y))
 let (div : t -> t -> t) =
-  fun x -> fun y -> let res = FStar_UInt64.div x y in res
-let (rem : t -> t -> t) = fun x -> fun y -> FStar_UInt64.rem x y
-let (gt : t -> t -> Prims.bool) = fun x -> fun y -> FStar_UInt64.gt x y
-let (gte : t -> t -> Prims.bool) = fun x -> fun y -> FStar_UInt64.gte x y
-let (lt : t -> t -> Prims.bool) = fun x -> fun y -> FStar_UInt64.lt x y
-let (lte : t -> t -> Prims.bool) = fun x -> fun y -> FStar_UInt64.lte x y
+  fun x ->
+    fun y ->
+      let res =
+        Sz (FStar_UInt64.div (__proj__Sz__item__x x) (__proj__Sz__item__x y)) in
+      res
+let (rem : t -> t -> t) =
+  fun x ->
+    fun y ->
+      Sz (FStar_UInt64.rem (__proj__Sz__item__x x) (__proj__Sz__item__x y))
+let (gt : t -> t -> Prims.bool) =
+  fun x ->
+    fun y -> FStar_UInt64.gt (__proj__Sz__item__x x) (__proj__Sz__item__x y)
+let (gte : t -> t -> Prims.bool) =
+  fun x ->
+    fun y -> FStar_UInt64.gte (__proj__Sz__item__x x) (__proj__Sz__item__x y)
+let (lt : t -> t -> Prims.bool) =
+  fun x ->
+    fun y -> FStar_UInt64.lt (__proj__Sz__item__x x) (__proj__Sz__item__x y)
+let (lte : t -> t -> Prims.bool) =
+  fun x ->
+    fun y -> FStar_UInt64.lte (__proj__Sz__item__x x) (__proj__Sz__item__x y)
 let (op_Plus_Hat : t -> t -> t) = add
 let (op_Subtraction_Hat : t -> t -> t) = sub
 let (op_Star_Hat : t -> t -> t) = mul

--- a/ulib/FStar.PtrdiffT.fst
+++ b/ulib/FStar.PtrdiffT.fst
@@ -41,7 +41,7 @@ let mk x = int_to_t (I16.v x)
 
 let ptrdifft_to_sizet x =
   bounds_lemma ();
-  Cast.int64_to_uint64 x
+  SizeT.Sz <| Cast.int64_to_uint64 x
 
 let add x y = I64.add x y
 

--- a/ulib/FStar.SizeT.fst
+++ b/ulib/FStar.SizeT.fst
@@ -10,7 +10,7 @@ module I64 = FStar.Int64
 assume
 val bound : x:erased nat { x >= pow2 16 }
 
-let t = x:U64.t { U64.v x < bound }
+type t : eqtype = | Sz : (x:U64.t { U64.v x < bound }) -> t
 
 let fits x =
   FStar.UInt.fits x U64.n == true /\
@@ -19,11 +19,11 @@ let fits x =
 let fits_at_least_16 _ = ()
 
 let v x =
-  U64.v x
+  U64.v (Sz?.x x)
 
 irreducible
 let uint_to_t x =
-  U64.uint_to_t x
+  Sz (U64.uint_to_t x)
 
 let size_v_inj (x: t) = ()
 let size_uint_to_t_inj (x: nat) = ()
@@ -62,22 +62,23 @@ let of_u64 (x: U64.t)
 let uint16_to_sizet x = uint_to_t (U16.v x)
 let uint32_to_sizet x = uint_to_t (U32.v x)
 let uint64_to_sizet x = uint_to_t (U64.v x)
-let sizet_to_uint32 x = FStar.Int.Cast.uint64_to_uint32 x
+let sizet_to_uint32 x = FStar.Int.Cast.uint64_to_uint32 (Sz?.x x)
 
 let fits_lte x y = ()
 
 #push-options "--z3rlimit 20"
-let add x y = U64.add x y
-let sub x y = U64.sub x y
-let mul x y = U64.mul x y
+let add x y = Sz <| U64.add x.x y.x
+let sub x y = Sz <| U64.sub x.x y.x
+let mul x y = Sz <| U64.mul x.x y.x
 let div x y =
-  let res = U64.div x y in
-  fits_lte (U64.v res) (U64.v x);
-  FStar.Math.Lib.slash_decr_axiom (U64.v x) (U64.v y);
-  assert (U64.v x / U64.v y <= U64.v x);
+  let res = Sz <| U64.div x.x y.x in
+  fits_lte (U64.v res.x) (U64.v x.x);
+  FStar.Math.Lib.slash_decr_axiom (U64.v x.x) (U64.v y.x);
+  assert (U64.v x.x / U64.v y.x <= U64.v x.x);
   res
-let rem x y = U64.rem x y
-let gt x y = U64.gt x y
-let gte x y = U64.gte x y
-let lt x y = U64.lt x y
-let lte x y = U64.lte x y
+
+let rem x y = Sz <| U64.rem x.x y.x
+let gt  x y = U64.gt  x.x y.x
+let gte x y = U64.gte x.x y.x
+let lt  x y = U64.lt  x.x y.x
+let lte x y = U64.lte x.x y.x

--- a/ulib/FStar.SizeT.fsti
+++ b/ulib/FStar.SizeT.fsti
@@ -6,6 +6,7 @@ module U16 = FStar.UInt16
 module U32 = FStar.UInt32
 module U64 = FStar.UInt64
 
+new
 val t : eqtype
 
 val fits (x: nat) : Tot prop


### PR DESCRIPTION
This PR improves responsiveness whenever we use a `SizeT.t` in a context where it is wrong to do so, like if the expected type is `int` (and we forgot the `v`). Instead of trying to prove `int == SizeT.t` by SMT, F* will now just fail during typechecking/unification. All other integer types already use `new`.

To do this, we must redefine `SizeT.t` as a fresh inductive, otherwise we cannot claim that it is `new`. I wonder if there's a reason against this, since I remember that this module had some custom extraction rules. Maybe @R1kM or @msprotz know?