### PR TITLE
Add a new syntax to support partial `open`s and `include`s

### DIFF
--- a/ocaml/fstar-lib/FStar_Parser_Parse.mly
+++ b/ocaml/fstar-lib/FStar_Parser_Parse.mly
@@ -362,15 +362,22 @@ typeclassDecl:
         (d, [at])
       }
 
+restriction:
+  | LBRACE ids=separated_list(COMMA, id=ident renamed=option(AS id=ident {id} ) {(id, renamed)}) RBRACE
+      { FStar_Syntax_Syntax.AllowList ids }
+  |   { FStar_Syntax_Syntax.Unrestricted  }
+
 rawDecl:
   | p=pragma
       { Pragma p }
-  | OPEN uid=quident
-      { Open uid }
+  | OPEN uid=quident r=restriction
+      { Open (uid, r) }
   | FRIEND uid=quident
       { Friend uid }
-  | INCLUDE uid=quident
-      { Include uid }
+  | INCLUDE uid=quident r=restriction
+      { Include (uid, r) }
+  | MODULE UNDERSCORE EQUALS uid=quident
+      { Open (uid, FStar_Syntax_Syntax.AllowList []) }
   | MODULE uid1=uident EQUALS uid2=quident
       { ModuleAbbrev(uid1, uid2) }
   | MODULE q=qlident

--- a/ocaml/fstar-lib/generated/FStar_CheckedFiles.ml
+++ b/ocaml/fstar-lib/generated/FStar_CheckedFiles.ml
@@ -1,7 +1,7 @@
 open Prims
 let (dbg : Prims.bool FStar_Compiler_Effect.ref) =
   FStar_Compiler_Debug.get_toggle "CheckedFiles"
-let (cache_version_number : Prims.int) = (Prims.of_int (67))
+let (cache_version_number : Prims.int) = (Prims.of_int (68))
 type tc_result =
   {
   checked_module: FStar_Syntax_Syntax.modul ;

--- a/ocaml/fstar-lib/generated/FStar_Interactive_PushHelper.ml
+++ b/ocaml/fstar-lib/generated/FStar_Interactive_PushHelper.ml
@@ -433,13 +433,13 @@ let (update_names_from_event :
               FStar_Interactive_CompletionTable.register_alias table uu___1
                 [] uu___2
             else table
-        | NTOpen (host, (included, kind)) ->
-            let uu___ = is_cur_mod host in
-            if uu___
+        | NTOpen (host, (included, kind, uu___)) ->
+            let uu___1 = is_cur_mod host in
+            if uu___1
             then
-              let uu___1 = query_of_lid included in
+              let uu___2 = query_of_lid included in
               FStar_Interactive_CompletionTable.register_open table
-                (kind = FStar_Syntax_Syntax.Open_module) [] uu___1
+                (kind = FStar_Syntax_Syntax.Open_module) [] uu___2
             else table
         | NTInclude (host, included) ->
             let uu___ =

--- a/ocaml/fstar-lib/generated/FStar_Parser_AST.ml
+++ b/ocaml/fstar-lib/generated/FStar_Parser_AST.ml
@@ -876,9 +876,9 @@ let (__proj__Mkto_be_desugared__item__dep_scan :
     | { lang_name; blob; idents; to_string; eq; dep_scan;_} -> dep_scan
 type decl' =
   | TopLevelModule of FStar_Ident.lid 
-  | Open of FStar_Ident.lid 
+  | Open of (FStar_Ident.lid * FStar_Syntax_Syntax.restriction) 
   | Friend of FStar_Ident.lid 
-  | Include of FStar_Ident.lid 
+  | Include of (FStar_Ident.lid * FStar_Syntax_Syntax.restriction) 
   | ModuleAbbrev of (FStar_Ident.ident * FStar_Ident.lid) 
   | TopLevelLet of (let_qualifier * (pattern * term) Prims.list) 
   | Tycon of (Prims.bool * Prims.bool * tycon Prims.list) 
@@ -916,7 +916,8 @@ let (__proj__TopLevelModule__item___0 : decl' -> FStar_Ident.lid) =
   fun projectee -> match projectee with | TopLevelModule _0 -> _0
 let (uu___is_Open : decl' -> Prims.bool) =
   fun projectee -> match projectee with | Open _0 -> true | uu___ -> false
-let (__proj__Open__item___0 : decl' -> FStar_Ident.lid) =
+let (__proj__Open__item___0 :
+  decl' -> (FStar_Ident.lid * FStar_Syntax_Syntax.restriction)) =
   fun projectee -> match projectee with | Open _0 -> _0
 let (uu___is_Friend : decl' -> Prims.bool) =
   fun projectee -> match projectee with | Friend _0 -> true | uu___ -> false
@@ -924,7 +925,8 @@ let (__proj__Friend__item___0 : decl' -> FStar_Ident.lid) =
   fun projectee -> match projectee with | Friend _0 -> _0
 let (uu___is_Include : decl' -> Prims.bool) =
   fun projectee -> match projectee with | Include _0 -> true | uu___ -> false
-let (__proj__Include__item___0 : decl' -> FStar_Ident.lid) =
+let (__proj__Include__item___0 :
+  decl' -> (FStar_Ident.lid * FStar_Syntax_Syntax.restriction)) =
   fun projectee -> match projectee with | Include _0 -> _0
 let (uu___is_ModuleAbbrev : decl' -> Prims.bool) =
   fun projectee ->
@@ -2456,19 +2458,50 @@ let (string_of_pragma : pragma -> Prims.string) =
     | PopOptions -> "pop-options"
     | RestartSolver -> "restart-solver"
     | PrintEffectsGraph -> "print-effects-graph"
+let (restriction_to_string : FStar_Syntax_Syntax.restriction -> Prims.string)
+  =
+  fun uu___ ->
+    match uu___ with
+    | FStar_Syntax_Syntax.Unrestricted -> ""
+    | FStar_Syntax_Syntax.AllowList allow_list ->
+        let uu___1 =
+          let uu___2 =
+            let uu___3 =
+              FStar_Compiler_List.map
+                (fun uu___4 ->
+                   match uu___4 with
+                   | (id, renamed) ->
+                       let uu___5 = FStar_Ident.string_of_id id in
+                       let uu___6 =
+                         let uu___7 =
+                           FStar_Compiler_Util.map_opt renamed
+                             (fun renamed1 ->
+                                let uu___8 =
+                                  FStar_Ident.string_of_id renamed1 in
+                                Prims.strcat " as " uu___8) in
+                         FStar_Compiler_Util.dflt "" uu___7 in
+                       Prims.strcat uu___5 uu___6) allow_list in
+            FStar_Compiler_String.concat ", " uu___3 in
+          Prims.strcat uu___2 "}" in
+        Prims.strcat " {" uu___1
 let rec (decl_to_string : decl -> Prims.string) =
   fun d ->
     match d.d with
     | TopLevelModule l ->
         let uu___ = FStar_Ident.string_of_lid l in
         Prims.strcat "module " uu___
-    | Open l ->
-        let uu___ = FStar_Ident.string_of_lid l in Prims.strcat "open " uu___
+    | Open (l, r) ->
+        let uu___ =
+          let uu___1 = FStar_Ident.string_of_lid l in
+          let uu___2 = restriction_to_string r in Prims.strcat uu___1 uu___2 in
+        Prims.strcat "open " uu___
     | Friend l ->
         let uu___ = FStar_Ident.string_of_lid l in
         Prims.strcat "friend " uu___
-    | Include l ->
-        let uu___ = FStar_Ident.string_of_lid l in
+    | Include (l, r) ->
+        let uu___ =
+          let uu___1 = FStar_Ident.string_of_lid l in
+          let uu___2 = restriction_to_string r in Prims.strcat uu___1 uu___2 in
         Prims.strcat "include " uu___
     | ModuleAbbrev (i, l) ->
         let uu___ = FStar_Ident.string_of_id i in

--- a/ocaml/fstar-lib/generated/FStar_Parser_AST_Util.ml
+++ b/ocaml/fstar-lib/generated/FStar_Parser_AST_Util.ml
@@ -544,6 +544,21 @@ let (eq_qualifier :
 let (eq_qualifiers :
   FStar_Parser_AST.qualifiers -> FStar_Parser_AST.qualifiers -> Prims.bool) =
   fun t1 -> fun t2 -> eq_list eq_qualifier t1 t2
+let (eq_restriction :
+  FStar_Syntax_Syntax.restriction ->
+    FStar_Syntax_Syntax.restriction -> Prims.bool)
+  =
+  fun restriction1 ->
+    fun restriction2 ->
+      match (restriction1, restriction2) with
+      | (FStar_Syntax_Syntax.Unrestricted, FStar_Syntax_Syntax.Unrestricted)
+          -> true
+      | (FStar_Syntax_Syntax.AllowList l1, FStar_Syntax_Syntax.AllowList l2)
+          ->
+          let eq_tuple eq_fst eq_snd uu___ uu___1 =
+            match (uu___, uu___1) with
+            | ((a, b), (c, d)) -> (eq_fst a c) && (eq_snd b d) in
+          eq_list (eq_tuple eq_ident (eq_option eq_ident)) l1 l2
 let rec (eq_decl' :
   FStar_Parser_AST.decl' -> FStar_Parser_AST.decl' -> Prims.bool) =
   fun d1 ->
@@ -551,12 +566,14 @@ let rec (eq_decl' :
       match (d1, d2) with
       | (FStar_Parser_AST.TopLevelModule lid1,
          FStar_Parser_AST.TopLevelModule lid2) -> eq_lid lid1 lid2
-      | (FStar_Parser_AST.Open lid1, FStar_Parser_AST.Open lid2) ->
-          eq_lid lid1 lid2
+      | (FStar_Parser_AST.Open (lid1, restriction1), FStar_Parser_AST.Open
+         (lid2, restriction2)) ->
+          (eq_lid lid1 lid2) && (eq_restriction restriction1 restriction2)
       | (FStar_Parser_AST.Friend lid1, FStar_Parser_AST.Friend lid2) ->
           eq_lid lid1 lid2
-      | (FStar_Parser_AST.Include lid1, FStar_Parser_AST.Include lid2) ->
-          eq_lid lid1 lid2
+      | (FStar_Parser_AST.Include (lid1, restriction1),
+         FStar_Parser_AST.Include (lid2, restriction2)) ->
+          (eq_lid lid1 lid2) && (eq_restriction restriction1 restriction2)
       | (FStar_Parser_AST.ModuleAbbrev (i1, lid1),
          FStar_Parser_AST.ModuleAbbrev (i2, lid2)) ->
           (eq_ident i1 i2) && (eq_lid lid1 lid2)
@@ -1004,9 +1021,9 @@ let rec (lidents_of_decl :
   fun d ->
     match d.FStar_Parser_AST.d with
     | FStar_Parser_AST.TopLevelModule uu___ -> []
-    | FStar_Parser_AST.Open l -> [l]
+    | FStar_Parser_AST.Open (l, uu___) -> [l]
     | FStar_Parser_AST.Friend l -> [l]
-    | FStar_Parser_AST.Include l -> [l]
+    | FStar_Parser_AST.Include (l, uu___) -> [l]
     | FStar_Parser_AST.ModuleAbbrev (uu___, l) -> [l]
     | FStar_Parser_AST.TopLevelLet (_q, lbs) ->
         (concat_map ())
@@ -1141,7 +1158,7 @@ let (as_open_namespaces_and_abbrevs :
       (fun d ->
          fun out ->
            match d.FStar_Parser_AST.d with
-           | FStar_Parser_AST.Open lid ->
+           | FStar_Parser_AST.Open (lid, uu___) ->
                {
                  open_namespaces = (lid :: (out.open_namespaces));
                  module_abbreviations = (out.module_abbreviations)

--- a/ocaml/fstar-lib/generated/FStar_Parser_Const.ml
+++ b/ocaml/fstar-lib/generated/FStar_Parser_Const.ml
@@ -343,6 +343,8 @@ let (admit_termination_lid : FStar_Ident.lident) =
   psconst "admit_termination"
 let (attr_substitute_lid : FStar_Ident.lident) =
   p2l ["FStar"; "Pervasives"; "Substitute"]
+let (desugar_of_variant_record_lid : FStar_Ident.lident) =
+  psconst "desugar_of_variant_record"
 let (well_founded_relation_lid : FStar_Ident.lident) =
   p2l ["FStar"; "WellFounded"; "well_founded_relation"]
 let (gen_reset : ((unit -> Prims.int) * (unit -> unit))) =

--- a/ocaml/fstar-lib/generated/FStar_Parser_Dep.ml
+++ b/ocaml/fstar-lib/generated/FStar_Parser_Dep.ml
@@ -1314,9 +1314,9 @@ let (collect_one :
                    | uu___3 -> ())) decls
            and collect_decl d =
              match d with
-             | FStar_Parser_AST.Include lid ->
+             | FStar_Parser_AST.Include (lid, uu___1) ->
                  add_to_parsing_data (P_open (false, lid))
-             | FStar_Parser_AST.Open lid ->
+             | FStar_Parser_AST.Open (lid, uu___1) ->
                  add_to_parsing_data (P_open (false, lid))
              | FStar_Parser_AST.Friend lid ->
                  let uu___1 =

--- a/ocaml/fstar-lib/generated/FStar_Parser_ToDocument.ml
+++ b/ocaml/fstar-lib/generated/FStar_Parser_ToDocument.ml
@@ -1181,10 +1181,10 @@ and (p_justSig : FStar_Parser_AST.decl -> FStar_Pprint.document) =
              let uu___1 = let uu___2 = str "let" in p_letlhs uu___2 lb false in
              FStar_Pprint.group uu___1) lbs
     | uu___ -> FStar_Pprint.empty
-and (p_list :
-  (FStar_Ident.ident -> FStar_Pprint.document) ->
-    FStar_Pprint.document ->
-      FStar_Ident.ident Prims.list -> FStar_Pprint.document)
+and p_list :
+  't .
+    ('t -> FStar_Pprint.document) ->
+      FStar_Pprint.document -> 't Prims.list -> FStar_Pprint.document
   =
   fun f ->
     fun sep ->
@@ -1203,19 +1203,46 @@ and (p_list :
           let uu___2 = p_list' l in
           let uu___3 = str "]" in FStar_Pprint.op_Hat_Hat uu___2 uu___3 in
         FStar_Pprint.op_Hat_Hat uu___ uu___1
+and (p_restriction :
+  FStar_Syntax_Syntax.restriction -> FStar_Pprint.document) =
+  fun uu___ ->
+    match uu___ with
+    | FStar_Syntax_Syntax.Unrestricted -> FStar_Pprint.empty
+    | FStar_Syntax_Syntax.AllowList ids ->
+        let uu___1 =
+          let uu___2 =
+            let uu___3 =
+              let uu___4 = str ", " in
+              p_list
+                (fun uu___5 ->
+                   match uu___5 with
+                   | (id, renamed) ->
+                       let uu___6 = p_ident id in
+                       let uu___7 = FStar_Pprint.optional p_ident renamed in
+                       FStar_Pprint.op_Hat_Slash_Hat uu___6 uu___7) uu___4
+                ids in
+            FStar_Pprint.op_Hat_Hat uu___3 FStar_Pprint.rbrace in
+          FStar_Pprint.op_Hat_Hat FStar_Pprint.lbrace uu___2 in
+        FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu___1
 and (p_rawDecl : FStar_Parser_AST.decl -> FStar_Pprint.document) =
   fun d ->
     match d.FStar_Parser_AST.d with
-    | FStar_Parser_AST.Open uid ->
+    | FStar_Parser_AST.Open (uid, r) ->
         let uu___ =
           let uu___1 = str "open" in
-          let uu___2 = p_quident uid in
+          let uu___2 =
+            let uu___3 = p_quident uid in
+            let uu___4 = p_restriction r in
+            FStar_Pprint.op_Hat_Slash_Hat uu___3 uu___4 in
           FStar_Pprint.op_Hat_Slash_Hat uu___1 uu___2 in
         FStar_Pprint.group uu___
-    | FStar_Parser_AST.Include uid ->
+    | FStar_Parser_AST.Include (uid, r) ->
         let uu___ =
           let uu___1 = str "include" in
-          let uu___2 = p_quident uid in
+          let uu___2 =
+            let uu___3 = p_quident uid in
+            let uu___4 = p_restriction r in
+            FStar_Pprint.op_Hat_Slash_Hat uu___3 uu___4 in
           FStar_Pprint.op_Hat_Slash_Hat uu___1 uu___2 in
         FStar_Pprint.group uu___
     | FStar_Parser_AST.Friend uid ->

--- a/ocaml/fstar-lib/generated/FStar_Syntax_DsEnv.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_DsEnv.ml
@@ -2757,62 +2757,103 @@ let elab_restriction :
                 let constructor_lid_to_desugared_record_lids =
                   let uu___ =
                     let uu___1 =
-                      let uu___2 =
-                        let uu___3 =
-                          let uu___4 =
-                            FStar_Compiler_List.concatMap
-                              (fun uu___5 ->
-                                 match uu___5 with
-                                 | (uu___6,
-                                    { FStar_Syntax_Syntax.name = uu___7;
+                      Obj.magic
+                        (FStar_Class_Monad.op_let_Bang
+                           FStar_Class_Monad.monad_list () ()
+                           (Obj.magic env1.modules)
+                           (fun uu___2 ->
+                              (fun uu___2 ->
+                                 let uu___2 = Obj.magic uu___2 in
+                                 match uu___2 with
+                                 | (uu___3,
+                                    { FStar_Syntax_Syntax.name = uu___4;
                                       FStar_Syntax_Syntax.declarations =
                                         declarations;
                                       FStar_Syntax_Syntax.is_interface =
-                                        uu___8;_})
-                                     -> declarations) env1.modules in
-                          FStar_Compiler_List.concatMap
-                            (fun sigelt ->
-                               match sigelt.FStar_Syntax_Syntax.sigel with
-                               | FStar_Syntax_Syntax.Sig_bundle
-                                   { FStar_Syntax_Syntax.ses = ses;
-                                     FStar_Syntax_Syntax.lids = uu___5;_}
-                                   -> ses
-                               | uu___5 -> []) uu___4 in
-                        FStar_Compiler_List.concatMap
-                          (fun sigelt ->
-                             FStar_Compiler_List.map
-                               (fun lid ->
-                                  (lid,
-                                    (sigelt.FStar_Syntax_Syntax.sigattrs)))
-                               (FStar_Syntax_Util.lids_of_sigelt sigelt))
-                          uu___3 in
-                      FStar_Compiler_List.filter_map
-                        (fun uu___3 ->
-                           match uu___3 with
-                           | (lid, attrs) ->
-                               let uu___4 =
-                                 FStar_Syntax_Util.get_attribute
-                                   FStar_Parser_Const.desugar_of_variant_record_lid
-                                   attrs in
-                               (match uu___4 with
-                                | FStar_Pervasives_Native.Some
-                                    (({
-                                        FStar_Syntax_Syntax.n =
-                                          FStar_Syntax_Syntax.Tm_constant
-                                          (FStar_Const.Const_string
-                                          (s, uu___5));
-                                        FStar_Syntax_Syntax.pos = uu___6;
-                                        FStar_Syntax_Syntax.vars = uu___7;
-                                        FStar_Syntax_Syntax.hash_code =
-                                          uu___8;_},
-                                      FStar_Pervasives_Native.None)::[])
-                                    ->
-                                    let uu___9 =
-                                      let uu___10 = FStar_Ident.lid_of_str s in
-                                      (uu___10, lid) in
-                                    FStar_Pervasives_Native.Some uu___9
-                                | uu___5 -> FStar_Pervasives_Native.None))
-                        uu___2 in
+                                        uu___5;_})
+                                     ->
+                                     Obj.magic
+                                       (FStar_Class_Monad.op_let_Bang
+                                          FStar_Class_Monad.monad_list () ()
+                                          (Obj.magic declarations)
+                                          (fun uu___6 ->
+                                             (fun sigelt ->
+                                                let sigelt = Obj.magic sigelt in
+                                                Obj.magic
+                                                  (FStar_Class_Monad.op_let_Bang
+                                                     FStar_Class_Monad.monad_list
+                                                     () ()
+                                                     (match sigelt.FStar_Syntax_Syntax.sigel
+                                                      with
+                                                      | FStar_Syntax_Syntax.Sig_bundle
+                                                          {
+                                                            FStar_Syntax_Syntax.ses
+                                                              = ses;
+                                                            FStar_Syntax_Syntax.lids
+                                                              = uu___6;_}
+                                                          -> Obj.magic ses
+                                                      | uu___6 ->
+                                                          Obj.magic [])
+                                                     (fun uu___6 ->
+                                                        (fun sigelt1 ->
+                                                           let sigelt1 =
+                                                             Obj.magic
+                                                               sigelt1 in
+                                                           Obj.magic
+                                                             (FStar_Class_Monad.op_let_Bang
+                                                                FStar_Class_Monad.monad_list
+                                                                () ()
+                                                                (Obj.magic
+                                                                   (FStar_Syntax_Util.lids_of_sigelt
+                                                                    sigelt1))
+                                                                (fun uu___6
+                                                                   ->
+                                                                   (fun lid
+                                                                    ->
+                                                                    let lid =
+                                                                    Obj.magic
+                                                                    lid in
+                                                                    let uu___6
+                                                                    =
+                                                                    FStar_Syntax_Util.get_attribute
+                                                                    FStar_Parser_Const.desugar_of_variant_record_lid
+                                                                    sigelt1.FStar_Syntax_Syntax.sigattrs in
+                                                                    match uu___6
+                                                                    with
+                                                                    | 
+                                                                    FStar_Pervasives_Native.Some
+                                                                    (({
+                                                                    FStar_Syntax_Syntax.n
+                                                                    =
+                                                                    FStar_Syntax_Syntax.Tm_constant
+                                                                    (FStar_Const.Const_string
+                                                                    (s,
+                                                                    uu___7));
+                                                                    FStar_Syntax_Syntax.pos
+                                                                    = uu___8;
+                                                                    FStar_Syntax_Syntax.vars
+                                                                    = uu___9;
+                                                                    FStar_Syntax_Syntax.hash_code
+                                                                    = uu___10;_},
+                                                                    FStar_Pervasives_Native.None)::[])
+                                                                    ->
+                                                                    let uu___11
+                                                                    =
+                                                                    let uu___12
+                                                                    =
+                                                                    FStar_Ident.lid_of_str
+                                                                    s in
+                                                                    (uu___12,
+                                                                    lid) in
+                                                                    Obj.magic
+                                                                    [uu___11]
+                                                                    | 
+                                                                    uu___7 ->
+                                                                    Obj.magic
+                                                                    [])
+                                                                    uu___6)))
+                                                          uu___6))) uu___6)))
+                                uu___2)) in
                     FStar_Compiler_List.filter
                       (fun uu___2 ->
                          match uu___2 with

--- a/ocaml/fstar-lib/generated/FStar_Syntax_DsEnv.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_DsEnv.ml
@@ -115,8 +115,8 @@ type env =
   exported_ids: exported_id_set FStar_Compiler_Util.smap ;
   trans_exported_ids: exported_id_set FStar_Compiler_Util.smap ;
   includes:
-    FStar_Ident.lident Prims.list FStar_Compiler_Effect.ref
-      FStar_Compiler_Util.smap
+    (FStar_Ident.lident * FStar_Syntax_Syntax.restriction) Prims.list
+      FStar_Compiler_Effect.ref FStar_Compiler_Util.smap
     ;
   sigaccum: FStar_Syntax_Syntax.sigelts ;
   sigmap: (FStar_Syntax_Syntax.sigelt * Prims.bool) FStar_Compiler_Util.smap ;
@@ -184,8 +184,8 @@ let (__proj__Mkenv__item__trans_exported_ids :
         ds_hooks; dep_graph;_} -> trans_exported_ids
 let (__proj__Mkenv__item__includes :
   env ->
-    FStar_Ident.lident Prims.list FStar_Compiler_Effect.ref
-      FStar_Compiler_Util.smap)
+    (FStar_Ident.lident * FStar_Syntax_Syntax.restriction) Prims.list
+      FStar_Compiler_Effect.ref FStar_Compiler_Util.smap)
   =
   fun projectee ->
     match projectee with
@@ -411,8 +411,7 @@ let (opens_and_abbrevs :
     FStar_Compiler_List.collect
       (fun uu___ ->
          match uu___ with
-         | Open_module_or_namespace (lid, info) ->
-             [FStar_Pervasives.Inl (lid, info)]
+         | Open_module_or_namespace payload -> [FStar_Pervasives.Inl payload]
          | Module_abbrev (id, lid) -> [FStar_Pervasives.Inr (id, lid)]
          | uu___1 -> []) env1.scope_mods
 let (open_modules :
@@ -423,7 +422,7 @@ let (open_modules_and_namespaces : env -> FStar_Ident.lident Prims.list) =
     FStar_Compiler_List.filter_map
       (fun uu___ ->
          match uu___ with
-         | Open_module_or_namespace (lid, _info) ->
+         | Open_module_or_namespace (lid, _info, _restriction) ->
              FStar_Pervasives_Native.Some lid
          | uu___1 -> FStar_Pervasives_Native.None) env1.scope_mods
 let (module_abbrevs :
@@ -770,11 +769,10 @@ let find_in_module_with_includes :
         fun env1 ->
           fun ns ->
             fun id ->
-              let idstr = FStar_Ident.string_of_id id in
               let rec aux uu___ =
                 match uu___ with
                 | [] -> find_in_module_default
-                | modul::q ->
+                | (modul, id1)::q ->
                     let mname = FStar_Ident.string_of_lid modul in
                     let not_shadowed =
                       let uu___1 = get_exported_id_set env1 mname in
@@ -784,10 +782,11 @@ let find_in_module_with_includes :
                           let mexports =
                             let uu___2 = mex eikind in
                             FStar_Compiler_Effect.op_Bang uu___2 in
+                          let uu___2 = FStar_Ident.string_of_id id1 in
                           FStar_Class_Setlike.mem ()
                             (Obj.magic
                                (FStar_Compiler_RBSet.setlike_rbset
-                                  FStar_Class_Ord.ord_string)) idstr
+                                  FStar_Class_Ord.ord_string)) uu___2
                             (Obj.magic mexports) in
                     let mincludes =
                       let uu___1 =
@@ -795,17 +794,26 @@ let find_in_module_with_includes :
                       match uu___1 with
                       | FStar_Pervasives_Native.None -> []
                       | FStar_Pervasives_Native.Some minc ->
-                          FStar_Compiler_Effect.op_Bang minc in
+                          let uu___2 = FStar_Compiler_Effect.op_Bang minc in
+                          FStar_Compiler_List.filter_map
+                            (fun uu___3 ->
+                               match uu___3 with
+                               | (ns1, restriction) ->
+                                   let opt =
+                                     FStar_Syntax_Syntax.is_ident_allowed_by_restriction
+                                       id1 restriction in
+                                   FStar_Compiler_Util.map_opt opt
+                                     (fun id2 -> (ns1, id2))) uu___2 in
                     let look_into =
                       if not_shadowed
                       then
-                        let uu___1 = qual modul id in find_in_module uu___1
+                        let uu___1 = qual modul id1 in find_in_module uu___1
                       else Cont_ignore in
                     (match look_into with
                      | Cont_ignore ->
                          aux (FStar_Compiler_List.op_At mincludes q)
                      | uu___1 -> look_into) in
-              aux [ns]
+              aux [(ns, id)]
 let try_lookup_id'' :
   'a .
     env ->
@@ -858,9 +866,15 @@ let try_lookup_id'' :
                                 used_marker1 true;
                               k_rec_binding r))
                     | Open_module_or_namespace
-                        (ns, FStar_Syntax_Syntax.Open_module) ->
-                        find_in_module_with_includes eikind find_in_module
-                          Cont_ignore env1 ns id
+                        (ns, FStar_Syntax_Syntax.Open_module, restriction) ->
+                        let uu___1 =
+                          FStar_Syntax_Syntax.is_ident_allowed_by_restriction
+                            id restriction in
+                        (match uu___1 with
+                         | FStar_Pervasives_Native.None -> Cont_ignore
+                         | FStar_Pervasives_Native.Some id1 ->
+                             find_in_module_with_includes eikind
+                               find_in_module Cont_ignore env1 ns id1)
                     | Top_level_def id' when
                         let uu___1 = FStar_Ident.string_of_id id' in
                         let uu___2 = FStar_Ident.string_of_id id in
@@ -998,7 +1012,8 @@ let (resolve_module_name :
               then FStar_Pervasives_Native.Some lid
               else FStar_Pervasives_Native.None
           | (Open_module_or_namespace
-              (ns, FStar_Syntax_Syntax.Open_namespace))::q when honor_ns ->
+              (ns, FStar_Syntax_Syntax.Open_namespace, restriction))::q when
+              honor_ns ->
               let new_lid =
                 let uu___1 =
                   let uu___2 = FStar_Ident.path_of_lid ns in
@@ -1026,7 +1041,8 @@ let (is_open :
         FStar_Compiler_List.existsb
           (fun uu___ ->
              match uu___ with
-             | Open_module_or_namespace (ns, k) ->
+             | Open_module_or_namespace
+                 (ns, k, FStar_Syntax_Syntax.Unrestricted) ->
                  (k = open_kind) && (FStar_Ident.lid_equals lid ns)
              | uu___1 -> false) env1.scope_mods
 let (namespace_is_open : env -> FStar_Ident.lident -> Prims.bool) =
@@ -1643,8 +1659,8 @@ let (try_lookup_definition :
         (fun uu___ -> FStar_Pervasives_Native.None)
         (fun uu___ -> FStar_Pervasives_Native.None) k_global_def
 let (empty_include_smap :
-  FStar_Ident.lident Prims.list FStar_Compiler_Effect.ref
-    FStar_Compiler_Util.smap)
+  (FStar_Ident.lident * FStar_Syntax_Syntax.restriction) Prims.list
+    FStar_Compiler_Effect.ref FStar_Compiler_Util.smap)
   = new_sigmap ()
 let (empty_exported_id_smap : exported_id_set FStar_Compiler_Util.smap) =
   new_sigmap ()
@@ -2610,140 +2626,619 @@ let (push_sigelt : env -> FStar_Syntax_Syntax.sigelt -> env) =
   fun env1 -> fun se -> push_sigelt' true env1 se
 let (push_sigelt_force : env -> FStar_Syntax_Syntax.sigelt -> env) =
   fun env1 -> fun se -> push_sigelt' false env1 se
-let (push_namespace : env -> FStar_Ident.lident -> env) =
+let (find_data_constructors_for_typ :
+  env ->
+    FStar_Ident.lident ->
+      FStar_Ident.lident Prims.list FStar_Pervasives_Native.option)
+  =
   fun env1 ->
-    fun ns ->
-      let uu___ =
-        let uu___1 = resolve_module_name env1 ns false in
-        match uu___1 with
-        | FStar_Pervasives_Native.None ->
-            let module_names =
-              FStar_Compiler_List.map FStar_Pervasives_Native.fst
-                env1.modules in
-            let module_names1 =
-              match env1.curmodule with
-              | FStar_Pervasives_Native.None -> module_names
-              | FStar_Pervasives_Native.Some l -> l :: module_names in
-            let uu___2 =
-              FStar_Compiler_Util.for_some
-                (fun m ->
-                   let uu___3 =
-                     let uu___4 = FStar_Ident.string_of_lid m in
-                     Prims.strcat uu___4 "." in
-                   let uu___4 =
-                     let uu___5 = FStar_Ident.string_of_lid ns in
-                     Prims.strcat uu___5 "." in
-                   FStar_Compiler_Util.starts_with uu___3 uu___4)
-                module_names1 in
-            if uu___2
-            then (ns, FStar_Syntax_Syntax.Open_namespace)
-            else
-              (let uu___4 =
-                 let uu___5 =
-                   let uu___6 = FStar_Ident.string_of_lid ns in
-                   FStar_Compiler_Util.format1 "Namespace %s cannot be found"
-                     uu___6 in
-                 (FStar_Errors_Codes.Fatal_NameSpaceNotFound, uu___5) in
-               let uu___5 = FStar_Ident.range_of_lid ns in
-               FStar_Errors.raise_error uu___4 uu___5)
-        | FStar_Pervasives_Native.Some ns' ->
-            (ns', FStar_Syntax_Syntax.Open_module) in
-      match uu___ with
-      | (ns', kd) ->
-          ((env1.ds_hooks).ds_push_open_hook env1 (ns', kd);
-           push_scope_mod env1 (Open_module_or_namespace (ns', kd)))
-let (push_include : env -> FStar_Ident.lident -> env) =
+    fun lid ->
+      let k_global_def lid1 uu___ =
+        match uu___ with
+        | ({
+             FStar_Syntax_Syntax.sigel =
+               FStar_Syntax_Syntax.Sig_inductive_typ
+               { FStar_Syntax_Syntax.lid = uu___1;
+                 FStar_Syntax_Syntax.us = uu___2;
+                 FStar_Syntax_Syntax.params = uu___3;
+                 FStar_Syntax_Syntax.num_uniform_params = uu___4;
+                 FStar_Syntax_Syntax.t = uu___5;
+                 FStar_Syntax_Syntax.mutuals = uu___6;
+                 FStar_Syntax_Syntax.ds = ds;
+                 FStar_Syntax_Syntax.injective_type_params = uu___7;_};
+             FStar_Syntax_Syntax.sigrng = uu___8;
+             FStar_Syntax_Syntax.sigquals = uu___9;
+             FStar_Syntax_Syntax.sigmeta = uu___10;
+             FStar_Syntax_Syntax.sigattrs = uu___11;
+             FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___12;
+             FStar_Syntax_Syntax.sigopts = uu___13;_},
+           uu___14) -> FStar_Pervasives_Native.Some ds
+        | uu___1 -> FStar_Pervasives_Native.None in
+      resolve_in_open_namespaces' env1 lid
+        (fun uu___ -> FStar_Pervasives_Native.None)
+        (fun uu___ -> FStar_Pervasives_Native.None) k_global_def
+let (find_binders_for_datacons :
+  env ->
+    FStar_Ident.lident ->
+      FStar_Ident.ident Prims.list FStar_Pervasives_Native.option)
+  =
   fun env1 ->
-    fun ns ->
-      let ns0 = ns in
-      let uu___ = resolve_module_name env1 ns false in
-      match uu___ with
-      | FStar_Pervasives_Native.Some ns1 ->
-          ((env1.ds_hooks).ds_push_include_hook env1 ns1;
-           (let env2 =
-              push_scope_mod env1
-                (Open_module_or_namespace
-                   (ns1, FStar_Syntax_Syntax.Open_module)) in
-            let curmod =
-              let uu___2 = current_module env2 in
-              FStar_Ident.string_of_lid uu___2 in
-            (let uu___3 =
-               FStar_Compiler_Util.smap_try_find env2.includes curmod in
-             match uu___3 with
-             | FStar_Pervasives_Native.None -> ()
-             | FStar_Pervasives_Native.Some incl ->
-                 let uu___4 =
-                   let uu___5 = FStar_Compiler_Effect.op_Bang incl in ns1 ::
-                     uu___5 in
-                 FStar_Compiler_Effect.op_Colon_Equals incl uu___4);
-            (match () with
-             | () ->
-                 let uu___3 =
-                   let uu___4 = FStar_Ident.string_of_lid ns1 in
-                   get_trans_exported_id_set env2 uu___4 in
-                 (match uu___3 with
-                  | FStar_Pervasives_Native.Some ns_trans_exports ->
-                      ((let uu___5 =
-                          let uu___6 = get_exported_id_set env2 curmod in
-                          let uu___7 = get_trans_exported_id_set env2 curmod in
-                          (uu___6, uu___7) in
-                        match uu___5 with
-                        | (FStar_Pervasives_Native.Some cur_exports,
-                           FStar_Pervasives_Native.Some cur_trans_exports) ->
-                            let update_exports k =
-                              let ns_ex =
-                                let uu___6 = ns_trans_exports k in
-                                FStar_Compiler_Effect.op_Bang uu___6 in
-                              let ex = cur_exports k in
-                              (let uu___7 =
-                                 let uu___8 =
-                                   FStar_Compiler_Effect.op_Bang ex in
-                                 Obj.magic
-                                   (FStar_Class_Setlike.diff ()
-                                      (Obj.magic
-                                         (FStar_Compiler_RBSet.setlike_rbset
-                                            FStar_Class_Ord.ord_string))
-                                      (Obj.magic uu___8) (Obj.magic ns_ex)) in
-                               FStar_Compiler_Effect.op_Colon_Equals ex
-                                 uu___7);
-                              (match () with
-                               | () ->
-                                   let trans_ex = cur_trans_exports k in
+    fun lid ->
+      let k_global_def lid1 uu___ =
+        match uu___ with
+        | ({
+             FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_datacon
+               { FStar_Syntax_Syntax.lid1 = uu___1;
+                 FStar_Syntax_Syntax.us1 = uu___2;
+                 FStar_Syntax_Syntax.t1 = t;
+                 FStar_Syntax_Syntax.ty_lid = uu___3;
+                 FStar_Syntax_Syntax.num_ty_params = uu___4;
+                 FStar_Syntax_Syntax.mutuals1 = uu___5;
+                 FStar_Syntax_Syntax.injective_type_params1 = uu___6;_};
+             FStar_Syntax_Syntax.sigrng = uu___7;
+             FStar_Syntax_Syntax.sigquals = uu___8;
+             FStar_Syntax_Syntax.sigmeta = uu___9;
+             FStar_Syntax_Syntax.sigattrs = uu___10;
+             FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___11;
+             FStar_Syntax_Syntax.sigopts = uu___12;_},
+           uu___13) ->
+            let uu___14 =
+              let uu___15 =
+                let uu___16 = FStar_Syntax_Util.arrow_formals_comp_ln t in
+                FStar_Pervasives_Native.fst uu___16 in
+              FStar_Compiler_List.map
+                (fun x ->
+                   (x.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.ppname)
+                uu___15 in
+            FStar_Pervasives_Native.Some uu___14
+        | uu___1 -> FStar_Pervasives_Native.None in
+      resolve_in_open_namespaces' env1 lid
+        (fun uu___ -> FStar_Pervasives_Native.None)
+        (fun uu___ -> FStar_Pervasives_Native.None) k_global_def
+let elab_restriction :
+  'uuuuu .
+    (env -> FStar_Ident.lident -> FStar_Syntax_Syntax.restriction -> 'uuuuu)
+      ->
+      env -> FStar_Ident.lident -> FStar_Syntax_Syntax.restriction -> 'uuuuu
+  =
+  fun f ->
+    fun env1 ->
+      fun ns ->
+        fun restriction ->
+          match restriction with
+          | FStar_Syntax_Syntax.Unrestricted -> f env1 ns restriction
+          | FStar_Syntax_Syntax.AllowList l ->
+              let mk_lid id =
+                let uu___ =
+                  let uu___1 =
+                    let uu___2 = FStar_Ident.qual_id ns id in
+                    FStar_Ident.ids_of_lid uu___2 in
+                  FStar_Ident.lid_of_ids uu___1 in
+                let uu___1 = FStar_Ident.range_of_id id in
+                FStar_Ident.set_lid_range uu___ uu___1 in
+              let name_exists id =
+                let lid = mk_lid id in
+                let uu___ = try_lookup_lid env1 lid in
+                match uu___ with
+                | FStar_Pervasives_Native.Some uu___1 -> true
+                | FStar_Pervasives_Native.None ->
+                    let uu___1 =
+                      try_lookup_record_or_dc_by_field_name env1 lid in
+                    FStar_Compiler_Util.is_some uu___1 in
+              let l1 =
+                let uu___ =
+                  let uu___1 =
+                    FStar_Compiler_List.map
+                      (fun uu___2 ->
+                         match uu___2 with
+                         | (id, renamed) ->
+                             let with_id_range =
+                               let uu___3 =
+                                 FStar_Ident.range_of_id
+                                   (FStar_Compiler_Util.dflt id renamed) in
+                               FStar_Ident.set_id_range uu___3 in
+                             let uu___3 =
+                               let uu___4 = mk_lid id in
+                               find_data_constructors_for_typ env1 uu___4 in
+                             (match uu___3 with
+                              | FStar_Pervasives_Native.Some idents ->
+                                  FStar_Compiler_List.map
+                                    (fun id1 ->
+                                       let uu___4 =
+                                         let uu___5 =
+                                           FStar_Ident.ident_of_lid id1 in
+                                         with_id_range uu___5 in
+                                       (uu___4, FStar_Pervasives_Native.None))
+                                    idents
+                              | FStar_Pervasives_Native.None -> [])) l in
+                  FStar_Compiler_List.flatten uu___1 in
+                FStar_Compiler_List.append l uu___ in
+              let l2 =
+                let constructor_lid_to_desugared_record_lids =
+                  let uu___ =
+                    let uu___1 =
+                      let uu___2 =
+                        let uu___3 =
+                          let uu___4 =
+                            FStar_Compiler_List.concatMap
+                              (fun uu___5 ->
+                                 match uu___5 with
+                                 | (uu___6,
+                                    { FStar_Syntax_Syntax.name = uu___7;
+                                      FStar_Syntax_Syntax.declarations =
+                                        declarations;
+                                      FStar_Syntax_Syntax.is_interface =
+                                        uu___8;_})
+                                     -> declarations) env1.modules in
+                          FStar_Compiler_List.concatMap
+                            (fun sigelt ->
+                               match sigelt.FStar_Syntax_Syntax.sigel with
+                               | FStar_Syntax_Syntax.Sig_bundle
+                                   { FStar_Syntax_Syntax.ses = ses;
+                                     FStar_Syntax_Syntax.lids = uu___5;_}
+                                   -> ses
+                               | uu___5 -> []) uu___4 in
+                        FStar_Compiler_List.concatMap
+                          (fun sigelt ->
+                             FStar_Compiler_List.map
+                               (fun lid ->
+                                  (lid,
+                                    (sigelt.FStar_Syntax_Syntax.sigattrs)))
+                               (FStar_Syntax_Util.lids_of_sigelt sigelt))
+                          uu___3 in
+                      FStar_Compiler_List.filter_map
+                        (fun uu___3 ->
+                           match uu___3 with
+                           | (lid, attrs) ->
+                               let uu___4 =
+                                 FStar_Syntax_Util.get_attribute
+                                   FStar_Parser_Const.desugar_of_variant_record_lid
+                                   attrs in
+                               (match uu___4 with
+                                | FStar_Pervasives_Native.Some
+                                    (({
+                                        FStar_Syntax_Syntax.n =
+                                          FStar_Syntax_Syntax.Tm_constant
+                                          (FStar_Const.Const_string
+                                          (s, uu___5));
+                                        FStar_Syntax_Syntax.pos = uu___6;
+                                        FStar_Syntax_Syntax.vars = uu___7;
+                                        FStar_Syntax_Syntax.hash_code =
+                                          uu___8;_},
+                                      FStar_Pervasives_Native.None)::[])
+                                    ->
+                                    let uu___9 =
+                                      let uu___10 = FStar_Ident.lid_of_str s in
+                                      (uu___10, lid) in
+                                    FStar_Pervasives_Native.Some uu___9
+                                | uu___5 -> FStar_Pervasives_Native.None))
+                        uu___2 in
+                    FStar_Compiler_List.filter
+                      (fun uu___2 ->
+                         match uu___2 with
+                         | (cons, lid) ->
+                             (let uu___3 = FStar_Ident.ns_of_lid cons in
+                              let uu___4 = FStar_Ident.ns_of_lid lid in
+                              FStar_Class_Deq.op_Equals_Question
+                                (FStar_Class_Ord.ord_eq
+                                   (FStar_Class_Ord.ord_list
+                                      FStar_Syntax_Syntax.ord_ident)) uu___3
+                                uu___4)
+                               &&
+                               (let uu___3 = FStar_Ident.ns_of_lid lid in
+                                let uu___4 = FStar_Ident.ids_of_lid ns in
+                                FStar_Class_Deq.op_Equals_Question
+                                  (FStar_Class_Ord.ord_eq
+                                     (FStar_Class_Ord.ord_list
+                                        FStar_Syntax_Syntax.ord_ident))
+                                  uu___3 uu___4)) uu___1 in
+                  FStar_Compiler_List.map
+                    (fun uu___1 ->
+                       match uu___1 with
+                       | (cons, lid) ->
+                           let uu___2 = FStar_Ident.ident_of_lid cons in
+                           let uu___3 = FStar_Ident.ident_of_lid lid in
+                           (uu___2, uu___3)) uu___ in
+                let uu___ =
+                  let uu___1 =
+                    FStar_Compiler_List.filter
+                      (fun uu___2 ->
+                         match uu___2 with
+                         | (cons, uu___3) ->
+                             let uu___4 =
+                               FStar_Compiler_List.find
+                                 (fun uu___5 ->
+                                    match uu___5 with
+                                    | (lid, uu___6) ->
+                                        FStar_Class_Deq.op_Equals_Question
+                                          FStar_Syntax_Syntax.deq_univ_name
+                                          lid cons) l1 in
+                             FStar_Pervasives_Native.uu___is_Some uu___4)
+                      constructor_lid_to_desugared_record_lids in
+                  FStar_Compiler_List.map
+                    (fun uu___2 ->
+                       match uu___2 with
+                       | (uu___3, lid) -> (lid, FStar_Pervasives_Native.None))
+                    uu___1 in
+                FStar_Compiler_List.append l1 uu___ in
+              let l3 =
+                let uu___ =
+                  let uu___1 =
+                    FStar_Compiler_List.map
+                      (fun uu___2 ->
+                         match uu___2 with
+                         | (id, renamed) ->
+                             let with_renamed_range =
+                               let uu___3 =
+                                 FStar_Ident.range_of_id
+                                   (FStar_Compiler_Util.dflt id renamed) in
+                               FStar_Ident.set_id_range uu___3 in
+                             let with_id_range =
+                               let uu___3 =
+                                 FStar_Ident.range_of_id
+                                   (FStar_Compiler_Util.dflt id renamed) in
+                               FStar_Ident.set_id_range uu___3 in
+                             let lid = mk_lid id in
+                             let uu___3 =
+                               let uu___4 =
+                                 let uu___5 =
+                                   let uu___6 =
+                                     find_binders_for_datacons env1 lid in
+                                   match uu___6 with
+                                   | FStar_Pervasives_Native.None -> []
+                                   | FStar_Pervasives_Native.Some l4 -> l4 in
+                                 FStar_Compiler_List.map
+                                   (fun binder ->
+                                      let uu___6 =
+                                        let uu___7 =
+                                          FStar_Syntax_Util.mk_field_projector_name_from_ident
+                                            lid binder in
+                                        FStar_Ident.ident_of_lid uu___7 in
+                                      let uu___7 =
+                                        FStar_Compiler_Util.map_opt renamed
+                                          (fun renamed1 ->
+                                             let uu___8 =
+                                               let uu___9 =
+                                                 FStar_Ident.lid_of_ids
+                                                   [renamed1] in
+                                               FStar_Syntax_Util.mk_field_projector_name_from_ident
+                                                 uu___9 binder in
+                                             FStar_Ident.ident_of_lid uu___8) in
+                                      (uu___6, uu___7)) uu___5 in
+                               let uu___5 =
+                                 let uu___6 =
+                                   let uu___7 =
+                                     let uu___8 =
+                                       let uu___9 =
+                                         let uu___10 =
+                                           let uu___11 =
+                                             FStar_Ident.lid_of_ids [id] in
+                                           FStar_Syntax_Util.mk_discriminator
+                                             uu___11 in
+                                         let uu___11 =
+                                           FStar_Compiler_Util.map_opt
+                                             renamed
+                                             (fun renamed1 ->
+                                                let uu___12 =
+                                                  FStar_Ident.lid_of_ids
+                                                    [renamed1] in
+                                                FStar_Syntax_Util.mk_discriminator
+                                                  uu___12) in
+                                         (uu___10, uu___11) in
+                                       [uu___9] in
+                                     FStar_Compiler_List.map
+                                       (fun uu___9 ->
+                                          match uu___9 with
+                                          | (x, y) ->
+                                              let uu___10 =
+                                                FStar_Ident.ident_of_lid x in
+                                              let uu___11 =
+                                                FStar_Compiler_Util.map_opt y
+                                                  FStar_Ident.ident_of_lid in
+                                              (uu___10, uu___11)) uu___8 in
+                                   FStar_Compiler_List.filter
+                                     (fun uu___8 ->
+                                        match uu___8 with
+                                        | (x, uu___9) -> name_exists x)
+                                     uu___7 in
+                                 let uu___7 =
                                    let uu___8 =
-                                     let uu___9 =
-                                       FStar_Compiler_Effect.op_Bang trans_ex in
-                                     Obj.magic
-                                       (FStar_Class_Setlike.union ()
-                                          (Obj.magic
-                                             (FStar_Compiler_RBSet.setlike_rbset
-                                                FStar_Class_Ord.ord_string))
-                                          (Obj.magic uu___9)
-                                          (Obj.magic ns_ex)) in
-                                   FStar_Compiler_Effect.op_Colon_Equals
-                                     trans_ex uu___8) in
-                            FStar_Compiler_List.iter update_exports
-                              all_exported_id_kinds
-                        | uu___6 -> ());
-                       (match () with | () -> env2))
-                  | FStar_Pervasives_Native.None ->
-                      let uu___4 =
-                        let uu___5 =
-                          let uu___6 = FStar_Ident.string_of_lid ns1 in
-                          FStar_Compiler_Util.format1
-                            "include: Module %s was not prepared" uu___6 in
-                        (FStar_Errors_Codes.Fatal_IncludeModuleNotPrepared,
-                          uu___5) in
-                      let uu___5 = FStar_Ident.range_of_lid ns1 in
-                      FStar_Errors.raise_error uu___4 uu___5))))
-      | uu___1 ->
-          let uu___2 =
-            let uu___3 =
-              let uu___4 = FStar_Ident.string_of_lid ns in
-              FStar_Compiler_Util.format1
-                "include: Module %s cannot be found" uu___4 in
-            (FStar_Errors_Codes.Fatal_ModuleNotFound, uu___3) in
-          let uu___3 = FStar_Ident.range_of_lid ns in
-          FStar_Errors.raise_error uu___2 uu___3
+                                     try_lookup_record_type env1 lid in
+                                   match uu___8 with
+                                   | FStar_Pervasives_Native.Some
+                                       { typename = uu___9; constrname;
+                                         parms = uu___10; fields;
+                                         is_private = uu___11;
+                                         is_record = uu___12;_}
+                                       ->
+                                       FStar_Compiler_List.map
+                                         (fun uu___13 ->
+                                            match uu___13 with
+                                            | (id1, uu___14) ->
+                                                (id1,
+                                                  FStar_Pervasives_Native.None))
+                                         fields
+                                   | FStar_Pervasives_Native.None -> [] in
+                                 FStar_Compiler_List.op_At uu___6 uu___7 in
+                               FStar_Compiler_List.op_At uu___4 uu___5 in
+                             FStar_Compiler_List.map
+                               (fun uu___4 ->
+                                  match uu___4 with
+                                  | (id1, renamed1) ->
+                                      let uu___5 = with_id_range id1 in
+                                      let uu___6 =
+                                        FStar_Compiler_Util.map_opt renamed1
+                                          with_renamed_range in
+                                      (uu___5, uu___6)) uu___3) l2 in
+                  FStar_Compiler_List.flatten uu___1 in
+                FStar_Compiler_List.append l2 uu___ in
+              ((let final_idents =
+                  FStar_Compiler_List.mapi
+                    (fun i ->
+                       fun uu___ ->
+                         match uu___ with
+                         | (id, renamed) ->
+                             ((FStar_Compiler_Util.dflt id renamed), i)) l3 in
+                let uu___ =
+                  FStar_Compiler_Util.find_dup
+                    (fun uu___1 ->
+                       fun uu___2 ->
+                         match (uu___1, uu___2) with
+                         | ((x, uu___3), (y, uu___4)) ->
+                             FStar_Class_Deq.op_Equals_Question
+                               FStar_Syntax_Syntax.deq_univ_name x y)
+                    final_idents in
+                match uu___ with
+                | FStar_Pervasives_Native.Some (id, i) ->
+                    let others =
+                      FStar_Compiler_List.filter
+                        (fun uu___1 ->
+                           match uu___1 with
+                           | (id', i') ->
+                               (FStar_Class_Deq.op_Equals_Question
+                                  FStar_Syntax_Syntax.deq_univ_name id id')
+                                 &&
+                                 (let uu___2 =
+                                    FStar_Class_Deq.op_Equals_Question
+                                      (FStar_Class_Ord.ord_eq
+                                         FStar_Class_Ord.ord_int) i i' in
+                                  Prims.op_Negation uu___2)) final_idents in
+                    ((let uu___2 =
+                        FStar_Compiler_List.mapi
+                          (fun nth ->
+                             fun uu___3 ->
+                               match uu___3 with
+                               | (other, uu___4) ->
+                                   let nth1 =
+                                     match nth with
+                                     | uu___5 when uu___5 = Prims.int_zero ->
+                                         "first"
+                                     | uu___5 when uu___5 = Prims.int_one ->
+                                         "second"
+                                     | uu___5 when
+                                         uu___5 = (Prims.of_int (2)) ->
+                                         "third"
+                                     | nth2 ->
+                                         let uu___5 =
+                                           FStar_Class_Show.show
+                                             (FStar_Class_Show.printableshow
+                                                FStar_Class_Printable.printable_int)
+                                             (nth2 + Prims.int_one) in
+                                         Prims.strcat uu___5 "th" in
+                                   let uu___5 =
+                                     let uu___6 =
+                                       let uu___7 =
+                                         let uu___8 =
+                                           FStar_Class_Show.show
+                                             FStar_Ident.showable_ident other in
+                                         Prims.strcat uu___8
+                                           (Prims.strcat " "
+                                              (Prims.strcat nth1
+                                                 " occurence comes from this declaration")) in
+                                       FStar_Errors_Msg.text uu___7 in
+                                     [uu___6] in
+                                   let uu___6 =
+                                     let uu___7 =
+                                       FStar_Ident.range_of_id other in
+                                     FStar_Pervasives_Native.Some uu___7 in
+                                   {
+                                     FStar_Errors.issue_msg = uu___5;
+                                     FStar_Errors.issue_level =
+                                       FStar_Errors.EError;
+                                     FStar_Errors.issue_range = uu___6;
+                                     FStar_Errors.issue_number =
+                                       FStar_Pervasives_Native.None;
+                                     FStar_Errors.issue_ctx = []
+                                   }) others in
+                      FStar_Errors.add_issues uu___2);
+                     (let uu___2 =
+                        let uu___3 =
+                          let uu___4 =
+                            let uu___5 =
+                              let uu___6 =
+                                FStar_Class_Show.show
+                                  (FStar_Class_Show.printableshow
+                                     FStar_Class_Printable.printable_int)
+                                  ((FStar_Compiler_List.length others) +
+                                     Prims.int_one) in
+                              Prims.strcat uu___6 " times" in
+                            Prims.strcat "The name %s was imported " uu___5 in
+                          let uu___5 = FStar_Ident.string_of_id id in
+                          FStar_Compiler_Util.format1 uu___4 uu___5 in
+                        (FStar_Errors_Codes.Fatal_DuplicateTopLevelNames,
+                          uu___3) in
+                      let uu___3 = FStar_Ident.range_of_id id in
+                      FStar_Errors.raise_error uu___2 uu___3))
+                | FStar_Pervasives_Native.None -> ());
+               FStar_Compiler_List.iter
+                 (fun uu___1 ->
+                    match uu___1 with
+                    | (id, _renamed) ->
+                        let uu___2 =
+                          let uu___3 = name_exists id in
+                          Prims.op_Negation uu___3 in
+                        if uu___2
+                        then
+                          let uu___3 =
+                            let uu___4 =
+                              let uu___5 =
+                                let uu___6 = mk_lid id in
+                                FStar_Ident.string_of_lid uu___6 in
+                              FStar_Compiler_Util.format1
+                                "Definition %s cannot be found" uu___5 in
+                            (FStar_Errors_Codes.Fatal_NameNotFound, uu___4) in
+                          let uu___4 = FStar_Ident.range_of_id id in
+                          FStar_Errors.raise_error uu___3 uu___4
+                        else ()) l3;
+               f env1 ns (FStar_Syntax_Syntax.AllowList l3))
+let (push_namespace' :
+  env -> FStar_Ident.lident -> FStar_Syntax_Syntax.restriction -> env) =
+  fun env1 ->
+    fun ns ->
+      fun restriction ->
+        let uu___ =
+          let uu___1 = resolve_module_name env1 ns false in
+          match uu___1 with
+          | FStar_Pervasives_Native.None ->
+              let module_names =
+                FStar_Compiler_List.map FStar_Pervasives_Native.fst
+                  env1.modules in
+              let module_names1 =
+                match env1.curmodule with
+                | FStar_Pervasives_Native.None -> module_names
+                | FStar_Pervasives_Native.Some l -> l :: module_names in
+              let uu___2 =
+                FStar_Compiler_Util.for_some
+                  (fun m ->
+                     let uu___3 =
+                       let uu___4 = FStar_Ident.string_of_lid m in
+                       Prims.strcat uu___4 "." in
+                     let uu___4 =
+                       let uu___5 = FStar_Ident.string_of_lid ns in
+                       Prims.strcat uu___5 "." in
+                     FStar_Compiler_Util.starts_with uu___3 uu___4)
+                  module_names1 in
+              if uu___2
+              then (ns, FStar_Syntax_Syntax.Open_namespace)
+              else
+                (let uu___4 =
+                   let uu___5 =
+                     let uu___6 = FStar_Ident.string_of_lid ns in
+                     FStar_Compiler_Util.format1
+                       "Namespace %s cannot be found" uu___6 in
+                   (FStar_Errors_Codes.Fatal_NameSpaceNotFound, uu___5) in
+                 let uu___5 = FStar_Ident.range_of_lid ns in
+                 FStar_Errors.raise_error uu___4 uu___5)
+          | FStar_Pervasives_Native.Some ns' ->
+              (ns', FStar_Syntax_Syntax.Open_module) in
+        match uu___ with
+        | (ns', kd) ->
+            ((env1.ds_hooks).ds_push_open_hook env1 (ns', kd, restriction);
+             push_scope_mod env1
+               (Open_module_or_namespace (ns', kd, restriction)))
+let (push_include' :
+  env -> FStar_Ident.lident -> FStar_Syntax_Syntax.restriction -> env) =
+  fun env1 ->
+    fun ns ->
+      fun restriction ->
+        let ns0 = ns in
+        let uu___ = resolve_module_name env1 ns false in
+        match uu___ with
+        | FStar_Pervasives_Native.Some ns1 ->
+            ((env1.ds_hooks).ds_push_include_hook env1 ns1;
+             (let env2 =
+                push_scope_mod env1
+                  (Open_module_or_namespace
+                     (ns1, FStar_Syntax_Syntax.Open_module, restriction)) in
+              let curmod =
+                let uu___2 = current_module env2 in
+                FStar_Ident.string_of_lid uu___2 in
+              (let uu___3 =
+                 FStar_Compiler_Util.smap_try_find env2.includes curmod in
+               match uu___3 with
+               | FStar_Pervasives_Native.None -> ()
+               | FStar_Pervasives_Native.Some incl ->
+                   let uu___4 =
+                     let uu___5 = FStar_Compiler_Effect.op_Bang incl in
+                     (ns1, restriction) :: uu___5 in
+                   FStar_Compiler_Effect.op_Colon_Equals incl uu___4);
+              (match () with
+               | () ->
+                   let uu___3 =
+                     let uu___4 = FStar_Ident.string_of_lid ns1 in
+                     get_trans_exported_id_set env2 uu___4 in
+                   (match uu___3 with
+                    | FStar_Pervasives_Native.Some ns_trans_exports ->
+                        ((let uu___5 =
+                            let uu___6 = get_exported_id_set env2 curmod in
+                            let uu___7 =
+                              get_trans_exported_id_set env2 curmod in
+                            (uu___6, uu___7) in
+                          match uu___5 with
+                          | (FStar_Pervasives_Native.Some cur_exports,
+                             FStar_Pervasives_Native.Some cur_trans_exports)
+                              ->
+                              let update_exports k =
+                                let ns_ex =
+                                  let uu___6 = ns_trans_exports k in
+                                  FStar_Compiler_Effect.op_Bang uu___6 in
+                                let ex = cur_exports k in
+                                (let uu___7 =
+                                   let uu___8 =
+                                     FStar_Compiler_Effect.op_Bang ex in
+                                   Obj.magic
+                                     (FStar_Class_Setlike.diff ()
+                                        (Obj.magic
+                                           (FStar_Compiler_RBSet.setlike_rbset
+                                              FStar_Class_Ord.ord_string))
+                                        (Obj.magic uu___8) (Obj.magic ns_ex)) in
+                                 FStar_Compiler_Effect.op_Colon_Equals ex
+                                   uu___7);
+                                (match () with
+                                 | () ->
+                                     let trans_ex = cur_trans_exports k in
+                                     let uu___8 =
+                                       let uu___9 =
+                                         FStar_Compiler_Effect.op_Bang
+                                           trans_ex in
+                                       Obj.magic
+                                         (FStar_Class_Setlike.union ()
+                                            (Obj.magic
+                                               (FStar_Compiler_RBSet.setlike_rbset
+                                                  FStar_Class_Ord.ord_string))
+                                            (Obj.magic uu___9)
+                                            (Obj.magic ns_ex)) in
+                                     FStar_Compiler_Effect.op_Colon_Equals
+                                       trans_ex uu___8) in
+                              FStar_Compiler_List.iter update_exports
+                                all_exported_id_kinds
+                          | uu___6 -> ());
+                         (match () with | () -> env2))
+                    | FStar_Pervasives_Native.None ->
+                        let uu___4 =
+                          let uu___5 =
+                            let uu___6 = FStar_Ident.string_of_lid ns1 in
+                            FStar_Compiler_Util.format1
+                              "include: Module %s was not prepared" uu___6 in
+                          (FStar_Errors_Codes.Fatal_IncludeModuleNotPrepared,
+                            uu___5) in
+                        let uu___5 = FStar_Ident.range_of_lid ns1 in
+                        FStar_Errors.raise_error uu___4 uu___5))))
+        | uu___1 ->
+            let uu___2 =
+              let uu___3 =
+                let uu___4 = FStar_Ident.string_of_lid ns in
+                FStar_Compiler_Util.format1
+                  "include: Module %s cannot be found" uu___4 in
+              (FStar_Errors_Codes.Fatal_ModuleNotFound, uu___3) in
+            let uu___3 = FStar_Ident.range_of_lid ns in
+            FStar_Errors.raise_error uu___2 uu___3
+let (push_namespace :
+  env -> FStar_Ident.lident -> FStar_Syntax_Syntax.restriction -> env) =
+  elab_restriction push_namespace'
+let (push_include :
+  env -> FStar_Ident.lident -> FStar_Syntax_Syntax.restriction -> env) =
+  elab_restriction push_include'
 let (push_module_abbrev :
   env -> FStar_Ident.ident -> FStar_Ident.lident -> env) =
   fun env1 ->
@@ -3198,7 +3693,10 @@ type module_inclusion_info =
   {
   mii_exported_ids: exported_ids FStar_Pervasives_Native.option ;
   mii_trans_exported_ids: exported_ids FStar_Pervasives_Native.option ;
-  mii_includes: FStar_Ident.lident Prims.list FStar_Pervasives_Native.option }
+  mii_includes:
+    (FStar_Ident.lident * FStar_Syntax_Syntax.restriction) Prims.list
+      FStar_Pervasives_Native.option
+    }
 let (__proj__Mkmodule_inclusion_info__item__mii_exported_ids :
   module_inclusion_info -> exported_ids FStar_Pervasives_Native.option) =
   fun projectee ->
@@ -3213,7 +3711,8 @@ let (__proj__Mkmodule_inclusion_info__item__mii_trans_exported_ids :
         mii_trans_exported_ids
 let (__proj__Mkmodule_inclusion_info__item__mii_includes :
   module_inclusion_info ->
-    FStar_Ident.lident Prims.list FStar_Pervasives_Native.option)
+    (FStar_Ident.lident * FStar_Syntax_Syntax.restriction) Prims.list
+      FStar_Pervasives_Native.option)
   =
   fun projectee ->
     match projectee with
@@ -3279,7 +3778,9 @@ let (prepare_module_or_interface :
                 FStar_Compiler_List.map
                   (fun uu___ ->
                      match uu___ with
-                     | (lid, kind) -> (lid, (convert_kind kind))) auto_open in
+                     | (lid, kind) ->
+                         (lid, (convert_kind kind),
+                           FStar_Syntax_Syntax.Unrestricted)) auto_open in
               let namespace_of_module =
                 let uu___ =
                   let uu___1 =
@@ -3292,7 +3793,8 @@ let (prepare_module_or_interface :
                     let uu___2 =
                       let uu___3 = FStar_Ident.ns_of_lid mname in
                       FStar_Ident.lid_of_ids uu___3 in
-                    (uu___2, FStar_Syntax_Syntax.Open_namespace) in
+                    (uu___2, FStar_Syntax_Syntax.Open_namespace,
+                      FStar_Syntax_Syntax.Unrestricted) in
                   [uu___1]
                 else [] in
               let auto_open2 =

--- a/ocaml/fstar-lib/generated/FStar_Tactics_V2_Basic.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_V2_Basic.ml
@@ -12370,7 +12370,8 @@ let (push_open_namespace :
            let uu___ =
              let uu___1 =
                FStar_Syntax_DsEnv.push_namespace
-                 e.FStar_TypeChecker_Env.dsenv lid in
+                 e.FStar_TypeChecker_Env.dsenv lid
+                 FStar_Syntax_Syntax.Unrestricted in
              {
                FStar_TypeChecker_Env.solver =
                  (e.FStar_TypeChecker_Env.solver);

--- a/ocaml/fstar-lib/generated/FStar_ToSyntax_ToSyntax.ml
+++ b/ocaml/fstar-lib/generated/FStar_ToSyntax_ToSyntax.ml
@@ -6798,17 +6798,15 @@ let rec (desugar_tycon :
                                         let uu___4 =
                                           let uu___5 =
                                             let uu___6 =
-                                              let uu___7 =
-                                                let uu___8 =
-                                                  FStar_Syntax_DsEnv.qualify
-                                                    env cid in
-                                                FStar_Ident.string_of_lid
-                                                  uu___8 in
-                                              (uu___7, range) in
-                                            FStar_Const.Const_string uu___6 in
-                                          FStar_Syntax_Syntax.Tm_constant
+                                              FStar_Syntax_DsEnv.qualify env
+                                                cid in
+                                            FStar_Ident.string_of_lid uu___6 in
+                                          FStar_Syntax_Embeddings_Base.embed
+                                            FStar_Syntax_Embeddings.e_string
                                             uu___5 in
-                                        FStar_Syntax_Syntax.mk uu___4 range in
+                                        uu___4 range
+                                          FStar_Pervasives_Native.None
+                                          FStar_Syntax_Embeddings_Base.id_norm_cb in
                                       FStar_Syntax_Syntax.mk_Tm_app
                                         desugar_attr
                                         [(cid_as_constant,

--- a/src/fstar/FStar.CheckedFiles.fst
+++ b/src/fstar/FStar.CheckedFiles.fst
@@ -36,7 +36,7 @@ let dbg = Debug.get_toggle "CheckedFiles"
  * detect when loading the cache that the version number is same
  * It needs to be kept in sync with prims.fst
  *)
-let cache_version_number = 67
+let cache_version_number = 68
 
 (*
  * Abbreviation for what we store in the checked files (stages as described below)

--- a/src/fstar/FStar.Interactive.PushHelper.fst
+++ b/src/fstar/FStar.Interactive.PushHelper.fst
@@ -209,7 +209,7 @@ let update_names_from_event cur_mod_str table evt =
         table (string_of_id id) [] (query_of_lid included)
     else
       table
-  | NTOpen (host, (included, kind)) ->
+  | NTOpen (host, (included, kind, _)) ->
     if is_cur_mod host then
       CTable.register_open
         table (kind = FStar.Syntax.Syntax.Open_module) [] (query_of_lid included)

--- a/src/parser/FStar.Parser.AST.fst
+++ b/src/parser/FStar.Parser.AST.fst
@@ -721,11 +721,16 @@ let string_of_pragma = function
   | RestartSolver -> "restart-solver"
   | PrintEffectsGraph -> "print-effects-graph"
 
+let restriction_to_string: FStar.Syntax.Syntax.restriction -> string =
+  let open FStar.Syntax.Syntax in
+  function | Unrestricted -> ""
+           | AllowList allow_list  -> " {" ^ String.concat ", " (List.map (fun (id, renamed) -> string_of_id id ^ dflt "" (map_opt renamed (fun renamed -> " as " ^ string_of_id renamed))) allow_list)  ^ "}"
+
 let rec decl_to_string (d:decl) = match d.d with
   | TopLevelModule l -> "module " ^ (string_of_lid l)
-  | Open l -> "open " ^ (string_of_lid l)
+  | Open (l, r) -> "open " ^ string_of_lid l ^ restriction_to_string r
   | Friend l -> "friend " ^ (string_of_lid l)
-  | Include l -> "include " ^ (string_of_lid l)
+  | Include (l, r) -> "include " ^ string_of_lid l ^ restriction_to_string r
   | ModuleAbbrev (i, l) -> Util.format2 "module %s = %s" (string_of_id i) (string_of_lid l)
   | TopLevelLet(_, pats) -> "let " ^ (lids_of_let pats |> List.map (fun l -> (string_of_lid l)) |> String.concat ", ")
   | Assume(i, _) -> "assume " ^ (string_of_id i)

--- a/src/parser/FStar.Parser.AST.fsti
+++ b/src/parser/FStar.Parser.AST.fsti
@@ -239,9 +239,9 @@ type to_be_desugared = {
 
 type decl' =
   | TopLevelModule of lid
-  | Open of lid
+  | Open of lid & FStar.Syntax.Syntax.restriction
   | Friend of lid
-  | Include of lid
+  | Include of lid & FStar.Syntax.Syntax.restriction
   | ModuleAbbrev of ident & lid
   | TopLevelLet of let_qualifier & list (pattern & term)
   | Tycon of bool & bool & list tycon

--- a/src/parser/FStar.Parser.Const.fst
+++ b/src/parser/FStar.Parser.Const.fst
@@ -380,6 +380,7 @@ let no_auto_projectors_attr = psconst "no_auto_projectors"
 let no_subtping_attr_lid = psconst "no_subtyping"
 let admit_termination_lid = psconst "admit_termination"
 let attr_substitute_lid = p2l ["FStar"; "Pervasives"; "Substitute"]
+let desugar_of_variant_record_lid = psconst "desugar_of_variant_record"
 
 
 //the type of well-founded relations, used for decreases clauses with relations

--- a/src/parser/FStar.Parser.Dep.fst
+++ b/src/parser/FStar.Parser.Dep.fst
@@ -817,8 +817,8 @@ let collect_one
 
       and collect_decl d =
         match d with
-        | Include lid
-        | Open lid ->
+        | Include (lid, _)
+        | Open (lid, _) ->
             add_to_parsing_data (P_open (false, lid))
         | Friend lid ->
             add_to_parsing_data (P_dep (true, (lowercase_join_longident lid true |> Ident.lid_of_str)))

--- a/src/parser/FStar.Parser.ToDocument.fst
+++ b/src/parser/FStar.Parser.ToDocument.fst
@@ -756,7 +756,7 @@ and p_justSig d = match d.d with
   | _ ->
       empty
 
-and p_list f sep l =
+and p_list #t (f: t -> _) sep l =
     let rec p_list' = function
         | [] -> empty
         | [x] -> f x
@@ -764,11 +764,22 @@ and p_list f sep l =
     in
     str "[" ^^ p_list' l ^^ str "]"
 
+and p_restriction
+  = let open FStar.Syntax.Syntax in
+    function | Unrestricted -> empty
+             | AllowList ids ->
+                space
+             ^^ lbrace
+             ^^ p_list (fun (id, renamed) ->
+                   p_ident id ^/^ optional p_ident renamed
+                ) (str ", ") ids
+             ^^ rbrace
+
 and p_rawDecl d = match d.d with
-  | Open uid ->
-    group (str "open" ^/^ p_quident uid)
-  | Include uid ->
-    group (str "include" ^/^ p_quident uid)
+  | Open (uid, r) ->
+    group (str "open" ^/^ p_quident uid ^/^ p_restriction r)
+  | Include (uid, r) ->
+    group (str "include" ^/^ p_quident uid ^/^ p_restriction r)
   | Friend uid ->
     group (str "friend" ^/^ p_quident uid)
   | ModuleAbbrev (uid1, uid2) ->

--- a/src/syntax/FStar.Syntax.DsEnv.fst
+++ b/src/syntax/FStar.Syntax.DsEnv.fst
@@ -75,7 +75,7 @@ type env = {
                                                              "include" relation: an identifier is in this set
                                                              for a module if and only if it is defined either
                                                              in this module or in one of its included modules. *)
-  includes:             BU.smap (ref (list lident));   (* list of "includes" declarations for each module. *)
+  includes:             BU.smap (ref (list (lident & restriction)));   (* list of "includes" declarations for each module. *)
   sigaccum:             sigelts;                          (* type declarations being accumulated for the current module *)
   sigmap:               BU.smap (sigelt & bool);         (* bool indicates that this was declared in an interface file *)
   iface:                bool;                             (* whether or not we're desugaring an interface; different scoping rules apply *)
@@ -116,7 +116,7 @@ let transitive_exported_ids env lid =
 let opens_and_abbrevs env : list (either open_module_or_namespace module_abbrev) =
     List.collect
        (function
-        | Open_module_or_namespace (lid, info) -> [Inl (lid, info)]
+        | Open_module_or_namespace payload -> [Inl payload]
         | Module_abbrev (id, lid) -> [Inr (id, lid)]
         | _ -> [])
     env.scope_mods
@@ -124,7 +124,7 @@ let opens_and_abbrevs env : list (either open_module_or_namespace module_abbrev)
 let open_modules e = e.modules
 let open_modules_and_namespaces env =
   List.filter_map (function
-                   | Open_module_or_namespace (lid, _info) -> Some lid
+                   | Open_module_or_namespace (lid, _info, _restriction) -> Some lid
                    | _ -> None)
     env.scope_mods
 let module_abbrevs env : list (ident & lident)=
@@ -250,21 +250,23 @@ let find_in_module_with_includes
     (ns: lident)
     (id: ident)
     : cont_t 'a =
-  let idstr = string_of_id id in
   let rec aux = function
   | [] ->
     find_in_module_default
-  | modul :: q ->
+  | (modul, id) :: q ->
     let mname = string_of_lid modul in
     let not_shadowed = match get_exported_id_set env mname with
     | None -> true
     | Some mex ->
       let mexports = !(mex eikind) in
-      mem idstr mexports
+      mem (string_of_id id) mexports
     in
     let mincludes = match BU.smap_try_find env.includes mname with
     | None -> []
-    | Some minc -> !minc
+    | Some minc ->
+      !minc |> filter_map (fun (ns, restriction) ->
+        let opt = is_ident_allowed_by_restriction id restriction in
+        map_opt opt (fun id -> (ns, id)))
     in
     let look_into =
      if not_shadowed
@@ -277,7 +279,7 @@ let find_in_module_with_includes
     | _ ->
       look_into
     end
-  in aux [ ns ]
+  in aux [ (ns, id) ]
 
 let try_lookup_id''
   env
@@ -309,8 +311,10 @@ let try_lookup_id''
         used_marker := true;
         k_rec_binding r
 
-      | Open_module_or_namespace (ns, Open_module) ->
-        find_in_module_with_includes eikind find_in_module Cont_ignore env ns id
+      | Open_module_or_namespace (ns, Open_module, restriction) ->
+        ( match is_ident_allowed_by_restriction id restriction with
+        | None -> Cont_ignore
+        | Some id -> find_in_module_with_includes eikind find_in_module Cont_ignore env ns id)
 
       | Top_level_def id'
         when string_of_id id' = string_of_id id ->
@@ -401,7 +405,7 @@ let resolve_module_name env lid (honor_ns: bool) : option lident =
           then Some lid
           else None
 
-        | Open_module_or_namespace (ns, Open_namespace) :: q
+        | Open_module_or_namespace (ns, Open_namespace, restriction) :: q
           when honor_ns ->
           let new_lid = lid_of_path (path_of_lid ns @ path_of_lid lid) (range_of_lid lid)
           in
@@ -422,7 +426,7 @@ let resolve_module_name env lid (honor_ns: bool) : option lident =
 
 let is_open env lid open_kind =
   List.existsb (function
-                | Open_module_or_namespace (ns, k) -> k = open_kind && lid_equals lid ns
+                | Open_module_or_namespace (ns, k, Unrestricted) -> k = open_kind && lid_equals lid ns
                 | _ -> false) env.scope_mods
 
 let namespace_is_open env lid =
@@ -657,7 +661,7 @@ let try_lookup_definition env (lid:lident) =
   resolve_in_open_namespaces' env lid (fun _ -> None) (fun _ -> None) k_global_def
 
 
-let empty_include_smap : BU.smap (ref (list lident)) = new_sigmap()
+let empty_include_smap : BU.smap (ref (list (lident & restriction))) = new_sigmap()
 let empty_exported_id_smap : BU.smap exported_id_set = new_sigmap()
 
 let try_lookup_lid' any_val exclude_interface env (lid:lident) : option (term & list attribute) =
@@ -1041,7 +1045,128 @@ let push_sigelt' fail_on_dup env s =
 let push_sigelt       env se = push_sigelt' true  env se
 let push_sigelt_force env se = push_sigelt' false env se
 
-let push_namespace env ns =
+let find_data_constructors_for_typ env (lid:lident) =
+  let k_global_def lid = function
+      | ({ sigel = Sig_inductive_typ {ds} }, _) -> Some ds
+      | _ -> None in
+  resolve_in_open_namespaces' env lid (fun _ -> None) (fun _ -> None) k_global_def
+
+let find_binders_for_datacons env (lid:lident) =
+  let k_global_def lid = function
+      | ({ sigel = Sig_datacon {t} }, _) ->
+          arrow_formals_comp_ln t
+        |> fst
+        |> List.map (fun x -> x.binder_bv.ppname)
+        |> Some
+      | _ -> None in
+  resolve_in_open_namespaces' env lid (fun _ -> None) (fun _ -> None) k_global_def
+
+// let x (xx: (lident & list term)) = show xx
+
+
+(** Elaborates a `restriction`: this function adds implicit names
+(projectors, discriminators, record fields) that F* generates
+automatically. It also checks that all the idents the user added
+actually exists in the given namespace. *)
+let elab_restriction f env ns restriction =
+  let open FStar.Class.Deq in
+  match restriction with
+  | Unrestricted -> f env ns restriction
+  | AllowList l  ->
+    let mk_lid (id: ident): lident = set_lid_range (lid_of_ids (ids_of_lid (qual_id ns id))) (range_of_id id) in
+    let name_exists id =
+      let lid = mk_lid id in
+      match try_lookup_lid env lid with
+      | Some _ -> true
+      | None   -> try_lookup_record_or_dc_by_field_name env lid |> is_some
+    in
+    // For every inductive, we include its constructors
+    let l = List.map (fun (id, renamed) ->
+      let with_id_range = dflt id renamed |> range_of_id |> set_id_range in
+        match find_data_constructors_for_typ env (mk_lid id) with
+      | Some idents -> List.map (fun id -> (ident_of_lid id |> with_id_range, None)) idents
+      | None -> []
+    ) l |> List.flatten |> List.append l in
+    // For every constructor, we include possible desugared record
+    // payloads types
+    let l =
+      (* A (precomputed) associated list that maps a constructors to
+         types that comes from a "record-on-a-variant" desugar. E.g. `A`
+         is mapped to `Mka__A__payload` for a `type a = | A {x:int}`. *)
+      let constructor_lid_to_desugared_record_lids: list (ident * ident) =
+        env.modules
+        |> List.concatMap (fun (_, {declarations}) -> declarations)
+        |> List.concatMap (fun sigelt -> match sigelt.sigel with | Sig_bundle {ses} -> ses | _ -> [])
+        |> List.concatMap (fun sigelt -> lids_of_sigelt sigelt |> List.map (fun lid -> (lid, sigelt.sigattrs)))
+        |> List.filter_map
+          (fun (lid, attrs) -> match U.get_attribute Const.desugar_of_variant_record_lid attrs with
+                            | Some [({n = Tm_constant (FStar.Const.Const_string (s, _))}, None)]
+                                -> Some (lid_of_str s, lid)
+                            | _ -> None)
+        |> List.filter (fun (cons, lid) -> ns_of_lid cons =? ns_of_lid lid && ns_of_lid lid =? ids_of_lid ns)
+        |> List.map (fun (cons, lid) -> (ident_of_lid cons, ident_of_lid lid))
+      in constructor_lid_to_desugared_record_lids
+       |> List.filter (fun (cons, _) -> List.find (fun (lid, _) -> lid =? cons) l |> Some?)
+       |> List.map (fun (_, lid) -> (lid, None))
+       |> List.append l
+    in
+    let l = List.map (fun (id, renamed) ->
+      let with_renamed_range = dflt id renamed |> range_of_id |> set_id_range in
+      let with_id_range = dflt id renamed |> range_of_id |> set_id_range in
+      let lid = mk_lid id in
+      begin
+      // If `id` is a datatype, we include its projections
+      ((match find_binders_for_datacons env lid with | None -> [] | Some l -> l)
+      |> List.map (fun binder ->
+        ( mk_field_projector_name_from_ident lid binder
+          |> ident_of_lid
+        , map_opt renamed (fun renamed ->
+            mk_field_projector_name_from_ident (lid_of_ids [renamed]) binder
+            |> ident_of_lid
+          )
+        )
+      ))
+      // If `id` is a datatype, we include its discriminator
+      // (actually, we always include a discriminator, it will be
+      // removed if it doesn't exist)
+      @ ( [ mk_discriminator (lid_of_ids [id])
+          , map_opt renamed (fun renamed -> mk_discriminator (lid_of_ids [renamed]))
+          ] |> List.map (fun (x, y) -> (ident_of_lid x, map_opt y ident_of_lid))
+            |> List.filter (fun (x, _) -> name_exists x))
+      // If `id` is a record, we include its fields
+      @ ( match try_lookup_record_type env lid with
+        | Some {constrname; fields} -> List.map (fun (id, _) -> (id, None)) fields
+        | None -> [])
+      end |> List.map (fun (id, renamed) -> (with_id_range id, map_opt renamed with_renamed_range))
+    ) l |> List.flatten |> List.append l in
+    let _error_on_duplicates =
+      let final_idents = List.mapi (fun i (id, renamed) -> (dflt id renamed, i)) l in
+      match final_idents |> find_dup (fun (x, _) (y, _) -> x =? y) with
+      | Some (id, i) ->
+        let others = List.filter (fun (id', i') -> id =? id' && not (i =? i')) final_idents in
+        List.mapi (fun nth (other, _) ->
+          let nth = match nth with | 0 -> "first" | 1 -> "second" | 2 -> "third" | nth -> show (nth + 1) ^ "th" in
+          {
+            issue_msg = [show other ^ " " ^ nth ^ " occurence comes from this declaration" |> FStar.Errors.Msg.text];
+            issue_level = EError;
+            issue_range = Some (range_of_id other);
+            issue_number = None;
+            issue_ctx = [];
+          }
+        ) others |> add_issues;
+        raise_error (Errors.Fatal_DuplicateTopLevelNames,
+                     BU.format1 ("The name %s was imported " ^ show (List.length others + 1) ^ " times") (string_of_id id))
+                    (Ident.range_of_id id)
+      | None -> ()
+    in
+    List.iter (fun (id, _renamed) ->
+        if name_exists id |> not
+        then raise_error (Errors.Fatal_NameNotFound,
+                          BU.format1 "Definition %s cannot be found" (mk_lid id |> string_of_lid))
+                         (Ident.range_of_id id)) l;
+    f env ns (AllowList l)
+
+let push_namespace' env ns restriction =
   (* namespace resolution disabled, but module abbrevs enabled *)
   (* GM: What's the rationale for this? *)
   let (ns', kd) =
@@ -1066,10 +1191,10 @@ let push_namespace env ns =
     | Some ns' ->
       (ns', Open_module)
   in
-     env.ds_hooks.ds_push_open_hook env (ns', kd);
-     push_scope_mod env (Open_module_or_namespace (ns', kd))
+     env.ds_hooks.ds_push_open_hook env (ns', kd, restriction);
+     push_scope_mod env (Open_module_or_namespace (ns', kd, restriction))
 
-let push_include env ns =
+let push_include' env ns restriction =
     (* similarly to push_namespace in the case of modules, we allow
        module abbrevs, but not namespace resolution *)
     let ns0 = ns in
@@ -1077,12 +1202,12 @@ let push_include env ns =
     | Some ns ->
       env.ds_hooks.ds_push_include_hook env ns;
       (* from within the current module, include is equivalent to open *)
-      let env = push_scope_mod env (Open_module_or_namespace (ns, Open_module)) in
+      let env = push_scope_mod env (Open_module_or_namespace (ns, Open_module, restriction)) in
       (* update the list of includes *)
       let curmod = string_of_lid (current_module env) in
       let () = match BU.smap_try_find env.includes curmod with
       | None -> ()
-      | Some incl -> incl := ns :: !incl
+      | Some incl -> incl := (ns, restriction) :: !incl
       in
       (* the names of the included module and its transitively
          included modules shadow the names of the current module *)
@@ -1108,6 +1233,9 @@ let push_include env ns =
       end
     | _ ->
       raise_error (Errors.Fatal_ModuleNotFound, (BU.format1 "include: Module %s cannot be found" (string_of_lid ns))) (Ident.range_of_lid ns)
+
+let push_namespace = elab_restriction push_namespace'
+let push_include   = elab_restriction push_include'
 
 let push_module_abbrev env x l =
   (* both namespace resolution and module abbrevs disabled:
@@ -1271,7 +1399,7 @@ let as_exported_id_set (e:option exported_ids) =
 type module_inclusion_info = {
     mii_exported_ids:option exported_ids;
     mii_trans_exported_ids:option exported_ids;
-    mii_includes:option (list lident)
+    mii_includes:option (list (lident & restriction))
 }
 
 let default_mii = {
@@ -1304,9 +1432,9 @@ let prepare_module_or_interface intf admitted env mname (mii:module_inclusion_in
       | FStar.Parser.Dep.Open_namespace -> Open_namespace
       | FStar.Parser.Dep.Open_module -> Open_module
       in
-      List.map (fun (lid, kind) -> (lid, convert_kind kind)) auto_open
+      List.map (fun (lid, kind) -> (lid, convert_kind kind, Unrestricted)) auto_open
     in
-    let namespace_of_module = if List.length (ns_of_lid mname) > 0 then [ (lid_of_ids (ns_of_lid mname), Open_namespace) ] else [] in
+    let namespace_of_module = if List.length (ns_of_lid mname) > 0 then [ (lid_of_ids (ns_of_lid mname), Open_namespace, Unrestricted) ] else [] in
     (* [scope_mods] is a stack, so reverse the order *)
     let auto_open = namespace_of_module @ List.rev auto_open in
 

--- a/src/syntax/FStar.Syntax.DsEnv.fst
+++ b/src/syntax/FStar.Syntax.DsEnv.fst
@@ -1061,9 +1061,6 @@ let find_binders_for_datacons env (lid:lident) =
       | _ -> None in
   resolve_in_open_namespaces' env lid (fun _ -> None) (fun _ -> None) k_global_def
 
-// let x (xx: (lident & list term)) = show xx
-
-
 (** Elaborates a `restriction`: this function adds implicit names
 (projectors, discriminators, record fields) that F* generates
 automatically. It also checks that all the idents the user added

--- a/src/syntax/FStar.Syntax.DsEnv.fsti
+++ b/src/syntax/FStar.Syntax.DsEnv.fsti
@@ -116,8 +116,8 @@ val push_bv': env -> ident -> env & bv & used_marker
 val push_bv: env -> ident -> env & bv
 val push_top_level_rec_binding: env -> ident -> env & ref bool
 val push_sigelt: env -> sigelt -> env
-val push_namespace: env -> lident -> env
-val push_include: env -> lident -> env
+val push_namespace: env -> lident -> restriction -> env
+val push_include: env -> lident -> restriction -> env
 val push_module_abbrev : env -> ident -> lident -> env
 val resolve_name: env -> lident -> option (either bv fv)
 

--- a/src/tactics/FStar.Tactics.V2.Basic.fst
+++ b/src/tactics/FStar.Tactics.V2.Basic.fst
@@ -2774,7 +2774,7 @@ let refl_maybe_unfold_head (g:env) (e:term) : tac (option term & issues) =
 
 let push_open_namespace (e:env) (ns:list string) =
   let lid = Ident.lid_of_path ns Range.dummyRange in
-  return { e with dsenv = FStar.Syntax.DsEnv.push_namespace e.dsenv lid }
+  return { e with dsenv = FStar.Syntax.DsEnv.push_namespace e.dsenv lid Unrestricted }
 
 let push_module_abbrev (e:env) (n:string) (m:list string) =
   let mlid = Ident.lid_of_path m Range.dummyRange in

--- a/src/tosyntax/FStar.ToSyntax.ToSyntax.fst
+++ b/src/tosyntax/FStar.ToSyntax.ToSyntax.fst
@@ -1538,7 +1538,7 @@ and desugar_term_maybe_top (top_level:bool) (env:env_t) (top:term) : S.term & an
       mk (Tm_meta {tm; meta=Meta_desugared Sequence}), s
 
     | LetOpen (lid, e) ->
-      let env = Env.push_namespace env lid in
+      let env = Env.push_namespace env lid Unrestricted in
       (if Env.expect_typ env then desugar_typ_aq else desugar_term_aq) env e
 
     | LetOpenRecord (r, rty, e) ->
@@ -3729,8 +3729,8 @@ and desugar_decl_core env (d_attrs:list S.term) (d:decl) : (env_t & sigelts) =
 
   | TopLevelModule id -> env, []
 
-  | Open lid ->
-    let env = Env.push_namespace env lid in
+  | Open (lid, restriction) ->
+    let env = Env.push_namespace env lid restriction in
     env, []
 
   | Friend lid ->
@@ -3748,8 +3748,8 @@ and desugar_decl_core env (d_attrs:list S.term) (d:decl) : (env_t & sigelts) =
                       "'friend' module has not been loaded; recompute dependences (C-c C-r) if in interactive mode") d.drange
     else env, []
 
-  | Include lid ->
-    let env = Env.push_include env lid in
+  | Include (lid, restriction) ->
+    let env = Env.push_include env lid restriction in
     env, []
 
   | ModuleAbbrev(x, l) ->
@@ -4290,8 +4290,8 @@ let desugar_decls env decls =
   env, sigelts
 
 let open_prims_all =
-    [AST.mk_decl (AST.Open C.prims_lid) Range.dummyRange;
-     AST.mk_decl (AST.Open C.all_lid) Range.dummyRange]
+    [AST.mk_decl (AST.Open (C.prims_lid, Unrestricted)) Range.dummyRange;
+     AST.mk_decl (AST.Open (C.all_lid, Unrestricted)) Range.dummyRange]
 
 (* Top-level functionality: from AST to a module
    Keeps track of the name of variables and so on (in the context)

--- a/src/tosyntax/FStar.ToSyntax.ToSyntax.fst
+++ b/src/tosyntax/FStar.ToSyntax.ToSyntax.fst
@@ -2898,7 +2898,7 @@ let mk_typ_abbrev env d lid uvs typars kopt t lids quals rng =
       sigopens_and_abbrevs = opens_and_abbrevs env
     }
 
-let rec desugar_tycon env (d: AST.decl) (d_attrs:list S.term) quals tcs : (env_t & sigelts) =
+let rec desugar_tycon env (d: AST.decl) (d_attrs_initial:list S.term) quals tcs : (env_t & sigelts) =
   let rng = d.drange in
   let tycon_id = function
     | TyconAbstract(id, _, _)
@@ -2922,7 +2922,14 @@ let rec desugar_tycon env (d: AST.decl) (d_attrs:list S.term) quals tcs : (env_t
                   let record_id = mk_ident (string_of_id id ^ "__" ^ string_of_id cid ^ "__payload", range_of_id cid) in
                   let record_id_t = {tm = lid_of_ns_and_id [] record_id |> Var; range = range_of_id cid; level = Type_level} in
                   let payload_typ = mkApp record_id_t (List.map (fun bd -> binder_to_term bd, Nothing) bds) (range_of_id record_id) in
-                  TyconRecord (record_id, bds, None, attrs, r) |> Some
+                  let desugar_marker = 
+                    let range = range_of_id record_id in
+                    let desugar_attr_fv = {fv_name = {v = FStar.Parser.Const.desugar_of_variant_record_lid; p = range}; fv_qual = None} in
+                    let desugar_attr = S.mk (Tm_fvar desugar_attr_fv) range in
+                    let cid_as_constant = S.mk (Const_string (qualify env cid |> string_of_lid, range) |> S.Tm_constant) range in
+                    S.mk_Tm_app desugar_attr [(cid_as_constant, None)] range
+                  in
+                  (TyconRecord (record_id, bds, None, attrs, r), desugar_marker::d_attrs_initial) |> Some
                 , (cid, Some ( match k with
                              | None   -> VpOfNotation payload_typ
                              | Some k -> 
@@ -2936,8 +2943,8 @@ let rec desugar_tycon env (d: AST.decl) (d_attrs:list S.term) quals tcs : (env_t
             ) variants |> unzip in
          // TODO: [concat_options] should live somewhere else
          let concat_options = filter_map (fun r -> r) in
-         concat_options additional_records @ [TyconVariant (id, bds, k, variants)]
-    | tycon -> [tycon] in
+         concat_options additional_records @ [(TyconVariant (id, bds, k, variants), d_attrs_initial)]
+    | tycon -> [(tycon, d_attrs_initial)] in
   let tcs = concatMap desugar_tycon_variant_record tcs in
   let tot rng = mk_term (Name (C.effect_Tot_lid)) rng Expr in
   let with_constructor_effect t = mk_term (App(tot t.range, t, Nothing)) t.range t.level in
@@ -2966,7 +2973,7 @@ let rec desugar_tycon env (d: AST.decl) (d_attrs:list S.term) quals tcs : (env_t
 
       TyconVariant(id, parms, kopt, [(constrName, Some (VpArbitrary constrTyp), attrs)]), fields |> List.map (fun (f, _, _, _) -> f)
     | _ -> failwith "impossible" in
-  let desugar_abstract_tc quals _env mutuals = function
+  let desugar_abstract_tc quals _env mutuals d_attrs = function
     | TyconAbstract(id, binders, kopt) ->
       let _env', typars = typars_of_binders _env binders in
       let k = match kopt with
@@ -3001,12 +3008,12 @@ let rec desugar_tycon env (d: AST.decl) (d_attrs:list S.term) quals tcs : (env_t
         env, (mk_binder_with_attrs y b.binder_qual b.binder_attrs)::tps) (env, []) bs in
     env, List.rev bs in
   match tcs with
-    | [TyconAbstract(id, bs, kopt)] ->
+    | [(TyconAbstract(id, bs, kopt), d_attrs)] ->
         let kopt = match kopt with
             | None -> Some (tm_type_z (range_of_id id))
             | _ -> kopt in
         let tc = TyconAbstract(id, bs, kopt) in
-        let _, _, se, _ = desugar_abstract_tc quals env [] tc in
+        let _, _, se, _ = desugar_abstract_tc quals env [] d_attrs tc in
         let se = match se.sigel with
            | Sig_inductive_typ {lid=l; params=typars; t=k; mutuals=[]; ds=[]} ->
              let quals = se.sigquals in
@@ -3027,7 +3034,7 @@ let rec desugar_tycon env (d: AST.decl) (d_attrs:list S.term) quals tcs : (env_t
         (* let _ = pr "Pushed %s\n" (string_of_lid (qualify env (tycon_id tc))) in *)
         env, [se]
 
-    | [TyconAbbrev(id, binders, kopt, t)] ->
+    | [(TyconAbbrev(id, binders, kopt, t), _d_attrs)] ->
         let env', typars = typars_of_binders env binders in
         let kopt = match kopt with
             | None ->
@@ -3081,31 +3088,32 @@ let rec desugar_tycon env (d: AST.decl) (d_attrs:list S.term) quals tcs : (env_t
         let env = push_sigelt env se in
         env, [se]
 
-    | [TyconRecord _] ->
-      let trec = List.hd tcs in
+    | [(TyconRecord payload, d_attrs)] ->
+      let trec = TyconRecord payload in
       let t, fs = tycon_record_as_variant trec in
       desugar_tycon env d d_attrs (RecordType (ids_of_lid (current_module env), fs)::quals) [t]
 
     |  _::_ ->
       let env0 = env in
-      let mutuals = List.map (fun x -> qualify env <| tycon_id x) tcs in
-      let rec collect_tcs quals et tc =
+      let mutuals = List.map (fun (x, _) -> qualify env <| tycon_id x) tcs in
+      let rec collect_tcs quals et (tc, d_attrs) =
         let (env, tcs) = et in
         match tc with
           | TyconRecord _ ->
             let trec = tc in
             let t, fs = tycon_record_as_variant trec in
-            collect_tcs (RecordType (ids_of_lid (current_module env), fs)::quals) (env, tcs) t
+            collect_tcs (RecordType (ids_of_lid (current_module env), fs)::quals) (env, tcs) (t, d_attrs)
           | TyconVariant(id, binders, kopt, constructors) ->
-            let env, _, se, tconstr = desugar_abstract_tc quals env mutuals (TyconAbstract(id, binders, kopt)) in
-            env, Inl(se, constructors, tconstr, quals)::tcs
+            let env, _, se, tconstr = desugar_abstract_tc quals env mutuals d_attrs (TyconAbstract(id, binders, kopt)) in
+            env, (Inl(se, constructors, tconstr, quals), d_attrs)::tcs
           | TyconAbbrev(id, binders, kopt, t) ->
-            let env, _, se, tconstr = desugar_abstract_tc quals env mutuals (TyconAbstract(id, binders, kopt)) in
-            env, Inr(se, binders, t, quals)::tcs
+            let env, _, se, tconstr = desugar_abstract_tc quals env mutuals d_attrs (TyconAbstract(id, binders, kopt)) in
+            env, (Inr(se, binders, t, quals), d_attrs)::tcs
           | _ -> raise_error (Errors.Fatal_NonInductiveInMutuallyDefinedType, ("Mutually defined type contains a non-inductive element")) rng in
       let env, tcs = List.fold_left (collect_tcs quals) (env, []) tcs in
       let tcs = List.rev tcs in
-      let tps_sigelts = tcs |> List.collect (function
+      let tps_sigelts = tcs |> List.collect (fun (tc, d_attrs) -> 
+          match tc with
         | Inr ({ sigel = Sig_inductive_typ {lid=id;
                                             us=uvs;
                                             params=tpars;

--- a/src/tosyntax/FStar.ToSyntax.ToSyntax.fst
+++ b/src/tosyntax/FStar.ToSyntax.ToSyntax.fst
@@ -2926,7 +2926,7 @@ let rec desugar_tycon env (d: AST.decl) (d_attrs_initial:list S.term) quals tcs 
                     let range = range_of_id record_id in
                     let desugar_attr_fv = {fv_name = {v = FStar.Parser.Const.desugar_of_variant_record_lid; p = range}; fv_qual = None} in
                     let desugar_attr = S.mk (Tm_fvar desugar_attr_fv) range in
-                    let cid_as_constant = S.mk (Const_string (qualify env cid |> string_of_lid, range) |> S.Tm_constant) range in
+                    let cid_as_constant = EMB.embed (string_of_lid (qualify env cid)) range None EMB.id_norm_cb in
                     S.mk_Tm_app desugar_attr [(cid_as_constant, None)] range
                   in
                   (TyconRecord (record_id, bds, None, attrs, r), desugar_marker::d_attrs_initial) |> Some

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -11,6 +11,7 @@ ALL_TEST_DIRS += machine_integers
 ALL_TEST_DIRS += micro-benchmarks
 ALL_TEST_DIRS += prettyprinting
 ALL_TEST_DIRS += projectors
+ALL_TEST_DIRS += restricted_includes
 ALL_TEST_DIRS += semiring
 ALL_TEST_DIRS += struct
 ALL_TEST_DIRS += tactics

--- a/tests/restricted_includes/Consumer.fst
+++ b/tests/restricted_includes/Consumer.fst
@@ -1,0 +1,68 @@
+module Consumer
+
+(**** Opening a type *)
+// Importing an inductive `a_type` will implicitely import each data
+// constructors and each associated desugared record types (here,
+// `a_type` as a constructor `Type3` with a record payload: the
+// implicit corresponding record type will be imported).
+open Definitions {a_type}
+
+// `a_type` and its constructors are available
+let _ = a_type
+let _ = AType1 0 1
+let _ = AType2 "hi"
+let _ = AType3 { a_type_C_field1 = 3
+               ; a_type_C_field2 = Definitions.BType1 (* BType1 is not in scope *) }
+
+// The automatically generated type `a_type__AType3__payload` is available as well
+let _ = a_type__AType3__payload
+let _ = Mka_type__AType3__payload
+let _ = { a_type_C_field1 = 3
+        ; a_type_C_field2 = Definitions.BType1 (* BType1 is not in scope *) }
+
+// Fields projectors are imported
+let _ = (AType1?.a1, AType2?._0, AType3?._0)
+
+// The constructors of `a_type` are imported:
+let _ = (AType1, AType2, AType3)
+
+// Fields names are imported correctly
+let _ = fun x -> x.a_type_C_field1
+
+// Other definitions are not visible:
+[@@expect_failure [72]] let _ = a_record
+[@@expect_failure [72]] let _ = fn_example
+[@@expect_failure [72]] let _ = b_type
+[@@expect_failure [72]] let _ = BType1
+[@@expect_failure [72]] let _ = BType2
+[@@expect_failure [72]] let _ = BType3
+
+(**** Include works as well *)
+// Exactly the same syntax and expressivity works for `include` as
+// well.
+include Definitions {a_type}
+
+(**** Renaming *)
+include Definitions {AType2 as AnotherNicerName}
+include Definitions {BType1 as RenamedBType1}
+include Definitions {BType2}
+include Definitions {fn_example as fn_renamed}
+
+let _: a_type = AnotherNicerName "hello"
+
+(**** Missing names or redundant names *)
+// If a include or open exposes missing redundant names, this is an error.
+[@@expect_failure [47]] open Definitions {AType2 as AType1, AType1}
+[@@expect_failure [47]] open Definitions {AType1, AType1}
+[@@expect_failure [47]] open Definitions {a_type, AType1}
+
+(**** Opening a module anonymously *)
+// Let's first bring in scope the method `to_int` of the typeclass `to_int_tc`:
+open TypeclassDefinition {to_int}
+
+// The module `TypeclassInstance` defines an instance of `to_int_tc`
+// for `int`. I can open it without exposing any name into my scope:
+open TypeclassInstance {}
+
+// Now, I can use `to_int` on int:
+let _ = to_int 3

--- a/tests/restricted_includes/ConsumerInterface.fsti
+++ b/tests/restricted_includes/ConsumerInterface.fsti
@@ -1,0 +1,69 @@
+module ConsumerInterface
+
+(**** Opening a type *)
+// Importing an inductive `a_type` will implicitely import each data
+// constructors and each associated desugared record types (here,
+// `a_type` as a constructor `Type3` with a record payload: the
+// implicit corresponding record type will be imported).
+open DefinitionsInterface {a_type}
+
+// `a_type` and its constructors are available
+let _ = a_type
+let _ = AType1 0 1
+let _ = AType2 "hi"
+let _ = AType3 { a_type_C_field1 = 3
+               ; a_type_C_field2 = DefinitionsInterface.BType1 (* BType1 is not in scope *) }
+
+// The automatically generated type `a_type__AType3__payload` is available as well
+let _ = a_type__AType3__payload
+let _ = Mka_type__AType3__payload
+let _ = { a_type_C_field1 = 3
+        ; a_type_C_field2 = DefinitionsInterface.BType1 (* BType1 is not in scope *) }
+
+// Fields projectors are imported
+let _ = (AType1?.a1, AType2?._0, AType3?._0)
+
+// The constructors of `a_type` are imported:
+let _ = (AType1, AType2, AType3)
+
+// Fields names are imported correctly
+let _ = fun x -> x.a_type_C_field1
+
+// Other definitions are not visible:
+[@@expect_failure [72]] let _ = a_record
+[@@expect_failure [72]] let _ = fn_example
+[@@expect_failure [72]] let _ = b_type
+[@@expect_failure [72]] let _ = BType1
+[@@expect_failure [72]] let _ = BType2
+[@@expect_failure [72]] let _ = BType3
+
+(**** Include works as well *)
+// Exactly the same syntax and expressivity works for `include` as
+// well.
+include DefinitionsInterface {a_type}
+
+(**** Renaming *)
+include DefinitionsInterface {AType2 as AnotherNicerName}
+include DefinitionsInterface {BType1 as RenamedBType1}
+include DefinitionsInterface {BType2}
+include DefinitionsInterface {fn_example as fn_renamed}
+
+let _: a_type = AnotherNicerName "hello"
+
+(**** Missing names or redundant names *)
+// If a include or open exposes missing redundant names, this is an error.
+[@@expect_failure [47]] open DefinitionsInterface {AType2 as AType1, AType1}
+[@@expect_failure [47]] open DefinitionsInterface {AType1, AType1}
+[@@expect_failure [47]] open DefinitionsInterface {a_type, AType1}
+
+(**** Opening a module anonymously *)
+// Let's first bring in scope the method `to_int` of the typeclass `to_int_tc`:
+open TypeclassDefinition {to_int}
+
+// The module `TypeclassInstance` defines an instance of `to_int_tc`
+// for `int`. I can open it without exposing any name into my scope:
+open TypeclassInstance {}
+
+// Now, I can use `to_int` on int:
+let _ = assert (to_int 3 == 3)
+

--- a/tests/restricted_includes/Definitions.fst
+++ b/tests/restricted_includes/Definitions.fst
@@ -1,0 +1,16 @@
+module Definitions
+
+type a_type = 
+  | AType1: a1:int -> a2:nat -> a_type
+  | AType2 of string
+  | AType3 { a_type_C_field1: int
+           ; a_type_C_field2: b_type }
+and b_type =
+  | BType1
+  | BType2 of a_type
+  | BType3 { b_type_F_field1: int
+           ; a_type_F_field2: a_type }
+
+type a_record = { a_record_field1: a_type; a_record_field2: int }
+
+let fn_example x y = x + y

--- a/tests/restricted_includes/DoubleIndirectConsumer.fst
+++ b/tests/restricted_includes/DoubleIndirectConsumer.fst
@@ -1,0 +1,6 @@
+module DoubleIndirectConsumer
+
+open IndirectConsumer {fn_renamed_again}
+
+let _ = fn_renamed_again
+

--- a/tests/restricted_includes/IndirectConsumer.fst
+++ b/tests/restricted_includes/IndirectConsumer.fst
@@ -1,0 +1,15 @@
+// This module tests reaching definitions of module `Definition` via
+// module `Consumer`.
+module IndirectConsumer
+
+open Consumer {fn_renamed}
+open Consumer {AnotherNicerName}
+
+include Consumer {fn_renamed as fn_renamed_again}
+
+let _ = AnotherNicerName
+let _ = Consumer.BType2
+
+let _ = assert_norm (fn_renamed 12 30 == 42)
+
+

--- a/tests/restricted_includes/Makefile
+++ b/tests/restricted_includes/Makefile
@@ -1,0 +1,15 @@
+FSTAR_HOME=../..
+
+FSTAR_FILES=$(wildcard *.fst)
+
+all: verify-all
+
+include $(FSTAR_HOME)/examples/Makefile.common
+
+verify-all: $(CACHE_DIR) $(addsuffix .checked, $(addprefix $(CACHE_DIR)/, $(FSTAR_FILES)))
+
+clean:
+	$(call msg, "CLEAN")
+	$(Q)rm -f .depend
+	$(Q)rm -rf _cache
+	$(Q)rm -rf _output

--- a/tests/restricted_includes/TypeclassDefinition.fst
+++ b/tests/restricted_includes/TypeclassDefinition.fst
@@ -1,0 +1,5 @@
+module TypeclassDefinition
+
+class to_int_tc t = {
+  to_int: t -> int
+}

--- a/tests/restricted_includes/TypeclassInstance.fst
+++ b/tests/restricted_includes/TypeclassInstance.fst
@@ -1,0 +1,5 @@
+module TypeclassInstance
+
+instance _: TypeclassDefinition.to_int_tc int = {
+  to_int = id
+}

--- a/ulib/FStar.Pervasives.fst
+++ b/ulib/FStar.Pervasives.fst
@@ -200,3 +200,5 @@ let admit_termination = ()
 let singleton #_ x = x
 
 let coercion = ()
+
+let desugar_of_variant_record _ = ()

--- a/ulib/FStar.Pervasives.fsti
+++ b/ulib/FStar.Pervasives.fsti
@@ -1218,10 +1218,9 @@ let coerce_eq (#a:Type) (#b:Type) (_:squash (a == b)) (x:a) : b = x
 val coercion : unit
 
 (** Marks a record type as being the result of an automatic desugar of
-//     a constructor with a record payload.
-
-//     For example, in a module `M`, `type foo = | A {x: int}` desugars
-//     to the type `M.foo` and a type `M.foo__A__payload`. That latter
-//     type `foo__A__payload` is decorated with an attribute
-//     `desugar_of_variant_record ["M", "foo__A__payload"]`. *)
+    a constructor with a record payload.
+    For example, in a module `M`, `type foo = | A {x: int}` desugars
+    to the type `M.foo` and a type `M.foo__A__payload`. That latter
+    type `foo__A__payload` is decorated with an attribute
+    `desugar_of_variant_record ["M.A"]`. *)
 val desugar_of_variant_record (type_name: string): unit

--- a/ulib/FStar.Pervasives.fsti
+++ b/ulib/FStar.Pervasives.fsti
@@ -1216,3 +1216,12 @@ unfold let eqtype_as_type (a:eqtype) : Type = a
 let coerce_eq (#a:Type) (#b:Type) (_:squash (a == b)) (x:a) : b = x
 
 val coercion : unit
+
+(** Marks a record type as being the result of an automatic desugar of
+//     a constructor with a record payload.
+
+//     For example, in a module `M`, `type foo = | A {x: int}` desugars
+//     to the type `M.foo` and a type `M.foo__A__payload`. That latter
+//     type `foo__A__payload` is decorated with an attribute
+//     `desugar_of_variant_record ["M", "foo__A__payload"]`. *)
+val desugar_of_variant_record (type_name: string): unit


### PR DESCRIPTION
Hi!

This PR introduces the following syntaxes:
```fstar
// brings `MyModule.some_function`, `MyModule.some_type` and `MyModule.SomeConstructor` only, nothing else is visible
open MyModule { some_function, some_type, SomeConstructor }
// `include` works the same
include MyModule { some_function, some_type, SomeConstructor }
// renaming is possible
include MyModule { some_function as f, SomeConstructor as X }
```

I call `{ ... }` a restriction that we impose on the open or include, maybe there's a better naming there.

This PR:
 - tags auto generated records (when `type foo = | Foo {...}`) with a new attribute `desugar_of_variant_record` (this is important, so that `open Module {foo}` is able to look for that attribute and bring `foo__Foo__payload` in scope too);
 - add a type `restriction`;
 - change the parser to allow the new restriction syntax;
 - tweaks `DsEnv` accordingly;
 - adds a `module _ = Foo` syntax (that desugars to `open Foo {}`)

What do you think about this new feature?

@mtzguido, I haven't hacked on F* for a while, and I have to say having typeclasses (and tactics, seems like! :eyes:) within the compiler sources is fantastic! Especially something as "stupid" as `showable` simplifies makes debugging much much nicer! 

--------------
More example in `tests/restricted_includes`, but here is a preview:

Given the following module:
```fstar
module Definitions

type a_type = 
  | AType1: a1:int -> a2:nat -> a_type
  | AType2 of string
  | AType3 { a_type_C_field1: int
           ; a_type_C_field2: b_type }
and b_type =
  | BType1
  | BType2 of a_type
  | BType3 { b_type_F_field1: int
           ; a_type_F_field2: a_type }

type a_record = { a_record_field1: a_type; a_record_field2: int }

let fn_example x y = x + y
```

You can:
```fstar
module Consumer

(**** Opening a type *)
// Importing an inductive `a_type` will implicitely import each data
// constructors and each associated desugared record types (here,
// `a_type` as a constructor `Type3` with a record payload: the
// implicit corresponding record type will be imported).
open Definitions {a_type}

// `a_type` and its constructors are available
let _ = a_type
let _ = AType1 0 1
let _ = AType2 "hi"
let _ = AType3 { a_type_C_field1 = 3
               ; a_type_C_field2 = Definitions.BType1 (* BType1 is not in scope *) }

// The automatically generated type `a_type__AType3__payload` is available as well
let _ = a_type__AType3__payload
let _ = Mka_type__AType3__payload
let _ = { a_type_C_field1 = 3
        ; a_type_C_field2 = Definitions.BType1 (* BType1 is not in scope *) }

// Fields projectors are imported
let _ = (AType1?.a1, AType2?._0, AType3?._0)

// The constructors of `a_type` are imported:
let _ = (AType1, AType2, AType3)

// Fields names are imported correctly
let _ = fun x -> x.a_type_C_field1

// Other definitions are not visible:
[@@expect_failure [72]] let _ = a_record
[@@expect_failure [72]] let _ = fn_example
[@@expect_failure [72]] let _ = b_type
[@@expect_failure [72]] let _ = BType1
[@@expect_failure [72]] let _ = BType2
[@@expect_failure [72]] let _ = BType3

(**** Include works as well *)
// Exactly the same syntax and expressivity works for `include` as
// well.
include Definitions {a_type}

(**** Renaming *)
include Definitions {AType2 as AnotherNicerName}
include Definitions {BType1 as RenamedBType1}
include Definitions {BType2}
include Definitions {fn_example as fn_renamed}

let _: a_type = AnotherNicerName "hello"

(**** Missing names or redundant names *)
// If a include or open exposes missing redundant names, this is an error.
[@@expect_failure [47]] open Definitions {AType2 as AType1, AType1}
[@@expect_failure [47]] open Definitions {AType1, AType1}
[@@expect_failure [47]] open Definitions {a_type, AType1}

(**** Opening a module anonymously *)
// Let's first bring in scope the method `to_int` of the typeclass `to_int_tc`:
open TypeclassDefinition {to_int}

// The module `TypeclassInstance` defines an instance of `to_int_tc`
// for `int`. I can open it without exposing any name into my scope:
open TypeclassInstance {}

// Now, I can use `to_int` on int:
let _ = to_int 3
``` 