### PR TITLE
Add a --krmloutput option to chose filename for krml extraction

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_Options.ml
+++ b/ocaml/fstar-lib/generated/FStar_Options.ml
@@ -338,6 +338,7 @@ let (defaults : (Prims.string * option_val) Prims.list) =
   ("no_plugins", (Bool false));
   ("no_tactics", (Bool false));
   ("normalize_pure_terms_for_extraction", (Bool false));
+  ("krmloutput", Unset);
   ("odir", Unset);
   ("output_deps_to", Unset);
   ("prims", Unset);
@@ -582,6 +583,8 @@ let (get_no_smt : unit -> Prims.bool) =
   fun uu___ -> lookup_opt "no_smt" as_bool
 let (get_normalize_pure_terms_for_extraction : unit -> Prims.bool) =
   fun uu___ -> lookup_opt "normalize_pure_terms_for_extraction" as_bool
+let (get_krmloutput : unit -> Prims.string FStar_Pervasives_Native.option) =
+  fun uu___ -> lookup_opt "krmloutput" (as_option as_string)
 let (get_odir : unit -> Prims.string FStar_Pervasives_Native.option) =
   fun uu___ -> lookup_opt "odir" (as_option as_string)
 let (get_output_deps_to :
@@ -1008,7 +1011,7 @@ let (interp_quake_arg : Prims.string -> (Prims.int * Prims.int * Prims.bool))
           let uu___ = ios f1 in let uu___1 = ios f2 in (uu___, uu___1, true)
         else FStar_Compiler_Effect.failwith "unexpected value for --quake"
     | uu___ -> FStar_Compiler_Effect.failwith "unexpected value for --quake"
-let (uu___451 : (((Prims.string -> unit) -> unit) * (Prims.string -> unit)))
+let (uu___452 : (((Prims.string -> unit) -> unit) * (Prims.string -> unit)))
   =
   let cb = FStar_Compiler_Util.mk_ref FStar_Pervasives_Native.None in
   let set1 f =
@@ -1020,11 +1023,11 @@ let (uu___451 : (((Prims.string -> unit) -> unit) * (Prims.string -> unit)))
     | FStar_Pervasives_Native.Some f -> f msg in
   (set1, call)
 let (set_option_warning_callback_aux : (Prims.string -> unit) -> unit) =
-  match uu___451 with
+  match uu___452 with
   | (set_option_warning_callback_aux1, option_warning_callback) ->
       set_option_warning_callback_aux1
 let (option_warning_callback : Prims.string -> unit) =
-  match uu___451 with
+  match uu___452 with
   | (set_option_warning_callback_aux1, option_warning_callback1) ->
       option_warning_callback1
 let (set_option_warning_callback : (Prims.string -> unit) -> unit) =
@@ -1932,13 +1935,11 @@ let rec (specs_with_types :
                                                                     let uu___123
                                                                     =
                                                                     text
-                                                                    "Place output in directory  dir" in
+                                                                    "Place KaRaMeL extraction output in file <filename>. The path can be relative or absolute and does not dependon the --odir option." in
                                                                     (FStar_Getopt.noshort,
-                                                                    "odir",
-                                                                    (PostProcessed
-                                                                    (pp_validate_dir,
+                                                                    "krmloutput",
                                                                     (PathStr
-                                                                    "dir"))),
+                                                                    "filename"),
                                                                     uu___123) in
                                                                     let uu___123
                                                                     =
@@ -1947,11 +1948,13 @@ let rec (specs_with_types :
                                                                     let uu___125
                                                                     =
                                                                     text
-                                                                    "Output the result of --dep into this file instead of to standard output." in
+                                                                    "Place output in directory  dir" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "output_deps_to",
+                                                                    "odir",
+                                                                    (PostProcessed
+                                                                    (pp_validate_dir,
                                                                     (PathStr
-                                                                    "file"),
+                                                                    "dir"))),
                                                                     uu___125) in
                                                                     let uu___125
                                                                     =
@@ -1960,9 +1963,9 @@ let rec (specs_with_types :
                                                                     let uu___127
                                                                     =
                                                                     text
-                                                                    "Use a custom prims.fst file. Do not use if you do not know exactly what you're doing." in
+                                                                    "Output the result of --dep into this file instead of to standard output." in
                                                                     (FStar_Getopt.noshort,
-                                                                    "prims",
+                                                                    "output_deps_to",
                                                                     (PathStr
                                                                     "file"),
                                                                     uu___127) in
@@ -1973,12 +1976,11 @@ let rec (specs_with_types :
                                                                     let uu___129
                                                                     =
                                                                     text
-                                                                    "Print the types of bound variables" in
+                                                                    "Use a custom prims.fst file. Do not use if you do not know exactly what you're doing." in
                                                                     (FStar_Getopt.noshort,
-                                                                    "print_bound_var_types",
-                                                                    (Const
-                                                                    (Bool
-                                                                    true)),
+                                                                    "prims",
+                                                                    (PathStr
+                                                                    "file"),
                                                                     uu___129) in
                                                                     let uu___129
                                                                     =
@@ -1987,9 +1989,9 @@ let rec (specs_with_types :
                                                                     let uu___131
                                                                     =
                                                                     text
-                                                                    "Print inferred predicate transformers for all computation types" in
+                                                                    "Print the types of bound variables" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "print_effect_args",
+                                                                    "print_bound_var_types",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2001,9 +2003,9 @@ let rec (specs_with_types :
                                                                     let uu___133
                                                                     =
                                                                     text
-                                                                    "Print the errors generated by declarations marked with expect_failure, useful for debugging error locations" in
+                                                                    "Print inferred predicate transformers for all computation types" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "print_expected_failures",
+                                                                    "print_effect_args",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2015,9 +2017,9 @@ let rec (specs_with_types :
                                                                     let uu___135
                                                                     =
                                                                     text
-                                                                    "Print full names of variables" in
+                                                                    "Print the errors generated by declarations marked with expect_failure, useful for debugging error locations" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "print_full_names",
+                                                                    "print_expected_failures",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2029,9 +2031,9 @@ let rec (specs_with_types :
                                                                     let uu___137
                                                                     =
                                                                     text
-                                                                    "Print implicit arguments" in
+                                                                    "Print full names of variables" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "print_implicits",
+                                                                    "print_full_names",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2043,9 +2045,9 @@ let rec (specs_with_types :
                                                                     let uu___139
                                                                     =
                                                                     text
-                                                                    "Print universes" in
+                                                                    "Print implicit arguments" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "print_universes",
+                                                                    "print_implicits",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2057,9 +2059,9 @@ let rec (specs_with_types :
                                                                     let uu___141
                                                                     =
                                                                     text
-                                                                    "Print Z3 statistics for each SMT query (details such as relevant modules, facts, etc. for each proof)" in
+                                                                    "Print universes" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "print_z3_statistics",
+                                                                    "print_universes",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2071,9 +2073,9 @@ let rec (specs_with_types :
                                                                     let uu___143
                                                                     =
                                                                     text
-                                                                    "Print full names (deprecated; use --print_full_names instead)" in
+                                                                    "Print Z3 statistics for each SMT query (details such as relevant modules, facts, etc. for each proof)" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "prn",
+                                                                    "print_z3_statistics",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2085,9 +2087,9 @@ let rec (specs_with_types :
                                                                     let uu___145
                                                                     =
                                                                     text
-                                                                    "Proof recovery mode: before failing an SMT query, retry 3 times, increasing rlimits. If the query goes through after retrying, verification will succeed, but a warning will be emitted. This feature is useful to restore a project after some change to its libraries or F* upgrade. Importantly, then, this option cannot be used in a pragma (#set-options, etc)." in
+                                                                    "Print full names (deprecated; use --print_full_names instead)" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "proof_recovery",
+                                                                    "prn",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2098,76 +2100,90 @@ let rec (specs_with_types :
                                                                     =
                                                                     let uu___147
                                                                     =
+                                                                    text
+                                                                    "Proof recovery mode: before failing an SMT query, retry 3 times, increasing rlimits. If the query goes through after retrying, verification will succeed, but a warning will be emitted. This feature is useful to restore a project after some change to its libraries or F* upgrade. Importantly, then, this option cannot be used in a pragma (#set-options, etc)." in
+                                                                    (FStar_Getopt.noshort,
+                                                                    "proof_recovery",
+                                                                    (Const
+                                                                    (Bool
+                                                                    true)),
+                                                                    uu___147) in
+                                                                    let uu___147
+                                                                    =
                                                                     let uu___148
                                                                     =
-                                                                    text
-                                                                    "Repeats SMT queries to check for robustness" in
                                                                     let uu___149
                                                                     =
                                                                     let uu___150
                                                                     =
+                                                                    text
+                                                                    "Repeats SMT queries to check for robustness" in
                                                                     let uu___151
                                                                     =
                                                                     let uu___152
                                                                     =
-                                                                    text
-                                                                    "--quake N/M repeats each query checks that it succeeds at least N out of M times, aborting early if possible" in
                                                                     let uu___153
                                                                     =
                                                                     let uu___154
                                                                     =
                                                                     text
-                                                                    "--quake N/M/k works as above, except it will unconditionally run M times" in
+                                                                    "--quake N/M repeats each query checks that it succeeds at least N out of M times, aborting early if possible" in
                                                                     let uu___155
                                                                     =
                                                                     let uu___156
                                                                     =
                                                                     text
-                                                                    "--quake N is an alias for --quake N/N" in
+                                                                    "--quake N/M/k works as above, except it will unconditionally run M times" in
                                                                     let uu___157
                                                                     =
                                                                     let uu___158
                                                                     =
                                                                     text
+                                                                    "--quake N is an alias for --quake N/N" in
+                                                                    let uu___159
+                                                                    =
+                                                                    let uu___160
+                                                                    =
+                                                                    text
                                                                     "--quake N/k is an alias for --quake N/N/k" in
-                                                                    [uu___158] in
+                                                                    [uu___160] in
+                                                                    uu___158
+                                                                    ::
+                                                                    uu___159 in
                                                                     uu___156
                                                                     ::
                                                                     uu___157 in
                                                                     uu___154
                                                                     ::
                                                                     uu___155 in
-                                                                    uu___152
-                                                                    ::
-                                                                    uu___153 in
                                                                     FStar_Errors_Msg.bulleted
-                                                                    uu___151 in
-                                                                    let uu___151
+                                                                    uu___153 in
+                                                                    let uu___153
                                                                     =
                                                                     text
                                                                     "Using --quake disables --retry. When quake testing, queries are not splitted for error reporting unless '--split_queries always' is given. Queries from the smt_sync tactic are not quake-tested." in
                                                                     FStar_Pprint.op_Hat_Hat
+                                                                    uu___152
+                                                                    uu___153 in
+                                                                    FStar_Pprint.op_Hat_Hat
                                                                     uu___150
                                                                     uu___151 in
-                                                                    FStar_Pprint.op_Hat_Hat
-                                                                    uu___148
-                                                                    uu___149 in
                                                                     (FStar_Getopt.noshort,
                                                                     "quake",
                                                                     (PostProcessed
                                                                     ((fun
-                                                                    uu___148
+                                                                    uu___150
                                                                     ->
-                                                                    match uu___148
+                                                                    match uu___150
                                                                     with
                                                                     | 
                                                                     String s
                                                                     ->
-                                                                    let uu___149
+                                                                    let uu___151
                                                                     =
                                                                     interp_quake_arg
                                                                     s in
-                                                                    (match uu___149
+                                                                    (match uu___151
                                                                     with
                                                                     | 
                                                                     (min,
@@ -2188,26 +2204,12 @@ let rec (specs_with_types :
                                                                     false);
                                                                     String s))
                                                                     | 
-                                                                    uu___149
+                                                                    uu___151
                                                                     ->
                                                                     FStar_Compiler_Effect.failwith
                                                                     "impos"),
                                                                     (SimpleStr
                                                                     "positive integer or pair of positive integers"))),
-                                                                    uu___147) in
-                                                                    let uu___147
-                                                                    =
-                                                                    let uu___148
-                                                                    =
-                                                                    let uu___149
-                                                                    =
-                                                                    text
-                                                                    "Keep a running cache of SMT queries to make verification faster. Only available in the interactive mode. NOTE: This feature is experimental and potentially unsound! Hence why\n          it is not allowed in batch mode (where it is also less useful). If you\n          find a query that is mistakenly accepted with the cache, please\n          report a bug to the F* issue tracker on GitHub." in
-                                                                    (FStar_Getopt.noshort,
-                                                                    "query_cache",
-                                                                    (Const
-                                                                    (Bool
-                                                                    true)),
                                                                     uu___149) in
                                                                     let uu___149
                                                                     =
@@ -2216,9 +2218,9 @@ let rec (specs_with_types :
                                                                     let uu___151
                                                                     =
                                                                     text
-                                                                    "Print SMT query statistics" in
+                                                                    "Keep a running cache of SMT queries to make verification faster. Only available in the interactive mode. NOTE: This feature is experimental and potentially unsound! Hence why\n          it is not allowed in batch mode (where it is also less useful). If you\n          find a query that is mistakenly accepted with the cache, please\n          report a bug to the F* issue tracker on GitHub." in
                                                                     (FStar_Getopt.noshort,
-                                                                    "query_stats",
+                                                                    "query_cache",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2230,9 +2232,9 @@ let rec (specs_with_types :
                                                                     let uu___153
                                                                     =
                                                                     text
-                                                                    "Record a database of hints for efficient proof replay" in
+                                                                    "Print SMT query statistics" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "record_hints",
+                                                                    "query_stats",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2244,9 +2246,9 @@ let rec (specs_with_types :
                                                                     let uu___155
                                                                     =
                                                                     text
-                                                                    "Record the state of options used to check each sigelt, useful for the `check_with` attribute and metaprogramming. Note that this implies a performance hit and increases the size of checked files." in
+                                                                    "Record a database of hints for efficient proof replay" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "record_options",
+                                                                    "record_hints",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2258,14 +2260,28 @@ let rec (specs_with_types :
                                                                     let uu___157
                                                                     =
                                                                     text
+                                                                    "Record the state of options used to check each sigelt, useful for the `check_with` attribute and metaprogramming. Note that this implies a performance hit and increases the size of checked files." in
+                                                                    (FStar_Getopt.noshort,
+                                                                    "record_options",
+                                                                    (Const
+                                                                    (Bool
+                                                                    true)),
+                                                                    uu___157) in
+                                                                    let uu___157
+                                                                    =
+                                                                    let uu___158
+                                                                    =
+                                                                    let uu___159
+                                                                    =
+                                                                    text
                                                                     "Retry each SMT query N times and succeed on the first try. Using --retry disables --quake." in
                                                                     (FStar_Getopt.noshort,
                                                                     "retry",
                                                                     (PostProcessed
                                                                     ((fun
-                                                                    uu___158
+                                                                    uu___160
                                                                     ->
-                                                                    match uu___158
+                                                                    match uu___160
                                                                     with
                                                                     | 
                                                                     Int i ->
@@ -2286,25 +2302,12 @@ let rec (specs_with_types :
                                                                     true);
                                                                     Bool true)
                                                                     | 
-                                                                    uu___159
+                                                                    uu___161
                                                                     ->
                                                                     FStar_Compiler_Effect.failwith
                                                                     "impos"),
                                                                     (IntStr
                                                                     "positive integer"))),
-                                                                    uu___157) in
-                                                                    let uu___157
-                                                                    =
-                                                                    let uu___158
-                                                                    =
-                                                                    let uu___159
-                                                                    =
-                                                                    text
-                                                                    "Optimistically, attempt using the recorded hint for  toplevel_name (a top-level name in the current module) when trying to verify some other term 'g'" in
-                                                                    (FStar_Getopt.noshort,
-                                                                    "reuse_hint_for",
-                                                                    (SimpleStr
-                                                                    "toplevel_name"),
                                                                     uu___159) in
                                                                     let uu___159
                                                                     =
@@ -2313,12 +2316,11 @@ let rec (specs_with_types :
                                                                     let uu___161
                                                                     =
                                                                     text
-                                                                    "Report every use of an escape hatch, include assume, admit, etc." in
+                                                                    "Optimistically, attempt using the recorded hint for  toplevel_name (a top-level name in the current module) when trying to verify some other term 'g'" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "report_assumes",
-                                                                    (EnumStr
-                                                                    ["warn";
-                                                                    "error"]),
+                                                                    "reuse_hint_for",
+                                                                    (SimpleStr
+                                                                    "toplevel_name"),
                                                                     uu___161) in
                                                                     let uu___161
                                                                     =
@@ -2327,12 +2329,12 @@ let rec (specs_with_types :
                                                                     let uu___163
                                                                     =
                                                                     text
-                                                                    "Disable all non-critical output" in
+                                                                    "Report every use of an escape hatch, include assume, admit, etc." in
                                                                     (FStar_Getopt.noshort,
-                                                                    "silent",
-                                                                    (Const
-                                                                    (Bool
-                                                                    true)),
+                                                                    "report_assumes",
+                                                                    (EnumStr
+                                                                    ["warn";
+                                                                    "error"]),
                                                                     uu___163) in
                                                                     let uu___163
                                                                     =
@@ -2341,11 +2343,12 @@ let rec (specs_with_types :
                                                                     let uu___165
                                                                     =
                                                                     text
-                                                                    "Path to the Z3 SMT solver (we could eventually support other solvers)" in
+                                                                    "Disable all non-critical output" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "smt",
-                                                                    (PathStr
-                                                                    "path"),
+                                                                    "silent",
+                                                                    (Const
+                                                                    (Bool
+                                                                    true)),
                                                                     uu___165) in
                                                                     let uu___165
                                                                     =
@@ -2354,10 +2357,11 @@ let rec (specs_with_types :
                                                                     let uu___167
                                                                     =
                                                                     text
-                                                                    "Toggle a peephole optimization that eliminates redundant uses of boxing/unboxing in the SMT encoding (default 'false')" in
+                                                                    "Path to the Z3 SMT solver (we could eventually support other solvers)" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "smtencoding.elim_box",
-                                                                    BoolStr,
+                                                                    "smt",
+                                                                    (PathStr
+                                                                    "path"),
                                                                     uu___167) in
                                                                     let uu___167
                                                                     =
@@ -2365,57 +2369,11 @@ let rec (specs_with_types :
                                                                     =
                                                                     let uu___169
                                                                     =
-                                                                    let uu___170
-                                                                    =
                                                                     text
-                                                                    "Control the representation of non-linear arithmetic functions in the SMT encoding:" in
-                                                                    let uu___171
-                                                                    =
-                                                                    let uu___172
-                                                                    =
-                                                                    let uu___173
-                                                                    =
-                                                                    let uu___174
-                                                                    =
-                                                                    text
-                                                                    "if 'boxwrap' use 'Prims.op_Multiply, Prims.op_Division, Prims.op_Modulus'" in
-                                                                    let uu___175
-                                                                    =
-                                                                    let uu___176
-                                                                    =
-                                                                    text
-                                                                    "if 'native' use '*, div, mod'" in
-                                                                    let uu___177
-                                                                    =
-                                                                    let uu___178
-                                                                    =
-                                                                    text
-                                                                    "if 'wrapped' use '_mul, _div, _mod : Int*Int -> Int'" in
-                                                                    [uu___178] in
-                                                                    uu___176
-                                                                    ::
-                                                                    uu___177 in
-                                                                    uu___174
-                                                                    ::
-                                                                    uu___175 in
-                                                                    FStar_Errors_Msg.bulleted
-                                                                    uu___173 in
-                                                                    let uu___173
-                                                                    =
-                                                                    text
-                                                                    "(default 'boxwrap')" in
-                                                                    FStar_Pprint.op_Hat_Hat
-                                                                    uu___172
-                                                                    uu___173 in
-                                                                    FStar_Pprint.op_Hat_Hat
-                                                                    uu___170
-                                                                    uu___171 in
+                                                                    "Toggle a peephole optimization that eliminates redundant uses of boxing/unboxing in the SMT encoding (default 'false')" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "smtencoding.nl_arith_repr",
-                                                                    (EnumStr
-                                                                    ["native";
-                                                                    "wrapped";
-                                                                    "boxwrap"]),
+                                                                    "smtencoding.elim_box",
+                                                                    BoolStr,
                                                                     uu___169) in
                                                                     let uu___169
                                                                     =
@@ -2426,7 +2384,7 @@ let rec (specs_with_types :
                                                                     let uu___172
                                                                     =
                                                                     text
-                                                                    "Toggle the representation of linear arithmetic functions in the SMT encoding:" in
+                                                                    "Control the representation of non-linear arithmetic functions in the SMT encoding:" in
                                                                     let uu___173
                                                                     =
                                                                     let uu___174
@@ -2436,14 +2394,23 @@ let rec (specs_with_types :
                                                                     let uu___176
                                                                     =
                                                                     text
-                                                                    "if 'boxwrap', use 'Prims.op_Addition, Prims.op_Subtraction, Prims.op_Minus'" in
+                                                                    "if 'boxwrap' use 'Prims.op_Multiply, Prims.op_Division, Prims.op_Modulus'" in
                                                                     let uu___177
                                                                     =
                                                                     let uu___178
                                                                     =
                                                                     text
-                                                                    "if 'native', use '+, -, -'" in
-                                                                    [uu___178] in
+                                                                    "if 'native' use '*, div, mod'" in
+                                                                    let uu___179
+                                                                    =
+                                                                    let uu___180
+                                                                    =
+                                                                    text
+                                                                    "if 'wrapped' use '_mul, _div, _mod : Int*Int -> Int'" in
+                                                                    [uu___180] in
+                                                                    uu___178
+                                                                    ::
+                                                                    uu___179 in
                                                                     uu___176
                                                                     ::
                                                                     uu___177 in
@@ -2460,9 +2427,10 @@ let rec (specs_with_types :
                                                                     uu___172
                                                                     uu___173 in
                                                                     (FStar_Getopt.noshort,
-                                                                    "smtencoding.l_arith_repr",
+                                                                    "smtencoding.nl_arith_repr",
                                                                     (EnumStr
                                                                     ["native";
+                                                                    "wrapped";
                                                                     "boxwrap"]),
                                                                     uu___171) in
                                                                     let uu___171
@@ -2471,24 +2439,10 @@ let rec (specs_with_types :
                                                                     =
                                                                     let uu___173
                                                                     =
-                                                                    text
-                                                                    "Include an axiom in the SMT encoding to introduce proof-irrelevance from a constructive proof" in
-                                                                    (FStar_Getopt.noshort,
-                                                                    "smtencoding.valid_intro",
-                                                                    BoolStr,
-                                                                    uu___173) in
-                                                                    let uu___173
-                                                                    =
                                                                     let uu___174
                                                                     =
-                                                                    let uu___175
-                                                                    =
                                                                     text
-                                                                    "Include an axiom in the SMT encoding to eliminate proof-irrelevance into the existence of a proof witness" in
-                                                                    (FStar_Getopt.noshort,
-                                                                    "smtencoding.valid_elim",
-                                                                    BoolStr,
-                                                                    uu___175) in
+                                                                    "Toggle the representation of linear arithmetic functions in the SMT encoding:" in
                                                                     let uu___175
                                                                     =
                                                                     let uu___176
@@ -2498,45 +2452,58 @@ let rec (specs_with_types :
                                                                     let uu___178
                                                                     =
                                                                     text
-                                                                    "Split SMT verification conditions into several separate queries, one per goal. Helps with localizing errors." in
+                                                                    "if 'boxwrap', use 'Prims.op_Addition, Prims.op_Subtraction, Prims.op_Minus'" in
                                                                     let uu___179
                                                                     =
                                                                     let uu___180
                                                                     =
-                                                                    let uu___181
-                                                                    =
                                                                     text
-                                                                    "Use 'no' to disable (this may reduce the quality of error messages)." in
-                                                                    let uu___182
-                                                                    =
-                                                                    let uu___183
-                                                                    =
-                                                                    text
-                                                                    "Use 'on_failure' to split queries and retry when discharging fails (the default)" in
-                                                                    let uu___184
-                                                                    =
-                                                                    let uu___185
-                                                                    =
-                                                                    text
-                                                                    "Use 'yes' to always split." in
-                                                                    [uu___185] in
-                                                                    uu___183
-                                                                    ::
-                                                                    uu___184 in
-                                                                    uu___181
-                                                                    ::
-                                                                    uu___182 in
-                                                                    FStar_Errors_Msg.bulleted
-                                                                    uu___180 in
-                                                                    FStar_Pprint.op_Hat_Hat
+                                                                    "if 'native', use '+, -, -'" in
+                                                                    [uu___180] in
                                                                     uu___178
+                                                                    ::
                                                                     uu___179 in
+                                                                    FStar_Errors_Msg.bulleted
+                                                                    uu___177 in
+                                                                    let uu___177
+                                                                    =
+                                                                    text
+                                                                    "(default 'boxwrap')" in
+                                                                    FStar_Pprint.op_Hat_Hat
+                                                                    uu___176
+                                                                    uu___177 in
+                                                                    FStar_Pprint.op_Hat_Hat
+                                                                    uu___174
+                                                                    uu___175 in
                                                                     (FStar_Getopt.noshort,
-                                                                    "split_queries",
+                                                                    "smtencoding.l_arith_repr",
                                                                     (EnumStr
-                                                                    ["no";
-                                                                    "on_failure";
-                                                                    "always"]),
+                                                                    ["native";
+                                                                    "boxwrap"]),
+                                                                    uu___173) in
+                                                                    let uu___173
+                                                                    =
+                                                                    let uu___174
+                                                                    =
+                                                                    let uu___175
+                                                                    =
+                                                                    text
+                                                                    "Include an axiom in the SMT encoding to introduce proof-irrelevance from a constructive proof" in
+                                                                    (FStar_Getopt.noshort,
+                                                                    "smtencoding.valid_intro",
+                                                                    BoolStr,
+                                                                    uu___175) in
+                                                                    let uu___175
+                                                                    =
+                                                                    let uu___176
+                                                                    =
+                                                                    let uu___177
+                                                                    =
+                                                                    text
+                                                                    "Include an axiom in the SMT encoding to eliminate proof-irrelevance into the existence of a proof witness" in
+                                                                    (FStar_Getopt.noshort,
+                                                                    "smtencoding.valid_elim",
+                                                                    BoolStr,
                                                                     uu___177) in
                                                                     let uu___177
                                                                     =
@@ -2544,13 +2511,48 @@ let rec (specs_with_types :
                                                                     =
                                                                     let uu___179
                                                                     =
+                                                                    let uu___180
+                                                                    =
                                                                     text
-                                                                    "Do not use the lexical scope of tactics to improve binder names" in
+                                                                    "Split SMT verification conditions into several separate queries, one per goal. Helps with localizing errors." in
+                                                                    let uu___181
+                                                                    =
+                                                                    let uu___182
+                                                                    =
+                                                                    let uu___183
+                                                                    =
+                                                                    text
+                                                                    "Use 'no' to disable (this may reduce the quality of error messages)." in
+                                                                    let uu___184
+                                                                    =
+                                                                    let uu___185
+                                                                    =
+                                                                    text
+                                                                    "Use 'on_failure' to split queries and retry when discharging fails (the default)" in
+                                                                    let uu___186
+                                                                    =
+                                                                    let uu___187
+                                                                    =
+                                                                    text
+                                                                    "Use 'yes' to always split." in
+                                                                    [uu___187] in
+                                                                    uu___185
+                                                                    ::
+                                                                    uu___186 in
+                                                                    uu___183
+                                                                    ::
+                                                                    uu___184 in
+                                                                    FStar_Errors_Msg.bulleted
+                                                                    uu___182 in
+                                                                    FStar_Pprint.op_Hat_Hat
+                                                                    uu___180
+                                                                    uu___181 in
                                                                     (FStar_Getopt.noshort,
-                                                                    "tactic_raw_binders",
-                                                                    (Const
-                                                                    (Bool
-                                                                    true)),
+                                                                    "split_queries",
+                                                                    (EnumStr
+                                                                    ["no";
+                                                                    "on_failure";
+                                                                    "always"]),
                                                                     uu___179) in
                                                                     let uu___179
                                                                     =
@@ -2559,9 +2561,9 @@ let rec (specs_with_types :
                                                                     let uu___181
                                                                     =
                                                                     text
-                                                                    "Do not recover from metaprogramming errors, and abort if one occurs" in
+                                                                    "Do not use the lexical scope of tactics to improve binder names" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "tactics_failhard",
+                                                                    "tactic_raw_binders",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2573,9 +2575,9 @@ let rec (specs_with_types :
                                                                     let uu___183
                                                                     =
                                                                     text
-                                                                    "Print some rough information on tactics, such as the time they take to run" in
+                                                                    "Do not recover from metaprogramming errors, and abort if one occurs" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "tactics_info",
+                                                                    "tactics_failhard",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2587,9 +2589,9 @@ let rec (specs_with_types :
                                                                     let uu___185
                                                                     =
                                                                     text
-                                                                    "Print a depth-indexed trace of tactic execution (Warning: very verbose)" in
+                                                                    "Print some rough information on tactics, such as the time they take to run" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "tactic_trace",
+                                                                    "tactics_info",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2601,11 +2603,12 @@ let rec (specs_with_types :
                                                                     let uu___187
                                                                     =
                                                                     text
-                                                                    "Trace tactics up to a certain binding depth" in
+                                                                    "Print a depth-indexed trace of tactic execution (Warning: very verbose)" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "tactic_trace_d",
-                                                                    (IntStr
-                                                                    "positive_integer"),
+                                                                    "tactic_trace",
+                                                                    (Const
+                                                                    (Bool
+                                                                    true)),
                                                                     uu___187) in
                                                                     let uu___187
                                                                     =
@@ -2614,12 +2617,11 @@ let rec (specs_with_types :
                                                                     let uu___189
                                                                     =
                                                                     text
-                                                                    "Use NBE to evaluate metaprograms (experimental)" in
+                                                                    "Trace tactics up to a certain binding depth" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "__tactics_nbe",
-                                                                    (Const
-                                                                    (Bool
-                                                                    true)),
+                                                                    "tactic_trace_d",
+                                                                    (IntStr
+                                                                    "positive_integer"),
                                                                     uu___189) in
                                                                     let uu___189
                                                                     =
@@ -2628,10 +2630,12 @@ let rec (specs_with_types :
                                                                     let uu___191
                                                                     =
                                                                     text
-                                                                    "Attempt to normalize definitions marked as tcnorm (default 'true')" in
+                                                                    "Use NBE to evaluate metaprograms (experimental)" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "tcnorm",
-                                                                    BoolStr,
+                                                                    "__tactics_nbe",
+                                                                    (Const
+                                                                    (Bool
+                                                                    true)),
                                                                     uu___191) in
                                                                     let uu___191
                                                                     =
@@ -2640,12 +2644,10 @@ let rec (specs_with_types :
                                                                     let uu___193
                                                                     =
                                                                     text
-                                                                    "Print the time it takes to verify each top-level definition. This is just an alias for an invocation of the profiler, so it may not work well if combined with --profile. In particular, it implies --profile_group_by_decl." in
+                                                                    "Attempt to normalize definitions marked as tcnorm (default 'true')" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "timing",
-                                                                    (Const
-                                                                    (Bool
-                                                                    true)),
+                                                                    "tcnorm",
+                                                                    BoolStr,
                                                                     uu___193) in
                                                                     let uu___193
                                                                     =
@@ -2654,9 +2656,9 @@ let rec (specs_with_types :
                                                                     let uu___195
                                                                     =
                                                                     text
-                                                                    "Attach stack traces on errors" in
+                                                                    "Print the time it takes to verify each top-level definition. This is just an alias for an invocation of the profiler, so it may not work well if combined with --profile. In particular, it implies --profile_group_by_decl." in
                                                                     (FStar_Getopt.noshort,
-                                                                    "trace_error",
+                                                                    "timing",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2668,9 +2670,9 @@ let rec (specs_with_types :
                                                                     let uu___197
                                                                     =
                                                                     text
-                                                                    "Emit output formatted for debugging" in
+                                                                    "Attach stack traces on errors" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "ugly",
+                                                                    "trace_error",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2682,9 +2684,9 @@ let rec (specs_with_types :
                                                                     let uu___199
                                                                     =
                                                                     text
-                                                                    "Let the SMT solver unfold inductive types to arbitrary depths (may affect verifier performance)" in
+                                                                    "Emit output formatted for debugging" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "unthrottle_inductives",
+                                                                    "ugly",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2696,9 +2698,9 @@ let rec (specs_with_types :
                                                                     let uu___201
                                                                     =
                                                                     text
-                                                                    "Allow tactics to run external processes. WARNING: checking an untrusted F* file while using this option can have disastrous effects." in
+                                                                    "Let the SMT solver unfold inductive types to arbitrary depths (may affect verifier performance)" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "unsafe_tactic_exec",
+                                                                    "unthrottle_inductives",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2710,9 +2712,9 @@ let rec (specs_with_types :
                                                                     let uu___203
                                                                     =
                                                                     text
-                                                                    "Use equality constraints when comparing higher-order types (Temporary)" in
+                                                                    "Allow tactics to run external processes. WARNING: checking an untrusted F* file while using this option can have disastrous effects." in
                                                                     (FStar_Getopt.noshort,
-                                                                    "use_eq_at_higher_order",
+                                                                    "unsafe_tactic_exec",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2724,9 +2726,9 @@ let rec (specs_with_types :
                                                                     let uu___205
                                                                     =
                                                                     text
-                                                                    "Use a previously recorded hints database for proof replay" in
+                                                                    "Use equality constraints when comparing higher-order types (Temporary)" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "use_hints",
+                                                                    "use_eq_at_higher_order",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2738,9 +2740,9 @@ let rec (specs_with_types :
                                                                     let uu___207
                                                                     =
                                                                     text
-                                                                    "Admit queries if their hash matches the hash recorded in the hints database" in
+                                                                    "Use a previously recorded hints database for proof replay" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "use_hint_hashes",
+                                                                    "use_hints",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2752,11 +2754,12 @@ let rec (specs_with_types :
                                                                     let uu___209
                                                                     =
                                                                     text
-                                                                    "Use compiled tactics from  path" in
+                                                                    "Admit queries if their hash matches the hash recorded in the hints database" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "use_native_tactics",
-                                                                    (PathStr
-                                                                    "path"),
+                                                                    "use_hint_hashes",
+                                                                    (Const
+                                                                    (Bool
+                                                                    true)),
                                                                     uu___209) in
                                                                     let uu___209
                                                                     =
@@ -2765,12 +2768,11 @@ let rec (specs_with_types :
                                                                     let uu___211
                                                                     =
                                                                     text
-                                                                    "Do not run plugins natively and interpret them as usual instead" in
+                                                                    "Use compiled tactics from  path" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "no_plugins",
-                                                                    (Const
-                                                                    (Bool
-                                                                    true)),
+                                                                    "use_native_tactics",
+                                                                    (PathStr
+                                                                    "path"),
                                                                     uu___211) in
                                                                     let uu___211
                                                                     =
@@ -2779,9 +2781,9 @@ let rec (specs_with_types :
                                                                     let uu___213
                                                                     =
                                                                     text
-                                                                    "Do not run the tactic engine before discharging a VC" in
+                                                                    "Do not run plugins natively and interpret them as usual instead" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "no_tactics",
+                                                                    "no_plugins",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2793,12 +2795,12 @@ let rec (specs_with_types :
                                                                     let uu___215
                                                                     =
                                                                     text
-                                                                    "Prunes the context to include only the facts from the given namespace or fact id. Facts can be include or excluded using the [+|-] qualifier. For example --using_facts_from '* -FStar.Reflection +FStar.Compiler.List -FStar.Compiler.List.Tot' will remove all facts from FStar.Compiler.List.Tot.*, retain all remaining facts from FStar.Compiler.List.*, remove all facts from FStar.Reflection.*, and retain all the rest. Note, the '+' is optional: --using_facts_from 'FStar.Compiler.List' is equivalent to --using_facts_from '+FStar.Compiler.List'. Multiple uses of this option accumulate, e.g., --using_facts_from A --using_facts_from B is interpreted as --using_facts_from A^B." in
+                                                                    "Do not run the tactic engine before discharging a VC" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "using_facts_from",
-                                                                    (ReverseAccumulated
-                                                                    (SimpleStr
-                                                                    "One or more space-separated occurrences of '[+|-]( * | namespace | fact id)'")),
+                                                                    "no_tactics",
+                                                                    (Const
+                                                                    (Bool
+                                                                    true)),
                                                                     uu___215) in
                                                                     let uu___215
                                                                     =
@@ -2807,12 +2809,12 @@ let rec (specs_with_types :
                                                                     let uu___217
                                                                     =
                                                                     text
-                                                                    "This does nothing and will be removed" in
+                                                                    "Prunes the context to include only the facts from the given namespace or fact id. Facts can be include or excluded using the [+|-] qualifier. For example --using_facts_from '* -FStar.Reflection +FStar.Compiler.List -FStar.Compiler.List.Tot' will remove all facts from FStar.Compiler.List.Tot.*, retain all remaining facts from FStar.Compiler.List.*, remove all facts from FStar.Reflection.*, and retain all the rest. Note, the '+' is optional: --using_facts_from 'FStar.Compiler.List' is equivalent to --using_facts_from '+FStar.Compiler.List'. Multiple uses of this option accumulate, e.g., --using_facts_from A --using_facts_from B is interpreted as --using_facts_from A^B." in
                                                                     (FStar_Getopt.noshort,
-                                                                    "__temp_fast_implicits",
-                                                                    (Const
-                                                                    (Bool
-                                                                    true)),
+                                                                    "using_facts_from",
+                                                                    (ReverseAccumulated
+                                                                    (SimpleStr
+                                                                    "One or more space-separated occurrences of '[+|-]( * | namespace | fact id)'")),
                                                                     uu___217) in
                                                                     let uu___217
                                                                     =
@@ -2821,20 +2823,12 @@ let rec (specs_with_types :
                                                                     let uu___219
                                                                     =
                                                                     text
-                                                                    "Display version number" in
-                                                                    (118,
-                                                                    "version",
-                                                                    (WithSideEffect
-                                                                    ((fun
-                                                                    uu___220
-                                                                    ->
-                                                                    display_version
-                                                                    ();
-                                                                    FStar_Compiler_Effect.exit
-                                                                    Prims.int_zero),
+                                                                    "This does nothing and will be removed" in
+                                                                    (FStar_Getopt.noshort,
+                                                                    "__temp_fast_implicits",
                                                                     (Const
                                                                     (Bool
-                                                                    true)))),
+                                                                    true)),
                                                                     uu___219) in
                                                                     let uu___219
                                                                     =
@@ -2843,12 +2837,20 @@ let rec (specs_with_types :
                                                                     let uu___221
                                                                     =
                                                                     text
-                                                                    "Warn when (a -> b) is desugared to (a -> Tot b)" in
-                                                                    (FStar_Getopt.noshort,
-                                                                    "warn_default_effects",
+                                                                    "Display version number" in
+                                                                    (118,
+                                                                    "version",
+                                                                    (WithSideEffect
+                                                                    ((fun
+                                                                    uu___222
+                                                                    ->
+                                                                    display_version
+                                                                    ();
+                                                                    FStar_Compiler_Effect.exit
+                                                                    Prims.int_zero),
                                                                     (Const
                                                                     (Bool
-                                                                    true)),
+                                                                    true)))),
                                                                     uu___221) in
                                                                     let uu___221
                                                                     =
@@ -2857,12 +2859,12 @@ let rec (specs_with_types :
                                                                     let uu___223
                                                                     =
                                                                     text
-                                                                    "Z3 command line options" in
+                                                                    "Warn when (a -> b) is desugared to (a -> Tot b)" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "z3cliopt",
-                                                                    (ReverseAccumulated
-                                                                    (SimpleStr
-                                                                    "option")),
+                                                                    "warn_default_effects",
+                                                                    (Const
+                                                                    (Bool
+                                                                    true)),
                                                                     uu___223) in
                                                                     let uu___223
                                                                     =
@@ -2871,9 +2873,9 @@ let rec (specs_with_types :
                                                                     let uu___225
                                                                     =
                                                                     text
-                                                                    "Z3 options in smt2 format" in
+                                                                    "Z3 command line options" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "z3smtopt",
+                                                                    "z3cliopt",
                                                                     (ReverseAccumulated
                                                                     (SimpleStr
                                                                     "option")),
@@ -2885,12 +2887,12 @@ let rec (specs_with_types :
                                                                     let uu___227
                                                                     =
                                                                     text
-                                                                    "Restart Z3 after each query; useful for ensuring proof robustness" in
+                                                                    "Z3 options in smt2 format" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "z3refresh",
-                                                                    (Const
-                                                                    (Bool
-                                                                    true)),
+                                                                    "z3smtopt",
+                                                                    (ReverseAccumulated
+                                                                    (SimpleStr
+                                                                    "option")),
                                                                     uu___227) in
                                                                     let uu___227
                                                                     =
@@ -2899,11 +2901,12 @@ let rec (specs_with_types :
                                                                     let uu___229
                                                                     =
                                                                     text
-                                                                    "Set the Z3 per-query resource limit (default 5 units, taking roughtly 5s)" in
+                                                                    "Restart Z3 after each query; useful for ensuring proof robustness" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "z3rlimit",
-                                                                    (IntStr
-                                                                    "positive_integer"),
+                                                                    "z3refresh",
+                                                                    (Const
+                                                                    (Bool
+                                                                    true)),
                                                                     uu___229) in
                                                                     let uu___229
                                                                     =
@@ -2912,9 +2915,9 @@ let rec (specs_with_types :
                                                                     let uu___231
                                                                     =
                                                                     text
-                                                                    "Set the Z3 per-query resource limit multiplier. This is useful when, say, regenerating hints and you want to be more lax. (default 1)" in
+                                                                    "Set the Z3 per-query resource limit (default 5 units, taking roughtly 5s)" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "z3rlimit_factor",
+                                                                    "z3rlimit",
                                                                     (IntStr
                                                                     "positive_integer"),
                                                                     uu___231) in
@@ -2925,9 +2928,9 @@ let rec (specs_with_types :
                                                                     let uu___233
                                                                     =
                                                                     text
-                                                                    "Set the Z3 random seed (default 0)" in
+                                                                    "Set the Z3 per-query resource limit multiplier. This is useful when, say, regenerating hints and you want to be more lax. (default 1)" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "z3seed",
+                                                                    "z3rlimit_factor",
                                                                     (IntStr
                                                                     "positive_integer"),
                                                                     uu___233) in
@@ -2938,11 +2941,11 @@ let rec (specs_with_types :
                                                                     let uu___235
                                                                     =
                                                                     text
-                                                                    "Set the version of Z3 that is to be used. Default: 4.8.5" in
+                                                                    "Set the Z3 random seed (default 0)" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "z3version",
-                                                                    (SimpleStr
-                                                                    "version"),
+                                                                    "z3seed",
+                                                                    (IntStr
+                                                                    "positive_integer"),
                                                                     uu___235) in
                                                                     let uu___235
                                                                     =
@@ -2951,12 +2954,25 @@ let rec (specs_with_types :
                                                                     let uu___237
                                                                     =
                                                                     text
+                                                                    "Set the version of Z3 that is to be used. Default: 4.8.5" in
+                                                                    (FStar_Getopt.noshort,
+                                                                    "z3version",
+                                                                    (SimpleStr
+                                                                    "version"),
+                                                                    uu___237) in
+                                                                    let uu___237
+                                                                    =
+                                                                    let uu___238
+                                                                    =
+                                                                    let uu___239
+                                                                    =
+                                                                    text
                                                                     "Don't check positivity of inductive types" in
                                                                     (FStar_Getopt.noshort,
                                                                     "__no_positivity",
                                                                     (WithSideEffect
                                                                     ((fun
-                                                                    uu___238
+                                                                    uu___240
                                                                     ->
                                                                     if
                                                                     warn_unsafe
@@ -2967,63 +2983,6 @@ let rec (specs_with_types :
                                                                     (Const
                                                                     (Bool
                                                                     true)))),
-                                                                    uu___237) in
-                                                                    let uu___237
-                                                                    =
-                                                                    let uu___238
-                                                                    =
-                                                                    let uu___239
-                                                                    =
-                                                                    let uu___240
-                                                                    =
-                                                                    text
-                                                                    "The [-warn_error] option follows the OCaml syntax, namely:" in
-                                                                    let uu___241
-                                                                    =
-                                                                    let uu___242
-                                                                    =
-                                                                    let uu___243
-                                                                    =
-                                                                    text
-                                                                    "[r] is a range of warnings (either a number [n], or a range [n..n])" in
-                                                                    let uu___244
-                                                                    =
-                                                                    let uu___245
-                                                                    =
-                                                                    text
-                                                                    "[-r] silences range [r]" in
-                                                                    let uu___246
-                                                                    =
-                                                                    let uu___247
-                                                                    =
-                                                                    text
-                                                                    "[+r] enables range [r] as warnings (NOTE: \"enabling\" an error will downgrade it to a warning)" in
-                                                                    let uu___248
-                                                                    =
-                                                                    let uu___249
-                                                                    =
-                                                                    text
-                                                                    "[@r] makes range [r] fatal." in
-                                                                    [uu___249] in
-                                                                    uu___247
-                                                                    ::
-                                                                    uu___248 in
-                                                                    uu___245
-                                                                    ::
-                                                                    uu___246 in
-                                                                    uu___243
-                                                                    ::
-                                                                    uu___244 in
-                                                                    FStar_Errors_Msg.bulleted
-                                                                    uu___242 in
-                                                                    FStar_Pprint.op_Hat_Hat
-                                                                    uu___240
-                                                                    uu___241 in
-                                                                    (FStar_Getopt.noshort,
-                                                                    "warn_error",
-                                                                    (ReverseAccumulated
-                                                                    (SimpleStr
-                                                                    "")),
                                                                     uu___239) in
                                                                     let uu___239
                                                                     =
@@ -3031,11 +2990,56 @@ let rec (specs_with_types :
                                                                     =
                                                                     let uu___241
                                                                     =
+                                                                    let uu___242
+                                                                    =
                                                                     text
-                                                                    "Use normalization by evaluation as the default normalization strategy (default 'false')" in
+                                                                    "The [-warn_error] option follows the OCaml syntax, namely:" in
+                                                                    let uu___243
+                                                                    =
+                                                                    let uu___244
+                                                                    =
+                                                                    let uu___245
+                                                                    =
+                                                                    text
+                                                                    "[r] is a range of warnings (either a number [n], or a range [n..n])" in
+                                                                    let uu___246
+                                                                    =
+                                                                    let uu___247
+                                                                    =
+                                                                    text
+                                                                    "[-r] silences range [r]" in
+                                                                    let uu___248
+                                                                    =
+                                                                    let uu___249
+                                                                    =
+                                                                    text
+                                                                    "[+r] enables range [r] as warnings (NOTE: \"enabling\" an error will downgrade it to a warning)" in
+                                                                    let uu___250
+                                                                    =
+                                                                    let uu___251
+                                                                    =
+                                                                    text
+                                                                    "[@r] makes range [r] fatal." in
+                                                                    [uu___251] in
+                                                                    uu___249
+                                                                    ::
+                                                                    uu___250 in
+                                                                    uu___247
+                                                                    ::
+                                                                    uu___248 in
+                                                                    uu___245
+                                                                    ::
+                                                                    uu___246 in
+                                                                    FStar_Errors_Msg.bulleted
+                                                                    uu___244 in
+                                                                    FStar_Pprint.op_Hat_Hat
+                                                                    uu___242
+                                                                    uu___243 in
                                                                     (FStar_Getopt.noshort,
-                                                                    "use_nbe",
-                                                                    BoolStr,
+                                                                    "warn_error",
+                                                                    (ReverseAccumulated
+                                                                    (SimpleStr
+                                                                    "")),
                                                                     uu___241) in
                                                                     let uu___241
                                                                     =
@@ -3044,9 +3048,9 @@ let rec (specs_with_types :
                                                                     let uu___243
                                                                     =
                                                                     text
-                                                                    "Use normalization by evaluation for normalizing terms before extraction (default 'false')" in
+                                                                    "Use normalization by evaluation as the default normalization strategy (default 'false')" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "use_nbe_for_extraction",
+                                                                    "use_nbe",
                                                                     BoolStr,
                                                                     uu___243) in
                                                                     let uu___243
@@ -3056,9 +3060,9 @@ let rec (specs_with_types :
                                                                     let uu___245
                                                                     =
                                                                     text
-                                                                    "Enforce trivial preconditions for unannotated effectful functions (default 'true')" in
+                                                                    "Use normalization by evaluation for normalizing terms before extraction (default 'false')" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "trivial_pre_for_unannotated_effectful_fns",
+                                                                    "use_nbe_for_extraction",
                                                                     BoolStr,
                                                                     uu___245) in
                                                                     let uu___245
@@ -3068,19 +3072,10 @@ let rec (specs_with_types :
                                                                     let uu___247
                                                                     =
                                                                     text
-                                                                    "Debug messages for embeddings/unembeddings of natively compiled terms" in
+                                                                    "Enforce trivial preconditions for unannotated effectful functions (default 'true')" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "__debug_embedding",
-                                                                    (WithSideEffect
-                                                                    ((fun
-                                                                    uu___248
-                                                                    ->
-                                                                    FStar_Compiler_Effect.op_Colon_Equals
-                                                                    debug_embedding
-                                                                    true),
-                                                                    (Const
-                                                                    (Bool
-                                                                    true)))),
+                                                                    "trivial_pre_for_unannotated_effectful_fns",
+                                                                    BoolStr,
                                                                     uu___247) in
                                                                     let uu___247
                                                                     =
@@ -3089,15 +3084,15 @@ let rec (specs_with_types :
                                                                     let uu___249
                                                                     =
                                                                     text
-                                                                    "Eagerly embed and unembed terms to primitive operations and plugins: not recommended except for benchmarking" in
+                                                                    "Debug messages for embeddings/unembeddings of natively compiled terms" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "eager_embedding",
+                                                                    "__debug_embedding",
                                                                     (WithSideEffect
                                                                     ((fun
                                                                     uu___250
                                                                     ->
                                                                     FStar_Compiler_Effect.op_Colon_Equals
-                                                                    eager_embedding
+                                                                    debug_embedding
                                                                     true),
                                                                     (Const
                                                                     (Bool
@@ -3110,12 +3105,19 @@ let rec (specs_with_types :
                                                                     let uu___251
                                                                     =
                                                                     text
-                                                                    "Emit profiles grouped by declaration rather than by module" in
+                                                                    "Eagerly embed and unembed terms to primitive operations and plugins: not recommended except for benchmarking" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "profile_group_by_decl",
+                                                                    "eager_embedding",
+                                                                    (WithSideEffect
+                                                                    ((fun
+                                                                    uu___252
+                                                                    ->
+                                                                    FStar_Compiler_Effect.op_Colon_Equals
+                                                                    eager_embedding
+                                                                    true),
                                                                     (Const
                                                                     (Bool
-                                                                    true)),
+                                                                    true)))),
                                                                     uu___251) in
                                                                     let uu___251
                                                                     =
@@ -3124,12 +3126,12 @@ let rec (specs_with_types :
                                                                     let uu___253
                                                                     =
                                                                     text
-                                                                    "Specific source locations in the compiler are instrumented with profiling counters. Pass `--profile_component FStar.TypeChecker` to enable all counters in the FStar.TypeChecker namespace. This option is a module or namespace selector, like many other options (e.g., `--extract`)" in
+                                                                    "Emit profiles grouped by declaration rather than by module" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "profile_component",
-                                                                    (Accumulated
-                                                                    (SimpleStr
-                                                                    "One or more space-separated occurrences of '[+|-]( * | namespace | module | identifier)'")),
+                                                                    "profile_group_by_decl",
+                                                                    (Const
+                                                                    (Bool
+                                                                    true)),
                                                                     uu___253) in
                                                                     let uu___253
                                                                     =
@@ -3138,12 +3140,12 @@ let rec (specs_with_types :
                                                                     let uu___255
                                                                     =
                                                                     text
-                                                                    "Profiling can be enabled when the compiler is processing a given set of source modules. Pass `--profile FStar.Pervasives` to enable profiling when the compiler is processing any module in FStar.Pervasives. This option is a module or namespace selector, like many other options (e.g., `--extract`)" in
+                                                                    "Specific source locations in the compiler are instrumented with profiling counters. Pass `--profile_component FStar.TypeChecker` to enable all counters in the FStar.TypeChecker namespace. This option is a module or namespace selector, like many other options (e.g., `--extract`)" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "profile",
+                                                                    "profile_component",
                                                                     (Accumulated
                                                                     (SimpleStr
-                                                                    "One or more space-separated occurrences of '[+|-]( * | namespace | module)'")),
+                                                                    "One or more space-separated occurrences of '[+|-]( * | namespace | module | identifier)'")),
                                                                     uu___255) in
                                                                     let uu___255
                                                                     =
@@ -3152,25 +3154,12 @@ let rec (specs_with_types :
                                                                     let uu___257
                                                                     =
                                                                     text
-                                                                    "Display this information" in
-                                                                    (104,
-                                                                    "help",
-                                                                    (WithSideEffect
-                                                                    ((fun
-                                                                    uu___258
-                                                                    ->
-                                                                    (
-                                                                    let uu___260
-                                                                    =
-                                                                    specs
-                                                                    warn_unsafe in
-                                                                    display_usage_aux
-                                                                    uu___260);
-                                                                    FStar_Compiler_Effect.exit
-                                                                    Prims.int_zero),
-                                                                    (Const
-                                                                    (Bool
-                                                                    true)))),
+                                                                    "Profiling can be enabled when the compiler is processing a given set of source modules. Pass `--profile FStar.Pervasives` to enable profiling when the compiler is processing any module in FStar.Pervasives. This option is a module or namespace selector, like many other options (e.g., `--extract`)" in
+                                                                    (FStar_Getopt.noshort,
+                                                                    "profile",
+                                                                    (Accumulated
+                                                                    (SimpleStr
+                                                                    "One or more space-separated occurrences of '[+|-]( * | namespace | module)'")),
                                                                     uu___257) in
                                                                     let uu___257
                                                                     =
@@ -3179,12 +3168,39 @@ let rec (specs_with_types :
                                                                     let uu___259
                                                                     =
                                                                     text
+                                                                    "Display this information" in
+                                                                    (104,
+                                                                    "help",
+                                                                    (WithSideEffect
+                                                                    ((fun
+                                                                    uu___260
+                                                                    ->
+                                                                    (
+                                                                    let uu___262
+                                                                    =
+                                                                    specs
+                                                                    warn_unsafe in
+                                                                    display_usage_aux
+                                                                    uu___262);
+                                                                    FStar_Compiler_Effect.exit
+                                                                    Prims.int_zero),
+                                                                    (Const
+                                                                    (Bool
+                                                                    true)))),
+                                                                    uu___259) in
+                                                                    let uu___259
+                                                                    =
+                                                                    let uu___260
+                                                                    =
+                                                                    let uu___261
+                                                                    =
+                                                                    text
                                                                     "List all debug keys and exit" in
                                                                     (FStar_Getopt.noshort,
                                                                     "list_debug_keys",
                                                                     (WithSideEffect
                                                                     ((fun
-                                                                    uu___260
+                                                                    uu___262
                                                                     ->
                                                                     display_debug_keys
                                                                     ();
@@ -3193,8 +3209,11 @@ let rec (specs_with_types :
                                                                     (Const
                                                                     (Bool
                                                                     true)))),
-                                                                    uu___259) in
-                                                                    [uu___258] in
+                                                                    uu___261) in
+                                                                    [uu___260] in
+                                                                    uu___258
+                                                                    ::
+                                                                    uu___259 in
                                                                     uu___256
                                                                     ::
                                                                     uu___257 in
@@ -3644,7 +3663,7 @@ let (settable_specs :
     (fun uu___ ->
        match uu___ with | ((uu___1, x, uu___2), uu___3) -> settable x)
     all_specs
-let (uu___659 :
+let (uu___660 :
   (((unit -> FStar_Getopt.parse_cmdline_res) -> unit) *
     (unit -> FStar_Getopt.parse_cmdline_res)))
   =
@@ -3661,11 +3680,11 @@ let (uu___659 :
   (set1, call)
 let (set_error_flags_callback_aux :
   (unit -> FStar_Getopt.parse_cmdline_res) -> unit) =
-  match uu___659 with
+  match uu___660 with
   | (set_error_flags_callback_aux1, set_error_flags) ->
       set_error_flags_callback_aux1
 let (set_error_flags : unit -> FStar_Getopt.parse_cmdline_res) =
-  match uu___659 with
+  match uu___660 with
   | (set_error_flags_callback_aux1, set_error_flags1) -> set_error_flags1
 let (set_error_flags_callback :
   (unit -> FStar_Getopt.parse_cmdline_res) -> unit) =
@@ -4138,6 +4157,8 @@ let (no_location_info : unit -> Prims.bool) =
   fun uu___ -> get_no_location_info ()
 let (no_plugins : unit -> Prims.bool) = fun uu___ -> get_no_plugins ()
 let (no_smt : unit -> Prims.bool) = fun uu___ -> get_no_smt ()
+let (krmloutput : unit -> Prims.string FStar_Pervasives_Native.option) =
+  fun uu___ -> get_krmloutput ()
 let (output_dir : unit -> Prims.string FStar_Pervasives_Native.option) =
   fun uu___ -> get_odir ()
 let (output_deps_to : unit -> Prims.string FStar_Pervasives_Native.option) =

--- a/ocaml/fstar-lib/generated/FStar_Universal.ml
+++ b/ocaml/fstar-lib/generated/FStar_Universal.ml
@@ -1040,14 +1040,19 @@ let (emit :
                    | (ue, mllibs1) ->
                        FStar_Extraction_Krml.translate ue mllibs1) mllibs in
             let bin = (FStar_Extraction_Krml.current_version, programs) in
-            (match programs with
-             | (name, uu___)::[] ->
-                 let uu___1 =
-                   FStar_Options.prepend_output_dir (Prims.strcat name ext) in
-                 FStar_Compiler_Util.save_value_to_file uu___1 bin
-             | uu___ ->
-                 let uu___1 = FStar_Options.prepend_output_dir "out.krml" in
-                 FStar_Compiler_Util.save_value_to_file uu___1 bin)
+            let oname =
+              let uu___ = FStar_Options.krmloutput () in
+              match uu___ with
+              | FStar_Pervasives_Native.Some fname -> fname
+              | uu___1 ->
+                  (match programs with
+                   | (name, uu___2)::[] ->
+                       FStar_Options.prepend_output_dir
+                         (Prims.strcat name ext)
+                   | uu___2 ->
+                       FStar_Options.prepend_output_dir
+                         (Prims.strcat "out" ext)) in
+            FStar_Compiler_Util.save_value_to_file oname bin
         | uu___ -> FStar_Compiler_Effect.failwith "Unrecognized option"
       else ()
 let (tc_one_file :

--- a/src/basic/FStar.Options.fst
+++ b/src/basic/FStar.Options.fst
@@ -217,6 +217,7 @@ let defaults =
       ("no_tactics"                   , Bool false);
       ("normalize_pure_terms_for_extraction"
                                       , Bool false);
+      ("krmloutput"                   , Unset);
       ("odir"                         , Unset);
       ("output_deps_to"               , Unset);
       ("prims"                        , Unset);
@@ -405,6 +406,7 @@ let get_no_plugins              ()      = lookup_opt "no_plugins"               
 let get_no_smt                  ()      = lookup_opt "no_smt"                   as_bool
 let get_normalize_pure_terms_for_extraction
                                 ()      = lookup_opt "normalize_pure_terms_for_extraction" as_bool
+let get_krmloutput              ()      = lookup_opt "krmloutput"               (as_option as_string)
 let get_odir                    ()      = lookup_opt "odir"                     (as_option as_string)
 let get_output_deps_to          ()      = lookup_opt "output_deps_to"           (as_option as_string)
 let get_ugly                    ()      = lookup_opt "ugly"                     as_bool
@@ -1042,6 +1044,12 @@ let rec specs_with_types warn_unsafe : list (char & string & opt_type & Pprint.d
     "normalize_pure_terms_for_extraction",
     Const (Bool true),
     text "Extract top-level pure terms after normalizing them. This can lead to very large code, but can result in more partial evaluation and compile-time specialization.");
+
+  ( noshort,
+    "krmloutput",
+    PathStr "filename",
+    text "Place KaRaMeL extraction output in file <filename>. The path can be relative or absolute and does not depend\
+    on the --odir option.");
 
   ( noshort,
     "odir",
@@ -1912,6 +1920,7 @@ let normalize_pure_terms_for_extraction
 let no_location_info             () = get_no_location_info            ()
 let no_plugins                   () = get_no_plugins                  ()
 let no_smt                       () = get_no_smt                      ()
+let krmloutput                   () = get_krmloutput                  ()
 let output_dir                   () = get_odir                        ()
 let output_deps_to               () = get_output_deps_to              ()
 let ugly                         () = get_ugly                        ()

--- a/src/basic/FStar.Options.fsti
+++ b/src/basic/FStar.Options.fsti
@@ -162,6 +162,7 @@ val no_plugins                  : unit    -> bool
 val no_smt                      : unit    -> bool
 val normalize_pure_terms_for_extraction
                                 : unit    -> bool
+val krmloutput                  : unit    -> option string
 val output_deps_to              : unit    -> option string
 val output_dir                  : unit    -> option string
 val prepend_cache_dir           : string  -> string

--- a/src/fstar/FStar.Universal.fst
+++ b/src/fstar/FStar.Universal.fst
@@ -334,12 +334,16 @@ let emit dep_graph (mllibs:list (uenv & MLSyntax.mllib)) =
                                   Extraction.Krml.translate ue mllibs)
       in
       let bin: Extraction.Krml.binary_format = Extraction.Krml.current_version, programs in
-      begin match programs with
-            | [ name, _ ] ->
-              save_value_to_file (Options.prepend_output_dir (name ^ ext)) bin
-            | _ ->
-             save_value_to_file (Options.prepend_output_dir "out.krml") bin
-      end
+      let oname : string =
+        match Options.krmloutput () with
+        | Some fname -> fname (* NB: no prepending odir nor adding extension, user chose a explicit path *)
+        | _ ->
+          match programs with
+          | [ name, _ ] -> name ^ ext  |> Options.prepend_output_dir
+          | _ -> "out" ^ ext |> Options.prepend_output_dir
+      in
+      save_value_to_file oname bin
+
    | _ -> failwith "Unrecognized option"
 
 let tc_one_file


### PR DESCRIPTION
Currently, when F* is extracting a file into krml, it will choose a filename based on the module name (e.g. `A.B.C.fst` -> `A_B_C.krml`), or, if there are several modules, just use `out.krml`. This heuristic makes some sense, but can be confusing and hard to work with especially when writing makefiles.

This PR adds a `--krmloutput` option to explicitly choose the output filename. The path will not be tweaked at all (no prepending `odir`, no adding `.krml` extension).

Wondering if @msprotz thinks this is sensible.