### PR TITLE
Resugaring for dependent tuples

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_Class_Monad.ml
+++ b/ocaml/fstar-lib/generated/FStar_Class_Monad.ml
@@ -73,6 +73,32 @@ let rec mapM :
                              Obj.magic
                                (return uu___ () (Obj.magic (y :: ys))))
                             uu___3))
+let mapMi :
+  'm .
+    'm monad ->
+      unit -> unit -> (Prims.int -> Obj.t -> 'm) -> Obj.t Prims.list -> 'm
+  =
+  fun uu___ ->
+    fun a ->
+      fun b ->
+        fun f ->
+          fun l ->
+            let rec mapMi_go i f1 l1 =
+              match l1 with
+              | [] -> return uu___ () (Obj.magic [])
+              | x::xs ->
+                  let uu___1 = f1 i x in
+                  op_let_Bang uu___ () () uu___1
+                    (fun y ->
+                       let uu___2 = mapMi_go (i + Prims.int_one) f1 xs in
+                       op_let_Bang uu___ () () uu___2
+                         (fun uu___3 ->
+                            (fun ys ->
+                               let ys = Obj.magic ys in
+                               Obj.magic
+                                 (return uu___ () (Obj.magic (y :: ys))))
+                              uu___3)) in
+            mapMi_go Prims.int_zero f l
 let map_optM :
   'm .
     'm monad ->

--- a/ocaml/fstar-lib/generated/FStar_Parser_ToDocument.ml
+++ b/ocaml/fstar-lib/generated/FStar_Parser_ToDocument.ml
@@ -51,8 +51,6 @@ let (all1_explicit :
             match uu___ with
             | (uu___1, FStar_Parser_AST.Nothing) -> true
             | uu___1 -> false) args)
-let (unfold_tuples : Prims.bool FStar_Compiler_Effect.ref) =
-  FStar_Compiler_Util.mk_ref true
 let (str : Prims.string -> FStar_Pprint.document) =
   fun s -> FStar_Pprint.doc_of_string s
 let default_or_map :
@@ -653,7 +651,7 @@ let (levels : Prims.string -> (Prims.int * Prims.int * Prims.int)) =
     let uu___ = assign_levels level_associativity_spec op in
     match uu___ with
     | (left, mine, right) ->
-        if op = "*"
+        if op = "&"
         then ((left - Prims.int_one), mine, right)
         else (left, mine, right)
 let (operatorInfix0ad12 : associativity_level Prims.list) =
@@ -4251,13 +4249,13 @@ and (paren_if_gt :
   fun curr ->
     fun mine ->
       fun doc ->
-        if mine <= curr
-        then doc
-        else
-          (let uu___1 =
-             let uu___2 = FStar_Pprint.op_Hat_Hat doc FStar_Pprint.rparen in
-             FStar_Pprint.op_Hat_Hat FStar_Pprint.lparen uu___2 in
-           FStar_Pprint.group uu___1)
+        if mine > curr
+        then
+          let uu___ =
+            let uu___1 = FStar_Pprint.op_Hat_Hat doc FStar_Pprint.rparen in
+            FStar_Pprint.op_Hat_Hat FStar_Pprint.lparen uu___1 in
+          FStar_Pprint.group uu___
+        else doc
 and (p_tmEqWith :
   (FStar_Parser_AST.term -> FStar_Pprint.document) ->
     FStar_Parser_AST.term -> FStar_Pprint.document)
@@ -4379,27 +4377,6 @@ and (p_tmNoEqWith' :
                      let uu___3 = p_tmNoEqWith' false p_X right res in
                      FStar_Pprint.op_Hat_Hat uu___2 uu___3 in
                    paren_if_gt curr mine uu___1)
-          | FStar_Parser_AST.Op (id, e1::e2::[]) when
-              (let uu___ = FStar_Ident.string_of_id id in uu___ = "*") &&
-                (FStar_Compiler_Effect.op_Bang unfold_tuples)
-              ->
-              let op = "*" in
-              let uu___ = levels op in
-              (match uu___ with
-               | (left, mine, right) ->
-                   if inside_tuple
-                   then
-                     let uu___1 = str op in
-                     let uu___2 = p_tmNoEqWith' true p_X left e1 in
-                     let uu___3 = p_tmNoEqWith' true p_X right e2 in
-                     infix0 uu___1 uu___2 uu___3
-                   else
-                     (let uu___2 =
-                        let uu___3 = str op in
-                        let uu___4 = p_tmNoEqWith' true p_X left e1 in
-                        let uu___5 = p_tmNoEqWith' true p_X right e2 in
-                        infix0 uu___3 uu___4 uu___5 in
-                      paren_if_gt curr mine uu___2))
           | FStar_Parser_AST.Op (op, e1::e2::[]) when is_operatorInfix34 op
               ->
               let op1 = FStar_Ident.string_of_id op in
@@ -5015,12 +4992,7 @@ and (p_atomicUniverse : FStar_Parser_AST.term -> FStar_Pprint.document) =
             uu___2 in
         FStar_Compiler_Effect.failwith uu___1
 let (term_to_document : FStar_Parser_AST.term -> FStar_Pprint.document) =
-  fun e ->
-    let old_unfold_tuples = FStar_Compiler_Effect.op_Bang unfold_tuples in
-    FStar_Compiler_Effect.op_Colon_Equals unfold_tuples false;
-    (let res = p_term false false e in
-     FStar_Compiler_Effect.op_Colon_Equals unfold_tuples old_unfold_tuples;
-     res)
+  fun e -> p_term false false e
 let (signature_to_document : FStar_Parser_AST.decl -> FStar_Pprint.document)
   = fun e -> p_justSig e
 let (decl_to_document : FStar_Parser_AST.decl -> FStar_Pprint.document) =

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Resugar.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Resugar.ml
@@ -889,7 +889,212 @@ let rec (resugar_term' :
                         FStar_Parser_AST.Project uu___7 in
                       mk uu___6)
                else
-                 (let uu___5 = resugar_term_as_op e in
+                 (let unsnoc l =
+                    let rec unsnoc' acc uu___5 =
+                      match uu___5 with
+                      | [] ->
+                          FStar_Compiler_Effect.failwith "unsnoc: empty list"
+                      | x::[] -> ((FStar_Compiler_List.rev acc), x)
+                      | x::xs -> unsnoc' (x :: acc) xs in
+                    unsnoc' [] l in
+                  let resugar_tuple_type env1 args2 =
+                    let typs =
+                      FStar_Compiler_List.map
+                        (fun uu___5 ->
+                           match uu___5 with
+                           | (x, uu___6) -> resugar_term' env1 x) args2 in
+                    let uu___5 = unsnoc typs in
+                    match uu___5 with
+                    | (pre, last1) ->
+                        let uu___6 =
+                          let uu___7 =
+                            let uu___8 =
+                              FStar_Compiler_List.map
+                                (fun uu___9 -> FStar_Pervasives.Inr uu___9)
+                                pre in
+                            (uu___8, last1) in
+                          FStar_Parser_AST.Sum uu___7 in
+                        mk uu___6 in
+                  let resugar_dtuple_type env1 hd args2 =
+                    let fancy_resugar uu___5 =
+                      (fun uu___5 ->
+                         let n = FStar_Compiler_List.length args2 in
+                         let take n1 l =
+                           let uu___6 = FStar_Compiler_List.splitAt n1 l in
+                           FStar_Pervasives_Native.fst uu___6 in
+                         let uu___6 =
+                           let uu___7 =
+                             let uu___8 = FStar_Compiler_List.last args2 in
+                             FStar_Pervasives_Native.fst uu___8 in
+                           FStar_Syntax_Util.abs_formals uu___7 in
+                         match uu___6 with
+                         | (bs, uu___7, uu___8) ->
+                             Obj.magic
+                               (FStar_Class_Monad.op_let_Bang
+                                  FStar_Class_Monad.monad_option () ()
+                                  (if
+                                     (FStar_Compiler_List.length bs) <
+                                       (n - Prims.int_one)
+                                   then FStar_Pervasives_Native.None
+                                   else FStar_Pervasives_Native.Some ())
+                                  (fun uu___9 ->
+                                     (fun uu___9 ->
+                                        let uu___9 = Obj.magic uu___9 in
+                                        let bs1 = take (n - Prims.int_one) bs in
+                                        let concatM uu___10 l =
+                                          FStar_Class_Monad.mapM uu___10 ()
+                                            ()
+                                            (fun uu___11 ->
+                                               (fun x ->
+                                                  let x = Obj.magic x in
+                                                  Obj.magic x) uu___11)
+                                            (Obj.magic l) in
+                                        let rec open_lambda_binders uu___11
+                                          uu___10 =
+                                          (fun t2 ->
+                                             fun bs2 ->
+                                               match bs2 with
+                                               | [] ->
+                                                   Obj.magic
+                                                     (Obj.repr
+                                                        (FStar_Pervasives_Native.Some
+                                                           t2))
+                                               | b::bs3 ->
+                                                   Obj.magic
+                                                     (Obj.repr
+                                                        (let uu___10 =
+                                                           FStar_Syntax_Util.abs_one_ln
+                                                             t2 in
+                                                         FStar_Class_Monad.op_let_Bang
+                                                           FStar_Class_Monad.monad_option
+                                                           () ()
+                                                           (Obj.magic uu___10)
+                                                           (fun uu___11 ->
+                                                              (fun uu___11 ->
+                                                                 let uu___11
+                                                                   =
+                                                                   Obj.magic
+                                                                    uu___11 in
+                                                                 match uu___11
+                                                                 with
+                                                                 | (uu___12,
+                                                                    body) ->
+                                                                    let uu___13
+                                                                    =
+                                                                    FStar_Syntax_Subst.open_term
+                                                                    [b] body in
+                                                                    (match uu___13
+                                                                    with
+                                                                    | 
+                                                                    (uu___14,
+                                                                    body1) ->
+                                                                    Obj.magic
+                                                                    (open_lambda_binders
+                                                                    body1 bs3)))
+                                                                uu___11))))
+                                            uu___11 uu___10 in
+                                        let uu___10 =
+                                          Obj.magic
+                                            (FStar_Class_Monad.mapMi
+                                               FStar_Class_Monad.monad_option
+                                               () ()
+                                               (fun uu___12 ->
+                                                  fun uu___11 ->
+                                                    (fun i ->
+                                                       fun uu___11 ->
+                                                         let uu___11 =
+                                                           Obj.magic uu___11 in
+                                                         match uu___11 with
+                                                         | (t2, uu___12) ->
+                                                             let uu___13 =
+                                                               take i bs1 in
+                                                             Obj.magic
+                                                               (open_lambda_binders
+                                                                  t2 uu___13))
+                                                      uu___12 uu___11)
+                                               (Obj.magic args2)) in
+                                        Obj.magic
+                                          (FStar_Class_Monad.op_let_Bang
+                                             FStar_Class_Monad.monad_option
+                                             () () (Obj.magic uu___10)
+                                             (fun uu___11 ->
+                                                (fun opened_bs_types ->
+                                                   let opened_bs_types =
+                                                     Obj.magic
+                                                       opened_bs_types in
+                                                   let set_binder_sort t2 b =
+                                                     {
+                                                       FStar_Syntax_Syntax.binder_bv
+                                                         =
+                                                         (let uu___11 =
+                                                            b.FStar_Syntax_Syntax.binder_bv in
+                                                          {
+                                                            FStar_Syntax_Syntax.ppname
+                                                              =
+                                                              (uu___11.FStar_Syntax_Syntax.ppname);
+                                                            FStar_Syntax_Syntax.index
+                                                              =
+                                                              (uu___11.FStar_Syntax_Syntax.index);
+                                                            FStar_Syntax_Syntax.sort
+                                                              = t2
+                                                          });
+                                                       FStar_Syntax_Syntax.binder_qual
+                                                         =
+                                                         (b.FStar_Syntax_Syntax.binder_qual);
+                                                       FStar_Syntax_Syntax.binder_positivity
+                                                         =
+                                                         (b.FStar_Syntax_Syntax.binder_positivity);
+                                                       FStar_Syntax_Syntax.binder_attrs
+                                                         =
+                                                         (b.FStar_Syntax_Syntax.binder_attrs)
+                                                     } in
+                                                   let uu___11 =
+                                                     unsnoc opened_bs_types in
+                                                   match uu___11 with
+                                                   | (pre_bs_types,
+                                                      last_type) ->
+                                                       let bs2 =
+                                                         FStar_Compiler_List.map2
+                                                           (fun b ->
+                                                              fun t2 ->
+                                                                let b1 =
+                                                                  set_binder_sort
+                                                                    t2 b in
+                                                                let uu___12 =
+                                                                  resugar_binder'
+                                                                    env1 b1
+                                                                    t2.FStar_Syntax_Syntax.pos in
+                                                                FStar_Compiler_Util.must
+                                                                  uu___12)
+                                                           bs1 pre_bs_types in
+                                                       let uu___12 =
+                                                         let uu___13 =
+                                                           let uu___14 =
+                                                             let uu___15 =
+                                                               FStar_Compiler_List.map
+                                                                 (fun uu___16
+                                                                    ->
+                                                                    FStar_Pervasives.Inl
+                                                                    uu___16)
+                                                                 bs2 in
+                                                             let uu___16 =
+                                                               resugar_term'
+                                                                 env1
+                                                                 last_type in
+                                                             (uu___15,
+                                                               uu___16) in
+                                                           FStar_Parser_AST.Sum
+                                                             uu___14 in
+                                                         mk uu___13 in
+                                                       Obj.magic
+                                                         (FStar_Pervasives_Native.Some
+                                                            uu___12)) uu___11)))
+                                       uu___9))) uu___5 in
+                    let uu___5 = fancy_resugar () in
+                    match uu___5 with
+                    | FStar_Pervasives_Native.Some r -> r
+                    | FStar_Pervasives_Native.None -> resugar_as_app hd args2 in
+                  let uu___5 = resugar_term_as_op e in
                   match uu___5 with
                   | FStar_Pervasives_Native.None -> resugar_as_app e args1
                   | FStar_Pervasives_Native.Some ("calc_finish", uu___6) ->
@@ -897,31 +1102,16 @@ let rec (resugar_term' :
                       (match uu___7 with
                        | FStar_Pervasives_Native.Some r -> r
                        | uu___8 -> resugar_as_app e args1)
-                  | FStar_Pervasives_Native.Some ("tuple", uu___6) ->
-                      let out =
-                        FStar_Compiler_List.fold_left
-                          (fun out1 ->
-                             fun uu___7 ->
-                               match uu___7 with
-                               | (x, uu___8) ->
-                                   let x1 = resugar_term' env x in
-                                   (match out1 with
-                                    | FStar_Pervasives_Native.None ->
-                                        FStar_Pervasives_Native.Some x1
-                                    | FStar_Pervasives_Native.Some prefix ->
-                                        let uu___9 =
-                                          let uu___10 =
-                                            let uu___11 =
-                                              let uu___12 =
-                                                FStar_Ident.id_of_text "*" in
-                                              (uu___12, [prefix; x1]) in
-                                            FStar_Parser_AST.Op uu___11 in
-                                          mk uu___10 in
-                                        FStar_Pervasives_Native.Some uu___9))
-                          FStar_Pervasives_Native.None args1 in
-                      FStar_Compiler_Option.get out
-                  | FStar_Pervasives_Native.Some ("dtuple", uu___6) ->
-                      resugar_as_app e args1
+                  | FStar_Pervasives_Native.Some ("tuple", n) when
+                      (FStar_Pervasives_Native.Some
+                         (FStar_Compiler_List.length args1))
+                        = n
+                      -> resugar_tuple_type env args1
+                  | FStar_Pervasives_Native.Some ("dtuple", n) when
+                      (FStar_Pervasives_Native.Some
+                         (FStar_Compiler_List.length args1))
+                        = n
+                      -> resugar_dtuple_type env e args1
                   | FStar_Pervasives_Native.Some (ref_read, uu___6) when
                       let uu___7 =
                         FStar_Ident.string_of_lid
@@ -2077,40 +2267,60 @@ and (resugar_binder' :
       FStar_Compiler_Range_Type.range ->
         FStar_Parser_AST.binder FStar_Pervasives_Native.option)
   =
-  fun env ->
-    fun b ->
-      fun r ->
-        let uu___ = resugar_bqual env b.FStar_Syntax_Syntax.binder_qual in
-        FStar_Compiler_Util.map_opt uu___
-          (fun imp ->
-             let e =
-               resugar_term' env
-                 (b.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort in
-             match e.FStar_Parser_AST.tm with
-             | FStar_Parser_AST.Wild ->
-                 let uu___1 =
-                   let uu___2 =
-                     bv_as_unique_ident b.FStar_Syntax_Syntax.binder_bv in
-                   FStar_Parser_AST.Variable uu___2 in
-                 FStar_Parser_AST.mk_binder uu___1 r
-                   FStar_Parser_AST.Type_level imp
-             | uu___1 ->
-                 let uu___2 =
-                   FStar_Syntax_Syntax.is_null_bv
-                     b.FStar_Syntax_Syntax.binder_bv in
-                 if uu___2
-                 then
-                   FStar_Parser_AST.mk_binder (FStar_Parser_AST.NoName e) r
-                     FStar_Parser_AST.Type_level imp
-                 else
-                   (let uu___4 =
-                      let uu___5 =
-                        let uu___6 =
-                          bv_as_unique_ident b.FStar_Syntax_Syntax.binder_bv in
-                        (uu___6, e) in
-                      FStar_Parser_AST.Annotated uu___5 in
-                    FStar_Parser_AST.mk_binder uu___4 r
-                      FStar_Parser_AST.Type_level imp))
+  fun uu___2 ->
+    fun uu___1 ->
+      fun uu___ ->
+        (fun env ->
+           fun b ->
+             fun r ->
+               let uu___ =
+                 resugar_bqual env b.FStar_Syntax_Syntax.binder_qual in
+               Obj.magic
+                 (FStar_Class_Monad.op_let_Bang
+                    FStar_Class_Monad.monad_option () () (Obj.magic uu___)
+                    (fun uu___1 ->
+                       (fun imp ->
+                          let imp = Obj.magic imp in
+                          let e =
+                            resugar_term' env
+                              (b.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort in
+                          match e.FStar_Parser_AST.tm with
+                          | FStar_Parser_AST.Wild ->
+                              let uu___1 =
+                                let uu___2 =
+                                  let uu___3 =
+                                    bv_as_unique_ident
+                                      b.FStar_Syntax_Syntax.binder_bv in
+                                  FStar_Parser_AST.Variable uu___3 in
+                                FStar_Parser_AST.mk_binder uu___2 r
+                                  FStar_Parser_AST.Type_level imp in
+                              Obj.magic (FStar_Pervasives_Native.Some uu___1)
+                          | uu___1 ->
+                              let uu___2 =
+                                FStar_Syntax_Syntax.is_null_bv
+                                  b.FStar_Syntax_Syntax.binder_bv in
+                              if uu___2
+                              then
+                                let uu___3 =
+                                  FStar_Parser_AST.mk_binder
+                                    (FStar_Parser_AST.NoName e) r
+                                    FStar_Parser_AST.Type_level imp in
+                                Obj.magic
+                                  (FStar_Pervasives_Native.Some uu___3)
+                              else
+                                (let uu___4 =
+                                   let uu___5 =
+                                     let uu___6 =
+                                       let uu___7 =
+                                         bv_as_unique_ident
+                                           b.FStar_Syntax_Syntax.binder_bv in
+                                       (uu___7, e) in
+                                     FStar_Parser_AST.Annotated uu___6 in
+                                   FStar_Parser_AST.mk_binder uu___5 r
+                                     FStar_Parser_AST.Type_level imp in
+                                 Obj.magic
+                                   (FStar_Pervasives_Native.Some uu___4)))
+                         uu___1))) uu___2 uu___1 uu___
 and (resugar_bv_as_pat' :
   FStar_Syntax_DsEnv.env ->
     FStar_Syntax_Syntax.bv ->

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Util.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Util.ml
@@ -2809,6 +2809,31 @@ let (arrow_one :
                         FStar_Compiler_Effect.failwith
                           "impossible: open_comp returned different amount of binders" in
                   FStar_Pervasives_Native.Some (b1, c1)))
+let (abs_one_ln :
+  FStar_Syntax_Syntax.typ ->
+    (FStar_Syntax_Syntax.binder * FStar_Syntax_Syntax.term)
+      FStar_Pervasives_Native.option)
+  =
+  fun t ->
+    let uu___ =
+      let uu___1 = FStar_Syntax_Subst.compress t in
+      uu___1.FStar_Syntax_Syntax.n in
+    match uu___ with
+    | FStar_Syntax_Syntax.Tm_abs
+        { FStar_Syntax_Syntax.bs = []; FStar_Syntax_Syntax.body = uu___1;
+          FStar_Syntax_Syntax.rc_opt = uu___2;_}
+        -> FStar_Compiler_Effect.failwith "fatal: empty binders on abs?"
+    | FStar_Syntax_Syntax.Tm_abs
+        { FStar_Syntax_Syntax.bs = b::[]; FStar_Syntax_Syntax.body = body;
+          FStar_Syntax_Syntax.rc_opt = uu___1;_}
+        -> FStar_Pervasives_Native.Some (b, body)
+    | FStar_Syntax_Syntax.Tm_abs
+        { FStar_Syntax_Syntax.bs = b::bs; FStar_Syntax_Syntax.body = body;
+          FStar_Syntax_Syntax.rc_opt = rc_opt;_}
+        ->
+        let uu___1 = let uu___2 = abs bs body rc_opt in (b, uu___2) in
+        FStar_Pervasives_Native.Some uu___1
+    | uu___1 -> FStar_Pervasives_Native.None
 let (is_free_in :
   FStar_Syntax_Syntax.bv -> FStar_Syntax_Syntax.term -> Prims.bool) =
   fun bv ->

--- a/src/class/FStar.Class.Monad.fst
+++ b/src/class/FStar.Class.Monad.fst
@@ -21,6 +21,18 @@ let rec mapM f l =
     let! ys = mapM f xs in
     return (y::ys)
 
+let mapMi #m #_ #a #b f l =
+  (* FIXME: need to annotate the return type, why? *)
+  let rec mapMi_go i f l : m (list b) =
+    match l with
+    | [] -> return []
+    | x::xs ->
+      let! y = f i x in
+      let! ys = mapMi_go (i+1) f xs in
+      return (y::ys)
+  in
+  mapMi_go 0 f l
+
 let map_optM f l =
   match l with
   | None -> return None

--- a/src/class/FStar.Class.Monad.fsti
+++ b/src/class/FStar.Class.Monad.fsti
@@ -17,6 +17,12 @@ val mapM
   (#a #b :Type)
 : (a -> m b) -> list a -> m (list b)
 
+val mapMi
+  (#m: Type -> Type)
+  {| monad m |}
+  (#a #b :Type)
+: (int -> a -> m b) -> list a -> m (list b)
+
 val map_optM
   (#m: Type -> Type)
   {| monad m |}

--- a/src/parser/FStar.Parser.ToDocument.fst
+++ b/src/parser/FStar.Parser.ToDocument.fst
@@ -35,9 +35,8 @@ module BU = FStar.Compiler.Util
 
 
 (* !!! SIDE EFFECT WARNING !!! *)
-(* There are 2 uses of global side-effect in the printer for : *)
+(* There is ONE use of global side-effect in the printer for : *)
 (* - Printing the comments [comment_stack] *)
-(* - Printing tuples [unfold_tuples] *)
 
 let maybe_unthunk t =
     match t.tm with
@@ -80,10 +79,6 @@ let all1_explicit (args:list (term*imp)) : bool =
     BU.for_all (function
                 | (_, Nothing) -> true
                 | _ -> false) args
-
-(* Tuples which come from a resugared AST, via term_to_document are already flattened *)
-(* This reference is set to false in term_to_document and checked in p_tmNoEqWith'    *)
-let unfold_tuples = BU.mk_ref true
 
 // abbrev
 let str s = doc_of_string s
@@ -1951,13 +1946,6 @@ and p_tmNoEqWith' inside_tuple p_X curr e = match e.tm with
         | Inr t -> p_tmNoEqWith' false p_X left t ^^ space ^^ str op ^^ break1
       in
       paren_if_gt curr mine (concat_map p_dsumfst binders ^^ p_tmNoEqWith' false p_X right res)
-  | Op(id, [e1; e2]) when string_of_id id = "*" && !unfold_tuples ->
-      let op = "*" in
-      let left, mine, right = levels op in
-      if inside_tuple then
-        infix0 (str op) (p_tmNoEqWith' true p_X left e1) (p_tmNoEqWith' true p_X right e2)
-      else
-        paren_if_gt curr mine (infix0 (str op) (p_tmNoEqWith' true p_X left e1) (p_tmNoEqWith' true p_X right e2))
   | Op (op, [e1; e2]) when is_operatorInfix34 op ->
       let op = Ident.string_of_id op in
       let left, mine, right = levels op in
@@ -2253,11 +2241,7 @@ and p_atomicUniverse u = match u.tm with
   | _ -> failwith (Util.format1 "Invalid term in universe context %s" (term_to_string u))
 
 let term_to_document e =
-  let old_unfold_tuples = !unfold_tuples in
-  unfold_tuples := false;
-  let res = p_term false false e in
-  unfold_tuples := old_unfold_tuples;
-  res
+  p_term false false e
 
 let signature_to_document e = p_justSig e
 

--- a/src/parser/FStar.Parser.ToDocument.fst
+++ b/src/parser/FStar.Parser.ToDocument.fst
@@ -389,18 +389,18 @@ let max_level l =
   in List.fold_left find_level_and_max 0 l
 
 let levels op =
-  (* See comment in parse.fsy: tuples MUST be parenthesized because [t * u * v]
-   * is not the same thing as [(t * u) * v]. So, we are conservative and make an
-   * exception for the "*" operator and treat it as, really, non-associative. If
+  (* See comment in parse.fsy: tuples MUST be parenthesized because [t & u & v]
+   * is not the same thing as [(t & u) & v]. So, we are conservative and make an
+   * exception for the "&" operator and treat it as, really, non-associative. If
    * the AST comes from the user, then the Paren node was there already and no
    * extra parentheses are added. If the AST comes from some client inside of
    * the F* compiler that doesn't know about this quirk, then it forces it to be
-   * parenthesized properly. In case the user overrode * to be a truly
-   * associative operator (e.g. multiplication) then we're just being a little
+   * parenthesized properly. In case the user overrode & to be a truly
+   * associative operator then we're just being a little
    * conservative because, unlike ToSyntax.fs, we don't have lexical context to
    * help us determine which operator this is, really. *)
   let left, mine, right = assign_levels level_associativity_spec op in
-  if op = "*" then
+  if op = "&" then
     left - 1, mine, right
   else
     left, mine, right
@@ -1904,10 +1904,10 @@ and p_tmTuple' e = match e.tm with
   | _ -> p_tmEq e
 
 and paren_if_gt curr mine doc =
-  if mine <= curr then
-    doc
-  else
+  if mine > curr then
     group (lparen ^^ doc ^^ rparen)
+  else
+    doc
 
 and p_tmEqWith p_X e =
   (* TODO : this should be precomputed but F* complains about a potential ML effect *)

--- a/src/syntax/FStar.Syntax.Resugar.fst
+++ b/src/syntax/FStar.Syntax.Resugar.fst
@@ -492,7 +492,7 @@ let rec resugar_term' (env: DsEnv.env) (t : S.term) : A.term =
                     match out with
                     | None -> Some x
                     | Some prefix ->
-                      Some (mk(A.Op(Ident.id_of_text "*", [prefix; x]))))
+                      Some (mk(A.Op(Ident.id_of_text "&", [prefix; x]))))
                     None
                     args
           in

--- a/src/syntax/FStar.Syntax.Resugar.fst
+++ b/src/syntax/FStar.Syntax.Resugar.fst
@@ -1074,17 +1074,16 @@ and resugar_comp' (env: DsEnv.env) (c:S.comp) : A.term =
       mk (A.Construct(maybe_shorten_lid env c.effect_name, [result]))
 
 and resugar_binder' env (b:S.binder) r : option A.binder =
-  BU.map_opt (resugar_bqual env b.binder_qual) begin fun imp ->
-    let e = resugar_term' env b.binder_bv.sort in
-    match (e.tm) with
-    | A.Wild ->
-      A.mk_binder (A.Variable(bv_as_unique_ident b.binder_bv)) r A.Type_level imp
-    | _ ->
-      if S.is_null_bv b.binder_bv then
-        A.mk_binder (A.NoName e) r A.Type_level imp
-      else
-        A.mk_binder (A.Annotated (bv_as_unique_ident b.binder_bv, e)) r A.Type_level imp
-  end
+  let! imp = resugar_bqual env b.binder_qual in
+  let e = resugar_term' env b.binder_bv.sort in
+  match (e.tm) with
+  | A.Wild ->
+    Some <| A.mk_binder (A.Variable(bv_as_unique_ident b.binder_bv)) r A.Type_level imp
+  | _ ->
+    if S.is_null_bv b.binder_bv then
+      Some <| A.mk_binder (A.NoName e) r A.Type_level imp
+    else
+      Some <| A.mk_binder (A.Annotated (bv_as_unique_ident b.binder_bv, e)) r A.Type_level imp
 
 and resugar_bv_as_pat' env (v: S.bv) aqual (body_bv: FlatSet.t bv) typ_opt =
   let mk a = A.mk_pattern a (S.range_of_bv v) in

--- a/src/syntax/FStar.Syntax.Util.fst
+++ b/src/syntax/FStar.Syntax.Util.fst
@@ -1223,6 +1223,17 @@ let arrow_one (t:typ) : option (binder * comp) =
     in
     Some (b, c))
 
+let abs_one_ln (t:typ) : option (binder * term) =
+    match (compress t).n with
+    | Tm_abs {bs=[]} ->
+        failwith "fatal: empty binders on abs?"
+    | Tm_abs {bs=[b]; body} ->
+        Some (b, body)
+    | Tm_abs {bs=b::bs; body; rc_opt} ->
+        Some (b, abs bs body rc_opt)
+    | _ ->
+        None
+
 let is_free_in (bv:bv) (t:term) : bool =
     mem bv (FStar.Syntax.Free.names t)
 

--- a/tests/error-messages/Bug2245.fst
+++ b/tests/error-messages/Bug2245.fst
@@ -1,0 +1,6 @@
+module Bug2245
+
+assume val a: int*int*int
+
+[@@expect_failure]
+let b: (int*int)*int = a

--- a/tests/error-messages/Bug2245.fst.expected
+++ b/tests/error-messages/Bug2245.fst.expected
@@ -1,0 +1,9 @@
+>> Got issues: [
+* Error 189 at Bug2245.fst(6,23-6,24):
+  - Expected expression of type (Prims.int & Prims.int) & Prims.int
+    got expression a
+    of type Prims.int & Prims.int & Prims.int
+
+>>]
+Verified module: Bug2245
+All verification conditions discharged successfully

--- a/tests/error-messages/Bug3099.fst.expected
+++ b/tests/error-messages/Bug3099.fst.expected
@@ -1,7 +1,7 @@
 proof-state: State dump @ depth 0 (X):
 Location: Bug3099.fst(11,50-11,64)
 Goal 1/1:
-(_: Prims.unit), (return_val: Prims.eqtype), (_: return_val == Prims.int * Prims.int * Prims.int * Prims.int), (any_result: Prims.bool), (_: true == any_result), (any_result'0: Prims.logical), (_: Prims.l_True == any_result'0) |- _ : Prims.squash ((1, (2, (3, 4))) = (1, (2, (3, 4))))
+(_: Prims.unit), (return_val: Prims.eqtype), (_: return_val == Prims.int & (Prims.int & (Prims.int & Prims.int))), (any_result: Prims.bool), (_: true == any_result), (any_result'0: Prims.logical), (_: Prims.l_True == any_result'0) |- _ : Prims.squash ((1, (2, (3, 4))) = (1, (2, (3, 4))))
 
 Verified module: Bug3099
 All verification conditions discharged successfully

--- a/tests/error-messages/Bug3145.fst
+++ b/tests/error-messages/Bug3145.fst
@@ -1,0 +1,6 @@
+module Bug3145
+
+let t1 = int * int * int
+let t2 = int * int & int
+let t3 = int & int * int
+let t4 = int & int & int

--- a/tests/error-messages/Bug3145.fst.expected
+++ b/tests/error-messages/Bug3145.fst.expected
@@ -1,0 +1,47 @@
+Module after desugaring:
+module Bug3145
+Declarations: [
+let t1 = Prims.int & Prims.int & Prims.int
+let t2 = (Prims.int & Prims.int) & Prims.int
+let t3 = Prims.int & (Prims.int & Prims.int)
+let t4 = Prims.int & Prims.int & Prims.int
+]
+Exports: [
+let t1 = Prims.int & Prims.int & Prims.int
+let t2 = (Prims.int & Prims.int) & Prims.int
+let t3 = Prims.int & (Prims.int & Prims.int)
+let t4 = Prims.int & Prims.int & Prims.int
+]
+
+Module before type checking:
+module Bug3145
+Declarations: [
+let t1 = Prims.int & Prims.int & Prims.int
+let t2 = (Prims.int & Prims.int) & Prims.int
+let t3 = Prims.int & (Prims.int & Prims.int)
+let t4 = Prims.int & Prims.int & Prims.int
+]
+Exports: [
+let t1 = Prims.int & Prims.int & Prims.int
+let t2 = (Prims.int & Prims.int) & Prims.int
+let t3 = Prims.int & (Prims.int & Prims.int)
+let t4 = Prims.int & Prims.int & Prims.int
+]
+
+Module after type checking:
+module Bug3145
+Declarations: [
+let t1 = Prims.int & Prims.int & Prims.int
+let t2 = (Prims.int & Prims.int) & Prims.int
+let t3 = Prims.int & (Prims.int & Prims.int)
+let t4 = Prims.int & Prims.int & Prims.int
+]
+Exports: [
+let t1 = Prims.int & Prims.int & Prims.int
+let t2 = (Prims.int & Prims.int) & Prims.int
+let t3 = Prims.int & (Prims.int & Prims.int)
+let t4 = Prims.int & Prims.int & Prims.int
+]
+
+Verified module: Bug3145
+All verification conditions discharged successfully

--- a/tests/error-messages/DTuples.fst
+++ b/tests/error-messages/DTuples.fst
@@ -1,0 +1,49 @@
+module DTuples
+
+(* Basic test *)
+let _ = a:int & b:int{a > b} & c:int{c == a+b}
+
+(* Desugared version, resugars to the same *)
+let _ = dtuple3 int
+                (fun a -> b:int{a > b})
+                (fun a b -> c:int{c == a+b})
+
+(* This one is resugared properly too, taking z to be the
+name of the component, and of type (b:int{a > b}). *)
+let _ = dtuple3 int
+                (fun a -> b:int{a > b})
+                (fun a z -> c:int{c == a+z})
+
+(* Bunch of regression tests. *)               
+let _ = (a:int & b:int{a>b} & unit)
+
+let _ = (a:int & b:int & int)
+let _ = (a:int & b:int & c:int & int)
+let _ = (a:int & b:int & c:int & d:int & int)
+
+
+let _ = (int & int)
+let _ = (int & int & int)
+let _ = (int & int & int & int)
+let _ = (int & int & int & int & int)
+
+let _ = (int & (int & int))
+let _ = (int & (int & (int & int)))
+let _ = (int & (int & (int & (int & int))))
+
+(* All of these were terribly broken in master *)
+let _ = tuple4 int bool
+let _ = (tuple4 int bool) string unit
+
+let _ = dtuple4 int (fun _ -> bool)
+
+let t1 = (1,2,3)
+let t2 = ((1,2),3)
+let t3 = (1,(2,3))
+
+let d1 = (|1,2,3|)
+let d2 = (|(1,2),3|)
+let d3 = (|1,(2,3)|)
+
+let dd2 = (|(|1,2|),3|)
+let dd3 = (|1,(|2,3|)|)

--- a/tests/error-messages/DTuples.fst.expected
+++ b/tests/error-messages/DTuples.fst.expected
@@ -1,0 +1,275 @@
+Module after desugaring:
+module DTuples
+Declarations: [
+private
+let _ = a: Prims.int & b: Prims.int{a > b} & c: Prims.int{c == a + b}
+private
+let _ = a: Prims.int & b: Prims.int{a > b} & c: Prims.int{c == a + b}
+private
+let _ = a: Prims.int & z: b: Prims.int{a > b} & c: Prims.int{c == a + z}
+private
+let _ = a: Prims.int & b: Prims.int{a > b} & Prims.unit
+private
+let _ = a: Prims.int & b: Prims.int & Prims.int
+private
+let _ = a: Prims.int & b: Prims.int & c: Prims.int & Prims.int
+private
+let _ = a: Prims.int & b: Prims.int & c: Prims.int & d: Prims.int & Prims.int
+private
+let _ = Prims.int & Prims.int
+private
+let _ = Prims.int & Prims.int & Prims.int
+private
+let _ = Prims.int & Prims.int & Prims.int & Prims.int
+private
+let _ = Prims.int & Prims.int & Prims.int & Prims.int & Prims.int
+private
+let _ = Prims.int & (Prims.int & Prims.int)
+private
+let _ = Prims.int & (Prims.int & (Prims.int & Prims.int))
+private
+let _ = Prims.int & (Prims.int & (Prims.int & (Prims.int & Prims.int)))
+private
+let _ = FStar.Pervasives.Native.tuple4 Prims.int Prims.bool
+private
+let _ = Prims.int & Prims.bool & Prims.string & Prims.unit
+private
+let _ = FStar.Pervasives.dtuple4 Prims.int (fun _ -> Prims.bool)
+let t1 = 1, 2, 3
+let t2 = (1, 2), 3
+let t3 = 1, (2, 3)
+let d1 = (| 1, 2, 3 |)
+let d2 = (| (1, 2), 3 |)
+let d3 = (| 1, (2, 3) |)
+let dd2 = (| (| 1, 2 |), 3 |)
+let dd3 = (| 1, (| 2, 3 |) |)
+]
+Exports: [
+private
+let _ = a: Prims.int & b: Prims.int{a > b} & c: Prims.int{c == a + b}
+private
+let _ = a: Prims.int & b: Prims.int{a > b} & c: Prims.int{c == a + b}
+private
+let _ = a: Prims.int & z: b: Prims.int{a > b} & c: Prims.int{c == a + z}
+private
+let _ = a: Prims.int & b: Prims.int{a > b} & Prims.unit
+private
+let _ = a: Prims.int & b: Prims.int & Prims.int
+private
+let _ = a: Prims.int & b: Prims.int & c: Prims.int & Prims.int
+private
+let _ = a: Prims.int & b: Prims.int & c: Prims.int & d: Prims.int & Prims.int
+private
+let _ = Prims.int & Prims.int
+private
+let _ = Prims.int & Prims.int & Prims.int
+private
+let _ = Prims.int & Prims.int & Prims.int & Prims.int
+private
+let _ = Prims.int & Prims.int & Prims.int & Prims.int & Prims.int
+private
+let _ = Prims.int & (Prims.int & Prims.int)
+private
+let _ = Prims.int & (Prims.int & (Prims.int & Prims.int))
+private
+let _ = Prims.int & (Prims.int & (Prims.int & (Prims.int & Prims.int)))
+private
+let _ = FStar.Pervasives.Native.tuple4 Prims.int Prims.bool
+private
+let _ = Prims.int & Prims.bool & Prims.string & Prims.unit
+private
+let _ = FStar.Pervasives.dtuple4 Prims.int (fun _ -> Prims.bool)
+let t1 = 1, 2, 3
+let t2 = (1, 2), 3
+let t3 = 1, (2, 3)
+let d1 = (| 1, 2, 3 |)
+let d2 = (| (1, 2), 3 |)
+let d3 = (| 1, (2, 3) |)
+let dd2 = (| (| 1, 2 |), 3 |)
+let dd3 = (| 1, (| 2, 3 |) |)
+]
+
+Module before type checking:
+module DTuples
+Declarations: [
+private
+let _ = a: Prims.int & b: Prims.int{a > b} & c: Prims.int{c == a + b}
+private
+let _ = a: Prims.int & b: Prims.int{a > b} & c: Prims.int{c == a + b}
+private
+let _ = a: Prims.int & z: b: Prims.int{a > b} & c: Prims.int{c == a + z}
+private
+let _ = a: Prims.int & b: Prims.int{a > b} & Prims.unit
+private
+let _ = a: Prims.int & b: Prims.int & Prims.int
+private
+let _ = a: Prims.int & b: Prims.int & c: Prims.int & Prims.int
+private
+let _ = a: Prims.int & b: Prims.int & c: Prims.int & d: Prims.int & Prims.int
+private
+let _ = Prims.int & Prims.int
+private
+let _ = Prims.int & Prims.int & Prims.int
+private
+let _ = Prims.int & Prims.int & Prims.int & Prims.int
+private
+let _ = Prims.int & Prims.int & Prims.int & Prims.int & Prims.int
+private
+let _ = Prims.int & (Prims.int & Prims.int)
+private
+let _ = Prims.int & (Prims.int & (Prims.int & Prims.int))
+private
+let _ = Prims.int & (Prims.int & (Prims.int & (Prims.int & Prims.int)))
+private
+let _ = FStar.Pervasives.Native.tuple4 Prims.int Prims.bool
+private
+let _ = Prims.int & Prims.bool & Prims.string & Prims.unit
+private
+let _ = FStar.Pervasives.dtuple4 Prims.int (fun _ -> Prims.bool)
+let t1 = 1, 2, 3
+let t2 = (1, 2), 3
+let t3 = 1, (2, 3)
+let d1 = (| 1, 2, 3 |)
+let d2 = (| (1, 2), 3 |)
+let d3 = (| 1, (2, 3) |)
+let dd2 = (| (| 1, 2 |), 3 |)
+let dd3 = (| 1, (| 2, 3 |) |)
+]
+Exports: [
+private
+let _ = a: Prims.int & b: Prims.int{a > b} & c: Prims.int{c == a + b}
+private
+let _ = a: Prims.int & b: Prims.int{a > b} & c: Prims.int{c == a + b}
+private
+let _ = a: Prims.int & z: b: Prims.int{a > b} & c: Prims.int{c == a + z}
+private
+let _ = a: Prims.int & b: Prims.int{a > b} & Prims.unit
+private
+let _ = a: Prims.int & b: Prims.int & Prims.int
+private
+let _ = a: Prims.int & b: Prims.int & c: Prims.int & Prims.int
+private
+let _ = a: Prims.int & b: Prims.int & c: Prims.int & d: Prims.int & Prims.int
+private
+let _ = Prims.int & Prims.int
+private
+let _ = Prims.int & Prims.int & Prims.int
+private
+let _ = Prims.int & Prims.int & Prims.int & Prims.int
+private
+let _ = Prims.int & Prims.int & Prims.int & Prims.int & Prims.int
+private
+let _ = Prims.int & (Prims.int & Prims.int)
+private
+let _ = Prims.int & (Prims.int & (Prims.int & Prims.int))
+private
+let _ = Prims.int & (Prims.int & (Prims.int & (Prims.int & Prims.int)))
+private
+let _ = FStar.Pervasives.Native.tuple4 Prims.int Prims.bool
+private
+let _ = Prims.int & Prims.bool & Prims.string & Prims.unit
+private
+let _ = FStar.Pervasives.dtuple4 Prims.int (fun _ -> Prims.bool)
+let t1 = 1, 2, 3
+let t2 = (1, 2), 3
+let t3 = 1, (2, 3)
+let d1 = (| 1, 2, 3 |)
+let d2 = (| (1, 2), 3 |)
+let d3 = (| 1, (2, 3) |)
+let dd2 = (| (| 1, 2 |), 3 |)
+let dd3 = (| 1, (| 2, 3 |) |)
+]
+
+Module after type checking:
+module DTuples
+Declarations: [
+private
+let _ = a: Prims.int & b: Prims.int{a > b} & c: Prims.int{c == a + b}
+private
+let _ = a: Prims.int & b: Prims.int{a > b} & c: Prims.int{c == a + b}
+private
+let _ = a: Prims.int & z: b: Prims.int{a > b} & c: Prims.int{c == a + z}
+private
+let _ = a: Prims.int & b: Prims.int{a > b} & Prims.unit
+private
+let _ = a: Prims.int & b: Prims.int & Prims.int
+private
+let _ = a: Prims.int & b: Prims.int & c: Prims.int & Prims.int
+private
+let _ = a: Prims.int & b: Prims.int & c: Prims.int & d: Prims.int & Prims.int
+private
+let _ = Prims.int & Prims.int
+private
+let _ = Prims.int & Prims.int & Prims.int
+private
+let _ = Prims.int & Prims.int & Prims.int & Prims.int
+private
+let _ = Prims.int & Prims.int & Prims.int & Prims.int & Prims.int
+private
+let _ = Prims.int & (Prims.int & Prims.int)
+private
+let _ = Prims.int & (Prims.int & (Prims.int & Prims.int))
+private
+let _ = Prims.int & (Prims.int & (Prims.int & (Prims.int & Prims.int)))
+private
+let _ = FStar.Pervasives.Native.tuple4 Prims.int Prims.bool
+private
+let _ = Prims.int & Prims.bool & Prims.string & Prims.unit
+private
+let _ = FStar.Pervasives.dtuple4 Prims.int (fun _ -> Prims.bool)
+let t1 = 1, 2, 3
+let t2 = (1, 2), 3
+let t3 = 1, (2, 3)
+let d1 = (| 1, 2, 3 |)
+let d2 = (| (1, 2), 3 |)
+let d3 = (| 1, (2, 3) |)
+let dd2 = (| (| 1, 2 |), 3 |)
+let dd3 = (| 1, (| 2, 3 |) |)
+]
+Exports: [
+private
+let _ = a: Prims.int & b: Prims.int{a > b} & c: Prims.int{c == a + b}
+private
+let _ = a: Prims.int & b: Prims.int{a > b} & c: Prims.int{c == a + b}
+private
+let _ = a: Prims.int & z: b: Prims.int{a > b} & c: Prims.int{c == a + z}
+private
+let _ = a: Prims.int & b: Prims.int{a > b} & Prims.unit
+private
+let _ = a: Prims.int & b: Prims.int & Prims.int
+private
+let _ = a: Prims.int & b: Prims.int & c: Prims.int & Prims.int
+private
+let _ = a: Prims.int & b: Prims.int & c: Prims.int & d: Prims.int & Prims.int
+private
+let _ = Prims.int & Prims.int
+private
+let _ = Prims.int & Prims.int & Prims.int
+private
+let _ = Prims.int & Prims.int & Prims.int & Prims.int
+private
+let _ = Prims.int & Prims.int & Prims.int & Prims.int & Prims.int
+private
+let _ = Prims.int & (Prims.int & Prims.int)
+private
+let _ = Prims.int & (Prims.int & (Prims.int & Prims.int))
+private
+let _ = Prims.int & (Prims.int & (Prims.int & (Prims.int & Prims.int)))
+private
+let _ = FStar.Pervasives.Native.tuple4 Prims.int Prims.bool
+private
+let _ = Prims.int & Prims.bool & Prims.string & Prims.unit
+private
+let _ = FStar.Pervasives.dtuple4 Prims.int (fun _ -> Prims.bool)
+let t1 = 1, 2, 3
+let t2 = (1, 2), 3
+let t3 = 1, (2, 3)
+let d1 = (| 1, 2, 3 |)
+let d2 = (| (1, 2), 3 |)
+let d3 = (| 1, (2, 3) |)
+let dd2 = (| (| 1, 2 |), 3 |)
+let dd3 = (| 1, (| 2, 3 |) |)
+]
+
+Verified module: DTuples
+All verification conditions discharged successfully

--- a/tests/error-messages/Makefile
+++ b/tests/error-messages/Makefile
@@ -28,6 +28,7 @@ Bug2820.fst.output: OTHERFLAGS+=--dump_module Bug2820
 Bug3227.fst.output: OTHERFLAGS+=--dump_module Bug3227
 Bug3292.fst.output: OTHERFLAGS+=--dump_module Bug3292
 CalcImpl.fst.output: OTHERFLAGS+=--dump_module CalcImpl
+DTuples.fst.output: OTHERFLAGS+=--dump_module DTuples
 
 include $(FSTAR_HOME)/examples/Makefile.common
 

--- a/tests/error-messages/Makefile
+++ b/tests/error-messages/Makefile
@@ -25,6 +25,7 @@ all: check-all
 # matches the expected file.
 Bug1997.fst.output: OTHERFLAGS+=--dump_module Bug1997
 Bug2820.fst.output: OTHERFLAGS+=--dump_module Bug2820
+Bug3145.fst.output: OTHERFLAGS+=--dump_module Bug3145
 Bug3227.fst.output: OTHERFLAGS+=--dump_module Bug3227
 Bug3292.fst.output: OTHERFLAGS+=--dump_module Bug3292
 CalcImpl.fst.output: OTHERFLAGS+=--dump_module CalcImpl

--- a/tests/ide/emacs/infotable.lookup.out.expected
+++ b/tests/ide/emacs/infotable.lookup.out.expected
@@ -1,6 +1,6 @@
 {"kind": "protocol-info", "rest": "[...]"}
 {"kind": "response", "query-id": "1", "response": [], "status": "success"}
 {"kind": "response", "query-id": "2", "response": [], "status": "success"}
-{"kind": "response", "query-id": "3", "response": {"defined-at": null, "definition": null, "documentation": null, "kind": "symbol", "name": "ccc", "type": "nat * (string * int)"}, "status": "success"}
+{"kind": "response", "query-id": "3", "response": {"defined-at": null, "definition": null, "documentation": null, "kind": "symbol", "name": "ccc", "type": "nat & (string & int)"}, "status": "success"}
 {"kind": "response", "query-id": "4", "response": {"defined-at": null, "definition": null, "documentation": null, "kind": "symbol", "name": "aaa", "type": "int"}, "status": "success"}
-{"kind": "response", "query-id": "5", "response": {"defined-at": null, "definition": null, "documentation": null, "kind": "symbol", "name": "bbb", "type": "string * int"}, "status": "success"}
+{"kind": "response", "query-id": "5", "response": {"defined-at": null, "definition": null, "documentation": null, "kind": "symbol", "name": "bbb", "type": "string & int"}, "status": "success"}

--- a/tests/tactics/Parsing.fst
+++ b/tests/tactics/Parsing.fst
@@ -18,11 +18,10 @@ let _ = assert (equals 42 ())
 let _ = assert (equals (unit * unit) ())
 let _ = assert (equals (unit * (unit * unit)) ())
 let _ = assert (equals ((unit * unit) * unit) ())
+let _ = assert (equals (unit * unit * unit) ())
 
 let _ = assert (equals (fun x -> x + 3) ())
 
-[@expect_failure] // as issue #2245
-let _ = assert (equals (unit * unit * unit) ())
 
 [@expect_failure] // as issue #1865
 let _ = assert (equals (forall (x: (y: int{y>0})). True) ())


### PR DESCRIPTION
This PR introduces resugaring for dependent tuples (we had none, except for printing out `dtupleN` explicitly) and fixes some other problems with resugaring of tuples. See this snippet:
```fstar
(* Basic dtuple3 *)
let _ = (a:int & b:int & z:int{z == a+b})

(* tuple3 and nested tuple2: all printed the same *)
let _ = int & int & int
let _ = ((int & int) & int)
let _ = (int & (int & int))

(* printed as int * bool *)
let _ = tuple4 int bool
```

Before (output with --dump_module):
```fstar
Exports: [
private
let _ =
  FStar.Pervasives.dtuple3 Prims.int (fun _ -> Prims.int) (fun a b -> z: Prims.int{z == a + b})
private
let _ = Prims.int * Prims.int * Prims.int
private
let _ = Prims.int * Prims.int * Prims.int
private
let _ = Prims.int * Prims.int * Prims.int
private
let _ = Prims.int * Prims.bool
]
```

After:
```fstar
Exports: [
private
let _ = a: Prims.int & b: Prims.int & z: Prims.int{z == a + b}
private
let _ = Prims.int & Prims.int & Prims.int
private
let _ = (Prims.int & Prims.int) & Prims.int
private
let _ = Prims.int & (Prims.int & Prims.int)
private
let _ = FStar.Pervasives.Native.tuple4 Prims.int Prims.bool
]
```

Also:
Fixes #2245 