### PR TITLE
Misc fixes (typeclasses, printing)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,11 @@ bootstrap:
 	+$(Q)$(MAKE) dune-snapshot
 	+$(Q)$(MAKE) fstar
 
+# This is a faster version of bootstrap, since it does not use dune
+# to install the binary and libraries, and instead just copies the binary
+# mannualy. HOWEVER, note that this means plugins will not work well,
+# since they are compiled against the objects in bin/, which will become
+# stale if this rule is used. Using bootstrap is usually safer.
 .PHONY: boot
 boot:
 	+$(Q)$(MAKE) dune-snapshot

--- a/ocaml/fstar-lib/generated/FStar_Compiler_Range_Ops.ml
+++ b/ocaml/fstar-lib/generated/FStar_Compiler_Range_Ops.ml
@@ -255,5 +255,12 @@ let (json_of_def_range : FStar_Compiler_Range_Type.range -> FStar_Json.json)
     let uu___ = file_of_range r in
     let uu___1 = start_of_range r in
     let uu___2 = end_of_range r in json_of_range_fields uu___ uu___1 uu___2
-let (show_range : FStar_Compiler_Range_Type.range FStar_Class_Show.showable)
-  = { FStar_Class_Show.show = string_of_range }
+let (showable_range :
+  FStar_Compiler_Range_Type.range FStar_Class_Show.showable) =
+  { FStar_Class_Show.show = string_of_range }
+let (pretty_range : FStar_Compiler_Range_Type.range FStar_Class_PP.pretty) =
+  {
+    FStar_Class_PP.pp =
+      (fun r ->
+         let uu___ = string_of_range r in FStar_Pprint.doc_of_string uu___)
+  }

--- a/ocaml/fstar-lib/generated/FStar_SMTEncoding_ErrorReporting.ml
+++ b/ocaml/fstar-lib/generated/FStar_SMTEncoding_ErrorReporting.ml
@@ -812,7 +812,7 @@ let (detail_errors :
                              let uu___8 =
                                let uu___9 =
                                  FStar_Class_Show.show
-                                   FStar_Compiler_Range_Ops.show_range r in
+                                   FStar_Compiler_Range_Ops.showable_range r in
                                FStar_Compiler_Util.format1
                                  "XX: proof obligation at %s failed." uu___9 in
                              FStar_Errors_Msg.text uu___8 in

--- a/ocaml/fstar-lib/generated/FStar_SMTEncoding_Solver.ml
+++ b/ocaml/fstar-lib/generated/FStar_SMTEncoding_Solver.ml
@@ -1066,7 +1066,7 @@ let (query_info : query_settings -> FStar_SMTEncoding_Z3.z3result -> unit) =
                    let uu___3 =
                      let uu___4 =
                        FStar_Class_Show.show
-                         FStar_Compiler_Range_Ops.show_range
+                         FStar_Compiler_Range_Ops.showable_range
                          settings.query_range in
                      Prims.strcat uu___4 (Prims.strcat at_log_file ")") in
                    Prims.strcat "(" uu___3 in

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Resugar.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Resugar.ml
@@ -756,506 +756,541 @@ let rec (resugar_term' :
                uu___7)::[];_}
           when can_resugar_machine_integer fv ->
           resugar_machine_integer fv i t.FStar_Syntax_Syntax.pos
-      | FStar_Syntax_Syntax.Tm_app
-          { FStar_Syntax_Syntax.hd = e; FStar_Syntax_Syntax.args = args;_} ->
-          let rec last uu___1 =
-            match uu___1 with
-            | hd::[] -> [hd]
-            | hd::tl -> last tl
-            | uu___2 ->
-                FStar_Compiler_Effect.failwith "last of an empty list" in
-          let first_two_explicit args1 =
-            let rec drop_implicits args2 =
-              match args2 with
-              | (uu___1, FStar_Pervasives_Native.Some
-                 { FStar_Syntax_Syntax.aqual_implicit = true;
-                   FStar_Syntax_Syntax.aqual_attributes = uu___2;_})::tl
-                  -> drop_implicits tl
-              | uu___1 -> args2 in
-            let uu___1 = drop_implicits args1 in
-            match uu___1 with
-            | [] ->
-                FStar_Compiler_Effect.failwith
-                  "not_enough explicit_arguments"
-            | uu___2::[] ->
-                FStar_Compiler_Effect.failwith
-                  "not_enough explicit_arguments"
-            | a1::a2::uu___2 -> [a1; a2] in
-          let resugar_as_app e1 args1 =
-            let args2 =
-              FStar_Compiler_List.map
-                (fun uu___1 ->
-                   match uu___1 with
-                   | (e2, qual) ->
-                       let uu___2 = resugar_term' env e2 in
-                       let uu___3 = resugar_aqual env qual in
-                       (uu___2, uu___3)) args1 in
-            let uu___1 = resugar_term' env e1 in
-            match uu___1 with
-            | {
-                FStar_Parser_AST.tm = FStar_Parser_AST.Construct
-                  (hd, previous_args);
-                FStar_Parser_AST.range = r; FStar_Parser_AST.level = l;_} ->
-                FStar_Parser_AST.mk_term
-                  (FStar_Parser_AST.Construct
-                     (hd, (FStar_Compiler_List.op_At previous_args args2))) r
-                  l
-            | e2 ->
-                FStar_Compiler_List.fold_left
-                  (fun acc ->
-                     fun uu___2 ->
-                       match uu___2 with
-                       | (x, qual) ->
-                           mk (FStar_Parser_AST.App (acc, x, qual))) e2 args2 in
-          let args1 =
-            let uu___1 = FStar_Options.print_implicits () in
-            if uu___1 then args else filter_imp_args args in
-          let is_projector t1 =
-            let uu___1 =
-              let uu___2 =
-                let uu___3 = FStar_Syntax_Subst.compress t1 in
-                FStar_Syntax_Util.un_uinst uu___3 in
-              uu___2.FStar_Syntax_Syntax.n in
-            match uu___1 with
-            | FStar_Syntax_Syntax.Tm_fvar fv ->
-                let a =
-                  (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                let length =
-                  let uu___2 =
-                    FStar_Ident.nsstr
-                      (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                  FStar_Compiler_String.length uu___2 in
-                let s =
-                  if length = Prims.int_zero
-                  then FStar_Ident.string_of_lid a
-                  else
-                    (let uu___3 = FStar_Ident.string_of_lid a in
-                     FStar_Compiler_Util.substring_from uu___3
-                       (length + Prims.int_one)) in
-                if
-                  FStar_Compiler_Util.starts_with s
-                    FStar_Syntax_Util.field_projector_prefix
-                then
-                  let rest =
-                    FStar_Compiler_Util.substring_from s
-                      (FStar_Compiler_String.length
-                         FStar_Syntax_Util.field_projector_prefix) in
-                  let r =
-                    FStar_Compiler_Util.split rest
-                      FStar_Syntax_Util.field_projector_sep in
-                  (match r with
-                   | fst::snd::[] ->
-                       let l =
-                         FStar_Ident.lid_of_path [fst]
-                           t1.FStar_Syntax_Syntax.pos in
-                       let r1 =
-                         FStar_Ident.mk_ident
-                           (snd, (t1.FStar_Syntax_Syntax.pos)) in
-                       FStar_Pervasives_Native.Some (l, r1)
-                   | uu___2 ->
-                       FStar_Compiler_Effect.failwith
-                         "wrong projector format")
-                else FStar_Pervasives_Native.None
-            | uu___2 -> FStar_Pervasives_Native.None in
-          let uu___1 =
-            (let uu___2 = is_projector e in
-             FStar_Pervasives_Native.uu___is_Some uu___2) &&
-              ((FStar_Compiler_List.length args1) = Prims.int_one) in
-          if uu___1
-          then
-            let uu___2 =
-              let uu___3 = is_projector e in
-              FStar_Pervasives_Native.__proj__Some__item__v uu___3 in
-            (match uu___2 with
-             | (uu___3, fi) ->
-                 let arg =
+      | FStar_Syntax_Syntax.Tm_app uu___1 ->
+          let t1 = FStar_Syntax_Util.canon_app t in
+          let uu___2 = t1.FStar_Syntax_Syntax.n in
+          (match uu___2 with
+           | FStar_Syntax_Syntax.Tm_app
+               { FStar_Syntax_Syntax.hd = e;
+                 FStar_Syntax_Syntax.args = args;_}
+               ->
+               let rec last uu___3 =
+                 match uu___3 with
+                 | hd::[] -> [hd]
+                 | hd::tl -> last tl
+                 | uu___4 ->
+                     FStar_Compiler_Effect.failwith "last of an empty list" in
+               let first_two_explicit args1 =
+                 let rec drop_implicits args2 =
+                   match args2 with
+                   | (uu___3, FStar_Pervasives_Native.Some
+                      { FStar_Syntax_Syntax.aqual_implicit = true;
+                        FStar_Syntax_Syntax.aqual_attributes = uu___4;_})::tl
+                       -> drop_implicits tl
+                   | uu___3 -> args2 in
+                 let uu___3 = drop_implicits args1 in
+                 match uu___3 with
+                 | [] ->
+                     FStar_Compiler_Effect.failwith
+                       "not_enough explicit_arguments"
+                 | uu___4::[] ->
+                     FStar_Compiler_Effect.failwith
+                       "not_enough explicit_arguments"
+                 | a1::a2::uu___4 -> [a1; a2] in
+               let resugar_as_app e1 args1 =
+                 let args2 =
+                   FStar_Compiler_List.map
+                     (fun uu___3 ->
+                        match uu___3 with
+                        | (e2, qual) ->
+                            let uu___4 = resugar_term' env e2 in
+                            let uu___5 = resugar_aqual env qual in
+                            (uu___4, uu___5)) args1 in
+                 let uu___3 = resugar_term' env e1 in
+                 match uu___3 with
+                 | {
+                     FStar_Parser_AST.tm = FStar_Parser_AST.Construct
+                       (hd, previous_args);
+                     FStar_Parser_AST.range = r;
+                     FStar_Parser_AST.level = l;_} ->
+                     FStar_Parser_AST.mk_term
+                       (FStar_Parser_AST.Construct
+                          (hd,
+                            (FStar_Compiler_List.op_At previous_args args2)))
+                       r l
+                 | e2 ->
+                     FStar_Compiler_List.fold_left
+                       (fun acc ->
+                          fun uu___4 ->
+                            match uu___4 with
+                            | (x, qual) ->
+                                mk (FStar_Parser_AST.App (acc, x, qual))) e2
+                       args2 in
+               let args1 =
+                 let uu___3 = FStar_Options.print_implicits () in
+                 if uu___3 then args else filter_imp_args args in
+               let is_projector t2 =
+                 let uu___3 =
                    let uu___4 =
-                     let uu___5 = FStar_Compiler_List.hd args1 in
-                     FStar_Pervasives_Native.fst uu___5 in
-                   resugar_term' env uu___4 in
+                     let uu___5 = FStar_Syntax_Subst.compress t2 in
+                     FStar_Syntax_Util.un_uinst uu___5 in
+                   uu___4.FStar_Syntax_Syntax.n in
+                 match uu___3 with
+                 | FStar_Syntax_Syntax.Tm_fvar fv ->
+                     let a =
+                       (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
+                     let length =
+                       let uu___4 =
+                         FStar_Ident.nsstr
+                           (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
+                       FStar_Compiler_String.length uu___4 in
+                     let s =
+                       if length = Prims.int_zero
+                       then FStar_Ident.string_of_lid a
+                       else
+                         (let uu___5 = FStar_Ident.string_of_lid a in
+                          FStar_Compiler_Util.substring_from uu___5
+                            (length + Prims.int_one)) in
+                     if
+                       FStar_Compiler_Util.starts_with s
+                         FStar_Syntax_Util.field_projector_prefix
+                     then
+                       let rest =
+                         FStar_Compiler_Util.substring_from s
+                           (FStar_Compiler_String.length
+                              FStar_Syntax_Util.field_projector_prefix) in
+                       let r =
+                         FStar_Compiler_Util.split rest
+                           FStar_Syntax_Util.field_projector_sep in
+                       (match r with
+                        | fst::snd::[] ->
+                            let l =
+                              FStar_Ident.lid_of_path [fst]
+                                t2.FStar_Syntax_Syntax.pos in
+                            let r1 =
+                              FStar_Ident.mk_ident
+                                (snd, (t2.FStar_Syntax_Syntax.pos)) in
+                            FStar_Pervasives_Native.Some (l, r1)
+                        | uu___4 ->
+                            FStar_Compiler_Effect.failwith
+                              "wrong projector format")
+                     else FStar_Pervasives_Native.None
+                 | uu___4 -> FStar_Pervasives_Native.None in
+               let uu___3 =
+                 (let uu___4 = is_projector e in
+                  FStar_Pervasives_Native.uu___is_Some uu___4) &&
+                   ((FStar_Compiler_List.length args1) = Prims.int_one) in
+               if uu___3
+               then
                  let uu___4 =
-                   let uu___5 =
-                     let uu___6 = FStar_Ident.lid_of_ids [fi] in
-                     (arg, uu___6) in
-                   FStar_Parser_AST.Project uu___5 in
-                 mk uu___4)
-          else
-            (let uu___3 = resugar_term_as_op e in
-             match uu___3 with
-             | FStar_Pervasives_Native.None -> resugar_as_app e args1
-             | FStar_Pervasives_Native.Some ("calc_finish", uu___4) ->
-                 let uu___5 = resugar_calc env t in
-                 (match uu___5 with
-                  | FStar_Pervasives_Native.Some r -> r
-                  | uu___6 -> resugar_as_app e args1)
-             | FStar_Pervasives_Native.Some ("tuple", uu___4) ->
-                 let out =
-                   FStar_Compiler_List.fold_left
-                     (fun out1 ->
-                        fun uu___5 ->
-                          match uu___5 with
-                          | (x, uu___6) ->
-                              let x1 = resugar_term' env x in
-                              (match out1 with
-                               | FStar_Pervasives_Native.None ->
-                                   FStar_Pervasives_Native.Some x1
-                               | FStar_Pervasives_Native.Some prefix ->
-                                   let uu___7 =
-                                     let uu___8 =
+                   let uu___5 = is_projector e in
+                   FStar_Pervasives_Native.__proj__Some__item__v uu___5 in
+                 (match uu___4 with
+                  | (uu___5, fi) ->
+                      let arg =
+                        let uu___6 =
+                          let uu___7 = FStar_Compiler_List.hd args1 in
+                          FStar_Pervasives_Native.fst uu___7 in
+                        resugar_term' env uu___6 in
+                      let uu___6 =
+                        let uu___7 =
+                          let uu___8 = FStar_Ident.lid_of_ids [fi] in
+                          (arg, uu___8) in
+                        FStar_Parser_AST.Project uu___7 in
+                      mk uu___6)
+               else
+                 (let uu___5 = resugar_term_as_op e in
+                  match uu___5 with
+                  | FStar_Pervasives_Native.None -> resugar_as_app e args1
+                  | FStar_Pervasives_Native.Some ("calc_finish", uu___6) ->
+                      let uu___7 = resugar_calc env t1 in
+                      (match uu___7 with
+                       | FStar_Pervasives_Native.Some r -> r
+                       | uu___8 -> resugar_as_app e args1)
+                  | FStar_Pervasives_Native.Some ("tuple", uu___6) ->
+                      let out =
+                        FStar_Compiler_List.fold_left
+                          (fun out1 ->
+                             fun uu___7 ->
+                               match uu___7 with
+                               | (x, uu___8) ->
+                                   let x1 = resugar_term' env x in
+                                   (match out1 with
+                                    | FStar_Pervasives_Native.None ->
+                                        FStar_Pervasives_Native.Some x1
+                                    | FStar_Pervasives_Native.Some prefix ->
+                                        let uu___9 =
+                                          let uu___10 =
+                                            let uu___11 =
+                                              let uu___12 =
+                                                FStar_Ident.id_of_text "*" in
+                                              (uu___12, [prefix; x1]) in
+                                            FStar_Parser_AST.Op uu___11 in
+                                          mk uu___10 in
+                                        FStar_Pervasives_Native.Some uu___9))
+                          FStar_Pervasives_Native.None args1 in
+                      FStar_Compiler_Option.get out
+                  | FStar_Pervasives_Native.Some ("dtuple", uu___6) ->
+                      resugar_as_app e args1
+                  | FStar_Pervasives_Native.Some (ref_read, uu___6) when
+                      let uu___7 =
+                        FStar_Ident.string_of_lid
+                          FStar_Parser_Const.sread_lid in
+                      ref_read = uu___7 ->
+                      let uu___7 = FStar_Compiler_List.hd args1 in
+                      (match uu___7 with
+                       | (t2, uu___8) ->
+                           let uu___9 =
+                             let uu___10 = FStar_Syntax_Subst.compress t2 in
+                             uu___10.FStar_Syntax_Syntax.n in
+                           (match uu___9 with
+                            | FStar_Syntax_Syntax.Tm_fvar fv when
+                                let uu___10 =
+                                  FStar_Ident.string_of_lid
+                                    (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
+                                FStar_Syntax_Util.field_projector_contains_constructor
+                                  uu___10
+                                ->
+                                let f =
+                                  let uu___10 =
+                                    let uu___11 =
+                                      FStar_Ident.string_of_lid
+                                        (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
+                                    [uu___11] in
+                                  FStar_Ident.lid_of_path uu___10
+                                    t2.FStar_Syntax_Syntax.pos in
+                                let uu___10 =
+                                  let uu___11 =
+                                    let uu___12 = resugar_term' env t2 in
+                                    (uu___12, f) in
+                                  FStar_Parser_AST.Project uu___11 in
+                                mk uu___10
+                            | uu___10 -> resugar_term' env t2))
+                  | FStar_Pervasives_Native.Some ("try_with", uu___6) when
+                      (FStar_Compiler_List.length args1) > Prims.int_one ->
+                      (try
+                         (fun uu___7 ->
+                            match () with
+                            | () ->
+                                let new_args = first_two_explicit args1 in
+                                let uu___8 =
+                                  match new_args with
+                                  | (a1, uu___9)::(a2, uu___10)::[] ->
+                                      (a1, a2)
+                                  | uu___9 ->
+                                      FStar_Compiler_Effect.failwith
+                                        "wrong arguments to try_with" in
+                                (match uu___8 with
+                                 | (body, handler) ->
+                                     let decomp term =
                                        let uu___9 =
                                          let uu___10 =
-                                           FStar_Ident.id_of_text "*" in
-                                         (uu___10, [prefix; x1]) in
-                                       FStar_Parser_AST.Op uu___9 in
-                                     mk uu___8 in
-                                   FStar_Pervasives_Native.Some uu___7))
-                     FStar_Pervasives_Native.None args1 in
-                 FStar_Compiler_Option.get out
-             | FStar_Pervasives_Native.Some ("dtuple", uu___4) ->
-                 resugar_as_app e args1
-             | FStar_Pervasives_Native.Some (ref_read, uu___4) when
-                 let uu___5 =
-                   FStar_Ident.string_of_lid FStar_Parser_Const.sread_lid in
-                 ref_read = uu___5 ->
-                 let uu___5 = FStar_Compiler_List.hd args1 in
-                 (match uu___5 with
-                  | (t1, uu___6) ->
-                      let uu___7 =
-                        let uu___8 = FStar_Syntax_Subst.compress t1 in
-                        uu___8.FStar_Syntax_Syntax.n in
-                      (match uu___7 with
-                       | FStar_Syntax_Syntax.Tm_fvar fv when
-                           let uu___8 =
-                             FStar_Ident.string_of_lid
-                               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                           FStar_Syntax_Util.field_projector_contains_constructor
-                             uu___8
-                           ->
-                           let f =
-                             let uu___8 =
-                               let uu___9 =
-                                 FStar_Ident.string_of_lid
-                                   (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                               [uu___9] in
-                             FStar_Ident.lid_of_path uu___8
-                               t1.FStar_Syntax_Syntax.pos in
-                           let uu___8 =
-                             let uu___9 =
-                               let uu___10 = resugar_term' env t1 in
-                               (uu___10, f) in
-                             FStar_Parser_AST.Project uu___9 in
-                           mk uu___8
-                       | uu___8 -> resugar_term' env t1))
-             | FStar_Pervasives_Native.Some ("try_with", uu___4) when
-                 (FStar_Compiler_List.length args1) > Prims.int_one ->
-                 (try
-                    (fun uu___5 ->
-                       match () with
-                       | () ->
-                           let new_args = first_two_explicit args1 in
-                           let uu___6 =
-                             match new_args with
-                             | (a1, uu___7)::(a2, uu___8)::[] -> (a1, a2)
-                             | uu___7 ->
-                                 FStar_Compiler_Effect.failwith
-                                   "wrong arguments to try_with" in
-                           (match uu___6 with
-                            | (body, handler) ->
-                                let decomp term =
-                                  let uu___7 =
-                                    let uu___8 =
-                                      FStar_Syntax_Subst.compress term in
-                                    uu___8.FStar_Syntax_Syntax.n in
-                                  match uu___7 with
-                                  | FStar_Syntax_Syntax.Tm_abs
-                                      { FStar_Syntax_Syntax.bs = x;
-                                        FStar_Syntax_Syntax.body = e1;
-                                        FStar_Syntax_Syntax.rc_opt = uu___8;_}
-                                      ->
-                                      let uu___9 =
-                                        FStar_Syntax_Subst.open_term x e1 in
-                                      (match uu___9 with | (x1, e2) -> e2)
-                                  | uu___8 ->
-                                      let uu___9 =
-                                        let uu___10 =
-                                          let uu___11 =
-                                            resugar_term' env term in
-                                          FStar_Parser_AST.term_to_string
-                                            uu___11 in
-                                        Prims.strcat
-                                          "wrong argument format to try_with: "
-                                          uu___10 in
-                                      FStar_Compiler_Effect.failwith uu___9 in
-                                let body1 =
-                                  let uu___7 = decomp body in
-                                  resugar_term' env uu___7 in
-                                let handler1 =
-                                  let uu___7 = decomp handler in
-                                  resugar_term' env uu___7 in
-                                let rec resugar_body t1 =
-                                  match t1.FStar_Parser_AST.tm with
-                                  | FStar_Parser_AST.Match
-                                      (e1, FStar_Pervasives_Native.None,
-                                       FStar_Pervasives_Native.None,
-                                       (uu___7, uu___8, b)::[])
-                                      -> b
-                                  | FStar_Parser_AST.Let (uu___7, uu___8, b)
-                                      -> b
-                                  | FStar_Parser_AST.Ascribed
-                                      (t11, t2, t3, use_eq) ->
-                                      let uu___7 =
-                                        let uu___8 =
-                                          let uu___9 = resugar_body t11 in
-                                          (uu___9, t2, t3, use_eq) in
-                                        FStar_Parser_AST.Ascribed uu___8 in
-                                      mk uu___7
-                                  | uu___7 ->
-                                      FStar_Compiler_Effect.failwith
-                                        "unexpected body format to try_with" in
-                                let e1 = resugar_body body1 in
-                                let rec resugar_branches t1 =
-                                  match t1.FStar_Parser_AST.tm with
-                                  | FStar_Parser_AST.Match
-                                      (e2, FStar_Pervasives_Native.None,
-                                       FStar_Pervasives_Native.None,
-                                       branches)
-                                      -> branches
-                                  | FStar_Parser_AST.Ascribed
-                                      (t11, t2, t3, uu___7) ->
-                                      resugar_branches t11
-                                  | uu___7 -> [] in
-                                let branches = resugar_branches handler1 in
-                                mk (FStar_Parser_AST.TryWith (e1, branches))))
-                      ()
-                  with | uu___5 -> resugar_as_app e args1)
-             | FStar_Pervasives_Native.Some ("try_with", uu___4) ->
-                 resugar_as_app e args1
-             | FStar_Pervasives_Native.Some (op, uu___4) when
-                 (((((((op = "=") || (op = "==")) || (op = "===")) ||
-                       (op = "@"))
-                      || (op = ":="))
-                     || (op = "|>"))
-                    || (op = "<<"))
-                   && (FStar_Options.print_implicits ())
-                 -> resugar_as_app e args1
-             | FStar_Pervasives_Native.Some (op, uu___4) when
-                 (FStar_Compiler_Util.starts_with op "forall") ||
-                   (FStar_Compiler_Util.starts_with op "exists")
-                 ->
-                 let rec uncurry xs pats t1 flavor_matches =
-                   match t1.FStar_Parser_AST.tm with
-                   | FStar_Parser_AST.QExists (xs', (uu___5, pats'), body)
-                       when flavor_matches t1 ->
-                       uncurry (FStar_Compiler_List.op_At xs xs')
-                         (FStar_Compiler_List.op_At pats pats') body
-                         flavor_matches
-                   | FStar_Parser_AST.QForall (xs', (uu___5, pats'), body)
-                       when flavor_matches t1 ->
-                       uncurry (FStar_Compiler_List.op_At xs xs')
-                         (FStar_Compiler_List.op_At pats pats') body
-                         flavor_matches
-                   | FStar_Parser_AST.QuantOp
-                       (uu___5, xs', (uu___6, pats'), body) when
-                       flavor_matches t1 ->
-                       uncurry (FStar_Compiler_List.op_At xs xs')
-                         (FStar_Compiler_List.op_At pats pats') body
-                         flavor_matches
-                   | uu___5 -> (xs, pats, t1) in
-                 let resugar_forall_body body =
-                   let uu___5 =
-                     let uu___6 = FStar_Syntax_Subst.compress body in
-                     uu___6.FStar_Syntax_Syntax.n in
-                   match uu___5 with
-                   | FStar_Syntax_Syntax.Tm_abs
-                       { FStar_Syntax_Syntax.bs = xs;
-                         FStar_Syntax_Syntax.body = body1;
-                         FStar_Syntax_Syntax.rc_opt = uu___6;_}
-                       ->
-                       let uu___7 = FStar_Syntax_Subst.open_term xs body1 in
-                       (match uu___7 with
-                        | (xs1, body2) ->
-                            let xs2 =
-                              let uu___8 = FStar_Options.print_implicits () in
-                              if uu___8 then xs1 else filter_imp_bs xs1 in
-                            let xs3 =
-                              (map_opt ())
-                                (fun b ->
-                                   resugar_binder' env b
-                                     t.FStar_Syntax_Syntax.pos) xs2 in
-                            let uu___8 =
-                              let uu___9 =
-                                let uu___10 =
-                                  FStar_Syntax_Subst.compress body2 in
-                                uu___10.FStar_Syntax_Syntax.n in
-                              match uu___9 with
-                              | FStar_Syntax_Syntax.Tm_meta
-                                  { FStar_Syntax_Syntax.tm2 = e1;
-                                    FStar_Syntax_Syntax.meta = m;_}
-                                  ->
-                                  let body3 = resugar_term' env e1 in
-                                  let uu___10 =
-                                    match m with
-                                    | FStar_Syntax_Syntax.Meta_pattern
-                                        (uu___11, pats) ->
-                                        let uu___12 =
-                                          FStar_Compiler_List.map
-                                            (fun es ->
+                                           FStar_Syntax_Subst.compress term in
+                                         uu___10.FStar_Syntax_Syntax.n in
+                                       match uu___9 with
+                                       | FStar_Syntax_Syntax.Tm_abs
+                                           { FStar_Syntax_Syntax.bs = x;
+                                             FStar_Syntax_Syntax.body = e1;
+                                             FStar_Syntax_Syntax.rc_opt =
+                                               uu___10;_}
+                                           ->
+                                           let uu___11 =
+                                             FStar_Syntax_Subst.open_term x
+                                               e1 in
+                                           (match uu___11 with
+                                            | (x1, e2) -> e2)
+                                       | uu___10 ->
+                                           let uu___11 =
+                                             let uu___12 =
+                                               let uu___13 =
+                                                 resugar_term' env term in
+                                               FStar_Parser_AST.term_to_string
+                                                 uu___13 in
+                                             Prims.strcat
+                                               "wrong argument format to try_with: "
+                                               uu___12 in
+                                           FStar_Compiler_Effect.failwith
+                                             uu___11 in
+                                     let body1 =
+                                       let uu___9 = decomp body in
+                                       resugar_term' env uu___9 in
+                                     let handler1 =
+                                       let uu___9 = decomp handler in
+                                       resugar_term' env uu___9 in
+                                     let rec resugar_body t2 =
+                                       match t2.FStar_Parser_AST.tm with
+                                       | FStar_Parser_AST.Match
+                                           (e1, FStar_Pervasives_Native.None,
+                                            FStar_Pervasives_Native.None,
+                                            (uu___9, uu___10, b)::[])
+                                           -> b
+                                       | FStar_Parser_AST.Let
+                                           (uu___9, uu___10, b) -> b
+                                       | FStar_Parser_AST.Ascribed
+                                           (t11, t21, t3, use_eq) ->
+                                           let uu___9 =
+                                             let uu___10 =
+                                               let uu___11 = resugar_body t11 in
+                                               (uu___11, t21, t3, use_eq) in
+                                             FStar_Parser_AST.Ascribed
+                                               uu___10 in
+                                           mk uu___9
+                                       | uu___9 ->
+                                           FStar_Compiler_Effect.failwith
+                                             "unexpected body format to try_with" in
+                                     let e1 = resugar_body body1 in
+                                     let rec resugar_branches t2 =
+                                       match t2.FStar_Parser_AST.tm with
+                                       | FStar_Parser_AST.Match
+                                           (e2, FStar_Pervasives_Native.None,
+                                            FStar_Pervasives_Native.None,
+                                            branches)
+                                           -> branches
+                                       | FStar_Parser_AST.Ascribed
+                                           (t11, t21, t3, uu___9) ->
+                                           resugar_branches t11
+                                       | uu___9 -> [] in
+                                     let branches = resugar_branches handler1 in
+                                     mk
+                                       (FStar_Parser_AST.TryWith
+                                          (e1, branches)))) ()
+                       with | uu___7 -> resugar_as_app e args1)
+                  | FStar_Pervasives_Native.Some ("try_with", uu___6) ->
+                      resugar_as_app e args1
+                  | FStar_Pervasives_Native.Some (op, uu___6) when
+                      (((((((op = "=") || (op = "==")) || (op = "===")) ||
+                            (op = "@"))
+                           || (op = ":="))
+                          || (op = "|>"))
+                         || (op = "<<"))
+                        && (FStar_Options.print_implicits ())
+                      -> resugar_as_app e args1
+                  | FStar_Pervasives_Native.Some (op, uu___6) when
+                      (FStar_Compiler_Util.starts_with op "forall") ||
+                        (FStar_Compiler_Util.starts_with op "exists")
+                      ->
+                      let rec uncurry xs pats t2 flavor_matches =
+                        match t2.FStar_Parser_AST.tm with
+                        | FStar_Parser_AST.QExists
+                            (xs', (uu___7, pats'), body) when
+                            flavor_matches t2 ->
+                            uncurry (FStar_Compiler_List.op_At xs xs')
+                              (FStar_Compiler_List.op_At pats pats') body
+                              flavor_matches
+                        | FStar_Parser_AST.QForall
+                            (xs', (uu___7, pats'), body) when
+                            flavor_matches t2 ->
+                            uncurry (FStar_Compiler_List.op_At xs xs')
+                              (FStar_Compiler_List.op_At pats pats') body
+                              flavor_matches
+                        | FStar_Parser_AST.QuantOp
+                            (uu___7, xs', (uu___8, pats'), body) when
+                            flavor_matches t2 ->
+                            uncurry (FStar_Compiler_List.op_At xs xs')
+                              (FStar_Compiler_List.op_At pats pats') body
+                              flavor_matches
+                        | uu___7 -> (xs, pats, t2) in
+                      let resugar_forall_body body =
+                        let uu___7 =
+                          let uu___8 = FStar_Syntax_Subst.compress body in
+                          uu___8.FStar_Syntax_Syntax.n in
+                        match uu___7 with
+                        | FStar_Syntax_Syntax.Tm_abs
+                            { FStar_Syntax_Syntax.bs = xs;
+                              FStar_Syntax_Syntax.body = body1;
+                              FStar_Syntax_Syntax.rc_opt = uu___8;_}
+                            ->
+                            let uu___9 =
+                              FStar_Syntax_Subst.open_term xs body1 in
+                            (match uu___9 with
+                             | (xs1, body2) ->
+                                 let xs2 =
+                                   let uu___10 =
+                                     FStar_Options.print_implicits () in
+                                   if uu___10 then xs1 else filter_imp_bs xs1 in
+                                 let xs3 =
+                                   (map_opt ())
+                                     (fun b ->
+                                        resugar_binder' env b
+                                          t1.FStar_Syntax_Syntax.pos) xs2 in
+                                 let uu___10 =
+                                   let uu___11 =
+                                     let uu___12 =
+                                       FStar_Syntax_Subst.compress body2 in
+                                     uu___12.FStar_Syntax_Syntax.n in
+                                   match uu___11 with
+                                   | FStar_Syntax_Syntax.Tm_meta
+                                       { FStar_Syntax_Syntax.tm2 = e1;
+                                         FStar_Syntax_Syntax.meta = m;_}
+                                       ->
+                                       let body3 = resugar_term' env e1 in
+                                       let uu___12 =
+                                         match m with
+                                         | FStar_Syntax_Syntax.Meta_pattern
+                                             (uu___13, pats) ->
+                                             let uu___14 =
                                                FStar_Compiler_List.map
-                                                 (fun uu___13 ->
-                                                    match uu___13 with
-                                                    | (e2, uu___14) ->
-                                                        resugar_term' env e2)
-                                                 es) pats in
-                                        (uu___12, body3)
-                                    | FStar_Syntax_Syntax.Meta_labeled
-                                        (s, r, p) ->
-                                        let uu___11 =
-                                          let uu___12 =
-                                            let uu___13 =
-                                              let uu___14 =
-                                                FStar_Errors_Msg.rendermsg s in
-                                              (body3, uu___14, p) in
-                                            FStar_Parser_AST.Labeled uu___13 in
-                                          mk uu___12 in
-                                        ([], uu___11)
-                                    | uu___11 ->
-                                        FStar_Compiler_Effect.failwith
-                                          "wrong pattern format for QForall/QExists" in
-                                  (match uu___10 with
-                                   | (pats, body4) -> (pats, body4))
-                              | uu___10 ->
-                                  let uu___11 = resugar_term' env body2 in
-                                  ([], uu___11) in
-                            (match uu___8 with
-                             | (pats, body3) ->
-                                 let decompile_op op1 =
-                                   let uu___9 =
-                                     FStar_Parser_AST.string_to_op op1 in
-                                   match uu___9 with
-                                   | FStar_Pervasives_Native.None -> op1
-                                   | FStar_Pervasives_Native.Some
-                                       (op2, uu___10) -> op2 in
-                                 let flavor_matches t1 =
-                                   match ((t1.FStar_Parser_AST.tm), op) with
-                                   | (FStar_Parser_AST.QExists uu___9,
-                                      "exists") -> true
-                                   | (FStar_Parser_AST.QForall uu___9,
-                                      "forall") -> true
-                                   | (FStar_Parser_AST.QuantOp
-                                      (id, uu___9, uu___10, uu___11),
-                                      uu___12) ->
-                                       let uu___13 =
-                                         FStar_Ident.string_of_id id in
-                                       uu___13 = op
-                                   | uu___9 -> false in
-                                 let uu___9 =
-                                   uncurry xs3 pats body3 flavor_matches in
-                                 (match uu___9 with
-                                  | (xs4, pats1, body4) ->
-                                      let binders =
-                                        FStar_Parser_AST.idents_of_binders
-                                          xs4 t.FStar_Syntax_Syntax.pos in
-                                      if op = "forall"
-                                      then
-                                        mk
-                                          (FStar_Parser_AST.QForall
-                                             (xs4, (binders, pats1), body4))
-                                      else
-                                        if op = "exists"
-                                        then
-                                          mk
-                                            (FStar_Parser_AST.QExists
-                                               (xs4, (binders, pats1), body4))
-                                        else
-                                          (let uu___12 =
+                                                 (fun es ->
+                                                    FStar_Compiler_List.map
+                                                      (fun uu___15 ->
+                                                         match uu___15 with
+                                                         | (e2, uu___16) ->
+                                                             resugar_term'
+                                                               env e2) es)
+                                                 pats in
+                                             (uu___14, body3)
+                                         | FStar_Syntax_Syntax.Meta_labeled
+                                             (s, r, p) ->
                                              let uu___13 =
                                                let uu___14 =
-                                                 FStar_Ident.id_of_text op in
-                                               (uu___14, xs4,
-                                                 (binders, pats1), body4) in
-                                             FStar_Parser_AST.QuantOp uu___13 in
-                                           mk uu___12))))
-                   | uu___6 ->
-                       if op = "forall"
-                       then
-                         let uu___7 =
-                           let uu___8 =
-                             let uu___9 = resugar_term' env body in
-                             ([], ([], []), uu___9) in
-                           FStar_Parser_AST.QForall uu___8 in
-                         mk uu___7
-                       else
-                         (let uu___8 =
-                            let uu___9 =
-                              let uu___10 = resugar_term' env body in
-                              ([], ([], []), uu___10) in
-                            FStar_Parser_AST.QExists uu___9 in
-                          mk uu___8) in
-                 if (FStar_Compiler_List.length args1) > Prims.int_zero
-                 then
-                   let args2 = last args1 in
-                   (match args2 with
-                    | (b, uu___5)::[] -> resugar_forall_body b
-                    | uu___5 ->
-                        FStar_Compiler_Effect.failwith
-                          "wrong args format to QForall")
-                 else resugar_as_app e args1
-             | FStar_Pervasives_Native.Some ("alloc", uu___4) ->
-                 let uu___5 = FStar_Compiler_List.hd args1 in
-                 (match uu___5 with | (e1, uu___6) -> resugar_term' env e1)
-             | FStar_Pervasives_Native.Some (op, expected_arity1) ->
-                 let op1 = FStar_Ident.id_of_text op in
-                 let resugar args2 =
-                   FStar_Compiler_List.map
-                     (fun uu___4 ->
-                        match uu___4 with
-                        | (e1, qual) ->
-                            let uu___5 = resugar_term' env e1 in
-                            let uu___6 = resugar_aqual env qual in
-                            (uu___5, uu___6)) args2 in
-                 (match expected_arity1 with
-                  | FStar_Pervasives_Native.None ->
-                      let resugared_args = resugar args1 in
-                      let expect_n =
-                        FStar_Parser_ToDocument.handleable_args_length op1 in
-                      if
-                        (FStar_Compiler_List.length resugared_args) >=
-                          expect_n
+                                                 let uu___15 =
+                                                   let uu___16 =
+                                                     FStar_Errors_Msg.rendermsg
+                                                       s in
+                                                   (body3, uu___16, p) in
+                                                 FStar_Parser_AST.Labeled
+                                                   uu___15 in
+                                               mk uu___14 in
+                                             ([], uu___13)
+                                         | uu___13 ->
+                                             FStar_Compiler_Effect.failwith
+                                               "wrong pattern format for QForall/QExists" in
+                                       (match uu___12 with
+                                        | (pats, body4) -> (pats, body4))
+                                   | uu___12 ->
+                                       let uu___13 = resugar_term' env body2 in
+                                       ([], uu___13) in
+                                 (match uu___10 with
+                                  | (pats, body3) ->
+                                      let decompile_op op1 =
+                                        let uu___11 =
+                                          FStar_Parser_AST.string_to_op op1 in
+                                        match uu___11 with
+                                        | FStar_Pervasives_Native.None -> op1
+                                        | FStar_Pervasives_Native.Some
+                                            (op2, uu___12) -> op2 in
+                                      let flavor_matches t2 =
+                                        match ((t2.FStar_Parser_AST.tm), op)
+                                        with
+                                        | (FStar_Parser_AST.QExists uu___11,
+                                           "exists") -> true
+                                        | (FStar_Parser_AST.QForall uu___11,
+                                           "forall") -> true
+                                        | (FStar_Parser_AST.QuantOp
+                                           (id, uu___11, uu___12, uu___13),
+                                           uu___14) ->
+                                            let uu___15 =
+                                              FStar_Ident.string_of_id id in
+                                            uu___15 = op
+                                        | uu___11 -> false in
+                                      let uu___11 =
+                                        uncurry xs3 pats body3 flavor_matches in
+                                      (match uu___11 with
+                                       | (xs4, pats1, body4) ->
+                                           let binders =
+                                             FStar_Parser_AST.idents_of_binders
+                                               xs4 t1.FStar_Syntax_Syntax.pos in
+                                           if op = "forall"
+                                           then
+                                             mk
+                                               (FStar_Parser_AST.QForall
+                                                  (xs4, (binders, pats1),
+                                                    body4))
+                                           else
+                                             if op = "exists"
+                                             then
+                                               mk
+                                                 (FStar_Parser_AST.QExists
+                                                    (xs4, (binders, pats1),
+                                                      body4))
+                                             else
+                                               (let uu___14 =
+                                                  let uu___15 =
+                                                    let uu___16 =
+                                                      FStar_Ident.id_of_text
+                                                        op in
+                                                    (uu___16, xs4,
+                                                      (binders, pats1),
+                                                      body4) in
+                                                  FStar_Parser_AST.QuantOp
+                                                    uu___15 in
+                                                mk uu___14))))
+                        | uu___8 ->
+                            if op = "forall"
+                            then
+                              let uu___9 =
+                                let uu___10 =
+                                  let uu___11 = resugar_term' env body in
+                                  ([], ([], []), uu___11) in
+                                FStar_Parser_AST.QForall uu___10 in
+                              mk uu___9
+                            else
+                              (let uu___10 =
+                                 let uu___11 =
+                                   let uu___12 = resugar_term' env body in
+                                   ([], ([], []), uu___12) in
+                                 FStar_Parser_AST.QExists uu___11 in
+                               mk uu___10) in
+                      if (FStar_Compiler_List.length args1) > Prims.int_zero
                       then
-                        let uu___4 =
-                          FStar_Compiler_Util.first_N expect_n resugared_args in
-                        (match uu___4 with
-                         | (op_args, rest) ->
-                             let head =
-                               let uu___5 =
-                                 let uu___6 =
-                                   let uu___7 =
-                                     FStar_Compiler_List.map
-                                       FStar_Pervasives_Native.fst op_args in
-                                   (op1, uu___7) in
-                                 FStar_Parser_AST.Op uu___6 in
-                               mk uu___5 in
-                             FStar_Compiler_List.fold_left
-                               (fun head1 ->
-                                  fun uu___5 ->
-                                    match uu___5 with
-                                    | (arg, qual) ->
-                                        mk
-                                          (FStar_Parser_AST.App
-                                             (head1, arg, qual))) head rest)
+                        let args2 = last args1 in
+                        (match args2 with
+                         | (b, uu___7)::[] -> resugar_forall_body b
+                         | uu___7 ->
+                             FStar_Compiler_Effect.failwith
+                               "wrong args format to QForall")
                       else resugar_as_app e args1
-                  | FStar_Pervasives_Native.Some n when
-                      (FStar_Compiler_List.length args1) = n ->
-                      let uu___4 =
-                        let uu___5 =
-                          let uu___6 =
-                            let uu___7 = resugar args1 in
-                            FStar_Compiler_List.map
-                              FStar_Pervasives_Native.fst uu___7 in
-                          (op1, uu___6) in
-                        FStar_Parser_AST.Op uu___5 in
-                      mk uu___4
-                  | uu___4 -> resugar_as_app e args1))
+                  | FStar_Pervasives_Native.Some ("alloc", uu___6) ->
+                      let uu___7 = FStar_Compiler_List.hd args1 in
+                      (match uu___7 with
+                       | (e1, uu___8) -> resugar_term' env e1)
+                  | FStar_Pervasives_Native.Some (op, expected_arity1) ->
+                      let op1 = FStar_Ident.id_of_text op in
+                      let resugar args2 =
+                        FStar_Compiler_List.map
+                          (fun uu___6 ->
+                             match uu___6 with
+                             | (e1, qual) ->
+                                 let uu___7 = resugar_term' env e1 in
+                                 let uu___8 = resugar_aqual env qual in
+                                 (uu___7, uu___8)) args2 in
+                      (match expected_arity1 with
+                       | FStar_Pervasives_Native.None ->
+                           let resugared_args = resugar args1 in
+                           let expect_n =
+                             FStar_Parser_ToDocument.handleable_args_length
+                               op1 in
+                           if
+                             (FStar_Compiler_List.length resugared_args) >=
+                               expect_n
+                           then
+                             let uu___6 =
+                               FStar_Compiler_Util.first_N expect_n
+                                 resugared_args in
+                             (match uu___6 with
+                              | (op_args, rest) ->
+                                  let head =
+                                    let uu___7 =
+                                      let uu___8 =
+                                        let uu___9 =
+                                          FStar_Compiler_List.map
+                                            FStar_Pervasives_Native.fst
+                                            op_args in
+                                        (op1, uu___9) in
+                                      FStar_Parser_AST.Op uu___8 in
+                                    mk uu___7 in
+                                  FStar_Compiler_List.fold_left
+                                    (fun head1 ->
+                                       fun uu___7 ->
+                                         match uu___7 with
+                                         | (arg, qual) ->
+                                             mk
+                                               (FStar_Parser_AST.App
+                                                  (head1, arg, qual))) head
+                                    rest)
+                           else resugar_as_app e args1
+                       | FStar_Pervasives_Native.Some n when
+                           (FStar_Compiler_List.length args1) = n ->
+                           let uu___6 =
+                             let uu___7 =
+                               let uu___8 =
+                                 let uu___9 = resugar args1 in
+                                 FStar_Compiler_List.map
+                                   FStar_Pervasives_Native.fst uu___9 in
+                               (op1, uu___8) in
+                             FStar_Parser_AST.Op uu___7 in
+                           mk uu___6
+                       | uu___6 -> resugar_as_app e args1)))
       | FStar_Syntax_Syntax.Tm_match
           { FStar_Syntax_Syntax.scrutinee = e;
             FStar_Syntax_Syntax.ret_opt = FStar_Pervasives_Native.None;

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Typeclasses.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Typeclasses.ml
@@ -1302,19 +1302,75 @@ let (global :
                                               (FStar_Tactics_NamedView.Tv_FVar
                                                  fv)) typ k)) uu___3)) 
                        st.glb)) uu___1)
+exception Next 
+let (uu___is_Next : Prims.exn -> Prims.bool) =
+  fun projectee -> match projectee with | Next -> true | uu___ -> false
+let (try_trivial :
+  st_t ->
+    tc_goal ->
+      (st_t -> (unit, unit) FStar_Tactics_Effect.tac_repr) ->
+        unit -> (unit, unit) FStar_Tactics_Effect.tac_repr)
+  =
+  fun st ->
+    fun g ->
+      fun k ->
+        fun uu___ ->
+          FStar_Tactics_Effect.tac_bind
+            (FStar_Sealed.seal
+               (Obj.magic
+                  (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
+                     (Prims.of_int (224)) (Prims.of_int (8))
+                     (Prims.of_int (224)) (Prims.of_int (11)))))
+            (FStar_Sealed.seal
+               (Obj.magic
+                  (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
+                     (Prims.of_int (224)) (Prims.of_int (2))
+                     (Prims.of_int (229)) (Prims.of_int (19)))))
+            (Obj.magic (FStar_Tactics_NamedView.inspect g.g))
+            (fun uu___1 ->
+               (fun uu___1 ->
+                  match uu___1 with
+                  | FStar_Tactics_NamedView.Tv_FVar fv ->
+                      Obj.magic
+                        (Obj.repr
+                           (if
+                              (FStar_Reflection_V2_Builtins.implode_qn
+                                 (FStar_Reflection_V2_Builtins.inspect_fv fv))
+                                = "Prims.unit"
+                            then
+                              Obj.repr
+                                (FStar_Tactics_V2_Derived.exact
+                                   (FStar_Reflection_V2_Builtins.pack_ln
+                                      (FStar_Reflection_V2_Data.Tv_Const
+                                         FStar_Reflection_V2_Data.C_Unit)))
+                            else Obj.repr (FStar_Tactics_Effect.raise Next)))
+                  | uu___2 ->
+                      Obj.magic (Obj.repr (FStar_Tactics_Effect.raise Next)))
+                 uu___1)
+let op_Less_Bar_Greater :
+  'a .
+    (unit -> ('a, unit) FStar_Tactics_Effect.tac_repr) ->
+      (unit -> ('a, unit) FStar_Tactics_Effect.tac_repr) ->
+        unit -> ('a, unit) FStar_Tactics_Effect.tac_repr
+  =
+  fun t1 ->
+    fun t2 ->
+      fun uu___ ->
+        FStar_Tactics_V2_Derived.try_with
+          (fun uu___1 -> match () with | () -> t1 ()) (fun uu___1 -> t2 ())
 let rec (tcresolve' : st_t -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
   fun st ->
     FStar_Tactics_Effect.tac_bind
       (FStar_Sealed.seal
          (Obj.magic
             (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-               (Prims.of_int (228)) (Prims.of_int (4)) (Prims.of_int (229))
+               (Prims.of_int (241)) (Prims.of_int (4)) (Prims.of_int (242))
                (Prims.of_int (18)))))
       (FStar_Sealed.seal
          (Obj.magic
             (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-               (Prims.of_int (230)) (Prims.of_int (4)) (Prims.of_int (257))
-               (Prims.of_int (60)))))
+               (Prims.of_int (243)) (Prims.of_int (4)) (Prims.of_int (272))
+               (Prims.of_int (33)))))
       (if st.fuel <= Prims.int_zero
        then FStar_Tactics_Effect.raise NoInst
        else FStar_Tactics_Effect.lift_div_tac (fun uu___1 -> ()))
@@ -1325,13 +1381,13 @@ let rec (tcresolve' : st_t -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                  (FStar_Sealed.seal
                     (Obj.magic
                        (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-                          (Prims.of_int (230)) (Prims.of_int (4))
-                          (Prims.of_int (230)) (Prims.of_int (55)))))
+                          (Prims.of_int (243)) (Prims.of_int (4))
+                          (Prims.of_int (243)) (Prims.of_int (55)))))
                  (FStar_Sealed.seal
                     (Obj.magic
                        (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-                          (Prims.of_int (232)) (Prims.of_int (4))
-                          (Prims.of_int (257)) (Prims.of_int (60)))))
+                          (Prims.of_int (245)) (Prims.of_int (4))
+                          (Prims.of_int (272)) (Prims.of_int (33)))))
                  (Obj.magic
                     (debug
                        (fun uu___1 ->
@@ -1350,14 +1406,14 @@ let rec (tcresolve' : st_t -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                (Obj.magic
                                   (FStar_Range.mk_range
                                      "FStar.Tactics.Typeclasses.fst"
-                                     (Prims.of_int (232)) (Prims.of_int (4))
-                                     (Prims.of_int (232)) (Prims.of_int (18)))))
+                                     (Prims.of_int (245)) (Prims.of_int (4))
+                                     (Prims.of_int (245)) (Prims.of_int (18)))))
                             (FStar_Sealed.seal
                                (Obj.magic
                                   (FStar_Range.mk_range
                                      "FStar.Tactics.Typeclasses.fst"
-                                     (Prims.of_int (232)) (Prims.of_int (19))
-                                     (Prims.of_int (257)) (Prims.of_int (60)))))
+                                     (Prims.of_int (245)) (Prims.of_int (19))
+                                     (Prims.of_int (272)) (Prims.of_int (33)))))
                             (Obj.magic (maybe_intros ()))
                             (fun uu___2 ->
                                (fun uu___2 ->
@@ -1367,18 +1423,18 @@ let rec (tcresolve' : st_t -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                           (Obj.magic
                                              (FStar_Range.mk_range
                                                 "FStar.Tactics.Typeclasses.fst"
-                                                (Prims.of_int (233))
+                                                (Prims.of_int (246))
                                                 (Prims.of_int (12))
-                                                (Prims.of_int (233))
+                                                (Prims.of_int (246))
                                                 (Prims.of_int (23)))))
                                        (FStar_Sealed.seal
                                           (Obj.magic
                                              (FStar_Range.mk_range
                                                 "FStar.Tactics.Typeclasses.fst"
-                                                (Prims.of_int (236))
+                                                (Prims.of_int (249))
                                                 (Prims.of_int (4))
-                                                (Prims.of_int (257))
-                                                (Prims.of_int (60)))))
+                                                (Prims.of_int (272))
+                                                (Prims.of_int (33)))))
                                        (Obj.magic
                                           (FStar_Tactics_V2_Derived.cur_goal
                                              ()))
@@ -1390,18 +1446,18 @@ let rec (tcresolve' : st_t -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                      (Obj.magic
                                                         (FStar_Range.mk_range
                                                            "FStar.Tactics.Typeclasses.fst"
-                                                           (Prims.of_int (236))
+                                                           (Prims.of_int (249))
                                                            (Prims.of_int (4))
-                                                           (Prims.of_int (239))
+                                                           (Prims.of_int (252))
                                                            (Prims.of_int (5)))))
                                                   (FStar_Sealed.seal
                                                      (Obj.magic
                                                         (FStar_Range.mk_range
                                                            "FStar.Tactics.Typeclasses.fst"
-                                                           (Prims.of_int (241))
+                                                           (Prims.of_int (254))
                                                            (Prims.of_int (4))
-                                                           (Prims.of_int (257))
-                                                           (Prims.of_int (60)))))
+                                                           (Prims.of_int (272))
+                                                           (Prims.of_int (33)))))
                                                   (if
                                                      FStar_List_Tot_Base.existsb
                                                        (FStar_Reflection_V2_TermEq.term_eq
@@ -1414,17 +1470,17 @@ let rec (tcresolve' : st_t -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                                 (Obj.magic
                                                                    (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (237))
+                                                                    (Prims.of_int (250))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (237))
+                                                                    (Prims.of_int (250))
                                                                     (Prims.of_int (30)))))
                                                              (FStar_Sealed.seal
                                                                 (Obj.magic
                                                                    (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (238))
+                                                                    (Prims.of_int (251))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (238))
+                                                                    (Prims.of_int (251))
                                                                     (Prims.of_int (18)))))
                                                              (Obj.magic
                                                                 (debug
@@ -1455,18 +1511,18 @@ let rec (tcresolve' : st_t -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                                 (Obj.magic
                                                                    (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (241))
+                                                                    (Prims.of_int (254))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (241))
+                                                                    (Prims.of_int (254))
                                                                     (Prims.of_int (15)))))
                                                              (FStar_Sealed.seal
                                                                 (Obj.magic
                                                                    (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (241))
+                                                                    (Prims.of_int (254))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (257))
-                                                                    (Prims.of_int (60)))))
+                                                                    (Prims.of_int (272))
+                                                                    (Prims.of_int (33)))))
                                                              (Obj.magic
                                                                 (hua g))
                                                              (fun uu___4 ->
@@ -1483,17 +1539,17 @@ let rec (tcresolve' : st_t -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (243))
+                                                                    (Prims.of_int (256))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (243))
+                                                                    (Prims.of_int (256))
                                                                     (Prims.of_int (61)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (244))
+                                                                    (Prims.of_int (257))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (244))
+                                                                    (Prims.of_int (257))
                                                                     (Prims.of_int (18)))))
                                                                     (Obj.magic
                                                                     (debug
@@ -1522,35 +1578,35 @@ let rec (tcresolve' : st_t -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (248))
+                                                                    (Prims.of_int (261))
                                                                     (Prims.of_int (17))
-                                                                    (Prims.of_int (248))
+                                                                    (Prims.of_int (261))
                                                                     (Prims.of_int (61)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (248))
+                                                                    (Prims.of_int (261))
                                                                     (Prims.of_int (64))
-                                                                    (Prims.of_int (257))
-                                                                    (Prims.of_int (60)))))
+                                                                    (Prims.of_int (272))
+                                                                    (Prims.of_int (33)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (248))
+                                                                    (Prims.of_int (261))
                                                                     (Prims.of_int (28))
-                                                                    (Prims.of_int (248))
+                                                                    (Prims.of_int (261))
                                                                     (Prims.of_int (40)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (248))
+                                                                    (Prims.of_int (261))
                                                                     (Prims.of_int (17))
-                                                                    (Prims.of_int (248))
+                                                                    (Prims.of_int (261))
                                                                     (Prims.of_int (61)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Derived.cur_env
@@ -1574,18 +1630,18 @@ let rec (tcresolve' : st_t -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (249))
+                                                                    (Prims.of_int (262))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (251))
+                                                                    (Prims.of_int (264))
                                                                     (Prims.of_int (39)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (252))
+                                                                    (Prims.of_int (265))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (257))
-                                                                    (Prims.of_int (60)))))
+                                                                    (Prims.of_int (272))
+                                                                    (Prims.of_int (33)))))
                                                                     (match c_se
                                                                     with
                                                                     | 
@@ -1615,18 +1671,18 @@ let rec (tcresolve' : st_t -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (254))
+                                                                    (Prims.of_int (267))
                                                                     (Prims.of_int (27))
-                                                                    (Prims.of_int (254))
+                                                                    (Prims.of_int (267))
                                                                     (Prims.of_int (89)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (254))
+                                                                    (Prims.of_int (267))
                                                                     (Prims.of_int (92))
-                                                                    (Prims.of_int (257))
-                                                                    (Prims.of_int (60)))))
+                                                                    (Prims.of_int (272))
+                                                                    (Prims.of_int (33)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Util.map
                                                                     (fun
@@ -1640,17 +1696,17 @@ let rec (tcresolve' : st_t -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (254))
+                                                                    (Prims.of_int (267))
                                                                     (Prims.of_int (67))
-                                                                    (Prims.of_int (254))
+                                                                    (Prims.of_int (267))
                                                                     (Prims.of_int (88)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (254))
+                                                                    (Prims.of_int (267))
                                                                     (Prims.of_int (59))
-                                                                    (Prims.of_int (254))
+                                                                    (Prims.of_int (267))
                                                                     (Prims.of_int (88)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1658,17 +1714,17 @@ let rec (tcresolve' : st_t -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (254))
+                                                                    (Prims.of_int (267))
                                                                     (Prims.of_int (73))
-                                                                    (Prims.of_int (254))
+                                                                    (Prims.of_int (267))
                                                                     (Prims.of_int (88)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (254))
+                                                                    (Prims.of_int (267))
                                                                     (Prims.of_int (67))
-                                                                    (Prims.of_int (254))
+                                                                    (Prims.of_int (267))
                                                                     (Prims.of_int (88)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Builtins.free_uvars
@@ -1699,18 +1755,18 @@ let rec (tcresolve' : st_t -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (255))
+                                                                    (Prims.of_int (268))
                                                                     (Prims.of_int (17))
-                                                                    (Prims.of_int (255))
+                                                                    (Prims.of_int (268))
                                                                     (Prims.of_int (44)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (255))
+                                                                    (Prims.of_int (268))
                                                                     (Prims.of_int (49))
-                                                                    (Prims.of_int (257))
-                                                                    (Prims.of_int (60)))))
+                                                                    (Prims.of_int (272))
+                                                                    (Prims.of_int (33)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
                                                                     uu___5 ->
@@ -1733,18 +1789,18 @@ let rec (tcresolve' : st_t -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (256))
+                                                                    (Prims.of_int (269))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (256))
+                                                                    (Prims.of_int (269))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (257))
+                                                                    (Prims.of_int (270))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (257))
-                                                                    (Prims.of_int (60)))))
+                                                                    (Prims.of_int (272))
+                                                                    (Prims.of_int (33)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
                                                                     uu___5 ->
@@ -1760,13 +1816,18 @@ let rec (tcresolve' : st_t -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                                     (fun g1
                                                                     ->
                                                                     Obj.magic
-                                                                    (FStar_Tactics_V2_Derived.or_else
-                                                                    (local
+                                                                    (op_Less_Bar_Greater
+                                                                    (op_Less_Bar_Greater
+                                                                    (try_trivial
                                                                     st1 g1
                                                                     tcresolve')
+                                                                    (local
+                                                                    st1 g1
+                                                                    tcresolve'))
                                                                     (global
                                                                     st1 g1
-                                                                    tcresolve')))
+                                                                    tcresolve')
+                                                                    ()))
                                                                     uu___5)))
                                                                     uu___5)))
                                                                     uu___5)))
@@ -1797,14 +1858,14 @@ let rec concatMap :
                           (Obj.magic
                              (FStar_Range.mk_range
                                 "FStar.Tactics.Typeclasses.fst"
-                                (Prims.of_int (262)) (Prims.of_int (13))
-                                (Prims.of_int (262)) (Prims.of_int (16)))))
+                                (Prims.of_int (277)) (Prims.of_int (13))
+                                (Prims.of_int (277)) (Prims.of_int (16)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range
                                 "FStar.Tactics.Typeclasses.fst"
-                                (Prims.of_int (262)) (Prims.of_int (13))
-                                (Prims.of_int (262)) (Prims.of_int (33)))))
+                                (Prims.of_int (277)) (Prims.of_int (13))
+                                (Prims.of_int (277)) (Prims.of_int (33)))))
                        (Obj.magic (f x))
                        (fun uu___ ->
                           (fun uu___ ->
@@ -1814,17 +1875,17 @@ let rec concatMap :
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "FStar.Tactics.Typeclasses.fst"
-                                           (Prims.of_int (262))
+                                           (Prims.of_int (277))
                                            (Prims.of_int (19))
-                                           (Prims.of_int (262))
+                                           (Prims.of_int (277))
                                            (Prims.of_int (33)))))
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range
                                            "FStar.Tactics.Typeclasses.fst"
-                                           (Prims.of_int (262))
+                                           (Prims.of_int (277))
                                            (Prims.of_int (13))
-                                           (Prims.of_int (262))
+                                           (Prims.of_int (277))
                                            (Prims.of_int (33)))))
                                   (Obj.magic (concatMap f xs))
                                   (fun uu___1 ->
@@ -1837,12 +1898,12 @@ let (tcresolve : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
       (FStar_Sealed.seal
          (Obj.magic
             (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-               (Prims.of_int (267)) (Prims.of_int (4)) (Prims.of_int (267))
+               (Prims.of_int (282)) (Prims.of_int (4)) (Prims.of_int (282))
                (Prims.of_int (54)))))
       (FStar_Sealed.seal
          (Obj.magic
             (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-               (Prims.of_int (267)) (Prims.of_int (55)) (Prims.of_int (300))
+               (Prims.of_int (282)) (Prims.of_int (55)) (Prims.of_int (315))
                (Prims.of_int (18)))))
       (Obj.magic
          (debug
@@ -1851,13 +1912,13 @@ let (tcresolve : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                  (FStar_Sealed.seal
                     (Obj.magic
                        (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-                          (Prims.of_int (267)) (Prims.of_int (21))
-                          (Prims.of_int (267)) (Prims.of_int (28)))))
+                          (Prims.of_int (282)) (Prims.of_int (21))
+                          (Prims.of_int (282)) (Prims.of_int (28)))))
                  (FStar_Sealed.seal
                     (Obj.magic
                        (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-                          (Prims.of_int (267)) (Prims.of_int (30))
-                          (Prims.of_int (267)) (Prims.of_int (53)))))
+                          (Prims.of_int (282)) (Prims.of_int (30))
+                          (Prims.of_int (282)) (Prims.of_int (53)))))
                  (Obj.magic (FStar_Tactics_V2_Builtins.dump ""))
                  (fun uu___2 ->
                     FStar_Tactics_Effect.lift_div_tac
@@ -1869,13 +1930,13 @@ let (tcresolve : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                  (FStar_Sealed.seal
                     (Obj.magic
                        (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-                          (Prims.of_int (268)) (Prims.of_int (12))
-                          (Prims.of_int (268)) (Prims.of_int (26)))))
+                          (Prims.of_int (283)) (Prims.of_int (12))
+                          (Prims.of_int (283)) (Prims.of_int (26)))))
                  (FStar_Sealed.seal
                     (Obj.magic
                        (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-                          (Prims.of_int (269)) (Prims.of_int (4))
-                          (Prims.of_int (300)) (Prims.of_int (18)))))
+                          (Prims.of_int (284)) (Prims.of_int (4))
+                          (Prims.of_int (315)) (Prims.of_int (18)))))
                  (Obj.magic (FStar_Tactics_V2_Derived.cur_witness ()))
                  (fun uu___2 ->
                     (fun w ->
@@ -1885,14 +1946,14 @@ let (tcresolve : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                (Obj.magic
                                   (FStar_Range.mk_range
                                      "FStar.Tactics.Typeclasses.fst"
-                                     (Prims.of_int (269)) (Prims.of_int (4))
-                                     (Prims.of_int (269)) (Prims.of_int (29)))))
+                                     (Prims.of_int (284)) (Prims.of_int (4))
+                                     (Prims.of_int (284)) (Prims.of_int (29)))))
                             (FStar_Sealed.seal
                                (Obj.magic
                                   (FStar_Range.mk_range
                                      "FStar.Tactics.Typeclasses.fst"
-                                     (Prims.of_int (272)) (Prims.of_int (4))
-                                     (Prims.of_int (300)) (Prims.of_int (18)))))
+                                     (Prims.of_int (287)) (Prims.of_int (4))
+                                     (Prims.of_int (315)) (Prims.of_int (18)))))
                             (Obj.magic
                                (FStar_Tactics_V2_Builtins.set_dump_on_failure
                                   false))
@@ -1904,17 +1965,17 @@ let (tcresolve : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                           (Obj.magic
                                              (FStar_Range.mk_range
                                                 "FStar.Tactics.Typeclasses.fst"
-                                                (Prims.of_int (272))
+                                                (Prims.of_int (287))
                                                 (Prims.of_int (4))
-                                                (Prims.of_int (272))
+                                                (Prims.of_int (287))
                                                 (Prims.of_int (19)))))
                                        (FStar_Sealed.seal
                                           (Obj.magic
                                              (FStar_Range.mk_range
                                                 "FStar.Tactics.Typeclasses.fst"
-                                                (Prims.of_int (272))
+                                                (Prims.of_int (287))
                                                 (Prims.of_int (20))
-                                                (Prims.of_int (300))
+                                                (Prims.of_int (315))
                                                 (Prims.of_int (18)))))
                                        (Obj.magic (maybe_intros ()))
                                        (fun uu___3 ->
@@ -1925,17 +1986,17 @@ let (tcresolve : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                      (Obj.magic
                                                         (FStar_Range.mk_range
                                                            "FStar.Tactics.Typeclasses.fst"
-                                                           (Prims.of_int (277))
+                                                           (Prims.of_int (292))
                                                            (Prims.of_int (14))
-                                                           (Prims.of_int (277))
+                                                           (Prims.of_int (292))
                                                            (Prims.of_int (56)))))
                                                   (FStar_Sealed.seal
                                                      (Obj.magic
                                                         (FStar_Range.mk_range
                                                            "FStar.Tactics.Typeclasses.fst"
-                                                           (Prims.of_int (277))
+                                                           (Prims.of_int (292))
                                                            (Prims.of_int (59))
-                                                           (Prims.of_int (300))
+                                                           (Prims.of_int (315))
                                                            (Prims.of_int (18)))))
                                                   (Obj.magic
                                                      (FStar_Tactics_Effect.tac_bind
@@ -1943,17 +2004,17 @@ let (tcresolve : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                            (Obj.magic
                                                               (FStar_Range.mk_range
                                                                  "FStar.Tactics.Typeclasses.fst"
-                                                                 (Prims.of_int (277))
+                                                                 (Prims.of_int (292))
                                                                  (Prims.of_int (44))
-                                                                 (Prims.of_int (277))
+                                                                 (Prims.of_int (292))
                                                                  (Prims.of_int (56)))))
                                                         (FStar_Sealed.seal
                                                            (Obj.magic
                                                               (FStar_Range.mk_range
                                                                  "FStar.Tactics.Typeclasses.fst"
-                                                                 (Prims.of_int (277))
+                                                                 (Prims.of_int (292))
                                                                  (Prims.of_int (14))
-                                                                 (Prims.of_int (277))
+                                                                 (Prims.of_int (292))
                                                                  (Prims.of_int (56)))))
                                                         (Obj.magic
                                                            (FStar_Tactics_V2_Derived.cur_env
@@ -1978,17 +2039,17 @@ let (tcresolve : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                                 (Obj.magic
                                                                    (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (278))
+                                                                    (Prims.of_int (293))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (280))
+                                                                    (Prims.of_int (295))
                                                                     (Prims.of_int (5)))))
                                                              (FStar_Sealed.seal
                                                                 (Obj.magic
                                                                    (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (281))
+                                                                    (Prims.of_int (296))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (300))
+                                                                    (Prims.of_int (315))
                                                                     (Prims.of_int (18)))))
                                                              (Obj.magic
                                                                 (concatMap
@@ -2015,17 +2076,17 @@ let (tcresolve : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (283))
+                                                                    (Prims.of_int (298))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (285))
+                                                                    (Prims.of_int (300))
                                                                     (Prims.of_int (16)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (287))
+                                                                    (Prims.of_int (302))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (300))
+                                                                    (Prims.of_int (315))
                                                                     (Prims.of_int (18)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2054,17 +2115,17 @@ let (tcresolve : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (288))
+                                                                    (Prims.of_int (303))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (288))
+                                                                    (Prims.of_int (303))
                                                                     (Prims.of_int (20)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (289))
+                                                                    (Prims.of_int (304))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (289))
+                                                                    (Prims.of_int (304))
                                                                     (Prims.of_int (59)))))
                                                                     (Obj.magic
                                                                     (tcresolve'
@@ -2082,9 +2143,9 @@ let (tcresolve : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (289))
+                                                                    (Prims.of_int (304))
                                                                     (Prims.of_int (42))
-                                                                    (Prims.of_int (289))
+                                                                    (Prims.of_int (304))
                                                                     (Prims.of_int (58)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -2121,17 +2182,17 @@ let (tcresolve : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (293))
+                                                                    (Prims.of_int (308))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (297))
+                                                                    (Prims.of_int (312))
                                                                     (Prims.of_int (7)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (293))
+                                                                    (Prims.of_int (308))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (297))
+                                                                    (Prims.of_int (312))
                                                                     (Prims.of_int (7)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2139,17 +2200,17 @@ let (tcresolve : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (293))
+                                                                    (Prims.of_int (308))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (297))
+                                                                    (Prims.of_int (312))
                                                                     (Prims.of_int (7)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (293))
+                                                                    (Prims.of_int (308))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (297))
+                                                                    (Prims.of_int (312))
                                                                     (Prims.of_int (7)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2157,17 +2218,17 @@ let (tcresolve : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (295))
+                                                                    (Prims.of_int (310))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (296))
-                                                                    (Prims.of_int (59)))))
+                                                                    (Prims.of_int (311))
+                                                                    (Prims.of_int (37)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (293))
+                                                                    (Prims.of_int (308))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (297))
+                                                                    (Prims.of_int (312))
                                                                     (Prims.of_int (7)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2175,54 +2236,36 @@ let (tcresolve : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (296))
+                                                                    (Prims.of_int (311))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (296))
-                                                                    (Prims.of_int (59)))))
+                                                                    (Prims.of_int (311))
+                                                                    (Prims.of_int (37)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (295))
+                                                                    (Prims.of_int (310))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (296))
-                                                                    (Prims.of_int (59)))))
+                                                                    (Prims.of_int (311))
+                                                                    (Prims.of_int (37)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (296))
-                                                                    (Prims.of_int (28))
-                                                                    (Prims.of_int (296))
-                                                                    (Prims.of_int (58)))))
+                                                                    (Prims.of_int (311))
+                                                                    (Prims.of_int (23))
+                                                                    (Prims.of_int (311))
+                                                                    (Prims.of_int (36)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (296))
+                                                                    (Prims.of_int (311))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (296))
-                                                                    (Prims.of_int (59)))))
-                                                                    (Obj.magic
-                                                                    (FStar_Tactics_Effect.tac_bind
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (296))
-                                                                    (Prims.of_int (44))
-                                                                    (Prims.of_int (296))
-                                                                    (Prims.of_int (57)))))
-                                                                    (FStar_Sealed.seal
-                                                                    (Obj.magic
-                                                                    (FStar_Range.mk_range
-                                                                    "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (296))
-                                                                    (Prims.of_int (28))
-                                                                    (Prims.of_int (296))
-                                                                    (Prims.of_int (58)))))
+                                                                    (Prims.of_int (311))
+                                                                    (Prims.of_int (37)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Derived.cur_goal
                                                                     ()))
@@ -2231,16 +2274,9 @@ let (tcresolve : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                                     (fun
                                                                     uu___5 ->
                                                                     Obj.magic
-                                                                    (FStar_Tactics_V2_Builtins.term_to_string
+                                                                    (FStar_Tactics_V2_Builtins.term_to_doc
                                                                     uu___5))
                                                                     uu___5)))
-                                                                    (fun
-                                                                    uu___5 ->
-                                                                    FStar_Tactics_Effect.lift_div_tac
-                                                                    (fun
-                                                                    uu___6 ->
-                                                                    FStar_Pprint.arbitrary_string
-                                                                    uu___5))))
                                                                     (fun
                                                                     uu___5 ->
                                                                     FStar_Tactics_Effect.lift_div_tac
@@ -2264,7 +2300,7 @@ let (tcresolve : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                                     (fun
                                                                     uu___6 ->
                                                                     (FStar_Pprint.arbitrary_string
-                                                                    "Typeclass resolution failed")
+                                                                    "Typeclass resolution failed.")
                                                                     :: uu___5))))
                                                                     (fun
                                                                     uu___5 ->
@@ -2280,7 +2316,7 @@ let (tcresolve : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                                     ())
                                                                     [
                                                                     FStar_Pprint.arbitrary_string
-                                                                    "Typeclass resolution failed"]
+                                                                    "Typeclass resolution failed."]
                                                                     msg)))
                                                                     | 
                                                                     e ->
@@ -2327,8 +2363,8 @@ let rec (mk_abs :
                           (Obj.magic
                              (FStar_Range.mk_range
                                 "FStar.Tactics.Typeclasses.fst"
-                                (Prims.of_int (309)) (Prims.of_int (20))
-                                (Prims.of_int (309)) (Prims.of_int (47)))))
+                                (Prims.of_int (324)) (Prims.of_int (20))
+                                (Prims.of_int (324)) (Prims.of_int (47)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "dummy" Prims.int_zero
@@ -2339,17 +2375,17 @@ let rec (mk_abs :
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "FStar.Tactics.Typeclasses.fst"
-                                      (Prims.of_int (309))
+                                      (Prims.of_int (324))
                                       (Prims.of_int (30))
-                                      (Prims.of_int (309))
+                                      (Prims.of_int (324))
                                       (Prims.of_int (46)))))
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "FStar.Tactics.Typeclasses.fst"
-                                      (Prims.of_int (309))
+                                      (Prims.of_int (324))
                                       (Prims.of_int (20))
-                                      (Prims.of_int (309))
+                                      (Prims.of_int (324))
                                       (Prims.of_int (47)))))
                              (Obj.magic (mk_abs bs1 body))
                              (fun uu___ ->
@@ -2408,12 +2444,12 @@ let (mk_class :
       (FStar_Sealed.seal
          (Obj.magic
             (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-               (Prims.of_int (333)) (Prims.of_int (13)) (Prims.of_int (333))
+               (Prims.of_int (348)) (Prims.of_int (13)) (Prims.of_int (348))
                (Prims.of_int (26)))))
       (FStar_Sealed.seal
          (Obj.magic
             (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-               (Prims.of_int (333)) (Prims.of_int (29)) (Prims.of_int (423))
+               (Prims.of_int (348)) (Prims.of_int (29)) (Prims.of_int (438))
                (Prims.of_int (5)))))
       (FStar_Tactics_Effect.lift_div_tac
          (fun uu___ -> FStar_Reflection_V2_Builtins.explode_qn nm))
@@ -2424,27 +2460,27 @@ let (mk_class :
                  (FStar_Sealed.seal
                     (Obj.magic
                        (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-                          (Prims.of_int (334)) (Prims.of_int (12))
-                          (Prims.of_int (334)) (Prims.of_int (38)))))
+                          (Prims.of_int (349)) (Prims.of_int (12))
+                          (Prims.of_int (349)) (Prims.of_int (38)))))
                  (FStar_Sealed.seal
                     (Obj.magic
                        (FStar_Range.mk_range "FStar.Tactics.Typeclasses.fst"
-                          (Prims.of_int (335)) (Prims.of_int (4))
-                          (Prims.of_int (423)) (Prims.of_int (5)))))
+                          (Prims.of_int (350)) (Prims.of_int (4))
+                          (Prims.of_int (438)) (Prims.of_int (5)))))
                  (Obj.magic
                     (FStar_Tactics_Effect.tac_bind
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range
                                 "FStar.Tactics.Typeclasses.fst"
-                                (Prims.of_int (334)) (Prims.of_int (23))
-                                (Prims.of_int (334)) (Prims.of_int (35)))))
+                                (Prims.of_int (349)) (Prims.of_int (23))
+                                (Prims.of_int (349)) (Prims.of_int (35)))))
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range
                                 "FStar.Tactics.Typeclasses.fst"
-                                (Prims.of_int (334)) (Prims.of_int (12))
-                                (Prims.of_int (334)) (Prims.of_int (38)))))
+                                (Prims.of_int (349)) (Prims.of_int (12))
+                                (Prims.of_int (349)) (Prims.of_int (38)))))
                        (Obj.magic (FStar_Tactics_V2_Builtins.top_env ()))
                        (fun uu___ ->
                           FStar_Tactics_Effect.lift_div_tac
@@ -2459,14 +2495,14 @@ let (mk_class :
                                (Obj.magic
                                   (FStar_Range.mk_range
                                      "FStar.Tactics.Typeclasses.fst"
-                                     (Prims.of_int (335)) (Prims.of_int (4))
-                                     (Prims.of_int (335)) (Prims.of_int (19)))))
+                                     (Prims.of_int (350)) (Prims.of_int (4))
+                                     (Prims.of_int (350)) (Prims.of_int (19)))))
                             (FStar_Sealed.seal
                                (Obj.magic
                                   (FStar_Range.mk_range
                                      "FStar.Tactics.Typeclasses.fst"
-                                     (Prims.of_int (335)) (Prims.of_int (20))
-                                     (Prims.of_int (423)) (Prims.of_int (5)))))
+                                     (Prims.of_int (350)) (Prims.of_int (20))
+                                     (Prims.of_int (438)) (Prims.of_int (5)))))
                             (Obj.magic
                                (FStar_Tactics_V2_Derived.guard
                                   (FStar_Pervasives_Native.uu___is_Some r)))
@@ -2478,17 +2514,17 @@ let (mk_class :
                                           (Obj.magic
                                              (FStar_Range.mk_range
                                                 "FStar.Tactics.Typeclasses.fst"
-                                                (Prims.of_int (336))
+                                                (Prims.of_int (351))
                                                 (Prims.of_int (18))
-                                                (Prims.of_int (336))
+                                                (Prims.of_int (351))
                                                 (Prims.of_int (19)))))
                                        (FStar_Sealed.seal
                                           (Obj.magic
                                              (FStar_Range.mk_range
                                                 "FStar.Tactics.Typeclasses.fst"
-                                                (Prims.of_int (335))
+                                                (Prims.of_int (350))
                                                 (Prims.of_int (20))
-                                                (Prims.of_int (423))
+                                                (Prims.of_int (438))
                                                 (Prims.of_int (5)))))
                                        (FStar_Tactics_Effect.lift_div_tac
                                           (fun uu___1 -> r))
@@ -2503,17 +2539,17 @@ let (mk_class :
                                                          (Obj.magic
                                                             (FStar_Range.mk_range
                                                                "FStar.Tactics.Typeclasses.fst"
-                                                               (Prims.of_int (337))
+                                                               (Prims.of_int (352))
                                                                (Prims.of_int (23))
-                                                               (Prims.of_int (337))
+                                                               (Prims.of_int (352))
                                                                (Prims.of_int (115)))))
                                                       (FStar_Sealed.seal
                                                          (Obj.magic
                                                             (FStar_Range.mk_range
                                                                "FStar.Tactics.Typeclasses.fst"
-                                                               (Prims.of_int (337))
+                                                               (Prims.of_int (352))
                                                                (Prims.of_int (118))
-                                                               (Prims.of_int (423))
+                                                               (Prims.of_int (438))
                                                                (Prims.of_int (5)))))
                                                       (FStar_Tactics_Effect.lift_div_tac
                                                          (fun uu___2 ->
@@ -2538,18 +2574,18 @@ let (mk_class :
                                                                     Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (338))
+                                                                    (Prims.of_int (353))
                                                                     (Prims.of_int (13))
-                                                                    (Prims.of_int (338))
+                                                                    (Prims.of_int (353))
                                                                     (Prims.of_int (30)))))
                                                                  (FStar_Sealed.seal
                                                                     (
                                                                     Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (339))
+                                                                    (Prims.of_int (354))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (423))
+                                                                    (Prims.of_int (438))
                                                                     (Prims.of_int (5)))))
                                                                  (Obj.magic
                                                                     (
@@ -2565,17 +2601,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (339))
+                                                                    (Prims.of_int (354))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (339))
+                                                                    (Prims.of_int (354))
                                                                     (Prims.of_int (28)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (339))
+                                                                    (Prims.of_int (354))
                                                                     (Prims.of_int (29))
-                                                                    (Prims.of_int (423))
+                                                                    (Prims.of_int (438))
                                                                     (Prims.of_int (5)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Derived.guard
@@ -2591,17 +2627,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (340))
+                                                                    (Prims.of_int (355))
                                                                     (Prims.of_int (63))
-                                                                    (Prims.of_int (340))
+                                                                    (Prims.of_int (355))
                                                                     (Prims.of_int (65)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (339))
+                                                                    (Prims.of_int (354))
                                                                     (Prims.of_int (29))
-                                                                    (Prims.of_int (423))
+                                                                    (Prims.of_int (438))
                                                                     (Prims.of_int (5)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2633,17 +2669,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (341))
+                                                                    (Prims.of_int (356))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (341))
+                                                                    (Prims.of_int (356))
                                                                     (Prims.of_int (87)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (342))
+                                                                    (Prims.of_int (357))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (423))
+                                                                    (Prims.of_int (438))
                                                                     (Prims.of_int (5)))))
                                                                     (Obj.magic
                                                                     (debug
@@ -2654,9 +2690,9 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (341))
+                                                                    (Prims.of_int (356))
                                                                     (Prims.of_int (35))
-                                                                    (Prims.of_int (341))
+                                                                    (Prims.of_int (356))
                                                                     (Prims.of_int (86)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -2688,17 +2724,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (342))
+                                                                    (Prims.of_int (357))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (342))
+                                                                    (Prims.of_int (357))
                                                                     (Prims.of_int (57)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (343))
+                                                                    (Prims.of_int (358))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (423))
+                                                                    (Prims.of_int (438))
                                                                     (Prims.of_int (5)))))
                                                                     (Obj.magic
                                                                     (debug
@@ -2725,17 +2761,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (343))
+                                                                    (Prims.of_int (358))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (343))
+                                                                    (Prims.of_int (358))
                                                                     (Prims.of_int (59)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (343))
+                                                                    (Prims.of_int (358))
                                                                     (Prims.of_int (60))
-                                                                    (Prims.of_int (423))
+                                                                    (Prims.of_int (438))
                                                                     (Prims.of_int (5)))))
                                                                     (Obj.magic
                                                                     (debug
@@ -2746,9 +2782,9 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (343))
+                                                                    (Prims.of_int (358))
                                                                     (Prims.of_int (40))
-                                                                    (Prims.of_int (343))
+                                                                    (Prims.of_int (358))
                                                                     (Prims.of_int (58)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -2779,17 +2815,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (344))
+                                                                    (Prims.of_int (359))
                                                                     (Prims.of_int (20))
-                                                                    (Prims.of_int (344))
+                                                                    (Prims.of_int (359))
                                                                     (Prims.of_int (29)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (346))
+                                                                    (Prims.of_int (361))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (423))
+                                                                    (Prims.of_int (438))
                                                                     (Prims.of_int (5)))))
                                                                     (Obj.magic
                                                                     (last
@@ -2805,17 +2841,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (346))
+                                                                    (Prims.of_int (361))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (346))
+                                                                    (Prims.of_int (361))
                                                                     (Prims.of_int (30)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (346))
+                                                                    (Prims.of_int (361))
                                                                     (Prims.of_int (31))
-                                                                    (Prims.of_int (423))
+                                                                    (Prims.of_int (438))
                                                                     (Prims.of_int (5)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Derived.guard
@@ -2832,17 +2868,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (347))
+                                                                    (Prims.of_int (362))
                                                                     (Prims.of_int (25))
-                                                                    (Prims.of_int (347))
+                                                                    (Prims.of_int (362))
                                                                     (Prims.of_int (30)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (346))
+                                                                    (Prims.of_int (361))
                                                                     (Prims.of_int (31))
-                                                                    (Prims.of_int (423))
+                                                                    (Prims.of_int (438))
                                                                     (Prims.of_int (5)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -2864,17 +2900,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (348))
+                                                                    (Prims.of_int (363))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (348))
+                                                                    (Prims.of_int (363))
                                                                     (Prims.of_int (87)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (348))
+                                                                    (Prims.of_int (363))
                                                                     (Prims.of_int (88))
-                                                                    (Prims.of_int (423))
+                                                                    (Prims.of_int (438))
                                                                     (Prims.of_int (5)))))
                                                                     (Obj.magic
                                                                     (debug
@@ -2885,9 +2921,9 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (348))
+                                                                    (Prims.of_int (363))
                                                                     (Prims.of_int (35))
-                                                                    (Prims.of_int (348))
+                                                                    (Prims.of_int (363))
                                                                     (Prims.of_int (86)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -2903,9 +2939,9 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (348))
+                                                                    (Prims.of_int (363))
                                                                     (Prims.of_int (55))
-                                                                    (Prims.of_int (348))
+                                                                    (Prims.of_int (363))
                                                                     (Prims.of_int (86)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -2921,9 +2957,9 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (348))
+                                                                    (Prims.of_int (363))
                                                                     (Prims.of_int (69))
-                                                                    (Prims.of_int (348))
+                                                                    (Prims.of_int (363))
                                                                     (Prims.of_int (86)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -2977,17 +3013,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (349))
+                                                                    (Prims.of_int (364))
                                                                     (Prims.of_int (18))
-                                                                    (Prims.of_int (349))
+                                                                    (Prims.of_int (364))
                                                                     (Prims.of_int (35)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (348))
+                                                                    (Prims.of_int (363))
                                                                     (Prims.of_int (88))
-                                                                    (Prims.of_int (423))
+                                                                    (Prims.of_int (438))
                                                                     (Prims.of_int (5)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_SyntaxHelpers.collect_arr_bs
@@ -3009,17 +3045,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (350))
+                                                                    (Prims.of_int (365))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (350))
+                                                                    (Prims.of_int (365))
                                                                     (Prims.of_int (28)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (351))
+                                                                    (Prims.of_int (366))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (423))
+                                                                    (Prims.of_int (438))
                                                                     (Prims.of_int (5)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3038,17 +3074,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (351))
+                                                                    (Prims.of_int (366))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (351))
+                                                                    (Prims.of_int (366))
                                                                     (Prims.of_int (22)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (351))
+                                                                    (Prims.of_int (366))
                                                                     (Prims.of_int (23))
-                                                                    (Prims.of_int (423))
+                                                                    (Prims.of_int (438))
                                                                     (Prims.of_int (5)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Derived.guard
@@ -3066,17 +3102,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (352))
+                                                                    (Prims.of_int (367))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (352))
+                                                                    (Prims.of_int (367))
                                                                     (Prims.of_int (23)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (351))
+                                                                    (Prims.of_int (366))
                                                                     (Prims.of_int (23))
-                                                                    (Prims.of_int (423))
+                                                                    (Prims.of_int (438))
                                                                     (Prims.of_int (5)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3099,17 +3135,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (354))
+                                                                    (Prims.of_int (369))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (354))
+                                                                    (Prims.of_int (369))
                                                                     (Prims.of_int (87)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (355))
+                                                                    (Prims.of_int (370))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (423))
+                                                                    (Prims.of_int (438))
                                                                     (Prims.of_int (5)))))
                                                                     (Obj.magic
                                                                     (debug
@@ -3121,9 +3157,9 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (354))
+                                                                    (Prims.of_int (369))
                                                                     (Prims.of_int (35))
-                                                                    (Prims.of_int (354))
+                                                                    (Prims.of_int (369))
                                                                     (Prims.of_int (86)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -3159,17 +3195,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (355))
+                                                                    (Prims.of_int (370))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (355))
+                                                                    (Prims.of_int (370))
                                                                     (Prims.of_int (81)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (356))
+                                                                    (Prims.of_int (371))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (423))
+                                                                    (Prims.of_int (438))
                                                                     (Prims.of_int (5)))))
                                                                     (Obj.magic
                                                                     (debug
@@ -3202,17 +3238,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (356))
+                                                                    (Prims.of_int (371))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (356))
+                                                                    (Prims.of_int (371))
                                                                     (Prims.of_int (76)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (357))
+                                                                    (Prims.of_int (372))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (423))
+                                                                    (Prims.of_int (438))
                                                                     (Prims.of_int (5)))))
                                                                     (Obj.magic
                                                                     (debug
@@ -3245,17 +3281,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (357))
+                                                                    (Prims.of_int (372))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (357))
+                                                                    (Prims.of_int (372))
                                                                     (Prims.of_int (51)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (357))
+                                                                    (Prims.of_int (372))
                                                                     (Prims.of_int (52))
-                                                                    (Prims.of_int (423))
+                                                                    (Prims.of_int (438))
                                                                     (Prims.of_int (5)))))
                                                                     (Obj.magic
                                                                     (debug
@@ -3267,9 +3303,9 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (357))
+                                                                    (Prims.of_int (372))
                                                                     (Prims.of_int (32))
-                                                                    (Prims.of_int (357))
+                                                                    (Prims.of_int (372))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -3304,17 +3340,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (361))
+                                                                    (Prims.of_int (376))
                                                                     (Prims.of_int (24))
-                                                                    (Prims.of_int (361))
+                                                                    (Prims.of_int (376))
                                                                     (Prims.of_int (61)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (364))
+                                                                    (Prims.of_int (379))
                                                                     (Prims.of_int (4))
-                                                                    (Prims.of_int (423))
+                                                                    (Prims.of_int (438))
                                                                     (Prims.of_int (5)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3338,17 +3374,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (366))
+                                                                    (Prims.of_int (381))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (366))
+                                                                    (Prims.of_int (381))
                                                                     (Prims.of_int (30)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (367))
+                                                                    (Prims.of_int (382))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (422))
+                                                                    (Prims.of_int (437))
                                                                     (Prims.of_int (8)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Derived.name_of_binder
@@ -3363,17 +3399,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (367))
+                                                                    (Prims.of_int (382))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (367))
+                                                                    (Prims.of_int (382))
                                                                     (Prims.of_int (48)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (367))
+                                                                    (Prims.of_int (382))
                                                                     (Prims.of_int (49))
-                                                                    (Prims.of_int (422))
+                                                                    (Prims.of_int (437))
                                                                     (Prims.of_int (8)))))
                                                                     (Obj.magic
                                                                     (debug
@@ -3404,17 +3440,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (368))
+                                                                    (Prims.of_int (383))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (368))
+                                                                    (Prims.of_int (383))
                                                                     (Prims.of_int (28)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (368))
+                                                                    (Prims.of_int (383))
                                                                     (Prims.of_int (31))
-                                                                    (Prims.of_int (422))
+                                                                    (Prims.of_int (437))
                                                                     (Prims.of_int (8)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Derived.cur_module
@@ -3430,17 +3466,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (369))
+                                                                    (Prims.of_int (384))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (369))
+                                                                    (Prims.of_int (384))
                                                                     (Prims.of_int (34)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (369))
+                                                                    (Prims.of_int (384))
                                                                     (Prims.of_int (37))
-                                                                    (Prims.of_int (422))
+                                                                    (Prims.of_int (437))
                                                                     (Prims.of_int (8)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3461,17 +3497,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (370))
+                                                                    (Prims.of_int (385))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (370))
+                                                                    (Prims.of_int (385))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (370))
+                                                                    (Prims.of_int (385))
                                                                     (Prims.of_int (41))
-                                                                    (Prims.of_int (422))
+                                                                    (Prims.of_int (437))
                                                                     (Prims.of_int (8)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Derived.fresh_namedv_named
@@ -3487,17 +3523,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (371))
+                                                                    (Prims.of_int (386))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (371))
+                                                                    (Prims.of_int (386))
                                                                     (Prims.of_int (28)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (371))
+                                                                    (Prims.of_int (386))
                                                                     (Prims.of_int (31))
-                                                                    (Prims.of_int (422))
+                                                                    (Prims.of_int (437))
                                                                     (Prims.of_int (8)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3521,17 +3557,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (373))
+                                                                    (Prims.of_int (388))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (377))
+                                                                    (Prims.of_int (392))
                                                                     (Prims.of_int (20)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (378))
+                                                                    (Prims.of_int (393))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (422))
+                                                                    (Prims.of_int (437))
                                                                     (Prims.of_int (8)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -3539,17 +3575,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (375))
+                                                                    (Prims.of_int (390))
                                                                     (Prims.of_int (17))
-                                                                    (Prims.of_int (375))
+                                                                    (Prims.of_int (390))
                                                                     (Prims.of_int (24)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (373))
+                                                                    (Prims.of_int (388))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (377))
+                                                                    (Prims.of_int (392))
                                                                     (Prims.of_int (20)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Builtins.fresh
@@ -3588,17 +3624,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (379))
+                                                                    (Prims.of_int (394))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (379))
+                                                                    (Prims.of_int (394))
                                                                     (Prims.of_int (48)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (379))
+                                                                    (Prims.of_int (394))
                                                                     (Prims.of_int (51))
-                                                                    (Prims.of_int (422))
+                                                                    (Prims.of_int (437))
                                                                     (Prims.of_int (8)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -3606,17 +3642,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (379))
+                                                                    (Prims.of_int (394))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (379))
+                                                                    (Prims.of_int (394))
                                                                     (Prims.of_int (35)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (379))
+                                                                    (Prims.of_int (394))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (379))
+                                                                    (Prims.of_int (394))
                                                                     (Prims.of_int (48)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Derived.cur_module
@@ -3645,17 +3681,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (380))
+                                                                    (Prims.of_int (395))
                                                                     (Prims.of_int (17))
-                                                                    (Prims.of_int (380))
+                                                                    (Prims.of_int (395))
                                                                     (Prims.of_int (51)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (380))
+                                                                    (Prims.of_int (395))
                                                                     (Prims.of_int (54))
-                                                                    (Prims.of_int (422))
+                                                                    (Prims.of_int (437))
                                                                     (Prims.of_int (8)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3676,17 +3712,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (383))
+                                                                    (Prims.of_int (398))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (388))
+                                                                    (Prims.of_int (403))
                                                                     (Prims.of_int (50)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (389))
+                                                                    (Prims.of_int (404))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (422))
+                                                                    (Prims.of_int (437))
                                                                     (Prims.of_int (8)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -3694,17 +3730,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (383))
+                                                                    (Prims.of_int (398))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (383))
+                                                                    (Prims.of_int (398))
                                                                     (Prims.of_int (47)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (383))
+                                                                    (Prims.of_int (398))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (388))
+                                                                    (Prims.of_int (403))
                                                                     (Prims.of_int (50)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -3712,17 +3748,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (383))
+                                                                    (Prims.of_int (398))
                                                                     (Prims.of_int (25))
-                                                                    (Prims.of_int (383))
+                                                                    (Prims.of_int (398))
                                                                     (Prims.of_int (37)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (383))
+                                                                    (Prims.of_int (398))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (383))
+                                                                    (Prims.of_int (398))
                                                                     (Prims.of_int (47)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Builtins.top_env
@@ -3762,17 +3798,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (386))
+                                                                    (Prims.of_int (401))
                                                                     (Prims.of_int (16))
-                                                                    (Prims.of_int (386))
+                                                                    (Prims.of_int (401))
                                                                     (Prims.of_int (33)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (386))
+                                                                    (Prims.of_int (401))
                                                                     (Prims.of_int (10))
-                                                                    (Prims.of_int (388))
+                                                                    (Prims.of_int (403))
                                                                     (Prims.of_int (50)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_NamedView.inspect_sigelt
@@ -3819,17 +3855,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (392))
+                                                                    (Prims.of_int (407))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (399))
+                                                                    (Prims.of_int (414))
                                                                     (Prims.of_int (37)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (400))
+                                                                    (Prims.of_int (415))
                                                                     (Prims.of_int (8))
-                                                                    (Prims.of_int (422))
+                                                                    (Prims.of_int (437))
                                                                     (Prims.of_int (8)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -3837,17 +3873,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (393))
+                                                                    (Prims.of_int (408))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (393))
+                                                                    (Prims.of_int (408))
                                                                     (Prims.of_int (51)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (392))
+                                                                    (Prims.of_int (407))
                                                                     (Prims.of_int (14))
-                                                                    (Prims.of_int (399))
+                                                                    (Prims.of_int (414))
                                                                     (Prims.of_int (37)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_SyntaxHelpers.collect_arr_bs
@@ -3869,17 +3905,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (394))
+                                                                    (Prims.of_int (409))
                                                                     (Prims.of_int (21))
-                                                                    (Prims.of_int (394))
+                                                                    (Prims.of_int (409))
                                                                     (Prims.of_int (75)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (393))
+                                                                    (Prims.of_int (408))
                                                                     (Prims.of_int (54))
-                                                                    (Prims.of_int (399))
+                                                                    (Prims.of_int (414))
                                                                     (Prims.of_int (37)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3918,17 +3954,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (398))
+                                                                    (Prims.of_int (413))
                                                                     (Prims.of_int (21))
-                                                                    (Prims.of_int (398))
+                                                                    (Prims.of_int (413))
                                                                     (Prims.of_int (43)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (399))
+                                                                    (Prims.of_int (414))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (399))
+                                                                    (Prims.of_int (414))
                                                                     (Prims.of_int (37)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -3962,17 +3998,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (401))
+                                                                    (Prims.of_int (416))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (408))
+                                                                    (Prims.of_int (423))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (410))
+                                                                    (Prims.of_int (425))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (422))
+                                                                    (Prims.of_int (437))
                                                                     (Prims.of_int (8)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -3980,17 +4016,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (402))
+                                                                    (Prims.of_int (417))
                                                                     (Prims.of_int (23))
-                                                                    (Prims.of_int (402))
+                                                                    (Prims.of_int (417))
                                                                     (Prims.of_int (49)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (401))
+                                                                    (Prims.of_int (416))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (408))
+                                                                    (Prims.of_int (423))
                                                                     (Prims.of_int (38)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_SyntaxHelpers.collect_abs
@@ -4012,17 +4048,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (403))
+                                                                    (Prims.of_int (418))
                                                                     (Prims.of_int (21))
-                                                                    (Prims.of_int (403))
+                                                                    (Prims.of_int (418))
                                                                     (Prims.of_int (75)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (402))
+                                                                    (Prims.of_int (417))
                                                                     (Prims.of_int (52))
-                                                                    (Prims.of_int (408))
+                                                                    (Prims.of_int (423))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -4061,17 +4097,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (407))
+                                                                    (Prims.of_int (422))
                                                                     (Prims.of_int (21))
-                                                                    (Prims.of_int (407))
+                                                                    (Prims.of_int (422))
                                                                     (Prims.of_int (43)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (408))
+                                                                    (Prims.of_int (423))
                                                                     (Prims.of_int (12))
-                                                                    (Prims.of_int (408))
+                                                                    (Prims.of_int (423))
                                                                     (Prims.of_int (38)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -4105,17 +4141,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (410))
+                                                                    (Prims.of_int (425))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (410))
+                                                                    (Prims.of_int (425))
                                                                     (Prims.of_int (53)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (411))
+                                                                    (Prims.of_int (426))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (422))
+                                                                    (Prims.of_int (437))
                                                                     (Prims.of_int (8)))))
                                                                     (Obj.magic
                                                                     (debug
@@ -4127,9 +4163,9 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (410))
+                                                                    (Prims.of_int (425))
                                                                     (Prims.of_int (34))
-                                                                    (Prims.of_int (410))
+                                                                    (Prims.of_int (425))
                                                                     (Prims.of_int (52)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -4164,17 +4200,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (411))
+                                                                    (Prims.of_int (426))
                                                                     (Prims.of_int (6))
-                                                                    (Prims.of_int (411))
+                                                                    (Prims.of_int (426))
                                                                     (Prims.of_int (52)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (411))
+                                                                    (Prims.of_int (426))
                                                                     (Prims.of_int (53))
-                                                                    (Prims.of_int (422))
+                                                                    (Prims.of_int (437))
                                                                     (Prims.of_int (8)))))
                                                                     (Obj.magic
                                                                     (debug
@@ -4186,9 +4222,9 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (411))
+                                                                    (Prims.of_int (426))
                                                                     (Prims.of_int (34))
-                                                                    (Prims.of_int (411))
+                                                                    (Prims.of_int (426))
                                                                     (Prims.of_int (51)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
@@ -4223,17 +4259,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (413))
+                                                                    (Prims.of_int (428))
                                                                     (Prims.of_int (22))
-                                                                    (Prims.of_int (413))
+                                                                    (Prims.of_int (428))
                                                                     (Prims.of_int (24)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (413))
+                                                                    (Prims.of_int (428))
                                                                     (Prims.of_int (27))
-                                                                    (Prims.of_int (422))
+                                                                    (Prims.of_int (437))
                                                                     (Prims.of_int (8)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -4250,17 +4286,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (414))
+                                                                    (Prims.of_int (429))
                                                                     (Prims.of_int (23))
-                                                                    (Prims.of_int (414))
+                                                                    (Prims.of_int (429))
                                                                     (Prims.of_int (26)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (414))
+                                                                    (Prims.of_int (429))
                                                                     (Prims.of_int (29))
-                                                                    (Prims.of_int (422))
+                                                                    (Prims.of_int (437))
                                                                     (Prims.of_int (8)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -4277,17 +4313,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (415))
+                                                                    (Prims.of_int (430))
                                                                     (Prims.of_int (21))
-                                                                    (Prims.of_int (415))
+                                                                    (Prims.of_int (430))
                                                                     (Prims.of_int (24)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (415))
+                                                                    (Prims.of_int (430))
                                                                     (Prims.of_int (27))
-                                                                    (Prims.of_int (422))
+                                                                    (Prims.of_int (437))
                                                                     (Prims.of_int (8)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -4304,17 +4340,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (417))
+                                                                    (Prims.of_int (432))
                                                                     (Prims.of_int (17))
-                                                                    (Prims.of_int (417))
+                                                                    (Prims.of_int (432))
                                                                     (Prims.of_int (70)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (417))
+                                                                    (Prims.of_int (432))
                                                                     (Prims.of_int (75))
-                                                                    (Prims.of_int (422))
+                                                                    (Prims.of_int (437))
                                                                     (Prims.of_int (8)))))
                                                                     (FStar_Tactics_Effect.lift_div_tac
                                                                     (fun
@@ -4342,17 +4378,17 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (418))
+                                                                    (Prims.of_int (433))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (418))
+                                                                    (Prims.of_int (433))
                                                                     (Prims.of_int (59)))))
                                                                     (FStar_Sealed.seal
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "FStar.Tactics.Typeclasses.fst"
-                                                                    (Prims.of_int (420))
+                                                                    (Prims.of_int (435))
                                                                     (Prims.of_int (15))
-                                                                    (Prims.of_int (420))
+                                                                    (Prims.of_int (435))
                                                                     (Prims.of_int (42)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_NamedView.pack_sigelt

--- a/ocaml/fstar-lib/generated/FStar_Tactics_V1_Basic.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_V1_Basic.ml
@@ -77,7 +77,7 @@ let (core_check :
                        let uu___5 =
                          let uu___6 = FStar_TypeChecker_Env.get_range env in
                          FStar_Class_Show.show
-                           FStar_Compiler_Range_Ops.show_range uu___6 in
+                           FStar_Compiler_Range_Ops.showable_range uu___6 in
                        let uu___6 =
                          FStar_TypeChecker_Core.print_error_short err in
                        let uu___7 =
@@ -1096,7 +1096,7 @@ let (__do_unify_wflags :
                                                       msg in
                                                   let uu___10 =
                                                     FStar_Class_Show.show
-                                                      FStar_Compiler_Range_Ops.show_range
+                                                      FStar_Compiler_Range_Ops.showable_range
                                                       r in
                                                   FStar_Compiler_Util.print2
                                                     ">> do_unify error, (%s) at (%s)\n"
@@ -9237,7 +9237,8 @@ let (comp_to_string :
 let (range_to_string :
   FStar_Compiler_Range_Type.range -> Prims.string FStar_Tactics_Monad.tac) =
   fun r ->
-    let uu___ = FStar_Class_Show.show FStar_Compiler_Range_Ops.show_range r in
+    let uu___ =
+      FStar_Class_Show.show FStar_Compiler_Range_Ops.showable_range r in
     ret uu___
 let (term_eq_old :
   FStar_Syntax_Syntax.term ->

--- a/ocaml/fstar-lib/generated/FStar_Tactics_V2_Basic.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_V2_Basic.ml
@@ -63,7 +63,7 @@ let (core_check :
                        let uu___5 =
                          let uu___6 = FStar_TypeChecker_Env.get_range env in
                          FStar_Class_Show.show
-                           FStar_Compiler_Range_Ops.show_range uu___6 in
+                           FStar_Compiler_Range_Ops.showable_range uu___6 in
                        let uu___6 =
                          FStar_TypeChecker_Core.print_error_short err in
                        let uu___7 =
@@ -1187,7 +1187,7 @@ let (__do_unify_wflags :
                                                                msg in
                                                            let uu___9 =
                                                              FStar_Class_Show.show
-                                                               FStar_Compiler_Range_Ops.show_range
+                                                               FStar_Compiler_Range_Ops.showable_range
                                                                r in
                                                            FStar_Compiler_Util.print2
                                                              ">> do_unify error, (%s) at (%s)\n"
@@ -9557,7 +9557,7 @@ let (range_to_string :
   fun uu___ ->
     (fun r ->
        let uu___ =
-         FStar_Class_Show.show FStar_Compiler_Range_Ops.show_range r in
+         FStar_Class_Show.show FStar_Compiler_Range_Ops.showable_range r in
        Obj.magic
          (FStar_Class_Monad.return FStar_Tactics_Monad.monad_tac ()
             (Obj.magic uu___))) uu___
@@ -10543,7 +10543,7 @@ let (refl_tc_term :
                           (fun uu___3 ->
                              let uu___4 =
                                FStar_Class_Show.show
-                                 FStar_Compiler_Range_Ops.show_range
+                                 FStar_Compiler_Range_Ops.showable_range
                                  e.FStar_Syntax_Syntax.pos in
                              let uu___5 =
                                FStar_Class_Show.show
@@ -10824,7 +10824,7 @@ let (refl_tc_term :
                                                  FStar_TypeChecker_Env.get_range
                                                    g3 in
                                                FStar_Class_Show.show
-                                                 FStar_Compiler_Range_Ops.show_range
+                                                 FStar_Compiler_Range_Ops.showable_range
                                                  uu___11 in
                                              let uu___11 =
                                                FStar_Class_Show.show
@@ -10832,7 +10832,7 @@ let (refl_tc_term :
                                                  guard in
                                              let uu___12 =
                                                FStar_Class_Show.show
-                                                 FStar_Compiler_Range_Ops.show_range
+                                                 FStar_Compiler_Range_Ops.showable_range
                                                  guard.FStar_Syntax_Syntax.pos in
                                              FStar_Compiler_Util.format3
                                                "Got guard in Env@%s |- %s@%s\n"
@@ -10855,7 +10855,7 @@ let (refl_tc_term :
                                              (fun uu___10 ->
                                                 let uu___11 =
                                                   FStar_Class_Show.show
-                                                    FStar_Compiler_Range_Ops.show_range
+                                                    FStar_Compiler_Range_Ops.showable_range
                                                     e2.FStar_Syntax_Syntax.pos in
                                                 let uu___12 =
                                                   FStar_Class_Show.show

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Generalize.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Generalize.ml
@@ -633,7 +633,7 @@ let (generalize' :
                         | (l, us, e, c, gvs) ->
                             let uu___6 =
                               FStar_Class_Show.show
-                                FStar_Compiler_Range_Ops.show_range
+                                FStar_Compiler_Range_Ops.showable_range
                                 e.FStar_Syntax_Syntax.pos in
                             let uu___7 =
                               FStar_Syntax_Print.lbname_to_string l in

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Normalize_Unfolding.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Normalize_Unfolding.ml
@@ -710,8 +710,8 @@ let (should_unfold :
                  FStar_Class_Show.show FStar_Syntax_Print.showable_fv fv in
                let uu___3 =
                  let uu___4 = FStar_Syntax_Syntax.range_of_fv fv in
-                 FStar_Class_Show.show FStar_Compiler_Range_Ops.show_range
-                   uu___4 in
+                 FStar_Class_Show.show
+                   FStar_Compiler_Range_Ops.showable_range uu___4 in
                let uu___4 =
                  FStar_Class_Show.show
                    (FStar_Class_Show.show_tuple3

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_TcTerm.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_TcTerm.ml
@@ -1939,7 +1939,8 @@ and (tc_maybe_toplevel_term :
         then
           let uu___3 =
             let uu___4 = FStar_TypeChecker_Env.get_range env1 in
-            FStar_Class_Show.show FStar_Compiler_Range_Ops.show_range uu___4 in
+            FStar_Class_Show.show FStar_Compiler_Range_Ops.showable_range
+              uu___4 in
           let uu___4 = FStar_Syntax_Print.tag_of_term top in
           let uu___5 =
             FStar_Class_Show.show FStar_Syntax_Print.showable_term top in
@@ -6753,7 +6754,8 @@ and (check_application_args :
                if uu___1
                then
                  let uu___2 =
-                   FStar_Class_Show.show FStar_Compiler_Range_Ops.show_range
+                   FStar_Class_Show.show
+                     FStar_Compiler_Range_Ops.showable_range
                      head.FStar_Syntax_Syntax.pos in
                  let uu___3 =
                    FStar_Class_Show.show FStar_Syntax_Print.showable_term

--- a/src/basic/FStar.Compiler.Range.Ops.fst
+++ b/src/basic/FStar.Compiler.Range.Ops.fst
@@ -121,6 +121,10 @@ let json_of_def_range r =
             (start_of_range r)
             (end_of_range r)
 
-instance show_range = {
+instance showable_range = {
   show = string_of_range;
+}
+
+instance pretty_range = {
+  pp = (fun r -> Pprint.doc_of_string (string_of_range r));
 }

--- a/src/basic/FStar.Compiler.Range.Ops.fsti
+++ b/src/basic/FStar.Compiler.Range.Ops.fsti
@@ -18,6 +18,7 @@ module FStar.Compiler.Range.Ops
 open FStar.Compiler.Range.Type
 open FStar.Compiler.Effect
 open FStar.Class.Show
+open FStar.Class.PP
 
 val union_rng: rng -> rng -> rng
 val union_ranges: range -> range -> range
@@ -47,4 +48,5 @@ val json_of_pos : pos -> Json.json
 val json_of_use_range : range -> Json.json
 val json_of_def_range : range -> Json.json
 
-instance val show_range : showable range
+instance val showable_range : showable range
+instance val pretty_range : pretty range

--- a/src/syntax/FStar.Syntax.Resugar.fst
+++ b/src/syntax/FStar.Syntax.Resugar.fst
@@ -411,7 +411,11 @@ let rec resugar_term' (env: DsEnv.env) (t : S.term) : A.term =
       when can_resugar_machine_integer fv ->
       resugar_machine_integer fv i t.pos
 
-    | Tm_app {hd=e; args} ->
+    | Tm_app _ ->
+      let t = U.canon_app t in
+      let Tm_app {hd=e; args} = t.n in
+      (* NB: This cannot fail since U.canon_app constructs a Tm_app. *)
+
       (* Op("=!=", args) is desugared into Op("~", Op("==") and not resugared back as "=!=" *)
       let rec last = function
             | hd :: [] -> [hd]

--- a/src/tactics/FStar.Tactics.V2.Basic.fst
+++ b/src/tactics/FStar.Tactics.V2.Basic.fst
@@ -578,7 +578,7 @@ let tadmit_t (t:term) : tac unit = wrap_err "tadmit_t" <| (
   let! ps = get in
   let! g = cur_goal in
   // should somehow taint the state instead of just printing a warning
-  Err.log_issue (pos #_ #(has_range_syntax ()) (goal_type g))
+  Err.log_issue (pos (goal_type g))
       (Errors.Warning_TacAdmit, BU.format1 "Tactics admitted goal <%s>\n\n"
                   (goal_to_string "" None ps g));
   solve' g t)

--- a/tests/error-messages/Bug1918.fst.expected
+++ b/tests/error-messages/Bug1918.fst.expected
@@ -1,8 +1,8 @@
 >> Got issues: [
 * Error 228 at Bug1918.fst(11,13-11,14):
-  - Typeclass resolution failed
+  - Typeclass resolution failed.
   - Could not solve constraint Bug1918.mon
-  - See also FStar.Tactics.Typeclasses.fst(293,6-297,7)
+  - See also FStar.Tactics.Typeclasses.fst(308,6-312,7)
 
 >>]
 Verified module: Bug1918

--- a/tests/typeclasses/Unit.fst
+++ b/tests/typeclasses/Unit.fst
@@ -1,0 +1,7 @@
+module Unit
+
+class c (t:Type) = { dummy:unit }
+
+instance c_int () : c int = { dummy=() }
+
+let _ : c int = Tactics.Typeclasses.solve

--- a/ulib/FStar.Tactics.Typeclasses.fst
+++ b/ulib/FStar.Tactics.Typeclasses.fst
@@ -306,12 +306,12 @@ let tcresolve () : Tac unit =
     | NoInst ->
       let open FStar.Stubs.Pprint in
       fail_doc [
-        text "Typeclass resolution failed";
+        text "Typeclass resolution failed.";
         prefix 2 1 (text "Could not solve constraint")
-          (arbitrary_string (term_to_string (cur_goal ())));
+          (term_to_doc (cur_goal ()));
       ]
     | TacticFailure msg ->
-      fail_doc ([text "Typeclass resolution failed"] @ msg)
+      fail_doc ([text "Typeclass resolution failed."] @ msg)
     | e -> raise e
 
 (**** Generating methods from a class ****)


### PR DESCRIPTION
- Make tcresolve solve trivial unit goals, which can show up
- Improve the fix for #3227 to consider nested applications, which should up pervasively in Pulse.