### PR TITLE
Debug: print stack dump on SIGINT when --trace_error

### DIFF
--- a/ocaml/fstar-lib/FStar_Compiler_Util.ml
+++ b/ocaml/fstar-lib/FStar_Compiler_Util.ml
@@ -38,6 +38,8 @@ let cur_sigint_handler : Sys.signal_behavior ref =
 exception SigInt
 type sigint_handler = Sys.signal_behavior
 
+let sigint_handler_f f = Sys.Signal_handle f
+
 let sigint_ignore: sigint_handler =
   Sys.Signal_ignore
 
@@ -59,6 +61,9 @@ let raise_sigint_maybe_delay _ =
 
 let sigint_raise: sigint_handler =
   Sys.Signal_handle raise_sigint_maybe_delay
+
+let get_sigint_handler () =
+  !cur_sigint_handler
 
 let set_sigint_handler sigint_handler =
   cur_sigint_handler := sigint_handler;

--- a/ocaml/fstar-lib/generated/FStar_Main.ml
+++ b/ocaml/fstar-lib/generated/FStar_Main.ml
@@ -133,154 +133,172 @@ let go : 'uuuuu . 'uuuuu -> unit =
     let uu___1 = process_args () in
     match uu___1 with
     | (res, filenames) ->
-        (match res with
-         | FStar_Getopt.Empty ->
-             (FStar_Options.display_usage ();
-              FStar_Compiler_Effect.exit Prims.int_one)
-         | FStar_Getopt.Help ->
-             (FStar_Options.display_usage ();
-              FStar_Compiler_Effect.exit Prims.int_zero)
-         | FStar_Getopt.Error msg ->
-             (FStar_Compiler_Util.print_error msg;
-              FStar_Compiler_Effect.exit Prims.int_one)
-         | uu___2 when FStar_Options.print_cache_version () ->
-             ((let uu___4 =
-                 FStar_Compiler_Util.string_of_int
-                   FStar_CheckedFiles.cache_version_number in
-               FStar_Compiler_Util.print1 "F* cache version number: %s\n"
-                 uu___4);
-              FStar_Compiler_Effect.exit Prims.int_zero)
-         | FStar_Getopt.Success ->
-             (FStar_Compiler_Effect.op_Colon_Equals fstar_files
-                (FStar_Pervasives_Native.Some filenames);
-              load_native_tactics ();
-              FStar_Syntax_Unionfind.set_ro ();
-              (let uu___5 =
-                 let uu___6 = FStar_Options.dep () in
-                 uu___6 <> FStar_Pervasives_Native.None in
-               if uu___5
-               then
-                 let uu___6 =
-                   FStar_Parser_Dep.collect filenames
-                     FStar_CheckedFiles.load_parsing_data_from_cache in
-                 match uu___6 with
-                 | (uu___7, deps) ->
-                     (FStar_Parser_Dep.print deps; report_errors [])
-               else
-                 (let uu___7 =
-                    (FStar_Options.print ()) ||
-                      (FStar_Options.print_in_place ()) in
-                  if uu___7
-                  then
-                    (if FStar_Platform.is_fstar_compiler_using_ocaml
-                     then
-                       let printing_mode =
-                         let uu___8 = FStar_Options.print () in
-                         if uu___8
-                         then FStar_Prettyprint.FromTempToStdout
-                         else FStar_Prettyprint.FromTempToFile in
-                       FStar_Prettyprint.generate printing_mode filenames
-                     else
-                       FStar_Compiler_Effect.failwith
-                         "You seem to be using the F#-generated version ofthe compiler ; \\o\n                         reindenting is not known to work yet with this version")
-                  else
-                    (let uu___9 =
-                       let uu___10 = FStar_Options.read_checked_file () in
-                       FStar_Pervasives_Native.uu___is_Some uu___10 in
-                     if uu___9
-                     then
-                       let path =
-                         let uu___10 = FStar_Options.read_checked_file () in
-                         FStar_Pervasives_Native.__proj__Some__item__v
-                           uu___10 in
-                       let env =
-                         FStar_Universal.init_env FStar_Parser_Dep.empty_deps in
-                       let res1 = FStar_CheckedFiles.load_tc_result path in
-                       match res1 with
-                       | FStar_Pervasives_Native.None ->
-                           let uu___10 =
-                             let uu___11 =
-                               let uu___12 =
-                                 let uu___13 =
-                                   FStar_Errors_Msg.text
-                                     "Could not read checked file:" in
-                                 let uu___14 =
-                                   FStar_Pprint.doc_of_string path in
-                                 FStar_Pprint.op_Hat_Slash_Hat uu___13
-                                   uu___14 in
-                               [uu___12] in
-                             (FStar_Errors_Codes.Fatal_ModuleOrFileNotFound,
-                               uu___11) in
-                           FStar_Errors.raise_err_doc uu___10
-                       | FStar_Pervasives_Native.Some (uu___10, tcr) ->
-                           let uu___11 =
-                             FStar_Class_Show.show
-                               FStar_Syntax_Print.showable_modul
-                               tcr.FStar_CheckedFiles.checked_module in
-                           FStar_Compiler_Util.print1 "%s\n" uu___11
-                     else
-                       (let uu___11 = FStar_Options.lsp_server () in
-                        if uu___11
-                        then FStar_Interactive_Lsp.start_server ()
-                        else
-                          (let uu___13 = FStar_Options.interactive () in
-                           if uu___13
-                           then
-                             (FStar_Syntax_Unionfind.set_rw ();
-                              (match filenames with
-                               | [] ->
-                                   (FStar_Errors.log_issue
-                                      FStar_Compiler_Range_Type.dummyRange
-                                      (FStar_Errors_Codes.Error_MissingFileName,
-                                        "--ide: Name of current file missing in command line invocation\n");
-                                    FStar_Compiler_Effect.exit Prims.int_one)
-                               | uu___15::uu___16::uu___17 ->
-                                   (FStar_Errors.log_issue
-                                      FStar_Compiler_Range_Type.dummyRange
-                                      (FStar_Errors_Codes.Error_TooManyFiles,
-                                        "--ide: Too many files in command line invocation\n");
-                                    FStar_Compiler_Effect.exit Prims.int_one)
-                               | filename::[] ->
-                                   let uu___15 =
-                                     FStar_Options.legacy_interactive () in
-                                   if uu___15
-                                   then
-                                     FStar_Interactive_Legacy.interactive_mode
-                                       filename
-                                   else
-                                     FStar_Interactive_Ide.interactive_mode
-                                       filename))
-                           else
-                             if
-                               (FStar_Compiler_List.length filenames) >=
-                                 Prims.int_one
-                             then
-                               (let uu___15 =
-                                  FStar_Dependencies.find_deps_if_needed
-                                    filenames
-                                    FStar_CheckedFiles.load_parsing_data_from_cache in
-                                match uu___15 with
-                                | (filenames1, dep_graph) ->
+        ((let uu___3 = FStar_Options.trace_error () in
+          if uu___3
+          then
+            let h = FStar_Compiler_Util.get_sigint_handler () in
+            let h' s =
+              FStar_Compiler_Debug.enable ();
+              FStar_Options.set_option "error_contexts"
+                (FStar_Options.Bool true);
+              (let uu___7 =
+                 let uu___8 = FStar_Errors_Msg.text "GOT SIGINT! Exiting" in
+                 [uu___8] in
+               FStar_Errors.diag_doc FStar_Compiler_Range_Type.dummyRange
+                 uu___7);
+              FStar_Compiler_Effect.exit Prims.int_one in
+            let uu___4 = FStar_Compiler_Util.sigint_handler_f h' in
+            FStar_Compiler_Util.set_sigint_handler uu___4
+          else ());
+         (match res with
+          | FStar_Getopt.Empty ->
+              (FStar_Options.display_usage ();
+               FStar_Compiler_Effect.exit Prims.int_one)
+          | FStar_Getopt.Help ->
+              (FStar_Options.display_usage ();
+               FStar_Compiler_Effect.exit Prims.int_zero)
+          | FStar_Getopt.Error msg ->
+              (FStar_Compiler_Util.print_error msg;
+               FStar_Compiler_Effect.exit Prims.int_one)
+          | uu___3 when FStar_Options.print_cache_version () ->
+              ((let uu___5 =
+                  FStar_Compiler_Util.string_of_int
+                    FStar_CheckedFiles.cache_version_number in
+                FStar_Compiler_Util.print1 "F* cache version number: %s\n"
+                  uu___5);
+               FStar_Compiler_Effect.exit Prims.int_zero)
+          | FStar_Getopt.Success ->
+              (FStar_Compiler_Effect.op_Colon_Equals fstar_files
+                 (FStar_Pervasives_Native.Some filenames);
+               load_native_tactics ();
+               FStar_Syntax_Unionfind.set_ro ();
+               (let uu___6 =
+                  let uu___7 = FStar_Options.dep () in
+                  uu___7 <> FStar_Pervasives_Native.None in
+                if uu___6
+                then
+                  let uu___7 =
+                    FStar_Parser_Dep.collect filenames
+                      FStar_CheckedFiles.load_parsing_data_from_cache in
+                  match uu___7 with
+                  | (uu___8, deps) ->
+                      (FStar_Parser_Dep.print deps; report_errors [])
+                else
+                  (let uu___8 =
+                     (FStar_Options.print ()) ||
+                       (FStar_Options.print_in_place ()) in
+                   if uu___8
+                   then
+                     (if FStar_Platform.is_fstar_compiler_using_ocaml
+                      then
+                        let printing_mode =
+                          let uu___9 = FStar_Options.print () in
+                          if uu___9
+                          then FStar_Prettyprint.FromTempToStdout
+                          else FStar_Prettyprint.FromTempToFile in
+                        FStar_Prettyprint.generate printing_mode filenames
+                      else
+                        FStar_Compiler_Effect.failwith
+                          "You seem to be using the F#-generated version ofthe compiler ; \\o\n                         reindenting is not known to work yet with this version")
+                   else
+                     (let uu___10 =
+                        let uu___11 = FStar_Options.read_checked_file () in
+                        FStar_Pervasives_Native.uu___is_Some uu___11 in
+                      if uu___10
+                      then
+                        let path =
+                          let uu___11 = FStar_Options.read_checked_file () in
+                          FStar_Pervasives_Native.__proj__Some__item__v
+                            uu___11 in
+                        let env =
+                          FStar_Universal.init_env
+                            FStar_Parser_Dep.empty_deps in
+                        let res1 = FStar_CheckedFiles.load_tc_result path in
+                        match res1 with
+                        | FStar_Pervasives_Native.None ->
+                            let uu___11 =
+                              let uu___12 =
+                                let uu___13 =
+                                  let uu___14 =
+                                    FStar_Errors_Msg.text
+                                      "Could not read checked file:" in
+                                  let uu___15 =
+                                    FStar_Pprint.doc_of_string path in
+                                  FStar_Pprint.op_Hat_Slash_Hat uu___14
+                                    uu___15 in
+                                [uu___13] in
+                              (FStar_Errors_Codes.Fatal_ModuleOrFileNotFound,
+                                uu___12) in
+                            FStar_Errors.raise_err_doc uu___11
+                        | FStar_Pervasives_Native.Some (uu___11, tcr) ->
+                            let uu___12 =
+                              FStar_Class_Show.show
+                                FStar_Syntax_Print.showable_modul
+                                tcr.FStar_CheckedFiles.checked_module in
+                            FStar_Compiler_Util.print1 "%s\n" uu___12
+                      else
+                        (let uu___12 = FStar_Options.lsp_server () in
+                         if uu___12
+                         then FStar_Interactive_Lsp.start_server ()
+                         else
+                           (let uu___14 = FStar_Options.interactive () in
+                            if uu___14
+                            then
+                              (FStar_Syntax_Unionfind.set_rw ();
+                               (match filenames with
+                                | [] ->
+                                    (FStar_Errors.log_issue
+                                       FStar_Compiler_Range_Type.dummyRange
+                                       (FStar_Errors_Codes.Error_MissingFileName,
+                                         "--ide: Name of current file missing in command line invocation\n");
+                                     FStar_Compiler_Effect.exit Prims.int_one)
+                                | uu___16::uu___17::uu___18 ->
+                                    (FStar_Errors.log_issue
+                                       FStar_Compiler_Range_Type.dummyRange
+                                       (FStar_Errors_Codes.Error_TooManyFiles,
+                                         "--ide: Too many files in command line invocation\n");
+                                     FStar_Compiler_Effect.exit Prims.int_one)
+                                | filename::[] ->
                                     let uu___16 =
-                                      FStar_Universal.batch_mode_tc
-                                        filenames1 dep_graph in
-                                    (match uu___16 with
-                                     | (tcrs, env, cleanup1) ->
-                                         ((let uu___18 = cleanup1 env in ());
-                                          (let module_names =
-                                             FStar_Compiler_List.map
-                                               (fun tcr ->
-                                                  FStar_Universal.module_or_interface_name
-                                                    tcr.FStar_CheckedFiles.checked_module)
-                                               tcrs in
-                                           report_errors module_names;
-                                           finished_message module_names
-                                             Prims.int_zero))))
-                             else
-                               FStar_Errors.raise_error
-                                 (FStar_Errors_Codes.Error_MissingFileName,
-                                   "No file provided")
-                                 FStar_Compiler_Range_Type.dummyRange)))))))
+                                      FStar_Options.legacy_interactive () in
+                                    if uu___16
+                                    then
+                                      FStar_Interactive_Legacy.interactive_mode
+                                        filename
+                                    else
+                                      FStar_Interactive_Ide.interactive_mode
+                                        filename))
+                            else
+                              if
+                                (FStar_Compiler_List.length filenames) >=
+                                  Prims.int_one
+                              then
+                                (let uu___16 =
+                                   FStar_Dependencies.find_deps_if_needed
+                                     filenames
+                                     FStar_CheckedFiles.load_parsing_data_from_cache in
+                                 match uu___16 with
+                                 | (filenames1, dep_graph) ->
+                                     let uu___17 =
+                                       FStar_Universal.batch_mode_tc
+                                         filenames1 dep_graph in
+                                     (match uu___17 with
+                                      | (tcrs, env, cleanup1) ->
+                                          ((let uu___19 = cleanup1 env in ());
+                                           (let module_names =
+                                              FStar_Compiler_List.map
+                                                (fun tcr ->
+                                                   FStar_Universal.module_or_interface_name
+                                                     tcr.FStar_CheckedFiles.checked_module)
+                                                tcrs in
+                                            report_errors module_names;
+                                            finished_message module_names
+                                              Prims.int_zero))))
+                              else
+                                FStar_Errors.raise_error
+                                  (FStar_Errors_Codes.Error_MissingFileName,
+                                    "No file provided")
+                                  FStar_Compiler_Range_Type.dummyRange))))))))
 let (lazy_chooser :
   FStar_Syntax_Syntax.lazy_kind ->
     FStar_Syntax_Syntax.lazyinfo ->

--- a/src/basic/FStar.Compiler.Util.fsti
+++ b/src/basic/FStar.Compiler.Util.fsti
@@ -187,8 +187,10 @@ val stack_dump : unit -> string
 
 exception SigInt
 type sigint_handler
+val sigint_handler_f : (int -> unit) -> sigint_handler
 val sigint_ignore: sigint_handler
 val sigint_raise: sigint_handler
+val get_sigint_handler: unit -> sigint_handler
 val set_sigint_handler: sigint_handler -> unit
 val with_sigint_handler: sigint_handler -> (unit -> 'a) -> 'a
 

--- a/src/fstar/FStar.Main.fst
+++ b/src/fstar/FStar.Main.fst
@@ -117,6 +117,21 @@ let fstar_files: ref (option (list string)) = Util.mk_ref None
 (****************************************************************************)
 let go _ =
   let res, filenames = process_args () in
+  if Options.trace_error () then begin
+    let h = get_sigint_handler () in
+    let h' s =
+      let open FStar.Pprint in
+      let open FStar.Errors.Msg in
+      Debug.enable (); (* make sure diag is printed *)
+      Options.set_option "error_contexts" (Options.Bool true);
+      (* ^ Print context. Stack trace will be added since we have trace_error. *)
+      Errors.diag_doc Range.dummyRange [
+        text "GOT SIGINT! Exiting";
+      ];
+      exit 1
+    in
+    set_sigint_handler (sigint_handler_f h')
+  end;
   match res with
     | Empty ->
         Options.display_usage(); exit 1


### PR DESCRIPTION

This is very useful to track places where F* starts consuming a bunch of
memory or taking too long. Example:

    [...]
    sub_comp of Prims.Tot (Rust_primitives.unsize_tc (*?u476*) _) --and-- Prims.Tot (Rust_primitives.unsize_tc (*?u476*) _) --with-- SUB
    sub_comp of Prims.Tot (Rust_primitives.unsize_tc (*?u476*) _) --and-- Prims.Tot (Rust_primitives.unsize_tc (*?u476*) _) --with-- SUB --- solved in 0 ms
    ramon: poll                 wall=03m57.000s usage=34.780s user=32.207s sys=02.573s mem=2099MiB roottime=20.400s load=0.97 rootload=0.96
    ramon: poll                 wall=03m58.000s usage=35.780s user=33.207s sys=02.573s mem=2099MiB roottime=21.400s load=1.00 rootload=1.00
    ramon: poll                 wall=03m59.000s usage=36.780s user=34.207s sys=02.573s mem=2123MiB roottime=22.400s load=1.00 rootload=1.00
    ramon: poll                 wall=04m00.000s usage=37.780s user=35.207s sys=02.573s mem=2153MiB roottime=23.400s load=1.00 rootload=1.00
    ramon: poll                 wall=04m01.000s usage=38.780s user=36.192s sys=02.588s mem=2592MiB roottime=24.390s load=1.00 rootload=0.99
    ramon: poll                 wall=04m02.000s usage=39.780s user=37.152s sys=02.628s mem=3031MiB roottime=25.350s load=1.00 rootload=0.96
    ramon: poll                 wall=04m03.000s usage=40.780s user=38.120s sys=02.660s mem=3418MiB roottime=26.320s load=1.00 rootload=0.97
    ramon: poll                 wall=04m04.000s usage=41.780s user=39.112s sys=02.668s mem=3803MiB roottime=27.310s load=1.00 rootload=0.99
    ^C* Info at Libcrux_ml_kem.Ind_cca.fst(196,0-325,75):
      - GOT SIGINT! Exiting
      - Stack trace:
        Raised by primitive operation at FStar_Compiler_Util.stack_dump in file "fstar-lib/FStar_Compiler_Util.ml", line 134, characters 53-82
        Called from FStar_Errors_Msg.backtrace_doc in file "fstar-lib/generated/FStar_Errors_Msg.ml", line 43, characters 12-45
        Called from FStar_Errors.maybe_add_backtrace in file "fstar-lib/generated/FStar_Errors.ml", line 643, characters 32-65
        Called from FStar_Errors.diag_doc in file "fstar-lib/generated/FStar_Errors.ml", line 654, characters 19-42
        Called from FStar_Main.go.h' in file "fstar-lib/generated/FStar_Main.ml", line 147, characters 15-97
        Called from FStar_Syntax_Subst.compose_uvar_subst.aux.(fun) in file "fstar-lib/generated/FStar_Syntax_Subst.ml", line 691, characters 38-53
        Called from BatList.map in file "src/batList.ml", line 246, characters 23-28
        Called from FStar_List.collect in file "fstar-lib/FStar_List.ml" (inlined), line 43, characters 34-51
        [...]
        Called from FStar_TypeChecker_Normalize.norm.fallback in file "fstar-lib/generated/FStar_TypeChecker_Normalize.ml", line 3362, characters 28-208
        Called from FStar_TypeChecker_Normalize.norm.fallback in file "fstar-lib/generated/FStar_TypeChecker_Normalize.ml", line 3362, characters 28-208
        Called from FStar_TypeChecker_Normalize.norm.fallback in file "fstar-lib/generated/FStar_TypeChecker_Normalize.ml", line 3362, characters 28-208
        Called from FStar_TypeChecker_Normalize.norm.fallback in file "fstar-lib/generated/FStar_TypeChecker_Normalize.ml", line 3362, characters 28-208
        Called from FStar_TypeChecker_Normalize.norm in file "fstar-lib/generated/FStar_TypeChecker_Normalize.ml", line 3717, characters 29-49
        Called from FStar_TypeChecker_Normalize.norm_comp.(fun) in file "fstar-lib/generated/FStar_TypeChecker_Normalize.ml", line 5576, characters 43-61
        Called from BatList.mapi in file "src/batList.ml", line 1022, characters 23-30
        Called from FStar_TypeChecker_Normalize.norm_comp in file "fstar-lib/generated/FStar_TypeChecker_Normalize.ml", line 5577, characters 15-56
        Called from FStar_Compiler_Util.record_time in file "fstar-lib/FStar_Compiler_Util.ml", line 26, characters 14-18
        Called from FStar_Errors.with_ctx in file "fstar-lib/generated/FStar_Errors.ml", line 1014, characters 27-31
        Called from FStar_TypeChecker_Normalize.normalize_comp.(fun) in file "fstar-lib/generated/FStar_TypeChecker_Normalize.ml", line 8221, characters 16-221
        Called from FStar_TypeChecker_TcTerm.norm_c in file "fstar-lib/generated/FStar_TypeChecker_TcTerm.ml" (inlined), line 213, characters 13-73
        Called from FStar_TypeChecker_TcTerm.check_expected_effect in file "fstar-lib/generated/FStar_TypeChecker_TcTerm.ml", line 782, characters 30-43
        Called from FStar_TypeChecker_TcTerm.tc_abs in file "fstar-lib/generated/FStar_TypeChecker_TcTerm.ml", line 6658, characters 45-151
        Called from FStar_TypeChecker_TcTerm.check_let_bound_def in file "fstar-lib/generated/FStar_TypeChecker_TcTerm.ml", line 11978, characters 21-1023
        Called from FStar_TypeChecker_TcTerm.check_top_level_let in file "fstar-lib/generated/FStar_TypeChecker_TcTerm.ml", line 10531, characters 22-54
        Called from FStar_TypeChecker_Tc.tc_sig_let.(fun) in file "fstar-lib/generated/FStar_TypeChecker_Tc.ml", line 1254, characters 40-1023
        Called from FStar_TypeChecker_Tc.tc_sig_let.(fun) in file "fstar-lib/generated/FStar_TypeChecker_Tc.ml", line 1251, characters 33-1023
        Called from FStar_TypeChecker_Tc.run_phase1 in file "fstar-lib/generated/FStar_TypeChecker_Tc.ml", line 682, characters 13-17
        Called from FStar_TypeChecker_Tc.tc_sig_let in file "fstar-lib/generated/FStar_TypeChecker_Tc.ml", line 1154, characters 26-1023
        Called from FStar_TypeChecker_Tc.tc_decl in file "fstar-lib/generated/FStar_TypeChecker_Tc.ml", line 4323, characters 16-32
        Called from FStar_Errors.with_ctx in file "fstar-lib/generated/FStar_Errors.ml", line 1014, characters 27-31
        Called from FStar_TypeChecker_Tc.tc_decls.process_one_decl in file "fstar-lib/generated/FStar_TypeChecker_Tc.ml", line 5071, characters 20-102
        Called from FStar_TypeChecker_Tc.tc_decls.process_one_decl_timed in file "fstar-lib/generated/FStar_TypeChecker_Tc.ml", line 5154, characters 15-159
        Called from FStar_Compiler_Util.fold_flatten in file "fstar-lib/FStar_Compiler_Util.ml", line 775, characters 30-37
        Called from FStar_Syntax_Unionfind.with_uf_enabled in file "fstar-lib/generated/FStar_Syntax_Unionfind.ml", line 107, characters 12-16
        Called from FStar_TypeChecker_Tc.tc_decls in file "fstar-lib/generated/FStar_TypeChecker_Tc.ml", line 5172, characters 8-170
        Called from FStar_TypeChecker_Tc.tc_partial_modul.(fun) in file "fstar-lib/generated/FStar_TypeChecker_Tc.ml", line 5371, characters 25-77
        Called from FStar_TypeChecker_Tc.tc_modul in file "fstar-lib/generated/FStar_TypeChecker_Tc.ml", line 5481, characters 20-44
        Called from FStar_TypeChecker_Tc.check_module in file "fstar-lib/generated/FStar_TypeChecker_Tc.ml", line 5672, characters 22-38
        Called from FStar_Universal.tc_one_file.tc_source_file.check_mod.check.(fun) in file "fstar-lib/generated/FStar_Universal.ml", line 1140, characters 29-141
        Called from FStar_Universal.with_tcenv_of_env in file "fstar-lib/generated/FStar_Universal.ml", line 131, characters 65-73
        Called from FStar_Universal.tc_one_file.tc_source_file.check_mod in file "fstar-lib/generated/FStar_Universal.ml", line 1161, characters 21-134
        Called from FStar_Universal.tc_one_file in file "fstar-lib/generated/FStar_Universal.ml", line 1251, characters 32-49
        Called from FStar_Universal.tc_one_file_from_remaining in file "fstar-lib/generated/FStar_Universal.ml", line 1393, characters 16-97
        Called from FStar_Universal.tc_fold_interleave in file "fstar-lib/generated/FStar_Universal.ml", line 1433, characters 19-71
        Called from FStar_Universal.batch_mode_tc in file "fstar-lib/generated/FStar_Universal.ml", line 1478, characters 20-72
        Called from FStar_Main.go in file "fstar-lib/generated/FStar_Main.ml", line 283, characters 39-130
        Called from FStar_Compiler_Util.record_time in file "fstar-lib/FStar_Compiler_Util.ml", line 26, characters 14-18
        Called from FStar_Main.main.(fun) in file "fstar-lib/generated/FStar_Main.ml", line 401, characters 28-62
        Called from Dune__exe__Main.x in file "fstar/main.ml", line 19, characters 6-24
      - > While normalizing a computation type
        > While typechecking the top-level declaration `let decapsulate`

    ramon: end                  Sat Aug 17 15:02:43 2024
    ramon: root.execname        fstar.exe
    ramon: root.utime           28.210s
    ramon: root.stime           2.660s
    ramon: group.total          42.732s
    ramon: group.utime          40.019s
    ramon: group.stime          2.712s
    ramon: group.mempeak        4250MiB
    ramon: group.pidpeak        4
    ramon: status               exited
    ramon: exitcode             1
    ramon: walltime             244.941s
    ramon: loadavg              0.17