### PR TITLE
Make sure to catch missing definitions

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_Extraction_ML_Modul.ml
+++ b/ocaml/fstar-lib/generated/FStar_Extraction_ML_Modul.ml
@@ -2669,7 +2669,9 @@ and (extract_sig_let :
                        (env.FStar_TypeChecker_Env.unif_allow_ref_guards);
                      FStar_TypeChecker_Env.erase_erasable_args = true;
                      FStar_TypeChecker_Env.core_check =
-                       (env.FStar_TypeChecker_Env.core_check)
+                       (env.FStar_TypeChecker_Env.core_check);
+                     FStar_TypeChecker_Env.missing_decl =
+                       (env.FStar_TypeChecker_Env.missing_decl)
                    } in
                  let lbd =
                    let uu___3 =

--- a/ocaml/fstar-lib/generated/FStar_Interactive_Ide.ml
+++ b/ocaml/fstar-lib/generated/FStar_Interactive_Ide.ml
@@ -1725,7 +1725,9 @@ let (run_push_without_deps :
                FStar_TypeChecker_Env.erase_erasable_args =
                  (uu___.FStar_TypeChecker_Env.erase_erasable_args);
                FStar_TypeChecker_Env.core_check =
-                 (uu___.FStar_TypeChecker_Env.core_check)
+                 (uu___.FStar_TypeChecker_Env.core_check);
+               FStar_TypeChecker_Env.missing_decl =
+                 (uu___.FStar_TypeChecker_Env.missing_decl)
              });
           FStar_Interactive_Ide_Types.repl_stdin =
             (st1.FStar_Interactive_Ide_Types.repl_stdin);

--- a/ocaml/fstar-lib/generated/FStar_Interactive_Legacy.ml
+++ b/ocaml/fstar-lib/generated/FStar_Interactive_Legacy.ml
@@ -146,7 +146,9 @@ let (push_with_kind :
               FStar_TypeChecker_Env.erase_erasable_args =
                 (env.FStar_TypeChecker_Env.erase_erasable_args);
               FStar_TypeChecker_Env.core_check =
-                (env.FStar_TypeChecker_Env.core_check)
+                (env.FStar_TypeChecker_Env.core_check);
+              FStar_TypeChecker_Env.missing_decl =
+                (env.FStar_TypeChecker_Env.missing_decl)
             } in
           let res = FStar_TypeChecker_Tc.push_context env1 msg in
           FStar_Options.push ();

--- a/ocaml/fstar-lib/generated/FStar_Interactive_PushHelper.ml
+++ b/ocaml/fstar-lib/generated/FStar_Interactive_PushHelper.ml
@@ -136,7 +136,9 @@ let (set_check_kind :
         FStar_TypeChecker_Env.erase_erasable_args =
           (env.FStar_TypeChecker_Env.erase_erasable_args);
         FStar_TypeChecker_Env.core_check =
-          (env.FStar_TypeChecker_Env.core_check)
+          (env.FStar_TypeChecker_Env.core_check);
+        FStar_TypeChecker_Env.missing_decl =
+          (env.FStar_TypeChecker_Env.missing_decl)
       }
 let (repl_ld_tasks_of_deps :
   Prims.string Prims.list ->

--- a/ocaml/fstar-lib/generated/FStar_SMTEncoding_Encode.ml
+++ b/ocaml/fstar-lib/generated/FStar_SMTEncoding_Encode.ml
@@ -1580,7 +1580,9 @@ let (encode_free_var :
                                       =
                                       (tcenv_comp.FStar_TypeChecker_Env.erase_erasable_args);
                                     FStar_TypeChecker_Env.core_check =
-                                      (tcenv_comp.FStar_TypeChecker_Env.core_check)
+                                      (tcenv_comp.FStar_TypeChecker_Env.core_check);
+                                    FStar_TypeChecker_Env.missing_decl =
+                                      (tcenv_comp.FStar_TypeChecker_Env.missing_decl)
                                   } comp FStar_Syntax_Syntax.U_unknown in
                               FStar_Syntax_Syntax.mk_Total uu___7
                             else comp in
@@ -2456,7 +2458,9 @@ let (encode_top_level_let :
                   FStar_TypeChecker_Env.erase_erasable_args =
                     (uu___1.FStar_TypeChecker_Env.erase_erasable_args);
                   FStar_TypeChecker_Env.core_check =
-                    (uu___1.FStar_TypeChecker_Env.core_check)
+                    (uu___1.FStar_TypeChecker_Env.core_check);
+                  FStar_TypeChecker_Env.missing_decl =
+                    (uu___1.FStar_TypeChecker_Env.missing_decl)
                 } in
               let subst_comp formals actuals comp =
                 let subst =

--- a/ocaml/fstar-lib/generated/FStar_SMTEncoding_EncodeTerm.ml
+++ b/ocaml/fstar-lib/generated/FStar_SMTEncoding_EncodeTerm.ml
@@ -1593,7 +1593,9 @@ and (encode_term :
                             FStar_TypeChecker_Env.erase_erasable_args =
                               (uu___6.FStar_TypeChecker_Env.erase_erasable_args);
                             FStar_TypeChecker_Env.core_check =
-                              (uu___6.FStar_TypeChecker_Env.core_check)
+                              (uu___6.FStar_TypeChecker_Env.core_check);
+                            FStar_TypeChecker_Env.missing_decl =
+                              (uu___6.FStar_TypeChecker_Env.missing_decl)
                           } in
                         let uu___6 =
                           FStar_TypeChecker_Util.pure_or_ghost_pre_and_post

--- a/ocaml/fstar-lib/generated/FStar_Tactics_CtrlRewrite.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_CtrlRewrite.ml
@@ -181,7 +181,10 @@ let (__do_rewrite :
                                               (env.FStar_TypeChecker_Env.erase_erasable_args);
                                             FStar_TypeChecker_Env.core_check
                                               =
-                                              (env.FStar_TypeChecker_Env.core_check)
+                                              (env.FStar_TypeChecker_Env.core_check);
+                                            FStar_TypeChecker_Env.missing_decl
+                                              =
+                                              (env.FStar_TypeChecker_Env.missing_decl)
                                           } tm in
                                       FStar_Pervasives_Native.Some uu___3))
                             ()

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Hooks.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Hooks.ml
@@ -954,7 +954,9 @@ let rec (traverse_for_spinoff :
                              FStar_TypeChecker_Env.erase_erasable_args =
                                (env2.FStar_TypeChecker_Env.erase_erasable_args);
                              FStar_TypeChecker_Env.core_check =
-                               (env2.FStar_TypeChecker_Env.core_check)
+                               (env2.FStar_TypeChecker_Env.core_check);
+                             FStar_TypeChecker_Env.missing_decl =
+                               (env2.FStar_TypeChecker_Env.missing_decl)
                            } e1 in
                        (match uu___4 with
                         | (e2, lc) ->
@@ -1974,7 +1976,9 @@ let (splice :
                                            =
                                            (env.FStar_TypeChecker_Env.erase_erasable_args);
                                          FStar_TypeChecker_Env.core_check =
-                                           (env.FStar_TypeChecker_Env.core_check)
+                                           (env.FStar_TypeChecker_Env.core_check);
+                                         FStar_TypeChecker_Env.missing_decl =
+                                           (env.FStar_TypeChecker_Env.missing_decl)
                                        }, val_t)
                                       (FStar_Syntax_Embeddings.e_tuple3
                                          (FStar_Syntax_Embeddings.e_list

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Interpreter.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Interpreter.ml
@@ -755,7 +755,9 @@ let run_unembedded_tactic_on_ps :
                        FStar_TypeChecker_Env.erase_erasable_args =
                          (uu___.FStar_TypeChecker_Env.erase_erasable_args);
                        FStar_TypeChecker_Env.core_check =
-                         (uu___.FStar_TypeChecker_Env.core_check)
+                         (uu___.FStar_TypeChecker_Env.core_check);
+                       FStar_TypeChecker_Env.missing_decl =
+                         (uu___.FStar_TypeChecker_Env.missing_decl)
                      });
                   FStar_Tactics_Types.all_implicits =
                     (ps.FStar_Tactics_Types.all_implicits);
@@ -889,7 +891,9 @@ let run_unembedded_tactic_on_ps :
                        FStar_TypeChecker_Env.erase_erasable_args =
                          (uu___.FStar_TypeChecker_Env.erase_erasable_args);
                        FStar_TypeChecker_Env.core_check =
-                         (uu___.FStar_TypeChecker_Env.core_check)
+                         (uu___.FStar_TypeChecker_Env.core_check);
+                       FStar_TypeChecker_Env.missing_decl =
+                         (uu___.FStar_TypeChecker_Env.missing_decl)
                      });
                   FStar_Tactics_Types.all_implicits =
                     (ps1.FStar_Tactics_Types.all_implicits);

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Monad.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Monad.ml
@@ -159,7 +159,9 @@ let (register_goal : FStar_Tactics_Types.goal -> unit) =
                  FStar_TypeChecker_Env.erase_erasable_args =
                    (env.FStar_TypeChecker_Env.erase_erasable_args);
                  FStar_TypeChecker_Env.core_check =
-                   (env.FStar_TypeChecker_Env.core_check)
+                   (env.FStar_TypeChecker_Env.core_check);
+                 FStar_TypeChecker_Env.missing_decl =
+                   (env.FStar_TypeChecker_Env.missing_decl)
                } in
              (let uu___6 = FStar_Compiler_Effect.op_Bang dbg_CoreEq in
               if uu___6

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Types.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Types.ml
@@ -340,7 +340,9 @@ let (goal_of_implicit :
           FStar_TypeChecker_Env.erase_erasable_args =
             (env.FStar_TypeChecker_Env.erase_erasable_args);
           FStar_TypeChecker_Env.core_check =
-            (env.FStar_TypeChecker_Env.core_check)
+            (env.FStar_TypeChecker_Env.core_check);
+          FStar_TypeChecker_Env.missing_decl =
+            (env.FStar_TypeChecker_Env.missing_decl)
         } i.FStar_TypeChecker_Common.imp_uvar uu___ false
         i.FStar_TypeChecker_Common.imp_reason
 let (decr_depth : proofstate -> proofstate) =

--- a/ocaml/fstar-lib/generated/FStar_Tactics_V1_Basic.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_V1_Basic.ml
@@ -806,7 +806,9 @@ let (tc_unifier_solved_implicits :
                          FStar_TypeChecker_Env.erase_erasable_args =
                            (env1.FStar_TypeChecker_Env.erase_erasable_args);
                          FStar_TypeChecker_Env.core_check =
-                           (env1.FStar_TypeChecker_Env.core_check)
+                           (env1.FStar_TypeChecker_Env.core_check);
+                         FStar_TypeChecker_Env.missing_decl =
+                           (env1.FStar_TypeChecker_Env.missing_decl)
                        } in
                      let must_tot1 =
                        must_tot &&
@@ -1590,7 +1592,9 @@ let (__tc :
                     FStar_TypeChecker_Env.erase_erasable_args =
                       (e.FStar_TypeChecker_Env.erase_erasable_args);
                     FStar_TypeChecker_Env.core_check =
-                      (e.FStar_TypeChecker_Env.core_check)
+                      (e.FStar_TypeChecker_Env.core_check);
+                    FStar_TypeChecker_Env.missing_decl =
+                      (e.FStar_TypeChecker_Env.missing_decl)
                   } in
                 try
                   (fun uu___2 ->
@@ -1737,7 +1741,9 @@ let (__tc_ghost :
                     FStar_TypeChecker_Env.erase_erasable_args =
                       (e.FStar_TypeChecker_Env.erase_erasable_args);
                     FStar_TypeChecker_Env.core_check =
-                      (e.FStar_TypeChecker_Env.core_check)
+                      (e.FStar_TypeChecker_Env.core_check);
+                    FStar_TypeChecker_Env.missing_decl =
+                      (e.FStar_TypeChecker_Env.missing_decl)
                   } in
                 let e2 =
                   {
@@ -1844,7 +1850,9 @@ let (__tc_ghost :
                     FStar_TypeChecker_Env.erase_erasable_args =
                       (e1.FStar_TypeChecker_Env.erase_erasable_args);
                     FStar_TypeChecker_Env.core_check =
-                      (e1.FStar_TypeChecker_Env.core_check)
+                      (e1.FStar_TypeChecker_Env.core_check);
+                    FStar_TypeChecker_Env.missing_decl =
+                      (e1.FStar_TypeChecker_Env.missing_decl)
                   } in
                 try
                   (fun uu___2 ->
@@ -1998,7 +2006,9 @@ let (__tc_lax :
                     FStar_TypeChecker_Env.erase_erasable_args =
                       (e.FStar_TypeChecker_Env.erase_erasable_args);
                     FStar_TypeChecker_Env.core_check =
-                      (e.FStar_TypeChecker_Env.core_check)
+                      (e.FStar_TypeChecker_Env.core_check);
+                    FStar_TypeChecker_Env.missing_decl =
+                      (e.FStar_TypeChecker_Env.missing_decl)
                   } in
                 let e2 =
                   {
@@ -2105,7 +2115,9 @@ let (__tc_lax :
                     FStar_TypeChecker_Env.erase_erasable_args =
                       (e1.FStar_TypeChecker_Env.erase_erasable_args);
                     FStar_TypeChecker_Env.core_check =
-                      (e1.FStar_TypeChecker_Env.core_check)
+                      (e1.FStar_TypeChecker_Env.core_check);
+                    FStar_TypeChecker_Env.missing_decl =
+                      (e1.FStar_TypeChecker_Env.missing_decl)
                   } in
                 let e3 =
                   {
@@ -2212,7 +2224,9 @@ let (__tc_lax :
                     FStar_TypeChecker_Env.erase_erasable_args =
                       (e2.FStar_TypeChecker_Env.erase_erasable_args);
                     FStar_TypeChecker_Env.core_check =
-                      (e2.FStar_TypeChecker_Env.core_check)
+                      (e2.FStar_TypeChecker_Env.core_check);
+                    FStar_TypeChecker_Env.missing_decl =
+                      (e2.FStar_TypeChecker_Env.missing_decl)
                   } in
                 try
                   (fun uu___2 ->
@@ -5491,7 +5505,9 @@ let (_t_trefl :
                                       =
                                       (uu___12.FStar_TypeChecker_Env.erase_erasable_args);
                                     FStar_TypeChecker_Env.core_check =
-                                      (uu___12.FStar_TypeChecker_Env.core_check)
+                                      (uu___12.FStar_TypeChecker_Env.core_check);
+                                    FStar_TypeChecker_Env.missing_decl =
+                                      (uu___12.FStar_TypeChecker_Env.missing_decl)
                                   } in
                                 let uu___12 =
                                   FStar_TypeChecker_Core.compute_term_type_handle_guards
@@ -6073,7 +6089,10 @@ let (join_goals :
                                                          (uu___7.FStar_TypeChecker_Env.erase_erasable_args);
                                                        FStar_TypeChecker_Env.core_check
                                                          =
-                                                         (uu___7.FStar_TypeChecker_Env.core_check)
+                                                         (uu___7.FStar_TypeChecker_Env.core_check);
+                                                       FStar_TypeChecker_Env.missing_decl
+                                                         =
+                                                         (uu___7.FStar_TypeChecker_Env.missing_decl)
                                                      } in
                                                    let uu___7 =
                                                      FStar_Tactics_Monad.mk_irrelevant_goal
@@ -6660,7 +6679,9 @@ let (unshelve : FStar_Syntax_Syntax.term -> unit FStar_Tactics_Monad.tac) =
                       FStar_TypeChecker_Env.erase_erasable_args =
                         (env1.FStar_TypeChecker_Env.erase_erasable_args);
                       FStar_TypeChecker_Env.core_check =
-                        (env1.FStar_TypeChecker_Env.core_check)
+                        (env1.FStar_TypeChecker_Env.core_check);
+                      FStar_TypeChecker_Env.missing_decl =
+                        (env1.FStar_TypeChecker_Env.missing_decl)
                     } in
                   let g =
                     FStar_Tactics_Types.mk_goal env2 ctx_uvar opts false "" in
@@ -8089,7 +8110,10 @@ let (t_destruct :
                                                                     (env1.FStar_TypeChecker_Env.erase_erasable_args);
                                                                     FStar_TypeChecker_Env.core_check
                                                                     =
-                                                                    (env1.FStar_TypeChecker_Env.core_check)
+                                                                    (env1.FStar_TypeChecker_Env.core_check);
+                                                                    FStar_TypeChecker_Env.missing_decl
+                                                                    =
+                                                                    (env1.FStar_TypeChecker_Env.missing_decl)
                                                                     } s_ty1
                                                                     pat in
                                                                     match uu___33
@@ -9225,7 +9249,9 @@ let (push_bv_dsenv :
                FStar_TypeChecker_Env.erase_erasable_args =
                  (e.FStar_TypeChecker_Env.erase_erasable_args);
                FStar_TypeChecker_Env.core_check =
-                 (e.FStar_TypeChecker_Env.core_check)
+                 (e.FStar_TypeChecker_Env.core_check);
+               FStar_TypeChecker_Env.missing_decl =
+                 (e.FStar_TypeChecker_Env.missing_decl)
              }, bv)
 let (term_to_string :
   FStar_Syntax_Syntax.term -> Prims.string FStar_Tactics_Monad.tac) =

--- a/ocaml/fstar-lib/generated/FStar_Tactics_V2_Basic.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_V2_Basic.ml
@@ -956,7 +956,9 @@ let (tc_unifier_solved_implicits :
                          FStar_TypeChecker_Env.erase_erasable_args =
                            (env1.FStar_TypeChecker_Env.erase_erasable_args);
                          FStar_TypeChecker_Env.core_check =
-                           (env1.FStar_TypeChecker_Env.core_check)
+                           (env1.FStar_TypeChecker_Env.core_check);
+                         FStar_TypeChecker_Env.missing_decl =
+                           (env1.FStar_TypeChecker_Env.missing_decl)
                        } in
                      let must_tot1 =
                        must_tot &&
@@ -2119,7 +2121,9 @@ let (__tc :
                                        =
                                        (e.FStar_TypeChecker_Env.erase_erasable_args);
                                      FStar_TypeChecker_Env.core_check =
-                                       (e.FStar_TypeChecker_Env.core_check)
+                                       (e.FStar_TypeChecker_Env.core_check);
+                                     FStar_TypeChecker_Env.missing_decl =
+                                       (e.FStar_TypeChecker_Env.missing_decl)
                                    } in
                                  Obj.magic
                                    (try
@@ -2354,7 +2358,9 @@ let (__tc_ghost :
                                        =
                                        (e.FStar_TypeChecker_Env.erase_erasable_args);
                                      FStar_TypeChecker_Env.core_check =
-                                       (e.FStar_TypeChecker_Env.core_check)
+                                       (e.FStar_TypeChecker_Env.core_check);
+                                     FStar_TypeChecker_Env.missing_decl =
+                                       (e.FStar_TypeChecker_Env.missing_decl)
                                    } in
                                  let e2 =
                                    {
@@ -2470,7 +2476,9 @@ let (__tc_ghost :
                                        =
                                        (e1.FStar_TypeChecker_Env.erase_erasable_args);
                                      FStar_TypeChecker_Env.core_check =
-                                       (e1.FStar_TypeChecker_Env.core_check)
+                                       (e1.FStar_TypeChecker_Env.core_check);
+                                     FStar_TypeChecker_Env.missing_decl =
+                                       (e1.FStar_TypeChecker_Env.missing_decl)
                                    } in
                                  Obj.magic
                                    (try
@@ -2717,7 +2725,9 @@ let (__tc_lax :
                                        =
                                        (e.FStar_TypeChecker_Env.erase_erasable_args);
                                      FStar_TypeChecker_Env.core_check =
-                                       (e.FStar_TypeChecker_Env.core_check)
+                                       (e.FStar_TypeChecker_Env.core_check);
+                                     FStar_TypeChecker_Env.missing_decl =
+                                       (e.FStar_TypeChecker_Env.missing_decl)
                                    } in
                                  let e2 =
                                    {
@@ -2833,7 +2843,9 @@ let (__tc_lax :
                                        =
                                        (e1.FStar_TypeChecker_Env.erase_erasable_args);
                                      FStar_TypeChecker_Env.core_check =
-                                       (e1.FStar_TypeChecker_Env.core_check)
+                                       (e1.FStar_TypeChecker_Env.core_check);
+                                     FStar_TypeChecker_Env.missing_decl =
+                                       (e1.FStar_TypeChecker_Env.missing_decl)
                                    } in
                                  let e3 =
                                    {
@@ -2949,7 +2961,9 @@ let (__tc_lax :
                                        =
                                        (e2.FStar_TypeChecker_Env.erase_erasable_args);
                                      FStar_TypeChecker_Env.core_check =
-                                       (e2.FStar_TypeChecker_Env.core_check)
+                                       (e2.FStar_TypeChecker_Env.core_check);
+                                     FStar_TypeChecker_Env.missing_decl =
+                                       (e2.FStar_TypeChecker_Env.missing_decl)
                                    } in
                                  Obj.magic
                                    (try
@@ -6377,7 +6391,9 @@ let (_t_trefl :
                                       =
                                       (uu___12.FStar_TypeChecker_Env.erase_erasable_args);
                                     FStar_TypeChecker_Env.core_check =
-                                      (uu___12.FStar_TypeChecker_Env.core_check)
+                                      (uu___12.FStar_TypeChecker_Env.core_check);
+                                    FStar_TypeChecker_Env.missing_decl =
+                                      (uu___12.FStar_TypeChecker_Env.missing_decl)
                                   } in
                                 let uu___12 =
                                   FStar_TypeChecker_Core.compute_term_type_handle_guards
@@ -6902,7 +6918,9 @@ let (join_goals :
                                       =
                                       (uu___3.FStar_TypeChecker_Env.erase_erasable_args);
                                     FStar_TypeChecker_Env.core_check =
-                                      (uu___3.FStar_TypeChecker_Env.core_check)
+                                      (uu___3.FStar_TypeChecker_Env.core_check);
+                                    FStar_TypeChecker_Env.missing_decl =
+                                      (uu___3.FStar_TypeChecker_Env.missing_decl)
                                   } in
                                 let uu___3 =
                                   FStar_Tactics_Monad.mk_irrelevant_goal
@@ -7573,7 +7591,9 @@ let (unshelve : FStar_Syntax_Syntax.term -> unit FStar_Tactics_Monad.tac) =
                       FStar_TypeChecker_Env.erase_erasable_args =
                         (env1.FStar_TypeChecker_Env.erase_erasable_args);
                       FStar_TypeChecker_Env.core_check =
-                        (env1.FStar_TypeChecker_Env.core_check)
+                        (env1.FStar_TypeChecker_Env.core_check);
+                      FStar_TypeChecker_Env.missing_decl =
+                        (env1.FStar_TypeChecker_Env.missing_decl)
                     } in
                   let g =
                     FStar_Tactics_Types.mk_goal env2 ctx_uvar opts false "" in
@@ -9074,7 +9094,10 @@ let (t_destruct :
                                                                     (env1.FStar_TypeChecker_Env.erase_erasable_args);
                                                                     FStar_TypeChecker_Env.core_check
                                                                     =
-                                                                    (env1.FStar_TypeChecker_Env.core_check)
+                                                                    (env1.FStar_TypeChecker_Env.core_check);
+                                                                    FStar_TypeChecker_Env.missing_decl
+                                                                    =
+                                                                    (env1.FStar_TypeChecker_Env.missing_decl)
                                                                     } s_ty1
                                                                     pat in
                                                                     match uu___33
@@ -9774,7 +9797,9 @@ let (push_bv_dsenv :
                     FStar_TypeChecker_Env.erase_erasable_args =
                       (e.FStar_TypeChecker_Env.erase_erasable_args);
                     FStar_TypeChecker_Env.core_check =
-                      (e.FStar_TypeChecker_Env.core_check)
+                      (e.FStar_TypeChecker_Env.core_check);
+                    FStar_TypeChecker_Env.missing_decl =
+                      (e.FStar_TypeChecker_Env.missing_decl)
                   }, uu___2) in
                Obj.magic
                  (FStar_Class_Monad.return FStar_Tactics_Monad.monad_tac ()
@@ -10954,7 +10979,9 @@ let (refl_tc_term :
                              FStar_TypeChecker_Env.erase_erasable_args =
                                (g1.FStar_TypeChecker_Env.erase_erasable_args);
                              FStar_TypeChecker_Env.core_check =
-                               (g1.FStar_TypeChecker_Env.core_check)
+                               (g1.FStar_TypeChecker_Env.core_check);
+                             FStar_TypeChecker_Env.missing_decl =
+                               (g1.FStar_TypeChecker_Env.missing_decl)
                            } in
                          let e1 =
                            let g3 =
@@ -11063,7 +11090,9 @@ let (refl_tc_term :
                                FStar_TypeChecker_Env.erase_erasable_args =
                                  (g2.FStar_TypeChecker_Env.erase_erasable_args);
                                FStar_TypeChecker_Env.core_check =
-                                 (g2.FStar_TypeChecker_Env.core_check)
+                                 (g2.FStar_TypeChecker_Env.core_check);
+                               FStar_TypeChecker_Env.missing_decl =
+                                 (g2.FStar_TypeChecker_Env.missing_decl)
                              } in
                            let must_tot = false in
                            let uu___4 =
@@ -11664,7 +11693,9 @@ let (refl_instantiate_implicits :
                              FStar_TypeChecker_Env.erase_erasable_args =
                                (g1.FStar_TypeChecker_Env.erase_erasable_args);
                              FStar_TypeChecker_Env.core_check =
-                               (g1.FStar_TypeChecker_Env.core_check)
+                               (g1.FStar_TypeChecker_Env.core_check);
+                             FStar_TypeChecker_Env.missing_decl =
+                               (g1.FStar_TypeChecker_Env.missing_decl)
                            } in
                          let uu___4 =
                            g2.FStar_TypeChecker_Env.typeof_tot_or_gtot_term
@@ -12105,7 +12136,10 @@ let (refl_try_unify :
                                                 (g1.FStar_TypeChecker_Env.erase_erasable_args);
                                               FStar_TypeChecker_Env.core_check
                                                 =
-                                                (g1.FStar_TypeChecker_Env.core_check)
+                                                (g1.FStar_TypeChecker_Env.core_check);
+                                              FStar_TypeChecker_Env.missing_decl
+                                                =
+                                                (g1.FStar_TypeChecker_Env.missing_decl)
                                             } in
                                           let guard_eq =
                                             let smt_ok = true in
@@ -12475,7 +12509,9 @@ let (push_open_namespace :
                FStar_TypeChecker_Env.erase_erasable_args =
                  (e.FStar_TypeChecker_Env.erase_erasable_args);
                FStar_TypeChecker_Env.core_check =
-                 (e.FStar_TypeChecker_Env.core_check)
+                 (e.FStar_TypeChecker_Env.core_check);
+               FStar_TypeChecker_Env.missing_decl =
+                 (e.FStar_TypeChecker_Env.missing_decl)
              } in
            Obj.magic
              (FStar_Class_Monad.return FStar_Tactics_Monad.monad_tac ()
@@ -12599,7 +12635,9 @@ let (push_module_abbrev :
                    FStar_TypeChecker_Env.erase_erasable_args =
                      (e.FStar_TypeChecker_Env.erase_erasable_args);
                    FStar_TypeChecker_Env.core_check =
-                     (e.FStar_TypeChecker_Env.core_check)
+                     (e.FStar_TypeChecker_Env.core_check);
+                   FStar_TypeChecker_Env.missing_decl =
+                     (e.FStar_TypeChecker_Env.missing_decl)
                  } in
                Obj.magic
                  (FStar_Class_Monad.return FStar_Tactics_Monad.monad_tac ()
@@ -12757,7 +12795,9 @@ let (tac_env : FStar_TypeChecker_Env.env -> FStar_TypeChecker_Env.env) =
             FStar_TypeChecker_Env.erase_erasable_args =
               (env2.FStar_TypeChecker_Env.erase_erasable_args);
             FStar_TypeChecker_Env.core_check =
-              (env2.FStar_TypeChecker_Env.core_check)
+              (env2.FStar_TypeChecker_Env.core_check);
+            FStar_TypeChecker_Env.missing_decl =
+              (env2.FStar_TypeChecker_Env.missing_decl)
           } in
         let env4 =
           {
@@ -12857,7 +12897,9 @@ let (tac_env : FStar_TypeChecker_Env.env -> FStar_TypeChecker_Env.env) =
             FStar_TypeChecker_Env.erase_erasable_args =
               (env3.FStar_TypeChecker_Env.erase_erasable_args);
             FStar_TypeChecker_Env.core_check =
-              (env3.FStar_TypeChecker_Env.core_check)
+              (env3.FStar_TypeChecker_Env.core_check);
+            FStar_TypeChecker_Env.missing_decl =
+              (env3.FStar_TypeChecker_Env.missing_decl)
           } in
         let env5 =
           {
@@ -12957,7 +12999,9 @@ let (tac_env : FStar_TypeChecker_Env.env -> FStar_TypeChecker_Env.env) =
             FStar_TypeChecker_Env.erase_erasable_args =
               (env4.FStar_TypeChecker_Env.erase_erasable_args);
             FStar_TypeChecker_Env.core_check =
-              (env4.FStar_TypeChecker_Env.core_check)
+              (env4.FStar_TypeChecker_Env.core_check);
+            FStar_TypeChecker_Env.missing_decl =
+              (env4.FStar_TypeChecker_Env.missing_decl)
           } in
         env5
 let (proofstate_of_goals :
@@ -13102,7 +13146,9 @@ let (proofstate_of_goal_ty :
             FStar_TypeChecker_Env.erase_erasable_args =
               (env1.FStar_TypeChecker_Env.erase_erasable_args);
             FStar_TypeChecker_Env.core_check =
-              (env1.FStar_TypeChecker_Env.core_check)
+              (env1.FStar_TypeChecker_Env.core_check);
+            FStar_TypeChecker_Env.missing_decl =
+              (env1.FStar_TypeChecker_Env.missing_decl)
           } in
         let env3 = tac_env env2 in
         let uu___ = FStar_Tactics_Types.goal_of_goal_ty env3 typ in

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_DeferredImplicits.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_DeferredImplicits.ml
@@ -366,7 +366,9 @@ let solve_goals_with_tac :
                    FStar_TypeChecker_Env.erase_erasable_args =
                      (env.FStar_TypeChecker_Env.erase_erasable_args);
                    FStar_TypeChecker_Env.core_check =
-                     (env.FStar_TypeChecker_Env.core_check)
+                     (env.FStar_TypeChecker_Env.core_check);
+                   FStar_TypeChecker_Env.missing_decl =
+                     (env.FStar_TypeChecker_Env.missing_decl)
                  } in
                env1.FStar_TypeChecker_Env.try_solve_implicits_hook env1
                  resolve_tac deferred_goals) uu___
@@ -498,7 +500,9 @@ let (solve_deferred_to_tactic_goals :
                              FStar_TypeChecker_Env.erase_erasable_args =
                                (env1.FStar_TypeChecker_Env.erase_erasable_args);
                              FStar_TypeChecker_Env.core_check =
-                               (env1.FStar_TypeChecker_Env.core_check)
+                               (env1.FStar_TypeChecker_Env.core_check);
+                             FStar_TypeChecker_Env.missing_decl =
+                               (env1.FStar_TypeChecker_Env.missing_decl)
                            } in
                          let env_lax =
                            {
@@ -605,7 +609,9 @@ let (solve_deferred_to_tactic_goals :
                              FStar_TypeChecker_Env.erase_erasable_args =
                                (env2.FStar_TypeChecker_Env.erase_erasable_args);
                              FStar_TypeChecker_Env.core_check =
-                               (env2.FStar_TypeChecker_Env.core_check)
+                               (env2.FStar_TypeChecker_Env.core_check);
+                             FStar_TypeChecker_Env.missing_decl =
+                               (env2.FStar_TypeChecker_Env.missing_decl)
                            } in
                          let uu___5 =
                            let t =

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Env.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Env.ml
@@ -478,7 +478,8 @@ and env =
           Prims.bool ->
             (FStar_Syntax_Syntax.typ FStar_Pervasives_Native.option,
               Prims.bool -> Prims.string) FStar_Pervasives.either
-    }
+    ;
+  missing_decl: FStar_Ident.lident FStar_Compiler_RBSet.t }
 and solver_t =
   {
   init: env -> unit ;
@@ -611,7 +612,8 @@ let (__proj__Mkenv__item__solver : env -> solver_t) =
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
         splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
         dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
-        unif_allow_ref_guards; erase_erasable_args; core_check;_} -> solver
+        unif_allow_ref_guards; erase_erasable_args; core_check;
+        missing_decl;_} -> solver
 let (__proj__Mkenv__item__range : env -> FStar_Compiler_Range_Type.range) =
   fun projectee ->
     match projectee with
@@ -625,7 +627,8 @@ let (__proj__Mkenv__item__range : env -> FStar_Compiler_Range_Type.range) =
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
         splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
         dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
-        unif_allow_ref_guards; erase_erasable_args; core_check;_} -> range
+        unif_allow_ref_guards; erase_erasable_args; core_check;
+        missing_decl;_} -> range
 let (__proj__Mkenv__item__curmodule : env -> FStar_Ident.lident) =
   fun projectee ->
     match projectee with
@@ -639,8 +642,8 @@ let (__proj__Mkenv__item__curmodule : env -> FStar_Ident.lident) =
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
         splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
         dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
-        unif_allow_ref_guards; erase_erasable_args; core_check;_} ->
-        curmodule
+        unif_allow_ref_guards; erase_erasable_args; core_check;
+        missing_decl;_} -> curmodule
 let (__proj__Mkenv__item__gamma :
   env -> FStar_Syntax_Syntax.binding Prims.list) =
   fun projectee ->
@@ -655,7 +658,8 @@ let (__proj__Mkenv__item__gamma :
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
         splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
         dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
-        unif_allow_ref_guards; erase_erasable_args; core_check;_} -> gamma
+        unif_allow_ref_guards; erase_erasable_args; core_check;
+        missing_decl;_} -> gamma
 let (__proj__Mkenv__item__gamma_sig : env -> sig_binding Prims.list) =
   fun projectee ->
     match projectee with
@@ -669,8 +673,8 @@ let (__proj__Mkenv__item__gamma_sig : env -> sig_binding Prims.list) =
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
         splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
         dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
-        unif_allow_ref_guards; erase_erasable_args; core_check;_} ->
-        gamma_sig
+        unif_allow_ref_guards; erase_erasable_args; core_check;
+        missing_decl;_} -> gamma_sig
 let (__proj__Mkenv__item__gamma_cache :
   env -> cached_elt FStar_Compiler_Util.smap) =
   fun projectee ->
@@ -685,8 +689,8 @@ let (__proj__Mkenv__item__gamma_cache :
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
         splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
         dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
-        unif_allow_ref_guards; erase_erasable_args; core_check;_} ->
-        gamma_cache
+        unif_allow_ref_guards; erase_erasable_args; core_check;
+        missing_decl;_} -> gamma_cache
 let (__proj__Mkenv__item__modules :
   env -> FStar_Syntax_Syntax.modul Prims.list) =
   fun projectee ->
@@ -701,7 +705,8 @@ let (__proj__Mkenv__item__modules :
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
         splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
         dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
-        unif_allow_ref_guards; erase_erasable_args; core_check;_} -> modules
+        unif_allow_ref_guards; erase_erasable_args; core_check;
+        missing_decl;_} -> modules
 let (__proj__Mkenv__item__expected_typ :
   env ->
     (FStar_Syntax_Syntax.typ * Prims.bool) FStar_Pervasives_Native.option)
@@ -718,8 +723,8 @@ let (__proj__Mkenv__item__expected_typ :
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
         splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
         dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
-        unif_allow_ref_guards; erase_erasable_args; core_check;_} ->
-        expected_typ
+        unif_allow_ref_guards; erase_erasable_args; core_check;
+        missing_decl;_} -> expected_typ
 let (__proj__Mkenv__item__sigtab :
   env -> FStar_Syntax_Syntax.sigelt FStar_Compiler_Util.smap) =
   fun projectee ->
@@ -734,7 +739,8 @@ let (__proj__Mkenv__item__sigtab :
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
         splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
         dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
-        unif_allow_ref_guards; erase_erasable_args; core_check;_} -> sigtab
+        unif_allow_ref_guards; erase_erasable_args; core_check;
+        missing_decl;_} -> sigtab
 let (__proj__Mkenv__item__attrtab :
   env -> FStar_Syntax_Syntax.sigelt Prims.list FStar_Compiler_Util.smap) =
   fun projectee ->
@@ -749,7 +755,8 @@ let (__proj__Mkenv__item__attrtab :
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
         splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
         dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
-        unif_allow_ref_guards; erase_erasable_args; core_check;_} -> attrtab
+        unif_allow_ref_guards; erase_erasable_args; core_check;
+        missing_decl;_} -> attrtab
 let (__proj__Mkenv__item__instantiate_imp : env -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -763,8 +770,8 @@ let (__proj__Mkenv__item__instantiate_imp : env -> Prims.bool) =
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
         splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
         dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
-        unif_allow_ref_guards; erase_erasable_args; core_check;_} ->
-        instantiate_imp
+        unif_allow_ref_guards; erase_erasable_args; core_check;
+        missing_decl;_} -> instantiate_imp
 let (__proj__Mkenv__item__effects : env -> effects) =
   fun projectee ->
     match projectee with
@@ -778,7 +785,8 @@ let (__proj__Mkenv__item__effects : env -> effects) =
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
         splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
         dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
-        unif_allow_ref_guards; erase_erasable_args; core_check;_} -> effects1
+        unif_allow_ref_guards; erase_erasable_args; core_check;
+        missing_decl;_} -> effects1
 let (__proj__Mkenv__item__generalize : env -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -792,8 +800,8 @@ let (__proj__Mkenv__item__generalize : env -> Prims.bool) =
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
         splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
         dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
-        unif_allow_ref_guards; erase_erasable_args; core_check;_} ->
-        generalize
+        unif_allow_ref_guards; erase_erasable_args; core_check;
+        missing_decl;_} -> generalize
 let (__proj__Mkenv__item__letrecs :
   env ->
     (FStar_Syntax_Syntax.lbname * Prims.int * FStar_Syntax_Syntax.typ *
@@ -811,7 +819,8 @@ let (__proj__Mkenv__item__letrecs :
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
         splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
         dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
-        unif_allow_ref_guards; erase_erasable_args; core_check;_} -> letrecs
+        unif_allow_ref_guards; erase_erasable_args; core_check;
+        missing_decl;_} -> letrecs
 let (__proj__Mkenv__item__top_level : env -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -825,8 +834,8 @@ let (__proj__Mkenv__item__top_level : env -> Prims.bool) =
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
         splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
         dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
-        unif_allow_ref_guards; erase_erasable_args; core_check;_} ->
-        top_level
+        unif_allow_ref_guards; erase_erasable_args; core_check;
+        missing_decl;_} -> top_level
 let (__proj__Mkenv__item__check_uvars : env -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -840,8 +849,8 @@ let (__proj__Mkenv__item__check_uvars : env -> Prims.bool) =
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
         splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
         dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
-        unif_allow_ref_guards; erase_erasable_args; core_check;_} ->
-        check_uvars
+        unif_allow_ref_guards; erase_erasable_args; core_check;
+        missing_decl;_} -> check_uvars
 let (__proj__Mkenv__item__use_eq_strict : env -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -855,8 +864,8 @@ let (__proj__Mkenv__item__use_eq_strict : env -> Prims.bool) =
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
         splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
         dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
-        unif_allow_ref_guards; erase_erasable_args; core_check;_} ->
-        use_eq_strict
+        unif_allow_ref_guards; erase_erasable_args; core_check;
+        missing_decl;_} -> use_eq_strict
 let (__proj__Mkenv__item__is_iface : env -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -870,7 +879,8 @@ let (__proj__Mkenv__item__is_iface : env -> Prims.bool) =
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
         splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
         dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
-        unif_allow_ref_guards; erase_erasable_args; core_check;_} -> is_iface
+        unif_allow_ref_guards; erase_erasable_args; core_check;
+        missing_decl;_} -> is_iface
 let (__proj__Mkenv__item__admit : env -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -884,7 +894,8 @@ let (__proj__Mkenv__item__admit : env -> Prims.bool) =
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
         splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
         dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
-        unif_allow_ref_guards; erase_erasable_args; core_check;_} -> admit
+        unif_allow_ref_guards; erase_erasable_args; core_check;
+        missing_decl;_} -> admit
 let (__proj__Mkenv__item__lax : env -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -898,7 +909,8 @@ let (__proj__Mkenv__item__lax : env -> Prims.bool) =
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
         splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
         dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
-        unif_allow_ref_guards; erase_erasable_args; core_check;_} -> lax
+        unif_allow_ref_guards; erase_erasable_args; core_check;
+        missing_decl;_} -> lax
 let (__proj__Mkenv__item__lax_universes : env -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -912,8 +924,8 @@ let (__proj__Mkenv__item__lax_universes : env -> Prims.bool) =
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
         splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
         dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
-        unif_allow_ref_guards; erase_erasable_args; core_check;_} ->
-        lax_universes
+        unif_allow_ref_guards; erase_erasable_args; core_check;
+        missing_decl;_} -> lax_universes
 let (__proj__Mkenv__item__phase1 : env -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -927,7 +939,8 @@ let (__proj__Mkenv__item__phase1 : env -> Prims.bool) =
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
         splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
         dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
-        unif_allow_ref_guards; erase_erasable_args; core_check;_} -> phase1
+        unif_allow_ref_guards; erase_erasable_args; core_check;
+        missing_decl;_} -> phase1
 let (__proj__Mkenv__item__failhard : env -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -941,7 +954,8 @@ let (__proj__Mkenv__item__failhard : env -> Prims.bool) =
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
         splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
         dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
-        unif_allow_ref_guards; erase_erasable_args; core_check;_} -> failhard
+        unif_allow_ref_guards; erase_erasable_args; core_check;
+        missing_decl;_} -> failhard
 let (__proj__Mkenv__item__nosynth : env -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -955,7 +969,8 @@ let (__proj__Mkenv__item__nosynth : env -> Prims.bool) =
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
         splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
         dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
-        unif_allow_ref_guards; erase_erasable_args; core_check;_} -> nosynth
+        unif_allow_ref_guards; erase_erasable_args; core_check;
+        missing_decl;_} -> nosynth
 let (__proj__Mkenv__item__uvar_subtyping : env -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -969,8 +984,8 @@ let (__proj__Mkenv__item__uvar_subtyping : env -> Prims.bool) =
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
         splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
         dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
-        unif_allow_ref_guards; erase_erasable_args; core_check;_} ->
-        uvar_subtyping
+        unif_allow_ref_guards; erase_erasable_args; core_check;
+        missing_decl;_} -> uvar_subtyping
 let (__proj__Mkenv__item__intactics : env -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -984,8 +999,8 @@ let (__proj__Mkenv__item__intactics : env -> Prims.bool) =
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
         splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
         dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
-        unif_allow_ref_guards; erase_erasable_args; core_check;_} ->
-        intactics
+        unif_allow_ref_guards; erase_erasable_args; core_check;
+        missing_decl;_} -> intactics
 let (__proj__Mkenv__item__nocoerce : env -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -999,7 +1014,8 @@ let (__proj__Mkenv__item__nocoerce : env -> Prims.bool) =
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
         splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
         dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
-        unif_allow_ref_guards; erase_erasable_args; core_check;_} -> nocoerce
+        unif_allow_ref_guards; erase_erasable_args; core_check;
+        missing_decl;_} -> nocoerce
 let (__proj__Mkenv__item__tc_term :
   env ->
     env ->
@@ -1019,7 +1035,8 @@ let (__proj__Mkenv__item__tc_term :
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
         splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
         dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
-        unif_allow_ref_guards; erase_erasable_args; core_check;_} -> tc_term
+        unif_allow_ref_guards; erase_erasable_args; core_check;
+        missing_decl;_} -> tc_term
 let (__proj__Mkenv__item__typeof_tot_or_gtot_term :
   env ->
     env ->
@@ -1040,8 +1057,8 @@ let (__proj__Mkenv__item__typeof_tot_or_gtot_term :
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
         splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
         dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
-        unif_allow_ref_guards; erase_erasable_args; core_check;_} ->
-        typeof_tot_or_gtot_term
+        unif_allow_ref_guards; erase_erasable_args; core_check;
+        missing_decl;_} -> typeof_tot_or_gtot_term
 let (__proj__Mkenv__item__universe_of :
   env -> env -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.universe) =
   fun projectee ->
@@ -1056,8 +1073,8 @@ let (__proj__Mkenv__item__universe_of :
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
         splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
         dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
-        unif_allow_ref_guards; erase_erasable_args; core_check;_} ->
-        universe_of
+        unif_allow_ref_guards; erase_erasable_args; core_check;
+        missing_decl;_} -> universe_of
 let (__proj__Mkenv__item__typeof_well_typed_tot_or_gtot_term :
   env ->
     env ->
@@ -1077,8 +1094,8 @@ let (__proj__Mkenv__item__typeof_well_typed_tot_or_gtot_term :
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
         splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
         dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
-        unif_allow_ref_guards; erase_erasable_args; core_check;_} ->
-        typeof_well_typed_tot_or_gtot_term
+        unif_allow_ref_guards; erase_erasable_args; core_check;
+        missing_decl;_} -> typeof_well_typed_tot_or_gtot_term
 let (__proj__Mkenv__item__teq_nosmt_force :
   env ->
     env -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term -> Prims.bool)
@@ -1095,8 +1112,8 @@ let (__proj__Mkenv__item__teq_nosmt_force :
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
         splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
         dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
-        unif_allow_ref_guards; erase_erasable_args; core_check;_} ->
-        teq_nosmt_force
+        unif_allow_ref_guards; erase_erasable_args; core_check;
+        missing_decl;_} -> teq_nosmt_force
 let (__proj__Mkenv__item__subtype_nosmt_force :
   env ->
     env -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term -> Prims.bool)
@@ -1113,8 +1130,8 @@ let (__proj__Mkenv__item__subtype_nosmt_force :
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
         splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
         dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
-        unif_allow_ref_guards; erase_erasable_args; core_check;_} ->
-        subtype_nosmt_force
+        unif_allow_ref_guards; erase_erasable_args; core_check;
+        missing_decl;_} -> subtype_nosmt_force
 let (__proj__Mkenv__item__qtbl_name_and_index :
   env ->
     ((FStar_Ident.lident * FStar_Syntax_Syntax.typ * Prims.int)
@@ -1132,8 +1149,8 @@ let (__proj__Mkenv__item__qtbl_name_and_index :
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
         splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
         dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
-        unif_allow_ref_guards; erase_erasable_args; core_check;_} ->
-        qtbl_name_and_index
+        unif_allow_ref_guards; erase_erasable_args; core_check;
+        missing_decl;_} -> qtbl_name_and_index
 let (__proj__Mkenv__item__normalized_eff_names :
   env -> FStar_Ident.lident FStar_Compiler_Util.smap) =
   fun projectee ->
@@ -1148,8 +1165,8 @@ let (__proj__Mkenv__item__normalized_eff_names :
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
         splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
         dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
-        unif_allow_ref_guards; erase_erasable_args; core_check;_} ->
-        normalized_eff_names
+        unif_allow_ref_guards; erase_erasable_args; core_check;
+        missing_decl;_} -> normalized_eff_names
 let (__proj__Mkenv__item__fv_delta_depths :
   env -> FStar_Syntax_Syntax.delta_depth FStar_Compiler_Util.smap) =
   fun projectee ->
@@ -1164,8 +1181,8 @@ let (__proj__Mkenv__item__fv_delta_depths :
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
         splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
         dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
-        unif_allow_ref_guards; erase_erasable_args; core_check;_} ->
-        fv_delta_depths
+        unif_allow_ref_guards; erase_erasable_args; core_check;
+        missing_decl;_} -> fv_delta_depths
 let (__proj__Mkenv__item__proof_ns : env -> proof_namespace) =
   fun projectee ->
     match projectee with
@@ -1179,7 +1196,8 @@ let (__proj__Mkenv__item__proof_ns : env -> proof_namespace) =
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
         splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
         dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
-        unif_allow_ref_guards; erase_erasable_args; core_check;_} -> proof_ns
+        unif_allow_ref_guards; erase_erasable_args; core_check;
+        missing_decl;_} -> proof_ns
 let (__proj__Mkenv__item__synth_hook :
   env ->
     env ->
@@ -1198,8 +1216,8 @@ let (__proj__Mkenv__item__synth_hook :
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
         splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
         dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
-        unif_allow_ref_guards; erase_erasable_args; core_check;_} ->
-        synth_hook
+        unif_allow_ref_guards; erase_erasable_args; core_check;
+        missing_decl;_} -> synth_hook
 let (__proj__Mkenv__item__try_solve_implicits_hook :
   env ->
     env ->
@@ -1217,8 +1235,8 @@ let (__proj__Mkenv__item__try_solve_implicits_hook :
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
         splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
         dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
-        unif_allow_ref_guards; erase_erasable_args; core_check;_} ->
-        try_solve_implicits_hook
+        unif_allow_ref_guards; erase_erasable_args; core_check;
+        missing_decl;_} -> try_solve_implicits_hook
 let (__proj__Mkenv__item__splice :
   env ->
     env ->
@@ -1240,7 +1258,8 @@ let (__proj__Mkenv__item__splice :
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
         splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
         dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
-        unif_allow_ref_guards; erase_erasable_args; core_check;_} -> splice
+        unif_allow_ref_guards; erase_erasable_args; core_check;
+        missing_decl;_} -> splice
 let (__proj__Mkenv__item__mpreprocess :
   env ->
     env ->
@@ -1259,8 +1278,8 @@ let (__proj__Mkenv__item__mpreprocess :
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
         splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
         dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
-        unif_allow_ref_guards; erase_erasable_args; core_check;_} ->
-        mpreprocess
+        unif_allow_ref_guards; erase_erasable_args; core_check;
+        missing_decl;_} -> mpreprocess
 let (__proj__Mkenv__item__postprocess :
   env ->
     env ->
@@ -1280,8 +1299,8 @@ let (__proj__Mkenv__item__postprocess :
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
         splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
         dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
-        unif_allow_ref_guards; erase_erasable_args; core_check;_} ->
-        postprocess
+        unif_allow_ref_guards; erase_erasable_args; core_check;
+        missing_decl;_} -> postprocess
 let (__proj__Mkenv__item__identifier_info :
   env -> FStar_TypeChecker_Common.id_info_table FStar_Compiler_Effect.ref) =
   fun projectee ->
@@ -1296,8 +1315,8 @@ let (__proj__Mkenv__item__identifier_info :
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
         splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
         dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
-        unif_allow_ref_guards; erase_erasable_args; core_check;_} ->
-        identifier_info
+        unif_allow_ref_guards; erase_erasable_args; core_check;
+        missing_decl;_} -> identifier_info
 let (__proj__Mkenv__item__tc_hooks : env -> tcenv_hooks) =
   fun projectee ->
     match projectee with
@@ -1311,7 +1330,8 @@ let (__proj__Mkenv__item__tc_hooks : env -> tcenv_hooks) =
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
         splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
         dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
-        unif_allow_ref_guards; erase_erasable_args; core_check;_} -> tc_hooks
+        unif_allow_ref_guards; erase_erasable_args; core_check;
+        missing_decl;_} -> tc_hooks
 let (__proj__Mkenv__item__dsenv : env -> FStar_Syntax_DsEnv.env) =
   fun projectee ->
     match projectee with
@@ -1325,7 +1345,8 @@ let (__proj__Mkenv__item__dsenv : env -> FStar_Syntax_DsEnv.env) =
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
         splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
         dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
-        unif_allow_ref_guards; erase_erasable_args; core_check;_} -> dsenv
+        unif_allow_ref_guards; erase_erasable_args; core_check;
+        missing_decl;_} -> dsenv
 let (__proj__Mkenv__item__nbe :
   env ->
     step Prims.list ->
@@ -1343,7 +1364,8 @@ let (__proj__Mkenv__item__nbe :
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
         splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
         dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
-        unif_allow_ref_guards; erase_erasable_args; core_check;_} -> nbe
+        unif_allow_ref_guards; erase_erasable_args; core_check;
+        missing_decl;_} -> nbe
 let (__proj__Mkenv__item__strict_args_tab :
   env ->
     Prims.int Prims.list FStar_Pervasives_Native.option
@@ -1361,8 +1383,8 @@ let (__proj__Mkenv__item__strict_args_tab :
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
         splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
         dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
-        unif_allow_ref_guards; erase_erasable_args; core_check;_} ->
-        strict_args_tab
+        unif_allow_ref_guards; erase_erasable_args; core_check;
+        missing_decl;_} -> strict_args_tab
 let (__proj__Mkenv__item__erasable_types_tab :
   env -> Prims.bool FStar_Compiler_Util.smap) =
   fun projectee ->
@@ -1377,8 +1399,8 @@ let (__proj__Mkenv__item__erasable_types_tab :
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
         splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
         dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
-        unif_allow_ref_guards; erase_erasable_args; core_check;_} ->
-        erasable_types_tab
+        unif_allow_ref_guards; erase_erasable_args; core_check;
+        missing_decl;_} -> erasable_types_tab
 let (__proj__Mkenv__item__enable_defer_to_tac : env -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -1392,8 +1414,8 @@ let (__proj__Mkenv__item__enable_defer_to_tac : env -> Prims.bool) =
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
         splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
         dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
-        unif_allow_ref_guards; erase_erasable_args; core_check;_} ->
-        enable_defer_to_tac
+        unif_allow_ref_guards; erase_erasable_args; core_check;
+        missing_decl;_} -> enable_defer_to_tac
 let (__proj__Mkenv__item__unif_allow_ref_guards : env -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -1407,8 +1429,8 @@ let (__proj__Mkenv__item__unif_allow_ref_guards : env -> Prims.bool) =
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
         splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
         dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
-        unif_allow_ref_guards; erase_erasable_args; core_check;_} ->
-        unif_allow_ref_guards
+        unif_allow_ref_guards; erase_erasable_args; core_check;
+        missing_decl;_} -> unif_allow_ref_guards
 let (__proj__Mkenv__item__erase_erasable_args : env -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -1422,8 +1444,8 @@ let (__proj__Mkenv__item__erase_erasable_args : env -> Prims.bool) =
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
         splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
         dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
-        unif_allow_ref_guards; erase_erasable_args; core_check;_} ->
-        erase_erasable_args
+        unif_allow_ref_guards; erase_erasable_args; core_check;
+        missing_decl;_} -> erase_erasable_args
 let (__proj__Mkenv__item__core_check :
   env ->
     env ->
@@ -1445,8 +1467,24 @@ let (__proj__Mkenv__item__core_check :
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
         splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
         dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
-        unif_allow_ref_guards; erase_erasable_args; core_check;_} ->
-        core_check
+        unif_allow_ref_guards; erase_erasable_args; core_check;
+        missing_decl;_} -> core_check
+let (__proj__Mkenv__item__missing_decl :
+  env -> FStar_Ident.lident FStar_Compiler_RBSet.t) =
+  fun projectee ->
+    match projectee with
+    | { solver; range; curmodule; gamma; gamma_sig; gamma_cache; modules;
+        expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
+        generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
+        admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
+        typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
+        subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
+        fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
+        splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
+        dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
+        unif_allow_ref_guards; erase_erasable_args; core_check;
+        missing_decl;_} -> missing_decl
 let (__proj__Mksolver_t__item__init : solver_t -> env -> unit) =
   fun projectee ->
     match projectee with
@@ -1578,16 +1616,6 @@ type core_check_t =
         Prims.bool ->
           (FStar_Syntax_Syntax.typ FStar_Pervasives_Native.option,
             Prims.bool -> Prims.string) FStar_Pervasives.either
-type implicit = FStar_TypeChecker_Common.implicit
-type implicits = FStar_TypeChecker_Common.implicits
-type guard_t = FStar_TypeChecker_Common.guard_t
-type tcenv_depth_t = (Prims.int * Prims.int * solver_depth_t * Prims.int)
-type qninfo =
-  (((FStar_Syntax_Syntax.universes * FStar_Syntax_Syntax.typ),
-    (FStar_Syntax_Syntax.sigelt * FStar_Syntax_Syntax.universes
-      FStar_Pervasives_Native.option))
-    FStar_Pervasives.either * FStar_Compiler_Range_Type.range)
-    FStar_Pervasives_Native.option
 let (preprocess :
   env ->
     FStar_Syntax_Syntax.term ->
@@ -1689,7 +1717,8 @@ let (rename_env : FStar_Syntax_Syntax.subst_t -> env -> env) =
         enable_defer_to_tac = (env1.enable_defer_to_tac);
         unif_allow_ref_guards = (env1.unif_allow_ref_guards);
         erase_erasable_args = (env1.erase_erasable_args);
-        core_check = (env1.core_check)
+        core_check = (env1.core_check);
+        missing_decl = (env1.missing_decl)
       }
 let (default_tc_hooks : tcenv_hooks) =
   { tc_push_in_gamma_hook = (fun uu___ -> fun uu___1 -> ()) }
@@ -1750,9 +1779,9 @@ let (set_tc_hooks : env -> tcenv_hooks -> env) =
         enable_defer_to_tac = (env1.enable_defer_to_tac);
         unif_allow_ref_guards = (env1.unif_allow_ref_guards);
         erase_erasable_args = (env1.erase_erasable_args);
-        core_check = (env1.core_check)
+        core_check = (env1.core_check);
+        missing_decl = (env1.missing_decl)
       }
-type env_t = env
 let (set_dep_graph : env -> FStar_Parser_Dep.deps -> env) =
   fun e ->
     fun g ->
@@ -1810,10 +1839,158 @@ let (set_dep_graph : env -> FStar_Parser_Dep.deps -> env) =
         enable_defer_to_tac = (e.enable_defer_to_tac);
         unif_allow_ref_guards = (e.unif_allow_ref_guards);
         erase_erasable_args = (e.erase_erasable_args);
-        core_check = (e.core_check)
+        core_check = (e.core_check);
+        missing_decl = (e.missing_decl)
       }
 let (dep_graph : env -> FStar_Parser_Dep.deps) =
   fun e -> FStar_Syntax_DsEnv.dep_graph e.dsenv
+let (record_val_for : env -> FStar_Ident.lident -> env) =
+  fun e ->
+    fun l ->
+      let uu___ =
+        Obj.magic
+          (FStar_Class_Setlike.add ()
+             (Obj.magic
+                (FStar_Compiler_RBSet.setlike_rbset
+                   FStar_Syntax_Syntax.ord_fv)) l (Obj.magic e.missing_decl)) in
+      {
+        solver = (e.solver);
+        range = (e.range);
+        curmodule = (e.curmodule);
+        gamma = (e.gamma);
+        gamma_sig = (e.gamma_sig);
+        gamma_cache = (e.gamma_cache);
+        modules = (e.modules);
+        expected_typ = (e.expected_typ);
+        sigtab = (e.sigtab);
+        attrtab = (e.attrtab);
+        instantiate_imp = (e.instantiate_imp);
+        effects = (e.effects);
+        generalize = (e.generalize);
+        letrecs = (e.letrecs);
+        top_level = (e.top_level);
+        check_uvars = (e.check_uvars);
+        use_eq_strict = (e.use_eq_strict);
+        is_iface = (e.is_iface);
+        admit = (e.admit);
+        lax = (e.lax);
+        lax_universes = (e.lax_universes);
+        phase1 = (e.phase1);
+        failhard = (e.failhard);
+        nosynth = (e.nosynth);
+        uvar_subtyping = (e.uvar_subtyping);
+        intactics = (e.intactics);
+        nocoerce = (e.nocoerce);
+        tc_term = (e.tc_term);
+        typeof_tot_or_gtot_term = (e.typeof_tot_or_gtot_term);
+        universe_of = (e.universe_of);
+        typeof_well_typed_tot_or_gtot_term =
+          (e.typeof_well_typed_tot_or_gtot_term);
+        teq_nosmt_force = (e.teq_nosmt_force);
+        subtype_nosmt_force = (e.subtype_nosmt_force);
+        qtbl_name_and_index = (e.qtbl_name_and_index);
+        normalized_eff_names = (e.normalized_eff_names);
+        fv_delta_depths = (e.fv_delta_depths);
+        proof_ns = (e.proof_ns);
+        synth_hook = (e.synth_hook);
+        try_solve_implicits_hook = (e.try_solve_implicits_hook);
+        splice = (e.splice);
+        mpreprocess = (e.mpreprocess);
+        postprocess = (e.postprocess);
+        identifier_info = (e.identifier_info);
+        tc_hooks = (e.tc_hooks);
+        dsenv = (e.dsenv);
+        nbe = (e.nbe);
+        strict_args_tab = (e.strict_args_tab);
+        erasable_types_tab = (e.erasable_types_tab);
+        enable_defer_to_tac = (e.enable_defer_to_tac);
+        unif_allow_ref_guards = (e.unif_allow_ref_guards);
+        erase_erasable_args = (e.erase_erasable_args);
+        core_check = (e.core_check);
+        missing_decl = uu___
+      }
+let (record_definition_for : env -> FStar_Ident.lident -> env) =
+  fun e ->
+    fun l ->
+      let uu___ =
+        Obj.magic
+          (FStar_Class_Setlike.remove ()
+             (Obj.magic
+                (FStar_Compiler_RBSet.setlike_rbset
+                   FStar_Syntax_Syntax.ord_fv)) l (Obj.magic e.missing_decl)) in
+      {
+        solver = (e.solver);
+        range = (e.range);
+        curmodule = (e.curmodule);
+        gamma = (e.gamma);
+        gamma_sig = (e.gamma_sig);
+        gamma_cache = (e.gamma_cache);
+        modules = (e.modules);
+        expected_typ = (e.expected_typ);
+        sigtab = (e.sigtab);
+        attrtab = (e.attrtab);
+        instantiate_imp = (e.instantiate_imp);
+        effects = (e.effects);
+        generalize = (e.generalize);
+        letrecs = (e.letrecs);
+        top_level = (e.top_level);
+        check_uvars = (e.check_uvars);
+        use_eq_strict = (e.use_eq_strict);
+        is_iface = (e.is_iface);
+        admit = (e.admit);
+        lax = (e.lax);
+        lax_universes = (e.lax_universes);
+        phase1 = (e.phase1);
+        failhard = (e.failhard);
+        nosynth = (e.nosynth);
+        uvar_subtyping = (e.uvar_subtyping);
+        intactics = (e.intactics);
+        nocoerce = (e.nocoerce);
+        tc_term = (e.tc_term);
+        typeof_tot_or_gtot_term = (e.typeof_tot_or_gtot_term);
+        universe_of = (e.universe_of);
+        typeof_well_typed_tot_or_gtot_term =
+          (e.typeof_well_typed_tot_or_gtot_term);
+        teq_nosmt_force = (e.teq_nosmt_force);
+        subtype_nosmt_force = (e.subtype_nosmt_force);
+        qtbl_name_and_index = (e.qtbl_name_and_index);
+        normalized_eff_names = (e.normalized_eff_names);
+        fv_delta_depths = (e.fv_delta_depths);
+        proof_ns = (e.proof_ns);
+        synth_hook = (e.synth_hook);
+        try_solve_implicits_hook = (e.try_solve_implicits_hook);
+        splice = (e.splice);
+        mpreprocess = (e.mpreprocess);
+        postprocess = (e.postprocess);
+        identifier_info = (e.identifier_info);
+        tc_hooks = (e.tc_hooks);
+        dsenv = (e.dsenv);
+        nbe = (e.nbe);
+        strict_args_tab = (e.strict_args_tab);
+        erasable_types_tab = (e.erasable_types_tab);
+        enable_defer_to_tac = (e.enable_defer_to_tac);
+        unif_allow_ref_guards = (e.unif_allow_ref_guards);
+        erase_erasable_args = (e.erase_erasable_args);
+        core_check = (e.core_check);
+        missing_decl = uu___
+      }
+let (missing_definition_list : env -> FStar_Ident.lident Prims.list) =
+  fun e ->
+    FStar_Class_Setlike.elems ()
+      (Obj.magic
+         (FStar_Compiler_RBSet.setlike_rbset FStar_Syntax_Syntax.ord_fv))
+      (Obj.magic e.missing_decl)
+type implicit = FStar_TypeChecker_Common.implicit
+type implicits = FStar_TypeChecker_Common.implicits
+type guard_t = FStar_TypeChecker_Common.guard_t
+type tcenv_depth_t = (Prims.int * Prims.int * solver_depth_t * Prims.int)
+type qninfo =
+  (((FStar_Syntax_Syntax.universes * FStar_Syntax_Syntax.typ),
+    (FStar_Syntax_Syntax.sigelt * FStar_Syntax_Syntax.universes
+      FStar_Pervasives_Native.option))
+    FStar_Pervasives.either * FStar_Compiler_Range_Type.range)
+    FStar_Pervasives_Native.option
+type env_t = env
 type sigtable = FStar_Syntax_Syntax.sigelt FStar_Compiler_Util.smap
 let (should_verify : env -> Prims.bool) =
   fun env1 ->
@@ -1904,6 +2081,12 @@ let (initial_env :
                           FStar_Compiler_Util.smap_create (Prims.of_int (20)) in
                         let uu___10 =
                           FStar_Compiler_Util.smap_create (Prims.of_int (20)) in
+                        let uu___11 =
+                          Obj.magic
+                            (FStar_Class_Setlike.empty ()
+                               (Obj.magic
+                                  (FStar_Compiler_RBSet.setlike_rbset
+                                     FStar_Syntax_Syntax.ord_fv)) ()) in
                         {
                           solver;
                           range = FStar_Compiler_Range_Type.dummyRange;
@@ -1946,18 +2129,18 @@ let (initial_env :
                             (fun env1 ->
                                fun t ->
                                  fun must_tot1 ->
-                                   let uu___11 =
+                                   let uu___12 =
                                      typeof_tot_or_gtot_term_fastpath env1 t
                                        must_tot1 in
-                                   match uu___11 with
+                                   match uu___12 with
                                    | FStar_Pervasives_Native.Some k ->
                                        (k,
                                          FStar_TypeChecker_Common.trivial_guard)
                                    | FStar_Pervasives_Native.None ->
-                                       let uu___12 =
+                                       let uu___13 =
                                          typeof_tot_or_gtot_term env1 t
                                            must_tot1 in
-                                       (match uu___12 with
+                                       (match uu___13 with
                                         | (t', k, g) -> (k, g)));
                           teq_nosmt_force;
                           subtype_nosmt_force;
@@ -2007,7 +2190,8 @@ let (initial_env :
                           enable_defer_to_tac = true;
                           unif_allow_ref_guards = false;
                           erase_erasable_args = false;
-                          core_check
+                          core_check;
+                          missing_decl = uu___11
                         }
 let (dsenv : env -> FStar_Syntax_DsEnv.env) = fun env1 -> env1.dsenv
 let (sigtab : env -> FStar_Syntax_Syntax.sigelt FStar_Compiler_Util.smap) =
@@ -2135,7 +2319,8 @@ let (push_stack : env -> env) =
        enable_defer_to_tac = (env1.enable_defer_to_tac);
        unif_allow_ref_guards = (env1.unif_allow_ref_guards);
        erase_erasable_args = (env1.erase_erasable_args);
-       core_check = (env1.core_check)
+       core_check = (env1.core_check);
+       missing_decl = (env1.missing_decl)
      })
 let (pop_stack : unit -> env) =
   fun uu___ ->
@@ -2228,7 +2413,8 @@ let (snapshot : env -> Prims.string -> (tcenv_depth_t * env)) =
                                     (env2.unif_allow_ref_guards);
                                   erase_erasable_args =
                                     (env2.erase_erasable_args);
-                                  core_check = (env2.core_check)
+                                  core_check = (env2.core_check);
+                                  missing_decl = (env2.missing_decl)
                                 })))))
 let (rollback :
   solver_t ->
@@ -2347,7 +2533,8 @@ let (incr_query_index : env -> env) =
                 enable_defer_to_tac = (env1.enable_defer_to_tac);
                 unif_allow_ref_guards = (env1.unif_allow_ref_guards);
                 erase_erasable_args = (env1.erase_erasable_args);
-                core_check = (env1.core_check)
+                core_check = (env1.core_check);
+                missing_decl = (env1.missing_decl)
               })
          | FStar_Pervasives_Native.Some (uu___1, m) ->
              let next = m + Prims.int_one in
@@ -2408,7 +2595,8 @@ let (incr_query_index : env -> env) =
                 enable_defer_to_tac = (env1.enable_defer_to_tac);
                 unif_allow_ref_guards = (env1.unif_allow_ref_guards);
                 erase_erasable_args = (env1.erase_erasable_args);
-                core_check = (env1.core_check)
+                core_check = (env1.core_check);
+                missing_decl = (env1.missing_decl)
               }))
 let (set_range : env -> FStar_Compiler_Range_Type.range -> env) =
   fun e ->
@@ -2469,7 +2657,8 @@ let (set_range : env -> FStar_Compiler_Range_Type.range -> env) =
           enable_defer_to_tac = (e.enable_defer_to_tac);
           unif_allow_ref_guards = (e.unif_allow_ref_guards);
           erase_erasable_args = (e.erase_erasable_args);
-          core_check = (e.core_check)
+          core_check = (e.core_check);
+          missing_decl = (e.missing_decl)
         }
 let (get_range : env -> FStar_Compiler_Range_Type.range) = fun e -> e.range
 let (toggle_id_info : env -> Prims.bool -> unit) =
@@ -2568,7 +2757,8 @@ let (set_current_module : env -> FStar_Ident.lident -> env) =
         enable_defer_to_tac = (env1.enable_defer_to_tac);
         unif_allow_ref_guards = (env1.unif_allow_ref_guards);
         erase_erasable_args = (env1.erase_erasable_args);
-        core_check = (env1.core_check)
+        core_check = (env1.core_check);
+        missing_decl = (env1.missing_decl)
       }
 let (has_interface : env -> FStar_Ident.lident -> Prims.bool) =
   fun env1 ->
@@ -5118,6 +5308,60 @@ let (reify_comp :
              FStar_Compiler_Effect.failwith
                "internal error: reifiable effect has no repr?"
          | FStar_Pervasives_Native.Some tm -> tm)
+let rec (record_vals_and_defns : env -> FStar_Syntax_Syntax.sigelt -> env) =
+  fun g ->
+    fun se ->
+      match se.FStar_Syntax_Syntax.sigel with
+      | FStar_Syntax_Syntax.Sig_declare_typ uu___ when
+          FStar_Compiler_Util.for_some
+            (fun uu___1 ->
+               match uu___1 with
+               | FStar_Syntax_Syntax.OnlyName -> true
+               | uu___2 -> false) se.FStar_Syntax_Syntax.sigquals
+          -> g
+      | FStar_Syntax_Syntax.Sig_let uu___ when
+          FStar_Compiler_Util.for_some
+            (fun uu___1 ->
+               match uu___1 with
+               | FStar_Syntax_Syntax.OnlyName -> true
+               | uu___2 -> false) se.FStar_Syntax_Syntax.sigquals
+          -> g
+      | FStar_Syntax_Syntax.Sig_declare_typ
+          { FStar_Syntax_Syntax.lid2 = lid; FStar_Syntax_Syntax.us2 = uu___;
+            FStar_Syntax_Syntax.t2 = uu___1;_}
+          ->
+          if
+            (FStar_Compiler_List.contains FStar_Syntax_Syntax.Assumption
+               se.FStar_Syntax_Syntax.sigquals)
+              || g.is_iface
+          then g
+          else record_val_for g lid
+      | FStar_Syntax_Syntax.Sig_let
+          { FStar_Syntax_Syntax.lbs1 = uu___;
+            FStar_Syntax_Syntax.lids1 = lids;_}
+          -> FStar_Compiler_List.fold_left record_definition_for g lids
+      | FStar_Syntax_Syntax.Sig_datacon
+          { FStar_Syntax_Syntax.lid1 = lid; FStar_Syntax_Syntax.us1 = uu___;
+            FStar_Syntax_Syntax.t1 = uu___1;
+            FStar_Syntax_Syntax.ty_lid = uu___2;
+            FStar_Syntax_Syntax.num_ty_params = uu___3;
+            FStar_Syntax_Syntax.mutuals1 = uu___4;
+            FStar_Syntax_Syntax.injective_type_params1 = uu___5;_}
+          -> record_definition_for g lid
+      | FStar_Syntax_Syntax.Sig_inductive_typ
+          { FStar_Syntax_Syntax.lid = lid; FStar_Syntax_Syntax.us = uu___;
+            FStar_Syntax_Syntax.params = uu___1;
+            FStar_Syntax_Syntax.num_uniform_params = uu___2;
+            FStar_Syntax_Syntax.t = uu___3;
+            FStar_Syntax_Syntax.mutuals = uu___4;
+            FStar_Syntax_Syntax.ds = uu___5;
+            FStar_Syntax_Syntax.injective_type_params = uu___6;_}
+          -> record_definition_for g lid
+      | FStar_Syntax_Syntax.Sig_bundle
+          { FStar_Syntax_Syntax.ses = ses;
+            FStar_Syntax_Syntax.lids = uu___;_}
+          -> FStar_Compiler_List.fold_left record_vals_and_defns g ses
+      | uu___ -> g
 let (push_sigelt' : Prims.bool -> env -> FStar_Syntax_Syntax.sigelt -> env) =
   fun force ->
     fun env1 ->
@@ -5177,11 +5421,12 @@ let (push_sigelt' : Prims.bool -> env -> FStar_Syntax_Syntax.sigelt -> env) =
             enable_defer_to_tac = (env1.enable_defer_to_tac);
             unif_allow_ref_guards = (env1.unif_allow_ref_guards);
             erase_erasable_args = (env1.erase_erasable_args);
-            core_check = (env1.core_check)
+            core_check = (env1.core_check);
+            missing_decl = (env1.missing_decl)
           } in
         add_sigelt force env2 s;
         (env2.tc_hooks).tc_push_in_gamma_hook env2 (FStar_Pervasives.Inr sb);
-        env2
+        (let env3 = record_vals_and_defns env2 s in env3)
 let (push_sigelt : env -> FStar_Syntax_Syntax.sigelt -> env) =
   push_sigelt' false
 let (push_sigelt_force : env -> FStar_Syntax_Syntax.sigelt -> env) =
@@ -5258,7 +5503,8 @@ let (push_new_effect :
             enable_defer_to_tac = (env1.enable_defer_to_tac);
             unif_allow_ref_guards = (env1.unif_allow_ref_guards);
             erase_erasable_args = (env1.erase_erasable_args);
-            core_check = (env1.core_check)
+            core_check = (env1.core_check);
+            missing_decl = (env1.missing_decl)
           }
 let (exists_polymonadic_bind :
   env ->
@@ -5682,7 +5928,8 @@ let (update_effect_lattice :
              enable_defer_to_tac = (env1.enable_defer_to_tac);
              unif_allow_ref_guards = (env1.unif_allow_ref_guards);
              erase_erasable_args = (env1.erase_erasable_args);
-             core_check = (env1.core_check)
+             core_check = (env1.core_check);
+             missing_decl = (env1.missing_decl)
            })
 let (add_polymonadic_bind :
   env ->
@@ -5756,7 +6003,8 @@ let (add_polymonadic_bind :
               enable_defer_to_tac = (env1.enable_defer_to_tac);
               unif_allow_ref_guards = (env1.unif_allow_ref_guards);
               erase_erasable_args = (env1.erase_erasable_args);
-              core_check = (env1.core_check)
+              core_check = (env1.core_check);
+              missing_decl = (env1.missing_decl)
             }
 let (add_polymonadic_subcomp :
   env ->
@@ -5833,7 +6081,8 @@ let (add_polymonadic_subcomp :
                 enable_defer_to_tac = (env1.enable_defer_to_tac);
                 unif_allow_ref_guards = (env1.unif_allow_ref_guards);
                 erase_erasable_args = (env1.erase_erasable_args);
-                core_check = (env1.core_check)
+                core_check = (env1.core_check);
+                missing_decl = (env1.missing_decl)
               }
 let (push_local_binding : env -> FStar_Syntax_Syntax.binding -> env) =
   fun env1 ->
@@ -5891,7 +6140,8 @@ let (push_local_binding : env -> FStar_Syntax_Syntax.binding -> env) =
         enable_defer_to_tac = (env1.enable_defer_to_tac);
         unif_allow_ref_guards = (env1.unif_allow_ref_guards);
         erase_erasable_args = (env1.erase_erasable_args);
-        core_check = (env1.core_check)
+        core_check = (env1.core_check);
+        missing_decl = (env1.missing_decl)
       }
 let (push_bv : env -> FStar_Syntax_Syntax.bv -> env) =
   fun env1 ->
@@ -5961,7 +6211,8 @@ let (pop_bv :
               enable_defer_to_tac = (env1.enable_defer_to_tac);
               unif_allow_ref_guards = (env1.unif_allow_ref_guards);
               erase_erasable_args = (env1.erase_erasable_args);
-              core_check = (env1.core_check)
+              core_check = (env1.core_check);
+              missing_decl = (env1.missing_decl)
             })
     | uu___ -> FStar_Pervasives_Native.None
 let (push_binders : env -> FStar_Syntax_Syntax.binders -> env) =
@@ -6075,7 +6326,8 @@ let (set_expected_typ : env -> FStar_Syntax_Syntax.typ -> env) =
         enable_defer_to_tac = (env1.enable_defer_to_tac);
         unif_allow_ref_guards = (env1.unif_allow_ref_guards);
         erase_erasable_args = (env1.erase_erasable_args);
-        core_check = (env1.core_check)
+        core_check = (env1.core_check);
+        missing_decl = (env1.missing_decl)
       }
 let (set_expected_typ_maybe_eq :
   env -> FStar_Syntax_Syntax.typ -> Prims.bool -> env) =
@@ -6135,7 +6387,8 @@ let (set_expected_typ_maybe_eq :
           enable_defer_to_tac = (env1.enable_defer_to_tac);
           unif_allow_ref_guards = (env1.unif_allow_ref_guards);
           erase_erasable_args = (env1.erase_erasable_args);
-          core_check = (env1.core_check)
+          core_check = (env1.core_check);
+          missing_decl = (env1.missing_decl)
         }
 let (expected_typ :
   env ->
@@ -6205,7 +6458,8 @@ let (clear_expected_typ :
        enable_defer_to_tac = (env_.enable_defer_to_tac);
        unif_allow_ref_guards = (env_.unif_allow_ref_guards);
        erase_erasable_args = (env_.erase_erasable_args);
-       core_check = (env_.core_check)
+       core_check = (env_.core_check);
+       missing_decl = (env_.missing_decl)
      }, uu___)
 let (finish_module : env -> FStar_Syntax_Syntax.modul -> env) =
   let empty_lid =
@@ -6213,72 +6467,98 @@ let (finish_module : env -> FStar_Syntax_Syntax.modul -> env) =
     FStar_Ident.lid_of_ids uu___ in
   fun env1 ->
     fun m ->
-      let sigs =
-        let uu___ =
-          FStar_Ident.lid_equals m.FStar_Syntax_Syntax.name
-            FStar_Parser_Const.prims_lid in
-        if uu___
-        then
-          let uu___1 =
-            FStar_Compiler_List.map FStar_Pervasives_Native.snd
-              env1.gamma_sig in
-          FStar_Compiler_List.rev uu___1
-        else m.FStar_Syntax_Syntax.declarations in
-      {
-        solver = (env1.solver);
-        range = (env1.range);
-        curmodule = empty_lid;
-        gamma = [];
-        gamma_sig = [];
-        gamma_cache = (env1.gamma_cache);
-        modules = (m :: (env1.modules));
-        expected_typ = (env1.expected_typ);
-        sigtab = (env1.sigtab);
-        attrtab = (env1.attrtab);
-        instantiate_imp = (env1.instantiate_imp);
-        effects = (env1.effects);
-        generalize = (env1.generalize);
-        letrecs = (env1.letrecs);
-        top_level = (env1.top_level);
-        check_uvars = (env1.check_uvars);
-        use_eq_strict = (env1.use_eq_strict);
-        is_iface = (env1.is_iface);
-        admit = (env1.admit);
-        lax = (env1.lax);
-        lax_universes = (env1.lax_universes);
-        phase1 = (env1.phase1);
-        failhard = (env1.failhard);
-        nosynth = (env1.nosynth);
-        uvar_subtyping = (env1.uvar_subtyping);
-        intactics = (env1.intactics);
-        nocoerce = (env1.nocoerce);
-        tc_term = (env1.tc_term);
-        typeof_tot_or_gtot_term = (env1.typeof_tot_or_gtot_term);
-        universe_of = (env1.universe_of);
-        typeof_well_typed_tot_or_gtot_term =
-          (env1.typeof_well_typed_tot_or_gtot_term);
-        teq_nosmt_force = (env1.teq_nosmt_force);
-        subtype_nosmt_force = (env1.subtype_nosmt_force);
-        qtbl_name_and_index = (env1.qtbl_name_and_index);
-        normalized_eff_names = (env1.normalized_eff_names);
-        fv_delta_depths = (env1.fv_delta_depths);
-        proof_ns = (env1.proof_ns);
-        synth_hook = (env1.synth_hook);
-        try_solve_implicits_hook = (env1.try_solve_implicits_hook);
-        splice = (env1.splice);
-        mpreprocess = (env1.mpreprocess);
-        postprocess = (env1.postprocess);
-        identifier_info = (env1.identifier_info);
-        tc_hooks = (env1.tc_hooks);
-        dsenv = (env1.dsenv);
-        nbe = (env1.nbe);
-        strict_args_tab = (env1.strict_args_tab);
-        erasable_types_tab = (env1.erasable_types_tab);
-        enable_defer_to_tac = (env1.enable_defer_to_tac);
-        unif_allow_ref_guards = (env1.unif_allow_ref_guards);
-        erase_erasable_args = (env1.erase_erasable_args);
-        core_check = (env1.core_check)
-      }
+      let missing = missing_definition_list env1 in
+      if Prims.uu___is_Cons missing
+      then
+        (let uu___1 =
+           let uu___2 =
+             let uu___3 =
+               let uu___4 =
+                 let uu___5 =
+                   let uu___6 =
+                     FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name in
+                   FStar_Compiler_Util.format1
+                     "Missing definitions in module %s:" uu___6 in
+                 FStar_Errors_Msg.text uu___5 in
+               let uu___5 =
+                 FStar_Pprint.separate_map FStar_Pprint.hardline
+                   (fun l ->
+                      let uu___6 = FStar_Ident.ident_of_lid l in
+                      FStar_Class_PP.pp FStar_Ident.pretty_ident uu___6)
+                   missing in
+               FStar_Pprint.prefix (Prims.of_int (2)) Prims.int_one uu___4
+                 uu___5 in
+             [uu___3] in
+           (FStar_Errors_Codes.Error_AdmitWithoutDefinition, uu___2) in
+         FStar_Errors.log_issue_doc env1.range uu___1)
+      else ();
+      (let sigs =
+         let uu___1 =
+           FStar_Ident.lid_equals m.FStar_Syntax_Syntax.name
+             FStar_Parser_Const.prims_lid in
+         if uu___1
+         then
+           let uu___2 =
+             FStar_Compiler_List.map FStar_Pervasives_Native.snd
+               env1.gamma_sig in
+           FStar_Compiler_List.rev uu___2
+         else m.FStar_Syntax_Syntax.declarations in
+       {
+         solver = (env1.solver);
+         range = (env1.range);
+         curmodule = empty_lid;
+         gamma = [];
+         gamma_sig = [];
+         gamma_cache = (env1.gamma_cache);
+         modules = (m :: (env1.modules));
+         expected_typ = (env1.expected_typ);
+         sigtab = (env1.sigtab);
+         attrtab = (env1.attrtab);
+         instantiate_imp = (env1.instantiate_imp);
+         effects = (env1.effects);
+         generalize = (env1.generalize);
+         letrecs = (env1.letrecs);
+         top_level = (env1.top_level);
+         check_uvars = (env1.check_uvars);
+         use_eq_strict = (env1.use_eq_strict);
+         is_iface = (env1.is_iface);
+         admit = (env1.admit);
+         lax = (env1.lax);
+         lax_universes = (env1.lax_universes);
+         phase1 = (env1.phase1);
+         failhard = (env1.failhard);
+         nosynth = (env1.nosynth);
+         uvar_subtyping = (env1.uvar_subtyping);
+         intactics = (env1.intactics);
+         nocoerce = (env1.nocoerce);
+         tc_term = (env1.tc_term);
+         typeof_tot_or_gtot_term = (env1.typeof_tot_or_gtot_term);
+         universe_of = (env1.universe_of);
+         typeof_well_typed_tot_or_gtot_term =
+           (env1.typeof_well_typed_tot_or_gtot_term);
+         teq_nosmt_force = (env1.teq_nosmt_force);
+         subtype_nosmt_force = (env1.subtype_nosmt_force);
+         qtbl_name_and_index = (env1.qtbl_name_and_index);
+         normalized_eff_names = (env1.normalized_eff_names);
+         fv_delta_depths = (env1.fv_delta_depths);
+         proof_ns = (env1.proof_ns);
+         synth_hook = (env1.synth_hook);
+         try_solve_implicits_hook = (env1.try_solve_implicits_hook);
+         splice = (env1.splice);
+         mpreprocess = (env1.mpreprocess);
+         postprocess = (env1.postprocess);
+         identifier_info = (env1.identifier_info);
+         tc_hooks = (env1.tc_hooks);
+         dsenv = (env1.dsenv);
+         nbe = (env1.nbe);
+         strict_args_tab = (env1.strict_args_tab);
+         erasable_types_tab = (env1.erasable_types_tab);
+         enable_defer_to_tac = (env1.enable_defer_to_tac);
+         unif_allow_ref_guards = (env1.unif_allow_ref_guards);
+         erase_erasable_args = (env1.erase_erasable_args);
+         core_check = (env1.core_check);
+         missing_decl = (env1.missing_decl)
+       })
 let (uvars_in_env : env -> FStar_Syntax_Syntax.uvars) =
   fun env1 ->
     let no_uvs =
@@ -6489,7 +6769,8 @@ let (cons_proof_ns : Prims.bool -> env -> name_prefix -> env) =
           enable_defer_to_tac = (e.enable_defer_to_tac);
           unif_allow_ref_guards = (e.unif_allow_ref_guards);
           erase_erasable_args = (e.erase_erasable_args);
-          core_check = (e.core_check)
+          core_check = (e.core_check);
+          missing_decl = (e.missing_decl)
         }
 let (add_proof_ns : env -> name_prefix -> env) =
   fun e -> fun path -> cons_proof_ns true e path
@@ -6552,7 +6833,8 @@ let (set_proof_ns : proof_namespace -> env -> env) =
         enable_defer_to_tac = (e.enable_defer_to_tac);
         unif_allow_ref_guards = (e.unif_allow_ref_guards);
         erase_erasable_args = (e.erase_erasable_args);
-        core_check = (e.core_check)
+        core_check = (e.core_check);
+        missing_decl = (e.missing_decl)
       }
 let (unbound_vars :
   env ->

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Normalize.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Normalize.ml
@@ -8796,7 +8796,9 @@ let (eta_expand :
                                   FStar_TypeChecker_Env.erase_erasable_args =
                                     (env1.FStar_TypeChecker_Env.erase_erasable_args);
                                   FStar_TypeChecker_Env.core_check =
-                                    (env1.FStar_TypeChecker_Env.core_check)
+                                    (env1.FStar_TypeChecker_Env.core_check);
+                                  FStar_TypeChecker_Env.missing_decl =
+                                    (env1.FStar_TypeChecker_Env.missing_decl)
                                 } t true in
                             match uu___5 with
                             | (uu___6, ty, uu___7) ->
@@ -8908,7 +8910,9 @@ let (eta_expand :
                           FStar_TypeChecker_Env.erase_erasable_args =
                             (env1.FStar_TypeChecker_Env.erase_erasable_args);
                           FStar_TypeChecker_Env.core_check =
-                            (env1.FStar_TypeChecker_Env.core_check)
+                            (env1.FStar_TypeChecker_Env.core_check);
+                          FStar_TypeChecker_Env.missing_decl =
+                            (env1.FStar_TypeChecker_Env.missing_decl)
                         } t true in
                     (match uu___4 with
                      | (uu___5, ty, uu___6) -> eta_expand_with_type env1 t ty)))

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Rel.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Rel.ml
@@ -494,7 +494,9 @@ let (copy_uvar :
               FStar_TypeChecker_Env.erase_erasable_args =
                 (uu___.FStar_TypeChecker_Env.erase_erasable_args);
               FStar_TypeChecker_Env.core_check =
-                (uu___.FStar_TypeChecker_Env.core_check)
+                (uu___.FStar_TypeChecker_Env.core_check);
+              FStar_TypeChecker_Env.missing_decl =
+                (uu___.FStar_TypeChecker_Env.missing_decl)
             } in
           let env1 = FStar_TypeChecker_Env.push_binders env bs in
           let uu___ = FStar_TypeChecker_Env.all_binders env1 in
@@ -823,7 +825,9 @@ let (p_env :
         FStar_TypeChecker_Env.erase_erasable_args =
           (uu___.FStar_TypeChecker_Env.erase_erasable_args);
         FStar_TypeChecker_Env.core_check =
-          (uu___.FStar_TypeChecker_Env.core_check)
+          (uu___.FStar_TypeChecker_Env.core_check);
+        FStar_TypeChecker_Env.missing_decl =
+          (uu___.FStar_TypeChecker_Env.missing_decl)
       }
 let (p_guard_env :
   worklist -> FStar_TypeChecker_Common.prob -> FStar_TypeChecker_Env.env) =
@@ -924,7 +928,9 @@ let (p_guard_env :
         FStar_TypeChecker_Env.erase_erasable_args =
           (uu___.FStar_TypeChecker_Env.erase_erasable_args);
         FStar_TypeChecker_Env.core_check =
-          (uu___.FStar_TypeChecker_Env.core_check)
+          (uu___.FStar_TypeChecker_Env.core_check);
+        FStar_TypeChecker_Env.missing_decl =
+          (uu___.FStar_TypeChecker_Env.missing_decl)
       }
 let (def_scope_wf :
   Prims.string ->
@@ -4441,7 +4447,9 @@ let (run_meta_arg_tac :
               FStar_TypeChecker_Env.erase_erasable_args =
                 (env.FStar_TypeChecker_Env.erase_erasable_args);
               FStar_TypeChecker_Env.core_check =
-                (env.FStar_TypeChecker_Env.core_check)
+                (env.FStar_TypeChecker_Env.core_check);
+              FStar_TypeChecker_Env.missing_decl =
+                (env.FStar_TypeChecker_Env.missing_decl)
             } in
           ((let uu___1 = FStar_Compiler_Effect.op_Bang dbg_Tac in
             if uu___1
@@ -7133,7 +7141,9 @@ and (solve_t_flex_rigid_eq :
                                         =
                                         (env1.FStar_TypeChecker_Env.erase_erasable_args);
                                       FStar_TypeChecker_Env.core_check =
-                                        (env1.FStar_TypeChecker_Env.core_check)
+                                        (env1.FStar_TypeChecker_Env.core_check);
+                                      FStar_TypeChecker_Env.missing_decl =
+                                        (env1.FStar_TypeChecker_Env.missing_decl)
                                     }
                                     (FStar_Pervasives_Native.fst last_arg_rhs)
                                     false in
@@ -7490,7 +7500,10 @@ and (solve_t_flex_rigid_eq :
                                                     (env.FStar_TypeChecker_Env.erase_erasable_args);
                                                   FStar_TypeChecker_Env.core_check
                                                     =
-                                                    (env.FStar_TypeChecker_Env.core_check)
+                                                    (env.FStar_TypeChecker_Env.core_check);
+                                                  FStar_TypeChecker_Env.missing_decl
+                                                    =
+                                                    (env.FStar_TypeChecker_Env.missing_decl)
                                                 } head1 false in
                                             match uu___13 with
                                             | (t_head, uu___14) ->
@@ -15309,7 +15322,9 @@ let (check_implicit_solution_and_discharge_guard :
                         FStar_TypeChecker_Env.erase_erasable_args =
                           (env.FStar_TypeChecker_Env.erase_erasable_args);
                         FStar_TypeChecker_Env.core_check =
-                          (env.FStar_TypeChecker_Env.core_check)
+                          (env.FStar_TypeChecker_Env.core_check);
+                        FStar_TypeChecker_Env.missing_decl =
+                          (env.FStar_TypeChecker_Env.missing_decl)
                       } in
                   FStar_Pervasives_Native.fst uu___2 in
                 let g =
@@ -15844,7 +15859,10 @@ let (resolve_implicits' :
                                                (env.FStar_TypeChecker_Env.erase_erasable_args);
                                              FStar_TypeChecker_Env.core_check
                                                =
-                                               (env.FStar_TypeChecker_Env.core_check)
+                                               (env.FStar_TypeChecker_Env.core_check);
+                                             FStar_TypeChecker_Env.missing_decl
+                                               =
+                                               (env.FStar_TypeChecker_Env.missing_decl)
                                            } in
                                          let typ =
                                            FStar_Syntax_Util.ctx_uvar_typ
@@ -16087,7 +16105,10 @@ let (resolve_implicits' :
                                                (env.FStar_TypeChecker_Env.erase_erasable_args);
                                              FStar_TypeChecker_Env.core_check
                                                =
-                                               (env.FStar_TypeChecker_Env.core_check)
+                                               (env.FStar_TypeChecker_Env.core_check);
+                                             FStar_TypeChecker_Env.missing_decl
+                                               =
+                                               (env.FStar_TypeChecker_Env.missing_decl)
                                            } in
                                          let tm1 =
                                            norm_with_steps

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Tc.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Tc.ml
@@ -164,7 +164,9 @@ let (set_hint_correlator :
             FStar_TypeChecker_Env.erase_erasable_args =
               (env.FStar_TypeChecker_Env.erase_erasable_args);
             FStar_TypeChecker_Env.core_check =
-              (env.FStar_TypeChecker_Env.core_check)
+              (env.FStar_TypeChecker_Env.core_check);
+            FStar_TypeChecker_Env.missing_decl =
+              (env.FStar_TypeChecker_Env.missing_decl)
           }
       | FStar_Pervasives_Native.None ->
           let lids = FStar_Syntax_Util.lids_of_sigelt se in
@@ -275,7 +277,9 @@ let (set_hint_correlator :
             FStar_TypeChecker_Env.erase_erasable_args =
               (env.FStar_TypeChecker_Env.erase_erasable_args);
             FStar_TypeChecker_Env.core_check =
-              (env.FStar_TypeChecker_Env.core_check)
+              (env.FStar_TypeChecker_Env.core_check);
+            FStar_TypeChecker_Env.missing_decl =
+              (env.FStar_TypeChecker_Env.missing_decl)
           }
 let (log : FStar_TypeChecker_Env.env -> Prims.bool) =
   fun env ->
@@ -1143,7 +1147,9 @@ let (tc_sig_let :
                           FStar_TypeChecker_Env.erase_erasable_args =
                             (env1.FStar_TypeChecker_Env.erase_erasable_args);
                           FStar_TypeChecker_Env.core_check =
-                            (env1.FStar_TypeChecker_Env.core_check)
+                            (env1.FStar_TypeChecker_Env.core_check);
+                          FStar_TypeChecker_Env.missing_decl =
+                            (env1.FStar_TypeChecker_Env.missing_decl)
                         } in
                       let e1 =
                         let uu___3 = do_two_phases env' in
@@ -1380,7 +1386,10 @@ let (tc_sig_let :
                                               (env'.FStar_TypeChecker_Env.erase_erasable_args);
                                             FStar_TypeChecker_Env.core_check
                                               =
-                                              (env'.FStar_TypeChecker_Env.core_check)
+                                              (env'.FStar_TypeChecker_Env.core_check);
+                                            FStar_TypeChecker_Env.missing_decl
+                                              =
+                                              (env'.FStar_TypeChecker_Env.missing_decl)
                                           } e in
                                       match uu___7 with
                                       | (e3, uu___8, uu___9) -> e3) uu___5
@@ -1643,7 +1652,9 @@ let (tc_sig_let :
                                           =
                                           (env'1.FStar_TypeChecker_Env.erase_erasable_args);
                                         FStar_TypeChecker_Env.core_check =
-                                          (env'1.FStar_TypeChecker_Env.core_check)
+                                          (env'1.FStar_TypeChecker_Env.core_check);
+                                        FStar_TypeChecker_Env.missing_decl =
+                                          (env'1.FStar_TypeChecker_Env.missing_decl)
                                       } e1) uu___5
                                  "FStar.TypeChecker.Tc.tc_sig_let-tc-phase2" in
                              let uu___5 =
@@ -1848,7 +1859,9 @@ let (tc_sig_let :
                                            =
                                            (env'1.FStar_TypeChecker_Env.erase_erasable_args);
                                          FStar_TypeChecker_Env.core_check =
-                                           (env'1.FStar_TypeChecker_Env.core_check)
+                                           (env'1.FStar_TypeChecker_Env.core_check);
+                                         FStar_TypeChecker_Env.missing_decl =
+                                           (env'1.FStar_TypeChecker_Env.missing_decl)
                                        } in
                                      let err s pos =
                                        FStar_Errors.raise_error
@@ -2130,7 +2143,9 @@ let (tc_decl' :
                      FStar_TypeChecker_Env.erase_erasable_args =
                        (env.FStar_TypeChecker_Env.erase_erasable_args);
                      FStar_TypeChecker_Env.core_check =
-                       (env.FStar_TypeChecker_Env.core_check)
+                       (env.FStar_TypeChecker_Env.core_check);
+                     FStar_TypeChecker_Env.missing_decl =
+                       (env.FStar_TypeChecker_Env.missing_decl)
                    }
                  else env in
                let env'1 = FStar_TypeChecker_Env.push env' "expect_failure" in
@@ -2351,7 +2366,9 @@ let (tc_decl' :
                                       =
                                       (env1.FStar_TypeChecker_Env.erase_erasable_args);
                                     FStar_TypeChecker_Env.core_check =
-                                      (env1.FStar_TypeChecker_Env.core_check)
+                                      (env1.FStar_TypeChecker_Env.core_check);
+                                    FStar_TypeChecker_Env.missing_decl =
+                                      (env1.FStar_TypeChecker_Env.missing_decl)
                                   } ses se2.FStar_Syntax_Syntax.sigquals
                                   se2.FStar_Syntax_Syntax.sigattrs lids in
                               FStar_Pervasives_Native.fst uu___6 in
@@ -2643,7 +2660,9 @@ let (tc_decl' :
                                          =
                                          (env.FStar_TypeChecker_Env.erase_erasable_args);
                                        FStar_TypeChecker_Env.core_check =
-                                         (env.FStar_TypeChecker_Env.core_check)
+                                         (env.FStar_TypeChecker_Env.core_check);
+                                       FStar_TypeChecker_Env.missing_decl =
+                                         (env.FStar_TypeChecker_Env.missing_decl)
                                      } ne se2.FStar_Syntax_Syntax.sigquals
                                      se2.FStar_Syntax_Syntax.sigattrs in
                                  {
@@ -2861,7 +2880,9 @@ let (tc_decl' :
                                   FStar_TypeChecker_Env.erase_erasable_args =
                                     (env.FStar_TypeChecker_Env.erase_erasable_args);
                                   FStar_TypeChecker_Env.core_check =
-                                    (env.FStar_TypeChecker_Env.core_check)
+                                    (env.FStar_TypeChecker_Env.core_check);
+                                  FStar_TypeChecker_Env.missing_decl =
+                                    (env.FStar_TypeChecker_Env.missing_decl)
                                 } (lid, uvs, tps, c) r in
                             match uu___7 with
                             | (lid1, uvs1, tps1, c1) ->
@@ -2951,21 +2972,32 @@ let (tc_decl' :
                { FStar_Syntax_Syntax.lid2 = lid;
                  FStar_Syntax_Syntax.us2 = uvs; FStar_Syntax_Syntax.t2 = t;_}
                ->
-               let env1 = FStar_TypeChecker_Env.set_range env r in
-               ((let uu___3 = FStar_TypeChecker_Env.lid_exists env1 lid in
+               ((let uu___3 = FStar_TypeChecker_Env.lid_exists env lid in
                  if uu___3
                  then
                    let uu___4 =
                      let uu___5 =
-                       let uu___6 = FStar_Ident.string_of_lid lid in
-                       FStar_Compiler_Util.format1
-                         "Top-level declaration %s for a name that is already used in this module; top-level declarations must be unique in their module"
-                         uu___6 in
+                       let uu___6 =
+                         let uu___7 =
+                           let uu___8 =
+                             FStar_Class_Show.show
+                               FStar_Ident.showable_lident lid in
+                           FStar_Compiler_Util.format1
+                             "Top-level declaration %s for a name that is already used in this module."
+                             uu___8 in
+                         FStar_Errors_Msg.text uu___7 in
+                       let uu___7 =
+                         let uu___8 =
+                           FStar_Errors_Msg.text
+                             "Top-level declarations must be unique in their module." in
+                         [uu___8] in
+                       uu___6 :: uu___7 in
                      (FStar_Errors_Codes.Fatal_AlreadyDefinedTopLevelDeclaration,
                        uu___5) in
-                   FStar_Errors.raise_error uu___4 r
+                   FStar_Errors.raise_error_doc uu___4 r
                  else ());
-                (let uu___3 =
+                (let env1 = FStar_TypeChecker_Env.set_range env r in
+                 let uu___3 =
                    let uu___4 = do_two_phases env1 in
                    if uu___4
                    then
@@ -3078,7 +3110,9 @@ let (tc_decl' :
                                 FStar_TypeChecker_Env.erase_erasable_args =
                                   (env1.FStar_TypeChecker_Env.erase_erasable_args);
                                 FStar_TypeChecker_Env.core_check =
-                                  (env1.FStar_TypeChecker_Env.core_check)
+                                  (env1.FStar_TypeChecker_Env.core_check);
+                                FStar_TypeChecker_Env.missing_decl =
+                                  (env1.FStar_TypeChecker_Env.missing_decl)
                               } (uvs, t) se2.FStar_Syntax_Syntax.sigrng in
                           match uu___6 with
                           | (uvs1, t1) ->
@@ -3262,7 +3296,9 @@ let (tc_decl' :
                                 FStar_TypeChecker_Env.erase_erasable_args =
                                   (env1.FStar_TypeChecker_Env.erase_erasable_args);
                                 FStar_TypeChecker_Env.core_check =
-                                  (env1.FStar_TypeChecker_Env.core_check)
+                                  (env1.FStar_TypeChecker_Env.core_check);
+                                FStar_TypeChecker_Env.missing_decl =
+                                  (env1.FStar_TypeChecker_Env.missing_decl)
                               } (uvs, t) se2.FStar_Syntax_Syntax.sigrng in
                           match uu___6 with
                           | (uvs1, t1) ->
@@ -3534,7 +3570,9 @@ let (tc_decl' :
                      FStar_TypeChecker_Env.erase_erasable_args =
                        (env.FStar_TypeChecker_Env.erase_erasable_args);
                      FStar_TypeChecker_Env.core_check =
-                       (env.FStar_TypeChecker_Env.core_check)
+                       (env.FStar_TypeChecker_Env.core_check);
+                     FStar_TypeChecker_Env.missing_decl =
+                       (env.FStar_TypeChecker_Env.missing_decl)
                    } in
                  (let uu___4 = FStar_Compiler_Debug.low () in
                   if uu___4
@@ -3690,7 +3728,9 @@ let (tc_decl' :
                                       =
                                       (env.FStar_TypeChecker_Env.erase_erasable_args);
                                     FStar_TypeChecker_Env.core_check =
-                                      (env.FStar_TypeChecker_Env.core_check)
+                                      (env.FStar_TypeChecker_Env.core_check);
+                                    FStar_TypeChecker_Env.missing_decl =
+                                      (env.FStar_TypeChecker_Env.missing_decl)
                                   } m n p t in
                               match uu___9 with
                               | (t2, ty, uu___10) ->
@@ -3935,7 +3975,9 @@ let (tc_decl' :
                                       =
                                       (env.FStar_TypeChecker_Env.erase_erasable_args);
                                     FStar_TypeChecker_Env.core_check =
-                                      (env.FStar_TypeChecker_Env.core_check)
+                                      (env.FStar_TypeChecker_Env.core_check);
+                                    FStar_TypeChecker_Env.missing_decl =
+                                      (env.FStar_TypeChecker_Env.missing_decl)
                                   } m n t in
                               match uu___9 with
                               | (t2, ty, uu___10) ->
@@ -4254,7 +4296,9 @@ let (add_sigelt_to_env :
                        FStar_TypeChecker_Env.erase_erasable_args =
                          (env1.FStar_TypeChecker_Env.erase_erasable_args);
                        FStar_TypeChecker_Env.core_check =
-                         (env1.FStar_TypeChecker_Env.core_check)
+                         (env1.FStar_TypeChecker_Env.core_check);
+                       FStar_TypeChecker_Env.missing_decl =
+                         (env1.FStar_TypeChecker_Env.missing_decl)
                      })
               | FStar_Syntax_Syntax.Sig_pragma
                   (FStar_Syntax_Syntax.PopOptions) ->
@@ -4366,7 +4410,9 @@ let (add_sigelt_to_env :
                        FStar_TypeChecker_Env.erase_erasable_args =
                          (env1.FStar_TypeChecker_Env.erase_erasable_args);
                        FStar_TypeChecker_Env.core_check =
-                         (env1.FStar_TypeChecker_Env.core_check)
+                         (env1.FStar_TypeChecker_Env.core_check);
+                       FStar_TypeChecker_Env.missing_decl =
+                         (env1.FStar_TypeChecker_Env.missing_decl)
                      })
               | FStar_Syntax_Syntax.Sig_pragma
                   (FStar_Syntax_Syntax.SetOptions uu___2) ->
@@ -4478,7 +4524,9 @@ let (add_sigelt_to_env :
                        FStar_TypeChecker_Env.erase_erasable_args =
                          (env1.FStar_TypeChecker_Env.erase_erasable_args);
                        FStar_TypeChecker_Env.core_check =
-                         (env1.FStar_TypeChecker_Env.core_check)
+                         (env1.FStar_TypeChecker_Env.core_check);
+                       FStar_TypeChecker_Env.missing_decl =
+                         (env1.FStar_TypeChecker_Env.missing_decl)
                      })
               | FStar_Syntax_Syntax.Sig_pragma
                   (FStar_Syntax_Syntax.ResetOptions uu___2) ->
@@ -4590,7 +4638,9 @@ let (add_sigelt_to_env :
                        FStar_TypeChecker_Env.erase_erasable_args =
                          (env1.FStar_TypeChecker_Env.erase_erasable_args);
                        FStar_TypeChecker_Env.core_check =
-                         (env1.FStar_TypeChecker_Env.core_check)
+                         (env1.FStar_TypeChecker_Env.core_check);
+                       FStar_TypeChecker_Env.missing_decl =
+                         (env1.FStar_TypeChecker_Env.missing_decl)
                      })
               | FStar_Syntax_Syntax.Sig_pragma
                   (FStar_Syntax_Syntax.RestartSolver) ->
@@ -4992,7 +5042,9 @@ let (tc_partial_modul :
            FStar_TypeChecker_Env.erase_erasable_args =
              (env.FStar_TypeChecker_Env.erase_erasable_args);
            FStar_TypeChecker_Env.core_check =
-             (env.FStar_TypeChecker_Env.core_check)
+             (env.FStar_TypeChecker_Env.core_check);
+           FStar_TypeChecker_Env.missing_decl =
+             (env.FStar_TypeChecker_Env.missing_decl)
          } in
        let env2 =
          FStar_TypeChecker_Env.set_current_module env1
@@ -5279,7 +5331,9 @@ let (check_module :
              FStar_TypeChecker_Env.erase_erasable_args =
                (env.FStar_TypeChecker_Env.erase_erasable_args);
              FStar_TypeChecker_Env.core_check =
-               (env.FStar_TypeChecker_Env.core_check)
+               (env.FStar_TypeChecker_Env.core_check);
+             FStar_TypeChecker_Env.missing_decl =
+               (env.FStar_TypeChecker_Env.missing_decl)
            } in
          let uu___2 = tc_modul env1 m b in
          match uu___2 with

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_TcEffect.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_TcEffect.ml
@@ -5737,7 +5737,10 @@ let (tc_layered_eff_decl :
                                                                (uu___20.FStar_TypeChecker_Env.erase_erasable_args);
                                                              FStar_TypeChecker_Env.core_check
                                                                =
-                                                               (uu___20.FStar_TypeChecker_Env.core_check)
+                                                               (uu___20.FStar_TypeChecker_Env.core_check);
+                                                             FStar_TypeChecker_Env.missing_decl
+                                                               =
+                                                               (uu___20.FStar_TypeChecker_Env.missing_decl)
                                                            } in
                                                          FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
                                                            uu___19
@@ -7816,7 +7819,10 @@ let (tc_non_layered_eff_decl :
                                                                     (env1.FStar_TypeChecker_Env.erase_erasable_args);
                                                                     FStar_TypeChecker_Env.core_check
                                                                     =
-                                                                    (env1.FStar_TypeChecker_Env.core_check)
+                                                                    (env1.FStar_TypeChecker_Env.core_check);
+                                                                    FStar_TypeChecker_Env.missing_decl
+                                                                    =
+                                                                    (env1.FStar_TypeChecker_Env.missing_decl)
                                                                     } in
                                                                 check_and_gen'
                                                                   "bind_repr"
@@ -8099,7 +8105,10 @@ let (tc_non_layered_eff_decl :
                                                                     (uu___24.FStar_TypeChecker_Env.erase_erasable_args);
                                                                    FStar_TypeChecker_Env.core_check
                                                                     =
-                                                                    (uu___24.FStar_TypeChecker_Env.core_check)
+                                                                    (uu___24.FStar_TypeChecker_Env.core_check);
+                                                                   FStar_TypeChecker_Env.missing_decl
+                                                                    =
+                                                                    (uu___24.FStar_TypeChecker_Env.missing_decl)
                                                                  } in
                                                                ((let uu___25
                                                                    =
@@ -8435,7 +8444,10 @@ let (tc_non_layered_eff_decl :
                                                                     (env1.FStar_TypeChecker_Env.erase_erasable_args);
                                                                     FStar_TypeChecker_Env.core_check
                                                                     =
-                                                                    (env1.FStar_TypeChecker_Env.core_check)
+                                                                    (env1.FStar_TypeChecker_Env.core_check);
+                                                                    FStar_TypeChecker_Env.missing_decl
+                                                                    =
+                                                                    (env1.FStar_TypeChecker_Env.missing_decl)
                                                                     } uu___30);
                                                                     (let act_typ3
                                                                     =
@@ -9228,7 +9240,9 @@ let (tc_lift :
                                FStar_TypeChecker_Env.erase_erasable_args =
                                  (env.FStar_TypeChecker_Env.erase_erasable_args);
                                FStar_TypeChecker_Env.core_check =
-                                 (env.FStar_TypeChecker_Env.core_check)
+                                 (env.FStar_TypeChecker_Env.core_check);
+                               FStar_TypeChecker_Env.missing_decl =
+                                 (env.FStar_TypeChecker_Env.missing_decl)
                              } in
                            let lift1 =
                              match lift with

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_TcTerm.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_TcTerm.ml
@@ -98,7 +98,9 @@ let (instantiate_both :
       FStar_TypeChecker_Env.erase_erasable_args =
         (env.FStar_TypeChecker_Env.erase_erasable_args);
       FStar_TypeChecker_Env.core_check =
-        (env.FStar_TypeChecker_Env.core_check)
+        (env.FStar_TypeChecker_Env.core_check);
+      FStar_TypeChecker_Env.missing_decl =
+        (env.FStar_TypeChecker_Env.missing_decl)
     }
 let (no_inst : FStar_TypeChecker_Env.env -> FStar_TypeChecker_Env.env) =
   fun env ->
@@ -180,7 +182,9 @@ let (no_inst : FStar_TypeChecker_Env.env -> FStar_TypeChecker_Env.env) =
       FStar_TypeChecker_Env.erase_erasable_args =
         (env.FStar_TypeChecker_Env.erase_erasable_args);
       FStar_TypeChecker_Env.core_check =
-        (env.FStar_TypeChecker_Env.core_check)
+        (env.FStar_TypeChecker_Env.core_check);
+      FStar_TypeChecker_Env.missing_decl =
+        (env.FStar_TypeChecker_Env.missing_decl)
     }
 let (is_eq :
   FStar_Syntax_Syntax.binder_qualifier FStar_Pervasives_Native.option ->
@@ -1294,7 +1298,9 @@ let (guard_letrecs :
                 FStar_TypeChecker_Env.erase_erasable_args =
                   (env.FStar_TypeChecker_Env.erase_erasable_args);
                 FStar_TypeChecker_Env.core_check =
-                  (env.FStar_TypeChecker_Env.core_check)
+                  (env.FStar_TypeChecker_Env.core_check);
+                FStar_TypeChecker_Env.missing_decl =
+                  (env.FStar_TypeChecker_Env.missing_decl)
               } in
             let decreases_clause bs c =
               (let uu___1 = FStar_Compiler_Debug.low () in
@@ -1948,7 +1954,9 @@ let rec (tc_term :
                   FStar_TypeChecker_Env.erase_erasable_args =
                     (env.FStar_TypeChecker_Env.erase_erasable_args);
                   FStar_TypeChecker_Env.core_check =
-                    (env.FStar_TypeChecker_Env.core_check)
+                    (env.FStar_TypeChecker_Env.core_check);
+                  FStar_TypeChecker_Env.missing_decl =
+                    (env.FStar_TypeChecker_Env.missing_decl)
                 } e) in
        match uu___2 with
        | (r, ms) ->
@@ -2271,7 +2279,9 @@ and (tc_maybe_toplevel_term :
                           FStar_TypeChecker_Env.erase_erasable_args =
                             (env'.FStar_TypeChecker_Env.erase_erasable_args);
                           FStar_TypeChecker_Env.core_check =
-                            (env'.FStar_TypeChecker_Env.core_check)
+                            (env'.FStar_TypeChecker_Env.core_check);
+                          FStar_TypeChecker_Env.missing_decl =
+                            (env'.FStar_TypeChecker_Env.missing_decl)
                         } in
                       let uu___4 = tc_term env'1 qt in
                       (match uu___4 with
@@ -4539,7 +4549,9 @@ and (tc_tactic :
               FStar_TypeChecker_Env.erase_erasable_args =
                 (env.FStar_TypeChecker_Env.erase_erasable_args);
               FStar_TypeChecker_Env.core_check =
-                (env.FStar_TypeChecker_Env.core_check)
+                (env.FStar_TypeChecker_Env.core_check);
+              FStar_TypeChecker_Env.missing_decl =
+                (env.FStar_TypeChecker_Env.missing_decl)
             } in
           let uu___ = FStar_Syntax_Syntax.t_tac_of a b in
           tc_check_tot_or_gtot_term env1 tau uu___ ""
@@ -5239,7 +5251,9 @@ and (tc_comp :
                 FStar_TypeChecker_Env.erase_erasable_args =
                   (env.FStar_TypeChecker_Env.erase_erasable_args);
                 FStar_TypeChecker_Env.core_check =
-                  (env.FStar_TypeChecker_Env.core_check)
+                  (env.FStar_TypeChecker_Env.core_check);
+                FStar_TypeChecker_Env.missing_decl =
+                  (env.FStar_TypeChecker_Env.missing_decl)
               } tc FStar_Syntax_Syntax.teff "" in
           (match uu___ with
            | (tc1, uu___1, f) ->
@@ -5742,7 +5756,9 @@ and (tc_abs_expected_function_typ :
                                FStar_TypeChecker_Env.erase_erasable_args =
                                  (envbody.FStar_TypeChecker_Env.erase_erasable_args);
                                FStar_TypeChecker_Env.core_check =
-                                 (envbody.FStar_TypeChecker_Env.core_check)
+                                 (envbody.FStar_TypeChecker_Env.core_check);
+                               FStar_TypeChecker_Env.missing_decl =
+                                 (envbody.FStar_TypeChecker_Env.missing_decl)
                              } in
                            let uu___2 =
                              FStar_Compiler_List.fold_left
@@ -5898,7 +5914,9 @@ and (tc_abs_expected_function_typ :
                              FStar_TypeChecker_Env.erase_erasable_args =
                                (env.FStar_TypeChecker_Env.erase_erasable_args);
                              FStar_TypeChecker_Env.core_check =
-                               (env.FStar_TypeChecker_Env.core_check)
+                               (env.FStar_TypeChecker_Env.core_check);
+                             FStar_TypeChecker_Env.missing_decl =
+                               (env.FStar_TypeChecker_Env.missing_decl)
                            } in
                          let uu___2 =
                            check_actuals_against_formals envbody bs
@@ -6015,7 +6033,9 @@ and (tc_abs_expected_function_typ :
                                   FStar_TypeChecker_Env.erase_erasable_args =
                                     (envbody1.FStar_TypeChecker_Env.erase_erasable_args);
                                   FStar_TypeChecker_Env.core_check =
-                                    (envbody1.FStar_TypeChecker_Env.core_check)
+                                    (envbody1.FStar_TypeChecker_Env.core_check);
+                                  FStar_TypeChecker_Env.missing_decl =
+                                    (envbody1.FStar_TypeChecker_Env.missing_decl)
                                 } in
                               let uu___3 = mk_letrec_env envbody2 bs1 c in
                               (match uu___3 with
@@ -6603,7 +6623,9 @@ and (tc_abs :
                                   FStar_TypeChecker_Env.erase_erasable_args =
                                     (envbody2.FStar_TypeChecker_Env.erase_erasable_args);
                                   FStar_TypeChecker_Env.core_check =
-                                    (envbody2.FStar_TypeChecker_Env.core_check)
+                                    (envbody2.FStar_TypeChecker_Env.core_check);
+                                  FStar_TypeChecker_Env.missing_decl =
+                                    (envbody2.FStar_TypeChecker_Env.missing_decl)
                                 } body2 in
                             (match uu___7 with
                              | (body3, cbody, guard_body) ->
@@ -10283,7 +10305,10 @@ and (tc_eqn :
                                                                     (uu___16.FStar_TypeChecker_Env.erase_erasable_args);
                                                                     FStar_TypeChecker_Env.core_check
                                                                     =
-                                                                    (uu___16.FStar_TypeChecker_Env.core_check)
+                                                                    (uu___16.FStar_TypeChecker_Env.core_check);
+                                                                    FStar_TypeChecker_Env.missing_decl
+                                                                    =
+                                                                    (uu___16.FStar_TypeChecker_Env.missing_decl)
                                                                     } in
                                                                    let uu___16
                                                                     =
@@ -10767,7 +10792,9 @@ and (check_inner_let :
               FStar_TypeChecker_Env.erase_erasable_args =
                 (env1.FStar_TypeChecker_Env.erase_erasable_args);
               FStar_TypeChecker_Env.core_check =
-                (env1.FStar_TypeChecker_Env.core_check)
+                (env1.FStar_TypeChecker_Env.core_check);
+              FStar_TypeChecker_Env.missing_decl =
+                (env1.FStar_TypeChecker_Env.missing_decl)
             } in
           let uu___ =
             let uu___1 =
@@ -11551,7 +11578,9 @@ and (build_let_rec_env :
                 FStar_TypeChecker_Env.erase_erasable_args =
                   (env01.FStar_TypeChecker_Env.erase_erasable_args);
                 FStar_TypeChecker_Env.core_check =
-                  (env01.FStar_TypeChecker_Env.core_check)
+                  (env01.FStar_TypeChecker_Env.core_check);
+                FStar_TypeChecker_Env.missing_decl =
+                  (env01.FStar_TypeChecker_Env.missing_decl)
               } t uu___1 "" in
           match uu___ with
           | (t1, uu___1, g) ->
@@ -11755,7 +11784,10 @@ and (build_let_rec_env :
                                              =
                                              (env2.FStar_TypeChecker_Env.erase_erasable_args);
                                            FStar_TypeChecker_Env.core_check =
-                                             (env2.FStar_TypeChecker_Env.core_check)
+                                             (env2.FStar_TypeChecker_Env.core_check);
+                                           FStar_TypeChecker_Env.missing_decl
+                                             =
+                                             (env2.FStar_TypeChecker_Env.missing_decl)
                                          } in
                                        (lb1, env3)))
                                  | FStar_Pervasives_Native.None ->
@@ -12037,7 +12069,9 @@ and (check_let_bound_def :
                          FStar_TypeChecker_Env.erase_erasable_args =
                            (env11.FStar_TypeChecker_Env.erase_erasable_args);
                          FStar_TypeChecker_Env.core_check =
-                           (env11.FStar_TypeChecker_Env.core_check)
+                           (env11.FStar_TypeChecker_Env.core_check);
+                         FStar_TypeChecker_Env.missing_decl =
+                           (env11.FStar_TypeChecker_Env.missing_decl)
                        } e11 in
                    match uu___4 with
                    | (e12, c1, g1) ->
@@ -12558,7 +12592,9 @@ let (typeof_tot_or_gtot_term :
              FStar_TypeChecker_Env.erase_erasable_args =
                (env.FStar_TypeChecker_Env.erase_erasable_args);
              FStar_TypeChecker_Env.core_check =
-               (env.FStar_TypeChecker_Env.core_check)
+               (env.FStar_TypeChecker_Env.core_check);
+             FStar_TypeChecker_Env.missing_decl =
+               (env.FStar_TypeChecker_Env.missing_decl)
            } in
          let uu___1 =
            try
@@ -12748,7 +12784,9 @@ let (level_of_type :
                          FStar_TypeChecker_Env.erase_erasable_args =
                            (env.FStar_TypeChecker_Env.erase_erasable_args);
                          FStar_TypeChecker_Env.core_check =
-                           (env.FStar_TypeChecker_Env.core_check)
+                           (env.FStar_TypeChecker_Env.core_check);
+                         FStar_TypeChecker_Env.missing_decl =
+                           (env.FStar_TypeChecker_Env.missing_decl)
                        } in
                      let g = FStar_TypeChecker_Rel.teq env1 t1 t_u in
                      ((match g.FStar_TypeChecker_Common.guard_f with
@@ -13161,7 +13199,9 @@ let rec (universe_of_aux :
                          FStar_TypeChecker_Env.erase_erasable_args =
                            (env2.FStar_TypeChecker_Env.erase_erasable_args);
                          FStar_TypeChecker_Env.core_check =
-                           (env2.FStar_TypeChecker_Env.core_check)
+                           (env2.FStar_TypeChecker_Env.core_check);
+                         FStar_TypeChecker_Env.missing_decl =
+                           (env2.FStar_TypeChecker_Env.missing_decl)
                        } in
                      ((let uu___5 =
                          FStar_Compiler_Effect.op_Bang dbg_UniverseOf in

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Util.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Util.ml
@@ -5681,7 +5681,10 @@ let (find_coercion :
                                                                     (env.FStar_TypeChecker_Env.erase_erasable_args);
                                                                     FStar_TypeChecker_Env.core_check
                                                                     =
-                                                                    (env.FStar_TypeChecker_Env.core_check)
+                                                                    (env.FStar_TypeChecker_Env.core_check);
+                                                                    FStar_TypeChecker_Env.missing_decl
+                                                                    =
+                                                                    (env.FStar_TypeChecker_Env.missing_decl)
                                                                     } tt in
                                                                     FStar_Pervasives_Native.Some
                                                                     uu___21)))))))))
@@ -8072,7 +8075,9 @@ let (update_env_sub_eff :
               FStar_TypeChecker_Env.erase_erasable_args =
                 (env.FStar_TypeChecker_Env.erase_erasable_args);
               FStar_TypeChecker_Env.core_check =
-                (env.FStar_TypeChecker_Env.core_check)
+                (env.FStar_TypeChecker_Env.core_check);
+              FStar_TypeChecker_Env.missing_decl =
+                (env.FStar_TypeChecker_Env.missing_decl)
             } sub.FStar_Syntax_Syntax.source sub.FStar_Syntax_Syntax.target
             uu___ in
         {
@@ -8169,7 +8174,9 @@ let (update_env_sub_eff :
           FStar_TypeChecker_Env.erase_erasable_args =
             (env1.FStar_TypeChecker_Env.erase_erasable_args);
           FStar_TypeChecker_Env.core_check =
-            (env1.FStar_TypeChecker_Env.core_check)
+            (env1.FStar_TypeChecker_Env.core_check);
+          FStar_TypeChecker_Env.missing_decl =
+            (env1.FStar_TypeChecker_Env.missing_decl)
         }
 let (update_env_polymonadic_bind :
   FStar_TypeChecker_Env.env ->

--- a/ocaml/fstar-lib/generated/FStar_Universal.ml
+++ b/ocaml/fstar-lib/generated/FStar_Universal.ml
@@ -116,7 +116,9 @@ let with_dsenv_of_tcenv :
               FStar_TypeChecker_Env.erase_erasable_args =
                 (tcenv.FStar_TypeChecker_Env.erase_erasable_args);
               FStar_TypeChecker_Env.core_check =
-                (tcenv.FStar_TypeChecker_Env.core_check)
+                (tcenv.FStar_TypeChecker_Env.core_check);
+              FStar_TypeChecker_Env.missing_decl =
+                (tcenv.FStar_TypeChecker_Env.missing_decl)
             })
 let with_tcenv_of_env :
   'a .
@@ -365,7 +367,9 @@ let (init_env : FStar_Parser_Dep.deps -> FStar_TypeChecker_Env.env) =
         FStar_TypeChecker_Env.erase_erasable_args =
           (env.FStar_TypeChecker_Env.erase_erasable_args);
         FStar_TypeChecker_Env.core_check =
-          (env.FStar_TypeChecker_Env.core_check)
+          (env.FStar_TypeChecker_Env.core_check);
+        FStar_TypeChecker_Env.missing_decl =
+          (env.FStar_TypeChecker_Env.missing_decl)
       } in
     let env2 =
       {
@@ -456,7 +460,9 @@ let (init_env : FStar_Parser_Dep.deps -> FStar_TypeChecker_Env.env) =
         FStar_TypeChecker_Env.erase_erasable_args =
           (env1.FStar_TypeChecker_Env.erase_erasable_args);
         FStar_TypeChecker_Env.core_check =
-          (env1.FStar_TypeChecker_Env.core_check)
+          (env1.FStar_TypeChecker_Env.core_check);
+        FStar_TypeChecker_Env.missing_decl =
+          (env1.FStar_TypeChecker_Env.missing_decl)
       } in
     let env3 =
       {
@@ -547,7 +553,9 @@ let (init_env : FStar_Parser_Dep.deps -> FStar_TypeChecker_Env.env) =
         FStar_TypeChecker_Env.erase_erasable_args =
           (env2.FStar_TypeChecker_Env.erase_erasable_args);
         FStar_TypeChecker_Env.core_check =
-          (env2.FStar_TypeChecker_Env.core_check)
+          (env2.FStar_TypeChecker_Env.core_check);
+        FStar_TypeChecker_Env.missing_decl =
+          (env2.FStar_TypeChecker_Env.missing_decl)
       } in
     let env4 =
       {
@@ -637,7 +645,9 @@ let (init_env : FStar_Parser_Dep.deps -> FStar_TypeChecker_Env.env) =
         FStar_TypeChecker_Env.erase_erasable_args =
           (env3.FStar_TypeChecker_Env.erase_erasable_args);
         FStar_TypeChecker_Env.core_check =
-          (env3.FStar_TypeChecker_Env.core_check)
+          (env3.FStar_TypeChecker_Env.core_check);
+        FStar_TypeChecker_Env.missing_decl =
+          (env3.FStar_TypeChecker_Env.missing_decl)
       } in
     let env5 =
       {
@@ -727,7 +737,9 @@ let (init_env : FStar_Parser_Dep.deps -> FStar_TypeChecker_Env.env) =
         FStar_TypeChecker_Env.erase_erasable_args =
           (env4.FStar_TypeChecker_Env.erase_erasable_args);
         FStar_TypeChecker_Env.core_check =
-          (env4.FStar_TypeChecker_Env.core_check)
+          (env4.FStar_TypeChecker_Env.core_check);
+        FStar_TypeChecker_Env.missing_decl =
+          (env4.FStar_TypeChecker_Env.missing_decl)
       } in
     (env5.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.init env5; env5
 let (tc_one_fragment :

--- a/ocaml/fstar-tests/generated/FStar_Tests_Pars.ml
+++ b/ocaml/fstar-tests/generated/FStar_Tests_Pars.ml
@@ -193,7 +193,9 @@ let (init_once : unit -> unit) =
              FStar_TypeChecker_Env.erase_erasable_args =
                (env.FStar_TypeChecker_Env.erase_erasable_args);
              FStar_TypeChecker_Env.core_check =
-               (env.FStar_TypeChecker_Env.core_check)
+               (env.FStar_TypeChecker_Env.core_check);
+             FStar_TypeChecker_Env.missing_decl =
+               (env.FStar_TypeChecker_Env.missing_decl)
            } in
          let uu___3 = FStar_TypeChecker_Tc.check_module env1 prims_mod false in
          (match uu___3 with
@@ -302,7 +304,9 @@ let (init_once : unit -> unit) =
                   FStar_TypeChecker_Env.erase_erasable_args =
                     (env2.FStar_TypeChecker_Env.erase_erasable_args);
                   FStar_TypeChecker_Env.core_check =
-                    (env2.FStar_TypeChecker_Env.core_check)
+                    (env2.FStar_TypeChecker_Env.core_check);
+                  FStar_TypeChecker_Env.missing_decl =
+                    (env2.FStar_TypeChecker_Env.missing_decl)
                 } in
               let env4 =
                 FStar_TypeChecker_Env.set_current_module env3 test_lid in
@@ -454,7 +458,9 @@ let (tc' :
         FStar_TypeChecker_Env.erase_erasable_args =
           (tcenv.FStar_TypeChecker_Env.erase_erasable_args);
         FStar_TypeChecker_Env.core_check =
-          (tcenv.FStar_TypeChecker_Env.core_check)
+          (tcenv.FStar_TypeChecker_Env.core_check);
+        FStar_TypeChecker_Env.missing_decl =
+          (tcenv.FStar_TypeChecker_Env.missing_decl)
       } in
     let uu___ = FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term tcenv1 tm in
     match uu___ with
@@ -555,7 +561,9 @@ let (tc_term : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
         FStar_TypeChecker_Env.erase_erasable_args =
           (tcenv.FStar_TypeChecker_Env.erase_erasable_args);
         FStar_TypeChecker_Env.core_check =
-          (tcenv.FStar_TypeChecker_Env.core_check)
+          (tcenv.FStar_TypeChecker_Env.core_check);
+        FStar_TypeChecker_Env.missing_decl =
+          (tcenv.FStar_TypeChecker_Env.missing_decl)
       } in
     let uu___ = FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term tcenv1 tm in
     match uu___ with

--- a/src/typechecker/FStar.TypeChecker.Env.fsti
+++ b/src/typechecker/FStar.TypeChecker.Env.fsti
@@ -24,6 +24,7 @@ open FStar.TypeChecker.Common
 open FStar.Class.Binders
 open FStar.Class.Deq
 open FStar.Class.Show
+open FStar.Class.Setlike
 
 module BU = FStar.Compiler.Util
 module S = FStar.Syntax.Syntax
@@ -223,6 +224,12 @@ and env = {
   erase_erasable_args: bool;                      (* This flag is set when running normalize_for_extraction, see Extraction.ML.Modul *)
 
   core_check: core_check_t;
+
+  (* A set of names for which we are missing a declaration.
+  Every val (Sig_declare_typ) is added here and removed
+  only when a definition for it is checked. At the of checking a module,
+  if anything remains here, we fail. *)
+  missing_decl : RBSet.t lident;
 }
 
 and solver_depth_t = int & int & int
@@ -246,6 +253,12 @@ and tcenv_hooks =
 
 and core_check_t =
   env -> term -> typ -> bool -> either (option typ) (bool -> string)
+
+(* Keeping track of declarations and definitions. This operates
+over the missing_decl field. *)
+val record_val_for (e:env) (l:lident) : env
+val record_definition_for (e:env) (l:lident) : env
+val missing_definition_list (e:env) : list lident
 
 type implicit = TcComm.implicit
 type implicits = TcComm.implicits

--- a/src/typechecker/FStar.TypeChecker.Tc.fst
+++ b/src/typechecker/FStar.TypeChecker.Tc.fst
@@ -719,13 +719,14 @@ let tc_decl' env0 se: list sigelt & list sigelt & Env.env =
       [], [], env0
 
   | Sig_declare_typ {lid; us=uvs; t} -> //NS: No checks on the qualifiers?
+
+    if lid_exists env lid then
+      raise_error_doc (Errors.Fatal_AlreadyDefinedTopLevelDeclaration, [
+        text (BU.format1 "Top-level declaration %s for a name that is already used in this module." (show lid));
+        text "Top-level declarations must be unique in their module."
+      ]) r;
+
     let env = Env.set_range env r in
-
-    if lid_exists env lid
-    then raise_error (Errors.Fatal_AlreadyDefinedTopLevelDeclaration, (BU.format1 "Top-level declaration %s for a name that is already used in this module; \
-                                   top-level declarations must be unique in their module"
-                                   (Ident.string_of_lid lid))) r;
-
     let uvs, t =
       if do_two_phases env then run_phase1 (fun _ ->
         let uvs, t = tc_declare_typ ({ env with phase1 = true; lax = true }) (uvs, t) se.sigrng in //|> N.normalize [Env.NoFullNorm; Env.Beta; Env.DoNotUnfoldPureLets] env in

--- a/tests/error-messages/ArgsAndQuals.fst.expected
+++ b/tests/error-messages/ArgsAndQuals.fst.expected
@@ -7,5 +7,8 @@
   - ArgsAndQuals.test1 is declared but no definition was found
   - Add an 'assume' if this is intentional
 
+* Warning 240 at ArgsAndQuals.fst(25,0-25,29):
+  - Missing definitions in module ArgsAndQuals: test1
+
 Verified module: ArgsAndQuals
 All verification conditions discharged successfully

--- a/tests/error-messages/Erasable.fst.expected
+++ b/tests/error-messages/Erasable.fst.expected
@@ -47,5 +47,10 @@
   - Erasable.e_nat_3 is declared but no definition was found
   - Add an 'assume' if this is intentional
 
+* Warning 240 at Erasable.fst(73,0-73,19):
+  - Missing definitions in module Erasable:
+      e_nat_2
+      e_nat_3
+
 Verified module: Erasable
 All verification conditions discharged successfully

--- a/tests/error-messages/NegativeTests.Bug260.fst.expected
+++ b/tests/error-messages/NegativeTests.Bug260.fst.expected
@@ -11,5 +11,8 @@
   - NegativeTests.Bug260.bad is declared but no definition was found
   - Add an 'assume' if this is intentional
 
+* Warning 240 at NegativeTests.Bug260.fst(26,0-26,19):
+  - Missing definitions in module NegativeTests.Bug260: bad
+
 Verified module: NegativeTests.Bug260
 All verification conditions discharged successfully

--- a/tests/error-messages/NegativeTests.False.fst.expected
+++ b/tests/error-messages/NegativeTests.False.fst.expected
@@ -26,5 +26,10 @@
   - NegativeTests.False.absurd is declared but no definition was found
   - Add an 'assume' if this is intentional
 
+* Warning 240 at NegativeTests.False.fst(30,0-30,66):
+  - Missing definitions in module NegativeTests.False:
+      absurd
+      bar
+
 Verified module: NegativeTests.False
 All verification conditions discharged successfully

--- a/tests/error-messages/NegativeTests.Neg.fst.expected
+++ b/tests/error-messages/NegativeTests.Neg.fst.expected
@@ -110,5 +110,13 @@
   - NegativeTests.Neg.bad_projector is declared but no definition was found
   - Add an 'assume' if this is intentional
 
+* Warning 240 at NegativeTests.Neg.fst(63,0-63,32):
+  - Missing definitions in module NegativeTests.Neg:
+      bad_projector
+      test_postcondition_label
+      test_precondition_label
+      x
+      y
+
 Verified module: NegativeTests.Neg
 All verification conditions discharged successfully

--- a/tests/error-messages/NegativeTests.Set.fst.expected
+++ b/tests/error-messages/NegativeTests.Set.fst.expected
@@ -31,5 +31,11 @@
   - NegativeTests.Set.should_fail3 is declared but no definition was found
   - Add an 'assume' if this is intentional
 
+* Warning 240 at NegativeTests.Set.fst(37,0-38,52):
+  - Missing definitions in module NegativeTests.Set:
+      should_fail1
+      should_fail2
+      should_fail3
+
 Verified module: NegativeTests.Set
 All verification conditions discharged successfully

--- a/tests/error-messages/NegativeTests.ShortCircuiting.fst.expected
+++ b/tests/error-messages/NegativeTests.ShortCircuiting.fst.expected
@@ -23,5 +23,10 @@
   - NegativeTests.ShortCircuiting.ff is declared but no definition was found
   - Add an 'assume' if this is intentional
 
+* Warning 240 at NegativeTests.ShortCircuiting.fst(25,0-25,36):
+  - Missing definitions in module NegativeTests.ShortCircuiting:
+      bad
+      ff
+
 Verified module: NegativeTests.ShortCircuiting
 All verification conditions discharged successfully

--- a/tests/error-messages/NegativeTests.Termination.fst.expected
+++ b/tests/error-messages/NegativeTests.Termination.fst.expected
@@ -120,5 +120,18 @@
   - NegativeTests.Termination.xxx is declared but no definition was found
   - Add an 'assume' if this is intentional
 
+* Warning 240 at NegativeTests.Termination.fst(93,0-96,26):
+  - Missing definitions in module NegativeTests.Termination:
+      ackermann_bad
+      bug15
+      length_bad
+      minus
+      plus
+      plus'
+      repeat_diverge
+      strangeZeroBad
+      t1
+      xxx
+
 Verified module: NegativeTests.Termination
 All verification conditions discharged successfully

--- a/tests/error-messages/NegativeTests.ZZImplicitFalse.fst.expected
+++ b/tests/error-messages/NegativeTests.ZZImplicitFalse.fst.expected
@@ -11,5 +11,8 @@
   - NegativeTests.ZZImplicitFalse.test is declared but no definition was found
   - Add an 'assume' if this is intentional
 
+* Warning 240 at NegativeTests.ZZImplicitFalse.fst(20,0-20,34):
+  - Missing definitions in module NegativeTests.ZZImplicitFalse: test
+
 Verified module: NegativeTests.ZZImplicitFalse
 All verification conditions discharged successfully

--- a/tests/error-messages/PatCoerce.fst.expected
+++ b/tests/error-messages/PatCoerce.fst.expected
@@ -7,5 +7,8 @@
   - PatCoerce.bla is declared but no definition was found
   - Add an 'assume' if this is intentional
 
+* Warning 240 at PatCoerce.fst(23,0-26,14):
+  - Missing definitions in module PatCoerce: bla
+
 Verified module: PatCoerce
 All verification conditions discharged successfully

--- a/tests/error-messages/TestErrorLocations.fst.expected
+++ b/tests/error-messages/TestErrorLocations.fst.expected
@@ -137,5 +137,11 @@
   - TestErrorLocations.test7 is declared but no definition was found
   - Add an 'assume' if this is intentional
 
+* Warning 240 at TestErrorLocations.fst(113,0-117,17):
+  - Missing definitions in module TestErrorLocations:
+      test5
+      test6
+      test7
+
 Verified module: TestErrorLocations
 All verification conditions discharged successfully


### PR DESCRIPTION
F* performs a _syntactic_ check to make sure an implementation file defines all `val`s in the signature. This mostly works fine for normal code, but if the `val` is spliced in from a syntax extension blob, then it is missed entirely. This means We can have
```fstar
val foo : ...
```
in the interface, without any implementation to back it up. Or, more dangerously, have
```fstar
let fooo = ...
```
in the implementation, mistakenly believing we are using it to implement `foo`, but the types could be completely unrelated.

This PR makes the typechecker env track names with a "missing" definition, and error out at the end of checking a module if any remain. (This is only ever called in batch mode.)

Mostly in support of https://github.com/FStarLang/pulse/pull/121.

Given this, we could consider completely removing the syntactic check.