### PR TITLE
Color warnings yellow, diagnostics blue

### DIFF
--- a/ocaml/fstar-lib/FStar_Compiler_Util.ml
+++ b/ocaml/fstar-lib/FStar_Compiler_Util.ml
@@ -545,7 +545,7 @@ type printer = {
 
 let default_printer =
   { printer_prinfo = (fun s -> pr "%s" s; flush stdout);
-    printer_prwarning = (fun s -> fpr stderr "%s" (colorize_cyan s); flush stdout; flush stderr);
+    printer_prwarning = (fun s -> fpr stderr "%s" (colorize_yellow s); flush stdout; flush stderr);
     printer_prerror = (fun s -> fpr stderr "%s" (colorize_red s); flush stdout; flush stderr);
     printer_prgeneric = fun label get_string get_json -> pr "%s: %s" label (get_string ())}
 

--- a/ocaml/fstar-lib/generated/FStar_Errors.ml
+++ b/ocaml/fstar-lib/generated/FStar_Errors.ml
@@ -412,7 +412,7 @@ let (print_issue : issue -> unit) =
       match issue1.issue_level with
       | EInfo ->
           (fun s ->
-             let uu___ = FStar_Compiler_Util.colorize_magenta s in
+             let uu___ = FStar_Compiler_Util.colorize_cyan s in
              FStar_Compiler_Util.print_string uu___)
       | EWarning -> FStar_Compiler_Util.print_warning
       | EError -> FStar_Compiler_Util.print_error

--- a/src/basic/FStar.Errors.fst
+++ b/src/basic/FStar.Errors.fst
@@ -203,7 +203,7 @@ let format_issue issue : string = format_issue' true issue
 let print_issue issue =
     let printer =
         match issue.issue_level with
-        | EInfo -> (fun s -> BU.print_string (colorize_magenta s))
+        | EInfo -> (fun s -> BU.print_string (colorize_cyan s))
         | EWarning -> BU.print_warning
         | EError -> BU.print_error
         | ENotImplemented -> BU.print_error in


### PR DESCRIPTION
This makes it consistent with the VS Code coloring, and yellow is usual for warnings anyway.

This does make the warnings much more eye-catching, which is probably good!