### PR TITLE
Introduce call_subtac_tm

### DIFF
--- a/ocaml/fstar-lib/FStar_Tactics_V2_Builtins.ml
+++ b/ocaml/fstar-lib/FStar_Tactics_V2_Builtins.ml
@@ -177,3 +177,5 @@ let ctrl_rewrite
 let call_subtac g (t : unit -> unit __tac) u ty =
   let t = to_tac_1 t () in
   from_tac_4 "B.call_subtac" B.call_subtac g t u ty
+
+let call_subtac_tm               = from_tac_4 "B.call_subtac_tm" B.call_subtac_tm

--- a/ocaml/fstar-lib/generated/FStar_Tactics_V2_Basic.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_V2_Basic.ml
@@ -13283,3 +13283,131 @@ let (call_subtac :
                                                (FStar_Pervasives_Native.None,
                                                  issues1))))) uu___1)))
             uu___3 uu___2 uu___1 uu___
+let run_tactic_on_ps_and_solve_remaining :
+  'a 'b .
+    FStar_Compiler_Range_Type.range ->
+      FStar_Compiler_Range_Type.range ->
+        Prims.bool ->
+          'a ->
+            FStar_Syntax_Syntax.term ->
+              FStar_Tactics_Types.proofstate -> unit
+  =
+  fun t_range ->
+    fun g_range ->
+      fun background ->
+        fun t ->
+          fun f_tm ->
+            fun ps ->
+              let uu___ =
+                FStar_Tactics_Interpreter.run_tactic_on_ps t_range g_range
+                  background FStar_Syntax_Embeddings.e_unit ()
+                  FStar_Syntax_Embeddings.e_unit f_tm false ps in
+              match uu___ with
+              | (remaining_goals, r) ->
+                  FStar_Compiler_List.iter
+                    (fun g ->
+                       let uu___2 =
+                         let uu___3 = FStar_Tactics_Types.goal_env g in
+                         let uu___4 = FStar_Tactics_Types.goal_type g in
+                         getprop uu___3 uu___4 in
+                       match uu___2 with
+                       | FStar_Pervasives_Native.Some vc ->
+                           let guard =
+                             {
+                               FStar_TypeChecker_Common.guard_f =
+                                 (FStar_TypeChecker_Common.NonTrivial vc);
+                               FStar_TypeChecker_Common.deferred_to_tac = [];
+                               FStar_TypeChecker_Common.deferred = [];
+                               FStar_TypeChecker_Common.univ_ineqs = ([], []);
+                               FStar_TypeChecker_Common.implicits = []
+                             } in
+                           let uu___3 = FStar_Tactics_Types.goal_env g in
+                           FStar_TypeChecker_Rel.force_trivial_guard uu___3
+                             guard
+                       | FStar_Pervasives_Native.None ->
+                           FStar_Errors.raise_error
+                             (FStar_Errors_Codes.Fatal_OpenGoalsInSynthesis,
+                               "tactic left a computationally-relevant goal unsolved")
+                             g_range) remaining_goals
+let (call_subtac_tm :
+  env ->
+    FStar_Syntax_Syntax.term ->
+      FStar_Syntax_Syntax.universe ->
+        FStar_Syntax_Syntax.typ ->
+          (FStar_Syntax_Syntax.term FStar_Pervasives_Native.option * issues)
+            FStar_Tactics_Monad.tac)
+  =
+  fun uu___3 ->
+    fun uu___2 ->
+      fun uu___1 ->
+        fun uu___ ->
+          (fun g ->
+             fun f_tm ->
+               fun _u ->
+                 fun goal_ty ->
+                   let uu___ =
+                     FStar_Class_Monad.return FStar_Tactics_Monad.monad_tac
+                       () (Obj.repr ()) in
+                   Obj.magic
+                     (FStar_Class_Monad.op_let_Bang
+                        FStar_Tactics_Monad.monad_tac () () uu___
+                        (fun uu___1 ->
+                           (fun uu___1 ->
+                              let uu___1 = Obj.magic uu___1 in
+                              let rng = FStar_TypeChecker_Env.get_range g in
+                              let uu___2 =
+                                proofstate_of_goal_ty rng g goal_ty in
+                              match uu___2 with
+                              | (ps, w) ->
+                                  let ps1 =
+                                    {
+                                      FStar_Tactics_Types.main_context =
+                                        (ps.FStar_Tactics_Types.main_context);
+                                      FStar_Tactics_Types.all_implicits =
+                                        (ps.FStar_Tactics_Types.all_implicits);
+                                      FStar_Tactics_Types.goals =
+                                        (ps.FStar_Tactics_Types.goals);
+                                      FStar_Tactics_Types.smt_goals =
+                                        (ps.FStar_Tactics_Types.smt_goals);
+                                      FStar_Tactics_Types.depth =
+                                        (ps.FStar_Tactics_Types.depth);
+                                      FStar_Tactics_Types.__dump =
+                                        (ps.FStar_Tactics_Types.__dump);
+                                      FStar_Tactics_Types.psc =
+                                        (ps.FStar_Tactics_Types.psc);
+                                      FStar_Tactics_Types.entry_range =
+                                        (ps.FStar_Tactics_Types.entry_range);
+                                      FStar_Tactics_Types.guard_policy =
+                                        (ps.FStar_Tactics_Types.guard_policy);
+                                      FStar_Tactics_Types.freshness =
+                                        (ps.FStar_Tactics_Types.freshness);
+                                      FStar_Tactics_Types.tac_verb_dbg =
+                                        (ps.FStar_Tactics_Types.tac_verb_dbg);
+                                      FStar_Tactics_Types.local_state =
+                                        (ps.FStar_Tactics_Types.local_state);
+                                      FStar_Tactics_Types.urgency =
+                                        (ps.FStar_Tactics_Types.urgency);
+                                      FStar_Tactics_Types.dump_on_failure =
+                                        false
+                                    } in
+                                  let uu___3 =
+                                    FStar_Errors.catch_errors_and_ignore_rest
+                                      (fun uu___4 ->
+                                         run_tactic_on_ps_and_solve_remaining
+                                           rng rng false () f_tm ps1) in
+                                  (match uu___3 with
+                                   | ([], FStar_Pervasives_Native.Some ()) ->
+                                       Obj.magic
+                                         (FStar_Class_Monad.return
+                                            FStar_Tactics_Monad.monad_tac ()
+                                            (Obj.magic
+                                               ((FStar_Pervasives_Native.Some
+                                                   w), [])))
+                                   | (issues1, uu___4) ->
+                                       Obj.magic
+                                         (FStar_Class_Monad.return
+                                            FStar_Tactics_Monad.monad_tac ()
+                                            (Obj.magic
+                                               (FStar_Pervasives_Native.None,
+                                                 issues1))))) uu___1)))
+            uu___3 uu___2 uu___1 uu___

--- a/ocaml/fstar-lib/generated/FStar_Tactics_V2_Primops.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_V2_Primops.ml
@@ -1882,7 +1882,37 @@ let (ops : FStar_TypeChecker_Primops_Base.primitive_step Prims.list) =
                                                                     FStar_TypeChecker_NBETerm.e_issue))
                                                                     FStar_Tactics_V2_Basic.call_subtac
                                                                     FStar_Tactics_V2_Basic.call_subtac in
-                                                                    [uu___220] in
+                                                                    let uu___221
+                                                                    =
+                                                                    let uu___222
+                                                                    =
+                                                                    FStar_Tactics_InterpFuns.mk_tac_step_4
+                                                                    Prims.int_zero
+                                                                    "call_subtac_tm"
+                                                                    FStar_Reflection_V2_Embeddings.e_env
+                                                                    uu___2
+                                                                    FStar_Reflection_V2_Embeddings.e_universe
+                                                                    uu___2
+                                                                    (FStar_Syntax_Embeddings.e_tuple2
+                                                                    (FStar_Syntax_Embeddings.e_option
+                                                                    uu___2)
+                                                                    (FStar_Syntax_Embeddings.e_list
+                                                                    FStar_Syntax_Embeddings.e_issue))
+                                                                    FStar_Reflection_V2_NBEEmbeddings.e_env
+                                                                    FStar_Reflection_V2_NBEEmbeddings.e_attribute
+                                                                    FStar_Reflection_V2_NBEEmbeddings.e_universe
+                                                                    FStar_Reflection_V2_NBEEmbeddings.e_attribute
+                                                                    (FStar_TypeChecker_NBETerm.e_tuple2
+                                                                    (FStar_TypeChecker_NBETerm.e_option
+                                                                    FStar_Reflection_V2_NBEEmbeddings.e_attribute)
+                                                                    (FStar_TypeChecker_NBETerm.e_list
+                                                                    FStar_TypeChecker_NBETerm.e_issue))
+                                                                    FStar_Tactics_V2_Basic.call_subtac_tm
+                                                                    FStar_Tactics_V2_Basic.call_subtac_tm in
+                                                                    [uu___222] in
+                                                                    uu___220
+                                                                    ::
+                                                                    uu___221 in
                                                                     uu___218
                                                                     ::
                                                                     uu___219 in

--- a/src/tactics/FStar.Tactics.V2.Basic.fsti
+++ b/src/tactics/FStar.Tactics.V2.Basic.fsti
@@ -149,3 +149,4 @@ val resolve_name                      : env -> list string -> tac (option (eithe
 val log_issues                        : list Errors.issue -> tac unit
 
 val call_subtac                       : env -> tac unit -> universe -> typ -> tac (option term & issues)
+val call_subtac_tm                    : env -> term     -> universe -> typ -> tac (option term & issues)

--- a/src/tactics/FStar.Tactics.V2.Primops.fst
+++ b/src/tactics/FStar.Tactics.V2.Primops.fst
@@ -275,4 +275,7 @@ let ops = [
     #_ #(TI.e_tactic_thunk e_unit) #_ #_ #_
     #_ #(TI.e_tactic_nbe_thunk NBET.e_unit) #_ #_ #_
     call_subtac call_subtac;
+
+  mk_tac_step_4 0 "call_subtac_tm"
+    call_subtac_tm call_subtac_tm;
 ]

--- a/tests/tactics/CallSubtac.fst
+++ b/tests/tactics/CallSubtac.fst
@@ -21,7 +21,9 @@ instance cc_list (a:Type) (_ : cc a) : cc (list a) = {
 let must #a (r : ret_t a) : Tac a =
   match r with
   | Some x, _ -> x
-  | _ -> fail "must failed"
+  | None, issues ->
+    // log_issues issues;
+    fail "must failed"
 
 let test1 () = assert True by (
   let g = cur_env () in
@@ -29,5 +31,28 @@ let test1 () = assert True by (
   let goal, _ = must <| tc_term g goal in
   let u = must <| universe_of g goal in
   let w = must <| call_subtac g FStar.Tactics.Typeclasses.tcresolve u goal in
+  dump ("witness = " ^ term_to_string w)
+)
+
+(* This is the same example, but it starts from the *term* for tcresolve,
+unembeds it into an actual Tac function, and calls it. *)
+let test2 () = assert True by (
+  let g = cur_env () in
+  let goal = `(cc (list (list int))) in
+  let goal, _ = must <| tc_term g goal in
+  let u = must <| universe_of g goal in
+  let tac_tm = `FStar.Tactics.Typeclasses.tcresolve in
+  let tac_f : unit -> Tac unit = unquote tac_tm in
+  let w = must <| call_subtac g tac_f u goal in
+  dump ("witness = " ^ term_to_string w)
+)
+
+let test3 () = assert True by (
+  let g = cur_env () in
+  let goal = `(cc (list (list int))) in
+  let goal, _ = must <| tc_term g goal in
+  let u = must <| universe_of g goal in
+  let tac_tm = `FStar.Tactics.Typeclasses.tcresolve in
+  let w = must <| call_subtac_tm g tac_tm u goal in
   dump ("witness = " ^ term_to_string w)
 )

--- a/ulib/FStar.Stubs.Tactics.V2.Builtins.fsti
+++ b/ulib/FStar.Stubs.Tactics.V2.Builtins.fsti
@@ -610,3 +610,8 @@ that solves it. *)
 val call_subtac (g:env) (t : unit -> Tac unit) (u:universe)
                 (goal_ty : term{typing_token g goal_ty (E_Total, pack_ln (Tv_Type u))})
   : Tac (ret_t (w:term{typing_token g w (E_Total, goal_ty)}))
+
+val call_subtac_tm
+    (g:env) (t : term) (u:universe)
+    (goal_ty : term{typing_token g goal_ty (E_Total, pack_ln (Tv_Type u))})
+  : Tac (ret_t (w:term{typing_token g w (E_Total, goal_ty)}))


### PR DESCRIPTION
This introduces a primitive similar to `call_subtac`, but which works with an embedded tactic (i.e. a term) instead of a `unit -> Tac unit` function.