### PR TITLE
ci: disable --query_stats

### DIFF
--- a/.docker/build/build_funs.sh
+++ b/.docker/build/build_funs.sh
@@ -1,6 +1,3 @@
-# Make sure to get verbose output from makefiles
-export V=1
-
 function export_home() {
     local home_path=""
     if command -v cygpath >/dev/null 2>&1; then
@@ -175,6 +172,7 @@ function build_fstar() {
 }
 
 # Some environment variables we want
+export V=1 # Make sure to get verbose output from makefiles
 export OCAMLRUNPARAM=b
-export OTHERFLAGS="--use_hints --query_stats"
-export MAKEFLAGS="$MAKEFLAGS -Otarget"
+export OTHERFLAGS="--use_hints"
+export MAKEFLAGS="$MAKEFLAGS -Otarget" # Group make output by target


### PR DESCRIPTION
Using --query_stats makes the log files much bigger than they have to be, and AFAIK we are not looking at this data at all. If we wanted to do some stats/profiling, we could do another run with `--query_stats` enabled or have an option that instead dumps them to a file.

For F* CI logs, this will reduce the line count by 27% and the file size by 62%, making it much smoother when opening in the browser.

If we are indeed not using this output anywhere I would disable it in everest too.