### PR TITLE
A fix in Core, revealed by FStarLang/pulse#100

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_Tactics_V2_Basic.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_V2_Basic.ml
@@ -1895,12 +1895,22 @@ let (tadmit_t : FStar_Syntax_Syntax.term -> unit FStar_Tactics_Monad.tac) =
                           let uu___3 =
                             let uu___4 =
                               let uu___5 =
-                                FStar_Tactics_Printing.goal_to_string ""
-                                  FStar_Pervasives_Native.None ps g in
-                              FStar_Compiler_Util.format1
-                                "Tactics admitted goal <%s>\n\n" uu___5 in
+                                FStar_Errors_Msg.text
+                                  "Tactics admitted goal." in
+                              let uu___6 =
+                                let uu___7 =
+                                  let uu___8 = FStar_Errors_Msg.text "Goal" in
+                                  let uu___9 =
+                                    let uu___10 =
+                                      FStar_Tactics_Printing.goal_to_string
+                                        "" FStar_Pervasives_Native.None ps g in
+                                    FStar_Pprint.arbitrary_string uu___10 in
+                                  FStar_Pprint.prefix (Prims.of_int (2))
+                                    Prims.int_one uu___8 uu___9 in
+                                [uu___7] in
+                              uu___5 :: uu___6 in
                             (FStar_Errors_Codes.Warning_TacAdmit, uu___4) in
-                          FStar_Errors.log_issue uu___2 uu___3);
+                          FStar_Errors.log_issue_doc uu___2 uu___3);
                          Obj.magic (solve' g t)) uu___1))) uu___1) in
     FStar_Tactics_Monad.wrap_err "tadmit_t" uu___
 let (fresh : unit -> FStar_BigInt.t FStar_Tactics_Monad.tac) =

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Core.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Core.ml
@@ -2312,8 +2312,110 @@ let rec (check_relation :
                               head_matches x0.FStar_Syntax_Syntax.sort t11 in
                             if uu___7
                             then
-                              check_relation1 g rel
-                                x0.FStar_Syntax_Syntax.sort t11
+                              let uu___8 =
+                                if rel = EQUALITY
+                                then
+                                  let uu___9 =
+                                    universe_of g x0.FStar_Syntax_Syntax.sort in
+                                  fun ctx01 ->
+                                    let uu___10 = uu___9 ctx01 in
+                                    match uu___10 with
+                                    | Success (x1, g11) ->
+                                        let uu___11 =
+                                          let uu___12 =
+                                            let uu___13 =
+                                              let uu___14 =
+                                                FStar_Syntax_Syntax.mk_binder
+                                                  x0 in
+                                              open_term g uu___14 f0 in
+                                            match uu___13 with
+                                            | (g2, b0, f01) ->
+                                                (fun ctx02 ->
+                                                   let uu___14 =
+                                                     guard_not_allowed ctx02 in
+                                                   match uu___14 with
+                                                   | Success (x2, g12) ->
+                                                       let uu___15 =
+                                                         let uu___16 =
+                                                           if x2
+                                                           then
+                                                             let uu___17 =
+                                                               check_relation1
+                                                                 g2 EQUALITY
+                                                                 FStar_Syntax_Util.t_true
+                                                                 f01 in
+                                                             with_binders
+                                                               [b0] [x1]
+                                                               uu___17
+                                                           else
+                                                             (let uu___18 =
+                                                                let uu___19 =
+                                                                  check_relation1
+                                                                    g2
+                                                                    EQUALITY
+                                                                    FStar_Syntax_Util.t_true
+                                                                    f01 in
+                                                                fun ctx ->
+                                                                  let uu___20
+                                                                    =
+                                                                    uu___19
+                                                                    ctx in
+                                                                  match uu___20
+                                                                  with
+                                                                  | Error
+                                                                    uu___21
+                                                                    ->
+                                                                    let uu___22
+                                                                    =
+                                                                    guard f01 in
+                                                                    uu___22
+                                                                    ctx
+                                                                  | res ->
+                                                                    res in
+                                                              with_binders
+                                                                [b0] 
+                                                                [x1] uu___18) in
+                                                         uu___16 ctx02 in
+                                                       (match uu___15 with
+                                                        | Success (y, g21) ->
+                                                            let uu___16 =
+                                                              let uu___17 =
+                                                                and_pre g12
+                                                                  g21 in
+                                                              ((), uu___17) in
+                                                            Success uu___16
+                                                        | err1 -> err1)
+                                                   | Error err1 -> Error err1) in
+                                          uu___12 ctx01 in
+                                        (match uu___11 with
+                                         | Success (y, g2) ->
+                                             let uu___12 =
+                                               let uu___13 = and_pre g11 g2 in
+                                               ((), uu___13) in
+                                             Success uu___12
+                                         | err1 -> err1)
+                                    | Error err1 -> Error err1
+                                else
+                                  (fun uu___10 ->
+                                     Success
+                                       ((), FStar_Pervasives_Native.None)) in
+                              (fun ctx01 ->
+                                 let uu___9 = uu___8 ctx01 in
+                                 match uu___9 with
+                                 | Success (x1, g11) ->
+                                     let uu___10 =
+                                       let uu___11 =
+                                         check_relation1 g rel
+                                           x0.FStar_Syntax_Syntax.sort t11 in
+                                       uu___11 ctx01 in
+                                     (match uu___10 with
+                                      | Success (y, g2) ->
+                                          let uu___11 =
+                                            let uu___12 = and_pre g11 g2 in
+                                            ((), uu___12) in
+                                          Success uu___11
+                                      | err1 -> err1)
+                                 | Error err1 -> Error err1)
                             else
                               (let uu___9 =
                                  maybe_unfold x0.FStar_Syntax_Syntax.sort t11 in

--- a/src/tactics/FStar.Tactics.V2.Basic.fst
+++ b/src/tactics/FStar.Tactics.V2.Basic.fst
@@ -591,9 +591,13 @@ let tadmit_t (t:term) : tac unit = wrap_err "tadmit_t" <| (
   let! ps = get in
   let! g = cur_goal in
   // should somehow taint the state instead of just printing a warning
-  Err.log_issue (pos (goal_type g))
-      (Errors.Warning_TacAdmit, BU.format1 "Tactics admitted goal <%s>\n\n"
-                  (goal_to_string "" None ps g));
+  let open FStar.Errors.Msg in
+  let open FStar.Pprint in
+  Err.log_issue_doc (pos (goal_type g)) (Errors.Warning_TacAdmit, [
+      text "Tactics admitted goal.";
+      prefix 2 1 (text "Goal")
+                 (arbitrary_string <| goal_to_string "" None ps g);
+    ]);
   solve' g t)
 
 let fresh () : tac Z.t =

--- a/src/typechecker/FStar.TypeChecker.Core.fst
+++ b/src/typechecker/FStar.TypeChecker.Core.fst
@@ -984,19 +984,16 @@ let rec check_relation (g:env) (rel:relation) (t0 t1:typ)
             check_relation g rel (U.flatten_refinement lhs) t1
         )
 
-
       | _, Tm_refine {b=x1; phi=f1} ->
         if head_matches t0 x1.sort
         then (
           let! u1 = universe_of g x1.sort in
           check_relation g EQUALITY t0 x1.sort ;!
           let g, b1, f1 = open_term g (S.mk_binder x1) f1 in
-          match! guard_not_allowed with
-          | true ->
+          if! guard_not_allowed then
             with_binders [b1] [u1]
               (check_relation g EQUALITY U.t_true f1)
-
-          | _ ->
+          else (
             match rel with
             | EQUALITY ->
               with_binders [b1] [u1]
@@ -1009,6 +1006,7 @@ let rec check_relation (g:env) (rel:relation) (t0 t1:typ)
 
             | SUBTYPING None ->
                  guard (U.mk_forall u1 b1.binder_bv f1)
+          )
         )
         else (
           match! maybe_unfold t0 x1.sort with

--- a/tests/bug-reports/Bug2756.fst
+++ b/tests/bug-reports/Bug2756.fst
@@ -35,6 +35,7 @@ assume val bar:
   unit
 
 let the_proof (): Tac unit =
+  compute();
   apply (`arrow_to_forall);
   compute();
   let x_term = binding_to_term (forall_intro ()) in
@@ -59,5 +60,18 @@ let _: unit =
               | TestDependentSum1 n1 n2 tdn1 ->
                 (| 0, (| n1, (| n2, tdn1 |) |) |)
               | TestDependentSum2 _0 -> (| 1, _0 |)))
-        (synth_by_tactic the_proof))
+        (fun _ -> ()))
 
+let _: unit =
+    (bar
+        (id #(encoded_type -> test_dependent_sum)
+            (fun x -> match x with
+              | (| 0, (| n1, (| n2, tdn1|)|)|) ->
+                TestDependentSum1 n1 n2 tdn1
+              | (| 1, _0|) -> TestDependentSum2 _0))
+        (id #(test_dependent_sum -> encoded_type)
+            (fun x -> match x with
+              | TestDependentSum1 n1 n2 tdn1 ->
+                (| 0, (| n1, (| n2, tdn1 |) |) |)
+              | TestDependentSum2 _0 -> (| 1, _0 |)))
+        (synth_by_tactic the_proof))

--- a/tests/micro-benchmarks/PulseBug100.fst
+++ b/tests/micro-benchmarks/PulseBug100.fst
@@ -1,0 +1,19 @@
+module PulseBug100
+
+open FStar.Tactics.V2
+
+let _ = assert True by begin
+  let g = top_env () in
+  match t_check_equiv false true g (`nat) (`int) with
+  | None, _ -> ()
+  | Some _, _ ->
+    fail "no! nat is not int!"
+end
+
+let _ = assert True by begin
+  let g = top_env () in
+  match t_check_equiv false true g (`int) (`nat) with
+  | None, _ -> ()
+  | Some _, _ ->
+    fail "no! nat is not int!"
+end


### PR DESCRIPTION
When checking equality via Core between `x:t{p}` and `t`, we were completely ignoring the refinement. We need to add a guard to check that it is constantly true. Also add a local regression test.

Fixes FStarLang/pulse#100