### PR TITLE
Tidying lax vs admit, options vs environment

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -18,7 +18,7 @@ all: prep verify special_cases
 # * miniparse: Needs Krml to build
 
 
-EXCLUDE_DIRS=old/ hello/ native_tactics/ kv_parsing/ miniparse/ 
+EXCLUDE_DIRS=old/ hello/ native_tactics/ kv_parsing/ miniparse/ sample_project/
 
 # F* contrib directory needed by crypto/ . Since this Makefile
 # supersedes crypto/Makefile, we need to determine the location of the
@@ -45,6 +45,7 @@ verify: prep $(filter-out $(CACHE_DIR)/Launch.fst.checked, $(ALL_CHECKED_FILES))
 
 HAS_OCAML := $(shell which ocamlfind 2>/dev/null)
 
+SPECIAL_CASES += sample_project
 ifneq (,$(HAS_OCAML))
 SPECIAL_CASES += hello
 SPECIAL_CASES += native_tactics

--- a/examples/dm4free/FStar.DM4F.Id.fst
+++ b/examples/dm4free/FStar.DM4F.Id.fst
@@ -35,7 +35,7 @@ total reifiable reflectable new_effect {
 
 // Paranoid check that dm4f didn't mess up something
 // GM: This is actually not very useful: if we mistakenly set
-// --lax, then this check will be skipped since it's not an
+// --admit_smt_queries true, then this check will be skipped since it's not an
 // expect_lax_failure, but we also cannot use expect_lax_failure.
 [@@expect_failure]
 let _ = assert False

--- a/examples/kv_parsing/EnumParsing.fst
+++ b/examples/kv_parsing/EnumParsing.fst
@@ -336,7 +336,7 @@ let ser_TwoNums' (n m:U32.t) : serializer_ty =
 let unfold_only (ns:list (list string)) : Tot (list norm_step) =
   FStar.List.Tot.map delta_only ns
 
-#reset-options "--lax"
+#push-options "--admit_smt_queries true"
 
 let ser_TwoNums'' (n m:U32.t) : serializer_ty =
   synth_by_tactic (fun () ->
@@ -344,7 +344,7 @@ let ser_TwoNums'' (n m:U32.t) : serializer_ty =
                       ["EnumParsing.ser_TwoNums";
                       "Serializing.ser_append"]] (ser_TwoNums n m <: serializer_ty))
 
-#reset-options
+#pop-options
 
 // this works, but perhaps it should be eta expanded for extraction purposes
 val ser_numbers_data: ns:numbers -> serializer (hide (encode_numbers_data ns))
@@ -370,23 +370,25 @@ let ser_numbers_data2 ns =
   | OneNum n -> ser_OneNum n
   | TwoNums n m -> ser_TwoNums n m
 
-//but doing it via tactic normalization does not; NS/JR/JP: We added the --lax on 09/14
+//but doing it via tactic normalization does not; NS/JR/JP: We added the --admit_smt_queries true on 09/14
 // this is the same as ser_numbers_data; haven't synthesized the eta expansion
-#set-options "--lax"
+#push-options "--admit_smt_queries true"
 let ser_numbers_data'' ns : serializer_ty =
     synth_by_tactic (fun () ->
                         normalize' [delta_only
                                    ["EnumParsing.ser_numbers_data2"]] (ser_numbers_data2 ns))
 
-#reset-options
+#pop-options
+
 val ser_numbers: ns:numbers -> serializer (hide (encode_numbers ns))
 let ser_numbers ns = fun buf ->
   (ser_numbers_tag (numbers_tag_val ns) `ser_append`
    ser_numbers_data ns) buf
 
 //same problem as ser_numbers_data''
-#set-options "--lax"
+#push-options "--admit_smt_queries true"
 let ser_numbers' ns : serializer_ty =
   synth_by_tactic (fun () -> normalize' [delta_only
                              ["EnumParsing.ser_numbers";
                               "Serializing.ser_append"]] (ser_numbers ns <: serializer_ty))
+#pop-options

--- a/examples/miniparse/MiniParse.Impl.List.fst
+++ b/examples/miniparse/MiniParse.Impl.List.fst
@@ -76,7 +76,7 @@ let list_assoc_append (#t: Type) (x: t) (l1 l2: list t) : Lemma
 = L.append_assoc (L.rev l1) [x] l2;
   L.rev_append [x] l1
 
-#set-options "--z3rlimit 64 --max_ifuel 8"
+#set-options "--z3rlimit 96 --max_ifuel 8"
 
 let parse_nlist_impl_inv_false_intro
   (#t: Type0)

--- a/examples/old/tls-record-layer/crypto/Buffer.Utils.fst
+++ b/examples/old/tls-record-layer/crypto/Buffer.Utils.fst
@@ -38,7 +38,7 @@ let bytes = buffer u8
 // JP: 20180402 this file dropped off CI a long while ago. Retained here,
 // currently used as a testcase for KaRaMeL extraction, but I would love to see
 // this re-enabled as a sanity check for F*'s long CI.
-#set-options "--lax"
+#set-options "--admit_smt_queries true"
 
 (** Rotate operators on UInt32.t *)
 let op_Greater_Greater_Greater (a:u32) (s:u32{v s <= 32}) =

--- a/examples/old/tls-record-layer/crypto/Crypto.AEAD.Encoding.fst
+++ b/examples/old/tls-record-layer/crypto/Crypto.AEAD.Encoding.fst
@@ -421,7 +421,7 @@ val accumulate:
 
 // 20170313 JP: this verifies on my OSX laptop but not on the CI machine. See
 // #893
-#reset-options "--initial_fuel 0 --max_fuel 0 --initial_ifuel 0 --max_ifuel 0 --z3rlimit 2048 --lax"
+#reset-options "--initial_fuel 0 --max_fuel 0 --initial_ifuel 0 --max_ifuel 0 --z3rlimit 2048 --admit_smt_queries true"
 let accumulate #i st aadlen aad txtlen cipher  = 
   let h = ST.get() in 
   let acc = CMA.start st in

--- a/examples/old/tls-record-layer/crypto/Crypto.KrmlTest.fst
+++ b/examples/old/tls-record-layer/crypto/Crypto.KrmlTest.fst
@@ -56,7 +56,7 @@ module E = Crypto.AEAD.Encrypt
 
 module L = FStar.List.Tot
 
-#set-options "--lax"
+#set-options "--admit_smt_queries true"
 
 
 let mk_buf_t (len:nat) =
@@ -85,7 +85,7 @@ let mk_ivBuffer : mk_buf_t 12
   = fun () ->
     Buffer.createL [0x07uy; 0x00uy; 0x00uy; 0x00uy; 0x40uy; 0x41uy; 0x42uy; 0x43uy; 0x44uy; 0x45uy; 0x46uy; 0x47uy ]
 
-#set-options "--lax"
+#set-options "--admit_smt_queries true"
 let mk_expected_cipher : mk_buf_t 130
   = fun () ->
     Buffer.createL [0xd3uy; 0x1auy; 0x8duy; 0x34uy; 0x64uy; 0x8euy; 0x60uy; 0xdbuy; 0x7buy; 0x86uy; 0xafuy; 0xbcuy; 0x53uy; 0xefuy; 0x7euy; 0xc2uy;

--- a/examples/old/tls-record-layer/crypto/Crypto.Symmetric.AES.fst
+++ b/examples/old/tls-record-layer/crypto/Crypto.Symmetric.AES.fst
@@ -76,7 +76,7 @@ let multiply a b =
   ^^ (xtime (xtime (xtime (xtime (xtime (xtime a))))) *%^ ((b >>^ 6ul) &^ 1uy))
   ^^ (xtime (xtime (xtime (xtime (xtime (xtime (xtime a)))))) *%^ ((b >>^ 7ul) &^ 1uy)))
 
-#set-options "--lax"
+#set-options "--admit_smt_queries true"
 // tables for S-box and inv-S-box, derived from GF256 specification.
 
 type sbox  = lbytes 256

--- a/examples/old/tls-record-layer/crypto/Crypto.Symmetric.AES128.fst
+++ b/examples/old/tls-record-layer/crypto/Crypto.Symmetric.AES128.fst
@@ -72,7 +72,7 @@ let multiply a b =
   ^^ (xtime (xtime (xtime (xtime (xtime (xtime a))))) *%^ ((b >>^ 6ul) &^ 1uy))
   ^^ (xtime (xtime (xtime (xtime (xtime (xtime (xtime a)))))) *%^ ((b >>^ 7ul) &^ 1uy)))
 
-#set-options "--lax"
+#set-options "--admit_smt_queries true"
 // tables for S-box and inv-S-box, derived from GF256 specification.
 
 type sbox  = lbytes 256

--- a/examples/old/tls-record-layer/crypto/Crypto.Symmetric.Chacha20.fst
+++ b/examples/old/tls-record-layer/crypto/Crypto.Symmetric.Chacha20.fst
@@ -37,7 +37,7 @@ module ST = FStar.HyperStack.ST
 type u64 = FStar.UInt64.t
 
 // JP: see comment in Buffer.Utils.fst
-#set-options "--lax"
+#set-options "--admit_smt_queries true"
 
 (*** Chacha 20 ***)
 

--- a/examples/old/tls-record-layer/crypto/Crypto.Symmetric.Poly1305.MAC.fst
+++ b/examples/old/tls-record-layer/crypto/Crypto.Symmetric.Poly1305.MAC.fst
@@ -398,7 +398,7 @@ let mac #i st l acc tag =
     end
 //16-09-24 why?
 
-#set-options "--lax"
+#set-options "--admit_smt_queries true"
 
 val verify: #i:id -> st:state i -> l:itext -> computed:accB i -> tag:tagB ->
   Stack bool

--- a/examples/old/tls-record-layer/crypto/Crypto.Test.fst
+++ b/examples/old/tls-record-layer/crypto/Crypto.Test.fst
@@ -88,7 +88,7 @@ let mk_ivBuffer : mk_buf_t 12
       0x07uy; 0x00uy; 0x00uy; 0x00uy; 0x40uy; 0x41uy; 0x42uy; 0x43uy; 
       0x44uy; 0x45uy; 0x46uy; 0x47uy ]
 
-#set-options "--lax"
+#set-options "--admit_smt_queries true"
 let mk_expected_cipher : mk_buf_t 130
   = fun () -> 
     createL 130 [

--- a/examples/old/tls-record-layer/crypto/stale/Curve.Fdifference.fst
+++ b/examples/old/tls-record-layer/crypto/stale/Curve.Fdifference.fst
@@ -25,7 +25,7 @@ open Math.Lib
 open Curve.Parameters
 open Curve.Bigint
 
-#set-options "--lax"
+#set-options "--admit_smt_queries true"
 
 module U8  = FStar.UInt8
 module U32 = FStar.UInt32

--- a/examples/old/tls-record-layer/crypto/stale/Curve.Fproduct.fst
+++ b/examples/old/tls-record-layer/crypto/stale/Curve.Fproduct.fst
@@ -25,7 +25,7 @@ open Math.Lib
 open Curve.Parameters
 open Curve.Bigint
 
-#set-options "--lax"
+#set-options "--admit_smt_queries true"
 
 module U8  = FStar.UInt8
 module U32 = FStar.UInt32

--- a/examples/old/tls-record-layer/crypto/stale/Curve.Fscalar.fst
+++ b/examples/old/tls-record-layer/crypto/stale/Curve.Fscalar.fst
@@ -25,7 +25,7 @@ open Math.Lib
 open Curve.Parameters
 open Curve.Bigint
 
-#set-options "--lax"
+#set-options "--admit_smt_queries true"
 
 module U8  = FStar.UInt8
 module U32 = FStar.UInt32

--- a/examples/old/tls-record-layer/crypto/stale/Curve.Fsum.fst
+++ b/examples/old/tls-record-layer/crypto/stale/Curve.Fsum.fst
@@ -25,7 +25,7 @@ open Math.Lib
 open Curve.Parameters
 open Curve.Bigint
 
-#set-options "--lax"
+#set-options "--admit_smt_queries true"
 
 module U8  = FStar.UInt8
 module U32 = FStar.UInt32

--- a/examples/old/tls-record-layer/crypto/stale/Curve.FsumWide.fst
+++ b/examples/old/tls-record-layer/crypto/stale/Curve.FsumWide.fst
@@ -25,7 +25,7 @@ open Math.Lib
 open Curve.Parameters
 open Curve.Bigint
 
-#set-options "--lax"
+#set-options "--admit_smt_queries true"
 
 module U8  = FStar.UInt8
 module U32 = FStar.UInt32

--- a/examples/old/tls-record-layer/old/ulib/FStar.Buffer.fst
+++ b/examples/old/tls-record-layer/old/ulib/FStar.Buffer.fst
@@ -250,7 +250,7 @@ let lemma_modifies_one_trans_1 (#a:Type) (b:buffer a) (h0:t) (h1:t) (h2:t): Lemm
   = ()
 
 #reset-options "--z3timeout 100"
-#set-options "--lax" // TODO: remove 
+#set-options "--admit_smt_queries true" // TODO: remove
 
 (* TODO: simplify, add triggers ? *)
 private val blit_aux: #a:Type -> b:buffer a -> idx_b:uint32{v idx_b<=length b} -> 

--- a/examples/old/tls-record-layer/old/ulib/aes.fst
+++ b/examples/old/tls-record-layer/old/ulib/aes.fst
@@ -22,7 +22,7 @@ open SInt
 open SInt.UInt8
 open FStar.Buffer
 
-#set-options "--lax"
+#set-options "--admit_smt_queries true"
 
 (* JK: bug, it is necessary to add this type abbreviation to make things typecheck *)
 type suint8 = uint8   // 

--- a/examples/old/tls-record-layer/old/ulib/hyperstack/FStar.Buffer.fst
+++ b/examples/old/tls-record-layer/old/ulib/hyperstack/FStar.Buffer.fst
@@ -280,7 +280,7 @@ let lemma_modifies_one_trans_1 (#a:Type) (b:buffer a) (h0:mem) (h1:mem) (h2:mem)
 
 #reset-options "--z3timeout 100"
 // TODO: remove 
-(* #set-options "--lax" *)
+(* #set-options "--admit_smt_queries true" *)
 
 (* TODO: simplify, add triggers ? *)
 private val blit_aux: #a:Type -> b:buffer a -> idx_b:u32 -> 

--- a/examples/old/tls-record-layer/old/ulib/hyperstack/chacha.fst
+++ b/examples/old/tls-record-layer/old/ulib/hyperstack/chacha.fst
@@ -151,7 +151,7 @@ let rec bytes_of_uint32s output m len =
       bytes_of_uint32s output m l
     end
 
-#set-options "--lax" // TODO
+#set-options "--admit_smt_queries true" // TODO
 
 val xor_bytes: output:bytes -> in1:bytes -> in2:bytes{disjoint in1 in2 /\ disjoint in1 output /\ disjoint in2 output} -> len:u32{v len <= length output /\ v len <= length in1 /\ v len <= length in2} -> STL unit
   (requires (fun h -> live h output /\ live h in1 /\ live h in2))

--- a/examples/old/tls-record-layer/parsing/FStar.ImmBuffer.fst
+++ b/examples/old/tls-record-layer/parsing/FStar.ImmBuffer.fst
@@ -246,7 +246,7 @@ let cast (#t:sizeof_t) (ty:serializable t) (#t':sizeof_t) (#ty':serializable t')
 (**           Concrete parser and serializers for basetypes          **)
 (** **************************************************************** **)
 
-#set-options "--lax"
+#set-options "--admit_smt_queries true"
 
 assume val le_uint8_serializer: serializer byte
 (* let le_uint8_serializer = *)

--- a/examples/old/tls-record-layer/parsing/MessagesParsing.fst
+++ b/examples/old/tls-record-layer/parsing/MessagesParsing.fst
@@ -23,7 +23,7 @@ open FStar.Int.Cast
 open FStar.Buffer
 open Messages2
 
-#set-options "--lax"
+#set-options "--admit_smt_queries true"
 
 
 (* Returns the length as a UInt32 *)

--- a/examples/old/tls-record-layer/parsing/Parsing3.fst
+++ b/examples/old/tls-record-layer/parsing/Parsing3.fst
@@ -24,7 +24,7 @@ open FStar.Int.Cast
 open FStar.Buffer
 open Low.Bytes
 
-#set-options "--lax"
+#set-options "--admit_smt_queries true"
 
 val read_length: b:bytes -> n:UInt32.t{v n = 1 \/ v n = 2 \/ v n = 3} -> STL UInt32.t
   (requires (fun h -> Buffer.live h b /\ v n <= Buffer.length b))

--- a/examples/preorders/Indexed_effect.fst.wish
+++ b/examples/preorders/Indexed_effect.fst.wish
@@ -28,8 +28,8 @@ let ist_wp   (state:Type) (a:Type) = ist_post state a -> Tot (ist_pre state)
 
 (* A WP-style preorder-indexed state monad. *)
 
-new_effect  ISTATE (state:Type0) (rel:relation state{preorder rel}) = STATE_h state //typechecks with --lax flag on
-//new_effect  ISTATE (state:Type) (rel:relation state{preorder rel}) = STATE_h state //does not typecheck with --lax flag on
+new_effect  ISTATE (state:Type0) (rel:relation state{preorder rel}) = STATE_h state //typechecks with --admit_smt_queries true flag on
+//new_effect  ISTATE (state:Type) (rel:relation state{preorder rel}) = STATE_h state //does not typecheck with --admit_smt_queries true flag on
 
 
 (* Currently not possible, but at this point one would like to show that 

--- a/ocaml/fstar-lib/generated/FStar_CheckedFiles.ml
+++ b/ocaml/fstar-lib/generated/FStar_CheckedFiles.ml
@@ -375,7 +375,7 @@ let (load_checked_file_with_tc_result :
                                let uu___10 =
                                  FStar_Parser_Dep.print_digest deps_dig in
                                FStar_Compiler_Util.print4
-                                 "Expected (%s) hashes:\n%s\n\nGot (%s) hashes:\n\t%s\n"
+                                 "FAILING to load.\nExpected (%s) hashes:\n%s\n\nGot (%s) hashes:\n\t%s\n"
                                  uu___7 uu___8 uu___9 uu___10);
                               if
                                 (FStar_Compiler_List.length deps_dig) =

--- a/ocaml/fstar-lib/generated/FStar_Extraction_ML_Modul.ml
+++ b/ocaml/fstar-lib/generated/FStar_Extraction_ML_Modul.ml
@@ -2604,8 +2604,6 @@ and (extract_sig_let :
                        (env.FStar_TypeChecker_Env.is_iface);
                      FStar_TypeChecker_Env.admit =
                        (env.FStar_TypeChecker_Env.admit);
-                     FStar_TypeChecker_Env.lax =
-                       (env.FStar_TypeChecker_Env.lax);
                      FStar_TypeChecker_Env.lax_universes =
                        (env.FStar_TypeChecker_Env.lax_universes);
                      FStar_TypeChecker_Env.phase1 =

--- a/ocaml/fstar-lib/generated/FStar_Interactive_Ide.ml
+++ b/ocaml/fstar-lib/generated/FStar_Interactive_Ide.ml
@@ -1683,7 +1683,6 @@ let (run_push_without_deps :
                  (uu___.FStar_TypeChecker_Env.is_iface);
                FStar_TypeChecker_Env.admit =
                  (uu___.FStar_TypeChecker_Env.admit);
-               FStar_TypeChecker_Env.lax = (uu___.FStar_TypeChecker_Env.lax);
                FStar_TypeChecker_Env.lax_universes =
                  (uu___.FStar_TypeChecker_Env.lax_universes);
                FStar_TypeChecker_Env.phase1 =

--- a/ocaml/fstar-lib/generated/FStar_Interactive_Legacy.ml
+++ b/ocaml/fstar-lib/generated/FStar_Interactive_Legacy.ml
@@ -83,8 +83,7 @@ let (push_with_kind :
                 (env.FStar_TypeChecker_Env.use_eq_strict);
               FStar_TypeChecker_Env.is_iface =
                 (env.FStar_TypeChecker_Env.is_iface);
-              FStar_TypeChecker_Env.admit = (env.FStar_TypeChecker_Env.admit);
-              FStar_TypeChecker_Env.lax = lax;
+              FStar_TypeChecker_Env.admit = lax;
               FStar_TypeChecker_Env.lax_universes =
                 (env.FStar_TypeChecker_Env.lax_universes);
               FStar_TypeChecker_Env.phase1 =

--- a/ocaml/fstar-lib/generated/FStar_Interactive_PushHelper.ml
+++ b/ocaml/fstar-lib/generated/FStar_Interactive_PushHelper.ml
@@ -81,8 +81,7 @@ let (set_check_kind :
         FStar_TypeChecker_Env.use_eq_strict =
           (env.FStar_TypeChecker_Env.use_eq_strict);
         FStar_TypeChecker_Env.is_iface = (env.FStar_TypeChecker_Env.is_iface);
-        FStar_TypeChecker_Env.admit = (env.FStar_TypeChecker_Env.admit);
-        FStar_TypeChecker_Env.lax = uu___;
+        FStar_TypeChecker_Env.admit = uu___;
         FStar_TypeChecker_Env.lax_universes =
           (env.FStar_TypeChecker_Env.lax_universes);
         FStar_TypeChecker_Env.phase1 = (env.FStar_TypeChecker_Env.phase1);

--- a/ocaml/fstar-lib/generated/FStar_Options.ml
+++ b/ocaml/fstar-lib/generated/FStar_Options.ml
@@ -3565,7 +3565,6 @@ let (settable : Prims.string -> Prims.bool) =
     | "initial_ifuel" -> true
     | "ide_id_info_off" -> true
     | "keep_query_captions" -> true
-    | "lax" -> true
     | "load" -> true
     | "load_cmxs" -> true
     | "log_queries" -> true
@@ -3645,7 +3644,7 @@ let (settable_specs :
     (fun uu___ ->
        match uu___ with | ((uu___1, x, uu___2), uu___3) -> settable x)
     all_specs
-let (uu___660 :
+let (uu___659 :
   (((unit -> FStar_Getopt.parse_cmdline_res) -> unit) *
     (unit -> FStar_Getopt.parse_cmdline_res)))
   =
@@ -3662,11 +3661,11 @@ let (uu___660 :
   (set1, call)
 let (set_error_flags_callback_aux :
   (unit -> FStar_Getopt.parse_cmdline_res) -> unit) =
-  match uu___660 with
+  match uu___659 with
   | (set_error_flags_callback_aux1, set_error_flags) ->
       set_error_flags_callback_aux1
 let (set_error_flags : unit -> FStar_Getopt.parse_cmdline_res) =
-  match uu___660 with
+  match uu___659 with
   | (set_error_flags_callback_aux1, set_error_flags1) -> set_error_flags1
 let (set_error_flags_callback :
   (unit -> FStar_Getopt.parse_cmdline_res) -> unit) =

--- a/ocaml/fstar-lib/generated/FStar_Parser_Dep.ml
+++ b/ocaml/fstar-lib/generated/FStar_Parser_Dep.ml
@@ -11,6 +11,8 @@ let (uu___is_Open_namespace : open_kind -> Prims.bool) =
 type module_name = Prims.string
 let (dbg : Prims.bool FStar_Compiler_Effect.ref) =
   FStar_Compiler_Debug.get_toggle "Dep"
+let (dbg_CheckedFiles : Prims.bool FStar_Compiler_Effect.ref) =
+  FStar_Compiler_Debug.get_toggle "CheckedFiles"
 let profile : 'uuuuu . (unit -> 'uuuuu) -> Prims.string -> 'uuuuu =
   fun f -> fun c -> FStar_Profiling.profile f FStar_Pervasives_Native.None c
 let with_file_outchannel :
@@ -560,17 +562,29 @@ let (cache_file_name : Prims.string -> Prims.string) =
                  expected_cache_file) in
           if uu___2 then expected_cache_file else path))
     | FStar_Pervasives_Native.None ->
-        let uu___1 = FStar_Options.should_be_already_cached mname in
-        if uu___1
-        then
-          let uu___2 =
-            let uu___3 =
-              FStar_Compiler_Util.format1
-                "Expected %s to be already checked but could not find it"
-                mname in
-            (FStar_Errors_Codes.Error_AlreadyCachedAssertionFailure, uu___3) in
-          FStar_Errors.raise_err uu___2
-        else FStar_Options.prepend_cache_dir cache_fn in
+        ((let uu___2 = FStar_Compiler_Effect.op_Bang dbg_CheckedFiles in
+          if uu___2
+          then
+            let uu___3 = FStar_Compiler_Util.basename cache_fn in
+            FStar_Compiler_Util.print1 "find_file(%s) returned None\n" uu___3
+          else ());
+         (let uu___3 = FStar_Options.should_be_already_cached mname in
+          if uu___3
+          then
+            let uu___4 =
+              let uu___5 =
+                let uu___6 =
+                  let uu___7 =
+                    FStar_Compiler_Util.format1
+                      "Expected %s to be already checked but could not find it."
+                      mname in
+                  FStar_Errors_Msg.text uu___7 in
+                [uu___6] in
+              (FStar_Errors_Codes.Error_AlreadyCachedAssertionFailure,
+                uu___5) in
+            FStar_Errors.raise_err_doc uu___4
+          else ());
+         FStar_Options.prepend_cache_dir cache_fn) in
   let memo = FStar_Compiler_Util.smap_create (Prims.of_int (100)) in
   let memo1 f x =
     let uu___ = FStar_Compiler_Util.smap_try_find memo x in

--- a/ocaml/fstar-lib/generated/FStar_SMTEncoding_Encode.ml
+++ b/ocaml/fstar-lib/generated/FStar_SMTEncoding_Encode.ml
@@ -1504,9 +1504,7 @@ let (encode_free_var :
                                       (tcenv_comp.FStar_TypeChecker_Env.use_eq_strict);
                                     FStar_TypeChecker_Env.is_iface =
                                       (tcenv_comp.FStar_TypeChecker_Env.is_iface);
-                                    FStar_TypeChecker_Env.admit =
-                                      (tcenv_comp.FStar_TypeChecker_Env.admit);
-                                    FStar_TypeChecker_Env.lax = true;
+                                    FStar_TypeChecker_Env.admit = true;
                                     FStar_TypeChecker_Env.lax_universes =
                                       (tcenv_comp.FStar_TypeChecker_Env.lax_universes);
                                     FStar_TypeChecker_Env.phase1 =
@@ -2392,9 +2390,7 @@ let (encode_top_level_let :
                     (uu___1.FStar_TypeChecker_Env.use_eq_strict);
                   FStar_TypeChecker_Env.is_iface =
                     (uu___1.FStar_TypeChecker_Env.is_iface);
-                  FStar_TypeChecker_Env.admit =
-                    (uu___1.FStar_TypeChecker_Env.admit);
-                  FStar_TypeChecker_Env.lax = true;
+                  FStar_TypeChecker_Env.admit = true;
                   FStar_TypeChecker_Env.lax_universes =
                     (uu___1.FStar_TypeChecker_Env.lax_universes);
                   FStar_TypeChecker_Env.phase1 =

--- a/ocaml/fstar-lib/generated/FStar_SMTEncoding_EncodeTerm.ml
+++ b/ocaml/fstar-lib/generated/FStar_SMTEncoding_EncodeTerm.ml
@@ -1526,9 +1526,7 @@ and (encode_term :
                               (uu___6.FStar_TypeChecker_Env.use_eq_strict);
                             FStar_TypeChecker_Env.is_iface =
                               (uu___6.FStar_TypeChecker_Env.is_iface);
-                            FStar_TypeChecker_Env.admit =
-                              (uu___6.FStar_TypeChecker_Env.admit);
-                            FStar_TypeChecker_Env.lax = true;
+                            FStar_TypeChecker_Env.admit = true;
                             FStar_TypeChecker_Env.lax_universes =
                               (uu___6.FStar_TypeChecker_Env.lax_universes);
                             FStar_TypeChecker_Env.phase1 =

--- a/ocaml/fstar-lib/generated/FStar_SMTEncoding_Solver.ml
+++ b/ocaml/fstar-lib/generated/FStar_SMTEncoding_Solver.ml
@@ -1965,7 +1965,7 @@ let (ask_solver :
                   | (configs, next_hint) ->
                       let default_settings = FStar_Compiler_List.hd configs in
                       let skip =
-                        ((FStar_Options.admit_smt_queries ()) ||
+                        (env.FStar_TypeChecker_Env.admit ||
                            (FStar_TypeChecker_Env.too_early_in_prims env))
                           ||
                           (let uu___1 = FStar_Options.admit_except () in
@@ -2432,21 +2432,20 @@ let (do_solve_maybe_split :
   fun use_env_msg ->
     fun tcenv ->
       fun q ->
-        let uu___ = FStar_Options.admit_smt_queries () in
-        if uu___
+        if tcenv.FStar_TypeChecker_Env.admit
         then ()
         else
-          (let uu___2 = FStar_Options.split_queries () in
-           match uu___2 with
+          (let uu___1 = FStar_Options.split_queries () in
+           match uu___1 with
            | FStar_Options.No -> do_solve false false use_env_msg tcenv q
            | FStar_Options.OnFailure ->
                let can_split =
-                 let uu___3 =
-                   let uu___4 = FStar_Options.quake_hi () in
-                   uu___4 > Prims.int_one in
-                 Prims.op_Negation uu___3 in
+                 let uu___2 =
+                   let uu___3 = FStar_Options.quake_hi () in
+                   uu___3 > Prims.int_one in
+                 Prims.op_Negation uu___2 in
                (try
-                  (fun uu___3 ->
+                  (fun uu___2 ->
                      match () with
                      | () -> do_solve can_split false use_env_msg tcenv q) ()
                 with

--- a/ocaml/fstar-lib/generated/FStar_SMTEncoding_Solver_Cache.ml
+++ b/ocaml/fstar-lib/generated/FStar_SMTEncoding_Solver_Cache.ml
@@ -324,11 +324,8 @@ let (hashable_env : FStar_TypeChecker_Env.env FStar_Class_Hashable.hashable)
                e.FStar_TypeChecker_Env.proof_ns in
            FStar_Hash.mix uu___1 uu___2 in
          let uu___1 =
-           FStar_Class_Hashable.hash
-             (FStar_Class_Hashable.hashable_tuple2
-                FStar_Class_Hashable.hashable_bool
-                FStar_Class_Hashable.hashable_bool)
-             ((e.FStar_TypeChecker_Env.admit), (e.FStar_TypeChecker_Env.lax)) in
+           FStar_Class_Hashable.hash FStar_Class_Hashable.hashable_bool
+             e.FStar_TypeChecker_Env.admit in
          FStar_Hash.mix uu___ uu___1)
   }
 let (query_cache_ref :

--- a/ocaml/fstar-lib/generated/FStar_Tactics_CtrlRewrite.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_CtrlRewrite.ml
@@ -95,8 +95,7 @@ let (__do_rewrite :
                                             FStar_TypeChecker_Env.is_iface =
                                               (env.FStar_TypeChecker_Env.is_iface);
                                             FStar_TypeChecker_Env.admit =
-                                              (env.FStar_TypeChecker_Env.admit);
-                                            FStar_TypeChecker_Env.lax = true;
+                                              true;
                                             FStar_TypeChecker_Env.lax_universes
                                               =
                                               (env.FStar_TypeChecker_Env.lax_universes);

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Hooks.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Hooks.ml
@@ -888,8 +888,6 @@ let rec (traverse_for_spinoff :
                              FStar_TypeChecker_Env.is_iface =
                                (env2.FStar_TypeChecker_Env.is_iface);
                              FStar_TypeChecker_Env.admit = true;
-                             FStar_TypeChecker_Env.lax =
-                               (env2.FStar_TypeChecker_Env.lax);
                              FStar_TypeChecker_Env.lax_universes =
                                (env2.FStar_TypeChecker_Env.lax_universes);
                              FStar_TypeChecker_Env.phase1 =
@@ -1624,13 +1622,11 @@ let (solve_implicits :
                                    FStar_Compiler_Util.print1
                                      "Synthesis left a goal: %s\n" uu___9
                                  else ());
-                                (let uu___8 =
-                                   let uu___9 =
-                                     FStar_Options.admit_smt_queries () in
-                                   Prims.op_Negation uu___9 in
-                                 if uu___8
-                                 then
-                                   let guard =
+                                if
+                                  Prims.op_Negation
+                                    env.FStar_TypeChecker_Env.admit
+                                then
+                                  (let guard =
                                      {
                                        FStar_TypeChecker_Common.guard_f =
                                          (FStar_TypeChecker_Common.NonTrivial
@@ -1644,14 +1640,14 @@ let (solve_implicits :
                                          []
                                      } in
                                    FStar_Profiling.profile
-                                     (fun uu___9 ->
-                                        let uu___10 =
+                                     (fun uu___8 ->
+                                        let uu___9 =
                                           FStar_Tactics_Types.goal_env g in
                                         FStar_TypeChecker_Rel.force_trivial_guard
-                                          uu___10 guard)
+                                          uu___9 guard)
                                      FStar_Pervasives_Native.None
-                                     "FStar.TypeChecker.Hooks.force_trivial_guard"
-                                 else ()))
+                                     "FStar.TypeChecker.Hooks.force_trivial_guard")
+                                else ())
                            | FStar_Pervasives_Native.None ->
                                let uu___7 =
                                  FStar_TypeChecker_Env.get_range env in
@@ -1894,7 +1890,6 @@ let (splice :
                                          FStar_TypeChecker_Env.is_iface =
                                            (env.FStar_TypeChecker_Env.is_iface);
                                          FStar_TypeChecker_Env.admit = false;
-                                         FStar_TypeChecker_Env.lax = false;
                                          FStar_TypeChecker_Env.lax_universes
                                            =
                                            (env.FStar_TypeChecker_Env.lax_universes);

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Interpreter.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Interpreter.ml
@@ -690,8 +690,6 @@ let run_unembedded_tactic_on_ps :
                          (uu___.FStar_TypeChecker_Env.is_iface);
                        FStar_TypeChecker_Env.admit =
                          (uu___.FStar_TypeChecker_Env.admit);
-                       FStar_TypeChecker_Env.lax =
-                         (uu___.FStar_TypeChecker_Env.lax);
                        FStar_TypeChecker_Env.lax_universes =
                          (uu___.FStar_TypeChecker_Env.lax_universes);
                        FStar_TypeChecker_Env.phase1 =
@@ -825,8 +823,6 @@ let run_unembedded_tactic_on_ps :
                          (uu___.FStar_TypeChecker_Env.is_iface);
                        FStar_TypeChecker_Env.admit =
                          (uu___.FStar_TypeChecker_Env.admit);
-                       FStar_TypeChecker_Env.lax =
-                         (uu___.FStar_TypeChecker_Env.lax);
                        FStar_TypeChecker_Env.lax_universes =
                          (uu___.FStar_TypeChecker_Env.lax_universes);
                        FStar_TypeChecker_Env.phase1 =

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Monad.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Monad.ml
@@ -43,17 +43,19 @@ let (register_goal : FStar_Tactics_Types.goal -> unit) =
     then ()
     else
       (let env = FStar_Tactics_Types.goal_env g in
-       if env.FStar_TypeChecker_Env.phase1 || env.FStar_TypeChecker_Env.lax
+       let uu___2 =
+         env.FStar_TypeChecker_Env.phase1 || (FStar_Options.lax ()) in
+       if uu___2
        then ()
        else
          (let uv = g.FStar_Tactics_Types.goal_ctx_uvar in
           let i = FStar_TypeChecker_Core.incr_goal_ctr () in
-          let uu___3 =
-            let uu___4 =
+          let uu___4 =
+            let uu___5 =
               FStar_Syntax_Util.ctx_uvar_should_check
                 g.FStar_Tactics_Types.goal_ctx_uvar in
-            FStar_Syntax_Syntax.uu___is_Allow_untyped uu___4 in
-          if uu___3
+            FStar_Syntax_Syntax.uu___is_Allow_untyped uu___5 in
+          if uu___4
           then ()
           else
             (let env1 =
@@ -96,7 +98,6 @@ let (register_goal : FStar_Tactics_Types.goal -> unit) =
                    (env.FStar_TypeChecker_Env.is_iface);
                  FStar_TypeChecker_Env.admit =
                    (env.FStar_TypeChecker_Env.admit);
-                 FStar_TypeChecker_Env.lax = (env.FStar_TypeChecker_Env.lax);
                  FStar_TypeChecker_Env.lax_universes =
                    (env.FStar_TypeChecker_Env.lax_universes);
                  FStar_TypeChecker_Env.phase1 =
@@ -163,64 +164,64 @@ let (register_goal : FStar_Tactics_Types.goal -> unit) =
                  FStar_TypeChecker_Env.missing_decl =
                    (env.FStar_TypeChecker_Env.missing_decl)
                } in
-             (let uu___6 = FStar_Compiler_Effect.op_Bang dbg_CoreEq in
-              if uu___6
+             (let uu___7 = FStar_Compiler_Effect.op_Bang dbg_CoreEq in
+              if uu___7
               then
-                let uu___7 =
+                let uu___8 =
                   FStar_Class_Show.show
                     (FStar_Class_Show.printableshow
                        FStar_Class_Printable.printable_int) i in
-                FStar_Compiler_Util.print1 "(%s) Registering goal\n" uu___7
+                FStar_Compiler_Util.print1 "(%s) Registering goal\n" uu___8
               else ());
              (let should_register = is_goal_safe_as_well_typed g in
               if Prims.op_Negation should_register
               then
-                let uu___7 =
+                let uu___8 =
                   (FStar_Compiler_Effect.op_Bang dbg_Core) ||
                     (FStar_Compiler_Effect.op_Bang dbg_RegisterGoal) in
-                (if uu___7
+                (if uu___8
                  then
-                   let uu___8 =
+                   let uu___9 =
                      FStar_Class_Show.show
                        (FStar_Class_Show.printableshow
                           FStar_Class_Printable.printable_int) i in
                    FStar_Compiler_Util.print1
                      "(%s) Not registering goal since it has unresolved uvar deps\n"
-                     uu___8
+                     uu___9
                  else ())
               else
-                ((let uu___8 =
+                ((let uu___9 =
                     (FStar_Compiler_Effect.op_Bang dbg_Core) ||
                       (FStar_Compiler_Effect.op_Bang dbg_RegisterGoal) in
-                  if uu___8
+                  if uu___9
                   then
-                    let uu___9 =
+                    let uu___10 =
                       FStar_Class_Show.show
                         (FStar_Class_Show.printableshow
                            FStar_Class_Printable.printable_int) i in
-                    let uu___10 =
+                    let uu___11 =
                       FStar_Class_Show.show FStar_Syntax_Print.showable_ctxu
                         uv in
                     FStar_Compiler_Util.print2
-                      "(%s) Registering goal for %s\n" uu___9 uu___10
+                      "(%s) Registering goal for %s\n" uu___10 uu___11
                   else ());
                  (let goal_ty = FStar_Syntax_Util.ctx_uvar_typ uv in
-                  let uu___8 =
+                  let uu___9 =
                     FStar_TypeChecker_Core.compute_term_type_handle_guards
-                      env1 goal_ty (fun uu___9 -> fun uu___10 -> true) in
-                  match uu___8 with
-                  | FStar_Pervasives.Inl uu___9 -> ()
+                      env1 goal_ty (fun uu___10 -> fun uu___11 -> true) in
+                  match uu___9 with
+                  | FStar_Pervasives.Inl uu___10 -> ()
                   | FStar_Pervasives.Inr err ->
                       let msg =
-                        let uu___9 =
-                          let uu___10 = FStar_Syntax_Util.ctx_uvar_typ uv in
-                          FStar_Class_Show.show
-                            FStar_Syntax_Print.showable_term uu___10 in
                         let uu___10 =
+                          let uu___11 = FStar_Syntax_Util.ctx_uvar_typ uv in
+                          FStar_Class_Show.show
+                            FStar_Syntax_Print.showable_term uu___11 in
+                        let uu___11 =
                           FStar_TypeChecker_Core.print_error_short err in
                         FStar_Compiler_Util.format2
                           "Failed to check initial tactic goal %s because %s"
-                          uu___9 uu___10 in
+                          uu___10 uu___11 in
                       FStar_Errors.log_issue
                         uv.FStar_Syntax_Syntax.ctx_uvar_range
                         (FStar_Errors_Codes.Warning_FailedToCheckInitialTacticGoal,

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Types.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Types.ml
@@ -282,7 +282,6 @@ let (goal_of_implicit :
           FStar_TypeChecker_Env.is_iface =
             (env.FStar_TypeChecker_Env.is_iface);
           FStar_TypeChecker_Env.admit = (env.FStar_TypeChecker_Env.admit);
-          FStar_TypeChecker_Env.lax = (env.FStar_TypeChecker_Env.lax);
           FStar_TypeChecker_Env.lax_universes =
             (env.FStar_TypeChecker_Env.lax_universes);
           FStar_TypeChecker_Env.phase1 = (env.FStar_TypeChecker_Env.phase1);

--- a/ocaml/fstar-lib/generated/FStar_Tactics_V1_Basic.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_V1_Basic.ml
@@ -740,8 +740,6 @@ let (tc_unifier_solved_implicits :
                            (env1.FStar_TypeChecker_Env.is_iface);
                          FStar_TypeChecker_Env.admit =
                            (env1.FStar_TypeChecker_Env.admit);
-                         FStar_TypeChecker_Env.lax =
-                           (env1.FStar_TypeChecker_Env.lax);
                          FStar_TypeChecker_Env.lax_universes =
                            (env1.FStar_TypeChecker_Env.lax_universes);
                          FStar_TypeChecker_Env.phase1 =
@@ -1529,7 +1527,6 @@ let (__tc :
                       (e.FStar_TypeChecker_Env.is_iface);
                     FStar_TypeChecker_Env.admit =
                       (e.FStar_TypeChecker_Env.admit);
-                    FStar_TypeChecker_Env.lax = (e.FStar_TypeChecker_Env.lax);
                     FStar_TypeChecker_Env.lax_universes =
                       (e.FStar_TypeChecker_Env.lax_universes);
                     FStar_TypeChecker_Env.phase1 =
@@ -1678,7 +1675,6 @@ let (__tc_ghost :
                       (e.FStar_TypeChecker_Env.is_iface);
                     FStar_TypeChecker_Env.admit =
                       (e.FStar_TypeChecker_Env.admit);
-                    FStar_TypeChecker_Env.lax = (e.FStar_TypeChecker_Env.lax);
                     FStar_TypeChecker_Env.lax_universes =
                       (e.FStar_TypeChecker_Env.lax_universes);
                     FStar_TypeChecker_Env.phase1 =
@@ -1784,8 +1780,6 @@ let (__tc_ghost :
                       (e1.FStar_TypeChecker_Env.is_iface);
                     FStar_TypeChecker_Env.admit =
                       (e1.FStar_TypeChecker_Env.admit);
-                    FStar_TypeChecker_Env.lax =
-                      (e1.FStar_TypeChecker_Env.lax);
                     FStar_TypeChecker_Env.lax_universes =
                       (e1.FStar_TypeChecker_Env.lax_universes);
                     FStar_TypeChecker_Env.phase1 =
@@ -1943,7 +1937,6 @@ let (__tc_lax :
                       (e.FStar_TypeChecker_Env.is_iface);
                     FStar_TypeChecker_Env.admit =
                       (e.FStar_TypeChecker_Env.admit);
-                    FStar_TypeChecker_Env.lax = (e.FStar_TypeChecker_Env.lax);
                     FStar_TypeChecker_Env.lax_universes =
                       (e.FStar_TypeChecker_Env.lax_universes);
                     FStar_TypeChecker_Env.phase1 =
@@ -2048,9 +2041,7 @@ let (__tc_lax :
                       (e1.FStar_TypeChecker_Env.use_eq_strict);
                     FStar_TypeChecker_Env.is_iface =
                       (e1.FStar_TypeChecker_Env.is_iface);
-                    FStar_TypeChecker_Env.admit =
-                      (e1.FStar_TypeChecker_Env.admit);
-                    FStar_TypeChecker_Env.lax = true;
+                    FStar_TypeChecker_Env.admit = true;
                     FStar_TypeChecker_Env.lax_universes =
                       (e1.FStar_TypeChecker_Env.lax_universes);
                     FStar_TypeChecker_Env.phase1 =
@@ -2158,8 +2149,6 @@ let (__tc_lax :
                       (e2.FStar_TypeChecker_Env.is_iface);
                     FStar_TypeChecker_Env.admit =
                       (e2.FStar_TypeChecker_Env.admit);
-                    FStar_TypeChecker_Env.lax =
-                      (e2.FStar_TypeChecker_Env.lax);
                     FStar_TypeChecker_Env.lax_universes =
                       (e2.FStar_TypeChecker_Env.lax_universes);
                     FStar_TypeChecker_Env.phase1 =
@@ -5430,8 +5419,6 @@ let (_t_trefl :
                                       (uu___12.FStar_TypeChecker_Env.is_iface);
                                     FStar_TypeChecker_Env.admit =
                                       (uu___12.FStar_TypeChecker_Env.admit);
-                                    FStar_TypeChecker_Env.lax =
-                                      (uu___12.FStar_TypeChecker_Env.lax);
                                     FStar_TypeChecker_Env.lax_universes =
                                       (uu___12.FStar_TypeChecker_Env.lax_universes);
                                     FStar_TypeChecker_Env.phase1 =
@@ -5991,9 +5978,6 @@ let (join_goals :
                                                        FStar_TypeChecker_Env.admit
                                                          =
                                                          (uu___7.FStar_TypeChecker_Env.admit);
-                                                       FStar_TypeChecker_Env.lax
-                                                         =
-                                                         (uu___7.FStar_TypeChecker_Env.lax);
                                                        FStar_TypeChecker_Env.lax_universes
                                                          =
                                                          (uu___7.FStar_TypeChecker_Env.lax_universes);
@@ -6263,7 +6247,7 @@ let (lax_on : unit -> Prims.bool FStar_Tactics_Monad.tac) =
                   let uu___1 =
                     (FStar_Options.lax ()) ||
                       (let uu___2 = FStar_Tactics_Types.goal_env g in
-                       uu___2.FStar_TypeChecker_Env.lax) in
+                       uu___2.FStar_TypeChecker_Env.admit) in
                   Obj.magic (ret uu___1)) uu___1))) uu___
 let (unquote :
   FStar_Syntax_Syntax.typ ->
@@ -6613,8 +6597,6 @@ let (unshelve : FStar_Syntax_Syntax.term -> unit FStar_Tactics_Monad.tac) =
                         (env1.FStar_TypeChecker_Env.is_iface);
                       FStar_TypeChecker_Env.admit =
                         (env1.FStar_TypeChecker_Env.admit);
-                      FStar_TypeChecker_Env.lax =
-                        (env1.FStar_TypeChecker_Env.lax);
                       FStar_TypeChecker_Env.lax_universes =
                         (env1.FStar_TypeChecker_Env.lax_universes);
                       FStar_TypeChecker_Env.phase1 =
@@ -8011,9 +7993,6 @@ let (t_destruct :
                                                                     =
                                                                     (env1.FStar_TypeChecker_Env.is_iface);
                                                                     FStar_TypeChecker_Env.admit
-                                                                    =
-                                                                    (env1.FStar_TypeChecker_Env.admit);
-                                                                    FStar_TypeChecker_Env.lax
                                                                     = true;
                                                                     FStar_TypeChecker_Env.lax_universes
                                                                     =
@@ -9187,7 +9166,6 @@ let (push_bv_dsenv :
                FStar_TypeChecker_Env.is_iface =
                  (e.FStar_TypeChecker_Env.is_iface);
                FStar_TypeChecker_Env.admit = (e.FStar_TypeChecker_Env.admit);
-               FStar_TypeChecker_Env.lax = (e.FStar_TypeChecker_Env.lax);
                FStar_TypeChecker_Env.lax_universes =
                  (e.FStar_TypeChecker_Env.lax_universes);
                FStar_TypeChecker_Env.phase1 =

--- a/ocaml/fstar-lib/generated/FStar_Tactics_V2_Basic.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_V2_Basic.ml
@@ -890,8 +890,6 @@ let (tc_unifier_solved_implicits :
                            (env1.FStar_TypeChecker_Env.is_iface);
                          FStar_TypeChecker_Env.admit =
                            (env1.FStar_TypeChecker_Env.admit);
-                         FStar_TypeChecker_Env.lax =
-                           (env1.FStar_TypeChecker_Env.lax);
                          FStar_TypeChecker_Env.lax_universes =
                            (env1.FStar_TypeChecker_Env.lax_universes);
                          FStar_TypeChecker_Env.phase1 =
@@ -2046,8 +2044,6 @@ let (__tc :
                                        (e.FStar_TypeChecker_Env.is_iface);
                                      FStar_TypeChecker_Env.admit =
                                        (e.FStar_TypeChecker_Env.admit);
-                                     FStar_TypeChecker_Env.lax =
-                                       (e.FStar_TypeChecker_Env.lax);
                                      FStar_TypeChecker_Env.lax_universes =
                                        (e.FStar_TypeChecker_Env.lax_universes);
                                      FStar_TypeChecker_Env.phase1 =
@@ -2283,8 +2279,6 @@ let (__tc_ghost :
                                        (e.FStar_TypeChecker_Env.is_iface);
                                      FStar_TypeChecker_Env.admit =
                                        (e.FStar_TypeChecker_Env.admit);
-                                     FStar_TypeChecker_Env.lax =
-                                       (e.FStar_TypeChecker_Env.lax);
                                      FStar_TypeChecker_Env.lax_universes =
                                        (e.FStar_TypeChecker_Env.lax_universes);
                                      FStar_TypeChecker_Env.phase1 =
@@ -2401,8 +2395,6 @@ let (__tc_ghost :
                                        (e1.FStar_TypeChecker_Env.is_iface);
                                      FStar_TypeChecker_Env.admit =
                                        (e1.FStar_TypeChecker_Env.admit);
-                                     FStar_TypeChecker_Env.lax =
-                                       (e1.FStar_TypeChecker_Env.lax);
                                      FStar_TypeChecker_Env.lax_universes =
                                        (e1.FStar_TypeChecker_Env.lax_universes);
                                      FStar_TypeChecker_Env.phase1 =
@@ -2650,8 +2642,6 @@ let (__tc_lax :
                                        (e.FStar_TypeChecker_Env.is_iface);
                                      FStar_TypeChecker_Env.admit =
                                        (e.FStar_TypeChecker_Env.admit);
-                                     FStar_TypeChecker_Env.lax =
-                                       (e.FStar_TypeChecker_Env.lax);
                                      FStar_TypeChecker_Env.lax_universes =
                                        (e.FStar_TypeChecker_Env.lax_universes);
                                      FStar_TypeChecker_Env.phase1 =
@@ -2767,9 +2757,7 @@ let (__tc_lax :
                                        (e1.FStar_TypeChecker_Env.use_eq_strict);
                                      FStar_TypeChecker_Env.is_iface =
                                        (e1.FStar_TypeChecker_Env.is_iface);
-                                     FStar_TypeChecker_Env.admit =
-                                       (e1.FStar_TypeChecker_Env.admit);
-                                     FStar_TypeChecker_Env.lax = true;
+                                     FStar_TypeChecker_Env.admit = true;
                                      FStar_TypeChecker_Env.lax_universes =
                                        (e1.FStar_TypeChecker_Env.lax_universes);
                                      FStar_TypeChecker_Env.phase1 =
@@ -2886,8 +2874,6 @@ let (__tc_lax :
                                        (e2.FStar_TypeChecker_Env.is_iface);
                                      FStar_TypeChecker_Env.admit =
                                        (e2.FStar_TypeChecker_Env.admit);
-                                     FStar_TypeChecker_Env.lax =
-                                       (e2.FStar_TypeChecker_Env.lax);
                                      FStar_TypeChecker_Env.lax_universes =
                                        (e2.FStar_TypeChecker_Env.lax_universes);
                                      FStar_TypeChecker_Env.phase1 =
@@ -6316,8 +6302,6 @@ let (_t_trefl :
                                       (uu___12.FStar_TypeChecker_Env.is_iface);
                                     FStar_TypeChecker_Env.admit =
                                       (uu___12.FStar_TypeChecker_Env.admit);
-                                    FStar_TypeChecker_Env.lax =
-                                      (uu___12.FStar_TypeChecker_Env.lax);
                                     FStar_TypeChecker_Env.lax_universes =
                                       (uu___12.FStar_TypeChecker_Env.lax_universes);
                                     FStar_TypeChecker_Env.phase1 =
@@ -6843,8 +6827,6 @@ let (join_goals :
                                       (uu___3.FStar_TypeChecker_Env.is_iface);
                                     FStar_TypeChecker_Env.admit =
                                       (uu___3.FStar_TypeChecker_Env.admit);
-                                    FStar_TypeChecker_Env.lax =
-                                      (uu___3.FStar_TypeChecker_Env.lax);
                                     FStar_TypeChecker_Env.lax_universes =
                                       (uu___3.FStar_TypeChecker_Env.lax_universes);
                                     FStar_TypeChecker_Env.phase1 =
@@ -7107,53 +7089,18 @@ let (top_env : unit -> env FStar_Tactics_Monad.tac) =
 let (lax_on : unit -> Prims.bool FStar_Tactics_Monad.tac) =
   fun uu___ ->
     (fun uu___ ->
-       let uu___1 =
-         FStar_Class_Monad.return FStar_Tactics_Monad.monad_tac ()
-           (Obj.repr ()) in
        Obj.magic
          (FStar_Class_Monad.op_let_Bang FStar_Tactics_Monad.monad_tac () ()
-            uu___1
-            (fun uu___2 ->
-               (fun uu___2 ->
-                  let uu___2 = Obj.magic uu___2 in
-                  let uu___3 =
-                    (FStar_Options.lax ()) ||
-                      (FStar_Options.admit_smt_queries ()) in
-                  if uu___3
-                  then
-                    Obj.magic
-                      (FStar_Class_Monad.return FStar_Tactics_Monad.monad_tac
-                         () (Obj.magic true))
-                  else
-                    (let uu___5 =
-                       FStar_Tactics_Monad.trytac
-                         FStar_Tactics_Monad.cur_goal in
-                     Obj.magic
-                       (FStar_Class_Monad.op_let_Bang
-                          FStar_Tactics_Monad.monad_tac () ()
-                          (Obj.magic uu___5)
-                          (fun uu___6 ->
-                             (fun uu___6 ->
-                                let uu___6 = Obj.magic uu___6 in
-                                match uu___6 with
-                                | FStar_Pervasives_Native.Some g ->
-                                    let uu___7 =
-                                      (let uu___8 =
-                                         FStar_Tactics_Types.goal_env g in
-                                       uu___8.FStar_TypeChecker_Env.lax) ||
-                                        (let uu___8 =
-                                           FStar_Tactics_Types.goal_env g in
-                                         uu___8.FStar_TypeChecker_Env.admit) in
-                                    Obj.magic
-                                      (FStar_Class_Monad.return
-                                         FStar_Tactics_Monad.monad_tac ()
-                                         (Obj.magic uu___7))
-                                | FStar_Pervasives_Native.None ->
-                                    Obj.magic
-                                      (FStar_Class_Monad.return
-                                         FStar_Tactics_Monad.monad_tac ()
-                                         (Obj.magic false))) uu___6))))
-                 uu___2))) uu___
+            (Obj.magic FStar_Tactics_Monad.get)
+            (fun uu___1 ->
+               (fun ps ->
+                  let ps = Obj.magic ps in
+                  Obj.magic
+                    (FStar_Class_Monad.return FStar_Tactics_Monad.monad_tac
+                       ()
+                       (Obj.magic
+                          (ps.FStar_Tactics_Types.main_context).FStar_TypeChecker_Env.admit)))
+                 uu___1))) uu___
 let (unquote :
   FStar_Syntax_Syntax.typ ->
     FStar_Syntax_Syntax.term ->
@@ -7525,8 +7472,6 @@ let (unshelve : FStar_Syntax_Syntax.term -> unit FStar_Tactics_Monad.tac) =
                         (env1.FStar_TypeChecker_Env.is_iface);
                       FStar_TypeChecker_Env.admit =
                         (env1.FStar_TypeChecker_Env.admit);
-                      FStar_TypeChecker_Env.lax =
-                        (env1.FStar_TypeChecker_Env.lax);
                       FStar_TypeChecker_Env.lax_universes =
                         (env1.FStar_TypeChecker_Env.lax_universes);
                       FStar_TypeChecker_Env.phase1 =
@@ -8995,9 +8940,6 @@ let (t_destruct :
                                                                     =
                                                                     (env1.FStar_TypeChecker_Env.is_iface);
                                                                     FStar_TypeChecker_Env.admit
-                                                                    =
-                                                                    (env1.FStar_TypeChecker_Env.admit);
-                                                                    FStar_TypeChecker_Env.lax
                                                                     = true;
                                                                     FStar_TypeChecker_Env.lax_universes
                                                                     =
@@ -9734,7 +9676,6 @@ let (push_bv_dsenv :
                       (e.FStar_TypeChecker_Env.is_iface);
                     FStar_TypeChecker_Env.admit =
                       (e.FStar_TypeChecker_Env.admit);
-                    FStar_TypeChecker_Env.lax = (e.FStar_TypeChecker_Env.lax);
                     FStar_TypeChecker_Env.lax_universes =
                       (e.FStar_TypeChecker_Env.lax_universes);
                     FStar_TypeChecker_Env.phase1 =
@@ -10913,8 +10854,6 @@ let (refl_tc_term :
                                (g1.FStar_TypeChecker_Env.is_iface);
                              FStar_TypeChecker_Env.admit =
                                (g1.FStar_TypeChecker_Env.admit);
-                             FStar_TypeChecker_Env.lax =
-                               (g1.FStar_TypeChecker_Env.lax);
                              FStar_TypeChecker_Env.lax_universes =
                                (g1.FStar_TypeChecker_Env.lax_universes);
                              FStar_TypeChecker_Env.phase1 =
@@ -11022,9 +10961,7 @@ let (refl_tc_term :
                                  (g2.FStar_TypeChecker_Env.use_eq_strict);
                                FStar_TypeChecker_Env.is_iface =
                                  (g2.FStar_TypeChecker_Env.is_iface);
-                               FStar_TypeChecker_Env.admit =
-                                 (g2.FStar_TypeChecker_Env.admit);
-                               FStar_TypeChecker_Env.lax = true;
+                               FStar_TypeChecker_Env.admit = true;
                                FStar_TypeChecker_Env.lax_universes =
                                  (g2.FStar_TypeChecker_Env.lax_universes);
                                FStar_TypeChecker_Env.phase1 = true;
@@ -11642,9 +11579,7 @@ let (refl_instantiate_implicits :
                                    (g2.FStar_TypeChecker_Env.use_eq_strict);
                                  FStar_TypeChecker_Env.is_iface =
                                    (g2.FStar_TypeChecker_Env.is_iface);
-                                 FStar_TypeChecker_Env.admit =
-                                   (g2.FStar_TypeChecker_Env.admit);
-                                 FStar_TypeChecker_Env.lax = true;
+                                 FStar_TypeChecker_Env.admit = true;
                                  FStar_TypeChecker_Env.lax_universes =
                                    (g2.FStar_TypeChecker_Env.lax_universes);
                                  FStar_TypeChecker_Env.phase1 = true;
@@ -12070,8 +12005,6 @@ let (refl_try_unify :
                                                 =
                                                 (g1.FStar_TypeChecker_Env.is_iface);
                                               FStar_TypeChecker_Env.admit =
-                                                (g1.FStar_TypeChecker_Env.admit);
-                                              FStar_TypeChecker_Env.lax =
                                                 true;
                                               FStar_TypeChecker_Env.lax_universes
                                                 =
@@ -12474,7 +12407,6 @@ let (push_open_namespace :
                FStar_TypeChecker_Env.is_iface =
                  (e.FStar_TypeChecker_Env.is_iface);
                FStar_TypeChecker_Env.admit = (e.FStar_TypeChecker_Env.admit);
-               FStar_TypeChecker_Env.lax = (e.FStar_TypeChecker_Env.lax);
                FStar_TypeChecker_Env.lax_universes =
                  (e.FStar_TypeChecker_Env.lax_universes);
                FStar_TypeChecker_Env.phase1 =
@@ -12600,7 +12532,6 @@ let (push_module_abbrev :
                      (e.FStar_TypeChecker_Env.is_iface);
                    FStar_TypeChecker_Env.admit =
                      (e.FStar_TypeChecker_Env.admit);
-                   FStar_TypeChecker_Env.lax = (e.FStar_TypeChecker_Env.lax);
                    FStar_TypeChecker_Env.lax_universes =
                      (e.FStar_TypeChecker_Env.lax_universes);
                    FStar_TypeChecker_Env.phase1 =
@@ -12760,7 +12691,6 @@ let (tac_env : FStar_TypeChecker_Env.env -> FStar_TypeChecker_Env.env) =
             FStar_TypeChecker_Env.is_iface =
               (env2.FStar_TypeChecker_Env.is_iface);
             FStar_TypeChecker_Env.admit = (env2.FStar_TypeChecker_Env.admit);
-            FStar_TypeChecker_Env.lax = (env2.FStar_TypeChecker_Env.lax);
             FStar_TypeChecker_Env.lax_universes =
               (env2.FStar_TypeChecker_Env.lax_universes);
             FStar_TypeChecker_Env.phase1 =
@@ -12863,7 +12793,6 @@ let (tac_env : FStar_TypeChecker_Env.env -> FStar_TypeChecker_Env.env) =
             FStar_TypeChecker_Env.is_iface =
               (env3.FStar_TypeChecker_Env.is_iface);
             FStar_TypeChecker_Env.admit = (env3.FStar_TypeChecker_Env.admit);
-            FStar_TypeChecker_Env.lax = (env3.FStar_TypeChecker_Env.lax);
             FStar_TypeChecker_Env.lax_universes =
               (env3.FStar_TypeChecker_Env.lax_universes);
             FStar_TypeChecker_Env.phase1 =
@@ -12965,7 +12894,6 @@ let (tac_env : FStar_TypeChecker_Env.env -> FStar_TypeChecker_Env.env) =
             FStar_TypeChecker_Env.is_iface =
               (env4.FStar_TypeChecker_Env.is_iface);
             FStar_TypeChecker_Env.admit = (env4.FStar_TypeChecker_Env.admit);
-            FStar_TypeChecker_Env.lax = (env4.FStar_TypeChecker_Env.lax);
             FStar_TypeChecker_Env.lax_universes =
               (env4.FStar_TypeChecker_Env.lax_universes);
             FStar_TypeChecker_Env.phase1 =
@@ -13111,7 +13039,6 @@ let (proofstate_of_goal_ty :
             FStar_TypeChecker_Env.is_iface =
               (env1.FStar_TypeChecker_Env.is_iface);
             FStar_TypeChecker_Env.admit = (env1.FStar_TypeChecker_Env.admit);
-            FStar_TypeChecker_Env.lax = (env1.FStar_TypeChecker_Env.lax);
             FStar_TypeChecker_Env.lax_universes =
               (env1.FStar_TypeChecker_Env.lax_universes);
             FStar_TypeChecker_Env.phase1 =

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_DeferredImplicits.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_DeferredImplicits.ml
@@ -302,8 +302,6 @@ let solve_goals_with_tac :
                      (env.FStar_TypeChecker_Env.is_iface);
                    FStar_TypeChecker_Env.admit =
                      (env.FStar_TypeChecker_Env.admit);
-                   FStar_TypeChecker_Env.lax =
-                     (env.FStar_TypeChecker_Env.lax);
                    FStar_TypeChecker_Env.lax_universes =
                      (env.FStar_TypeChecker_Env.lax_universes);
                    FStar_TypeChecker_Env.phase1 =
@@ -434,8 +432,6 @@ let (solve_deferred_to_tactic_goals :
                                (env1.FStar_TypeChecker_Env.is_iface);
                              FStar_TypeChecker_Env.admit =
                                (env1.FStar_TypeChecker_Env.admit);
-                             FStar_TypeChecker_Env.lax =
-                               (env1.FStar_TypeChecker_Env.lax);
                              FStar_TypeChecker_Env.lax_universes =
                                (env1.FStar_TypeChecker_Env.lax_universes);
                              FStar_TypeChecker_Env.phase1 =
@@ -542,9 +538,7 @@ let (solve_deferred_to_tactic_goals :
                                (env2.FStar_TypeChecker_Env.use_eq_strict);
                              FStar_TypeChecker_Env.is_iface =
                                (env2.FStar_TypeChecker_Env.is_iface);
-                             FStar_TypeChecker_Env.admit =
-                               (env2.FStar_TypeChecker_Env.admit);
-                             FStar_TypeChecker_Env.lax = true;
+                             FStar_TypeChecker_Env.admit = true;
                              FStar_TypeChecker_Env.lax_universes =
                                (env2.FStar_TypeChecker_Env.lax_universes);
                              FStar_TypeChecker_Env.phase1 =

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Env.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Env.ml
@@ -387,7 +387,6 @@ and env =
   use_eq_strict: Prims.bool ;
   is_iface: Prims.bool ;
   admit: Prims.bool ;
-  lax: Prims.bool ;
   lax_universes: Prims.bool ;
   phase1: Prims.bool ;
   failhard: Prims.bool ;
@@ -605,9 +604,8 @@ let (__proj__Mkenv__item__solver : env -> solver_t) =
     | { solver; range; curmodule; gamma; gamma_sig; gamma_cache; modules;
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
-        admit; lax; lax_universes; phase1; failhard; flychecking;
-        uvar_subtyping; intactics; nocoerce; tc_term;
-        typeof_tot_or_gtot_term; universe_of;
+        admit; lax_universes; phase1; failhard; flychecking; uvar_subtyping;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -621,9 +619,8 @@ let (__proj__Mkenv__item__range : env -> FStar_Compiler_Range_Type.range) =
     | { solver; range; curmodule; gamma; gamma_sig; gamma_cache; modules;
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
-        admit; lax; lax_universes; phase1; failhard; flychecking;
-        uvar_subtyping; intactics; nocoerce; tc_term;
-        typeof_tot_or_gtot_term; universe_of;
+        admit; lax_universes; phase1; failhard; flychecking; uvar_subtyping;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -637,9 +634,8 @@ let (__proj__Mkenv__item__curmodule : env -> FStar_Ident.lident) =
     | { solver; range; curmodule; gamma; gamma_sig; gamma_cache; modules;
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
-        admit; lax; lax_universes; phase1; failhard; flychecking;
-        uvar_subtyping; intactics; nocoerce; tc_term;
-        typeof_tot_or_gtot_term; universe_of;
+        admit; lax_universes; phase1; failhard; flychecking; uvar_subtyping;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -654,9 +650,8 @@ let (__proj__Mkenv__item__gamma :
     | { solver; range; curmodule; gamma; gamma_sig; gamma_cache; modules;
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
-        admit; lax; lax_universes; phase1; failhard; flychecking;
-        uvar_subtyping; intactics; nocoerce; tc_term;
-        typeof_tot_or_gtot_term; universe_of;
+        admit; lax_universes; phase1; failhard; flychecking; uvar_subtyping;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -670,9 +665,8 @@ let (__proj__Mkenv__item__gamma_sig : env -> sig_binding Prims.list) =
     | { solver; range; curmodule; gamma; gamma_sig; gamma_cache; modules;
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
-        admit; lax; lax_universes; phase1; failhard; flychecking;
-        uvar_subtyping; intactics; nocoerce; tc_term;
-        typeof_tot_or_gtot_term; universe_of;
+        admit; lax_universes; phase1; failhard; flychecking; uvar_subtyping;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -687,9 +681,8 @@ let (__proj__Mkenv__item__gamma_cache :
     | { solver; range; curmodule; gamma; gamma_sig; gamma_cache; modules;
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
-        admit; lax; lax_universes; phase1; failhard; flychecking;
-        uvar_subtyping; intactics; nocoerce; tc_term;
-        typeof_tot_or_gtot_term; universe_of;
+        admit; lax_universes; phase1; failhard; flychecking; uvar_subtyping;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -704,9 +697,8 @@ let (__proj__Mkenv__item__modules :
     | { solver; range; curmodule; gamma; gamma_sig; gamma_cache; modules;
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
-        admit; lax; lax_universes; phase1; failhard; flychecking;
-        uvar_subtyping; intactics; nocoerce; tc_term;
-        typeof_tot_or_gtot_term; universe_of;
+        admit; lax_universes; phase1; failhard; flychecking; uvar_subtyping;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -723,9 +715,8 @@ let (__proj__Mkenv__item__expected_typ :
     | { solver; range; curmodule; gamma; gamma_sig; gamma_cache; modules;
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
-        admit; lax; lax_universes; phase1; failhard; flychecking;
-        uvar_subtyping; intactics; nocoerce; tc_term;
-        typeof_tot_or_gtot_term; universe_of;
+        admit; lax_universes; phase1; failhard; flychecking; uvar_subtyping;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -740,9 +731,8 @@ let (__proj__Mkenv__item__sigtab :
     | { solver; range; curmodule; gamma; gamma_sig; gamma_cache; modules;
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
-        admit; lax; lax_universes; phase1; failhard; flychecking;
-        uvar_subtyping; intactics; nocoerce; tc_term;
-        typeof_tot_or_gtot_term; universe_of;
+        admit; lax_universes; phase1; failhard; flychecking; uvar_subtyping;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -757,9 +747,8 @@ let (__proj__Mkenv__item__attrtab :
     | { solver; range; curmodule; gamma; gamma_sig; gamma_cache; modules;
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
-        admit; lax; lax_universes; phase1; failhard; flychecking;
-        uvar_subtyping; intactics; nocoerce; tc_term;
-        typeof_tot_or_gtot_term; universe_of;
+        admit; lax_universes; phase1; failhard; flychecking; uvar_subtyping;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -773,9 +762,8 @@ let (__proj__Mkenv__item__instantiate_imp : env -> Prims.bool) =
     | { solver; range; curmodule; gamma; gamma_sig; gamma_cache; modules;
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
-        admit; lax; lax_universes; phase1; failhard; flychecking;
-        uvar_subtyping; intactics; nocoerce; tc_term;
-        typeof_tot_or_gtot_term; universe_of;
+        admit; lax_universes; phase1; failhard; flychecking; uvar_subtyping;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -789,9 +777,8 @@ let (__proj__Mkenv__item__effects : env -> effects) =
     | { solver; range; curmodule; gamma; gamma_sig; gamma_cache; modules;
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
-        admit; lax; lax_universes; phase1; failhard; flychecking;
-        uvar_subtyping; intactics; nocoerce; tc_term;
-        typeof_tot_or_gtot_term; universe_of;
+        admit; lax_universes; phase1; failhard; flychecking; uvar_subtyping;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -805,9 +792,8 @@ let (__proj__Mkenv__item__generalize : env -> Prims.bool) =
     | { solver; range; curmodule; gamma; gamma_sig; gamma_cache; modules;
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
-        admit; lax; lax_universes; phase1; failhard; flychecking;
-        uvar_subtyping; intactics; nocoerce; tc_term;
-        typeof_tot_or_gtot_term; universe_of;
+        admit; lax_universes; phase1; failhard; flychecking; uvar_subtyping;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -825,9 +811,8 @@ let (__proj__Mkenv__item__letrecs :
     | { solver; range; curmodule; gamma; gamma_sig; gamma_cache; modules;
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
-        admit; lax; lax_universes; phase1; failhard; flychecking;
-        uvar_subtyping; intactics; nocoerce; tc_term;
-        typeof_tot_or_gtot_term; universe_of;
+        admit; lax_universes; phase1; failhard; flychecking; uvar_subtyping;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -841,9 +826,8 @@ let (__proj__Mkenv__item__top_level : env -> Prims.bool) =
     | { solver; range; curmodule; gamma; gamma_sig; gamma_cache; modules;
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
-        admit; lax; lax_universes; phase1; failhard; flychecking;
-        uvar_subtyping; intactics; nocoerce; tc_term;
-        typeof_tot_or_gtot_term; universe_of;
+        admit; lax_universes; phase1; failhard; flychecking; uvar_subtyping;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -857,9 +841,8 @@ let (__proj__Mkenv__item__check_uvars : env -> Prims.bool) =
     | { solver; range; curmodule; gamma; gamma_sig; gamma_cache; modules;
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
-        admit; lax; lax_universes; phase1; failhard; flychecking;
-        uvar_subtyping; intactics; nocoerce; tc_term;
-        typeof_tot_or_gtot_term; universe_of;
+        admit; lax_universes; phase1; failhard; flychecking; uvar_subtyping;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -873,9 +856,8 @@ let (__proj__Mkenv__item__use_eq_strict : env -> Prims.bool) =
     | { solver; range; curmodule; gamma; gamma_sig; gamma_cache; modules;
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
-        admit; lax; lax_universes; phase1; failhard; flychecking;
-        uvar_subtyping; intactics; nocoerce; tc_term;
-        typeof_tot_or_gtot_term; universe_of;
+        admit; lax_universes; phase1; failhard; flychecking; uvar_subtyping;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -889,9 +871,8 @@ let (__proj__Mkenv__item__is_iface : env -> Prims.bool) =
     | { solver; range; curmodule; gamma; gamma_sig; gamma_cache; modules;
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
-        admit; lax; lax_universes; phase1; failhard; flychecking;
-        uvar_subtyping; intactics; nocoerce; tc_term;
-        typeof_tot_or_gtot_term; universe_of;
+        admit; lax_universes; phase1; failhard; flychecking; uvar_subtyping;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -905,9 +886,8 @@ let (__proj__Mkenv__item__admit : env -> Prims.bool) =
     | { solver; range; curmodule; gamma; gamma_sig; gamma_cache; modules;
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
-        admit; lax; lax_universes; phase1; failhard; flychecking;
-        uvar_subtyping; intactics; nocoerce; tc_term;
-        typeof_tot_or_gtot_term; universe_of;
+        admit; lax_universes; phase1; failhard; flychecking; uvar_subtyping;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -915,31 +895,14 @@ let (__proj__Mkenv__item__admit : env -> Prims.bool) =
         dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
         unif_allow_ref_guards; erase_erasable_args; core_check;
         missing_decl;_} -> admit
-let (__proj__Mkenv__item__lax : env -> Prims.bool) =
-  fun projectee ->
-    match projectee with
-    | { solver; range; curmodule; gamma; gamma_sig; gamma_cache; modules;
-        expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
-        generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
-        admit; lax; lax_universes; phase1; failhard; flychecking;
-        uvar_subtyping; intactics; nocoerce; tc_term;
-        typeof_tot_or_gtot_term; universe_of;
-        typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
-        subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
-        fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
-        splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
-        dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
-        unif_allow_ref_guards; erase_erasable_args; core_check;
-        missing_decl;_} -> lax
 let (__proj__Mkenv__item__lax_universes : env -> Prims.bool) =
   fun projectee ->
     match projectee with
     | { solver; range; curmodule; gamma; gamma_sig; gamma_cache; modules;
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
-        admit; lax; lax_universes; phase1; failhard; flychecking;
-        uvar_subtyping; intactics; nocoerce; tc_term;
-        typeof_tot_or_gtot_term; universe_of;
+        admit; lax_universes; phase1; failhard; flychecking; uvar_subtyping;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -953,9 +916,8 @@ let (__proj__Mkenv__item__phase1 : env -> Prims.bool) =
     | { solver; range; curmodule; gamma; gamma_sig; gamma_cache; modules;
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
-        admit; lax; lax_universes; phase1; failhard; flychecking;
-        uvar_subtyping; intactics; nocoerce; tc_term;
-        typeof_tot_or_gtot_term; universe_of;
+        admit; lax_universes; phase1; failhard; flychecking; uvar_subtyping;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -969,9 +931,8 @@ let (__proj__Mkenv__item__failhard : env -> Prims.bool) =
     | { solver; range; curmodule; gamma; gamma_sig; gamma_cache; modules;
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
-        admit; lax; lax_universes; phase1; failhard; flychecking;
-        uvar_subtyping; intactics; nocoerce; tc_term;
-        typeof_tot_or_gtot_term; universe_of;
+        admit; lax_universes; phase1; failhard; flychecking; uvar_subtyping;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -985,9 +946,8 @@ let (__proj__Mkenv__item__flychecking : env -> Prims.bool) =
     | { solver; range; curmodule; gamma; gamma_sig; gamma_cache; modules;
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
-        admit; lax; lax_universes; phase1; failhard; flychecking;
-        uvar_subtyping; intactics; nocoerce; tc_term;
-        typeof_tot_or_gtot_term; universe_of;
+        admit; lax_universes; phase1; failhard; flychecking; uvar_subtyping;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -1001,9 +961,8 @@ let (__proj__Mkenv__item__uvar_subtyping : env -> Prims.bool) =
     | { solver; range; curmodule; gamma; gamma_sig; gamma_cache; modules;
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
-        admit; lax; lax_universes; phase1; failhard; flychecking;
-        uvar_subtyping; intactics; nocoerce; tc_term;
-        typeof_tot_or_gtot_term; universe_of;
+        admit; lax_universes; phase1; failhard; flychecking; uvar_subtyping;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -1017,9 +976,8 @@ let (__proj__Mkenv__item__intactics : env -> Prims.bool) =
     | { solver; range; curmodule; gamma; gamma_sig; gamma_cache; modules;
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
-        admit; lax; lax_universes; phase1; failhard; flychecking;
-        uvar_subtyping; intactics; nocoerce; tc_term;
-        typeof_tot_or_gtot_term; universe_of;
+        admit; lax_universes; phase1; failhard; flychecking; uvar_subtyping;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -1033,9 +991,8 @@ let (__proj__Mkenv__item__nocoerce : env -> Prims.bool) =
     | { solver; range; curmodule; gamma; gamma_sig; gamma_cache; modules;
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
-        admit; lax; lax_universes; phase1; failhard; flychecking;
-        uvar_subtyping; intactics; nocoerce; tc_term;
-        typeof_tot_or_gtot_term; universe_of;
+        admit; lax_universes; phase1; failhard; flychecking; uvar_subtyping;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -1055,9 +1012,8 @@ let (__proj__Mkenv__item__tc_term :
     | { solver; range; curmodule; gamma; gamma_sig; gamma_cache; modules;
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
-        admit; lax; lax_universes; phase1; failhard; flychecking;
-        uvar_subtyping; intactics; nocoerce; tc_term;
-        typeof_tot_or_gtot_term; universe_of;
+        admit; lax_universes; phase1; failhard; flychecking; uvar_subtyping;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -1078,9 +1034,8 @@ let (__proj__Mkenv__item__typeof_tot_or_gtot_term :
     | { solver; range; curmodule; gamma; gamma_sig; gamma_cache; modules;
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
-        admit; lax; lax_universes; phase1; failhard; flychecking;
-        uvar_subtyping; intactics; nocoerce; tc_term;
-        typeof_tot_or_gtot_term; universe_of;
+        admit; lax_universes; phase1; failhard; flychecking; uvar_subtyping;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -1095,9 +1050,8 @@ let (__proj__Mkenv__item__universe_of :
     | { solver; range; curmodule; gamma; gamma_sig; gamma_cache; modules;
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
-        admit; lax; lax_universes; phase1; failhard; flychecking;
-        uvar_subtyping; intactics; nocoerce; tc_term;
-        typeof_tot_or_gtot_term; universe_of;
+        admit; lax_universes; phase1; failhard; flychecking; uvar_subtyping;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -1117,9 +1071,8 @@ let (__proj__Mkenv__item__typeof_well_typed_tot_or_gtot_term :
     | { solver; range; curmodule; gamma; gamma_sig; gamma_cache; modules;
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
-        admit; lax; lax_universes; phase1; failhard; flychecking;
-        uvar_subtyping; intactics; nocoerce; tc_term;
-        typeof_tot_or_gtot_term; universe_of;
+        admit; lax_universes; phase1; failhard; flychecking; uvar_subtyping;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -1136,9 +1089,8 @@ let (__proj__Mkenv__item__teq_nosmt_force :
     | { solver; range; curmodule; gamma; gamma_sig; gamma_cache; modules;
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
-        admit; lax; lax_universes; phase1; failhard; flychecking;
-        uvar_subtyping; intactics; nocoerce; tc_term;
-        typeof_tot_or_gtot_term; universe_of;
+        admit; lax_universes; phase1; failhard; flychecking; uvar_subtyping;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -1155,9 +1107,8 @@ let (__proj__Mkenv__item__subtype_nosmt_force :
     | { solver; range; curmodule; gamma; gamma_sig; gamma_cache; modules;
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
-        admit; lax; lax_universes; phase1; failhard; flychecking;
-        uvar_subtyping; intactics; nocoerce; tc_term;
-        typeof_tot_or_gtot_term; universe_of;
+        admit; lax_universes; phase1; failhard; flychecking; uvar_subtyping;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -1175,9 +1126,8 @@ let (__proj__Mkenv__item__qtbl_name_and_index :
     | { solver; range; curmodule; gamma; gamma_sig; gamma_cache; modules;
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
-        admit; lax; lax_universes; phase1; failhard; flychecking;
-        uvar_subtyping; intactics; nocoerce; tc_term;
-        typeof_tot_or_gtot_term; universe_of;
+        admit; lax_universes; phase1; failhard; flychecking; uvar_subtyping;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -1192,9 +1142,8 @@ let (__proj__Mkenv__item__normalized_eff_names :
     | { solver; range; curmodule; gamma; gamma_sig; gamma_cache; modules;
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
-        admit; lax; lax_universes; phase1; failhard; flychecking;
-        uvar_subtyping; intactics; nocoerce; tc_term;
-        typeof_tot_or_gtot_term; universe_of;
+        admit; lax_universes; phase1; failhard; flychecking; uvar_subtyping;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -1209,9 +1158,8 @@ let (__proj__Mkenv__item__fv_delta_depths :
     | { solver; range; curmodule; gamma; gamma_sig; gamma_cache; modules;
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
-        admit; lax; lax_universes; phase1; failhard; flychecking;
-        uvar_subtyping; intactics; nocoerce; tc_term;
-        typeof_tot_or_gtot_term; universe_of;
+        admit; lax_universes; phase1; failhard; flychecking; uvar_subtyping;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -1225,9 +1173,8 @@ let (__proj__Mkenv__item__proof_ns : env -> proof_namespace) =
     | { solver; range; curmodule; gamma; gamma_sig; gamma_cache; modules;
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
-        admit; lax; lax_universes; phase1; failhard; flychecking;
-        uvar_subtyping; intactics; nocoerce; tc_term;
-        typeof_tot_or_gtot_term; universe_of;
+        admit; lax_universes; phase1; failhard; flychecking; uvar_subtyping;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -1246,9 +1193,8 @@ let (__proj__Mkenv__item__synth_hook :
     | { solver; range; curmodule; gamma; gamma_sig; gamma_cache; modules;
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
-        admit; lax; lax_universes; phase1; failhard; flychecking;
-        uvar_subtyping; intactics; nocoerce; tc_term;
-        typeof_tot_or_gtot_term; universe_of;
+        admit; lax_universes; phase1; failhard; flychecking; uvar_subtyping;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -1266,9 +1212,8 @@ let (__proj__Mkenv__item__try_solve_implicits_hook :
     | { solver; range; curmodule; gamma; gamma_sig; gamma_cache; modules;
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
-        admit; lax; lax_universes; phase1; failhard; flychecking;
-        uvar_subtyping; intactics; nocoerce; tc_term;
-        typeof_tot_or_gtot_term; universe_of;
+        admit; lax_universes; phase1; failhard; flychecking; uvar_subtyping;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -1290,9 +1235,8 @@ let (__proj__Mkenv__item__splice :
     | { solver; range; curmodule; gamma; gamma_sig; gamma_cache; modules;
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
-        admit; lax; lax_universes; phase1; failhard; flychecking;
-        uvar_subtyping; intactics; nocoerce; tc_term;
-        typeof_tot_or_gtot_term; universe_of;
+        admit; lax_universes; phase1; failhard; flychecking; uvar_subtyping;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -1311,9 +1255,8 @@ let (__proj__Mkenv__item__mpreprocess :
     | { solver; range; curmodule; gamma; gamma_sig; gamma_cache; modules;
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
-        admit; lax; lax_universes; phase1; failhard; flychecking;
-        uvar_subtyping; intactics; nocoerce; tc_term;
-        typeof_tot_or_gtot_term; universe_of;
+        admit; lax_universes; phase1; failhard; flychecking; uvar_subtyping;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -1333,9 +1276,8 @@ let (__proj__Mkenv__item__postprocess :
     | { solver; range; curmodule; gamma; gamma_sig; gamma_cache; modules;
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
-        admit; lax; lax_universes; phase1; failhard; flychecking;
-        uvar_subtyping; intactics; nocoerce; tc_term;
-        typeof_tot_or_gtot_term; universe_of;
+        admit; lax_universes; phase1; failhard; flychecking; uvar_subtyping;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -1350,9 +1292,8 @@ let (__proj__Mkenv__item__identifier_info :
     | { solver; range; curmodule; gamma; gamma_sig; gamma_cache; modules;
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
-        admit; lax; lax_universes; phase1; failhard; flychecking;
-        uvar_subtyping; intactics; nocoerce; tc_term;
-        typeof_tot_or_gtot_term; universe_of;
+        admit; lax_universes; phase1; failhard; flychecking; uvar_subtyping;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -1366,9 +1307,8 @@ let (__proj__Mkenv__item__tc_hooks : env -> tcenv_hooks) =
     | { solver; range; curmodule; gamma; gamma_sig; gamma_cache; modules;
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
-        admit; lax; lax_universes; phase1; failhard; flychecking;
-        uvar_subtyping; intactics; nocoerce; tc_term;
-        typeof_tot_or_gtot_term; universe_of;
+        admit; lax_universes; phase1; failhard; flychecking; uvar_subtyping;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -1382,9 +1322,8 @@ let (__proj__Mkenv__item__dsenv : env -> FStar_Syntax_DsEnv.env) =
     | { solver; range; curmodule; gamma; gamma_sig; gamma_cache; modules;
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
-        admit; lax; lax_universes; phase1; failhard; flychecking;
-        uvar_subtyping; intactics; nocoerce; tc_term;
-        typeof_tot_or_gtot_term; universe_of;
+        admit; lax_universes; phase1; failhard; flychecking; uvar_subtyping;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -1402,9 +1341,8 @@ let (__proj__Mkenv__item__nbe :
     | { solver; range; curmodule; gamma; gamma_sig; gamma_cache; modules;
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
-        admit; lax; lax_universes; phase1; failhard; flychecking;
-        uvar_subtyping; intactics; nocoerce; tc_term;
-        typeof_tot_or_gtot_term; universe_of;
+        admit; lax_universes; phase1; failhard; flychecking; uvar_subtyping;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -1422,9 +1360,8 @@ let (__proj__Mkenv__item__strict_args_tab :
     | { solver; range; curmodule; gamma; gamma_sig; gamma_cache; modules;
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
-        admit; lax; lax_universes; phase1; failhard; flychecking;
-        uvar_subtyping; intactics; nocoerce; tc_term;
-        typeof_tot_or_gtot_term; universe_of;
+        admit; lax_universes; phase1; failhard; flychecking; uvar_subtyping;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -1439,9 +1376,8 @@ let (__proj__Mkenv__item__erasable_types_tab :
     | { solver; range; curmodule; gamma; gamma_sig; gamma_cache; modules;
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
-        admit; lax; lax_universes; phase1; failhard; flychecking;
-        uvar_subtyping; intactics; nocoerce; tc_term;
-        typeof_tot_or_gtot_term; universe_of;
+        admit; lax_universes; phase1; failhard; flychecking; uvar_subtyping;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -1455,9 +1391,8 @@ let (__proj__Mkenv__item__enable_defer_to_tac : env -> Prims.bool) =
     | { solver; range; curmodule; gamma; gamma_sig; gamma_cache; modules;
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
-        admit; lax; lax_universes; phase1; failhard; flychecking;
-        uvar_subtyping; intactics; nocoerce; tc_term;
-        typeof_tot_or_gtot_term; universe_of;
+        admit; lax_universes; phase1; failhard; flychecking; uvar_subtyping;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -1471,9 +1406,8 @@ let (__proj__Mkenv__item__unif_allow_ref_guards : env -> Prims.bool) =
     | { solver; range; curmodule; gamma; gamma_sig; gamma_cache; modules;
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
-        admit; lax; lax_universes; phase1; failhard; flychecking;
-        uvar_subtyping; intactics; nocoerce; tc_term;
-        typeof_tot_or_gtot_term; universe_of;
+        admit; lax_universes; phase1; failhard; flychecking; uvar_subtyping;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -1487,9 +1421,8 @@ let (__proj__Mkenv__item__erase_erasable_args : env -> Prims.bool) =
     | { solver; range; curmodule; gamma; gamma_sig; gamma_cache; modules;
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
-        admit; lax; lax_universes; phase1; failhard; flychecking;
-        uvar_subtyping; intactics; nocoerce; tc_term;
-        typeof_tot_or_gtot_term; universe_of;
+        admit; lax_universes; phase1; failhard; flychecking; uvar_subtyping;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -1511,9 +1444,8 @@ let (__proj__Mkenv__item__core_check :
     | { solver; range; curmodule; gamma; gamma_sig; gamma_cache; modules;
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
-        admit; lax; lax_universes; phase1; failhard; flychecking;
-        uvar_subtyping; intactics; nocoerce; tc_term;
-        typeof_tot_or_gtot_term; universe_of;
+        admit; lax_universes; phase1; failhard; flychecking; uvar_subtyping;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -1528,9 +1460,8 @@ let (__proj__Mkenv__item__missing_decl :
     | { solver; range; curmodule; gamma; gamma_sig; gamma_cache; modules;
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
-        admit; lax; lax_universes; phase1; failhard; flychecking;
-        uvar_subtyping; intactics; nocoerce; tc_term;
-        typeof_tot_or_gtot_term; universe_of;
+        admit; lax_universes; phase1; failhard; flychecking; uvar_subtyping;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -1737,7 +1668,6 @@ let (rename_env : FStar_Syntax_Syntax.subst_t -> env -> env) =
         use_eq_strict = (env1.use_eq_strict);
         is_iface = (env1.is_iface);
         admit = (env1.admit);
-        lax = (env1.lax);
         lax_universes = (env1.lax_universes);
         phase1 = (env1.phase1);
         failhard = (env1.failhard);
@@ -1799,7 +1729,6 @@ let (set_tc_hooks : env -> tcenv_hooks -> env) =
         use_eq_strict = (env1.use_eq_strict);
         is_iface = (env1.is_iface);
         admit = (env1.admit);
-        lax = (env1.lax);
         lax_universes = (env1.lax_universes);
         phase1 = (env1.phase1);
         failhard = (env1.failhard);
@@ -1859,7 +1788,6 @@ let (set_dep_graph : env -> FStar_Parser_Dep.deps -> env) =
         use_eq_strict = (e.use_eq_strict);
         is_iface = (e.is_iface);
         admit = (e.admit);
-        lax = (e.lax);
         lax_universes = (e.lax_universes);
         phase1 = (e.phase1);
         failhard = (e.failhard);
@@ -1926,7 +1854,6 @@ let (record_val_for : env -> FStar_Ident.lident -> env) =
         use_eq_strict = (e.use_eq_strict);
         is_iface = (e.is_iface);
         admit = (e.admit);
-        lax = (e.lax);
         lax_universes = (e.lax_universes);
         phase1 = (e.phase1);
         failhard = (e.failhard);
@@ -1991,7 +1918,6 @@ let (record_definition_for : env -> FStar_Ident.lident -> env) =
         use_eq_strict = (e.use_eq_strict);
         is_iface = (e.is_iface);
         admit = (e.admit);
-        lax = (e.lax);
         lax_universes = (e.lax_universes);
         phase1 = (e.phase1);
         failhard = (e.failhard);
@@ -2047,7 +1973,9 @@ type env_t = env
 type sigtable = FStar_Syntax_Syntax.sigelt FStar_Compiler_Util.smap
 let (should_verify : env -> Prims.bool) =
   fun env1 ->
-    ((Prims.op_Negation env1.lax) && (Prims.op_Negation env1.admit)) &&
+    ((let uu___ = FStar_Options.lax () in Prims.op_Negation uu___) &&
+       (Prims.op_Negation env1.admit))
+      &&
       (let uu___ = FStar_Ident.string_of_lid env1.curmodule in
        FStar_Options.should_verify uu___)
 let (visible_at : delta_level -> FStar_Syntax_Syntax.qualifier -> Prims.bool)
@@ -2167,7 +2095,6 @@ let (initial_env :
                           use_eq_strict = false;
                           is_iface = false;
                           admit = false;
-                          lax = false;
                           lax_universes = false;
                           phase1 = false;
                           failhard = false;
@@ -2339,7 +2266,6 @@ let (push_stack : env -> env) =
        use_eq_strict = (env1.use_eq_strict);
        is_iface = (env1.is_iface);
        admit = (env1.admit);
-       lax = (env1.lax);
        lax_universes = (env1.lax_universes);
        phase1 = (env1.phase1);
        failhard = (env1.failhard);
@@ -2424,7 +2350,6 @@ let (snapshot : env -> Prims.string -> (tcenv_depth_t * env)) =
                                   use_eq_strict = (env2.use_eq_strict);
                                   is_iface = (env2.is_iface);
                                   admit = (env2.admit);
-                                  lax = (env2.lax);
                                   lax_universes = (env2.lax_universes);
                                   phase1 = (env2.phase1);
                                   failhard = (env2.failhard);
@@ -2552,7 +2477,6 @@ let (incr_query_index : env -> env) =
                 use_eq_strict = (env1.use_eq_strict);
                 is_iface = (env1.is_iface);
                 admit = (env1.admit);
-                lax = (env1.lax);
                 lax_universes = (env1.lax_universes);
                 phase1 = (env1.phase1);
                 failhard = (env1.failhard);
@@ -2614,7 +2538,6 @@ let (incr_query_index : env -> env) =
                 use_eq_strict = (env1.use_eq_strict);
                 is_iface = (env1.is_iface);
                 admit = (env1.admit);
-                lax = (env1.lax);
                 lax_universes = (env1.lax_universes);
                 phase1 = (env1.phase1);
                 failhard = (env1.failhard);
@@ -2677,7 +2600,6 @@ let (set_range : env -> FStar_Compiler_Range_Type.range -> env) =
           use_eq_strict = (e.use_eq_strict);
           is_iface = (e.is_iface);
           admit = (e.admit);
-          lax = (e.lax);
           lax_universes = (e.lax_universes);
           phase1 = (e.phase1);
           failhard = (e.failhard);
@@ -2777,7 +2699,6 @@ let (set_current_module : env -> FStar_Ident.lident -> env) =
         use_eq_strict = (env1.use_eq_strict);
         is_iface = (env1.is_iface);
         admit = (env1.admit);
-        lax = (env1.lax);
         lax_universes = (env1.lax_universes);
         phase1 = (env1.phase1);
         failhard = (env1.failhard);
@@ -5441,7 +5362,6 @@ let (push_sigelt' : Prims.bool -> env -> FStar_Syntax_Syntax.sigelt -> env) =
             use_eq_strict = (env1.use_eq_strict);
             is_iface = (env1.is_iface);
             admit = (env1.admit);
-            lax = (env1.lax);
             lax_universes = (env1.lax_universes);
             phase1 = (env1.phase1);
             failhard = (env1.failhard);
@@ -5523,7 +5443,6 @@ let (push_new_effect :
             use_eq_strict = (env1.use_eq_strict);
             is_iface = (env1.is_iface);
             admit = (env1.admit);
-            lax = (env1.lax);
             lax_universes = (env1.lax_universes);
             phase1 = (env1.phase1);
             failhard = (env1.failhard);
@@ -5948,7 +5867,6 @@ let (update_effect_lattice :
              use_eq_strict = (env1.use_eq_strict);
              is_iface = (env1.is_iface);
              admit = (env1.admit);
-             lax = (env1.lax);
              lax_universes = (env1.lax_universes);
              phase1 = (env1.phase1);
              failhard = (env1.failhard);
@@ -6023,7 +5941,6 @@ let (add_polymonadic_bind :
               use_eq_strict = (env1.use_eq_strict);
               is_iface = (env1.is_iface);
               admit = (env1.admit);
-              lax = (env1.lax);
               lax_universes = (env1.lax_universes);
               phase1 = (env1.phase1);
               failhard = (env1.failhard);
@@ -6101,7 +6018,6 @@ let (add_polymonadic_subcomp :
                 use_eq_strict = (env1.use_eq_strict);
                 is_iface = (env1.is_iface);
                 admit = (env1.admit);
-                lax = (env1.lax);
                 lax_universes = (env1.lax_universes);
                 phase1 = (env1.phase1);
                 failhard = (env1.failhard);
@@ -6160,7 +6076,6 @@ let (push_local_binding : env -> FStar_Syntax_Syntax.binding -> env) =
         use_eq_strict = (env1.use_eq_strict);
         is_iface = (env1.is_iface);
         admit = (env1.admit);
-        lax = (env1.lax);
         lax_universes = (env1.lax_universes);
         phase1 = (env1.phase1);
         failhard = (env1.failhard);
@@ -6231,7 +6146,6 @@ let (pop_bv :
               use_eq_strict = (env1.use_eq_strict);
               is_iface = (env1.is_iface);
               admit = (env1.admit);
-              lax = (env1.lax);
               lax_universes = (env1.lax_universes);
               phase1 = (env1.phase1);
               failhard = (env1.failhard);
@@ -6346,7 +6260,6 @@ let (set_expected_typ : env -> FStar_Syntax_Syntax.typ -> env) =
         use_eq_strict = (env1.use_eq_strict);
         is_iface = (env1.is_iface);
         admit = (env1.admit);
-        lax = (env1.lax);
         lax_universes = (env1.lax_universes);
         phase1 = (env1.phase1);
         failhard = (env1.failhard);
@@ -6407,7 +6320,6 @@ let (set_expected_typ_maybe_eq :
           use_eq_strict = (env1.use_eq_strict);
           is_iface = (env1.is_iface);
           admit = (env1.admit);
-          lax = (env1.lax);
           lax_universes = (env1.lax_universes);
           phase1 = (env1.phase1);
           failhard = (env1.failhard);
@@ -6478,7 +6390,6 @@ let (clear_expected_typ :
        use_eq_strict = (env_.use_eq_strict);
        is_iface = (env_.is_iface);
        admit = (env_.admit);
-       lax = (env_.lax);
        lax_universes = (env_.lax_universes);
        phase1 = (env_.phase1);
        failhard = (env_.failhard);
@@ -6551,7 +6462,6 @@ let (finish_module : env -> FStar_Syntax_Syntax.modul -> env) =
         use_eq_strict = (env1.use_eq_strict);
         is_iface = (env1.is_iface);
         admit = (env1.admit);
-        lax = (env1.lax);
         lax_universes = (env1.lax_universes);
         phase1 = (env1.phase1);
         failhard = (env1.failhard);
@@ -6764,7 +6674,6 @@ let (cons_proof_ns : Prims.bool -> env -> name_prefix -> env) =
           use_eq_strict = (e.use_eq_strict);
           is_iface = (e.is_iface);
           admit = (e.admit);
-          lax = (e.lax);
           lax_universes = (e.lax_universes);
           phase1 = (e.phase1);
           failhard = (e.failhard);
@@ -6828,7 +6737,6 @@ let (set_proof_ns : proof_namespace -> env -> env) =
         use_eq_strict = (e.use_eq_strict);
         is_iface = (e.is_iface);
         admit = (e.admit);
-        lax = (e.lax);
         lax_universes = (e.lax_universes);
         phase1 = (e.phase1);
         failhard = (e.failhard);

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Normalize.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Normalize.ml
@@ -8770,9 +8770,7 @@ let (eta_expand :
                                     (env1.FStar_TypeChecker_Env.use_eq_strict);
                                   FStar_TypeChecker_Env.is_iface =
                                     (env1.FStar_TypeChecker_Env.is_iface);
-                                  FStar_TypeChecker_Env.admit =
-                                    (env1.FStar_TypeChecker_Env.admit);
-                                  FStar_TypeChecker_Env.lax = true;
+                                  FStar_TypeChecker_Env.admit = true;
                                   FStar_TypeChecker_Env.lax_universes =
                                     (env1.FStar_TypeChecker_Env.lax_universes);
                                   FStar_TypeChecker_Env.phase1 =
@@ -8888,9 +8886,7 @@ let (eta_expand :
                             (env1.FStar_TypeChecker_Env.use_eq_strict);
                           FStar_TypeChecker_Env.is_iface =
                             (env1.FStar_TypeChecker_Env.is_iface);
-                          FStar_TypeChecker_Env.admit =
-                            (env1.FStar_TypeChecker_Env.admit);
-                          FStar_TypeChecker_Env.lax = true;
+                          FStar_TypeChecker_Env.admit = true;
                           FStar_TypeChecker_Env.lax_universes =
                             (env1.FStar_TypeChecker_Env.lax_universes);
                           FStar_TypeChecker_Env.phase1 =

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Rel.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Rel.ml
@@ -431,7 +431,6 @@ let (copy_uvar :
                 (uu___.FStar_TypeChecker_Env.is_iface);
               FStar_TypeChecker_Env.admit =
                 (uu___.FStar_TypeChecker_Env.admit);
-              FStar_TypeChecker_Env.lax = (uu___.FStar_TypeChecker_Env.lax);
               FStar_TypeChecker_Env.lax_universes =
                 (uu___.FStar_TypeChecker_Env.lax_universes);
               FStar_TypeChecker_Env.phase1 =
@@ -767,7 +766,6 @@ let (p_env :
         FStar_TypeChecker_Env.is_iface =
           (uu___.FStar_TypeChecker_Env.is_iface);
         FStar_TypeChecker_Env.admit = (uu___.FStar_TypeChecker_Env.admit);
-        FStar_TypeChecker_Env.lax = (uu___.FStar_TypeChecker_Env.lax);
         FStar_TypeChecker_Env.lax_universes =
           (uu___.FStar_TypeChecker_Env.lax_universes);
         FStar_TypeChecker_Env.phase1 = (uu___.FStar_TypeChecker_Env.phase1);
@@ -871,7 +869,6 @@ let (p_guard_env :
         FStar_TypeChecker_Env.is_iface =
           (uu___.FStar_TypeChecker_Env.is_iface);
         FStar_TypeChecker_Env.admit = (uu___.FStar_TypeChecker_Env.admit);
-        FStar_TypeChecker_Env.lax = (uu___.FStar_TypeChecker_Env.lax);
         FStar_TypeChecker_Env.lax_universes =
           (uu___.FStar_TypeChecker_Env.lax_universes);
         FStar_TypeChecker_Env.phase1 = (uu___.FStar_TypeChecker_Env.phase1);
@@ -4396,7 +4393,6 @@ let (run_meta_arg_tac :
               FStar_TypeChecker_Env.is_iface =
                 (env.FStar_TypeChecker_Env.is_iface);
               FStar_TypeChecker_Env.admit = (env.FStar_TypeChecker_Env.admit);
-              FStar_TypeChecker_Env.lax = (env.FStar_TypeChecker_Env.lax);
               FStar_TypeChecker_Env.lax_universes =
                 (env.FStar_TypeChecker_Env.lax_universes);
               FStar_TypeChecker_Env.phase1 =
@@ -7076,9 +7072,7 @@ and (solve_t_flex_rigid_eq :
                                         (env1.FStar_TypeChecker_Env.use_eq_strict);
                                       FStar_TypeChecker_Env.is_iface =
                                         (env1.FStar_TypeChecker_Env.is_iface);
-                                      FStar_TypeChecker_Env.admit =
-                                        (env1.FStar_TypeChecker_Env.admit);
-                                      FStar_TypeChecker_Env.lax = true;
+                                      FStar_TypeChecker_Env.admit = true;
                                       FStar_TypeChecker_Env.lax_universes =
                                         (env1.FStar_TypeChecker_Env.lax_universes);
                                       FStar_TypeChecker_Env.phase1 =
@@ -7413,10 +7407,7 @@ and (solve_t_flex_rigid_eq :
                                                     =
                                                     (env.FStar_TypeChecker_Env.is_iface);
                                                   FStar_TypeChecker_Env.admit
-                                                    =
-                                                    (env.FStar_TypeChecker_Env.admit);
-                                                  FStar_TypeChecker_Env.lax =
-                                                    true;
+                                                    = true;
                                                   FStar_TypeChecker_Env.lax_universes
                                                     =
                                                     (env.FStar_TypeChecker_Env.lax_universes);
@@ -13393,18 +13384,19 @@ and (solve_c :
                               let uu___8 = attempt [prob] wl2 in solve uu___8)
                        else
                          (let g =
-                            if env.FStar_TypeChecker_Env.lax
+                            let uu___8 = FStar_Options.lax () in
+                            if uu___8
                             then FStar_Syntax_Util.t_true
                             else
                               (let wpc1_2 =
-                                 let uu___9 = lift_c1 () in
+                                 let uu___10 = lift_c1 () in
                                  FStar_Compiler_List.hd
-                                   uu___9.FStar_Syntax_Syntax.effect_args in
+                                   uu___10.FStar_Syntax_Syntax.effect_args in
                                if is_null_wp_2
                                then
-                                 ((let uu___10 =
+                                 ((let uu___11 =
                                      FStar_Compiler_Effect.op_Bang dbg_Rel in
-                                   if uu___10
+                                   if uu___11
                                    then
                                      FStar_Compiler_Util.print_string
                                        "Using trivial wp ... \n"
@@ -13413,59 +13405,59 @@ and (solve_c :
                                      env.FStar_TypeChecker_Env.universe_of
                                        env c11.FStar_Syntax_Syntax.result_typ in
                                    let trivial =
-                                     let uu___10 =
+                                     let uu___11 =
                                        FStar_Syntax_Util.get_wp_trivial_combinator
                                          c2_decl in
-                                     match uu___10 with
+                                     match uu___11 with
                                      | FStar_Pervasives_Native.None ->
                                          FStar_Compiler_Effect.failwith
                                            "Rel doesn't yet handle undefined trivial combinator in an effect"
                                      | FStar_Pervasives_Native.Some t -> t in
-                                   let uu___10 =
-                                     let uu___11 =
-                                       let uu___12 =
+                                   let uu___11 =
+                                     let uu___12 =
+                                       let uu___13 =
                                          FStar_TypeChecker_Env.inst_effect_fun_with
                                            [c1_univ] env c2_decl trivial in
-                                       let uu___13 =
-                                         let uu___14 =
+                                       let uu___14 =
+                                         let uu___15 =
                                            FStar_Syntax_Syntax.as_arg
                                              c11.FStar_Syntax_Syntax.result_typ in
-                                         [uu___14; wpc1_2] in
+                                         [uu___15; wpc1_2] in
                                        {
-                                         FStar_Syntax_Syntax.hd = uu___12;
-                                         FStar_Syntax_Syntax.args = uu___13
+                                         FStar_Syntax_Syntax.hd = uu___13;
+                                         FStar_Syntax_Syntax.args = uu___14
                                        } in
-                                     FStar_Syntax_Syntax.Tm_app uu___11 in
-                                   FStar_Syntax_Syntax.mk uu___10 r))
+                                     FStar_Syntax_Syntax.Tm_app uu___12 in
+                                   FStar_Syntax_Syntax.mk uu___11 r))
                                else
                                  (let c2_univ =
                                     env.FStar_TypeChecker_Env.universe_of env
                                       c21.FStar_Syntax_Syntax.result_typ in
                                   let stronger =
-                                    let uu___10 =
+                                    let uu___11 =
                                       FStar_Syntax_Util.get_stronger_vc_combinator
                                         c2_decl in
-                                    FStar_Pervasives_Native.fst uu___10 in
-                                  let uu___10 =
-                                    let uu___11 =
-                                      let uu___12 =
+                                    FStar_Pervasives_Native.fst uu___11 in
+                                  let uu___11 =
+                                    let uu___12 =
+                                      let uu___13 =
                                         FStar_TypeChecker_Env.inst_effect_fun_with
                                           [c2_univ] env c2_decl stronger in
-                                      let uu___13 =
-                                        let uu___14 =
+                                      let uu___14 =
+                                        let uu___15 =
                                           FStar_Syntax_Syntax.as_arg
                                             c21.FStar_Syntax_Syntax.result_typ in
-                                        let uu___15 =
-                                          let uu___16 =
+                                        let uu___16 =
+                                          let uu___17 =
                                             FStar_Syntax_Syntax.as_arg wpc2 in
-                                          [uu___16; wpc1_2] in
-                                        uu___14 :: uu___15 in
+                                          [uu___17; wpc1_2] in
+                                        uu___15 :: uu___16 in
                                       {
-                                        FStar_Syntax_Syntax.hd = uu___12;
-                                        FStar_Syntax_Syntax.args = uu___13
+                                        FStar_Syntax_Syntax.hd = uu___13;
+                                        FStar_Syntax_Syntax.args = uu___14
                                       } in
-                                    FStar_Syntax_Syntax.Tm_app uu___11 in
-                                  FStar_Syntax_Syntax.mk uu___10 r)) in
+                                    FStar_Syntax_Syntax.Tm_app uu___12 in
+                                  FStar_Syntax_Syntax.mk uu___11 r)) in
                           (let uu___9 = FStar_Compiler_Effect.op_Bang dbg_Rel in
                            if uu___9
                            then
@@ -14899,20 +14891,29 @@ let (discharge_guard' :
                FStar_TypeChecker_Common.implicits =
                  (g1.FStar_TypeChecker_Common.implicits)
              } in
-           let uu___1 =
-             let uu___2 = FStar_TypeChecker_Env.should_verify env in
-             Prims.op_Negation uu___2 in
-           if uu___1
+           if env.FStar_TypeChecker_Env.admit
            then
              (if
-                debug && (Prims.op_Negation env.FStar_TypeChecker_Env.phase1)
+                (debug &&
+                   (Prims.op_Negation
+                      (FStar_TypeChecker_Common.uu___is_Trivial
+                         g1.FStar_TypeChecker_Common.guard_f)))
+                  && (Prims.op_Negation env.FStar_TypeChecker_Env.phase1)
               then
-                (let uu___3 =
-                   let uu___4 =
+                (let uu___2 =
+                   let uu___3 =
                      FStar_Errors_Msg.text
-                       "Skipping VC because verification is disabled" in
-                   [uu___4] in
-                 diag_doc uu___3)
+                       "Skipping VC because verification is disabled." in
+                   let uu___4 =
+                     let uu___5 =
+                       let uu___6 = FStar_Errors_Msg.text "VC =" in
+                       let uu___7 =
+                         FStar_Class_PP.pp FStar_TypeChecker_Env.pretty_guard
+                           g1 in
+                       FStar_Pprint.op_Hat_Slash_Hat uu___6 uu___7 in
+                     [uu___5] in
+                   uu___3 :: uu___4 in
+                 diag_doc uu___2)
               else ();
               FStar_Pervasives_Native.Some ret_g)
            else
@@ -14924,16 +14925,16 @@ let (discharge_guard' :
                   Prims.op_Negation use_smt ->
                   (if debug
                    then
-                     (let uu___4 =
-                        let uu___5 =
-                          let uu___6 =
+                     (let uu___3 =
+                        let uu___4 =
+                          let uu___5 =
                             FStar_Errors_Msg.text "Cannot solve without SMT:" in
-                          let uu___7 =
+                          let uu___6 =
                             FStar_Class_PP.pp FStar_Syntax_Print.pretty_term
                               vc in
-                          FStar_Pprint.op_Hat_Slash_Hat uu___6 uu___7 in
-                        [uu___5] in
-                      diag_doc uu___4)
+                          FStar_Pprint.op_Hat_Slash_Hat uu___5 uu___6 in
+                        [uu___4] in
+                      diag_doc uu___3)
                    else ();
                    FStar_Pervasives_Native.None)
               | FStar_TypeChecker_Common.NonTrivial vc ->
@@ -15308,8 +15309,6 @@ let (check_implicit_solution_and_discharge_guard :
                           (env.FStar_TypeChecker_Env.is_iface);
                         FStar_TypeChecker_Env.admit =
                           (env.FStar_TypeChecker_Env.admit);
-                        FStar_TypeChecker_Env.lax =
-                          (env.FStar_TypeChecker_Env.lax);
                         FStar_TypeChecker_Env.lax_universes =
                           (env.FStar_TypeChecker_Env.lax_universes);
                         FStar_TypeChecker_Env.phase1 =
@@ -15384,7 +15383,7 @@ let (check_implicit_solution_and_discharge_guard :
                     (fun uu___2 ->
                        let skip_core =
                          ((env1.FStar_TypeChecker_Env.phase1 ||
-                             env1.FStar_TypeChecker_Env.lax)
+                             env1.FStar_TypeChecker_Env.admit)
                             ||
                             (FStar_Syntax_Syntax.uu___is_Allow_untyped
                                uvar_should_check))
@@ -15394,7 +15393,7 @@ let (check_implicit_solution_and_discharge_guard :
                        let must_tot =
                          Prims.op_Negation
                            ((env1.FStar_TypeChecker_Env.phase1 ||
-                               env1.FStar_TypeChecker_Env.lax)
+                               env1.FStar_TypeChecker_Env.admit)
                               ||
                               (FStar_Syntax_Syntax.uu___is_Allow_ghost
                                  uvar_should_check)) in
@@ -15824,8 +15823,6 @@ let (resolve_implicits' :
                                                (env.FStar_TypeChecker_Env.is_iface);
                                              FStar_TypeChecker_Env.admit =
                                                (env.FStar_TypeChecker_Env.admit);
-                                             FStar_TypeChecker_Env.lax =
-                                               (env.FStar_TypeChecker_Env.lax);
                                              FStar_TypeChecker_Env.lax_universes
                                                =
                                                (env.FStar_TypeChecker_Env.lax_universes);
@@ -16071,8 +16068,6 @@ let (resolve_implicits' :
                                                (env.FStar_TypeChecker_Env.is_iface);
                                              FStar_TypeChecker_Env.admit =
                                                (env.FStar_TypeChecker_Env.admit);
-                                             FStar_TypeChecker_Env.lax =
-                                               (env.FStar_TypeChecker_Env.lax);
                                              FStar_TypeChecker_Env.lax_universes
                                                =
                                                (env.FStar_TypeChecker_Env.lax_universes);

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Tc.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Tc.ml
@@ -105,7 +105,6 @@ let (set_hint_correlator :
             FStar_TypeChecker_Env.is_iface =
               (env.FStar_TypeChecker_Env.is_iface);
             FStar_TypeChecker_Env.admit = (env.FStar_TypeChecker_Env.admit);
-            FStar_TypeChecker_Env.lax = (env.FStar_TypeChecker_Env.lax);
             FStar_TypeChecker_Env.lax_universes =
               (env.FStar_TypeChecker_Env.lax_universes);
             FStar_TypeChecker_Env.phase1 = (env.FStar_TypeChecker_Env.phase1);
@@ -218,7 +217,6 @@ let (set_hint_correlator :
             FStar_TypeChecker_Env.is_iface =
               (env.FStar_TypeChecker_Env.is_iface);
             FStar_TypeChecker_Env.admit = (env.FStar_TypeChecker_Env.admit);
-            FStar_TypeChecker_Env.lax = (env.FStar_TypeChecker_Env.lax);
             FStar_TypeChecker_Env.lax_universes =
               (env.FStar_TypeChecker_Env.lax_universes);
             FStar_TypeChecker_Env.phase1 = (env.FStar_TypeChecker_Env.phase1);
@@ -676,8 +674,8 @@ let (tc_decls_knot :
        (FStar_Syntax_Syntax.sigelt Prims.list * FStar_TypeChecker_Env.env))
     FStar_Pervasives_Native.option FStar_Compiler_Effect.ref)
   = FStar_Compiler_Util.mk_ref FStar_Pervasives_Native.None
-let (do_two_phases : FStar_TypeChecker_Env.env -> Prims.bool) =
-  fun env -> FStar_TypeChecker_Env.should_verify env
+let do_two_phases : 'uuuuu . 'uuuuu -> Prims.bool =
+  fun env -> let uu___ = FStar_Options.lax () in Prims.op_Negation uu___
 let run_phase1 : 'a . (unit -> 'a) -> 'a =
   fun f ->
     FStar_TypeChecker_Core.clear_memo_table ();
@@ -1081,8 +1079,6 @@ let (tc_sig_let :
                             (env1.FStar_TypeChecker_Env.is_iface);
                           FStar_TypeChecker_Env.admit =
                             (env1.FStar_TypeChecker_Env.admit);
-                          FStar_TypeChecker_Env.lax =
-                            (env1.FStar_TypeChecker_Env.lax);
                           FStar_TypeChecker_Env.lax_universes =
                             (env1.FStar_TypeChecker_Env.lax_universes);
                           FStar_TypeChecker_Env.phase1 =
@@ -1300,8 +1296,7 @@ let (tc_sig_let :
                                             FStar_TypeChecker_Env.is_iface =
                                               (env'.FStar_TypeChecker_Env.is_iface);
                                             FStar_TypeChecker_Env.admit =
-                                              (env'.FStar_TypeChecker_Env.admit);
-                                            FStar_TypeChecker_Env.lax = true;
+                                              true;
                                             FStar_TypeChecker_Env.lax_universes
                                               =
                                               (env'.FStar_TypeChecker_Env.lax_universes);
@@ -1573,8 +1568,6 @@ let (tc_sig_let :
                                           (env'1.FStar_TypeChecker_Env.is_iface);
                                         FStar_TypeChecker_Env.admit =
                                           (env'1.FStar_TypeChecker_Env.admit);
-                                        FStar_TypeChecker_Env.lax =
-                                          (env'1.FStar_TypeChecker_Env.lax);
                                         FStar_TypeChecker_Env.lax_universes =
                                           (env'1.FStar_TypeChecker_Env.lax_universes);
                                         FStar_TypeChecker_Env.phase1 =
@@ -1779,8 +1772,6 @@ let (tc_sig_let :
                                            (env'1.FStar_TypeChecker_Env.is_iface);
                                          FStar_TypeChecker_Env.admit =
                                            (env'1.FStar_TypeChecker_Env.admit);
-                                         FStar_TypeChecker_Env.lax =
-                                           (env'1.FStar_TypeChecker_Env.lax);
                                          FStar_TypeChecker_Env.lax_universes
                                            =
                                            (env'1.FStar_TypeChecker_Env.lax_universes);
@@ -2027,11 +2018,7 @@ let (tc_decl' :
                { FStar_Syntax_Syntax.errs = uu___2;
                  FStar_Syntax_Syntax.fail_in_lax = false;
                  FStar_Syntax_Syntax.ses1 = uu___3;_}
-               when
-               (let uu___4 = FStar_TypeChecker_Env.should_verify env in
-                Prims.op_Negation uu___4) ||
-                 (FStar_Options.admit_smt_queries ())
-               ->
+               when env.FStar_TypeChecker_Env.admit ->
                ((let uu___5 = FStar_Compiler_Debug.any () in
                  if uu___5
                  then
@@ -2086,9 +2073,7 @@ let (tc_decl' :
                        (env.FStar_TypeChecker_Env.use_eq_strict);
                      FStar_TypeChecker_Env.is_iface =
                        (env.FStar_TypeChecker_Env.is_iface);
-                     FStar_TypeChecker_Env.admit =
-                       (env.FStar_TypeChecker_Env.admit);
-                     FStar_TypeChecker_Env.lax = true;
+                     FStar_TypeChecker_Env.admit = true;
                      FStar_TypeChecker_Env.lax_universes =
                        (env.FStar_TypeChecker_Env.lax_universes);
                      FStar_TypeChecker_Env.phase1 =
@@ -2301,9 +2286,7 @@ let (tc_decl' :
                                       (env1.FStar_TypeChecker_Env.use_eq_strict);
                                     FStar_TypeChecker_Env.is_iface =
                                       (env1.FStar_TypeChecker_Env.is_iface);
-                                    FStar_TypeChecker_Env.admit =
-                                      (env1.FStar_TypeChecker_Env.admit);
-                                    FStar_TypeChecker_Env.lax = true;
+                                    FStar_TypeChecker_Env.admit = true;
                                     FStar_TypeChecker_Env.lax_universes =
                                       (env1.FStar_TypeChecker_Env.lax_universes);
                                     FStar_TypeChecker_Env.phase1 = true;
@@ -2591,9 +2574,7 @@ let (tc_decl' :
                                          (env.FStar_TypeChecker_Env.use_eq_strict);
                                        FStar_TypeChecker_Env.is_iface =
                                          (env.FStar_TypeChecker_Env.is_iface);
-                                       FStar_TypeChecker_Env.admit =
-                                         (env.FStar_TypeChecker_Env.admit);
-                                       FStar_TypeChecker_Env.lax = true;
+                                       FStar_TypeChecker_Env.admit = true;
                                        FStar_TypeChecker_Env.lax_universes =
                                          (env.FStar_TypeChecker_Env.lax_universes);
                                        FStar_TypeChecker_Env.phase1 = true;
@@ -2820,9 +2801,7 @@ let (tc_decl' :
                                     (env.FStar_TypeChecker_Env.use_eq_strict);
                                   FStar_TypeChecker_Env.is_iface =
                                     (env.FStar_TypeChecker_Env.is_iface);
-                                  FStar_TypeChecker_Env.admit =
-                                    (env.FStar_TypeChecker_Env.admit);
-                                  FStar_TypeChecker_Env.lax = true;
+                                  FStar_TypeChecker_Env.admit = true;
                                   FStar_TypeChecker_Env.lax_universes =
                                     (env.FStar_TypeChecker_Env.lax_universes);
                                   FStar_TypeChecker_Env.phase1 = true;
@@ -3052,9 +3031,7 @@ let (tc_decl' :
                                   (env1.FStar_TypeChecker_Env.use_eq_strict);
                                 FStar_TypeChecker_Env.is_iface =
                                   (env1.FStar_TypeChecker_Env.is_iface);
-                                FStar_TypeChecker_Env.admit =
-                                  (env1.FStar_TypeChecker_Env.admit);
-                                FStar_TypeChecker_Env.lax = true;
+                                FStar_TypeChecker_Env.admit = true;
                                 FStar_TypeChecker_Env.lax_universes =
                                   (env1.FStar_TypeChecker_Env.lax_universes);
                                 FStar_TypeChecker_Env.phase1 = true;
@@ -3238,9 +3215,7 @@ let (tc_decl' :
                                   (env1.FStar_TypeChecker_Env.use_eq_strict);
                                 FStar_TypeChecker_Env.is_iface =
                                   (env1.FStar_TypeChecker_Env.is_iface);
-                                FStar_TypeChecker_Env.admit =
-                                  (env1.FStar_TypeChecker_Env.admit);
-                                FStar_TypeChecker_Env.lax = true;
+                                FStar_TypeChecker_Env.admit = true;
                                 FStar_TypeChecker_Env.lax_universes =
                                   (env1.FStar_TypeChecker_Env.lax_universes);
                                 FStar_TypeChecker_Env.phase1 = true;
@@ -3515,8 +3490,6 @@ let (tc_decl' :
                        (env.FStar_TypeChecker_Env.is_iface);
                      FStar_TypeChecker_Env.admit =
                        (env.FStar_TypeChecker_Env.admit);
-                     FStar_TypeChecker_Env.lax =
-                       (env.FStar_TypeChecker_Env.lax);
                      FStar_TypeChecker_Env.lax_universes =
                        (env.FStar_TypeChecker_Env.lax_universes);
                      FStar_TypeChecker_Env.phase1 =
@@ -3663,9 +3636,7 @@ let (tc_decl' :
                                       (env.FStar_TypeChecker_Env.use_eq_strict);
                                     FStar_TypeChecker_Env.is_iface =
                                       (env.FStar_TypeChecker_Env.is_iface);
-                                    FStar_TypeChecker_Env.admit =
-                                      (env.FStar_TypeChecker_Env.admit);
-                                    FStar_TypeChecker_Env.lax = true;
+                                    FStar_TypeChecker_Env.admit = true;
                                     FStar_TypeChecker_Env.lax_universes =
                                       (env.FStar_TypeChecker_Env.lax_universes);
                                     FStar_TypeChecker_Env.phase1 = true;
@@ -3910,9 +3881,7 @@ let (tc_decl' :
                                       (env.FStar_TypeChecker_Env.use_eq_strict);
                                     FStar_TypeChecker_Env.is_iface =
                                       (env.FStar_TypeChecker_Env.is_iface);
-                                    FStar_TypeChecker_Env.admit =
-                                      (env.FStar_TypeChecker_Env.admit);
-                                    FStar_TypeChecker_Env.lax = true;
+                                    FStar_TypeChecker_Env.admit = true;
                                     FStar_TypeChecker_Env.lax_universes =
                                       (env.FStar_TypeChecker_Env.lax_universes);
                                     FStar_TypeChecker_Env.phase1 = true;
@@ -4107,7 +4076,114 @@ let (tc_decl :
   =
   fun env ->
     fun se ->
+      let env0 = env in
       let env1 = set_hint_correlator env se in
+      let env2 =
+        let uu___ = FStar_Options.admit_smt_queries () in
+        if uu___
+        then
+          {
+            FStar_TypeChecker_Env.solver =
+              (env1.FStar_TypeChecker_Env.solver);
+            FStar_TypeChecker_Env.range = (env1.FStar_TypeChecker_Env.range);
+            FStar_TypeChecker_Env.curmodule =
+              (env1.FStar_TypeChecker_Env.curmodule);
+            FStar_TypeChecker_Env.gamma = (env1.FStar_TypeChecker_Env.gamma);
+            FStar_TypeChecker_Env.gamma_sig =
+              (env1.FStar_TypeChecker_Env.gamma_sig);
+            FStar_TypeChecker_Env.gamma_cache =
+              (env1.FStar_TypeChecker_Env.gamma_cache);
+            FStar_TypeChecker_Env.modules =
+              (env1.FStar_TypeChecker_Env.modules);
+            FStar_TypeChecker_Env.expected_typ =
+              (env1.FStar_TypeChecker_Env.expected_typ);
+            FStar_TypeChecker_Env.sigtab =
+              (env1.FStar_TypeChecker_Env.sigtab);
+            FStar_TypeChecker_Env.attrtab =
+              (env1.FStar_TypeChecker_Env.attrtab);
+            FStar_TypeChecker_Env.instantiate_imp =
+              (env1.FStar_TypeChecker_Env.instantiate_imp);
+            FStar_TypeChecker_Env.effects =
+              (env1.FStar_TypeChecker_Env.effects);
+            FStar_TypeChecker_Env.generalize =
+              (env1.FStar_TypeChecker_Env.generalize);
+            FStar_TypeChecker_Env.letrecs =
+              (env1.FStar_TypeChecker_Env.letrecs);
+            FStar_TypeChecker_Env.top_level =
+              (env1.FStar_TypeChecker_Env.top_level);
+            FStar_TypeChecker_Env.check_uvars =
+              (env1.FStar_TypeChecker_Env.check_uvars);
+            FStar_TypeChecker_Env.use_eq_strict =
+              (env1.FStar_TypeChecker_Env.use_eq_strict);
+            FStar_TypeChecker_Env.is_iface =
+              (env1.FStar_TypeChecker_Env.is_iface);
+            FStar_TypeChecker_Env.admit = true;
+            FStar_TypeChecker_Env.lax_universes =
+              (env1.FStar_TypeChecker_Env.lax_universes);
+            FStar_TypeChecker_Env.phase1 =
+              (env1.FStar_TypeChecker_Env.phase1);
+            FStar_TypeChecker_Env.failhard =
+              (env1.FStar_TypeChecker_Env.failhard);
+            FStar_TypeChecker_Env.flychecking =
+              (env1.FStar_TypeChecker_Env.flychecking);
+            FStar_TypeChecker_Env.uvar_subtyping =
+              (env1.FStar_TypeChecker_Env.uvar_subtyping);
+            FStar_TypeChecker_Env.intactics =
+              (env1.FStar_TypeChecker_Env.intactics);
+            FStar_TypeChecker_Env.nocoerce =
+              (env1.FStar_TypeChecker_Env.nocoerce);
+            FStar_TypeChecker_Env.tc_term =
+              (env1.FStar_TypeChecker_Env.tc_term);
+            FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
+              (env1.FStar_TypeChecker_Env.typeof_tot_or_gtot_term);
+            FStar_TypeChecker_Env.universe_of =
+              (env1.FStar_TypeChecker_Env.universe_of);
+            FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term =
+              (env1.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+            FStar_TypeChecker_Env.teq_nosmt_force =
+              (env1.FStar_TypeChecker_Env.teq_nosmt_force);
+            FStar_TypeChecker_Env.subtype_nosmt_force =
+              (env1.FStar_TypeChecker_Env.subtype_nosmt_force);
+            FStar_TypeChecker_Env.qtbl_name_and_index =
+              (env1.FStar_TypeChecker_Env.qtbl_name_and_index);
+            FStar_TypeChecker_Env.normalized_eff_names =
+              (env1.FStar_TypeChecker_Env.normalized_eff_names);
+            FStar_TypeChecker_Env.fv_delta_depths =
+              (env1.FStar_TypeChecker_Env.fv_delta_depths);
+            FStar_TypeChecker_Env.proof_ns =
+              (env1.FStar_TypeChecker_Env.proof_ns);
+            FStar_TypeChecker_Env.synth_hook =
+              (env1.FStar_TypeChecker_Env.synth_hook);
+            FStar_TypeChecker_Env.try_solve_implicits_hook =
+              (env1.FStar_TypeChecker_Env.try_solve_implicits_hook);
+            FStar_TypeChecker_Env.splice =
+              (env1.FStar_TypeChecker_Env.splice);
+            FStar_TypeChecker_Env.mpreprocess =
+              (env1.FStar_TypeChecker_Env.mpreprocess);
+            FStar_TypeChecker_Env.postprocess =
+              (env1.FStar_TypeChecker_Env.postprocess);
+            FStar_TypeChecker_Env.identifier_info =
+              (env1.FStar_TypeChecker_Env.identifier_info);
+            FStar_TypeChecker_Env.tc_hooks =
+              (env1.FStar_TypeChecker_Env.tc_hooks);
+            FStar_TypeChecker_Env.dsenv = (env1.FStar_TypeChecker_Env.dsenv);
+            FStar_TypeChecker_Env.nbe = (env1.FStar_TypeChecker_Env.nbe);
+            FStar_TypeChecker_Env.strict_args_tab =
+              (env1.FStar_TypeChecker_Env.strict_args_tab);
+            FStar_TypeChecker_Env.erasable_types_tab =
+              (env1.FStar_TypeChecker_Env.erasable_types_tab);
+            FStar_TypeChecker_Env.enable_defer_to_tac =
+              (env1.FStar_TypeChecker_Env.enable_defer_to_tac);
+            FStar_TypeChecker_Env.unif_allow_ref_guards =
+              (env1.FStar_TypeChecker_Env.unif_allow_ref_guards);
+            FStar_TypeChecker_Env.erase_erasable_args =
+              (env1.FStar_TypeChecker_Env.erase_erasable_args);
+            FStar_TypeChecker_Env.core_check =
+              (env1.FStar_TypeChecker_Env.core_check);
+            FStar_TypeChecker_Env.missing_decl =
+              (env1.FStar_TypeChecker_Env.missing_decl)
+          }
+        else env1 in
       (let uu___1 = FStar_Compiler_Debug.any () in
        if uu___1
        then
@@ -4118,28 +4194,253 @@ let (tc_decl :
        if uu___2
        then
          let uu___3 =
+           FStar_Class_Show.show
+             (FStar_Class_Show.printableshow
+                FStar_Class_Printable.printable_bool)
+             env2.FStar_TypeChecker_Env.admit in
+         let uu___4 =
            FStar_Class_Show.show FStar_Syntax_Print.showable_sigelt se in
-         FStar_Compiler_Util.print1 ">>>>>>>>>>>>>>tc_decl %s\n" uu___3
+         FStar_Compiler_Util.print2 ">>>>>>>>>>>>>>tc_decl admit=%s %s\n"
+           uu___3 uu___4
        else ());
       (let result =
          if
            (se.FStar_Syntax_Syntax.sigmeta).FStar_Syntax_Syntax.sigmeta_already_checked
-         then ([se], [], env1)
+         then ([se], [], env2)
          else
            if
              (se.FStar_Syntax_Syntax.sigmeta).FStar_Syntax_Syntax.sigmeta_admit
            then
-             (let old = FStar_Options.admit_smt_queries () in
-              FStar_Options.set_admit_smt_queries true;
-              (let result1 = tc_decl' env1 se in
-               FStar_Options.set_admit_smt_queries old; result1))
-           else tc_decl' env1 se in
+             (let result1 =
+                tc_decl'
+                  {
+                    FStar_TypeChecker_Env.solver =
+                      (env2.FStar_TypeChecker_Env.solver);
+                    FStar_TypeChecker_Env.range =
+                      (env2.FStar_TypeChecker_Env.range);
+                    FStar_TypeChecker_Env.curmodule =
+                      (env2.FStar_TypeChecker_Env.curmodule);
+                    FStar_TypeChecker_Env.gamma =
+                      (env2.FStar_TypeChecker_Env.gamma);
+                    FStar_TypeChecker_Env.gamma_sig =
+                      (env2.FStar_TypeChecker_Env.gamma_sig);
+                    FStar_TypeChecker_Env.gamma_cache =
+                      (env2.FStar_TypeChecker_Env.gamma_cache);
+                    FStar_TypeChecker_Env.modules =
+                      (env2.FStar_TypeChecker_Env.modules);
+                    FStar_TypeChecker_Env.expected_typ =
+                      (env2.FStar_TypeChecker_Env.expected_typ);
+                    FStar_TypeChecker_Env.sigtab =
+                      (env2.FStar_TypeChecker_Env.sigtab);
+                    FStar_TypeChecker_Env.attrtab =
+                      (env2.FStar_TypeChecker_Env.attrtab);
+                    FStar_TypeChecker_Env.instantiate_imp =
+                      (env2.FStar_TypeChecker_Env.instantiate_imp);
+                    FStar_TypeChecker_Env.effects =
+                      (env2.FStar_TypeChecker_Env.effects);
+                    FStar_TypeChecker_Env.generalize =
+                      (env2.FStar_TypeChecker_Env.generalize);
+                    FStar_TypeChecker_Env.letrecs =
+                      (env2.FStar_TypeChecker_Env.letrecs);
+                    FStar_TypeChecker_Env.top_level =
+                      (env2.FStar_TypeChecker_Env.top_level);
+                    FStar_TypeChecker_Env.check_uvars =
+                      (env2.FStar_TypeChecker_Env.check_uvars);
+                    FStar_TypeChecker_Env.use_eq_strict =
+                      (env2.FStar_TypeChecker_Env.use_eq_strict);
+                    FStar_TypeChecker_Env.is_iface =
+                      (env2.FStar_TypeChecker_Env.is_iface);
+                    FStar_TypeChecker_Env.admit = true;
+                    FStar_TypeChecker_Env.lax_universes =
+                      (env2.FStar_TypeChecker_Env.lax_universes);
+                    FStar_TypeChecker_Env.phase1 =
+                      (env2.FStar_TypeChecker_Env.phase1);
+                    FStar_TypeChecker_Env.failhard =
+                      (env2.FStar_TypeChecker_Env.failhard);
+                    FStar_TypeChecker_Env.flychecking =
+                      (env2.FStar_TypeChecker_Env.flychecking);
+                    FStar_TypeChecker_Env.uvar_subtyping =
+                      (env2.FStar_TypeChecker_Env.uvar_subtyping);
+                    FStar_TypeChecker_Env.intactics =
+                      (env2.FStar_TypeChecker_Env.intactics);
+                    FStar_TypeChecker_Env.nocoerce =
+                      (env2.FStar_TypeChecker_Env.nocoerce);
+                    FStar_TypeChecker_Env.tc_term =
+                      (env2.FStar_TypeChecker_Env.tc_term);
+                    FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
+                      (env2.FStar_TypeChecker_Env.typeof_tot_or_gtot_term);
+                    FStar_TypeChecker_Env.universe_of =
+                      (env2.FStar_TypeChecker_Env.universe_of);
+                    FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
+                      =
+                      (env2.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                    FStar_TypeChecker_Env.teq_nosmt_force =
+                      (env2.FStar_TypeChecker_Env.teq_nosmt_force);
+                    FStar_TypeChecker_Env.subtype_nosmt_force =
+                      (env2.FStar_TypeChecker_Env.subtype_nosmt_force);
+                    FStar_TypeChecker_Env.qtbl_name_and_index =
+                      (env2.FStar_TypeChecker_Env.qtbl_name_and_index);
+                    FStar_TypeChecker_Env.normalized_eff_names =
+                      (env2.FStar_TypeChecker_Env.normalized_eff_names);
+                    FStar_TypeChecker_Env.fv_delta_depths =
+                      (env2.FStar_TypeChecker_Env.fv_delta_depths);
+                    FStar_TypeChecker_Env.proof_ns =
+                      (env2.FStar_TypeChecker_Env.proof_ns);
+                    FStar_TypeChecker_Env.synth_hook =
+                      (env2.FStar_TypeChecker_Env.synth_hook);
+                    FStar_TypeChecker_Env.try_solve_implicits_hook =
+                      (env2.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                    FStar_TypeChecker_Env.splice =
+                      (env2.FStar_TypeChecker_Env.splice);
+                    FStar_TypeChecker_Env.mpreprocess =
+                      (env2.FStar_TypeChecker_Env.mpreprocess);
+                    FStar_TypeChecker_Env.postprocess =
+                      (env2.FStar_TypeChecker_Env.postprocess);
+                    FStar_TypeChecker_Env.identifier_info =
+                      (env2.FStar_TypeChecker_Env.identifier_info);
+                    FStar_TypeChecker_Env.tc_hooks =
+                      (env2.FStar_TypeChecker_Env.tc_hooks);
+                    FStar_TypeChecker_Env.dsenv =
+                      (env2.FStar_TypeChecker_Env.dsenv);
+                    FStar_TypeChecker_Env.nbe =
+                      (env2.FStar_TypeChecker_Env.nbe);
+                    FStar_TypeChecker_Env.strict_args_tab =
+                      (env2.FStar_TypeChecker_Env.strict_args_tab);
+                    FStar_TypeChecker_Env.erasable_types_tab =
+                      (env2.FStar_TypeChecker_Env.erasable_types_tab);
+                    FStar_TypeChecker_Env.enable_defer_to_tac =
+                      (env2.FStar_TypeChecker_Env.enable_defer_to_tac);
+                    FStar_TypeChecker_Env.unif_allow_ref_guards =
+                      (env2.FStar_TypeChecker_Env.unif_allow_ref_guards);
+                    FStar_TypeChecker_Env.erase_erasable_args =
+                      (env2.FStar_TypeChecker_Env.erase_erasable_args);
+                    FStar_TypeChecker_Env.core_check =
+                      (env2.FStar_TypeChecker_Env.core_check);
+                    FStar_TypeChecker_Env.missing_decl =
+                      (env2.FStar_TypeChecker_Env.missing_decl)
+                  } se in
+              result1)
+           else tc_decl' env2 se in
        (let uu___3 = result in
         match uu___3 with
         | (ses, uu___4, uu___5) ->
             FStar_Compiler_List.iter
-              (FStar_TypeChecker_Quals.check_sigelt_quals_post env1) ses);
-       (match () with | () -> result))
+              (FStar_TypeChecker_Quals.check_sigelt_quals_post env2) ses);
+       (match () with
+        | () ->
+            let result1 =
+              let uu___3 = result in
+              match uu___3 with
+              | (ses, ses_e, env3) ->
+                  (ses, ses_e,
+                    {
+                      FStar_TypeChecker_Env.solver =
+                        (env3.FStar_TypeChecker_Env.solver);
+                      FStar_TypeChecker_Env.range =
+                        (env3.FStar_TypeChecker_Env.range);
+                      FStar_TypeChecker_Env.curmodule =
+                        (env3.FStar_TypeChecker_Env.curmodule);
+                      FStar_TypeChecker_Env.gamma =
+                        (env3.FStar_TypeChecker_Env.gamma);
+                      FStar_TypeChecker_Env.gamma_sig =
+                        (env3.FStar_TypeChecker_Env.gamma_sig);
+                      FStar_TypeChecker_Env.gamma_cache =
+                        (env3.FStar_TypeChecker_Env.gamma_cache);
+                      FStar_TypeChecker_Env.modules =
+                        (env3.FStar_TypeChecker_Env.modules);
+                      FStar_TypeChecker_Env.expected_typ =
+                        (env3.FStar_TypeChecker_Env.expected_typ);
+                      FStar_TypeChecker_Env.sigtab =
+                        (env3.FStar_TypeChecker_Env.sigtab);
+                      FStar_TypeChecker_Env.attrtab =
+                        (env3.FStar_TypeChecker_Env.attrtab);
+                      FStar_TypeChecker_Env.instantiate_imp =
+                        (env3.FStar_TypeChecker_Env.instantiate_imp);
+                      FStar_TypeChecker_Env.effects =
+                        (env3.FStar_TypeChecker_Env.effects);
+                      FStar_TypeChecker_Env.generalize =
+                        (env3.FStar_TypeChecker_Env.generalize);
+                      FStar_TypeChecker_Env.letrecs =
+                        (env3.FStar_TypeChecker_Env.letrecs);
+                      FStar_TypeChecker_Env.top_level =
+                        (env3.FStar_TypeChecker_Env.top_level);
+                      FStar_TypeChecker_Env.check_uvars =
+                        (env3.FStar_TypeChecker_Env.check_uvars);
+                      FStar_TypeChecker_Env.use_eq_strict =
+                        (env3.FStar_TypeChecker_Env.use_eq_strict);
+                      FStar_TypeChecker_Env.is_iface =
+                        (env3.FStar_TypeChecker_Env.is_iface);
+                      FStar_TypeChecker_Env.admit =
+                        (env0.FStar_TypeChecker_Env.admit);
+                      FStar_TypeChecker_Env.lax_universes =
+                        (env3.FStar_TypeChecker_Env.lax_universes);
+                      FStar_TypeChecker_Env.phase1 =
+                        (env3.FStar_TypeChecker_Env.phase1);
+                      FStar_TypeChecker_Env.failhard =
+                        (env3.FStar_TypeChecker_Env.failhard);
+                      FStar_TypeChecker_Env.flychecking =
+                        (env3.FStar_TypeChecker_Env.flychecking);
+                      FStar_TypeChecker_Env.uvar_subtyping =
+                        (env3.FStar_TypeChecker_Env.uvar_subtyping);
+                      FStar_TypeChecker_Env.intactics =
+                        (env3.FStar_TypeChecker_Env.intactics);
+                      FStar_TypeChecker_Env.nocoerce =
+                        (env3.FStar_TypeChecker_Env.nocoerce);
+                      FStar_TypeChecker_Env.tc_term =
+                        (env3.FStar_TypeChecker_Env.tc_term);
+                      FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
+                        (env3.FStar_TypeChecker_Env.typeof_tot_or_gtot_term);
+                      FStar_TypeChecker_Env.universe_of =
+                        (env3.FStar_TypeChecker_Env.universe_of);
+                      FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
+                        =
+                        (env3.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                      FStar_TypeChecker_Env.teq_nosmt_force =
+                        (env3.FStar_TypeChecker_Env.teq_nosmt_force);
+                      FStar_TypeChecker_Env.subtype_nosmt_force =
+                        (env3.FStar_TypeChecker_Env.subtype_nosmt_force);
+                      FStar_TypeChecker_Env.qtbl_name_and_index =
+                        (env3.FStar_TypeChecker_Env.qtbl_name_and_index);
+                      FStar_TypeChecker_Env.normalized_eff_names =
+                        (env3.FStar_TypeChecker_Env.normalized_eff_names);
+                      FStar_TypeChecker_Env.fv_delta_depths =
+                        (env3.FStar_TypeChecker_Env.fv_delta_depths);
+                      FStar_TypeChecker_Env.proof_ns =
+                        (env3.FStar_TypeChecker_Env.proof_ns);
+                      FStar_TypeChecker_Env.synth_hook =
+                        (env3.FStar_TypeChecker_Env.synth_hook);
+                      FStar_TypeChecker_Env.try_solve_implicits_hook =
+                        (env3.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                      FStar_TypeChecker_Env.splice =
+                        (env3.FStar_TypeChecker_Env.splice);
+                      FStar_TypeChecker_Env.mpreprocess =
+                        (env3.FStar_TypeChecker_Env.mpreprocess);
+                      FStar_TypeChecker_Env.postprocess =
+                        (env3.FStar_TypeChecker_Env.postprocess);
+                      FStar_TypeChecker_Env.identifier_info =
+                        (env3.FStar_TypeChecker_Env.identifier_info);
+                      FStar_TypeChecker_Env.tc_hooks =
+                        (env3.FStar_TypeChecker_Env.tc_hooks);
+                      FStar_TypeChecker_Env.dsenv =
+                        (env3.FStar_TypeChecker_Env.dsenv);
+                      FStar_TypeChecker_Env.nbe =
+                        (env3.FStar_TypeChecker_Env.nbe);
+                      FStar_TypeChecker_Env.strict_args_tab =
+                        (env3.FStar_TypeChecker_Env.strict_args_tab);
+                      FStar_TypeChecker_Env.erasable_types_tab =
+                        (env3.FStar_TypeChecker_Env.erasable_types_tab);
+                      FStar_TypeChecker_Env.enable_defer_to_tac =
+                        (env3.FStar_TypeChecker_Env.enable_defer_to_tac);
+                      FStar_TypeChecker_Env.unif_allow_ref_guards =
+                        (env3.FStar_TypeChecker_Env.unif_allow_ref_guards);
+                      FStar_TypeChecker_Env.erase_erasable_args =
+                        (env3.FStar_TypeChecker_Env.erase_erasable_args);
+                      FStar_TypeChecker_Env.core_check =
+                        (env3.FStar_TypeChecker_Env.core_check);
+                      FStar_TypeChecker_Env.missing_decl =
+                        (env3.FStar_TypeChecker_Env.missing_decl)
+                    }) in
+            result1))
 let (add_sigelt_to_env :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.sigelt -> Prims.bool -> FStar_TypeChecker_Env.env)
@@ -4241,8 +4542,6 @@ let (add_sigelt_to_env :
                          (env1.FStar_TypeChecker_Env.is_iface);
                        FStar_TypeChecker_Env.admit =
                          (env1.FStar_TypeChecker_Env.admit);
-                       FStar_TypeChecker_Env.lax =
-                         (env1.FStar_TypeChecker_Env.lax);
                        FStar_TypeChecker_Env.lax_universes =
                          (env1.FStar_TypeChecker_Env.lax_universes);
                        FStar_TypeChecker_Env.phase1 =
@@ -4355,8 +4654,6 @@ let (add_sigelt_to_env :
                          (env1.FStar_TypeChecker_Env.is_iface);
                        FStar_TypeChecker_Env.admit =
                          (env1.FStar_TypeChecker_Env.admit);
-                       FStar_TypeChecker_Env.lax =
-                         (env1.FStar_TypeChecker_Env.lax);
                        FStar_TypeChecker_Env.lax_universes =
                          (env1.FStar_TypeChecker_Env.lax_universes);
                        FStar_TypeChecker_Env.phase1 =
@@ -4469,8 +4766,6 @@ let (add_sigelt_to_env :
                          (env1.FStar_TypeChecker_Env.is_iface);
                        FStar_TypeChecker_Env.admit =
                          (env1.FStar_TypeChecker_Env.admit);
-                       FStar_TypeChecker_Env.lax =
-                         (env1.FStar_TypeChecker_Env.lax);
                        FStar_TypeChecker_Env.lax_universes =
                          (env1.FStar_TypeChecker_Env.lax_universes);
                        FStar_TypeChecker_Env.phase1 =
@@ -4583,8 +4878,6 @@ let (add_sigelt_to_env :
                          (env1.FStar_TypeChecker_Env.is_iface);
                        FStar_TypeChecker_Env.admit =
                          (env1.FStar_TypeChecker_Env.admit);
-                       FStar_TypeChecker_Env.lax =
-                         (env1.FStar_TypeChecker_Env.lax);
                        FStar_TypeChecker_Env.lax_universes =
                          (env1.FStar_TypeChecker_Env.lax_universes);
                        FStar_TypeChecker_Env.phase1 =
@@ -4882,7 +5175,7 @@ let (tc_decls :
                ([], env) ses) in
       match uu___ with
       | (ses1, env1) -> ((FStar_Compiler_List.rev_append ses1 []), env1)
-let (uu___875 : unit) =
+let (uu___880 : unit) =
   FStar_Compiler_Effect.op_Colon_Equals tc_decls_knot
     (FStar_Pervasives_Native.Some tc_decls)
 let (snapshot_context :
@@ -4994,7 +5287,6 @@ let (tc_partial_modul :
            FStar_TypeChecker_Env.is_iface =
              (modul.FStar_Syntax_Syntax.is_interface);
            FStar_TypeChecker_Env.admit = (Prims.op_Negation verify);
-           FStar_TypeChecker_Env.lax = (env.FStar_TypeChecker_Env.lax);
            FStar_TypeChecker_Env.lax_universes =
              (env.FStar_TypeChecker_Env.lax_universes);
            FStar_TypeChecker_Env.phase1 = (env.FStar_TypeChecker_Env.phase1);
@@ -5246,7 +5538,7 @@ let (check_module :
     FStar_Syntax_Syntax.modul ->
       Prims.bool -> (FStar_Syntax_Syntax.modul * FStar_TypeChecker_Env.env))
   =
-  fun env ->
+  fun env0 ->
     fun m ->
       fun b ->
         (let uu___1 = FStar_Compiler_Debug.any () in
@@ -5268,7 +5560,7 @@ let (check_module :
            FStar_Compiler_Util.print1 "Module before type checking:\n%s\n"
              uu___3
          else ());
-        (let env1 =
+        (let env =
            let uu___2 =
              let uu___3 =
                let uu___4 =
@@ -5277,109 +5569,214 @@ let (check_module :
              Prims.op_Negation uu___3 in
            {
              FStar_TypeChecker_Env.solver =
-               (env.FStar_TypeChecker_Env.solver);
-             FStar_TypeChecker_Env.range = (env.FStar_TypeChecker_Env.range);
+               (env0.FStar_TypeChecker_Env.solver);
+             FStar_TypeChecker_Env.range = (env0.FStar_TypeChecker_Env.range);
              FStar_TypeChecker_Env.curmodule =
-               (env.FStar_TypeChecker_Env.curmodule);
-             FStar_TypeChecker_Env.gamma = (env.FStar_TypeChecker_Env.gamma);
+               (env0.FStar_TypeChecker_Env.curmodule);
+             FStar_TypeChecker_Env.gamma = (env0.FStar_TypeChecker_Env.gamma);
              FStar_TypeChecker_Env.gamma_sig =
-               (env.FStar_TypeChecker_Env.gamma_sig);
+               (env0.FStar_TypeChecker_Env.gamma_sig);
              FStar_TypeChecker_Env.gamma_cache =
-               (env.FStar_TypeChecker_Env.gamma_cache);
+               (env0.FStar_TypeChecker_Env.gamma_cache);
              FStar_TypeChecker_Env.modules =
-               (env.FStar_TypeChecker_Env.modules);
+               (env0.FStar_TypeChecker_Env.modules);
              FStar_TypeChecker_Env.expected_typ =
-               (env.FStar_TypeChecker_Env.expected_typ);
+               (env0.FStar_TypeChecker_Env.expected_typ);
              FStar_TypeChecker_Env.sigtab =
-               (env.FStar_TypeChecker_Env.sigtab);
+               (env0.FStar_TypeChecker_Env.sigtab);
              FStar_TypeChecker_Env.attrtab =
-               (env.FStar_TypeChecker_Env.attrtab);
+               (env0.FStar_TypeChecker_Env.attrtab);
              FStar_TypeChecker_Env.instantiate_imp =
-               (env.FStar_TypeChecker_Env.instantiate_imp);
+               (env0.FStar_TypeChecker_Env.instantiate_imp);
              FStar_TypeChecker_Env.effects =
-               (env.FStar_TypeChecker_Env.effects);
+               (env0.FStar_TypeChecker_Env.effects);
              FStar_TypeChecker_Env.generalize =
-               (env.FStar_TypeChecker_Env.generalize);
+               (env0.FStar_TypeChecker_Env.generalize);
              FStar_TypeChecker_Env.letrecs =
-               (env.FStar_TypeChecker_Env.letrecs);
+               (env0.FStar_TypeChecker_Env.letrecs);
              FStar_TypeChecker_Env.top_level =
-               (env.FStar_TypeChecker_Env.top_level);
+               (env0.FStar_TypeChecker_Env.top_level);
              FStar_TypeChecker_Env.check_uvars =
-               (env.FStar_TypeChecker_Env.check_uvars);
+               (env0.FStar_TypeChecker_Env.check_uvars);
              FStar_TypeChecker_Env.use_eq_strict =
-               (env.FStar_TypeChecker_Env.use_eq_strict);
+               (env0.FStar_TypeChecker_Env.use_eq_strict);
              FStar_TypeChecker_Env.is_iface =
-               (env.FStar_TypeChecker_Env.is_iface);
-             FStar_TypeChecker_Env.admit = (env.FStar_TypeChecker_Env.admit);
-             FStar_TypeChecker_Env.lax = uu___2;
+               (env0.FStar_TypeChecker_Env.is_iface);
+             FStar_TypeChecker_Env.admit = uu___2;
              FStar_TypeChecker_Env.lax_universes =
-               (env.FStar_TypeChecker_Env.lax_universes);
+               (env0.FStar_TypeChecker_Env.lax_universes);
              FStar_TypeChecker_Env.phase1 =
-               (env.FStar_TypeChecker_Env.phase1);
+               (env0.FStar_TypeChecker_Env.phase1);
              FStar_TypeChecker_Env.failhard =
-               (env.FStar_TypeChecker_Env.failhard);
+               (env0.FStar_TypeChecker_Env.failhard);
              FStar_TypeChecker_Env.flychecking =
-               (env.FStar_TypeChecker_Env.flychecking);
+               (env0.FStar_TypeChecker_Env.flychecking);
              FStar_TypeChecker_Env.uvar_subtyping =
-               (env.FStar_TypeChecker_Env.uvar_subtyping);
+               (env0.FStar_TypeChecker_Env.uvar_subtyping);
              FStar_TypeChecker_Env.intactics =
-               (env.FStar_TypeChecker_Env.intactics);
+               (env0.FStar_TypeChecker_Env.intactics);
              FStar_TypeChecker_Env.nocoerce =
-               (env.FStar_TypeChecker_Env.nocoerce);
+               (env0.FStar_TypeChecker_Env.nocoerce);
              FStar_TypeChecker_Env.tc_term =
-               (env.FStar_TypeChecker_Env.tc_term);
+               (env0.FStar_TypeChecker_Env.tc_term);
              FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
-               (env.FStar_TypeChecker_Env.typeof_tot_or_gtot_term);
+               (env0.FStar_TypeChecker_Env.typeof_tot_or_gtot_term);
              FStar_TypeChecker_Env.universe_of =
-               (env.FStar_TypeChecker_Env.universe_of);
+               (env0.FStar_TypeChecker_Env.universe_of);
              FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term =
-               (env.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+               (env0.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
              FStar_TypeChecker_Env.teq_nosmt_force =
-               (env.FStar_TypeChecker_Env.teq_nosmt_force);
+               (env0.FStar_TypeChecker_Env.teq_nosmt_force);
              FStar_TypeChecker_Env.subtype_nosmt_force =
-               (env.FStar_TypeChecker_Env.subtype_nosmt_force);
+               (env0.FStar_TypeChecker_Env.subtype_nosmt_force);
              FStar_TypeChecker_Env.qtbl_name_and_index =
-               (env.FStar_TypeChecker_Env.qtbl_name_and_index);
+               (env0.FStar_TypeChecker_Env.qtbl_name_and_index);
              FStar_TypeChecker_Env.normalized_eff_names =
-               (env.FStar_TypeChecker_Env.normalized_eff_names);
+               (env0.FStar_TypeChecker_Env.normalized_eff_names);
              FStar_TypeChecker_Env.fv_delta_depths =
-               (env.FStar_TypeChecker_Env.fv_delta_depths);
+               (env0.FStar_TypeChecker_Env.fv_delta_depths);
              FStar_TypeChecker_Env.proof_ns =
-               (env.FStar_TypeChecker_Env.proof_ns);
+               (env0.FStar_TypeChecker_Env.proof_ns);
              FStar_TypeChecker_Env.synth_hook =
-               (env.FStar_TypeChecker_Env.synth_hook);
+               (env0.FStar_TypeChecker_Env.synth_hook);
              FStar_TypeChecker_Env.try_solve_implicits_hook =
-               (env.FStar_TypeChecker_Env.try_solve_implicits_hook);
+               (env0.FStar_TypeChecker_Env.try_solve_implicits_hook);
              FStar_TypeChecker_Env.splice =
-               (env.FStar_TypeChecker_Env.splice);
+               (env0.FStar_TypeChecker_Env.splice);
              FStar_TypeChecker_Env.mpreprocess =
-               (env.FStar_TypeChecker_Env.mpreprocess);
+               (env0.FStar_TypeChecker_Env.mpreprocess);
              FStar_TypeChecker_Env.postprocess =
-               (env.FStar_TypeChecker_Env.postprocess);
+               (env0.FStar_TypeChecker_Env.postprocess);
              FStar_TypeChecker_Env.identifier_info =
-               (env.FStar_TypeChecker_Env.identifier_info);
+               (env0.FStar_TypeChecker_Env.identifier_info);
              FStar_TypeChecker_Env.tc_hooks =
-               (env.FStar_TypeChecker_Env.tc_hooks);
-             FStar_TypeChecker_Env.dsenv = (env.FStar_TypeChecker_Env.dsenv);
-             FStar_TypeChecker_Env.nbe = (env.FStar_TypeChecker_Env.nbe);
+               (env0.FStar_TypeChecker_Env.tc_hooks);
+             FStar_TypeChecker_Env.dsenv = (env0.FStar_TypeChecker_Env.dsenv);
+             FStar_TypeChecker_Env.nbe = (env0.FStar_TypeChecker_Env.nbe);
              FStar_TypeChecker_Env.strict_args_tab =
-               (env.FStar_TypeChecker_Env.strict_args_tab);
+               (env0.FStar_TypeChecker_Env.strict_args_tab);
              FStar_TypeChecker_Env.erasable_types_tab =
-               (env.FStar_TypeChecker_Env.erasable_types_tab);
+               (env0.FStar_TypeChecker_Env.erasable_types_tab);
              FStar_TypeChecker_Env.enable_defer_to_tac =
-               (env.FStar_TypeChecker_Env.enable_defer_to_tac);
+               (env0.FStar_TypeChecker_Env.enable_defer_to_tac);
              FStar_TypeChecker_Env.unif_allow_ref_guards =
-               (env.FStar_TypeChecker_Env.unif_allow_ref_guards);
+               (env0.FStar_TypeChecker_Env.unif_allow_ref_guards);
              FStar_TypeChecker_Env.erase_erasable_args =
-               (env.FStar_TypeChecker_Env.erase_erasable_args);
+               (env0.FStar_TypeChecker_Env.erase_erasable_args);
              FStar_TypeChecker_Env.core_check =
-               (env.FStar_TypeChecker_Env.core_check);
+               (env0.FStar_TypeChecker_Env.core_check);
              FStar_TypeChecker_Env.missing_decl =
-               (env.FStar_TypeChecker_Env.missing_decl)
+               (env0.FStar_TypeChecker_Env.missing_decl)
            } in
-         let uu___2 = tc_modul env1 m b in
+         let uu___2 = tc_modul env m b in
          match uu___2 with
-         | (m1, env2) ->
+         | (m1, env1) ->
+             let env2 =
+               {
+                 FStar_TypeChecker_Env.solver =
+                   (env1.FStar_TypeChecker_Env.solver);
+                 FStar_TypeChecker_Env.range =
+                   (env1.FStar_TypeChecker_Env.range);
+                 FStar_TypeChecker_Env.curmodule =
+                   (env1.FStar_TypeChecker_Env.curmodule);
+                 FStar_TypeChecker_Env.gamma =
+                   (env1.FStar_TypeChecker_Env.gamma);
+                 FStar_TypeChecker_Env.gamma_sig =
+                   (env1.FStar_TypeChecker_Env.gamma_sig);
+                 FStar_TypeChecker_Env.gamma_cache =
+                   (env1.FStar_TypeChecker_Env.gamma_cache);
+                 FStar_TypeChecker_Env.modules =
+                   (env1.FStar_TypeChecker_Env.modules);
+                 FStar_TypeChecker_Env.expected_typ =
+                   (env1.FStar_TypeChecker_Env.expected_typ);
+                 FStar_TypeChecker_Env.sigtab =
+                   (env1.FStar_TypeChecker_Env.sigtab);
+                 FStar_TypeChecker_Env.attrtab =
+                   (env1.FStar_TypeChecker_Env.attrtab);
+                 FStar_TypeChecker_Env.instantiate_imp =
+                   (env1.FStar_TypeChecker_Env.instantiate_imp);
+                 FStar_TypeChecker_Env.effects =
+                   (env1.FStar_TypeChecker_Env.effects);
+                 FStar_TypeChecker_Env.generalize =
+                   (env1.FStar_TypeChecker_Env.generalize);
+                 FStar_TypeChecker_Env.letrecs =
+                   (env1.FStar_TypeChecker_Env.letrecs);
+                 FStar_TypeChecker_Env.top_level =
+                   (env1.FStar_TypeChecker_Env.top_level);
+                 FStar_TypeChecker_Env.check_uvars =
+                   (env1.FStar_TypeChecker_Env.check_uvars);
+                 FStar_TypeChecker_Env.use_eq_strict =
+                   (env1.FStar_TypeChecker_Env.use_eq_strict);
+                 FStar_TypeChecker_Env.is_iface =
+                   (env1.FStar_TypeChecker_Env.is_iface);
+                 FStar_TypeChecker_Env.admit =
+                   (env0.FStar_TypeChecker_Env.admit);
+                 FStar_TypeChecker_Env.lax_universes =
+                   (env1.FStar_TypeChecker_Env.lax_universes);
+                 FStar_TypeChecker_Env.phase1 =
+                   (env1.FStar_TypeChecker_Env.phase1);
+                 FStar_TypeChecker_Env.failhard =
+                   (env1.FStar_TypeChecker_Env.failhard);
+                 FStar_TypeChecker_Env.flychecking =
+                   (env1.FStar_TypeChecker_Env.flychecking);
+                 FStar_TypeChecker_Env.uvar_subtyping =
+                   (env1.FStar_TypeChecker_Env.uvar_subtyping);
+                 FStar_TypeChecker_Env.intactics =
+                   (env1.FStar_TypeChecker_Env.intactics);
+                 FStar_TypeChecker_Env.nocoerce =
+                   (env1.FStar_TypeChecker_Env.nocoerce);
+                 FStar_TypeChecker_Env.tc_term =
+                   (env1.FStar_TypeChecker_Env.tc_term);
+                 FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
+                   (env1.FStar_TypeChecker_Env.typeof_tot_or_gtot_term);
+                 FStar_TypeChecker_Env.universe_of =
+                   (env1.FStar_TypeChecker_Env.universe_of);
+                 FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term =
+                   (env1.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                 FStar_TypeChecker_Env.teq_nosmt_force =
+                   (env1.FStar_TypeChecker_Env.teq_nosmt_force);
+                 FStar_TypeChecker_Env.subtype_nosmt_force =
+                   (env1.FStar_TypeChecker_Env.subtype_nosmt_force);
+                 FStar_TypeChecker_Env.qtbl_name_and_index =
+                   (env1.FStar_TypeChecker_Env.qtbl_name_and_index);
+                 FStar_TypeChecker_Env.normalized_eff_names =
+                   (env1.FStar_TypeChecker_Env.normalized_eff_names);
+                 FStar_TypeChecker_Env.fv_delta_depths =
+                   (env1.FStar_TypeChecker_Env.fv_delta_depths);
+                 FStar_TypeChecker_Env.proof_ns =
+                   (env1.FStar_TypeChecker_Env.proof_ns);
+                 FStar_TypeChecker_Env.synth_hook =
+                   (env1.FStar_TypeChecker_Env.synth_hook);
+                 FStar_TypeChecker_Env.try_solve_implicits_hook =
+                   (env1.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                 FStar_TypeChecker_Env.splice =
+                   (env1.FStar_TypeChecker_Env.splice);
+                 FStar_TypeChecker_Env.mpreprocess =
+                   (env1.FStar_TypeChecker_Env.mpreprocess);
+                 FStar_TypeChecker_Env.postprocess =
+                   (env1.FStar_TypeChecker_Env.postprocess);
+                 FStar_TypeChecker_Env.identifier_info =
+                   (env1.FStar_TypeChecker_Env.identifier_info);
+                 FStar_TypeChecker_Env.tc_hooks =
+                   (env1.FStar_TypeChecker_Env.tc_hooks);
+                 FStar_TypeChecker_Env.dsenv =
+                   (env1.FStar_TypeChecker_Env.dsenv);
+                 FStar_TypeChecker_Env.nbe = (env1.FStar_TypeChecker_Env.nbe);
+                 FStar_TypeChecker_Env.strict_args_tab =
+                   (env1.FStar_TypeChecker_Env.strict_args_tab);
+                 FStar_TypeChecker_Env.erasable_types_tab =
+                   (env1.FStar_TypeChecker_Env.erasable_types_tab);
+                 FStar_TypeChecker_Env.enable_defer_to_tac =
+                   (env1.FStar_TypeChecker_Env.enable_defer_to_tac);
+                 FStar_TypeChecker_Env.unif_allow_ref_guards =
+                   (env1.FStar_TypeChecker_Env.unif_allow_ref_guards);
+                 FStar_TypeChecker_Env.erase_erasable_args =
+                   (env1.FStar_TypeChecker_Env.erase_erasable_args);
+                 FStar_TypeChecker_Env.core_check =
+                   (env1.FStar_TypeChecker_Env.core_check);
+                 FStar_TypeChecker_Env.missing_decl =
+                   (env1.FStar_TypeChecker_Env.missing_decl)
+               } in
              ((let uu___4 =
                  let uu___5 =
                    FStar_Ident.string_of_lid m1.FStar_Syntax_Syntax.name in

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_TcEffect.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_TcEffect.ml
@@ -5639,9 +5639,6 @@ let (tc_layered_eff_decl :
                                                              FStar_TypeChecker_Env.admit
                                                                =
                                                                (uu___20.FStar_TypeChecker_Env.admit);
-                                                             FStar_TypeChecker_Env.lax
-                                                               =
-                                                               (uu___20.FStar_TypeChecker_Env.lax);
                                                              FStar_TypeChecker_Env.lax_universes
                                                                =
                                                                (uu___20.FStar_TypeChecker_Env.lax_universes);
@@ -7720,9 +7717,6 @@ let (tc_non_layered_eff_decl :
                                                                     =
                                                                     (env1.FStar_TypeChecker_Env.is_iface);
                                                                     FStar_TypeChecker_Env.admit
-                                                                    =
-                                                                    (env1.FStar_TypeChecker_Env.admit);
-                                                                    FStar_TypeChecker_Env.lax
                                                                     = true;
                                                                     FStar_TypeChecker_Env.lax_universes
                                                                     =
@@ -8007,9 +8001,6 @@ let (tc_non_layered_eff_decl :
                                                                    FStar_TypeChecker_Env.admit
                                                                     =
                                                                     (uu___24.FStar_TypeChecker_Env.admit);
-                                                                   FStar_TypeChecker_Env.lax
-                                                                    =
-                                                                    (uu___24.FStar_TypeChecker_Env.lax);
                                                                    FStar_TypeChecker_Env.lax_universes
                                                                     =
                                                                     (uu___24.FStar_TypeChecker_Env.lax_universes);
@@ -8345,9 +8336,6 @@ let (tc_non_layered_eff_decl :
                                                                     =
                                                                     (env1.FStar_TypeChecker_Env.is_iface);
                                                                     FStar_TypeChecker_Env.admit
-                                                                    =
-                                                                    (env1.FStar_TypeChecker_Env.admit);
-                                                                    FStar_TypeChecker_Env.lax
                                                                     = true;
                                                                     FStar_TypeChecker_Env.lax_universes
                                                                     =
@@ -9171,9 +9159,7 @@ let (tc_lift :
                                  (env.FStar_TypeChecker_Env.use_eq_strict);
                                FStar_TypeChecker_Env.is_iface =
                                  (env.FStar_TypeChecker_Env.is_iface);
-                               FStar_TypeChecker_Env.admit =
-                                 (env.FStar_TypeChecker_Env.admit);
-                               FStar_TypeChecker_Env.lax = true;
+                               FStar_TypeChecker_Env.admit = true;
                                FStar_TypeChecker_Env.lax_universes =
                                  (env.FStar_TypeChecker_Env.lax_universes);
                                FStar_TypeChecker_Env.phase1 =

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_TcTerm.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_TcTerm.ml
@@ -45,7 +45,6 @@ let (instantiate_both :
         (env.FStar_TypeChecker_Env.use_eq_strict);
       FStar_TypeChecker_Env.is_iface = (env.FStar_TypeChecker_Env.is_iface);
       FStar_TypeChecker_Env.admit = (env.FStar_TypeChecker_Env.admit);
-      FStar_TypeChecker_Env.lax = (env.FStar_TypeChecker_Env.lax);
       FStar_TypeChecker_Env.lax_universes =
         (env.FStar_TypeChecker_Env.lax_universes);
       FStar_TypeChecker_Env.phase1 = (env.FStar_TypeChecker_Env.phase1);
@@ -130,7 +129,6 @@ let (no_inst : FStar_TypeChecker_Env.env -> FStar_TypeChecker_Env.env) =
         (env.FStar_TypeChecker_Env.use_eq_strict);
       FStar_TypeChecker_Env.is_iface = (env.FStar_TypeChecker_Env.is_iface);
       FStar_TypeChecker_Env.admit = (env.FStar_TypeChecker_Env.admit);
-      FStar_TypeChecker_Env.lax = (env.FStar_TypeChecker_Env.lax);
       FStar_TypeChecker_Env.lax_universes =
         (env.FStar_TypeChecker_Env.lax_universes);
       FStar_TypeChecker_Env.phase1 = (env.FStar_TypeChecker_Env.phase1);
@@ -656,8 +654,7 @@ let (check_expected_effect :
                           FStar_Ident.lid_equals uu___3
                             (FStar_Syntax_Util.comp_effect_name c)))
                         ||
-                        (((FStar_Options.ml_ish ()) &&
-                            env.FStar_TypeChecker_Env.lax)
+                        (((FStar_Options.ml_ish ()) && (FStar_Options.lax ()))
                            &&
                            (let uu___3 =
                               FStar_Syntax_Util.is_pure_or_ghost_comp c in
@@ -1237,7 +1234,6 @@ let (guard_letrecs :
                   (env.FStar_TypeChecker_Env.is_iface);
                 FStar_TypeChecker_Env.admit =
                   (env.FStar_TypeChecker_Env.admit);
-                FStar_TypeChecker_Env.lax = (env.FStar_TypeChecker_Env.lax);
                 FStar_TypeChecker_Env.lax_universes =
                   (env.FStar_TypeChecker_Env.lax_universes);
                 FStar_TypeChecker_Env.phase1 =
@@ -1893,7 +1889,6 @@ let rec (tc_term :
                     (env.FStar_TypeChecker_Env.is_iface);
                   FStar_TypeChecker_Env.admit =
                     (env.FStar_TypeChecker_Env.admit);
-                  FStar_TypeChecker_Env.lax = (env.FStar_TypeChecker_Env.lax);
                   FStar_TypeChecker_Env.lax_universes =
                     (env.FStar_TypeChecker_Env.lax_universes);
                   FStar_TypeChecker_Env.phase1 =
@@ -2214,9 +2209,7 @@ and (tc_maybe_toplevel_term :
                             (env'.FStar_TypeChecker_Env.use_eq_strict);
                           FStar_TypeChecker_Env.is_iface =
                             (env'.FStar_TypeChecker_Env.is_iface);
-                          FStar_TypeChecker_Env.admit =
-                            (env'.FStar_TypeChecker_Env.admit);
-                          FStar_TypeChecker_Env.lax = true;
+                          FStar_TypeChecker_Env.admit = true;
                           FStar_TypeChecker_Env.lax_universes =
                             (env'.FStar_TypeChecker_Env.lax_universes);
                           FStar_TypeChecker_Env.phase1 =
@@ -3659,7 +3652,8 @@ and (tc_maybe_toplevel_term :
                    | (chead1, g_head1) ->
                        let uu___5 =
                          let uu___6 =
-                           ((Prims.op_Negation env2.FStar_TypeChecker_Env.lax)
+                           ((Prims.op_Negation
+                               env2.FStar_TypeChecker_Env.admit)
                               &&
                               (let uu___7 = FStar_Options.lax () in
                                Prims.op_Negation uu___7))
@@ -3685,12 +3679,7 @@ and (tc_maybe_toplevel_term :
                                 (FStar_TypeChecker_Common.is_tot_or_gtot_lcomp
                                    c)
                                   ||
-                                  ((env2.FStar_TypeChecker_Env.phase1 ||
-                                      (let uu___8 =
-                                         FStar_TypeChecker_Env.should_verify
-                                           env2 in
-                                       Prims.op_Negation uu___8))
-                                     &&
+                                  (env2.FStar_TypeChecker_Env.phase1 &&
                                      (FStar_TypeChecker_Common.is_pure_or_ghost_lcomp
                                         c)) in
                               if uu___7
@@ -4494,7 +4483,6 @@ and (tc_tactic :
               FStar_TypeChecker_Env.is_iface =
                 (env.FStar_TypeChecker_Env.is_iface);
               FStar_TypeChecker_Env.admit = (env.FStar_TypeChecker_Env.admit);
-              FStar_TypeChecker_Env.lax = (env.FStar_TypeChecker_Env.lax);
               FStar_TypeChecker_Env.lax_universes =
                 (env.FStar_TypeChecker_Env.lax_universes);
               FStar_TypeChecker_Env.phase1 =
@@ -5195,7 +5183,6 @@ and (tc_comp :
                   (env.FStar_TypeChecker_Env.is_iface);
                 FStar_TypeChecker_Env.admit =
                   (env.FStar_TypeChecker_Env.admit);
-                FStar_TypeChecker_Env.lax = (env.FStar_TypeChecker_Env.lax);
                 FStar_TypeChecker_Env.lax_universes =
                   (env.FStar_TypeChecker_Env.lax_universes);
                 FStar_TypeChecker_Env.phase1 =
@@ -5694,8 +5681,6 @@ and (tc_abs_expected_function_typ :
                                  (envbody.FStar_TypeChecker_Env.is_iface);
                                FStar_TypeChecker_Env.admit =
                                  (envbody.FStar_TypeChecker_Env.admit);
-                               FStar_TypeChecker_Env.lax =
-                                 (envbody.FStar_TypeChecker_Env.lax);
                                FStar_TypeChecker_Env.lax_universes =
                                  (envbody.FStar_TypeChecker_Env.lax_universes);
                                FStar_TypeChecker_Env.phase1 =
@@ -5854,8 +5839,6 @@ and (tc_abs_expected_function_typ :
                                (env.FStar_TypeChecker_Env.is_iface);
                              FStar_TypeChecker_Env.admit =
                                (env.FStar_TypeChecker_Env.admit);
-                             FStar_TypeChecker_Env.lax =
-                               (env.FStar_TypeChecker_Env.lax);
                              FStar_TypeChecker_Env.lax_universes =
                                (env.FStar_TypeChecker_Env.lax_universes);
                              FStar_TypeChecker_Env.phase1 =
@@ -5969,8 +5952,6 @@ and (tc_abs_expected_function_typ :
                                     (envbody1.FStar_TypeChecker_Env.is_iface);
                                   FStar_TypeChecker_Env.admit =
                                     (envbody1.FStar_TypeChecker_Env.admit);
-                                  FStar_TypeChecker_Env.lax =
-                                    (envbody1.FStar_TypeChecker_Env.lax);
                                   FStar_TypeChecker_Env.lax_universes =
                                     (envbody1.FStar_TypeChecker_Env.lax_universes);
                                   FStar_TypeChecker_Env.phase1 =
@@ -6589,8 +6570,6 @@ and (tc_abs :
                                     (envbody2.FStar_TypeChecker_Env.is_iface);
                                   FStar_TypeChecker_Env.admit =
                                     (envbody2.FStar_TypeChecker_Env.admit);
-                                  FStar_TypeChecker_Env.lax =
-                                    (envbody2.FStar_TypeChecker_Env.lax);
                                   FStar_TypeChecker_Env.lax_universes =
                                     (envbody2.FStar_TypeChecker_Env.lax_universes);
                                   FStar_TypeChecker_Env.phase1 =
@@ -10244,9 +10223,6 @@ and (tc_eqn :
                                                                     =
                                                                     (uu___16.FStar_TypeChecker_Env.is_iface);
                                                                     FStar_TypeChecker_Env.admit
-                                                                    =
-                                                                    (uu___16.FStar_TypeChecker_Env.admit);
-                                                                    FStar_TypeChecker_Env.lax
                                                                     = true;
                                                                     FStar_TypeChecker_Env.lax_universes
                                                                     =
@@ -10767,7 +10743,6 @@ and (check_inner_let :
                 (env1.FStar_TypeChecker_Env.is_iface);
               FStar_TypeChecker_Env.admit =
                 (env1.FStar_TypeChecker_Env.admit);
-              FStar_TypeChecker_Env.lax = (env1.FStar_TypeChecker_Env.lax);
               FStar_TypeChecker_Env.lax_universes =
                 (env1.FStar_TypeChecker_Env.lax_universes);
               FStar_TypeChecker_Env.phase1 =
@@ -11553,7 +11528,6 @@ and (build_let_rec_env :
                   (env01.FStar_TypeChecker_Env.is_iface);
                 FStar_TypeChecker_Env.admit =
                   (env01.FStar_TypeChecker_Env.admit);
-                FStar_TypeChecker_Env.lax = (env01.FStar_TypeChecker_Env.lax);
                 FStar_TypeChecker_Env.lax_universes =
                   (env01.FStar_TypeChecker_Env.lax_universes);
                 FStar_TypeChecker_Env.phase1 =
@@ -11738,8 +11712,6 @@ and (build_let_rec_env :
                                              (env2.FStar_TypeChecker_Env.is_iface);
                                            FStar_TypeChecker_Env.admit =
                                              (env2.FStar_TypeChecker_Env.admit);
-                                           FStar_TypeChecker_Env.lax =
-                                             (env2.FStar_TypeChecker_Env.lax);
                                            FStar_TypeChecker_Env.lax_universes
                                              =
                                              (env2.FStar_TypeChecker_Env.lax_universes);
@@ -12042,8 +12014,6 @@ and (check_let_bound_def :
                            (env11.FStar_TypeChecker_Env.is_iface);
                          FStar_TypeChecker_Env.admit =
                            (env11.FStar_TypeChecker_Env.admit);
-                         FStar_TypeChecker_Env.lax =
-                           (env11.FStar_TypeChecker_Env.lax);
                          FStar_TypeChecker_Env.lax_universes =
                            (env11.FStar_TypeChecker_Env.lax_universes);
                          FStar_TypeChecker_Env.phase1 =
@@ -12569,7 +12539,6 @@ let (typeof_tot_or_gtot_term :
              FStar_TypeChecker_Env.is_iface =
                (env.FStar_TypeChecker_Env.is_iface);
              FStar_TypeChecker_Env.admit = (env.FStar_TypeChecker_Env.admit);
-             FStar_TypeChecker_Env.lax = (env.FStar_TypeChecker_Env.lax);
              FStar_TypeChecker_Env.lax_universes =
                (env.FStar_TypeChecker_Env.lax_universes);
              FStar_TypeChecker_Env.phase1 =
@@ -12756,9 +12725,7 @@ let (level_of_type :
                            (env.FStar_TypeChecker_Env.use_eq_strict);
                          FStar_TypeChecker_Env.is_iface =
                            (env.FStar_TypeChecker_Env.is_iface);
-                         FStar_TypeChecker_Env.admit =
-                           (env.FStar_TypeChecker_Env.admit);
-                         FStar_TypeChecker_Env.lax = true;
+                         FStar_TypeChecker_Env.admit = true;
                          FStar_TypeChecker_Env.lax_universes =
                            (env.FStar_TypeChecker_Env.lax_universes);
                          FStar_TypeChecker_Env.phase1 =
@@ -13171,9 +13138,7 @@ let rec (universe_of_aux :
                            (env2.FStar_TypeChecker_Env.use_eq_strict);
                          FStar_TypeChecker_Env.is_iface =
                            (env2.FStar_TypeChecker_Env.is_iface);
-                         FStar_TypeChecker_Env.admit =
-                           (env2.FStar_TypeChecker_Env.admit);
-                         FStar_TypeChecker_Env.lax = true;
+                         FStar_TypeChecker_Env.admit = true;
                          FStar_TypeChecker_Env.lax_universes =
                            (env2.FStar_TypeChecker_Env.lax_universes);
                          FStar_TypeChecker_Env.phase1 =

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Util.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Util.ml
@@ -846,8 +846,7 @@ let (mk_wp_return :
                    else
                      (let wp =
                         let uu___4 =
-                          env.FStar_TypeChecker_Env.lax &&
-                            (FStar_Options.ml_ish ()) in
+                          (FStar_Options.lax ()) && (FStar_Options.ml_ish ()) in
                         if uu___4
                         then FStar_Syntax_Syntax.tun
                         else
@@ -1188,8 +1187,7 @@ let (close_wp_comp :
          if uu___1
          then c
          else
-           (let uu___3 =
-              env.FStar_TypeChecker_Env.lax && (FStar_Options.ml_ish ()) in
+           (let uu___3 = (FStar_Options.lax ()) && (FStar_Options.ml_ish ()) in
             if uu___3
             then c
             else
@@ -2815,7 +2813,7 @@ let (strengthen_comp :
         fun f ->
           fun flags ->
             let uu___ =
-              env.FStar_TypeChecker_Env.lax ||
+              env.FStar_TypeChecker_Env.phase1 ||
                 (FStar_TypeChecker_Env.too_early_in_prims env) in
             if uu___
             then (c, FStar_TypeChecker_Env.trivial_guard)
@@ -2973,7 +2971,7 @@ let (weaken_precondition :
           match uu___1 with
           | (c, g_c) ->
               let uu___2 =
-                env.FStar_TypeChecker_Env.lax && (FStar_Options.ml_ish ()) in
+                (FStar_Options.lax ()) && (FStar_Options.ml_ish ()) in
               if uu___2
               then (c, g_c)
               else
@@ -3040,34 +3038,35 @@ let (strengthen_precondition :
                  let uu___3 = FStar_TypeChecker_Common.lcomp_comp lc in
                  match uu___3 with
                  | (c, g_c) ->
-                     if env.FStar_TypeChecker_Env.lax
+                     let uu___4 = FStar_Options.lax () in
+                     if uu___4
                      then (c, g_c)
                      else
                        (let g01 = FStar_TypeChecker_Rel.simplify_guard env g0 in
-                        let uu___5 = FStar_TypeChecker_Env.guard_form g01 in
-                        match uu___5 with
+                        let uu___6 = FStar_TypeChecker_Env.guard_form g01 in
+                        match uu___6 with
                         | FStar_TypeChecker_Common.Trivial -> (c, g_c)
                         | FStar_TypeChecker_Common.NonTrivial f ->
-                            ((let uu___7 = FStar_Compiler_Debug.extreme () in
-                              if uu___7
+                            ((let uu___8 = FStar_Compiler_Debug.extreme () in
+                              if uu___8
                               then
-                                let uu___8 =
+                                let uu___9 =
                                   FStar_TypeChecker_Normalize.term_to_string
                                     env e_for_debugging_only in
-                                let uu___9 =
+                                let uu___10 =
                                   FStar_TypeChecker_Normalize.term_to_string
                                     env f in
                                 FStar_Compiler_Util.print2
                                   "-------------Strengthening pre-condition of term %s with guard %s\n"
-                                  uu___8 uu___9
+                                  uu___9 uu___10
                               else ());
-                             (let uu___7 =
+                             (let uu___8 =
                                 strengthen_comp env reason c f flags in
-                              match uu___7 with
+                              match uu___8 with
                               | (c1, g_s) ->
-                                  let uu___8 =
+                                  let uu___9 =
                                     FStar_TypeChecker_Env.conj_guard g_c g_s in
-                                  (c1, uu___8)))) in
+                                  (c1, uu___9)))) in
                let uu___2 =
                  let uu___3 =
                    FStar_TypeChecker_Env.norm_eff_name env
@@ -3208,8 +3207,7 @@ let (bind :
                           else flags) in
                      let bind_it uu___2 =
                        let uu___3 =
-                         env.FStar_TypeChecker_Env.lax &&
-                           (FStar_Options.ml_ish ()) in
+                         (FStar_Options.lax ()) && (FStar_Options.ml_ish ()) in
                        if uu___3
                        then
                          let u_t =
@@ -3753,7 +3751,7 @@ let (maybe_assume_result_eq_pure_term_in_m :
       fun e ->
         fun lc ->
           let should_return1 =
-            (((Prims.op_Negation env.FStar_TypeChecker_Env.lax) &&
+            (((Prims.op_Negation env.FStar_TypeChecker_Env.phase1) &&
                 (let uu___ = FStar_TypeChecker_Env.too_early_in_prims env in
                  Prims.op_Negation uu___))
                && (should_return env (FStar_Pervasives_Native.Some e) lc))
@@ -4535,7 +4533,7 @@ let (bind_cases :
               let bind_cases1 uu___1 =
                 let u_res_t = env.FStar_TypeChecker_Env.universe_of env res_t in
                 let uu___2 =
-                  env.FStar_TypeChecker_Env.lax && (FStar_Options.ml_ish ()) in
+                  (FStar_Options.lax ()) && (FStar_Options.ml_ish ()) in
                 if uu___2
                 then
                   let uu___3 = lax_mk_tot_or_comp_l eff u_res_t res_t [] in
@@ -5583,9 +5581,6 @@ let (find_coercion :
                                                                     =
                                                                     (env.FStar_TypeChecker_Env.is_iface);
                                                                     FStar_TypeChecker_Env.admit
-                                                                    =
-                                                                    (env.FStar_TypeChecker_Env.admit);
-                                                                    FStar_TypeChecker_Env.lax
                                                                     = true;
                                                                     FStar_TypeChecker_Env.lax_universes
                                                                     =
@@ -5702,10 +5697,8 @@ let (maybe_coerce_lc :
       fun lc ->
         fun exp_t ->
           let should_coerce =
-            ((env.FStar_TypeChecker_Env.phase1 ||
-                env.FStar_TypeChecker_Env.lax)
-               || (FStar_Options.lax ()))
-              && (Prims.op_Negation env.FStar_TypeChecker_Env.nocoerce) in
+            (env.FStar_TypeChecker_Env.phase1 || (FStar_Options.lax ())) &&
+              (Prims.op_Negation env.FStar_TypeChecker_Env.nocoerce) in
           if Prims.op_Negation should_coerce
           then
             ((let uu___1 = FStar_Compiler_Effect.op_Bang dbg_Coercions in
@@ -6065,8 +6058,7 @@ let (weaken_result_typ :
                         } in
                       let strengthen uu___2 =
                         let uu___3 =
-                          env.FStar_TypeChecker_Env.lax &&
-                            (FStar_Options.ml_ish ()) in
+                          (FStar_Options.lax ()) && (FStar_Options.ml_ish ()) in
                         if uu___3
                         then FStar_TypeChecker_Common.lcomp_comp lc
                         else
@@ -8043,7 +8035,6 @@ let (update_env_sub_eff :
               FStar_TypeChecker_Env.is_iface =
                 (env.FStar_TypeChecker_Env.is_iface);
               FStar_TypeChecker_Env.admit = (env.FStar_TypeChecker_Env.admit);
-              FStar_TypeChecker_Env.lax = (env.FStar_TypeChecker_Env.lax);
               FStar_TypeChecker_Env.lax_universes =
                 (env.FStar_TypeChecker_Env.lax_universes);
               FStar_TypeChecker_Env.phase1 =
@@ -8144,7 +8135,6 @@ let (update_env_sub_eff :
           FStar_TypeChecker_Env.is_iface =
             (env1.FStar_TypeChecker_Env.is_iface);
           FStar_TypeChecker_Env.admit = (env1.FStar_TypeChecker_Env.admit);
-          FStar_TypeChecker_Env.lax = (env1.FStar_TypeChecker_Env.lax);
           FStar_TypeChecker_Env.lax_universes =
             (env1.FStar_TypeChecker_Env.lax_universes);
           FStar_TypeChecker_Env.phase1 = (env1.FStar_TypeChecker_Env.phase1);

--- a/ocaml/fstar-lib/generated/FStar_Universal.ml
+++ b/ocaml/fstar-lib/generated/FStar_Universal.ml
@@ -54,7 +54,6 @@ let with_dsenv_of_tcenv :
                 (tcenv.FStar_TypeChecker_Env.is_iface);
               FStar_TypeChecker_Env.admit =
                 (tcenv.FStar_TypeChecker_Env.admit);
-              FStar_TypeChecker_Env.lax = (tcenv.FStar_TypeChecker_Env.lax);
               FStar_TypeChecker_Env.lax_universes =
                 (tcenv.FStar_TypeChecker_Env.lax_universes);
               FStar_TypeChecker_Env.phase1 =
@@ -314,7 +313,6 @@ let (init_env : FStar_Parser_Dep.deps -> FStar_TypeChecker_Env.env) =
           (env.FStar_TypeChecker_Env.use_eq_strict);
         FStar_TypeChecker_Env.is_iface = (env.FStar_TypeChecker_Env.is_iface);
         FStar_TypeChecker_Env.admit = (env.FStar_TypeChecker_Env.admit);
-        FStar_TypeChecker_Env.lax = (env.FStar_TypeChecker_Env.lax);
         FStar_TypeChecker_Env.lax_universes =
           (env.FStar_TypeChecker_Env.lax_universes);
         FStar_TypeChecker_Env.phase1 = (env.FStar_TypeChecker_Env.phase1);
@@ -403,7 +401,6 @@ let (init_env : FStar_Parser_Dep.deps -> FStar_TypeChecker_Env.env) =
         FStar_TypeChecker_Env.is_iface =
           (env1.FStar_TypeChecker_Env.is_iface);
         FStar_TypeChecker_Env.admit = (env1.FStar_TypeChecker_Env.admit);
-        FStar_TypeChecker_Env.lax = (env1.FStar_TypeChecker_Env.lax);
         FStar_TypeChecker_Env.lax_universes =
           (env1.FStar_TypeChecker_Env.lax_universes);
         FStar_TypeChecker_Env.phase1 = (env1.FStar_TypeChecker_Env.phase1);
@@ -497,7 +494,6 @@ let (init_env : FStar_Parser_Dep.deps -> FStar_TypeChecker_Env.env) =
         FStar_TypeChecker_Env.is_iface =
           (env2.FStar_TypeChecker_Env.is_iface);
         FStar_TypeChecker_Env.admit = (env2.FStar_TypeChecker_Env.admit);
-        FStar_TypeChecker_Env.lax = (env2.FStar_TypeChecker_Env.lax);
         FStar_TypeChecker_Env.lax_universes =
           (env2.FStar_TypeChecker_Env.lax_universes);
         FStar_TypeChecker_Env.phase1 = (env2.FStar_TypeChecker_Env.phase1);
@@ -591,7 +587,6 @@ let (init_env : FStar_Parser_Dep.deps -> FStar_TypeChecker_Env.env) =
         FStar_TypeChecker_Env.is_iface =
           (env3.FStar_TypeChecker_Env.is_iface);
         FStar_TypeChecker_Env.admit = (env3.FStar_TypeChecker_Env.admit);
-        FStar_TypeChecker_Env.lax = (env3.FStar_TypeChecker_Env.lax);
         FStar_TypeChecker_Env.lax_universes =
           (env3.FStar_TypeChecker_Env.lax_universes);
         FStar_TypeChecker_Env.phase1 = (env3.FStar_TypeChecker_Env.phase1);
@@ -684,7 +679,6 @@ let (init_env : FStar_Parser_Dep.deps -> FStar_TypeChecker_Env.env) =
         FStar_TypeChecker_Env.is_iface =
           (env4.FStar_TypeChecker_Env.is_iface);
         FStar_TypeChecker_Env.admit = (env4.FStar_TypeChecker_Env.admit);
-        FStar_TypeChecker_Env.lax = (env4.FStar_TypeChecker_Env.lax);
         FStar_TypeChecker_Env.lax_universes =
           (env4.FStar_TypeChecker_Env.lax_universes);
         FStar_TypeChecker_Env.phase1 = (env4.FStar_TypeChecker_Env.phase1);
@@ -1205,32 +1199,49 @@ let (tc_one_file :
              match r1 with
              | FStar_Pervasives_Native.None ->
                  ((let uu___3 =
-                     let uu___4 = FStar_Parser_Dep.module_name_of_file fn in
-                     FStar_Options.should_be_already_cached uu___4 in
+                     (let uu___4 = FStar_Parser_Dep.module_name_of_file fn in
+                      FStar_Options.should_be_already_cached uu___4) &&
+                       (let uu___4 = FStar_Options.force () in
+                        Prims.op_Negation uu___4) in
                    if uu___3
                    then
                      let uu___4 =
                        let uu___5 =
-                         FStar_Compiler_Util.format1
-                           "Expected %s to already be checked" fn in
+                         let uu___6 =
+                           let uu___7 =
+                             FStar_Compiler_Util.format1
+                               "Expected %s to already be checked." fn in
+                           FStar_Errors_Msg.text uu___7 in
+                         [uu___6] in
                        (FStar_Errors_Codes.Error_AlreadyCachedAssertionFailure,
                          uu___5) in
-                     FStar_Errors.raise_err uu___4
+                     FStar_Errors.raise_err_doc uu___4
                    else ());
                   (let uu___4 =
-                     (let uu___5 = FStar_Options.codegen () in
-                      FStar_Compiler_Option.isSome uu___5) &&
-                       (FStar_Options.cmi ()) in
+                     ((let uu___5 = FStar_Options.codegen () in
+                       FStar_Compiler_Option.isSome uu___5) &&
+                        (FStar_Options.cmi ()))
+                       &&
+                       (let uu___5 = FStar_Options.force () in
+                        Prims.op_Negation uu___5) in
                    if uu___4
                    then
                      let uu___5 =
                        let uu___6 =
-                         FStar_Compiler_Util.format1
-                           "Cross-module inlining expects all modules to be checked first; %s was not checked"
-                           fn in
+                         let uu___7 =
+                           FStar_Errors_Msg.text
+                             "Cross-module inlining expects all modules to be checked first." in
+                         let uu___8 =
+                           let uu___9 =
+                             let uu___10 =
+                               FStar_Compiler_Util.format1
+                                 "Module %s was not checked." fn in
+                             FStar_Errors_Msg.text uu___10 in
+                           [uu___9] in
+                         uu___7 :: uu___8 in
                        (FStar_Errors_Codes.Error_AlreadyCachedAssertionFailure,
                          uu___6) in
-                     FStar_Errors.raise_err uu___5
+                     FStar_Errors.raise_err_doc uu___5
                    else ());
                   (let uu___4 = tc_source_file () in
                    match uu___4 with

--- a/ocaml/fstar-tests/generated/FStar_Tests_Pars.ml
+++ b/ocaml/fstar-tests/generated/FStar_Tests_Pars.ml
@@ -132,7 +132,6 @@ let (init_once : unit -> unit) =
              FStar_TypeChecker_Env.is_iface =
                (env.FStar_TypeChecker_Env.is_iface);
              FStar_TypeChecker_Env.admit = (env.FStar_TypeChecker_Env.admit);
-             FStar_TypeChecker_Env.lax = (env.FStar_TypeChecker_Env.lax);
              FStar_TypeChecker_Env.lax_universes =
                (env.FStar_TypeChecker_Env.lax_universes);
              FStar_TypeChecker_Env.phase1 =
@@ -241,8 +240,6 @@ let (init_once : unit -> unit) =
                     (env2.FStar_TypeChecker_Env.is_iface);
                   FStar_TypeChecker_Env.admit =
                     (env2.FStar_TypeChecker_Env.admit);
-                  FStar_TypeChecker_Env.lax =
-                    (env2.FStar_TypeChecker_Env.lax);
                   FStar_TypeChecker_Env.lax_universes =
                     (env2.FStar_TypeChecker_Env.lax_universes);
                   FStar_TypeChecker_Env.phase1 =
@@ -401,10 +398,9 @@ let (tc' :
         FStar_TypeChecker_Env.is_iface =
           (tcenv.FStar_TypeChecker_Env.is_iface);
         FStar_TypeChecker_Env.admit = (tcenv.FStar_TypeChecker_Env.admit);
-        FStar_TypeChecker_Env.lax = (tcenv.FStar_TypeChecker_Env.lax);
         FStar_TypeChecker_Env.lax_universes =
           (tcenv.FStar_TypeChecker_Env.lax_universes);
-        FStar_TypeChecker_Env.phase1 = (tcenv.FStar_TypeChecker_Env.phase1);
+        FStar_TypeChecker_Env.phase1 = true;
         FStar_TypeChecker_Env.failhard =
           (tcenv.FStar_TypeChecker_Env.failhard);
         FStar_TypeChecker_Env.flychecking =
@@ -505,7 +501,6 @@ let (tc_term : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
         FStar_TypeChecker_Env.is_iface =
           (tcenv.FStar_TypeChecker_Env.is_iface);
         FStar_TypeChecker_Env.admit = (tcenv.FStar_TypeChecker_Env.admit);
-        FStar_TypeChecker_Env.lax = (tcenv.FStar_TypeChecker_Env.lax);
         FStar_TypeChecker_Env.lax_universes =
           (tcenv.FStar_TypeChecker_Env.lax_universes);
         FStar_TypeChecker_Env.phase1 = (tcenv.FStar_TypeChecker_Env.phase1);

--- a/src/basic/FStar.Options.fst
+++ b/src/basic/FStar.Options.fst
@@ -1503,7 +1503,6 @@ let settable = function
     | "initial_ifuel"
     | "ide_id_info_off"
     | "keep_query_captions"
-    | "lax"
     | "load"
     | "load_cmxs"
     | "log_queries"

--- a/src/fstar/FStar.CheckedFiles.fst
+++ b/src/fstar/FStar.CheckedFiles.fst
@@ -311,7 +311,7 @@ let load_checked_file_with_tc_result (deps:Dep.deps) (fn:string) (checked_fn:str
       else begin
         if !dbg
         then begin
-          BU.print4 "Expected (%s) hashes:\n%s\n\nGot (%s) hashes:\n\t%s\n"
+          BU.print4 "FAILING to load.\nExpected (%s) hashes:\n%s\n\nGot (%s) hashes:\n\t%s\n"
             (BU.string_of_int (List.length deps_dig'))
             (FStar.Parser.Dep.print_digest deps_dig')
             (BU.string_of_int (List.length deps_dig))

--- a/src/fstar/FStar.Interactive.Legacy.fst
+++ b/src/fstar/FStar.Interactive.Legacy.fst
@@ -64,7 +64,7 @@ let pop env msg =
     Options.pop()
 
 let push_with_kind env lax restore_cmd_line_options msg =
-    let env = { env with lax = lax } in
+    let env = { env with admit = lax } in
     let res = TypeChecker.Tc.push_context env msg in
     Options.push();
     if restore_cmd_line_options then Options.restore_cmd_line_options false |> ignore;

--- a/src/fstar/FStar.Interactive.PushHelper.fst
+++ b/src/fstar/FStar.Interactive.PushHelper.fst
@@ -42,7 +42,7 @@ module CTable = FStar.Interactive.CompletionTable
 let repl_stack: ref repl_stack_t = U.mk_ref []
 
 let set_check_kind env check_kind =
-  { env with lax = (check_kind = LaxCheck || Options.lax());
+  { env with admit = (check_kind = LaxCheck || Options.lax());
              dsenv = DsEnv.set_syntax_only env.dsenv (check_kind = SyntaxCheck)}
 
 (** Build a list of dependency loading tasks from a list of dependencies **)

--- a/src/fstar/FStar.Universal.fst
+++ b/src/fstar/FStar.Universal.fst
@@ -444,16 +444,16 @@ let tc_one_file
       match r with
       | None ->
         if Options.should_be_already_cached (FStar.Parser.Dep.module_name_of_file fn)
-        then FStar.Errors.raise_err
-                (FStar.Errors.Error_AlreadyCachedAssertionFailure,
-                 BU.format1 "Expected %s to already be checked" fn);
+        then FStar.Errors.raise_err_doc (FStar.Errors.Error_AlreadyCachedAssertionFailure, [
+                 text <| BU.format1 "Expected %s to already be checked." fn
+               ]);
 
         if (Option.isSome (Options.codegen())
         && Options.cmi())
-        then FStar.Errors.raise_err
-                (FStar.Errors.Error_AlreadyCachedAssertionFailure,
-                 BU.format1 "Cross-module inlining expects all modules to be checked first; %s was not checked"
-                            fn);
+        then FStar.Errors.raise_err_doc (FStar.Errors.Error_AlreadyCachedAssertionFailure, [
+                 text "Cross-module inlining expects all modules to be checked first.";
+                 text <| BU.format1 "Module %s was not checked." fn;
+               ]);
 
         let tc_result, mllib, env = tc_source_file () in
 

--- a/src/fstar/FStar.Universal.fst
+++ b/src/fstar/FStar.Universal.fst
@@ -444,12 +444,14 @@ let tc_one_file
       match r with
       | None ->
         if Options.should_be_already_cached (FStar.Parser.Dep.module_name_of_file fn)
+        && not (Options.force ())
         then FStar.Errors.raise_err_doc (FStar.Errors.Error_AlreadyCachedAssertionFailure, [
                  text <| BU.format1 "Expected %s to already be checked." fn
                ]);
 
         if (Option.isSome (Options.codegen())
         && Options.cmi())
+        && not (Options.force ())
         then FStar.Errors.raise_err_doc (FStar.Errors.Error_AlreadyCachedAssertionFailure, [
                  text "Cross-module inlining expects all modules to be checked first.";
                  text <| BU.format1 "Module %s was not checked." fn;

--- a/src/smtencoding/FStar.SMTEncoding.Encode.fst
+++ b/src/smtencoding/FStar.SMTEncoding.Encode.fst
@@ -400,7 +400,7 @@ let encode_free_var uninterpreted env fv tt t_norm quals :decls_t & env_t =
                 let tcenv_comp = Env.push_binders env.tcenv args in
                 let comp =
                   if is_smt_reifiable_comp env.tcenv comp
-                  then S.mk_Total (reify_comp ({tcenv_comp with lax=true}) comp U_unknown)
+                  then S.mk_Total (reify_comp ({tcenv_comp with admit=true}) comp U_unknown)
                   else comp
                 in
                 if encode_non_total_function_typ
@@ -626,7 +626,7 @@ let encode_top_level_let :
     =
       (* The input type [t_norm] might contain reifiable computation type which must be reified at this point *)
 
-      let tcenv = {env.tcenv with lax=true} in
+      let tcenv = {env.tcenv with admit=true} in
 
       let subst_comp formals actuals comp =
           let subst = List.map2 (fun ({binder_bv=x}) ({binder_bv=b}) -> NT(x, S.bv_to_name b)) formals actuals in

--- a/src/smtencoding/FStar.SMTEncoding.EncodeTerm.fst
+++ b/src/smtencoding/FStar.SMTEncoding.EncodeTerm.fst
@@ -721,7 +721,7 @@ and encode_term (t:typ) (env:env_t) : (term         (* encoding of t, expects t 
              let fsym = mk_fv (varops.fresh module_name "f", Term_sort) in
              let f = mkFreeV  fsym in
              let app = mk_Apply f vars in
-             let tcenv_bs = { env'.tcenv with lax=true } in
+             let tcenv_bs = { env'.tcenv with admit=true } in
              let pre_opt, res_t = TcUtil.pure_or_ghost_pre_and_post tcenv_bs res in
              let res_pred, decls' = encode_term_pred None res_t env' app in
              let guards, guard_decls = match pre_opt with
@@ -1231,7 +1231,7 @@ and encode_term (t:typ) (env:env_t) : (term         (* encoding of t, expects t 
 //            let reified_body = TcUtil.reify_body env.tcenv body in
 //            let c = match c with
 //              | Inl lc ->
-//                let typ = reify_comp ({env.tcenv with lax=true}) (lc.comp ()) U_unknown in
+//                let typ = reify_comp ({env.tcenv with admit=true}) (lc.comp ()) U_unknown in
 //                Inl (U.lcomp_of_comp (S.mk_Total typ))
 //
 //              (* In this case we don't have enough information to reconstruct the *)

--- a/src/smtencoding/FStar.SMTEncoding.Solver.Cache.fst
+++ b/src/smtencoding/FStar.SMTEncoding.Solver.Cache.fst
@@ -133,7 +133,7 @@ instance hashable_env : hashable env = {
     hash e.gamma `mix`
     hash e.gamma_sig `mix`
     hash e.proof_ns `mix`
-    hash (e.admit, e.lax)
+    hash e.admit
   );
 }
 

--- a/src/smtencoding/FStar.SMTEncoding.Solver.fst
+++ b/src/smtencoding/FStar.SMTEncoding.Solver.fst
@@ -1175,7 +1175,7 @@ let ask_solver
     (Though all other configs also contain it.) *)
     let default_settings = List.hd configs in
     let skip : bool =
-        Options.admit_smt_queries () ||
+        env.admit ||
         Env.too_early_in_prims env   ||
         (match Options.admit_except () with
          | Some id ->
@@ -1429,7 +1429,7 @@ sync SMT queries do not pass via this function. *)
 let do_solve_maybe_split use_env_msg tcenv q : unit =
   (* If we are admiting queries, don't do anything, and bail out
   right now to save time/memory *)
-  if Options.admit_smt_queries () then () else begin
+  if tcenv.admit then () else begin
     match Options.split_queries () with
     | Options.No -> do_solve false false use_env_msg tcenv q
     | Options.OnFailure ->

--- a/src/tactics/FStar.Tactics.CtrlRewrite.fst
+++ b/src/tactics/FStar.Tactics.CtrlRewrite.fst
@@ -92,7 +92,7 @@ let __do_rewrite
         Errors.with_ctx "While typechecking a subterm for ctrl_rewrite" (fun () ->
           (* NS: Should we use Core here? *)
           
-          Some (env.tc_term ({ env with Env.lax = true }) tm))
+          Some (env.tc_term ({ env with admit = true }) tm))
       with
       | Errors.Error (Errors.Error_LayeredMissingAnnot, _, _, _) -> None
       | e -> raise e

--- a/src/tactics/FStar.Tactics.Hooks.fst
+++ b/src/tactics/FStar.Tactics.Hooks.fst
@@ -750,7 +750,7 @@ let solve_implicits (env:Env.env) (tau:term) (imps:Env.implicits) : unit =
           begin
             if !dbg_Tac then
               BU.print1 "Synthesis left a goal: %s\n" (show vc);
-            if not (Options.admit_smt_queries())
+            if not env.admit
             then (
               let guard = { guard_f = NonTrivial vc
                           ; deferred_to_tac = []
@@ -891,7 +891,7 @@ let splice
             : list goal & dsl_tac_result_t =
             run_tactic_on_ps tau.pos tau.pos false
               FStar.Tactics.Typeclasses.solve
-              ({env with lax=false; admit=false; gamma=[]}, val_t)
+              ({env with admit=false; gamma=[]}, val_t)
               FStar.Tactics.Typeclasses.solve
               tau
               tactic_already_typed

--- a/src/tactics/FStar.Tactics.Monad.fst
+++ b/src/tactics/FStar.Tactics.Monad.fst
@@ -69,7 +69,7 @@ let is_goal_safe_as_well_typed (g:goal) =
 let register_goal (g:goal) =
   if not (Options.compat_pre_core_should_register()) then () else
   let env = goal_env g in
-  if env.phase1 || env.lax then () else
+  if env.phase1 || Options.lax () then () else
   let uv = g.goal_ctx_uvar in
   let i = Core.incr_goal_ctr () in
   if Allow_untyped? (U.ctx_uvar_should_check g.goal_ctx_uvar) then () else

--- a/src/tactics/FStar.Tactics.V1.Basic.fst
+++ b/src/tactics/FStar.Tactics.V1.Basic.fst
@@ -634,7 +634,7 @@ let __tc_lax (e : env) (t : term) : tac (term & lcomp & guard_t) =
                            (show t)
                            (Env.all_binders e |> Print.binders_to_string ", ")) (fun () ->
     let e = {e with uvar_subtyping=false} in
-    let e = {e with lax = true} in
+    let e = {e with admit = true} in
     let e = {e with letrecs=[]} in
     try ret (TcTerm.tc_term e t)
     with | Errors.Err (_, msg, _)
@@ -1611,7 +1611,7 @@ let top_env     () : tac env  = bind get (fun ps -> ret <| ps.main_context)
 
 let lax_on () : tac bool =
     let! g = cur_goal in
-    ret (Options.lax () || (goal_env g).lax)
+    ret (Options.lax () || (goal_env g).admit)
 
 let unquote (ty : term) (tm : term) : tac term = wrap_err "unquote" <| (
     if_verbose (fun () -> BU.print1 "unquote: tm = %s\n" (show tm)) ;!
@@ -1882,7 +1882,7 @@ let t_destruct (s_tm : term) : tac (list (fv & Z.t)) = wrap_err "destruct" <| (
                         let cod = goal_type g in
                         let equ = env.universe_of env s_ty in
                         (* Typecheck the pattern, to fill-in the universes and get an expression out of it *)
-                        let _ , _, _, _, pat_t, _, _guard_pat, _erasable = TcTerm.tc_pat ({ env with lax = true }) s_ty pat in
+                        let _ , _, _, _, pat_t, _, _guard_pat, _erasable = TcTerm.tc_pat ({ env with admit = true }) s_ty pat in
                         let eq_b = S.gen_bv "breq" None (U.mk_squash S.U_zero (U.mk_eq2 equ s_ty s_tm pat_t)) in
                         let cod = U.arrow [S.mk_binder eq_b] (mk_Total cod) in
 

--- a/src/tactics/FStar.Tactics.V2.Basic.fst
+++ b/src/tactics/FStar.Tactics.V2.Basic.fst
@@ -643,7 +643,7 @@ let __tc_lax (e : env) (t : term) : tac (term & lcomp & guard_t) =
                            (show t)
                            (Env.all_binders e |> Print.binders_to_string ", "));!
     let e = {e with uvar_subtyping=false} in
-    let e = {e with lax = true} in
+    let e = {e with admit = true} in
     let e = {e with letrecs=[]} in
     try return (TcTerm.tc_term e t)
     with | Errors.Err (_, msg, _)
@@ -1638,16 +1638,9 @@ let set_options (s : string) : tac unit = wrap_err "set_options" <| (
 let top_env     () : tac env  = let! ps = get in return <| ps.main_context
 
 let lax_on () : tac bool =
-  return ();!
-  if Options.lax () || Options.admit_smt_queries () then
-   return true
-  else
-    (* Check the goal if any *)
-    match! trytac cur_goal with
-    | Some g ->
-      return ((goal_env g).lax || (goal_env g).admit)
-    | None ->
-      return false
+  (* Check the goal if any??? *)
+  let! ps = get in
+  return ps.main_context.admit
 
 let unquote (ty : term) (tm : term) : tac term = wrap_err "unquote" <| (
     if_verbose (fun () -> BU.print1 "unquote: tm = %s\n" (show tm)) ;!
@@ -1929,7 +1922,7 @@ let t_destruct (s_tm : term) : tac (list (fv & Z.t)) = wrap_err "destruct" <| (
                         let cod = goal_type g in
                         let equ = env.universe_of env s_ty in
                         (* Typecheck the pattern, to fill-in the universes and get an expression out of it *)
-                        let _ , _, _, _, pat_t, _, _guard_pat, _erasable = TcTerm.tc_pat ({ env with lax = true }) s_ty pat in
+                        let _ , _, _, _, pat_t, _, _guard_pat, _erasable = TcTerm.tc_pat ({ env with admit = true }) s_ty pat in
                         let eq_b = S.gen_bv "breq" None (U.mk_squash S.U_zero (U.mk_eq2 equ s_ty s_tm pat_t)) in
                         let cod = U.arrow [S.mk_binder eq_b] (mk_Total cod) in
 
@@ -2456,7 +2449,7 @@ let refl_tc_term (g:env) (e:term) : tac (option (term & (Core.tot_or_ghost & typ
     // lax check to elaborate
     //
     let e =
-      let g = {g with phase1 = true; lax = true} in
+      let g = {g with phase1 = true; admit = true} in
       //
       // AR: we are lax checking to infer implicits,
       //     ghost is ok
@@ -2607,7 +2600,7 @@ let refl_instantiate_implicits (g:env) (e:term) (expected_typ : option term)
       | None -> Env.clear_expected_typ g |> fst
       | Some typ -> Env.set_expected_typ g typ
     in
-    let g = {g with instantiate_imp=false; phase1=true; lax=true} in
+    let g = {g with instantiate_imp=false; phase1=true; admit=true} in
     let e, t, guard = g.typeof_tot_or_gtot_term g e must_tot in
     //
     // We don't worry about the logical payload,
@@ -2700,7 +2693,7 @@ let refl_try_unify (g:env) (uvs:list (bv & typ)) (t0 t1:term)
       BU.pimap_add tbl uv_id (ctx_u.ctx_uvar_head, bv)
     ) (Env.trivial_guard, [], (BU.pimap_empty ())) uvs in
     let t0, t1 = SS.subst ss t0, SS.subst ss t1 in
-    let g = { g with phase1=true; lax=true } in
+    let g = { g with phase1=true; admit=true } in
     let guard_eq =
       let smt_ok = true in
       Rel.try_teq smt_ok g t0 t1 in

--- a/src/tests/FStar.Tests.Pars.fst
+++ b/src/tests/FStar.Tests.Pars.fst
@@ -139,7 +139,9 @@ let pars s =
 let tc' s =
     let tm = pars s in
     let tcenv = init() in
-    let tcenv = {tcenv with top_level=false} in
+    (* We set phase1=true to allow the typechecker to insert
+    coercions. *)
+    let tcenv = {tcenv with phase1=true; top_level=false} in
     let tm, _, g = TcTerm.tc_tot_or_gtot_term tcenv tm in
     Rel.force_trivial_guard tcenv g;
     let tm = FStar.Syntax.Compress.deep_compress false false tm in

--- a/src/typechecker/FStar.TypeChecker.DeferredImplicits.fst
+++ b/src/typechecker/FStar.TypeChecker.DeferredImplicits.fst
@@ -215,7 +215,7 @@ let solve_deferred_to_tactic_goals env g =
       | TProb tp when tp.relation=EQ ->
         let env, _ = Env.clear_expected_typ env in
         let env = {env with gamma=tp.logical_guard_uvar.ctx_uvar_gamma} in
-        let env_lax = {env with lax=true; enable_defer_to_tac=false} in
+        let env_lax = {env with admit=true; enable_defer_to_tac=false} in
         let _, t_eq, _ =
           //Prefer to use the type of the flex term to compute the
           //type instantiation of the equality, since it is more efficient

--- a/src/typechecker/FStar.TypeChecker.Env.fst
+++ b/src/typechecker/FStar.TypeChecker.Env.fst
@@ -176,7 +176,7 @@ let missing_definition_list (e:env) : list lident =
 type sigtable = BU.smap sigelt
 
 let should_verify env =
-    not env.lax
+    not (Options.lax ())
     && not env.admit
     && Options.should_verify (string_of_lid env.curmodule)
 
@@ -220,7 +220,6 @@ let initial_env deps
     use_eq_strict=false;
     is_iface=false;
     admit=false;
-    lax=false;
     lax_universes=false;
     phase1=false;
     nocoerce=false;

--- a/src/typechecker/FStar.TypeChecker.Env.fsti
+++ b/src/typechecker/FStar.TypeChecker.Env.fsti
@@ -184,7 +184,6 @@ and env = {
                                                 (* i.e. using type equality instead of subtyping *)
   is_iface       :bool;                         (* is the module we're currently checking an interface? *)
   admit          :bool;                         (* admit VCs in the current module *)
-  lax            :bool;                         (* don't even generate VCs *)
   lax_universes  :bool;                         (* don't check universe constraints *)
   phase1         :bool;                         (* running in phase 1, phase 2 to come after *)
   failhard       :bool;                         (* don't try to carry on after a typechecking error *)

--- a/src/typechecker/FStar.TypeChecker.Normalize.fst
+++ b/src/typechecker/FStar.TypeChecker.Normalize.fst
@@ -3235,10 +3235,10 @@ let eta_expand (env:Env.env) (t:term) : term =
         let formals, _tres = U.arrow_formals (SS.subst' s (U.ctx_uvar_typ u)) in
         if List.length formals = List.length args
         then t
-        else let _, ty, _ = env.typeof_tot_or_gtot_term ({env with lax=true; expected_typ=None}) t true in
+        else let _, ty, _ = env.typeof_tot_or_gtot_term ({env with admit=true; expected_typ=None}) t true in
              eta_expand_with_type env t ty
       | _ ->
-        let _, ty, _ = env.typeof_tot_or_gtot_term ({env with lax=true; expected_typ=None}) t true in
+        let _, ty, _ = env.typeof_tot_or_gtot_term ({env with admit=true; expected_typ=None}) t true in
         eta_expand_with_type env t ty
       end
 

--- a/src/typechecker/FStar.TypeChecker.TcEffect.fst
+++ b/src/typechecker/FStar.TypeChecker.TcEffect.fst
@@ -2238,7 +2238,7 @@ Errors.with_ctx (BU.format1 "While checking effect definition `%s`" (string_of_l
                         (S.mk_Total res) in
         let k, _, _ = tc_tot_or_gtot_term env k in
         let env = Env.set_range env (snd bind_repr_ts).pos in
-        let env = {env with lax=true} |> Some in //we do not expect the bind to verify, since that requires internalizing monotonicity of WPs
+        let env = {env with admit = true} |> Some in //we do not expect the bind to verify, since that requires internalizing monotonicity of WPs
         check_and_gen' "bind_repr" 2 env bind_repr_ts (Some k) in
 
       log_combinator "bind_repr" bind_repr;
@@ -2320,7 +2320,7 @@ Errors.with_ctx (BU.format1 "While checking effect definition `%s`" (string_of_l
                           BU.format1 "Unexpected non trivial guard formula when checking action type shape (%s)"
                             (Print.term_to_string act_typ)) act_defn.pos
            | Trivial ->
-             Rel.force_trivial_guard {env with lax=true} (Env.conj_guards [g_k; g]));
+             Rel.force_trivial_guard {env with admit=true} (Env.conj_guards [g_k; g]));
 
           // 4) Do a bunch of plumbing to assign a type in the new monad to
           //    the action
@@ -2540,7 +2540,7 @@ let tc_lift env sub r =
     in
     (* we do not expect the lift to verify, *)
     (* since that requires internalizing monotonicity of WPs *)
-    let env = {env with lax=true} in
+    let env = {env with admit=true} in
     let lift = match lift with
     | None -> None
     | Some (uvs, lift) ->

--- a/src/typechecker/FStar.TypeChecker.TcTerm.fst
+++ b/src/typechecker/FStar.TypeChecker.TcTerm.fst
@@ -1314,10 +1314,9 @@ and tc_maybe_toplevel_term env (e:term) : term                  (* type-checked 
                   else check_application_args env head chead g_head args (Env.expected_typ env0) in
     let e, c, implicits =
         if TcComm.is_tot_or_gtot_lcomp c
-        //Also instantiate in phase1, dropping any precondition,
-        //since it will be recomputed correctly in phase2. Also in lax.
-        // Essentially we are checking that we are *not* in a phase2.
-        || ((env.phase1 || not (Env.should_verify env)) && TcComm.is_pure_or_ghost_lcomp c)
+        // Also instantiate in phase1, dropping any precondition,
+        // since it will be recomputed correctly in phase2.
+        || (env.phase1 && TcComm.is_pure_or_ghost_lcomp c)
         then let e, res_typ, implicits = TcUtil.maybe_instantiate env0 e c.res_typ in
              e, TcComm.set_result_typ_lc c res_typ, implicits
         else e, c, Env.trivial_guard

--- a/src/typechecker/FStar.TypeChecker.TcTerm.fst
+++ b/src/typechecker/FStar.TypeChecker.TcTerm.fst
@@ -303,7 +303,7 @@ let check_expected_effect env (use_eq:bool) (copt:option comp) (ec : term & comp
         if (Options.ml_ish()
             && Ident.lid_equals (Const.effect_ALL_lid()) (U.comp_effect_name c))
         || (Options.ml_ish ()
-            && env.lax
+            && Options.lax ()
             && not (U.is_pure_or_ghost_comp c))
         then Some (U.ml_comp ct e.pos), c, None
         else if U.is_tot_or_gtot_comp c //these are already the defaults for their particular effects
@@ -835,7 +835,7 @@ and tc_maybe_toplevel_term env (e:term) : term                  (* type-checked 
 
         (* Typechecked the quoted term just to elaborate it *)
         let env', _ = Env.clear_expected_typ env in
-        let env' = { env' with lax = true } in
+        let env' = { env' with admit = true } in
         let qt, _, g = tc_term env' qt in
         let g0 = { g with guard_f = Trivial } in //explicitly dropping the logical guard; this is just a quotation
         let g0 = Rel.resolve_implicits env' g0 in
@@ -1300,7 +1300,7 @@ and tc_maybe_toplevel_term env (e:term) : term                  (* type-checked 
     //Don't instantiate head; instantiations will be computed below, accounting for implicits/explicits
     let head, chead, g_head = tc_term (no_inst env) head in
     let chead, g_head = TcComm.lcomp_comp chead |> (fun (c, g) -> c, Env.conj_guard g_head g) in
-    let e, c, g = if not env.lax && not (Options.lax()) && TcUtil.short_circuit_head head
+    let e, c, g = if not env.admit && not (Options.lax()) && TcUtil.short_circuit_head head
                   then let e, c, g = check_short_circuit_args env head chead g_head args (Env.expected_typ env0) in
                        // //TODO: this is not efficient:
                        // //      It is quadratic in the size of boolean terms
@@ -3836,7 +3836,7 @@ and tc_eqn (scrutinee:bv) (env:Env.env) (ret_opt : option match_returns_ascripti
            //note, we are explicitly setting lax = true, since these terms apply projectors
            //which we know are sound as per the branch guard, but hard to convince the typechecker
            //AR: TODO: should we instead do the non-lax typechecking but drop the logical payload in the guard?
-           let env = { (Env.push_bv env scrutinee) with lax = true } in
+           let env = { (Env.push_bv env scrutinee) with admit = true } in
            List.fold_left2 (fun (substs, acc) pat_bv_tm bv ->
              let expected_t = SS.subst substs bv.sort in
              //we also substitute in the pat_bv_tm, since in the case of nested patterns,
@@ -4577,7 +4577,7 @@ let level_of_type env e t =
           then let t = Normalize.normalize [Env.UnfoldUntil delta_constant] env t in
                aux false t
           else let t_u, u = U.type_u() in
-               let env = {env with lax=true} in
+               let env = {env with admit = true} in
                (*
                 * AR: This is a little harsh
                 *     If t is a uvar, then this prevents t to be inferred as something more
@@ -4749,7 +4749,7 @@ let rec universe_of_aux env e : term =
           type_of_head false env hd args
         | _ ->
           let env, _ = Env.clear_expected_typ env in
-          let env = {env with lax=true; top_level=false} in
+          let env = {env with admit=true; top_level=false} in
           if !dbg_UniverseOf
           then BU.print2 "%s: About to type-check %s\n"
                         (Range.string_of_range (Env.get_range env))

--- a/tests/bug-reports/Bug1730a.fst
+++ b/tests/bug-reports/Bug1730a.fst
@@ -1,5 +1,5 @@
 module Bug1730a
 
-#set-options "--lax"
+#set-options "--admit_smt_queries true"
 
 let x = 2

--- a/tests/bug-reports/Bug2146.fst
+++ b/tests/bug-reports/Bug2146.fst
@@ -1,11 +1,11 @@
 module Bug2146
 
 (* This file should work anyway, but the bug we're checking for was at
-desugaring time, so even --lax took forever. It should take about a
-second. Without --lax, this takes about 30 seconds since it builds a big
+desugaring time, so even --admit_smt_queries true took forever. It should take about a
+second. Without --admit_smt_queries true, this takes about 30 seconds since it builds a big
 VC. *)
 
-#set-options "--lax"
+#set-options "--admit_smt_queries true"
 
 let f (args:list int) : int =
   match args with

--- a/tests/bug-reports/Bug2193.fst
+++ b/tests/bug-reports/Bug2193.fst
@@ -1,6 +1,6 @@
 module Bug2193
 
-#set-options "--lax"
+#set-options "--admit_smt_queries true"
 
 type foo: Type u#m = | FOO
 

--- a/tests/bug-reports/Bug2478.fst
+++ b/tests/bug-reports/Bug2478.fst
@@ -28,7 +28,7 @@ let key0 (bytes:Type0) (#pf: bytes_like bytes) = bytes
 // assume
 // val ps_key0: #bytes:Type0 -> (#pf: bytes_like bytes ) -> test_type bytes (key0 bytes #pf)
 
-// //#push-options "--debug Rel,RelCheck,Tac --lax"
+// //#push-options "--debug Rel,RelCheck,Tac --admit_smt_queries true"
 // let ps_pair3_0 (bytes:Type0) (#pf: bytes_like bytes ): (test_type bytes (x0:bytes & (x1:bytes & bytes))) =
 //     ps_key0 #_ #_;;
 //     ps_key0 ;;
@@ -39,7 +39,7 @@ let key (bytes:Type0) {|bytes_like bytes|} = bytes
 
 assume val ps_key: #bytes:Type0 -> {|bytes_like bytes|} -> test_type bytes (key bytes)
 
-// #push-options "--debug Rel,RelCheck,Tac --lax"
+// #push-options "--debug Rel,RelCheck,Tac --admit_smt_queries true"
 let ps_pair3 (bytes:Type0) {| pf: bytes_like bytes|}: (test_type bytes (x0:bytes & (x1:bytes & bytes))) =
     ps_key #_ #_;;
     ps_key;;

--- a/tests/bug-reports/Bug3286a.fst
+++ b/tests/bug-reports/Bug3286a.fst
@@ -1,6 +1,6 @@
 module Bug3286a
 
-#set-options "--lax"
+#set-options "--admit_smt_queries true"
 
 class machin (a:eqtype) = {
   chose: unit;

--- a/tests/bug-reports/Bug3286b.fst
+++ b/tests/bug-reports/Bug3286b.fst
@@ -1,6 +1,6 @@
 module Bug3286b
 
-#set-options "--lax"
+#set-options "--admit_smt_queries true"
 
 class machin (a:eqtype) = {
   chose: unit;

--- a/tests/error-messages/ExpectFailure.fst
+++ b/tests/error-messages/ExpectFailure.fst
@@ -29,8 +29,8 @@ let _ = assert False
 [@@ (expect_failure [19])]
 let _ = assert False
 
-(* Now for interaction with --lax *)
-#set-options "--lax"
+(* Now for interaction with --admit_smt_queries true *)
+#set-options "--admit_smt_queries true"
 
 (* These are ignored, since we're laxing and using the ordinary `expect_failure` *)
 [@@expect_failure]
@@ -44,7 +44,7 @@ let _ = 1 + 'a'
 
 #reset-options ""
 
-(* Expecting a lax failure can be done without --lax too, the flag
+(* Expecting a lax failure can be done without --admit_smt_queries true too, the flag
  * will be internally set when `expect_lax_failure` is specified. *)
 [@@expect_lax_failure]
 let _ = 1 + 'a'

--- a/tests/error-messages/NegativeTests.Bug260.fst
+++ b/tests/error-messages/NegativeTests.Bug260.fst
@@ -26,10 +26,11 @@ val bad : t:pnat -> Tot (validity (S (S t)))
 let bad t = VSucc t
 
 
-(* Hard to keep this one in the suite since the program fails to even --lax check *)
-(* module EscapingVariable *)
-(* assume type Good : int -> Type *)
-(* assume val enc: plain:int -> c:unit{Good plain} *)
-(* assume val repr : int -> int *)
+(* Hard to keep this one in the suite since the program fails to check even with --admit_smt_queries true *)
+(* Update 2024/06/29: This now works and seems totally fine. *)
 
-(* let f (text:int) = enc (repr text) //should fail; plain escapes *)
+assume val good : int -> Type
+assume val enc: plain:int -> c:unit{good plain}
+assume val repr : int -> int
+
+let f (text:int) = enc (repr text)

--- a/tests/error-messages/NegativeTests.Bug260.fst.expected
+++ b/tests/error-messages/NegativeTests.Bug260.fst.expected
@@ -11,7 +11,7 @@
   - NegativeTests.Bug260.bad is declared but no definition was found
   - Add an 'assume' if this is intentional
 
-* Warning 240 at NegativeTests.Bug260.fst(26,0-26,19):
+* Warning 240 at NegativeTests.Bug260.fst(36,0-36,34):
   - Missing definitions in module NegativeTests.Bug260: bad
 
 Verified module: NegativeTests.Bug260

--- a/tests/extraction/Micro.fst
+++ b/tests/extraction/Micro.fst
@@ -30,7 +30,7 @@ let weird0 (a:Type) : Pure a (requires (a == unit)) (ensures fun _ -> True) =
 let weird1 (a:Type) (f: (int -> unit)) : Pure a (requires (a == unit)) (ensures fun _ -> True) =
   f1 0
 
-#set-options "--lax"
+#set-options "--admit_smt_queries true"
 let weird2 (a:Type) (f: int -> unit) : Pure a (requires (a == (int -> unit))) (ensures fun _ -> True) =
   f1
 #reset-options
@@ -41,7 +41,7 @@ let h4 (#a:Type) (x:nat) : GTot nat = f4 x
 
 assume
 val f5 : nat -> Dv bool
-#set-options "--lax"
+#set-options "--admit_smt_queries true"
 let h5 (x:nat) = f5 x && f5 x
 #reset-options
 

--- a/tests/machine_integers/TestShift.fst
+++ b/tests/machine_integers/TestShift.fst
@@ -94,7 +94,7 @@ let test_i32_arith_right () : ML unit =
         (I32.to_string (I32.int_to_t (- pow2 31) `I32.shift_arithmetic_right` 31ul) = "-1");
     ()
 
-#push-options "--lax" // sigh, it's this or a huge rlimit
+#push-options "--admit_smt_queries true" // sigh, it's this or a huge rlimit
 let test_i32_left () : ML unit =
     check "i32l0"
         (I32.to_string (I32.int_to_t 1 `I32.shift_left` 0ul)  = "1");

--- a/tests/micro-benchmarks/ExpectFailure.fst
+++ b/tests/micro-benchmarks/ExpectFailure.fst
@@ -29,8 +29,8 @@ let _ = assert False
 [@@ (expect_failure [19])]
 let _ = assert False
 
-(* Now for interaction with --lax *)
-#set-options "--lax"
+(* Now for interaction with --admit_smt_queries true *)
+#set-options "--admit_smt_queries true"
 
 (* These are ignored, since we're laxing and using the ordinary `expect_failure` *)
 [@@expect_failure]
@@ -44,7 +44,7 @@ let _ = 1 + 'a'
 
 #reset-options ""
 
-(* Expecting a lax failure can be done without --lax too, the flag
+(* Expecting a lax failure can be done without --admit_smt_queries true too, the flag
  * will be internally set when `expect_lax_failure` is specified. *)
 [@@expect_lax_failure]
 let _ = 1 + 'a'

--- a/tests/micro-benchmarks/NegativeTests.Bug260.fst
+++ b/tests/micro-benchmarks/NegativeTests.Bug260.fst
@@ -24,12 +24,3 @@ val bad : t:pnat -> Tot (validity (S (S t)))
 
 [@@(expect_failure [19])]
 let bad t = VSucc t
-
-
-(* Hard to keep this one in the suite since the program fails to even --lax check *)
-(* module EscapingVariable *)
-(* assume type Good : int -> Type *)
-(* assume val enc: plain:int -> c:unit{Good plain} *)
-(* assume val repr : int -> int *)
-
-(* let f (text:int) = enc (repr text) //should fail; plain escapes *)

--- a/tests/micro-benchmarks/Test.QuickCode.fst
+++ b/tests/micro-benchmarks/Test.QuickCode.fst
@@ -48,7 +48,7 @@ let upd (r:reg_file) (x:int) (v:int) = fun y -> if x=y then v else sel r y
 ////////////////////////////////////////////////////////////////////////////////
 // Something a bit more involved, but more representative of Vale's quick code
 ////////////////////////////////////////////////////////////////////////////////
-//#reset-options "--z3rlimit 10 --lax"
+//#reset-options "--z3rlimit 10 --admit_smt_queries true"
 
 #set-options "--debug NBE"
 //#set-options "--debug print_normalized_terms,NBE"

--- a/tests/tactics/Bug3175.fst
+++ b/tests/tactics/Bug3175.fst
@@ -2,7 +2,7 @@ module Bug3175
 
 open FStar.Tactics.V2
 
-#set-options "--lax"
+#set-options "--admit_smt_queries true"
 
 [@@expect_failure [217]]
 let aux2 (p:Type0)

--- a/tests/tactics/LaxOn.fst
+++ b/tests/tactics/LaxOn.fst
@@ -21,7 +21,7 @@ let a : int =
     synth_by_tactic (fun () -> guard (not (lax_on ()));
                                exact (`1))
 
-#set-options "--lax"
+#set-options "--admit_smt_queries true"
 
 let b : int =
     synth_by_tactic (fun () -> guard (lax_on ());

--- a/ulib/FStar.Char.fsti
+++ b/ulib/FStar.Char.fsti
@@ -60,7 +60,7 @@ let char_of_int (i: nat{i < 0xd7ff \/ (i >= 0xe000 /\ i <= 0x10ffff)}) : char = 
 val lowercase: char -> Tot char
 val uppercase: char -> Tot char
 
-#set-options "--lax"
+#set-options "--admit_smt_queries true"
 
 (** This private primitive is used internally by the compiler to
     translate character literals with a desugaring-time check of the

--- a/ulib/FStar.Int128.fsti
+++ b/ulib/FStar.Int128.fsti
@@ -160,7 +160,7 @@ val to_string: t -> Tot string
 
 val of_string: string -> Tot t
 
-#set-options "--lax"
+#set-options "--admit_smt_queries true"
 //This private primitive is used internally by the
 //compiler to translate bounded integer constants
 //with a desugaring-time check of the size of the number,

--- a/ulib/FStar.Int16.fsti
+++ b/ulib/FStar.Int16.fsti
@@ -160,7 +160,7 @@ val to_string: t -> Tot string
 
 val of_string: string -> Tot t
 
-#set-options "--lax"
+#set-options "--admit_smt_queries true"
 //This private primitive is used internally by the
 //compiler to translate bounded integer constants
 //with a desugaring-time check of the size of the number,

--- a/ulib/FStar.Int32.fsti
+++ b/ulib/FStar.Int32.fsti
@@ -160,7 +160,7 @@ val to_string: t -> Tot string
 
 val of_string: string -> Tot t
 
-#set-options "--lax"
+#set-options "--admit_smt_queries true"
 //This private primitive is used internally by the
 //compiler to translate bounded integer constants
 //with a desugaring-time check of the size of the number,

--- a/ulib/FStar.Int64.fsti
+++ b/ulib/FStar.Int64.fsti
@@ -160,7 +160,7 @@ val to_string: t -> Tot string
 
 val of_string: string -> Tot t
 
-#set-options "--lax"
+#set-options "--admit_smt_queries true"
 //This private primitive is used internally by the
 //compiler to translate bounded integer constants
 //with a desugaring-time check of the size of the number,

--- a/ulib/FStar.Int8.fsti
+++ b/ulib/FStar.Int8.fsti
@@ -160,7 +160,7 @@ val to_string: t -> Tot string
 
 val of_string: string -> Tot t
 
-#set-options "--lax"
+#set-options "--admit_smt_queries true"
 //This private primitive is used internally by the
 //compiler to translate bounded integer constants
 //with a desugaring-time check of the size of the number,

--- a/ulib/FStar.IntN.fstip
+++ b/ulib/FStar.IntN.fstip
@@ -139,7 +139,7 @@ val to_string: t -> Tot string
 
 val of_string: string -> Tot t
 
-#set-options "--lax"
+#set-options "--admit_smt_queries true"
 //This private primitive is used internally by the
 //compiler to translate bounded integer constants
 //with a desugaring-time check of the size of the number,

--- a/ulib/FStar.Pervasives.fsti
+++ b/ulib/FStar.Pervasives.fsti
@@ -892,7 +892,7 @@ val dm4f_bind_range : unit
     specified multiplicity, but order does not matter. *)
 val expect_failure (errs: list int) : Tot unit
 
-(** When --lax is present, with the previous attribute since some
+(** When --admit_smt_queries true is present, with the previous attribute since some
   definitions only fail when verification is turned on. With this
   attribute, one can ensure that a definition fails while lax-checking
   too. Same semantics as above, but lax mode will be turned on for the

--- a/ulib/FStar.Stubs.Tactics.V1.Builtins.fsti
+++ b/ulib/FStar.Stubs.Tactics.V1.Builtins.fsti
@@ -348,7 +348,7 @@ val get_guard_policy : unit -> Tac guard_policy
 val set_guard_policy : guard_policy -> Tac unit
 
 (** [lax_on] returns true iff the current environment has the
-`--lax` option set, and thus drops all verification conditions. *)
+`--admit_smt_queries true` option set, and thus drops all verification conditions. *)
 val lax_on : unit -> Tac bool
 
 (** Admit the current goal and set the witness to the given term.

--- a/ulib/FStar.Stubs.Tactics.V2.Builtins.fsti
+++ b/ulib/FStar.Stubs.Tactics.V2.Builtins.fsti
@@ -354,7 +354,7 @@ val get_guard_policy : unit -> Tac guard_policy
 val set_guard_policy : guard_policy -> Tac unit
 
 (** [lax_on] returns true iff the current environment has the
-`--lax` option set, and thus drops all verification conditions. *)
+`--admit_smt_queries true` option set, and thus drops all verification conditions. *)
 val lax_on : unit -> Tac bool
 
 (** Admit the current goal and set the witness to the given term.

--- a/ulib/FStar.UInt16.fsti
+++ b/ulib/FStar.UInt16.fsti
@@ -347,7 +347,7 @@ val to_string_hex_pad: t -> Tot string
 
 val of_string: string -> Tot t
 
-#set-options "--lax"
+#set-options "--admit_smt_queries true"
 //This private primitive is used internally by the
 //compiler to translate bounded integer constants
 //with a desugaring-time check of the size of the number,

--- a/ulib/FStar.UInt32.fsti
+++ b/ulib/FStar.UInt32.fsti
@@ -347,7 +347,7 @@ val to_string_hex_pad: t -> Tot string
 
 val of_string: string -> Tot t
 
-#set-options "--lax"
+#set-options "--admit_smt_queries true"
 //This private primitive is used internally by the
 //compiler to translate bounded integer constants
 //with a desugaring-time check of the size of the number,

--- a/ulib/FStar.UInt64.fsti
+++ b/ulib/FStar.UInt64.fsti
@@ -347,7 +347,7 @@ val to_string_hex_pad: t -> Tot string
 
 val of_string: string -> Tot t
 
-#set-options "--lax"
+#set-options "--admit_smt_queries true"
 //This private primitive is used internally by the
 //compiler to translate bounded integer constants
 //with a desugaring-time check of the size of the number,

--- a/ulib/FStar.UInt8.fsti
+++ b/ulib/FStar.UInt8.fsti
@@ -347,7 +347,7 @@ val to_string_hex_pad: t -> Tot string
 
 val of_string: string -> Tot t
 
-#set-options "--lax"
+#set-options "--admit_smt_queries true"
 //This private primitive is used internally by the
 //compiler to translate bounded integer constants
 //with a desugaring-time check of the size of the number,

--- a/ulib/FStar.UIntN.fstip
+++ b/ulib/FStar.UIntN.fstip
@@ -326,7 +326,7 @@ val to_string_hex_pad: t -> Tot string
 
 val of_string: string -> Tot t
 
-#set-options "--lax"
+#set-options "--admit_smt_queries true"
 //This private primitive is used internally by the
 //compiler to translate bounded integer constants
 //with a desugaring-time check of the size of the number,


### PR DESCRIPTION
Internally, there are many different toggles that imply we are not fully verifying a file.

We can be running with `--lax` or `--admit_smt_queries true` set, which are part of the option state. They are independent, so we sometimes need to check both, or at least it is unclear which one to check. Further, the typechecker environment has two fields `lax` and `admit`, which also have unclear meaning. They mostly follow the options, but not always. This PR tries to bring some order to these things.

The main changes are:
- `--lax` is not settable within a file, only from the CLI. This option implies that we will admit all queries and only produce `.checked.lax` files.
- The `env.lax` field is removed. When needed, we just check `Options.lax()`, which is constant throughout an invocation.
- The `env.admit` field is now populated from the optionstate before checking each top-level decl.
- We do not check `Options.admit_smt_queries()` during typechecking any more, only `env.admit`.
- We always do 2-phase typechecking, unless `--lax`. This has one undesirable implication: when loading a dependency that does not have a checked file, we will do 2-phase checking, which is roughly 2x slower. This _does_ make it more consistent though, and eliminates some bugs from ever popping up:
  - #2589
  - #2611 
  - #1567
  - #3286
  -  And probably more

If we want to only do 1-phase checking for dependencies, I think the clean way is adding a `checking_dependency` field in the environment and branch on that. Previously the condition was `Env.should_verify env`, which is rather misleading.

Also, we have a "dummy" SMT solver used during the tests. This seems fine right now, it's only used for `fstar_tests.exe` and when `--lax` is set, but it's another point where VCs could be dropped.

This was motivated also by the Pulse checker running with `lax=true` during flycheck and causing spurious errors. I will post follow up patches for always running tactics without admit/lax, and for preventing these flycheck spurious errors.