### PR TITLE
git protocol deprecated, use https instead

### DIFF
--- a/fstar.opam
+++ b/fstar.opam
@@ -29,7 +29,7 @@ build: [
 install: [
   [make "PREFIX=%{prefix}%" "install"]
 ]
-dev-repo: "git://github.com/FStarLang/FStar"
+dev-repo: "git+https://github.com/FStarLang/FStar"
 bug-reports: "https://github.com/FStarLang/FStar/issues"
 synopsis: "Verification system for effectful programs"
 url {


### PR DESCRIPTION
`git://` has been [deprecated by github for 2 years](https://github.com/ocaml/opam/issues/5874). `git+https://` will use the https protocol to fetch code instead, which is also the protocol the official repository use: https://github.com/ocaml/opam-repository/blob/47c192ba656a7b302c16bde355fbbe34e0dbf937/packages/fstar/fstar.2022.01.15/opam#L36C1-L36C51.

Without the fix, one can only `opam pin fstar --dev-repo` once, and pinning any further will always timeout unless you unpin first. I discovered the issue when I was switching between specific opam dev versions.