### PR TITLE
Tactics: make splice_t always run without admit/lax

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_Tactics_Hooks.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Hooks.ml
@@ -1893,10 +1893,8 @@ let (splice :
                                            (env.FStar_TypeChecker_Env.use_eq_strict);
                                          FStar_TypeChecker_Env.is_iface =
                                            (env.FStar_TypeChecker_Env.is_iface);
-                                         FStar_TypeChecker_Env.admit =
-                                           (env.FStar_TypeChecker_Env.admit);
-                                         FStar_TypeChecker_Env.lax =
-                                           (env.FStar_TypeChecker_Env.lax);
+                                         FStar_TypeChecker_Env.admit = false;
+                                         FStar_TypeChecker_Env.lax = false;
                                          FStar_TypeChecker_Env.lax_universes
                                            =
                                            (env.FStar_TypeChecker_Env.lax_universes);

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Tc.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Tc.ml
@@ -2031,7 +2031,16 @@ let (tc_decl' :
                (let uu___4 = FStar_TypeChecker_Env.should_verify env in
                 Prims.op_Negation uu___4) ||
                  (FStar_Options.admit_smt_queries ())
-               -> ([], [], env)
+               ->
+               ((let uu___5 = FStar_Compiler_Debug.any () in
+                 if uu___5
+                 then
+                   let uu___6 = FStar_Syntax_Print.sigelt_to_string_short se2 in
+                   FStar_Compiler_Util.print1
+                     "Skipping %s since env.admit=true and this is not an expect_lax_failure\n"
+                     uu___6
+                 else ());
+                ([], [], env))
            | FStar_Syntax_Syntax.Sig_fail
                { FStar_Syntax_Syntax.errs = expected_errors;
                  FStar_Syntax_Syntax.fail_in_lax = lax;
@@ -4871,7 +4880,7 @@ let (tc_decls :
                ([], env) ses) in
       match uu___ with
       | (ses1, env1) -> ((FStar_Compiler_List.rev_append ses1 []), env1)
-let (uu___873 : unit) =
+let (uu___875 : unit) =
   FStar_Compiler_Effect.op_Colon_Equals tc_decls_knot
     (FStar_Pervasives_Native.Some tc_decls)
 let (snapshot_context :

--- a/src/tactics/FStar.Tactics.Hooks.fst
+++ b/src/tactics/FStar.Tactics.Hooks.fst
@@ -891,7 +891,7 @@ let splice
             : list goal & dsl_tac_result_t =
             run_tactic_on_ps tau.pos tau.pos false
               FStar.Tactics.Typeclasses.solve
-              ({env with gamma=[]}, val_t)
+              ({env with lax=false; admit=false; gamma=[]}, val_t)
               FStar.Tactics.Typeclasses.solve
               tau
               tactic_already_typed

--- a/src/typechecker/FStar.TypeChecker.Tc.fst
+++ b/src/typechecker/FStar.TypeChecker.Tc.fst
@@ -572,6 +572,9 @@ let tc_decl' env0 se: list sigelt & list sigelt & Env.env =
 
   (* If we're --laxing, and this is not an `expect_lax_failure`, then just ignore the definition *)
   | Sig_fail {fail_in_lax=false} when not (Env.should_verify env) || Options.admit_smt_queries () ->
+    if Debug.any () then
+      BU.print1 "Skipping %s since env.admit=true and this is not an expect_lax_failure\n"
+        (Print.sigelt_to_string_short se);
     [], [], env
 
   | Sig_fail {errs=expected_errors; fail_in_lax=lax; ses} ->

--- a/tests/error-messages/OptionStack.fst
+++ b/tests/error-messages/OptionStack.fst
@@ -15,14 +15,25 @@
 *)
 module OptionStack
 
+assume val p : int -> prop
+
 [@@expect_failure]
-let _ = assert False
+let t0 = assert (p 1)
+
+[@@expect_failure]
+let t1 = assert (p 2)
+
+[@@expect_failure]
+let t2 = assert False
 
 #push-options "--admit_smt_queries true"
 
-let _ = assert False
+let t3 = assert False
+let t4 = assert False
+let t5 = assert False
+let t6 = assert False
 
 #pop-options
 
 [@@expect_failure]
-let _ = assert False
+let t7 = assert False

--- a/tests/error-messages/OptionStack.fst.expected
+++ b/tests/error-messages/OptionStack.fst.expected
@@ -1,17 +1,33 @@
 >> Got issues: [
-* Error 19 at OptionStack.fst(19,8-19,14):
+* Error 19 at OptionStack.fst(21,9-21,15):
   - Assertion failed
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
-  - See also OptionStack.fst(19,15-19,20)
+  - See also OptionStack.fst(21,16-21,21)
 
 >>]
 >> Got issues: [
-* Error 19 at OptionStack.fst(28,8-28,14):
+* Error 19 at OptionStack.fst(24,9-24,15):
   - Assertion failed
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
-  - See also OptionStack.fst(28,15-28,20)
+  - See also OptionStack.fst(24,16-24,21)
+
+>>]
+>> Got issues: [
+* Error 19 at OptionStack.fst(27,9-27,15):
+  - Assertion failed
+  - The SMT solver could not prove the query. Use --query_stats for more
+    details.
+  - See also OptionStack.fst(27,16-27,21)
+
+>>]
+>> Got issues: [
+* Error 19 at OptionStack.fst(39,9-39,15):
+  - Assertion failed
+  - The SMT solver could not prove the query. Use --query_stats for more
+    details.
+  - See also OptionStack.fst(39,16-39,21)
 
 >>]
 Verified module: OptionStack

--- a/tests/tactics/Admit.fst
+++ b/tests/tactics/Admit.fst
@@ -1,0 +1,16 @@
+module Admit
+
+open FStar.Tactics.V2
+
+#push-options "--admit_smt_queries true"
+let test () : squash False =
+  _ by (
+    ()
+  )
+#pop-options
+
+[@@expect_failure [19]]
+let test2 () : squash False =
+  _ by (
+    ()
+  )


### PR DESCRIPTION
In the interactive mode, flycheck queries are run with `lax=true` in the environment, which causes SMT queries to be dropped. This in turn will "confuse" the Pulse checker whenever we are doing flychecking, and report spurious errors such as FStarLang/Pulse#122.

This is a bigger problem with confusion between `--admit_smt_queries true`, `--lax`, and the `env.lax` and `env.admit` fields. I'm wrapping up a PR about that.

Meanwhile, just make all entries into a `splice_t` tactic run with admit=false and lax=false.

Another thing we should do is simply *not* flycheck syntax extension blobs. Emacs' fstar-mode does this already, but apparently not the VS code extension. We have an internal environment flag `flychecking:bool` for this purpose, but it's not set from VS code queries apparently.