### PR TITLE
Plugin: fix arity mismatch

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_Extraction_ML_RegEmb.ml
+++ b/ocaml/fstar-lib/generated/FStar_Extraction_ML_RegEmb.ml
@@ -1411,7 +1411,7 @@ let (interpret_plugin_as_term_fun :
                     (pattern, FStar_Pervasives_Native.None,
                       (mk
                          (FStar_Extraction_ML_Syntax.MLE_App
-                            (body, [as_name1 ([], "args")])))) in
+                            (body, [as_name1 ([], "args_tail")])))) in
                   let default_branch =
                     (FStar_Extraction_ML_Syntax.MLP_Wild,
                       FStar_Pervasives_Native.None,
@@ -1542,17 +1542,7 @@ let (interpret_plugin_as_term_fun :
                                     let uu___4 =
                                       let uu___5 =
                                         let uu___6 = lid_to_name fv_lid1 in
-                                        [uu___6;
-                                        FStar_Extraction_ML_Syntax.with_ty
-                                          FStar_Extraction_ML_Syntax.MLTY_Top
-                                          (FStar_Extraction_ML_Syntax.MLE_Const
-                                             (FStar_Extraction_ML_Syntax.MLC_Int
-                                                ((Prims.string_of_int
-                                                    tvar_arity),
-                                                  FStar_Pervasives_Native.None)));
-                                        fv_lid_embedded;
-                                        cb;
-                                        us] in
+                                        [uu___6; fv_lid_embedded; cb; us] in
                                       res_embedding :: uu___5 in
                                     FStar_Compiler_List.op_At
                                       arg_unembeddings uu___4 in

--- a/ocaml/fstar-lib/generated/FStar_Reflection_TermEq.ml
+++ b/ocaml/fstar-lib/generated/FStar_Reflection_TermEq.ml
@@ -504,7 +504,7 @@ let _ =
                   (FStar_Syntax_Embeddings.arrow_as_prim_step_2
                      FStar_Reflection_V2_Embeddings.e_term
                      FStar_Reflection_V2_Embeddings.e_term
-                     FStar_Syntax_Embeddings.e_bool term_eq Prims.int_zero
+                     FStar_Syntax_Embeddings.e_bool term_eq
                      (FStar_Ident.lid_of_str
                         "FStar.Reflection.TermEq.term_eq") cb us) args))
     (fun cb ->
@@ -516,7 +516,7 @@ let _ =
                 (FStar_TypeChecker_NBETerm.arrow_as_prim_step_2
                    FStar_Reflection_V2_NBEEmbeddings.e_term
                    FStar_Reflection_V2_NBEEmbeddings.e_term
-                   FStar_TypeChecker_NBETerm.e_bool term_eq Prims.int_zero
+                   FStar_TypeChecker_NBETerm.e_bool term_eq
                    (FStar_Ident.lid_of_str "FStar.Reflection.TermEq.term_eq")
                    cb us) args))
 let (term_eq_dec : faithful_term -> faithful_term -> Prims.bool) =
@@ -535,7 +535,6 @@ let _ =
                      FStar_Reflection_V2_Embeddings.e_term
                      FStar_Reflection_V2_Embeddings.e_term
                      FStar_Syntax_Embeddings.e_bool term_eq_dec
-                     Prims.int_zero
                      (FStar_Ident.lid_of_str
                         "FStar.Reflection.TermEq.term_eq_dec") cb us) args))
     (fun cb ->
@@ -548,7 +547,6 @@ let _ =
                    FStar_Reflection_V2_NBEEmbeddings.e_term
                    FStar_Reflection_V2_NBEEmbeddings.e_term
                    FStar_TypeChecker_NBETerm.e_bool term_eq_dec
-                   Prims.int_zero
                    (FStar_Ident.lid_of_str
                       "FStar.Reflection.TermEq.term_eq_dec") cb us) args))
 let (univ_eq :
@@ -568,7 +566,7 @@ let _ =
                   (FStar_Syntax_Embeddings.arrow_as_prim_step_2
                      FStar_Reflection_V2_Embeddings.e_universe
                      FStar_Reflection_V2_Embeddings.e_universe
-                     FStar_Syntax_Embeddings.e_bool univ_eq Prims.int_zero
+                     FStar_Syntax_Embeddings.e_bool univ_eq
                      (FStar_Ident.lid_of_str
                         "FStar.Reflection.TermEq.univ_eq") cb us) args))
     (fun cb ->
@@ -580,7 +578,7 @@ let _ =
                 (FStar_TypeChecker_NBETerm.arrow_as_prim_step_2
                    FStar_Reflection_V2_NBEEmbeddings.e_universe
                    FStar_Reflection_V2_NBEEmbeddings.e_universe
-                   FStar_TypeChecker_NBETerm.e_bool univ_eq Prims.int_zero
+                   FStar_TypeChecker_NBETerm.e_bool univ_eq
                    (FStar_Ident.lid_of_str "FStar.Reflection.TermEq.univ_eq")
                    cb us) args))
 let (univ_eq_dec : faithful_universe -> faithful_universe -> Prims.bool) =
@@ -599,7 +597,6 @@ let _ =
                      FStar_Reflection_V2_Embeddings.e_universe
                      FStar_Reflection_V2_Embeddings.e_universe
                      FStar_Syntax_Embeddings.e_bool univ_eq_dec
-                     Prims.int_zero
                      (FStar_Ident.lid_of_str
                         "FStar.Reflection.TermEq.univ_eq_dec") cb us) args))
     (fun cb ->
@@ -612,6 +609,5 @@ let _ =
                    FStar_Reflection_V2_NBEEmbeddings.e_universe
                    FStar_Reflection_V2_NBEEmbeddings.e_universe
                    FStar_TypeChecker_NBETerm.e_bool univ_eq_dec
-                   Prims.int_zero
                    (FStar_Ident.lid_of_str
                       "FStar.Reflection.TermEq.univ_eq_dec") cb us) args))

--- a/ocaml/fstar-lib/generated/FStar_Reflection_TermEq_Simple.ml
+++ b/ocaml/fstar-lib/generated/FStar_Reflection_TermEq_Simple.ml
@@ -15,7 +15,7 @@ let _ =
                   (FStar_Syntax_Embeddings.arrow_as_prim_step_2
                      FStar_Reflection_V2_Embeddings.e_term
                      FStar_Reflection_V2_Embeddings.e_term
-                     FStar_Syntax_Embeddings.e_bool term_eq Prims.int_zero
+                     FStar_Syntax_Embeddings.e_bool term_eq
                      (FStar_Ident.lid_of_str
                         "FStar.Reflection.TermEq.Simple.term_eq") cb us) args))
     (fun cb ->
@@ -27,7 +27,7 @@ let _ =
                 (FStar_TypeChecker_NBETerm.arrow_as_prim_step_2
                    FStar_Reflection_V2_NBEEmbeddings.e_term
                    FStar_Reflection_V2_NBEEmbeddings.e_term
-                   FStar_TypeChecker_NBETerm.e_bool term_eq Prims.int_zero
+                   FStar_TypeChecker_NBETerm.e_bool term_eq
                    (FStar_Ident.lid_of_str
                       "FStar.Reflection.TermEq.Simple.term_eq") cb us) args))
 let (univ_eq :
@@ -47,7 +47,7 @@ let _ =
                   (FStar_Syntax_Embeddings.arrow_as_prim_step_2
                      FStar_Reflection_V2_Embeddings.e_universe
                      FStar_Reflection_V2_Embeddings.e_universe
-                     FStar_Syntax_Embeddings.e_bool univ_eq Prims.int_zero
+                     FStar_Syntax_Embeddings.e_bool univ_eq
                      (FStar_Ident.lid_of_str
                         "FStar.Reflection.TermEq.Simple.univ_eq") cb us) args))
     (fun cb ->
@@ -59,6 +59,6 @@ let _ =
                 (FStar_TypeChecker_NBETerm.arrow_as_prim_step_2
                    FStar_Reflection_V2_NBEEmbeddings.e_universe
                    FStar_Reflection_V2_NBEEmbeddings.e_universe
-                   FStar_TypeChecker_NBETerm.e_bool univ_eq Prims.int_zero
+                   FStar_TypeChecker_NBETerm.e_bool univ_eq
                    (FStar_Ident.lid_of_str
                       "FStar.Reflection.TermEq.Simple.univ_eq") cb us) args))

--- a/ocaml/fstar-lib/generated/FStar_Reflection_V2_Compare.ml
+++ b/ocaml/fstar-lib/generated/FStar_Reflection_V2_Compare.ml
@@ -25,7 +25,7 @@ let _ =
                         FStar_Syntax_Embeddings.e_string)
                      (FStar_Syntax_Embeddings.e_list
                         FStar_Syntax_Embeddings.e_string) FStar_Order.e_order
-                     compare_name Prims.int_zero
+                     compare_name
                      (FStar_Ident.lid_of_str
                         "FStar.Reflection.V2.Compare.compare_name") cb us)
                     args))
@@ -41,7 +41,6 @@ let _ =
                    (FStar_TypeChecker_NBETerm.e_list
                       FStar_TypeChecker_NBETerm.e_string)
                    (FStar_TypeChecker_NBETerm.e_unsupported ()) compare_name
-                   Prims.int_zero
                    (FStar_Ident.lid_of_str
                       "FStar.Reflection.V2.Compare.compare_name") cb us) args))
 let (compare_fv :
@@ -64,7 +63,7 @@ let _ =
                   (FStar_Syntax_Embeddings.arrow_as_prim_step_2
                      FStar_Reflection_V2_Embeddings.e_fv
                      FStar_Reflection_V2_Embeddings.e_fv FStar_Order.e_order
-                     compare_fv Prims.int_zero
+                     compare_fv
                      (FStar_Ident.lid_of_str
                         "FStar.Reflection.V2.Compare.compare_fv") cb us) args))
     (fun cb ->
@@ -77,7 +76,6 @@ let _ =
                    FStar_Reflection_V2_NBEEmbeddings.e_fv
                    FStar_Reflection_V2_NBEEmbeddings.e_fv
                    (FStar_TypeChecker_NBETerm.e_unsupported ()) compare_fv
-                   Prims.int_zero
                    (FStar_Ident.lid_of_str
                       "FStar.Reflection.V2.Compare.compare_fv") cb us) args))
 let (compare_const :
@@ -140,7 +138,7 @@ let _ =
                   (FStar_Syntax_Embeddings.arrow_as_prim_step_2
                      FStar_Reflection_V2_Embeddings.e_vconst
                      FStar_Reflection_V2_Embeddings.e_vconst
-                     FStar_Order.e_order compare_const Prims.int_zero
+                     FStar_Order.e_order compare_const
                      (FStar_Ident.lid_of_str
                         "FStar.Reflection.V2.Compare.compare_const") cb us)
                     args))
@@ -154,7 +152,6 @@ let _ =
                    FStar_Reflection_V2_NBEEmbeddings.e_vconst
                    FStar_Reflection_V2_NBEEmbeddings.e_vconst
                    (FStar_TypeChecker_NBETerm.e_unsupported ()) compare_const
-                   Prims.int_zero
                    (FStar_Ident.lid_of_str
                       "FStar.Reflection.V2.Compare.compare_const") cb us)
                   args))
@@ -185,7 +182,7 @@ let _ =
                   (FStar_Syntax_Embeddings.arrow_as_prim_step_2
                      FStar_Reflection_V2_Embeddings.e_ident
                      FStar_Reflection_V2_Embeddings.e_ident
-                     FStar_Order.e_order compare_ident Prims.int_zero
+                     FStar_Order.e_order compare_ident
                      (FStar_Ident.lid_of_str
                         "FStar.Reflection.V2.Compare.compare_ident") cb us)
                     args))
@@ -199,7 +196,6 @@ let _ =
                    FStar_Reflection_V2_NBEEmbeddings.e_ident
                    FStar_Reflection_V2_NBEEmbeddings.e_ident
                    (FStar_TypeChecker_NBETerm.e_unsupported ()) compare_ident
-                   Prims.int_zero
                    (FStar_Ident.lid_of_str
                       "FStar.Reflection.V2.Compare.compare_ident") cb us)
                   args))
@@ -255,7 +251,7 @@ let _ =
                   (FStar_Syntax_Embeddings.arrow_as_prim_step_2
                      FStar_Reflection_V2_Embeddings.e_universe
                      FStar_Reflection_V2_Embeddings.e_universe
-                     FStar_Order.e_order compare_universe Prims.int_zero
+                     FStar_Order.e_order compare_universe
                      (FStar_Ident.lid_of_str
                         "FStar.Reflection.V2.Compare.compare_universe") cb us)
                     args))
@@ -269,7 +265,7 @@ let _ =
                    FStar_Reflection_V2_NBEEmbeddings.e_universe
                    FStar_Reflection_V2_NBEEmbeddings.e_universe
                    (FStar_TypeChecker_NBETerm.e_unsupported ())
-                   compare_universe Prims.int_zero
+                   compare_universe
                    (FStar_Ident.lid_of_str
                       "FStar.Reflection.V2.Compare.compare_universe") cb us)
                   args))
@@ -292,7 +288,7 @@ let _ =
                         FStar_Reflection_V2_Embeddings.e_universe)
                      (FStar_Syntax_Embeddings.e_list
                         FStar_Reflection_V2_Embeddings.e_universe)
-                     FStar_Order.e_order compare_universes Prims.int_zero
+                     FStar_Order.e_order compare_universes
                      (FStar_Ident.lid_of_str
                         "FStar.Reflection.V2.Compare.compare_universes") cb
                      us) args))
@@ -308,7 +304,7 @@ let _ =
                    (FStar_TypeChecker_NBETerm.e_list
                       FStar_Reflection_V2_NBEEmbeddings.e_universe)
                    (FStar_TypeChecker_NBETerm.e_unsupported ())
-                   compare_universes Prims.int_zero
+                   compare_universes
                    (FStar_Ident.lid_of_str
                       "FStar.Reflection.V2.Compare.compare_universes") cb us)
                   args))
@@ -577,7 +573,7 @@ let _ =
                   (FStar_Syntax_Embeddings.arrow_as_prim_step_2
                      FStar_Reflection_V2_Embeddings.e_term
                      FStar_Reflection_V2_Embeddings.e_term
-                     FStar_Order.e_order compare_term Prims.int_zero
+                     FStar_Order.e_order compare_term
                      (FStar_Ident.lid_of_str
                         "FStar.Reflection.V2.Compare.compare_term") cb us)
                     args))
@@ -591,7 +587,6 @@ let _ =
                    FStar_Reflection_V2_NBEEmbeddings.e_term
                    FStar_Reflection_V2_NBEEmbeddings.e_term
                    (FStar_TypeChecker_NBETerm.e_unsupported ()) compare_term
-                   Prims.int_zero
                    (FStar_Ident.lid_of_str
                       "FStar.Reflection.V2.Compare.compare_term") cb us) args))
 let (compare_comp :
@@ -611,7 +606,7 @@ let _ =
                   (FStar_Syntax_Embeddings.arrow_as_prim_step_2
                      FStar_Reflection_V2_Embeddings.e_comp
                      FStar_Reflection_V2_Embeddings.e_comp
-                     FStar_Order.e_order compare_comp Prims.int_zero
+                     FStar_Order.e_order compare_comp
                      (FStar_Ident.lid_of_str
                         "FStar.Reflection.V2.Compare.compare_comp") cb us)
                     args))
@@ -625,7 +620,6 @@ let _ =
                    FStar_Reflection_V2_NBEEmbeddings.e_comp
                    FStar_Reflection_V2_NBEEmbeddings.e_comp
                    (FStar_TypeChecker_NBETerm.e_unsupported ()) compare_comp
-                   Prims.int_zero
                    (FStar_Ident.lid_of_str
                       "FStar.Reflection.V2.Compare.compare_comp") cb us) args))
 let (compare_binder :
@@ -645,7 +639,7 @@ let _ =
                   (FStar_Syntax_Embeddings.arrow_as_prim_step_2
                      FStar_Reflection_V2_Embeddings.e_binder
                      FStar_Reflection_V2_Embeddings.e_binder
-                     FStar_Order.e_order compare_binder Prims.int_zero
+                     FStar_Order.e_order compare_binder
                      (FStar_Ident.lid_of_str
                         "FStar.Reflection.V2.Compare.compare_binder") cb us)
                     args))
@@ -659,7 +653,7 @@ let _ =
                    FStar_Reflection_V2_NBEEmbeddings.e_binder
                    FStar_Reflection_V2_NBEEmbeddings.e_binder
                    (FStar_TypeChecker_NBETerm.e_unsupported ())
-                   compare_binder Prims.int_zero
+                   compare_binder
                    (FStar_Ident.lid_of_str
                       "FStar.Reflection.V2.Compare.compare_binder") cb us)
                   args))

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Embeddings.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Embeddings.ml
@@ -2359,7 +2359,49 @@ let arrow_as_prim_step_1 :
     'a FStar_Syntax_Embeddings_Base.embedding ->
       'b FStar_Syntax_Embeddings_Base.embedding ->
         ('a -> 'b) ->
-          Prims.int ->
+          FStar_Ident.lid ->
+            FStar_Syntax_Embeddings_Base.norm_cb ->
+              FStar_Syntax_Syntax.universes ->
+                FStar_Syntax_Syntax.args ->
+                  FStar_Syntax_Syntax.term FStar_Pervasives_Native.option
+  =
+  fun ea ->
+    fun eb ->
+      fun f ->
+        fun fv_lid ->
+          fun norm ->
+            let rng = FStar_Ident.range_of_lid fv_lid in
+            let f_wrapped _us args =
+              let uu___ = args in
+              match uu___ with
+              | (x, uu___1)::[] ->
+                  let shadow_app =
+                    let uu___2 =
+                      FStar_Thunk.mk
+                        (fun uu___3 ->
+                           let uu___4 = norm (FStar_Pervasives.Inl fv_lid) in
+                           FStar_Syntax_Syntax.mk_Tm_app uu___4 args rng) in
+                    FStar_Pervasives_Native.Some uu___2 in
+                  let uu___2 =
+                    let uu___3 =
+                      FStar_Syntax_Embeddings_Base.try_unembed ea x norm in
+                    FStar_Compiler_Util.map_opt uu___3
+                      (fun x1 ->
+                         let uu___4 =
+                           let uu___5 = f x1 in
+                           FStar_Syntax_Embeddings_Base.embed eb uu___5 in
+                         uu___4 rng shadow_app norm) in
+                  (match uu___2 with
+                   | FStar_Pervasives_Native.Some x1 ->
+                       FStar_Pervasives_Native.Some x1
+                   | FStar_Pervasives_Native.None -> force_shadow shadow_app) in
+            f_wrapped
+let arrow_as_prim_step_2 :
+  'a 'b 'c .
+    'a FStar_Syntax_Embeddings_Base.embedding ->
+      'b FStar_Syntax_Embeddings_Base.embedding ->
+        'c FStar_Syntax_Embeddings_Base.embedding ->
+          ('a -> 'b -> 'c) ->
             FStar_Ident.lid ->
               FStar_Syntax_Embeddings_Base.norm_cb ->
                 FStar_Syntax_Syntax.universes ->
@@ -2368,51 +2410,52 @@ let arrow_as_prim_step_1 :
   =
   fun ea ->
     fun eb ->
-      fun f ->
-        fun n_tvars ->
+      fun ec ->
+        fun f ->
           fun fv_lid ->
             fun norm ->
               let rng = FStar_Ident.range_of_lid fv_lid in
               let f_wrapped _us args =
-                let uu___ = FStar_Compiler_List.splitAt n_tvars args in
+                let uu___ = args in
                 match uu___ with
-                | (_tvar_args, rest_args) ->
-                    let uu___1 = rest_args in
-                    (match uu___1 with
-                     | (x, uu___2)::[] ->
-                         let shadow_app =
-                           let uu___3 =
-                             FStar_Thunk.mk
-                               (fun uu___4 ->
-                                  let uu___5 =
-                                    norm (FStar_Pervasives.Inl fv_lid) in
-                                  FStar_Syntax_Syntax.mk_Tm_app uu___5 args
-                                    rng) in
-                           FStar_Pervasives_Native.Some uu___3 in
-                         let uu___3 =
-                           let uu___4 =
-                             FStar_Syntax_Embeddings_Base.try_unembed ea x
+                | (x, uu___1)::(y, uu___2)::[] ->
+                    let shadow_app =
+                      let uu___3 =
+                        FStar_Thunk.mk
+                          (fun uu___4 ->
+                             let uu___5 = norm (FStar_Pervasives.Inl fv_lid) in
+                             FStar_Syntax_Syntax.mk_Tm_app uu___5 args rng) in
+                      FStar_Pervasives_Native.Some uu___3 in
+                    let uu___3 =
+                      let uu___4 =
+                        FStar_Syntax_Embeddings_Base.try_unembed ea x norm in
+                      FStar_Compiler_Util.bind_opt uu___4
+                        (fun x1 ->
+                           let uu___5 =
+                             FStar_Syntax_Embeddings_Base.try_unembed eb y
                                norm in
-                           FStar_Compiler_Util.map_opt uu___4
-                             (fun x1 ->
-                                let uu___5 =
-                                  let uu___6 = f x1 in
-                                  FStar_Syntax_Embeddings_Base.embed eb
-                                    uu___6 in
-                                uu___5 rng shadow_app norm) in
-                         (match uu___3 with
-                          | FStar_Pervasives_Native.Some x1 ->
-                              FStar_Pervasives_Native.Some x1
-                          | FStar_Pervasives_Native.None ->
-                              force_shadow shadow_app)) in
+                           FStar_Compiler_Util.bind_opt uu___5
+                             (fun y1 ->
+                                let uu___6 =
+                                  let uu___7 =
+                                    let uu___8 = f x1 y1 in
+                                    FStar_Syntax_Embeddings_Base.embed ec
+                                      uu___8 in
+                                  uu___7 rng shadow_app norm in
+                                FStar_Pervasives_Native.Some uu___6)) in
+                    (match uu___3 with
+                     | FStar_Pervasives_Native.Some x1 ->
+                         FStar_Pervasives_Native.Some x1
+                     | FStar_Pervasives_Native.None ->
+                         force_shadow shadow_app) in
               f_wrapped
-let arrow_as_prim_step_2 :
-  'a 'b 'c .
+let arrow_as_prim_step_3 :
+  'a 'b 'c 'd .
     'a FStar_Syntax_Embeddings_Base.embedding ->
       'b FStar_Syntax_Embeddings_Base.embedding ->
         'c FStar_Syntax_Embeddings_Base.embedding ->
-          ('a -> 'b -> 'c) ->
-            Prims.int ->
+          'd FStar_Syntax_Embeddings_Base.embedding ->
+            ('a -> 'b -> 'c -> 'd) ->
               FStar_Ident.lid ->
                 FStar_Syntax_Embeddings_Base.norm_cb ->
                   FStar_Syntax_Syntax.universes ->
@@ -2422,121 +2465,51 @@ let arrow_as_prim_step_2 :
   fun ea ->
     fun eb ->
       fun ec ->
-        fun f ->
-          fun n_tvars ->
+        fun ed ->
+          fun f ->
             fun fv_lid ->
               fun norm ->
                 let rng = FStar_Ident.range_of_lid fv_lid in
                 let f_wrapped _us args =
-                  let uu___ = FStar_Compiler_List.splitAt n_tvars args in
+                  let uu___ = args in
                   match uu___ with
-                  | (_tvar_args, rest_args) ->
-                      let uu___1 = rest_args in
-                      (match uu___1 with
-                       | (x, uu___2)::(y, uu___3)::[] ->
-                           let shadow_app =
-                             let uu___4 =
-                               FStar_Thunk.mk
-                                 (fun uu___5 ->
-                                    let uu___6 =
-                                      norm (FStar_Pervasives.Inl fv_lid) in
-                                    FStar_Syntax_Syntax.mk_Tm_app uu___6 args
-                                      rng) in
-                             FStar_Pervasives_Native.Some uu___4 in
-                           let uu___4 =
-                             let uu___5 =
-                               FStar_Syntax_Embeddings_Base.try_unembed ea x
-                                 norm in
-                             FStar_Compiler_Util.bind_opt uu___5
-                               (fun x1 ->
-                                  let uu___6 =
-                                    FStar_Syntax_Embeddings_Base.try_unembed
-                                      eb y norm in
-                                  FStar_Compiler_Util.bind_opt uu___6
-                                    (fun y1 ->
-                                       let uu___7 =
-                                         let uu___8 =
-                                           let uu___9 = f x1 y1 in
-                                           FStar_Syntax_Embeddings_Base.embed
-                                             ec uu___9 in
-                                         uu___8 rng shadow_app norm in
-                                       FStar_Pervasives_Native.Some uu___7)) in
-                           (match uu___4 with
-                            | FStar_Pervasives_Native.Some x1 ->
-                                FStar_Pervasives_Native.Some x1
-                            | FStar_Pervasives_Native.None ->
-                                force_shadow shadow_app)) in
-                f_wrapped
-let arrow_as_prim_step_3 :
-  'a 'b 'c 'd .
-    'a FStar_Syntax_Embeddings_Base.embedding ->
-      'b FStar_Syntax_Embeddings_Base.embedding ->
-        'c FStar_Syntax_Embeddings_Base.embedding ->
-          'd FStar_Syntax_Embeddings_Base.embedding ->
-            ('a -> 'b -> 'c -> 'd) ->
-              Prims.int ->
-                FStar_Ident.lid ->
-                  FStar_Syntax_Embeddings_Base.norm_cb ->
-                    FStar_Syntax_Syntax.universes ->
-                      FStar_Syntax_Syntax.args ->
-                        FStar_Syntax_Syntax.term
-                          FStar_Pervasives_Native.option
-  =
-  fun ea ->
-    fun eb ->
-      fun ec ->
-        fun ed ->
-          fun f ->
-            fun n_tvars ->
-              fun fv_lid ->
-                fun norm ->
-                  let rng = FStar_Ident.range_of_lid fv_lid in
-                  let f_wrapped _us args =
-                    let uu___ = FStar_Compiler_List.splitAt n_tvars args in
-                    match uu___ with
-                    | (_tvar_args, rest_args) ->
-                        let uu___1 = rest_args in
-                        (match uu___1 with
-                         | (x, uu___2)::(y, uu___3)::(z, uu___4)::[] ->
-                             let shadow_app =
-                               let uu___5 =
-                                 FStar_Thunk.mk
-                                   (fun uu___6 ->
-                                      let uu___7 =
-                                        norm (FStar_Pervasives.Inl fv_lid) in
-                                      FStar_Syntax_Syntax.mk_Tm_app uu___7
-                                        args rng) in
-                               FStar_Pervasives_Native.Some uu___5 in
-                             let uu___5 =
+                  | (x, uu___1)::(y, uu___2)::(z, uu___3)::[] ->
+                      let shadow_app =
+                        let uu___4 =
+                          FStar_Thunk.mk
+                            (fun uu___5 ->
                                let uu___6 =
-                                 FStar_Syntax_Embeddings_Base.try_unembed ea
-                                   x norm in
-                               FStar_Compiler_Util.bind_opt uu___6
-                                 (fun x1 ->
-                                    let uu___7 =
-                                      FStar_Syntax_Embeddings_Base.try_unembed
-                                        eb y norm in
-                                    FStar_Compiler_Util.bind_opt uu___7
-                                      (fun y1 ->
-                                         let uu___8 =
-                                           FStar_Syntax_Embeddings_Base.try_unembed
-                                             ec z norm in
-                                         FStar_Compiler_Util.bind_opt uu___8
-                                           (fun z1 ->
-                                              let uu___9 =
-                                                let uu___10 =
-                                                  let uu___11 = f x1 y1 z1 in
-                                                  FStar_Syntax_Embeddings_Base.embed
-                                                    ed uu___11 in
-                                                uu___10 rng shadow_app norm in
-                                              FStar_Pervasives_Native.Some
-                                                uu___9))) in
-                             (match uu___5 with
-                              | FStar_Pervasives_Native.Some x1 ->
-                                  FStar_Pervasives_Native.Some x1
-                              | FStar_Pervasives_Native.None ->
-                                  force_shadow shadow_app)) in
-                  f_wrapped
+                                 norm (FStar_Pervasives.Inl fv_lid) in
+                               FStar_Syntax_Syntax.mk_Tm_app uu___6 args rng) in
+                        FStar_Pervasives_Native.Some uu___4 in
+                      let uu___4 =
+                        let uu___5 =
+                          FStar_Syntax_Embeddings_Base.try_unembed ea x norm in
+                        FStar_Compiler_Util.bind_opt uu___5
+                          (fun x1 ->
+                             let uu___6 =
+                               FStar_Syntax_Embeddings_Base.try_unembed eb y
+                                 norm in
+                             FStar_Compiler_Util.bind_opt uu___6
+                               (fun y1 ->
+                                  let uu___7 =
+                                    FStar_Syntax_Embeddings_Base.try_unembed
+                                      ec z norm in
+                                  FStar_Compiler_Util.bind_opt uu___7
+                                    (fun z1 ->
+                                       let uu___8 =
+                                         let uu___9 =
+                                           let uu___10 = f x1 y1 z1 in
+                                           FStar_Syntax_Embeddings_Base.embed
+                                             ed uu___10 in
+                                         uu___9 rng shadow_app norm in
+                                       FStar_Pervasives_Native.Some uu___8))) in
+                      (match uu___4 with
+                       | FStar_Pervasives_Native.Some x1 ->
+                           FStar_Pervasives_Native.Some x1
+                       | FStar_Pervasives_Native.None ->
+                           force_shadow shadow_app) in
+                f_wrapped
 let debug_wrap : 'a . Prims.string -> (unit -> 'a) -> 'a =
   fun s ->
     fun f ->

--- a/ocaml/fstar-lib/generated/FStar_Tactics_NamedView.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_NamedView.ml
@@ -1484,7 +1484,7 @@ let _ =
                (fun _ ->
                   (FStar_Syntax_Embeddings.arrow_as_prim_step_1
                      FStar_Reflection_V2_Embeddings.e_universe
-                     e_named_universe_view inspect_universe Prims.int_zero
+                     e_named_universe_view inspect_universe
                      (FStar_Ident.lid_of_str
                         "FStar.Tactics.NamedView.inspect_universe") cb us)
                     args))
@@ -1497,7 +1497,7 @@ let _ =
                 (FStar_TypeChecker_NBETerm.arrow_as_prim_step_1
                    FStar_Reflection_V2_NBEEmbeddings.e_universe
                    (FStar_TypeChecker_NBETerm.e_unsupported ())
-                   inspect_universe Prims.int_zero
+                   inspect_universe
                    (FStar_Ident.lid_of_str
                       "FStar.Tactics.NamedView.inspect_universe") cb us) args))
 let (close_universe_view :
@@ -1530,7 +1530,6 @@ let _ =
                   (FStar_Syntax_Embeddings.arrow_as_prim_step_1
                      e_named_universe_view
                      FStar_Reflection_V2_Embeddings.e_universe pack_universe
-                     Prims.int_zero
                      (FStar_Ident.lid_of_str
                         "FStar.Tactics.NamedView.pack_universe") cb us) args))
     (fun cb ->
@@ -1542,7 +1541,6 @@ let _ =
                 (FStar_TypeChecker_NBETerm.arrow_as_prim_step_1
                    (FStar_TypeChecker_NBETerm.e_unsupported ())
                    FStar_Reflection_V2_NBEEmbeddings.e_universe pack_universe
-                   Prims.int_zero
                    (FStar_Ident.lid_of_str
                       "FStar.Tactics.NamedView.pack_universe") cb us) args))
 let (__binding_to_binder :
@@ -1864,7 +1862,6 @@ let _ =
                      (FStar_Syntax_Embeddings.e_tuple2
                         FStar_Reflection_V2_Embeddings.e_binder
                         FStar_Reflection_V2_Embeddings.e_term) close_term
-                     Prims.int_zero
                      (FStar_Ident.lid_of_str
                         "FStar.Tactics.NamedView.close_term") cb us) args))
     (fun cb ->
@@ -1879,7 +1876,6 @@ let _ =
                    (FStar_TypeChecker_NBETerm.e_tuple2
                       FStar_Reflection_V2_NBEEmbeddings.e_binder
                       FStar_Reflection_V2_NBEEmbeddings.e_term) close_term
-                   Prims.int_zero
                    (FStar_Ident.lid_of_str
                       "FStar.Tactics.NamedView.close_term") cb us) args))
 let (close_comp : binder -> comp -> (FStar_Reflection_Types.binder * comp)) =
@@ -3066,7 +3062,7 @@ let _ =
                (fun _ ->
                   (FStar_Syntax_Embeddings.arrow_as_prim_step_1
                      e_named_term_view FStar_Reflection_V2_Embeddings.e_term
-                     pack Prims.int_zero
+                     pack
                      (FStar_Ident.lid_of_str "FStar.Tactics.NamedView.pack")
                      cb us) args))
     (fun cb ->
@@ -3077,7 +3073,6 @@ let _ =
                 (FStar_TypeChecker_NBETerm.arrow_as_prim_step_1
                    (FStar_TypeChecker_NBETerm.e_unsupported ())
                    FStar_Reflection_V2_NBEEmbeddings.e_term pack
-                   Prims.int_zero
                    (FStar_Ident.lid_of_str "FStar.Tactics.NamedView.pack") cb
                    us) args))
 let (open_univ_s :

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_NBETerm.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_NBETerm.ml
@@ -1965,7 +1965,30 @@ let arrow_as_prim_step_1 :
     'a embedding ->
       'b embedding ->
         ('a -> 'b) ->
-          Prims.int ->
+          FStar_Ident.lid ->
+            nbe_cbs ->
+              FStar_Syntax_Syntax.universes ->
+                args -> t FStar_Pervasives_Native.option
+  =
+  fun ea ->
+    fun eb ->
+      fun f ->
+        fun _fv_lid ->
+          fun cb ->
+            let f_wrapped _us args1 =
+              let uu___ = FStar_Compiler_List.hd args1 in
+              match uu___ with
+              | (x, uu___1) ->
+                  let uu___2 = unembed ea cb x in
+                  FStar_Compiler_Util.map_opt uu___2
+                    (fun x1 -> let uu___3 = f x1 in embed eb cb uu___3) in
+            f_wrapped
+let arrow_as_prim_step_2 :
+  'a 'b 'c .
+    'a embedding ->
+      'b embedding ->
+        'c embedding ->
+          ('a -> 'b -> 'c) ->
             FStar_Ident.lid ->
               nbe_cbs ->
                 FStar_Syntax_Syntax.universes ->
@@ -1973,28 +1996,37 @@ let arrow_as_prim_step_1 :
   =
   fun ea ->
     fun eb ->
-      fun f ->
-        fun n_tvars ->
+      fun ec ->
+        fun f ->
           fun _fv_lid ->
             fun cb ->
               let f_wrapped _us args1 =
-                let uu___ = FStar_Compiler_List.splitAt n_tvars args1 in
+                let uu___ = FStar_Compiler_List.hd args1 in
                 match uu___ with
-                | (_tvar_args, rest_args) ->
-                    let uu___1 = FStar_Compiler_List.hd rest_args in
-                    (match uu___1 with
-                     | (x, uu___2) ->
-                         let uu___3 = unembed ea cb x in
-                         FStar_Compiler_Util.map_opt uu___3
-                           (fun x1 -> let uu___4 = f x1 in embed eb cb uu___4)) in
+                | (x, uu___1) ->
+                    let uu___2 =
+                      let uu___3 = FStar_Compiler_List.tl args1 in
+                      FStar_Compiler_List.hd uu___3 in
+                    (match uu___2 with
+                     | (y, uu___3) ->
+                         let uu___4 = unembed ea cb x in
+                         FStar_Compiler_Util.bind_opt uu___4
+                           (fun x1 ->
+                              let uu___5 = unembed eb cb y in
+                              FStar_Compiler_Util.bind_opt uu___5
+                                (fun y1 ->
+                                   let uu___6 =
+                                     let uu___7 = f x1 y1 in
+                                     embed ec cb uu___7 in
+                                   FStar_Pervasives_Native.Some uu___6))) in
               f_wrapped
-let arrow_as_prim_step_2 :
-  'a 'b 'c .
+let arrow_as_prim_step_3 :
+  'a 'b 'c 'd .
     'a embedding ->
       'b embedding ->
         'c embedding ->
-          ('a -> 'b -> 'c) ->
-            Prims.int ->
+          'd embedding ->
+            ('a -> 'b -> 'c -> 'd) ->
               FStar_Ident.lid ->
                 nbe_cbs ->
                   FStar_Syntax_Syntax.universes ->
@@ -2003,92 +2035,41 @@ let arrow_as_prim_step_2 :
   fun ea ->
     fun eb ->
       fun ec ->
-        fun f ->
-          fun n_tvars ->
+        fun ed ->
+          fun f ->
             fun _fv_lid ->
               fun cb ->
                 let f_wrapped _us args1 =
-                  let uu___ = FStar_Compiler_List.splitAt n_tvars args1 in
+                  let uu___ = FStar_Compiler_List.hd args1 in
                   match uu___ with
-                  | (_tvar_args, rest_args) ->
-                      let uu___1 = FStar_Compiler_List.hd rest_args in
-                      (match uu___1 with
-                       | (x, uu___2) ->
-                           let uu___3 =
-                             let uu___4 = FStar_Compiler_List.tl rest_args in
-                             FStar_Compiler_List.hd uu___4 in
-                           (match uu___3 with
-                            | (y, uu___4) ->
-                                let uu___5 = unembed ea cb x in
-                                FStar_Compiler_Util.bind_opt uu___5
+                  | (x, uu___1) ->
+                      let uu___2 =
+                        let uu___3 = FStar_Compiler_List.tl args1 in
+                        FStar_Compiler_List.hd uu___3 in
+                      (match uu___2 with
+                       | (y, uu___3) ->
+                           let uu___4 =
+                             let uu___5 =
+                               let uu___6 = FStar_Compiler_List.tl args1 in
+                               FStar_Compiler_List.tl uu___6 in
+                             FStar_Compiler_List.hd uu___5 in
+                           (match uu___4 with
+                            | (z, uu___5) ->
+                                let uu___6 = unembed ea cb x in
+                                FStar_Compiler_Util.bind_opt uu___6
                                   (fun x1 ->
-                                     let uu___6 = unembed eb cb y in
-                                     FStar_Compiler_Util.bind_opt uu___6
+                                     let uu___7 = unembed eb cb y in
+                                     FStar_Compiler_Util.bind_opt uu___7
                                        (fun y1 ->
-                                          let uu___7 =
-                                            let uu___8 = f x1 y1 in
-                                            embed ec cb uu___8 in
-                                          FStar_Pervasives_Native.Some uu___7)))) in
+                                          let uu___8 = unembed ec cb z in
+                                          FStar_Compiler_Util.bind_opt uu___8
+                                            (fun z1 ->
+                                               let uu___9 =
+                                                 let uu___10 = f x1 y1 z1 in
+                                                 embed ed cb uu___10 in
+                                               FStar_Pervasives_Native.Some
+                                                 uu___9))))) in
                 f_wrapped
-let arrow_as_prim_step_3 :
-  'a 'b 'c 'd .
-    'a embedding ->
-      'b embedding ->
-        'c embedding ->
-          'd embedding ->
-            ('a -> 'b -> 'c -> 'd) ->
-              Prims.int ->
-                FStar_Ident.lid ->
-                  nbe_cbs ->
-                    FStar_Syntax_Syntax.universes ->
-                      args -> t FStar_Pervasives_Native.option
-  =
-  fun ea ->
-    fun eb ->
-      fun ec ->
-        fun ed ->
-          fun f ->
-            fun n_tvars ->
-              fun _fv_lid ->
-                fun cb ->
-                  let f_wrapped _us args1 =
-                    let uu___ = FStar_Compiler_List.splitAt n_tvars args1 in
-                    match uu___ with
-                    | (_tvar_args, rest_args) ->
-                        let uu___1 = FStar_Compiler_List.hd rest_args in
-                        (match uu___1 with
-                         | (x, uu___2) ->
-                             let uu___3 =
-                               let uu___4 = FStar_Compiler_List.tl rest_args in
-                               FStar_Compiler_List.hd uu___4 in
-                             (match uu___3 with
-                              | (y, uu___4) ->
-                                  let uu___5 =
-                                    let uu___6 =
-                                      let uu___7 =
-                                        FStar_Compiler_List.tl rest_args in
-                                      FStar_Compiler_List.tl uu___7 in
-                                    FStar_Compiler_List.hd uu___6 in
-                                  (match uu___5 with
-                                   | (z, uu___6) ->
-                                       let uu___7 = unembed ea cb x in
-                                       FStar_Compiler_Util.bind_opt uu___7
-                                         (fun x1 ->
-                                            let uu___8 = unembed eb cb y in
-                                            FStar_Compiler_Util.bind_opt
-                                              uu___8
-                                              (fun y1 ->
-                                                 let uu___9 = unembed ec cb z in
-                                                 FStar_Compiler_Util.bind_opt
-                                                   uu___9
-                                                   (fun z1 ->
-                                                      let uu___10 =
-                                                        let uu___11 =
-                                                          f x1 y1 z1 in
-                                                        embed ed cb uu___11 in
-                                                      FStar_Pervasives_Native.Some
-                                                        uu___10)))))) in
-                  f_wrapped
 let (e_order : FStar_Order.order embedding) =
   let ord_Lt_lid =
     FStar_Ident.lid_of_path ["FStar"; "Order"; "Lt"]

--- a/src/extraction/FStar.Extraction.ML.RegEmb.fst
+++ b/src/extraction/FStar.Extraction.ML.RegEmb.fst
@@ -425,7 +425,7 @@ let interpret_plugin_as_term_fun (env:UEnv.uenv) (fv:fv) (t:typ) (arity_opt:opti
           let branch =
              pattern,
              None,
-             mk <| MLE_App(body, [as_name ([], "args")])
+             mk <| MLE_App(body, [as_name ([], "args_tail")])
           in
           let default_branch =
               MLP_Wild,
@@ -516,7 +516,6 @@ let interpret_plugin_as_term_fun (env:UEnv.uenv) (fv:fv) (t:typ) (arity_opt:opti
             let args = arg_unembeddings
                     @ [res_embedding;
                        lid_to_name fv_lid;
-                       with_ty MLTY_Top <| MLE_Const (MLC_Int(string_of_int tvar_arity, None));
                        fv_lid_embedded;
                        cb;
                        us]

--- a/src/syntax/FStar.Syntax.Embeddings.fst
+++ b/src/syntax/FStar.Syntax.Embeddings.fst
@@ -1095,13 +1095,12 @@ let e_document : embedding Pprint.document = e_lazy Lazy_doc (S.fvar PC.document
  /////////////////////////////////////////////////////////////////////
 
 let arrow_as_prim_step_1 (ea:embedding 'a) (eb:embedding 'b)
-                         (f:'a -> 'b) (n_tvars:int) (fv_lid:Ident.lid) norm
+                         (f:'a -> 'b) (fv_lid:Ident.lid) norm
    : universes -> args -> option term =
     let rng = Ident.range_of_lid fv_lid in
     let f_wrapped _us args =
-        let _tvar_args, rest_args = List.splitAt n_tvars args in
         //arity mismatches are handled by the caller
-        let [(x, _)] = rest_args in
+        let [(x, _)] = args in
         let shadow_app =
             Some (Thunk.mk (fun () -> S.mk_Tm_app (norm (Inl fv_lid)) args rng))
         in
@@ -1116,13 +1115,12 @@ let arrow_as_prim_step_1 (ea:embedding 'a) (eb:embedding 'b)
     f_wrapped
 
 let arrow_as_prim_step_2 (ea:embedding 'a) (eb:embedding 'b) (ec:embedding 'c)
-                         (f:'a -> 'b -> 'c) n_tvars fv_lid norm
+                         (f:'a -> 'b -> 'c) fv_lid norm
    : universes -> args -> option term =
     let rng = Ident.range_of_lid fv_lid in
     let f_wrapped _us args =
-        let _tvar_args, rest_args = List.splitAt n_tvars args in
         //arity mismatches are handled by the caller
-        let [(x, _); (y, _)] = rest_args in
+        let [(x, _); (y, _)] = args in
         let shadow_app =
             Some (Thunk.mk (fun () -> S.mk_Tm_app (norm (Inl fv_lid)) args rng))
         in
@@ -1139,13 +1137,12 @@ let arrow_as_prim_step_2 (ea:embedding 'a) (eb:embedding 'b) (ec:embedding 'c)
 
 let arrow_as_prim_step_3 (ea:embedding 'a) (eb:embedding 'b)
                          (ec:embedding 'c) (ed:embedding 'd)
-                         (f:'a -> 'b -> 'c -> 'd) n_tvars fv_lid norm
+                         (f:'a -> 'b -> 'c -> 'd) fv_lid norm
    : universes -> args -> option term =
     let rng = Ident.range_of_lid fv_lid in
     let f_wrapped _us args =
-        let _tvar_args, rest_args = List.splitAt n_tvars args in
         //arity mismatches are handled by the caller
-        let [(x, _); (y, _); (z, _)] = rest_args in
+        let [(x, _); (y, _); (z, _)] = args in
         let shadow_app =
             Some (Thunk.mk (fun () -> S.mk_Tm_app (norm (Inl fv_lid)) args rng))
         in

--- a/src/syntax/FStar.Syntax.Embeddings.fsti
+++ b/src/syntax/FStar.Syntax.Embeddings.fsti
@@ -72,7 +72,6 @@ val mk_any_emb : typ -> embedding term
 val arrow_as_prim_step_1:  embedding 'a
                         -> embedding 'b
                         -> ('a -> 'b)
-                        -> n_tvars:int
                         -> repr_f:Ident.lid
                         -> norm_cb
                         -> (universes -> args -> option term)
@@ -81,7 +80,6 @@ val arrow_as_prim_step_2:  embedding 'a
                         -> embedding 'b
                         -> embedding 'c
                         -> ('a -> 'b -> 'c)
-                        -> n_tvars:int
                         -> repr_f:Ident.lid
                         -> norm_cb
                         -> (universes -> args -> option term)
@@ -91,7 +89,6 @@ val arrow_as_prim_step_3:  embedding 'a
                         -> embedding 'c
                         -> embedding 'd
                         -> ('a -> 'b -> 'c -> 'd)
-                        -> n_tvars:int
                         -> repr_f:Ident.lid
                         -> norm_cb
                         -> (universes -> args -> option term)

--- a/src/typechecker/FStar.TypeChecker.NBETerm.fst
+++ b/src/typechecker/FStar.TypeChecker.NBETerm.fst
@@ -797,11 +797,10 @@ let or_op (args:args) : option t =
 
 
 let arrow_as_prim_step_1 (ea:embedding 'a) (eb:embedding 'b)
-                         (f:'a -> 'b) (n_tvars:int) (_fv_lid:Ident.lid) cb
+                         (f:'a -> 'b) (_fv_lid:Ident.lid) cb
    : universes -> args -> option t =
     let f_wrapped _us args =
-        let _tvar_args, rest_args = List.splitAt n_tvars args in
-        let x, _ = List.hd rest_args in //arity mismatches are handled by code that dispatches here
+        let x, _ = List.hd args in //arity mismatches are handled by code that dispatches here
         BU.map_opt
                 (unembed ea cb x) (fun x ->
                  embed eb cb (f x))
@@ -809,12 +808,11 @@ let arrow_as_prim_step_1 (ea:embedding 'a) (eb:embedding 'b)
     f_wrapped
 
 let arrow_as_prim_step_2 (ea:embedding 'a) (eb:embedding 'b) (ec:embedding 'c)
-                         (f:'a -> 'b -> 'c) (n_tvars:int) (_fv_lid:Ident.lid) cb
+                         (f:'a -> 'b -> 'c) (_fv_lid:Ident.lid) cb
    : universes -> args -> option t =
     let f_wrapped _us args =
-        let _tvar_args, rest_args = List.splitAt n_tvars args in
-        let x, _ = List.hd rest_args in //arity mismatches are handled by code that dispatches here
-        let y, _ = List.hd (List.tl rest_args) in
+        let x, _ = List.hd args in //arity mismatches are handled by code that dispatches here
+        let y, _ = List.hd (List.tl args) in
         BU.bind_opt (unembed ea cb x) (fun x ->
         BU.bind_opt (unembed eb cb y) (fun y ->
         Some (embed ec cb (f x y))))
@@ -824,13 +822,12 @@ let arrow_as_prim_step_2 (ea:embedding 'a) (eb:embedding 'b) (ec:embedding 'c)
 
 let arrow_as_prim_step_3 (ea:embedding 'a) (eb:embedding 'b)
                          (ec:embedding 'c) (ed:embedding 'd)
-                         (f:'a -> 'b -> 'c -> 'd) (n_tvars:int) (_fv_lid:Ident.lid) cb
+                         (f:'a -> 'b -> 'c -> 'd) (_fv_lid:Ident.lid) cb
    : universes -> args -> option t =
     let f_wrapped _us args =
-        let _tvar_args, rest_args = List.splitAt n_tvars args in
-        let x, _ = List.hd rest_args in //arity mismatches are handled by code that dispatches here
-        let y, _ = List.hd (List.tl rest_args) in
-        let z, _ = List.hd (List.tl (List.tl rest_args)) in
+        let x, _ = List.hd args in //arity mismatches are handled by code that dispatches here
+        let y, _ = List.hd (List.tl args) in
+        let z, _ = List.hd (List.tl (List.tl args)) in
         BU.bind_opt (unembed ea cb x) (fun x ->
         BU.bind_opt (unembed eb cb y) (fun y ->
         BU.bind_opt (unembed ec cb z) (fun z ->

--- a/src/typechecker/FStar.TypeChecker.NBETerm.fsti
+++ b/src/typechecker/FStar.TypeChecker.NBETerm.fsti
@@ -308,7 +308,6 @@ val e_unsupported : #a:Type -> embedding a
 val arrow_as_prim_step_1:  embedding 'a
                         -> embedding 'b
                         -> ('a -> 'b)
-                        -> n_tvars:int
                         -> repr_f:Ident.lid
                         -> nbe_cbs
                         -> (universes -> args -> option t)
@@ -317,7 +316,6 @@ val arrow_as_prim_step_2:  embedding 'a
                         -> embedding 'b
                         -> embedding 'c
                         -> ('a -> 'b -> 'c)
-                        -> n_tvars:int
                         -> repr_f:Ident.lid
                         -> nbe_cbs
                         -> (universes -> args -> option t)
@@ -327,12 +325,9 @@ val arrow_as_prim_step_3:  embedding 'a
                         -> embedding 'c
                         -> embedding 'd
                         -> ('a -> 'b -> 'c -> 'd)
-                        -> n_tvars:int
                         -> repr_f:Ident.lid
                         -> nbe_cbs
                         -> (universes -> args -> option t)
-
-
 
 // Interface for NBE interpretations
 


### PR DESCRIPTION
Normal (Tot) plugins were expecting to be called with a full set
of arguments, including type arguments to be dropped, while
tactic plugins expected to be called on an already trimmed list. The
registry code was matching on the list of arguments and finding the
type arguments, but then passing them as-is to the interpretation
function. This meant that polymorphic Tac plugins were broken.

This fixes it by making all interpretation functions expected a trimmed
list.