### PR TITLE
Fix a possible crash for empty record patterns

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_Errors_Codes.ml
+++ b/ocaml/fstar-lib/generated/FStar_Errors_Codes.ml
@@ -375,6 +375,7 @@ type raw_error =
   | Warning_SolverMismatch 
   | Warning_SolverVersionMismatch 
   | Warning_ProofRecovery 
+  | Error_CannotResolveRecord 
 let (uu___is_Error_DependencyAnalysisFailed : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -1923,6 +1924,9 @@ let (uu___is_Warning_SolverVersionMismatch : raw_error -> Prims.bool) =
 let (uu___is_Warning_ProofRecovery : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with | Warning_ProofRecovery -> true | uu___ -> false
+let (uu___is_Error_CannotResolveRecord : raw_error -> Prims.bool) =
+  fun projectee ->
+    match projectee with | Error_CannotResolveRecord -> true | uu___ -> false
 type error_setting = (raw_error * error_flag * Prims.int)
 let (default_settings : error_setting Prims.list) =
   [(Error_DependencyAnalysisFailed, CAlwaysError, Prims.int_zero);
@@ -2289,4 +2293,5 @@ let (default_settings : error_setting Prims.list) =
   (Warning_UnexpectedZ3Stderr, CWarning, (Prims.of_int (356)));
   (Warning_SolverMismatch, CError, (Prims.of_int (357)));
   (Warning_SolverVersionMismatch, CError, (Prims.of_int (358)));
-  (Warning_ProofRecovery, CWarning, (Prims.of_int (359)))]
+  (Warning_ProofRecovery, CWarning, (Prims.of_int (359)));
+  (Error_CannotResolveRecord, CAlwaysError, (Prims.of_int (360)))]

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Util.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Util.ml
@@ -8292,31 +8292,45 @@ let (find_record_or_dc_from_typ :
       fun uc ->
         fun rng ->
           let default_rdc uu___ =
-            match uc.FStar_Syntax_Syntax.uc_typename with
-            | FStar_Pervasives_Native.None ->
-                let f =
-                  FStar_Compiler_List.hd uc.FStar_Syntax_Syntax.uc_fields in
+            match ((uc.FStar_Syntax_Syntax.uc_typename),
+                    (uc.FStar_Syntax_Syntax.uc_fields))
+            with
+            | (FStar_Pervasives_Native.None, []) ->
                 let uu___1 =
                   let uu___2 =
-                    let uu___3 = FStar_Ident.string_of_lid f in
-                    FStar_Compiler_Util.format1
-                      "Field name %s could not be resolved" uu___3 in
-                  (FStar_Errors_Codes.Fatal_IdentifierNotFound, uu___2) in
-                let uu___2 = FStar_Ident.range_of_lid f in
-                FStar_Errors.raise_error uu___1 uu___2
-            | FStar_Pervasives_Native.Some tn ->
-                let uu___1 = try_lookup_record_type env tn in
-                (match uu___1 with
+                    let uu___3 =
+                      FStar_Errors_Msg.text
+                        "Could not resolve the type for this record." in
+                    [uu___3] in
+                  (FStar_Errors_Codes.Error_CannotResolveRecord, uu___2) in
+                FStar_Errors.raise_error_doc uu___1 rng
+            | (FStar_Pervasives_Native.None, f::uu___1) ->
+                let f1 =
+                  FStar_Compiler_List.hd uc.FStar_Syntax_Syntax.uc_fields in
+                let uu___2 =
+                  let uu___3 =
+                    let uu___4 =
+                      let uu___5 =
+                        let uu___6 = FStar_Ident.string_of_lid f1 in
+                        FStar_Compiler_Util.format1
+                          "Field name %s could not be resolved." uu___6 in
+                      FStar_Errors_Msg.text uu___5 in
+                    [uu___4] in
+                  (FStar_Errors_Codes.Error_CannotResolveRecord, uu___3) in
+                FStar_Errors.raise_error_doc uu___2 rng
+            | (FStar_Pervasives_Native.Some tn, uu___1) ->
+                let uu___2 = try_lookup_record_type env tn in
+                (match uu___2 with
                  | FStar_Pervasives_Native.Some rdc -> rdc
                  | FStar_Pervasives_Native.None ->
-                     let uu___2 =
-                       let uu___3 =
-                         let uu___4 = FStar_Ident.string_of_lid tn in
+                     let uu___3 =
+                       let uu___4 =
+                         let uu___5 = FStar_Ident.string_of_lid tn in
                          FStar_Compiler_Util.format1
-                           "Record name %s not found" uu___4 in
-                       (FStar_Errors_Codes.Fatal_NameNotFound, uu___3) in
-                     let uu___3 = FStar_Ident.range_of_lid tn in
-                     FStar_Errors.raise_error uu___2 uu___3) in
+                           "Record name %s not found." uu___5 in
+                       (FStar_Errors_Codes.Fatal_NameNotFound, uu___4) in
+                     let uu___4 = FStar_Ident.range_of_lid tn in
+                     FStar_Errors.raise_error uu___3 uu___4) in
           let rdc =
             match t with
             | FStar_Pervasives_Native.None -> default_rdc ()

--- a/src/basic/FStar.Errors.Codes.fst
+++ b/src/basic/FStar.Errors.Codes.fst
@@ -375,4 +375,5 @@ let default_settings : list error_setting =
     Warning_SolverMismatch                            , CError, 357;
     Warning_SolverVersionMismatch                     , CError, 358;
     Warning_ProofRecovery                             , CWarning, 359;
+    Error_CannotResolveRecord                         , CAlwaysError, 360;
     ]

--- a/src/basic/FStar.Errors.Codes.fsti
+++ b/src/basic/FStar.Errors.Codes.fsti
@@ -387,6 +387,7 @@ type raw_error =
   | Warning_SolverMismatch
   | Warning_SolverVersionMismatch
   | Warning_ProofRecovery
+  | Error_CannotResolveRecord
 
 type error_setting = raw_error & error_flag & int
 

--- a/tests/error-messages/BadEmptyRecord.fst
+++ b/tests/error-messages/BadEmptyRecord.fst
@@ -1,0 +1,9 @@
+module BadEmptyRecord
+
+type t =
+  | A of int
+
+[@@expect_failure [360]]
+let test (x:t) =
+  match x with
+  | A {} -> ()

--- a/tests/error-messages/BadEmptyRecord.fst.expected
+++ b/tests/error-messages/BadEmptyRecord.fst.expected
@@ -1,0 +1,7 @@
+>> Got issues: [
+* Error 360 at BadEmptyRecord.fst(9,6-9,8):
+  - Could not resolve the type for this record.
+
+>>]
+Verified module: BadEmptyRecord
+All verification conditions discharged successfully


### PR DESCRIPTION
The error reporting was assuming non-emptiness, fix it and change the
error code to something more significant.