### PR TITLE
Allow empty record patterns

### DIFF
--- a/ocaml/fstar-lib/FStar_Parser_Parse.mly
+++ b/ocaml/fstar-lib/FStar_Parser_Parse.mly
@@ -640,7 +640,7 @@ atomicPattern:
       }
   | LBRACK pats=separated_list(SEMICOLON, tuplePattern) RBRACK
       { mk_pattern (PatList pats) (rr2 $loc($1) $loc($3)) }
-  | LBRACE record_pat=right_flexible_nonempty_list(SEMICOLON, fieldPattern) RBRACE
+  | LBRACE record_pat=right_flexible_list(SEMICOLON, fieldPattern) RBRACE
       { mk_pattern (PatRecord record_pat) (rr $loc) }
   | LENS_PAREN_LEFT pat0=constructorPattern COMMA pats=separated_nonempty_list(COMMA, constructorPattern) LENS_PAREN_RIGHT
       { mk_pattern (PatTuple(pat0::pats, true)) (rr $loc) }

--- a/ocaml/fstar-lib/generated/FStar_ToSyntax_ToSyntax.ml
+++ b/ocaml/fstar-lib/generated/FStar_ToSyntax_ToSyntax.ml
@@ -2083,22 +2083,18 @@ let rec (desugar_data_pat :
                    (loc1, aqs1, env2,
                      (LocalBinder (x, FStar_Pervasives_Native.None, [])),
                      uu___1, annots))
-          | FStar_Parser_AST.PatRecord [] ->
-              FStar_Errors.raise_error
-                (FStar_Errors_Codes.Fatal_UnexpectedPattern,
-                  "Unexpected pattern") p1.FStar_Parser_AST.prange
           | FStar_Parser_AST.PatRecord fields ->
-              let uu___ = FStar_Compiler_List.hd fields in
+              let uu___ = FStar_Compiler_List.unzip fields in
               (match uu___ with
-               | (f, uu___1) ->
-                   let uu___2 = FStar_Compiler_List.unzip fields in
-                   (match uu___2 with
-                    | (field_names, pats) ->
-                        let uu___3 =
-                          let uu___4 =
-                            FStar_Syntax_DsEnv.try_lookup_record_by_field_name
-                              env1 f in
-                          match uu___4 with
+               | (field_names, pats) ->
+                   let uu___1 =
+                     match fields with
+                     | [] -> (FStar_Pervasives_Native.None, field_names)
+                     | (f, uu___2)::uu___3 ->
+                         let uu___4 =
+                           FStar_Syntax_DsEnv.try_lookup_record_by_field_name
+                             env1 f in
+                         (match uu___4 with
                           | FStar_Pervasives_Native.None ->
                               (FStar_Pervasives_Native.None, field_names)
                           | FStar_Pervasives_Native.Some r ->
@@ -2106,58 +2102,55 @@ let rec (desugar_data_pat :
                                 qualify_field_names
                                   r.FStar_Syntax_DsEnv.typename field_names in
                               ((FStar_Pervasives_Native.Some
-                                  (r.FStar_Syntax_DsEnv.typename)), uu___5) in
-                        (match uu___3 with
-                         | (typename, field_names1) ->
-                             let candidate_constructor =
-                               let lid =
-                                 FStar_Ident.lid_of_path ["__dummy__"]
-                                   p1.FStar_Parser_AST.prange in
-                               FStar_Syntax_Syntax.lid_and_dd_as_fv lid
+                                  (r.FStar_Syntax_DsEnv.typename)), uu___5)) in
+                   (match uu___1 with
+                    | (typename, field_names1) ->
+                        let candidate_constructor =
+                          let lid =
+                            FStar_Ident.lid_of_path ["__dummy__"]
+                              p1.FStar_Parser_AST.prange in
+                          FStar_Syntax_Syntax.lid_and_dd_as_fv lid
+                            (FStar_Pervasives_Native.Some
+                               (FStar_Syntax_Syntax.Unresolved_constructor
+                                  {
+                                    FStar_Syntax_Syntax.uc_base_term = false;
+                                    FStar_Syntax_Syntax.uc_typename =
+                                      typename;
+                                    FStar_Syntax_Syntax.uc_fields =
+                                      field_names1
+                                  })) in
+                        let uu___2 =
+                          FStar_Compiler_List.fold_left
+                            (fun uu___3 ->
+                               fun p2 ->
+                                 match uu___3 with
+                                 | (loc1, aqs1, env2, annots, pats1) ->
+                                     let uu___4 = aux loc1 aqs1 env2 p2 in
+                                     (match uu___4 with
+                                      | (loc2, aqs2, env3, uu___5, pat, ann)
+                                          ->
+                                          (loc2, aqs2, env3,
+                                            (FStar_Compiler_List.op_At ann
+                                               annots), ((pat, false) ::
+                                            pats1))))
+                            (loc, aqs, env1, [], []) pats in
+                        (match uu___2 with
+                         | (loc1, aqs1, env2, annots, pats1) ->
+                             let pats2 = FStar_Compiler_List.rev pats1 in
+                             let pat =
+                               pos
+                                 (FStar_Syntax_Syntax.Pat_cons
+                                    (candidate_constructor,
+                                      FStar_Pervasives_Native.None, pats2)) in
+                             let x =
+                               let uu___3 = tun_r p1.FStar_Parser_AST.prange in
+                               FStar_Syntax_Syntax.new_bv
                                  (FStar_Pervasives_Native.Some
-                                    (FStar_Syntax_Syntax.Unresolved_constructor
-                                       {
-                                         FStar_Syntax_Syntax.uc_base_term =
-                                           false;
-                                         FStar_Syntax_Syntax.uc_typename =
-                                           typename;
-                                         FStar_Syntax_Syntax.uc_fields =
-                                           field_names1
-                                       })) in
-                             let uu___4 =
-                               FStar_Compiler_List.fold_left
-                                 (fun uu___5 ->
-                                    fun p2 ->
-                                      match uu___5 with
-                                      | (loc1, aqs1, env2, annots, pats1) ->
-                                          let uu___6 = aux loc1 aqs1 env2 p2 in
-                                          (match uu___6 with
-                                           | (loc2, aqs2, env3, uu___7, pat,
-                                              ann) ->
-                                               (loc2, aqs2, env3,
-                                                 (FStar_Compiler_List.op_At
-                                                    ann annots),
-                                                 ((pat, false) :: pats1))))
-                                 (loc, aqs, env1, [], []) pats in
-                             (match uu___4 with
-                              | (loc1, aqs1, env2, annots, pats1) ->
-                                  let pats2 = FStar_Compiler_List.rev pats1 in
-                                  let pat =
-                                    pos
-                                      (FStar_Syntax_Syntax.Pat_cons
-                                         (candidate_constructor,
-                                           FStar_Pervasives_Native.None,
-                                           pats2)) in
-                                  let x =
-                                    let uu___5 =
-                                      tun_r p1.FStar_Parser_AST.prange in
-                                    FStar_Syntax_Syntax.new_bv
-                                      (FStar_Pervasives_Native.Some
-                                         (p1.FStar_Parser_AST.prange)) uu___5 in
-                                  (loc1, aqs1, env2,
-                                    (LocalBinder
-                                       (x, FStar_Pervasives_Native.None, [])),
-                                    pat, annots)))))
+                                    (p1.FStar_Parser_AST.prange)) uu___3 in
+                             (loc1, aqs1, env2,
+                               (LocalBinder
+                                  (x, FStar_Pervasives_Native.None, [])),
+                               pat, annots))))
         and aux loc aqs env1 p1 = aux' false loc aqs env1 p1 in
         let aux_maybe_or env1 p1 =
           let loc = [] in

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Rel.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Rel.ml
@@ -2113,6 +2113,8 @@ let (wl_to_string : worklist -> Prims.string) =
       probs_to_string uu___2 in
     FStar_Compiler_Util.format2
       "{ attempting = [ %s ];\ndeferred = [ %s ] }\n" uu___ uu___1
+let (showable_wl : worklist FStar_Class_Show.showable) =
+  { FStar_Class_Show.show = wl_to_string }
 type flex_t =
   | Flex of (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.ctx_uvar *
   FStar_Syntax_Syntax.args) 
@@ -5904,7 +5906,9 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                     if uu___5
                     then
                       let uu___6 =
-                        FStar_Compiler_Util.string_of_int
+                        FStar_Class_Show.show
+                          (FStar_Class_Show.printableshow
+                             FStar_Class_Printable.printable_int)
                           tp.FStar_TypeChecker_Common.pid in
                       FStar_Compiler_Util.print1
                         "Trying to solve by meeting refinements:%s\n" uu___6
@@ -14524,9 +14528,11 @@ let (try_solve_deferred_constraints :
                              (FStar_Class_Show.printableshow
                                 FStar_Class_Printable.printable_bool)
                              deferred_to_tac_ok in
-                         let uu___7 = wl_to_string wl in
+                         let uu___7 = FStar_Class_Show.show showable_wl wl in
                          let uu___8 =
-                           FStar_Compiler_Util.string_of_int
+                           FStar_Class_Show.show
+                             (FStar_Class_Show.printableshow
+                                FStar_Class_Printable.printable_nat)
                              (FStar_Compiler_List.length
                                 g.FStar_TypeChecker_Common.implicits) in
                          FStar_Compiler_Util.print4

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_TcTerm.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_TcTerm.ml
@@ -332,40 +332,48 @@ let (check_no_escape :
                             with | uu___4 -> fail x) in
                    aux false kt)
 let (check_expected_aqual_for_binder :
-  FStar_Syntax_Syntax.arg_qualifier FStar_Pervasives_Native.option ->
+  FStar_Syntax_Syntax.aqual ->
     FStar_Syntax_Syntax.binder ->
-      FStar_Compiler_Range_Type.range ->
-        FStar_Syntax_Syntax.arg_qualifier FStar_Pervasives_Native.option)
+      FStar_Compiler_Range_Type.range -> FStar_Syntax_Syntax.aqual)
   =
   fun aq ->
     fun b ->
       fun pos ->
-        let expected_aq = FStar_Syntax_Util.aqual_of_binder b in
-        match (aq, expected_aq) with
-        | (FStar_Pervasives_Native.None, FStar_Pervasives_Native.None) -> aq
-        | (FStar_Pervasives_Native.None, FStar_Pervasives_Native.Some eaq) ->
-            if eaq.FStar_Syntax_Syntax.aqual_implicit
-            then
-              FStar_Errors.raise_error
-                (FStar_Errors_Codes.Fatal_InconsistentImplicitQualifier,
-                  "Inconsistent implicit qualifiers (expected implicit annotation on the argument)")
-                pos
-            else expected_aq
-        | (FStar_Pervasives_Native.Some aq1, FStar_Pervasives_Native.None) ->
-            FStar_Errors.raise_error
-              (FStar_Errors_Codes.Fatal_InconsistentImplicitQualifier,
-                "Inconsistent implicit qualifiers (did not expect argument aquals)")
+        let uu___ =
+          let expected_aq = FStar_Syntax_Util.aqual_of_binder b in
+          match (aq, expected_aq) with
+          | (FStar_Pervasives_Native.None, FStar_Pervasives_Native.None) ->
+              FStar_Pervasives.Inr aq
+          | (FStar_Pervasives_Native.None, FStar_Pervasives_Native.Some eaq)
+              ->
+              if eaq.FStar_Syntax_Syntax.aqual_implicit
+              then
+                FStar_Pervasives.Inl
+                  "expected implicit annotation on the argument"
+              else FStar_Pervasives.Inr expected_aq
+          | (FStar_Pervasives_Native.Some aq1, FStar_Pervasives_Native.None)
+              ->
+              FStar_Pervasives.Inl
+                "expected an explicit argument (without annotation)"
+          | (FStar_Pervasives_Native.Some aq1, FStar_Pervasives_Native.Some
+             eaq) ->
+              if
+                aq1.FStar_Syntax_Syntax.aqual_implicit <>
+                  eaq.FStar_Syntax_Syntax.aqual_implicit
+              then FStar_Pervasives.Inl "mismatch"
+              else FStar_Pervasives.Inr expected_aq in
+        match uu___ with
+        | FStar_Pervasives.Inl err ->
+            let msg =
+              let uu___1 =
+                FStar_Errors_Msg.text
+                  (Prims.strcat "Inconsistent argument qualifiers: "
+                     (Prims.strcat err ".")) in
+              [uu___1] in
+            FStar_Errors.raise_error_doc
+              (FStar_Errors_Codes.Fatal_InconsistentImplicitQualifier, msg)
               pos
-        | (FStar_Pervasives_Native.Some aq1, FStar_Pervasives_Native.Some
-           eaq) ->
-            if
-              aq1.FStar_Syntax_Syntax.aqual_implicit <>
-                eaq.FStar_Syntax_Syntax.aqual_implicit
-            then
-              FStar_Errors.raise_error
-                (FStar_Errors_Codes.Fatal_InconsistentImplicitQualifier,
-                  "Inconsistent implicit qualifiers (mismatch)") pos
-            else expected_aq
+        | FStar_Pervasives.Inr r -> r
 let (check_erasable_binder_attributes :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax Prims.list ->

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Util.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Util.ml
@@ -8503,18 +8503,25 @@ let make_record_fields_in_order :
                                             let uu___6 =
                                               let uu___7 =
                                                 let uu___8 =
-                                                  FStar_Ident.string_of_id
-                                                    field_name in
-                                                let uu___9 =
-                                                  FStar_Ident.string_of_lid
-                                                    rdc.FStar_Syntax_DsEnv.typename in
-                                                FStar_Compiler_Util.format2
-                                                  "Field %s of record type %s is missing"
-                                                  uu___8 uu___9 in
+                                                  let uu___9 =
+                                                    let uu___10 =
+                                                      FStar_Class_Show.show
+                                                        FStar_Ident.showable_ident
+                                                        field_name in
+                                                    let uu___11 =
+                                                      FStar_Class_Show.show
+                                                        FStar_Ident.showable_lident
+                                                        rdc.FStar_Syntax_DsEnv.typename in
+                                                    FStar_Compiler_Util.format2
+                                                      "Field '%s' of record type '%s' is missing."
+                                                      uu___10 uu___11 in
+                                                  FStar_Errors_Msg.text
+                                                    uu___9 in
+                                                [uu___8] in
                                               (FStar_Errors_Codes.Fatal_MissingFieldInRecord,
                                                 uu___7) in
-                                            FStar_Errors.raise_error uu___6
-                                              rng
+                                            FStar_Errors.raise_error_doc
+                                              uu___6 rng
                                         | FStar_Pervasives_Native.Some a1 ->
                                             (rest, (a1 :: as_rev)))
                                    | uu___5 ->

--- a/src/tosyntax/FStar.ToSyntax.ToSyntax.fst
+++ b/src/tosyntax/FStar.ToSyntax.ToSyntax.fst
@@ -957,17 +957,16 @@ let rec desugar_data_pat
         let x = S.new_bv (Some p.prange) (tun_r p.prange) in
         loc, aqs, env, LocalBinder(x, None, []), pos <| Pat_cons(l, None, args), annots
 
-      | PatRecord ([]) ->
-        raise_error (Errors.Fatal_UnexpectedPattern, "Unexpected pattern") p.prange
-
       | PatRecord (fields) ->
         (* Record patterns have to wait for type information to be fully resolved *)
-        let (f, _) = List.hd fields in
         let field_names, pats = List.unzip fields in
         let typename, field_names =
-          match try_lookup_record_by_field_name env f with
-          | None -> None, field_names
-          | Some r -> Some r.typename, qualify_field_names r.typename field_names
+          match fields with
+          | [] -> None, field_names
+          | (f, _)::_ ->
+            match try_lookup_record_by_field_name env f with
+            | None -> None, field_names
+            | Some r -> Some r.typename, qualify_field_names r.typename field_names
         in
         (* Just build a candidate constructor, as we do for Record literals *)
         let candidate_constructor =

--- a/src/typechecker/FStar.TypeChecker.Util.fst
+++ b/src/typechecker/FStar.TypeChecker.Util.fst
@@ -3740,11 +3740,11 @@ let make_record_fields_in_order env uc topt
              match not_found field_name with
              | None ->
 //               debug();
-               raise_error
-                 (Errors.Fatal_MissingFieldInRecord,
-                   BU.format2 "Field %s of record type %s is missing"
-                     (string_of_id field_name)
-                     (string_of_lid rdc.typename))
+               raise_error_doc
+                 (Errors.Fatal_MissingFieldInRecord, [
+                   Errors.Msg.text <| BU.format2 "Field '%s' of record type '%s' is missing."
+                     (show field_name)
+                     (show rdc.typename)])
                  rng
              | Some a ->
                rest, a::as_rev

--- a/tests/bug-reports/Bug3320.fst
+++ b/tests/bug-reports/Bug3320.fst
@@ -1,0 +1,10 @@
+module Bug3320
+
+type t =
+  | A { x:int; y:int }
+  | B { z:bool }
+
+let is_A (x:t) : bool =
+  match x with
+  | A {} -> true
+  | _ -> false

--- a/tests/bug-reports/Makefile
+++ b/tests/bug-reports/Makefile
@@ -79,7 +79,7 @@ SHOULD_VERIFY_CLOSED=\
 	Bug3213.fst Bug3213b.fst Bug3207.fst Bug3207b.fst Bug3207c.fst			\
 	Bug2155.fst Bug3224a.fst Bug3224b.fst Bug3236.fst Bug3252.fst \
 	BugBoxInjectivity.fst BugTypeParamProjector.fst Bug2172.fst Bug3266.fst		\
-	Bug3264a.fst Bug3264b.fst Bug3286a.fst Bug3286b.fst
+	Bug3264a.fst Bug3264b.fst Bug3286a.fst Bug3286b.fst Bug3320.fst
 
 SHOULD_VERIFY_INTERFACE_CLOSED=Bug771.fsti Bug771b.fsti
 SHOULD_VERIFY_AND_WARN_CLOSED=Bug016.fst

--- a/tests/error-messages/RecordFields.fst.expected
+++ b/tests/error-messages/RecordFields.fst.expected
@@ -5,12 +5,12 @@
 >>]
 >> Got issues: [
 * Error 118 at RecordFields.fst(11,14-11,22):
-  - Field c of record type RecordFields.r is missing
+  - Field 'c' of record type 'RecordFields.r' is missing.
 
 >>]
 >> Got issues: [
 * Error 118 at RecordFields.fst(14,14-14,27):
-  - Field c of record type RecordFields.r is missing
+  - Field 'c' of record type 'RecordFields.r' is missing.
 
 >>]
 Verified module: RecordFields


### PR DESCRIPTION
Related to #3320, I noticed we cannot write matches over a record without specifying one of its fields. The pattern `{}` does not even parse, and will not desugar even if it did. I think this comes from when we really needed to resolve the fields immediately to find the record type, but now that we have unresolved record constructors and projectors, we definitely can allow empty patterns.

The patch seems easy enough and we can now write something like this:
```fstar
type t =
  | A { x:int; y:int }
  | B { z:bool }

let is_A (x:t) : bool =
  match x with
  | A {} -> true
  | _ -> false
```