### PR TITLE
Resugar: improve resugaring for projectors

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_Syntax_Resugar.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Resugar.ml
@@ -867,27 +867,43 @@ let rec (resugar_term' :
                      else FStar_Pervasives_Native.None
                  | uu___4 -> FStar_Pervasives_Native.None in
                let uu___3 =
-                 (let uu___4 = is_projector e in
-                  FStar_Pervasives_Native.uu___is_Some uu___4) &&
-                   ((FStar_Compiler_List.length args1) = Prims.int_one) in
+                 ((let uu___4 = is_projector e in
+                   FStar_Pervasives_Native.uu___is_Some uu___4) &&
+                    ((FStar_Compiler_List.length args1) >= Prims.int_one))
+                   &&
+                   (let uu___4 =
+                      let uu___5 = FStar_Compiler_List.hd args1 in
+                      FStar_Pervasives_Native.snd uu___5 in
+                    FStar_Pervasives_Native.uu___is_None uu___4) in
                if uu___3
                then
-                 let uu___4 =
-                   let uu___5 = is_projector e in
-                   FStar_Pervasives_Native.__proj__Some__item__v uu___5 in
+                 let uu___4 = args1 in
                  (match uu___4 with
-                  | (uu___5, fi) ->
-                      let arg =
-                        let uu___6 =
-                          let uu___7 = FStar_Compiler_List.hd args1 in
-                          FStar_Pervasives_Native.fst uu___7 in
-                        resugar_term' env uu___6 in
-                      let uu___6 =
-                        let uu___7 =
-                          let uu___8 = FStar_Ident.lid_of_ids [fi] in
-                          (arg, uu___8) in
-                        FStar_Parser_AST.Project uu___7 in
-                      mk uu___6)
+                  | arg1::rest_args ->
+                      let uu___5 =
+                        let uu___6 = is_projector e in
+                        FStar_Pervasives_Native.__proj__Some__item__v uu___6 in
+                      (match uu___5 with
+                       | (uu___6, fi) ->
+                           let arg =
+                             resugar_term' env
+                               (FStar_Pervasives_Native.fst arg1) in
+                           let h =
+                             let uu___7 =
+                               let uu___8 =
+                                 let uu___9 = FStar_Ident.lid_of_ids [fi] in
+                                 (arg, uu___9) in
+                               FStar_Parser_AST.Project uu___8 in
+                             mk uu___7 in
+                           FStar_Compiler_List.fold_left
+                             (fun acc ->
+                                fun uu___7 ->
+                                  match uu___7 with
+                                  | (a, q) ->
+                                      let aa = resugar_term' env a in
+                                      let qq = resugar_aqual env q in
+                                      mk (FStar_Parser_AST.App (acc, aa, qq)))
+                             h rest_args))
                else
                  (let unsnoc l =
                     let rec unsnoc' acc uu___5 =

--- a/tests/error-messages/Bug3227.fst
+++ b/tests/error-messages/Bug3227.fst
@@ -6,3 +6,15 @@ let proj (b : box (box (box int))) : int = b.x.x.x
 type box2 (a:Type) = | Box2 : x:a -> box2 a
 
 let test (b : box2 (box2 int)) = Box2? b && Box2? (Box2?.x b)
+
+noeq
+type boxf (a:Type) = { ff : a -> a }
+
+let test2 (r : boxf int) = r.ff 5
+
+noeq
+type boxfi (a:Type) = { ff : (#_:a -> a) }
+
+let test3 (r : boxfi int) = r.ff #5
+
+let test4 (#a:Type) (r : boxf a) (x:a) : a = r.ff x

--- a/tests/error-messages/Bug3227.fst.expected
+++ b/tests/error-messages/Bug3227.fst.expected
@@ -9,6 +9,15 @@ type box2 (a: Type) = | Box2 : x: a -> Bug3227.box2 a
 
 
 let test b = Box2? b && Box2? b.x
+noeq
+type boxf (a: Type) = {  }
+
+let test2 r = ff r 5
+noeq
+type boxfi (a: Type) = {  }
+
+let test3 r = ff r
+let test4 r x = ff r x <: a
 ]
 Exports: [
 type box (a: Type) = {  }
@@ -19,6 +28,15 @@ type box2 (a: Type) = | Box2 : x: a -> Bug3227.box2 a
 
 
 let test b = Box2? b && Box2? b.x
+noeq
+type boxf (a: Type) = {  }
+
+let test2 r = ff r 5
+noeq
+type boxfi (a: Type) = {  }
+
+let test3 r = ff r
+let test4 r x = ff r x <: a
 ]
 
 Module before type checking:
@@ -32,6 +50,15 @@ type box2 (a: Type) = | Box2 : x: a -> Bug3227.box2 a
 
 
 let test b = Box2? b && Box2? b.x
+noeq
+type boxf (a: Type) = {  }
+
+let test2 r = ff r 5
+noeq
+type boxfi (a: Type) = {  }
+
+let test3 r = ff r
+let test4 r x = ff r x <: a
 ]
 Exports: [
 type box (a: Type) = {  }
@@ -42,6 +69,15 @@ type box2 (a: Type) = | Box2 : x: a -> Bug3227.box2 a
 
 
 let test b = Box2? b && Box2? b.x
+noeq
+type boxf (a: Type) = {  }
+
+let test2 r = ff r 5
+noeq
+type boxfi (a: Type) = {  }
+
+let test3 r = ff r
+let test4 r x = ff r x <: a
 ]
 
 Module after type checking:
@@ -61,6 +97,17 @@ val box2__uu___haseq: forall (a: Type). {:pattern Prims.hasEq (Bug3227.box2 a)}
 
 
 let test b = Box2? b && Box2? b.x
+noeq
+type boxf (a: Type) = { ff:_: a -> a }
+
+
+let test2 r = r.ff 5
+noeq
+type boxfi (a: Type) = { ff:a }
+
+
+let test3 r = r.ff
+let test4 r x = r.ff x <: a
 ]
 Exports: [
 type box (a: Type) = { x:a }
@@ -77,6 +124,17 @@ val box2__uu___haseq: forall (a: Type). {:pattern Prims.hasEq (Bug3227.box2 a)}
 
 
 let test b = Box2? b && Box2? b.x
+noeq
+type boxf (a: Type) = { ff:_: a -> a }
+
+
+let test2 r = r.ff 5
+noeq
+type boxfi (a: Type) = { ff:a }
+
+
+let test3 r = r.ff
+let test4 r x = r.ff x <: a
 ]
 
 Verified module: Bug3227


### PR DESCRIPTION
It was not properly handling cases where the field is a function, that can be further applied. Noticed this while debugging a proof.

Before:
![Screenshot 2024-07-03 140333](https://github.com/FStarLang/FStar/assets/4195583/f7b38daf-e40d-4a29-8366-9fe60dd9e713)
After:
![Screenshot 2024-07-03 140136](https://github.com/FStarLang/FStar/assets/4195583/0927d1cc-f9e9-48d1-8c78-2956a12e9754)



And with implicits:
Before:
![Screenshot 2024-07-03 140042](https://github.com/FStarLang/FStar/assets/4195583/93ab4ae6-6051-4230-80a2-c03d8a69511f)
After:
![Screenshot 2024-07-03 140126](https://github.com/FStarLang/FStar/assets/4195583/813c85d2-6bde-406b-a4fe-3e664bbb05c2)
