### PR TITLE
Make parenthesis break binding on dtuples

### DIFF
--- a/ocaml/fstar-lib/FStar_Parser_Parse.mly
+++ b/ocaml/fstar-lib/FStar_Parser_Parse.mly
@@ -1150,7 +1150,7 @@ tmArrow(Tm):
   | dom=tmArrowDomain(Tm) RARROW tgt=tmArrow(Tm)
      {
        let ((aq_opt, attrs), dom_tm) = dom in
-       let b = match extract_named_refinement dom_tm with
+       let b = match extract_named_refinement true dom_tm with
          | None -> mk_binder_with_attrs (NoName dom_tm) (rr $loc(dom)) Un aq_opt attrs
          | Some (x, t, f) -> mkRefinedBinder x t true f (rr2 $loc(dom) $loc(dom)) aq_opt attrs
        in
@@ -1162,7 +1162,7 @@ simpleArrow:
   | dom=simpleArrowDomain RARROW tgt=simpleArrow
      {
        let ((aq_opt, attrs), dom_tm) = dom in
-       let b = match extract_named_refinement dom_tm with
+       let b = match extract_named_refinement true dom_tm with
          | None -> mk_binder_with_attrs (NoName dom_tm) (rr $loc(dom)) Un aq_opt attrs
          | Some (x, t, f) -> mkRefinedBinder x t true f (rr2 $loc(dom) $loc(dom)) aq_opt attrs
        in
@@ -1240,7 +1240,7 @@ tmNoEqWith(X):
   | e1=tmNoEqWith(X) AMP e2=tmNoEqWith(X)
       {
             let dom =
-               match extract_named_refinement e1 with
+               match extract_named_refinement false e1 with
                | Some (x, t, f) ->
                  let dom = mkRefinedBinder x t true f (rr $loc(e1)) None [] in
                  Inl dom

--- a/ocaml/fstar-lib/generated/FStar_Parser_AST.ml
+++ b/ocaml/fstar-lib/generated/FStar_Parser_AST.ml
@@ -1498,23 +1498,26 @@ let (mkRefinedPattern :
               mk_pattern
                 (PatAscribed (pat, (t1, FStar_Pervasives_Native.None))) range
 let rec (extract_named_refinement :
-  term ->
-    (FStar_Ident.ident * term * term FStar_Pervasives_Native.option)
-      FStar_Pervasives_Native.option)
+  Prims.bool ->
+    term ->
+      (FStar_Ident.ident * term * term FStar_Pervasives_Native.option)
+        FStar_Pervasives_Native.option)
   =
-  fun t1 ->
-    match t1.tm with
-    | NamedTyp (x, t) ->
-        FStar_Pervasives_Native.Some (x, t, FStar_Pervasives_Native.None)
-    | Refine
-        ({ b = Annotated (x, t); brange = uu___; blevel = uu___1;
-           aqual = uu___2; battributes = uu___3;_},
-         t')
-        ->
-        FStar_Pervasives_Native.Some
-          (x, t, (FStar_Pervasives_Native.Some t'))
-    | Paren t -> extract_named_refinement t
-    | uu___ -> FStar_Pervasives_Native.None
+  fun remove_parens ->
+    fun t1 ->
+      match t1.tm with
+      | NamedTyp (x, t) ->
+          FStar_Pervasives_Native.Some (x, t, FStar_Pervasives_Native.None)
+      | Refine
+          ({ b = Annotated (x, t); brange = uu___; blevel = uu___1;
+             aqual = uu___2; battributes = uu___3;_},
+           t')
+          ->
+          FStar_Pervasives_Native.Some
+            (x, t, (FStar_Pervasives_Native.Some t'))
+      | Paren t when remove_parens ->
+          extract_named_refinement remove_parens t
+      | uu___ -> FStar_Pervasives_Native.None
 let rec (as_mlist :
   ((FStar_Ident.lid * decl) * decl Prims.list) -> decl Prims.list -> modul) =
   fun cur ->

--- a/src/parser/FStar.Parser.AST.fst
+++ b/src/parser/FStar.Parser.AST.fst
@@ -219,12 +219,12 @@ let mkRefinedPattern pat t should_bind_pat phi_opt t_range range =
      in
      mk_pattern (PatAscribed(pat, (t, None))) range
 
-let rec extract_named_refinement t1  =
-    match t1.tm with
-        | NamedTyp(x, t) -> Some (x, t, None)
-        | Refine({b=Annotated(x, t)}, t') ->  Some (x, t, Some t')
-    | Paren t -> extract_named_refinement t
-        | _ -> None
+let rec extract_named_refinement (remove_parens:bool) (t1:term) : option (ident & term & option typ) =
+  match t1.tm with
+  | NamedTyp(x, t) -> Some (x, t, None)
+  | Refine({b=Annotated(x, t)}, t') -> Some (x, t, Some t')
+  | Paren t when remove_parens -> extract_named_refinement remove_parens t
+  | _ -> None
 
 (* Some helpers that parse.mly and parse.fsy will want too *)
 

--- a/src/parser/FStar.Parser.AST.fsti
+++ b/src/parser/FStar.Parser.AST.fsti
@@ -294,7 +294,7 @@ val mkTuple : list term -> range -> term
 val mkDTuple : list term -> range -> term
 val mkRefinedBinder : ident -> term -> bool -> option term -> range -> aqual -> list term -> binder
 val mkRefinedPattern : pattern -> term -> bool -> option term -> range -> range -> pattern
-val extract_named_refinement : term -> option (ident & term & option term)
+val extract_named_refinement : bool -> term -> option (ident & term & option term)
 
 val as_frag : list decl -> inputFragment
 

--- a/tests/micro-benchmarks/TwoPhaseTC.fst
+++ b/tests/micro-benchmarks/TwoPhaseTC.fst
@@ -145,7 +145,7 @@ let rec nth_tot_1124 l n =
   | Some x -> x
 
 #set-options "--max_fuel 1 --max_ifuel 1 --initial_fuel 1 --initial_ifuel 1"
-assume val calc_1124: #a:Type -> es:list ((e:(a*a)) & (solve_1124 (fst e) (snd e))){Cons? es} -> 
+assume val calc_1124: #a:Type -> es:list (e:(a*a) & (solve_1124 (fst e) (snd e))){Cons? es} ->
   Lemma (normalize(fst (dfst (hd es)) == snd (dfst (nth_tot_1124 es ((length es) - 1)))))
 
 (*

--- a/tests/micro-benchmarks/Unit1.Parser.fst
+++ b/tests/micro-benchmarks/Unit1.Parser.fst
@@ -20,8 +20,8 @@ type t1 = x:int{x >= 0} -> tint x
 type t2 = x:int -> tint x
 type t3 = (a:eqtype) -> (x:int) -> result:list a{result=[] /\ x=18}
 type t4 = x:nat & y:nat{y > x}
-type t4' = (x:nat) & y:nat{y > x}
-type t4'' = (x:nat) & (y:nat{y > x}) //parentheses are not significant
+type t4' = (x:nat & y:nat{y > x})
+type t4'' = (x:nat & (y:nat{y > x})) //parentheses are not significant
 type t5 = x:int{x=0} * int
 //type t5' = x:int{x=0} * y:int // not allowed after #1905
 //type t5' = x:int{x=0} * tint x

--- a/ulib/FStar.FiniteMap.Base.fst
+++ b/ulib/FStar.FiniteMap.Base.fst
@@ -43,7 +43,7 @@ open FStar.FiniteSet.Ambient
 module T = FStar.Tactics.V2
 
 // Finite maps
-type map (a: eqtype) (b: Type u#b) = (keys: FSet.set a) & (setfun_t a b keys)
+type map (a: eqtype) (b: Type u#b) = (keys: FSet.set a & setfun_t a b keys)
 
 let domain (#a: eqtype) (#b: Type u#b) (m: map a b) : FSet.set a =
   let (| keys, _ |) = m in 


### PR DESCRIPTION
As discussed here https://github.com/FStarLang/FStar/pull/2816, sometimes we want to have a refinement on the LHS of a non-dependent tuple, but the parser will still take `(x:a{p x}) & b` to be dependent. This PR changes this behavior to make parenthesis break the binding on a tuple type.

(Notably function types like `(x:a) -> Tot (b x)` do bind across a parenthesis.)

Regressions in F* are minor, checking everest now.