### PR TITLE
Normalizer: ditch inline_closure_env, use a lazy substitution

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_Syntax_Compress.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Compress.ml
@@ -117,11 +117,9 @@ let (deep_compress :
       fun tm ->
         FStar_Errors.with_ctx "While deep-compressing a term"
           (fun uu___ ->
-             let uu___1 =
-               let uu___2 = compress1_t allow_uvars allow_names in
-               let uu___3 = compress1_u allow_uvars allow_names in
-               FStar_Syntax_Visit.visit_term_univs uu___2 uu___3 in
-             uu___1 tm)
+             let uu___1 = compress1_t allow_uvars allow_names in
+             let uu___2 = compress1_u allow_uvars allow_names in
+             FStar_Syntax_Visit.visit_term_univs true uu___1 uu___2 tm)
 let (deep_compress_uvars :
   FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
   deep_compress false true
@@ -137,11 +135,9 @@ let (deep_compress_if_no_uvars :
               match () with
               | () ->
                   let uu___2 =
-                    let uu___3 =
-                      let uu___4 = compress1_t false true in
-                      let uu___5 = compress1_u false true in
-                      FStar_Syntax_Visit.visit_term_univs uu___4 uu___5 in
-                    uu___3 tm in
+                    let uu___3 = compress1_t false true in
+                    let uu___4 = compress1_u false true in
+                    FStar_Syntax_Visit.visit_term_univs true uu___3 uu___4 tm in
                   FStar_Pervasives_Native.Some uu___2) ()
          with
          | FStar_Errors.Err
@@ -160,8 +156,6 @@ let (deep_compress_se :
           FStar_Compiler_Util.format1 "While deep-compressing %s" uu___1 in
         FStar_Errors.with_ctx uu___
           (fun uu___1 ->
-             let uu___2 =
-               let uu___3 = compress1_t allow_uvars allow_names in
-               let uu___4 = compress1_u allow_uvars allow_names in
-               FStar_Syntax_Visit.visit_sigelt uu___3 uu___4 in
-             uu___2 se)
+             let uu___2 = compress1_t allow_uvars allow_names in
+             let uu___3 = compress1_u allow_uvars allow_names in
+             FStar_Syntax_Visit.visit_sigelt true uu___2 uu___3 se)

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Visit.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Visit.ml
@@ -28,51 +28,57 @@ let op_Less_Less :
     ('uuuuu -> 'uuuuu1) -> ('uuuuu2 -> 'uuuuu) -> 'uuuuu2 -> 'uuuuu1
   = fun f -> fun g -> fun x -> let uu___ = g x in f uu___
 let (visit_term :
-  (FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) ->
-    FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
-  =
-  fun vt ->
-    fun t ->
-      let uu___ =
-        Obj.magic
-          (FStar_Syntax_VisitM.visitM_term uu___9
-             (fun uu___1 ->
-                (Obj.magic (op_Less_Less (fun uu___1 -> I uu___1) vt)) uu___1)
-             t) in
-      __proj__I__item__run uu___
-let (visit_term_univs :
-  (FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) ->
-    (FStar_Syntax_Syntax.universe -> FStar_Syntax_Syntax.universe) ->
+  Prims.bool ->
+    (FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) ->
       FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
   =
-  fun vt ->
-    fun vu ->
+  fun pq ->
+    fun vt ->
       fun t ->
         let uu___ =
           Obj.magic
-            (FStar_Syntax_VisitM.visitM_term_univs uu___9
+            (FStar_Syntax_VisitM.visitM_term uu___9 pq
                (fun uu___1 ->
                   (Obj.magic (op_Less_Less (fun uu___1 -> I uu___1) vt))
-                    uu___1)
-               (fun uu___1 ->
-                  (Obj.magic (op_Less_Less (fun uu___1 -> I uu___1) vu))
                     uu___1) t) in
         __proj__I__item__run uu___
-let (visit_sigelt :
-  (FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) ->
-    (FStar_Syntax_Syntax.universe -> FStar_Syntax_Syntax.universe) ->
-      FStar_Syntax_Syntax.sigelt -> FStar_Syntax_Syntax.sigelt)
+let (visit_term_univs :
+  Prims.bool ->
+    (FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) ->
+      (FStar_Syntax_Syntax.universe -> FStar_Syntax_Syntax.universe) ->
+        FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
   =
-  fun vt ->
-    fun vu ->
-      fun se ->
-        let uu___ =
-          Obj.magic
-            (FStar_Syntax_VisitM.visitM_sigelt uu___9
-               (fun uu___1 ->
-                  (Obj.magic (op_Less_Less (fun uu___1 -> I uu___1) vt))
-                    uu___1)
-               (fun uu___1 ->
-                  (Obj.magic (op_Less_Less (fun uu___1 -> I uu___1) vu))
-                    uu___1) se) in
-        __proj__I__item__run uu___
+  fun pq ->
+    fun vt ->
+      fun vu ->
+        fun t ->
+          let uu___ =
+            Obj.magic
+              (FStar_Syntax_VisitM.visitM_term_univs uu___9 pq
+                 (fun uu___1 ->
+                    (Obj.magic (op_Less_Less (fun uu___1 -> I uu___1) vt))
+                      uu___1)
+                 (fun uu___1 ->
+                    (Obj.magic (op_Less_Less (fun uu___1 -> I uu___1) vu))
+                      uu___1) t) in
+          __proj__I__item__run uu___
+let (visit_sigelt :
+  Prims.bool ->
+    (FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) ->
+      (FStar_Syntax_Syntax.universe -> FStar_Syntax_Syntax.universe) ->
+        FStar_Syntax_Syntax.sigelt -> FStar_Syntax_Syntax.sigelt)
+  =
+  fun pq ->
+    fun vt ->
+      fun vu ->
+        fun se ->
+          let uu___ =
+            Obj.magic
+              (FStar_Syntax_VisitM.visitM_sigelt uu___9 pq
+                 (fun uu___1 ->
+                    (Obj.magic (op_Less_Less (fun uu___1 -> I uu___1) vt))
+                      uu___1)
+                 (fun uu___1 ->
+                    (Obj.magic (op_Less_Less (fun uu___1 -> I uu___1) vu))
+                      uu___1) se) in
+          __proj__I__item__run uu___

--- a/ocaml/fstar-lib/generated/FStar_Syntax_VisitM.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_VisitM.ml
@@ -9,101 +9,117 @@ type 'm lvm =
   f_br: ('m, FStar_Syntax_Syntax.branch) endo ;
   f_comp: ('m, FStar_Syntax_Syntax.comp) endo ;
   f_residual_comp: ('m, FStar_Syntax_Syntax.residual_comp) endo ;
-  f_univ: ('m, FStar_Syntax_Syntax.universe) endo }
+  f_univ: ('m, FStar_Syntax_Syntax.universe) endo ;
+  proc_quotes: Prims.bool }
 let __proj__Mklvm__item__lvm_monad :
   'm . 'm lvm -> 'm FStar_Class_Monad.monad =
   fun projectee ->
     match projectee with
     | { lvm_monad; f_term; f_binder; f_binding_bv; f_br; f_comp;
-        f_residual_comp; f_univ;_} -> lvm_monad
+        f_residual_comp; f_univ; proc_quotes;_} -> lvm_monad
 let __proj__Mklvm__item__f_term :
   'm . 'm lvm -> ('m, FStar_Syntax_Syntax.term) endo =
   fun projectee ->
     match projectee with
     | { lvm_monad; f_term; f_binder; f_binding_bv; f_br; f_comp;
-        f_residual_comp; f_univ;_} -> f_term
+        f_residual_comp; f_univ; proc_quotes;_} -> f_term
 let __proj__Mklvm__item__f_binder :
   'm . 'm lvm -> ('m, FStar_Syntax_Syntax.binder) endo =
   fun projectee ->
     match projectee with
     | { lvm_monad; f_term; f_binder; f_binding_bv; f_br; f_comp;
-        f_residual_comp; f_univ;_} -> f_binder
+        f_residual_comp; f_univ; proc_quotes;_} -> f_binder
 let __proj__Mklvm__item__f_binding_bv :
   'm . 'm lvm -> ('m, FStar_Syntax_Syntax.bv) endo =
   fun projectee ->
     match projectee with
     | { lvm_monad; f_term; f_binder; f_binding_bv; f_br; f_comp;
-        f_residual_comp; f_univ;_} -> f_binding_bv
+        f_residual_comp; f_univ; proc_quotes;_} -> f_binding_bv
 let __proj__Mklvm__item__f_br :
   'm . 'm lvm -> ('m, FStar_Syntax_Syntax.branch) endo =
   fun projectee ->
     match projectee with
     | { lvm_monad; f_term; f_binder; f_binding_bv; f_br; f_comp;
-        f_residual_comp; f_univ;_} -> f_br
+        f_residual_comp; f_univ; proc_quotes;_} -> f_br
 let __proj__Mklvm__item__f_comp :
   'm . 'm lvm -> ('m, FStar_Syntax_Syntax.comp) endo =
   fun projectee ->
     match projectee with
     | { lvm_monad; f_term; f_binder; f_binding_bv; f_br; f_comp;
-        f_residual_comp; f_univ;_} -> f_comp
+        f_residual_comp; f_univ; proc_quotes;_} -> f_comp
 let __proj__Mklvm__item__f_residual_comp :
   'm . 'm lvm -> ('m, FStar_Syntax_Syntax.residual_comp) endo =
   fun projectee ->
     match projectee with
     | { lvm_monad; f_term; f_binder; f_binding_bv; f_br; f_comp;
-        f_residual_comp; f_univ;_} -> f_residual_comp
+        f_residual_comp; f_univ; proc_quotes;_} -> f_residual_comp
 let __proj__Mklvm__item__f_univ :
   'm . 'm lvm -> ('m, FStar_Syntax_Syntax.universe) endo =
   fun projectee ->
     match projectee with
     | { lvm_monad; f_term; f_binder; f_binding_bv; f_br; f_comp;
-        f_residual_comp; f_univ;_} -> f_univ
+        f_residual_comp; f_univ; proc_quotes;_} -> f_univ
+let __proj__Mklvm__item__proc_quotes : 'm . 'm lvm -> Prims.bool =
+  fun projectee ->
+    match projectee with
+    | { lvm_monad; f_term; f_binder; f_binding_bv; f_br; f_comp;
+        f_residual_comp; f_univ; proc_quotes;_} -> proc_quotes
 let lvm_monad : 'm . 'm lvm -> 'm FStar_Class_Monad.monad =
   fun projectee ->
     match projectee with
     | { lvm_monad = lvm_monad1; f_term; f_binder; f_binding_bv; f_br; 
-        f_comp; f_residual_comp; f_univ;_} -> lvm_monad1
+        f_comp; f_residual_comp; f_univ; proc_quotes;_} -> lvm_monad1
 let f_term : 'm . 'm lvm -> ('m, FStar_Syntax_Syntax.term) endo =
   fun projectee ->
     match projectee with
     | { lvm_monad = lvm_monad1; f_term = f_term1; f_binder; f_binding_bv;
-        f_br; f_comp; f_residual_comp; f_univ;_} -> f_term1
+        f_br; f_comp; f_residual_comp; f_univ; proc_quotes;_} -> f_term1
 let f_binder : 'm . 'm lvm -> ('m, FStar_Syntax_Syntax.binder) endo =
   fun projectee ->
     match projectee with
     | { lvm_monad = lvm_monad1; f_term = f_term1; f_binder = f_binder1;
-        f_binding_bv; f_br; f_comp; f_residual_comp; f_univ;_} -> f_binder1
+        f_binding_bv; f_br; f_comp; f_residual_comp; f_univ; proc_quotes;_}
+        -> f_binder1
 let f_binding_bv : 'm . 'm lvm -> ('m, FStar_Syntax_Syntax.bv) endo =
   fun projectee ->
     match projectee with
     | { lvm_monad = lvm_monad1; f_term = f_term1; f_binder = f_binder1;
-        f_binding_bv = f_binding_bv1; f_br; f_comp; f_residual_comp;
-        f_univ;_} -> f_binding_bv1
+        f_binding_bv = f_binding_bv1; f_br; f_comp; f_residual_comp; 
+        f_univ; proc_quotes;_} -> f_binding_bv1
 let f_br : 'm . 'm lvm -> ('m, FStar_Syntax_Syntax.branch) endo =
   fun projectee ->
     match projectee with
     | { lvm_monad = lvm_monad1; f_term = f_term1; f_binder = f_binder1;
         f_binding_bv = f_binding_bv1; f_br = f_br1; f_comp; f_residual_comp;
-        f_univ;_} -> f_br1
+        f_univ; proc_quotes;_} -> f_br1
 let f_comp : 'm . 'm lvm -> ('m, FStar_Syntax_Syntax.comp) endo =
   fun projectee ->
     match projectee with
     | { lvm_monad = lvm_monad1; f_term = f_term1; f_binder = f_binder1;
         f_binding_bv = f_binding_bv1; f_br = f_br1; f_comp = f_comp1;
-        f_residual_comp; f_univ;_} -> f_comp1
+        f_residual_comp; f_univ; proc_quotes;_} -> f_comp1
 let f_residual_comp :
   'm . 'm lvm -> ('m, FStar_Syntax_Syntax.residual_comp) endo =
   fun projectee ->
     match projectee with
     | { lvm_monad = lvm_monad1; f_term = f_term1; f_binder = f_binder1;
         f_binding_bv = f_binding_bv1; f_br = f_br1; f_comp = f_comp1;
-        f_residual_comp = f_residual_comp1; f_univ;_} -> f_residual_comp1
+        f_residual_comp = f_residual_comp1; f_univ; proc_quotes;_} ->
+        f_residual_comp1
 let f_univ : 'm . 'm lvm -> ('m, FStar_Syntax_Syntax.universe) endo =
   fun projectee ->
     match projectee with
     | { lvm_monad = lvm_monad1; f_term = f_term1; f_binder = f_binder1;
         f_binding_bv = f_binding_bv1; f_br = f_br1; f_comp = f_comp1;
-        f_residual_comp = f_residual_comp1; f_univ = f_univ1;_} -> f_univ1
+        f_residual_comp = f_residual_comp1; f_univ = f_univ1; proc_quotes;_}
+        -> f_univ1
+let proc_quotes : 'm . 'm lvm -> Prims.bool =
+  fun projectee ->
+    match projectee with
+    | { lvm_monad = lvm_monad1; f_term = f_term1; f_binder = f_binder1;
+        f_binding_bv = f_binding_bv1; f_br = f_br1; f_comp = f_comp1;
+        f_residual_comp = f_residual_comp1; f_univ = f_univ1;
+        proc_quotes = proc_quotes1;_} -> proc_quotes1
 let _lvm_monad : 'm . 'm lvm -> 'm FStar_Class_Monad.monad =
   fun uu___ -> lvm_monad uu___
 let novfs : 'm . 'm FStar_Class_Monad.monad -> 'm lvm =
@@ -116,7 +132,8 @@ let novfs : 'm . 'm FStar_Class_Monad.monad -> 'm lvm =
       f_br = (Obj.magic (FStar_Class_Monad.return uu___ ()));
       f_comp = (Obj.magic (FStar_Class_Monad.return uu___ ()));
       f_residual_comp = (Obj.magic (FStar_Class_Monad.return uu___ ()));
-      f_univ = (Obj.magic (FStar_Class_Monad.return uu___ ()))
+      f_univ = (Obj.magic (FStar_Class_Monad.return uu___ ()));
+      proc_quotes = false
     }
 let f_aqual : 'm . 'm lvm -> FStar_Syntax_Syntax.arg_qualifier -> 'm =
   fun uu___ ->
@@ -695,7 +712,22 @@ let on_sub_term : 'm . 'm lvm -> FStar_Syntax_Syntax.term -> 'm =
                                (FStar_Class_Monad.return (_lvm_monad d) ()
                                   (Obj.magic uu___2))) uu___2))) uu___1)
       | FStar_Syntax_Syntax.Tm_quoted (qtm, qi) ->
-          FStar_Class_Monad.return (_lvm_monad d) () (Obj.magic tm1)
+          if
+            d.proc_quotes ||
+              (qi.FStar_Syntax_Syntax.qkind =
+                 FStar_Syntax_Syntax.Quote_dynamic)
+          then
+            let uu___ = f_term d qtm in
+            FStar_Class_Monad.op_let_Bang (_lvm_monad d) () () uu___
+              (fun uu___1 ->
+                 (fun qtm1 ->
+                    let qtm1 = Obj.magic qtm1 in
+                    let uu___1 =
+                      mk (FStar_Syntax_Syntax.Tm_quoted (qtm1, qi)) in
+                    Obj.magic
+                      (FStar_Class_Monad.return (_lvm_monad d) ()
+                         (Obj.magic uu___1))) uu___1)
+          else FStar_Class_Monad.return (_lvm_monad d) () (Obj.magic tm1)
       | FStar_Syntax_Syntax.Tm_meta
           { FStar_Syntax_Syntax.tm2 = t; FStar_Syntax_Syntax.meta = md;_} ->
           let uu___ = f_term d t in
@@ -2185,70 +2217,79 @@ let tie_bu : 'm . 'm FStar_Class_Monad.monad -> 'm lvm -> 'm lvm =
                   let uu___4 = FStar_Compiler_Effect.op_Bang r in
                   on_sub_univ uu___4 x in
                 op_Less_Less_Bar md () ()
-                  (fun uu___4 -> (Obj.magic (f_univ d)) uu___4) uu___3)
+                  (fun uu___4 -> (Obj.magic (f_univ d)) uu___4) uu___3);
+           proc_quotes = (d.proc_quotes)
          } in
        FStar_Compiler_Effect.op_Colon_Equals r uu___1);
       FStar_Compiler_Effect.op_Bang r
 let visitM_term_univs :
   'm .
     'm FStar_Class_Monad.monad ->
-      (FStar_Syntax_Syntax.term -> 'm) ->
-        (FStar_Syntax_Syntax.universe -> 'm) ->
-          FStar_Syntax_Syntax.term -> 'm
+      Prims.bool ->
+        (FStar_Syntax_Syntax.term -> 'm) ->
+          (FStar_Syntax_Syntax.universe -> 'm) ->
+            FStar_Syntax_Syntax.term -> 'm
   =
   fun md ->
-    fun vt ->
-      fun vu ->
-        fun tm ->
-          let dict =
-            let uu___ =
-              let uu___1 = novfs md in
-              {
-                lvm_monad = (uu___1.lvm_monad);
-                f_term = vt;
-                f_binder = (uu___1.f_binder);
-                f_binding_bv = (uu___1.f_binding_bv);
-                f_br = (uu___1.f_br);
-                f_comp = (uu___1.f_comp);
-                f_residual_comp = (uu___1.f_residual_comp);
-                f_univ = vu
-              } in
-            tie_bu md uu___ in
-          f_term dict tm
+    fun proc_quotes1 ->
+      fun vt ->
+        fun vu ->
+          fun tm ->
+            let dict =
+              let uu___ =
+                let uu___1 = novfs md in
+                {
+                  lvm_monad = (uu___1.lvm_monad);
+                  f_term = vt;
+                  f_binder = (uu___1.f_binder);
+                  f_binding_bv = (uu___1.f_binding_bv);
+                  f_br = (uu___1.f_br);
+                  f_comp = (uu___1.f_comp);
+                  f_residual_comp = (uu___1.f_residual_comp);
+                  f_univ = vu;
+                  proc_quotes = proc_quotes1
+                } in
+              tie_bu md uu___ in
+            f_term dict tm
 let visitM_term :
   'm .
     'm FStar_Class_Monad.monad ->
-      (FStar_Syntax_Syntax.term -> 'm) -> FStar_Syntax_Syntax.term -> 'm
+      Prims.bool ->
+        (FStar_Syntax_Syntax.term -> 'm) -> FStar_Syntax_Syntax.term -> 'm
   =
   fun md ->
-    fun vt ->
-      fun tm ->
-        visitM_term_univs md vt
-          (fun uu___ -> (Obj.magic (FStar_Class_Monad.return md ())) uu___)
-          tm
+    fun proc_quotes1 ->
+      fun vt ->
+        fun tm ->
+          visitM_term_univs md true vt
+            (fun uu___ -> (Obj.magic (FStar_Class_Monad.return md ())) uu___)
+            tm
 let visitM_sigelt :
   'm .
     'm FStar_Class_Monad.monad ->
-      (FStar_Syntax_Syntax.term -> 'm) ->
-        (FStar_Syntax_Syntax.universe -> 'm) ->
-          FStar_Syntax_Syntax.sigelt -> 'm
+      Prims.bool ->
+        (FStar_Syntax_Syntax.term -> 'm) ->
+          (FStar_Syntax_Syntax.universe -> 'm) ->
+            FStar_Syntax_Syntax.sigelt -> 'm
   =
   fun md ->
-    fun vt ->
-      fun vu ->
-        fun tm ->
-          let dict =
-            let uu___ =
-              let uu___1 = novfs md in
-              {
-                lvm_monad = (uu___1.lvm_monad);
-                f_term = vt;
-                f_binder = (uu___1.f_binder);
-                f_binding_bv = (uu___1.f_binding_bv);
-                f_br = (uu___1.f_br);
-                f_comp = (uu___1.f_comp);
-                f_residual_comp = (uu___1.f_residual_comp);
-                f_univ = vu
-              } in
-            tie_bu md uu___ in
-          on_sub_sigelt dict tm
+    fun proc_quotes1 ->
+      fun vt ->
+        fun vu ->
+          fun tm ->
+            let dict =
+              let uu___ =
+                let uu___1 = novfs md in
+                {
+                  lvm_monad = (uu___1.lvm_monad);
+                  f_term = vt;
+                  f_binder = (uu___1.f_binder);
+                  f_binding_bv = (uu___1.f_binding_bv);
+                  f_br = (uu___1.f_br);
+                  f_comp = (uu___1.f_comp);
+                  f_residual_comp = (uu___1.f_residual_comp);
+                  f_univ = vu;
+                  proc_quotes = proc_quotes1
+                } in
+              tie_bu md uu___ in
+            on_sub_sigelt dict tm

--- a/ocaml/fstar-lib/generated/FStar_Syntax_VisitM.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_VisitM.ml
@@ -694,16 +694,8 @@ let on_sub_term : 'm . 'm lvm -> FStar_Syntax_Syntax.term -> 'm =
                              Obj.magic
                                (FStar_Class_Monad.return (_lvm_monad d) ()
                                   (Obj.magic uu___2))) uu___2))) uu___1)
-      | FStar_Syntax_Syntax.Tm_quoted (tm2, qi) ->
-          let uu___ = f_term d tm2 in
-          FStar_Class_Monad.op_let_Bang (_lvm_monad d) () () uu___
-            (fun uu___1 ->
-               (fun tm3 ->
-                  let tm3 = Obj.magic tm3 in
-                  let uu___1 = mk (FStar_Syntax_Syntax.Tm_quoted (tm3, qi)) in
-                  Obj.magic
-                    (FStar_Class_Monad.return (_lvm_monad d) ()
-                       (Obj.magic uu___1))) uu___1)
+      | FStar_Syntax_Syntax.Tm_quoted (qtm, qi) ->
+          FStar_Class_Monad.return (_lvm_monad d) () (Obj.magic tm1)
       | FStar_Syntax_Syntax.Tm_meta
           { FStar_Syntax_Syntax.tm2 = t; FStar_Syntax_Syntax.meta = md;_} ->
           let uu___ = f_term d t in

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Interpreter.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Interpreter.ml
@@ -195,6 +195,7 @@ let unembed_tactic_0 :
                                         Obj.magic
                                           (FStar_Syntax_VisitM.visitM_term
                                              FStar_Class_Monad.monad_option
+                                             false
                                              (fun uu___ ->
                                                 (fun t ->
                                                    match t.FStar_Syntax_Syntax.n

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Typeclasses.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Typeclasses.ml
@@ -487,10 +487,9 @@ let (extract_fundeps :
                                 (Obj.magic
                                    (FStar_Range.mk_range
                                       "FStar.Tactics.Typeclasses.fst"
-                                      (Prims.of_int (160))
-                                      (Prims.of_int (12))
-                                      (Prims.of_int (160))
-                                      (Prims.of_int (28)))))
+                                      (Prims.of_int (160)) (Prims.of_int (6))
+                                      (Prims.of_int (167))
+                                      (Prims.of_int (18)))))
                              (Obj.magic
                                 (FStar_Tactics_V2_SyntaxHelpers.collect_app
                                    attr))

--- a/ocaml/fstar-lib/generated/FStar_ToSyntax_ToSyntax.ml
+++ b/ocaml/fstar-lib/generated/FStar_ToSyntax_ToSyntax.ml
@@ -1041,14 +1041,12 @@ let rec (generalize_annotated_univs :
       let uu___1 = FStar_Compiler_Effect.op_Bang vars in
       FStar_Compiler_List.rev uu___1 in
     let uu___ =
-      let uu___1 =
-        FStar_Syntax_Visit.visit_sigelt (fun t -> t)
-          (fun u ->
-             (match u with
-              | FStar_Syntax_Syntax.U_name nm -> reg nm
-              | uu___4 -> ());
-             u) in
-      uu___1 s in
+      FStar_Syntax_Visit.visit_sigelt false (fun t -> t)
+        (fun u ->
+           (match u with
+            | FStar_Syntax_Syntax.U_name nm -> reg nm
+            | uu___3 -> ());
+           u) s in
     let unames = get () in
     match s.FStar_Syntax_Syntax.sigel with
     | FStar_Syntax_Syntax.Sig_inductive_typ uu___1 ->

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Core.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Core.ml
@@ -368,7 +368,8 @@ let (relation_to_string : relation -> Prims.string) =
     | EQUALITY -> "=?="
     | SUBTYPING (FStar_Pervasives_Native.None) -> "<:?"
     | SUBTYPING (FStar_Pervasives_Native.Some tm) ->
-        let uu___1 = FStar_Syntax_Print.term_to_string tm in
+        let uu___1 =
+          FStar_Class_Show.show FStar_Syntax_Print.showable_term tm in
         FStar_Compiler_Util.format1 "( <:? %s)" uu___1
 type context_term =
   | CtxTerm of FStar_Syntax_Syntax.term 
@@ -389,11 +390,13 @@ let (__proj__CtxRel__item___2 : context_term -> FStar_Syntax_Syntax.term) =
 let (context_term_to_string : context_term -> Prims.string) =
   fun c ->
     match c with
-    | CtxTerm term -> FStar_Syntax_Print.term_to_string term
+    | CtxTerm term ->
+        FStar_Class_Show.show FStar_Syntax_Print.showable_term term
     | CtxRel (t0, r, t1) ->
-        let uu___ = FStar_Syntax_Print.term_to_string t0 in
+        let uu___ = FStar_Class_Show.show FStar_Syntax_Print.showable_term t0 in
         let uu___1 = relation_to_string r in
-        let uu___2 = FStar_Syntax_Print.term_to_string t1 in
+        let uu___2 =
+          FStar_Class_Show.show FStar_Syntax_Print.showable_term t1 in
         FStar_Compiler_Util.format3 "%s %s %s" uu___ uu___1 uu___2
 type context =
   {
@@ -712,7 +715,8 @@ let (is_type :
             (fun uu___1 -> Success (u, FStar_Pervasives_Native.None))
         | uu___1 ->
             let uu___2 =
-              let uu___3 = FStar_Syntax_Print.term_to_string t1 in
+              let uu___3 =
+                FStar_Class_Show.show FStar_Syntax_Print.showable_term t1 in
               FStar_Compiler_Util.format1 "Expected a type; got %s" uu___3 in
             fail uu___2 in
       fun ctx ->
@@ -879,7 +883,8 @@ let rec (is_arrow :
         | uu___1 ->
             let uu___2 =
               let uu___3 = FStar_Syntax_Print.tag_of_term t1 in
-              let uu___4 = FStar_Syntax_Print.term_to_string t1 in
+              let uu___4 =
+                FStar_Class_Show.show FStar_Syntax_Print.showable_term t1 in
               FStar_Compiler_Util.format2 "Expected an arrow, got (%s) %s"
                 uu___3 uu___4 in
             fail uu___2 in
@@ -1182,7 +1187,8 @@ let no_guard : 'a . 'a result -> 'a result =
       | Success (x, FStar_Pervasives_Native.Some g1) ->
           let uu___1 =
             let uu___2 =
-              let uu___3 = FStar_Syntax_Print.term_to_string g1 in
+              let uu___3 =
+                FStar_Class_Show.show FStar_Syntax_Print.showable_term g1 in
               FStar_Compiler_Util.format1 "Unexpected guard: %s" uu___3 in
             fail uu___2 in
           uu___1 ctx
@@ -1335,7 +1341,31 @@ let (lookup :
             context_included he.he_gamma
               (g.tcenv).FStar_TypeChecker_Env.gamma in
           if uu___1
-          then (record_cache_hit (); (fun uu___3 -> Success (he.he_res)))
+          then
+            (record_cache_hit ();
+             (let uu___4 = FStar_Compiler_Effect.op_Bang dbg in
+              if uu___4
+              then
+                let uu___5 =
+                  FStar_Class_Show.show
+                    (FStar_Class_Show.show_list
+                       FStar_Syntax_Print.showable_binding)
+                    (g.tcenv).FStar_TypeChecker_Env.gamma in
+                let uu___6 =
+                  FStar_Class_Show.show FStar_Syntax_Print.showable_term e in
+                let uu___7 =
+                  FStar_Class_Show.show FStar_Syntax_Print.showable_term
+                    (FStar_Pervasives_Native.snd
+                       (FStar_Pervasives_Native.fst he.he_res)) in
+                let uu___8 =
+                  FStar_Class_Show.show
+                    (FStar_Class_Show.show_list
+                       FStar_Syntax_Print.showable_binding) he.he_gamma in
+                FStar_Compiler_Util.print4
+                  "cache hit\n %s |- %s : %s\nmatching env %s\n" uu___5
+                  uu___6 uu___7 uu___8
+              else ());
+             (fun uu___4 -> Success (he.he_res)))
           else fail "not in cache"
 let (check_no_escape :
   FStar_Syntax_Syntax.binders -> FStar_Syntax_Syntax.term -> unit result) =
@@ -1694,15 +1724,19 @@ let rec (check_relation :
             match rel with
             | EQUALITY ->
                 let uu___1 =
-                  let uu___2 = FStar_Syntax_Print.term_to_string t0 in
-                  let uu___3 = FStar_Syntax_Print.term_to_string t1 in
+                  let uu___2 =
+                    FStar_Class_Show.show FStar_Syntax_Print.showable_term t0 in
+                  let uu___3 =
+                    FStar_Class_Show.show FStar_Syntax_Print.showable_term t1 in
                   FStar_Compiler_Util.format2 "not equal terms: %s <> %s"
                     uu___2 uu___3 in
                 fail uu___1
             | uu___1 ->
                 let uu___2 =
-                  let uu___3 = FStar_Syntax_Print.term_to_string t0 in
-                  let uu___4 = FStar_Syntax_Print.term_to_string t1 in
+                  let uu___3 =
+                    FStar_Class_Show.show FStar_Syntax_Print.showable_term t0 in
+                  let uu___4 =
+                    FStar_Class_Show.show FStar_Syntax_Print.showable_term t1 in
                   FStar_Compiler_Util.format2 "%s is not a subtype of %s"
                     uu___3 uu___4 in
                 fail uu___2 in
@@ -3988,7 +4022,8 @@ and (do_check :
           (match uu___ with
            | FStar_Pervasives_Native.None ->
                let uu___1 =
-                 let uu___2 = FStar_Syntax_Print.bv_to_string x in
+                 let uu___2 =
+                   FStar_Class_Show.show FStar_Syntax_Print.showable_bv x in
                  FStar_Compiler_Util.format1 "Variable not found: %s" uu___2 in
                fail uu___1
            | FStar_Pervasives_Native.Some (t, uu___1) ->
@@ -4971,7 +5006,8 @@ and (do_check :
                | Error err -> Error err)
           else
             (let uu___5 =
-               let uu___6 = FStar_Syntax_Print.comp_to_string c in
+               let uu___6 =
+                 FStar_Class_Show.show FStar_Syntax_Print.showable_comp c in
                FStar_Compiler_Util.format1
                  "Effect ascriptions are not fully handled yet: %s" uu___6 in
              fail uu___5)
@@ -7268,8 +7304,10 @@ and (check_scrutinee_pattern_type_compatible :
       fun t_pat ->
         let err s =
           let uu___ =
-            let uu___1 = FStar_Syntax_Print.term_to_string t_sc in
-            let uu___2 = FStar_Syntax_Print.term_to_string t_pat in
+            let uu___1 =
+              FStar_Class_Show.show FStar_Syntax_Print.showable_term t_sc in
+            let uu___2 =
+              FStar_Class_Show.show FStar_Syntax_Print.showable_term t_pat in
             FStar_Compiler_Util.format3
               "Scrutinee type %s and Pattern type %s are not compatible because %s"
               uu___1 uu___2 s in
@@ -7350,7 +7388,8 @@ and (check_scrutinee_pattern_type_compatible :
                               else
                                 (let uu___9 =
                                    let uu___10 =
-                                     FStar_Syntax_Print.fv_to_string x in
+                                     FStar_Class_Show.show
+                                       FStar_Syntax_Print.showable_fv x in
                                    FStar_Compiler_Util.format1
                                      "%s is not a type constructor" uu___10 in
                                  err uu___9) in
@@ -7867,7 +7906,9 @@ let (check_term_top_gh :
              then
                let uu___2 =
                  let uu___3 = get_goal_ctr () in
-                 FStar_Compiler_Util.string_of_int uu___3 in
+                 FStar_Class_Show.show
+                   (FStar_Class_Show.printableshow
+                      FStar_Class_Printable.printable_int) uu___3 in
                FStar_Compiler_Util.print1 "(%s) Entering core ... \n" uu___2
              else ());
             (let uu___2 =
@@ -7877,13 +7918,15 @@ let (check_term_top_gh :
              then
                let uu___3 =
                  let uu___4 = get_goal_ctr () in
-                 FStar_Compiler_Util.string_of_int uu___4 in
-               let uu___4 = FStar_Syntax_Print.term_to_string e in
+                 FStar_Class_Show.show
+                   (FStar_Class_Show.printableshow
+                      FStar_Class_Printable.printable_int) uu___4 in
+               let uu___4 =
+                 FStar_Class_Show.show FStar_Syntax_Print.showable_term e in
                let uu___5 =
-                 match topt with
-                 | FStar_Pervasives_Native.None -> ""
-                 | FStar_Pervasives_Native.Some t ->
-                     FStar_Syntax_Print.term_to_string t in
+                 FStar_Class_Show.show
+                   (FStar_Class_Show.show_option
+                      FStar_Syntax_Print.showable_term) topt in
                FStar_Compiler_Util.print3
                  "(%s) Entering core with %s <: %s\n" uu___3 uu___4 uu___5
              else ());
@@ -7921,9 +7964,11 @@ let (check_term_top_gh :
                            let uu___8 = get_goal_ctr () in
                            FStar_Compiler_Util.string_of_int uu___8 in
                          let uu___8 =
-                           FStar_Syntax_Print.term_to_string guard0 in
+                           FStar_Class_Show.show
+                             FStar_Syntax_Print.showable_term guard0 in
                          let uu___9 =
-                           FStar_Syntax_Print.term_to_string guard1 in
+                           FStar_Class_Show.show
+                             FStar_Syntax_Print.showable_term guard1 in
                          FStar_Compiler_Util.print3
                            "(%s) Exiting core: Simplified guard from {{%s}} to {{%s}}\n"
                            uu___7 uu___8 uu___9);
@@ -7952,7 +7997,8 @@ let (check_term_top_gh :
                          | FStar_Pervasives_Native.Some bv ->
                              let uu___8 =
                                let uu___9 = FStar_Syntax_Syntax.bv_to_name bv in
-                               FStar_Syntax_Print.term_to_string uu___9 in
+                               FStar_Class_Show.show
+                                 FStar_Syntax_Print.showable_term uu___9 in
                              FStar_Compiler_Util.print1
                                "WARNING: %s is free in the core generated guard\n"
                                uu___8

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Normalize.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Normalize.ml
@@ -524,20 +524,16 @@ let (filter_out_lcomp_cflags :
 let (default_univ_uvars_to_zero :
   FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
   fun t ->
-    let uu___ =
-      FStar_Syntax_Visit.visit_term_univs (fun t1 -> t1)
-        (fun u ->
-           match u with
-           | FStar_Syntax_Syntax.U_unif uu___1 -> FStar_Syntax_Syntax.U_zero
-           | uu___1 -> u) in
-    uu___ t
+    FStar_Syntax_Visit.visit_term_univs false (fun t1 -> t1)
+      (fun u ->
+         match u with
+         | FStar_Syntax_Syntax.U_unif uu___ -> FStar_Syntax_Syntax.U_zero
+         | uu___ -> u) t
 let (_erase_universes : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
   =
   fun t ->
-    let uu___ =
-      FStar_Syntax_Visit.visit_term_univs (fun t1 -> t1)
-        (fun u -> FStar_Syntax_Syntax.U_unknown) in
-    uu___ t
+    FStar_Syntax_Visit.visit_term_univs false (fun t1 -> t1)
+      (fun u -> FStar_Syntax_Syntax.U_unknown) t
 let (closure_as_term :
   FStar_TypeChecker_Cfg.cfg ->
     env -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
@@ -1669,7 +1665,7 @@ let (is_quantified_const :
                let replace_full_applications_with bv1 arity s t =
                  let chgd = FStar_Compiler_Util.mk_ref false in
                  let t' =
-                   FStar_Syntax_Visit.visit_term
+                   FStar_Syntax_Visit.visit_term false
                      (fun t1 ->
                         let uu___ = FStar_Syntax_Util.head_and_args t1 in
                         match uu___ with

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Normalize.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Normalize.ml
@@ -49,23 +49,27 @@ let cases :
         | FStar_Pervasives_Native.Some x -> f x
         | FStar_Pervasives_Native.None -> d
 type 'a cfg_memo = (FStar_TypeChecker_Cfg.cfg * 'a) FStar_Syntax_Syntax.memo
-let fresh_memo : 'a . unit -> 'a cfg_memo =
+let fresh_memo : 'a . unit -> 'a FStar_Syntax_Syntax.memo =
   fun uu___ -> FStar_Compiler_Util.mk_ref FStar_Pervasives_Native.None
 type closure =
   | Clos of ((FStar_Syntax_Syntax.binder FStar_Pervasives_Native.option *
-  closure) Prims.list * FStar_Syntax_Syntax.term *
-  ((FStar_Syntax_Syntax.binder FStar_Pervasives_Native.option * closure)
-  Prims.list * FStar_Syntax_Syntax.term) cfg_memo * Prims.bool) 
+  closure * FStar_Syntax_Syntax.subst_t FStar_Syntax_Syntax.memo) Prims.list
+  * FStar_Syntax_Syntax.term * ((FStar_Syntax_Syntax.binder
+  FStar_Pervasives_Native.option * closure * FStar_Syntax_Syntax.subst_t
+  FStar_Syntax_Syntax.memo) Prims.list * FStar_Syntax_Syntax.term) cfg_memo *
+  Prims.bool) 
   | Univ of FStar_Syntax_Syntax.universe 
   | Dummy 
 let (uu___is_Clos : closure -> Prims.bool) =
   fun projectee -> match projectee with | Clos _0 -> true | uu___ -> false
 let (__proj__Clos__item___0 :
   closure ->
-    ((FStar_Syntax_Syntax.binder FStar_Pervasives_Native.option * closure)
-      Prims.list * FStar_Syntax_Syntax.term * ((FStar_Syntax_Syntax.binder
-      FStar_Pervasives_Native.option * closure) Prims.list *
-      FStar_Syntax_Syntax.term) cfg_memo * Prims.bool))
+    ((FStar_Syntax_Syntax.binder FStar_Pervasives_Native.option * closure *
+      FStar_Syntax_Syntax.subst_t FStar_Syntax_Syntax.memo) Prims.list *
+      FStar_Syntax_Syntax.term * ((FStar_Syntax_Syntax.binder
+      FStar_Pervasives_Native.option * closure * FStar_Syntax_Syntax.subst_t
+      FStar_Syntax_Syntax.memo) Prims.list * FStar_Syntax_Syntax.term)
+      cfg_memo * Prims.bool))
   = fun projectee -> match projectee with | Clos _0 -> _0
 let (uu___is_Univ : closure -> Prims.bool) =
   fun projectee -> match projectee with | Univ _0 -> true | uu___ -> false
@@ -74,12 +78,33 @@ let (__proj__Univ__item___0 : closure -> FStar_Syntax_Syntax.universe) =
 let (uu___is_Dummy : closure -> Prims.bool) =
   fun projectee -> match projectee with | Dummy -> true | uu___ -> false
 type env =
-  (FStar_Syntax_Syntax.binder FStar_Pervasives_Native.option * closure)
-    Prims.list
+  (FStar_Syntax_Syntax.binder FStar_Pervasives_Native.option * closure *
+    FStar_Syntax_Syntax.subst_t FStar_Syntax_Syntax.memo) Prims.list
+let showable_memo :
+  'a .
+    'a FStar_Class_Show.showable ->
+      'a FStar_Syntax_Syntax.memo FStar_Class_Show.showable
+  =
+  fun uu___ ->
+    {
+      FStar_Class_Show.show =
+        (fun m ->
+           let uu___1 = FStar_Compiler_Effect.op_Bang m in
+           match uu___1 with
+           | FStar_Pervasives_Native.None -> "no_memo"
+           | FStar_Pervasives_Native.Some x ->
+               let uu___2 = FStar_Class_Show.show uu___ x in
+               Prims.strcat "memo=" uu___2)
+    }
 let (empty_env : env) = []
 let (dummy :
-  (FStar_Syntax_Syntax.binder FStar_Pervasives_Native.option * closure)) =
-  (FStar_Pervasives_Native.None, Dummy)
+  unit ->
+    (FStar_Syntax_Syntax.binder FStar_Pervasives_Native.option * closure *
+      FStar_Syntax_Syntax.subst_t FStar_Syntax_Syntax.memo))
+  =
+  fun uu___ ->
+    let uu___1 = fresh_memo () in
+    (FStar_Pervasives_Native.None, Dummy, uu___1)
 type branches =
   (FStar_Syntax_Syntax.pat * FStar_Syntax_Syntax.term
     FStar_Pervasives_Native.option * FStar_Syntax_Syntax.term) Prims.list
@@ -278,7 +303,7 @@ let (lookup_bvar : env -> FStar_Syntax_Syntax.bv -> closure) =
            | () ->
                let uu___1 =
                  FStar_Compiler_List.nth env1 x.FStar_Syntax_Syntax.index in
-               FStar_Pervasives_Native.snd uu___1) ()
+               FStar_Pervasives_Native.__proj__Mktuple3__item___2 uu___1) ()
       with
       | uu___ ->
           let uu___1 =
@@ -286,10 +311,12 @@ let (lookup_bvar : env -> FStar_Syntax_Syntax.bv -> closure) =
             let uu___3 =
               FStar_Class_Show.show
                 (FStar_Class_Show.show_list
-                   (FStar_Class_Show.show_tuple2
+                   (FStar_Class_Show.show_tuple3
                       (FStar_Class_Show.show_option
-                         FStar_Syntax_Print.showable_binder) showable_closure))
-                env1 in
+                         FStar_Syntax_Print.showable_binder) showable_closure
+                      (showable_memo
+                         (FStar_Class_Show.show_list
+                            FStar_Syntax_Print.showable_subst_elt)))) env1 in
             FStar_Compiler_Util.format2 "Failed to find %s\nEnv is %s\n"
               uu___2 uu___3 in
           FStar_Compiler_Effect.failwith uu___1
@@ -349,7 +376,8 @@ let (norm_universe :
                     | () ->
                         let uu___1 =
                           let uu___2 = FStar_Compiler_List.nth env1 x in
-                          FStar_Pervasives_Native.snd uu___2 in
+                          FStar_Pervasives_Native.__proj__Mktuple3__item___2
+                            uu___2 in
                         (match uu___1 with
                          | Univ u3 ->
                              ((let uu___3 =
@@ -438,852 +466,51 @@ let (norm_universe :
            | (FStar_Syntax_Syntax.U_zero)::us -> FStar_Syntax_Syntax.U_max us
            | u1::[] -> u1
            | us -> FStar_Syntax_Syntax.U_max us)
-let rec (inline_closure_env :
-  FStar_TypeChecker_Cfg.cfg ->
-    env ->
-      stack_elt Prims.list ->
-        FStar_Syntax_Syntax.term ->
-          FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
-  =
-  fun cfg ->
-    fun env1 ->
-      fun stack1 ->
-        fun t ->
-          FStar_TypeChecker_Cfg.log cfg
-            (fun uu___1 ->
-               let uu___2 = FStar_Syntax_Print.tag_of_term t in
-               let uu___3 =
-                 FStar_Class_Show.show
-                   (FStar_Class_Show.show_list
-                      (FStar_Class_Show.show_tuple2
-                         (FStar_Class_Show.show_option
-                            FStar_Syntax_Print.showable_binder)
-                         showable_closure)) env1 in
-               let uu___4 =
-                 FStar_Class_Show.show FStar_Syntax_Print.showable_term t in
-               FStar_Compiler_Util.print3
-                 ">>> %s (env=%s)\nClosure_as_term %s\n" uu___2 uu___3 uu___4);
-          (match env1 with
-           | [] when
-               Prims.op_Negation
-                 (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.compress_uvars
-               -> rebuild_closure cfg env1 stack1 t
-           | uu___1 ->
-               (match t.FStar_Syntax_Syntax.n with
-                | FStar_Syntax_Syntax.Tm_delayed uu___2 ->
-                    let uu___3 = FStar_Syntax_Subst.compress t in
-                    inline_closure_env cfg env1 stack1 uu___3
-                | FStar_Syntax_Syntax.Tm_unknown ->
-                    rebuild_closure cfg env1 stack1 t
-                | FStar_Syntax_Syntax.Tm_constant uu___2 ->
-                    rebuild_closure cfg env1 stack1 t
-                | FStar_Syntax_Syntax.Tm_name uu___2 ->
-                    rebuild_closure cfg env1 stack1 t
-                | FStar_Syntax_Syntax.Tm_lazy uu___2 ->
-                    rebuild_closure cfg env1 stack1 t
-                | FStar_Syntax_Syntax.Tm_fvar uu___2 ->
-                    rebuild_closure cfg env1 stack1 t
-                | FStar_Syntax_Syntax.Tm_uvar (uv, s) ->
-                    if
-                      (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.check_no_uvars
-                    then
-                      let t1 = FStar_Syntax_Subst.compress t in
-                      (match t1.FStar_Syntax_Syntax.n with
-                       | FStar_Syntax_Syntax.Tm_uvar uu___2 ->
-                           let uu___3 =
-                             let uu___4 =
-                               FStar_Compiler_Range_Ops.string_of_range
-                                 t1.FStar_Syntax_Syntax.pos in
-                             let uu___5 =
-                               FStar_Class_Show.show
-                                 FStar_Syntax_Print.showable_term t1 in
-                             FStar_Compiler_Util.format2
-                               "(%s): CheckNoUvars: Unexpected unification variable remains: %s"
-                               uu___4 uu___5 in
-                           FStar_Compiler_Effect.failwith uu___3
-                       | uu___2 -> inline_closure_env cfg env1 stack1 t1)
-                    else
-                      (let s' =
-                         FStar_Compiler_List.map
-                           (fun s1 ->
-                              FStar_Compiler_List.map
-                                (fun uu___3 ->
-                                   match uu___3 with
-                                   | FStar_Syntax_Syntax.NT (x, t1) ->
-                                       let uu___4 =
-                                         let uu___5 =
-                                           inline_closure_env cfg env1 [] t1 in
-                                         (x, uu___5) in
-                                       FStar_Syntax_Syntax.NT uu___4
-                                   | FStar_Syntax_Syntax.NM (x, i) ->
-                                       let x_i =
-                                         FStar_Syntax_Syntax.bv_to_tm
-                                           {
-                                             FStar_Syntax_Syntax.ppname =
-                                               (x.FStar_Syntax_Syntax.ppname);
-                                             FStar_Syntax_Syntax.index = i;
-                                             FStar_Syntax_Syntax.sort =
-                                               (x.FStar_Syntax_Syntax.sort)
-                                           } in
-                                       let t1 =
-                                         inline_closure_env cfg env1 [] x_i in
-                                       (match t1.FStar_Syntax_Syntax.n with
-                                        | FStar_Syntax_Syntax.Tm_bvar x_j ->
-                                            FStar_Syntax_Syntax.NM
-                                              (x,
-                                                (x_j.FStar_Syntax_Syntax.index))
-                                        | uu___4 ->
-                                            FStar_Syntax_Syntax.NT (x, t1))
-                                   | uu___4 ->
-                                       FStar_Compiler_Effect.failwith
-                                         "Impossible: subst invariant of uvar nodes")
-                                s1) (FStar_Pervasives_Native.fst s) in
-                       let t1 =
-                         {
-                           FStar_Syntax_Syntax.n =
-                             (FStar_Syntax_Syntax.Tm_uvar
-                                (uv, (s', (FStar_Pervasives_Native.snd s))));
-                           FStar_Syntax_Syntax.pos =
-                             (t.FStar_Syntax_Syntax.pos);
-                           FStar_Syntax_Syntax.vars =
-                             (t.FStar_Syntax_Syntax.vars);
-                           FStar_Syntax_Syntax.hash_code =
-                             (t.FStar_Syntax_Syntax.hash_code)
-                         } in
-                       rebuild_closure cfg env1 stack1 t1)
-                | FStar_Syntax_Syntax.Tm_type u ->
-                    let t1 =
-                      let uu___2 =
-                        let uu___3 = norm_universe cfg env1 u in
-                        FStar_Syntax_Syntax.Tm_type uu___3 in
-                      FStar_Syntax_Syntax.mk uu___2 t.FStar_Syntax_Syntax.pos in
-                    rebuild_closure cfg env1 stack1 t1
-                | FStar_Syntax_Syntax.Tm_uinst (t', us) ->
-                    let t1 =
-                      let uu___2 =
-                        FStar_Compiler_List.map (norm_universe cfg env1) us in
-                      FStar_Syntax_Syntax.mk_Tm_uinst t' uu___2 in
-                    rebuild_closure cfg env1 stack1 t1
-                | FStar_Syntax_Syntax.Tm_bvar x ->
-                    let uu___2 = lookup_bvar env1 x in
-                    (match uu___2 with
-                     | Univ uu___3 ->
-                         FStar_Compiler_Effect.failwith
-                           "Impossible: term variable is bound to a universe"
-                     | Dummy ->
-                         let x1 =
-                           {
-                             FStar_Syntax_Syntax.ppname =
-                               (x.FStar_Syntax_Syntax.ppname);
-                             FStar_Syntax_Syntax.index =
-                               (x.FStar_Syntax_Syntax.index);
-                             FStar_Syntax_Syntax.sort =
-                               FStar_Syntax_Syntax.tun
-                           } in
-                         let t1 =
-                           FStar_Syntax_Syntax.mk
-                             (FStar_Syntax_Syntax.Tm_bvar x1)
-                             t.FStar_Syntax_Syntax.pos in
-                         rebuild_closure cfg env1 stack1 t1
-                     | Clos (env2, t0, uu___3, uu___4) ->
-                         inline_closure_env cfg env2 stack1 t0)
-                | FStar_Syntax_Syntax.Tm_app
-                    { FStar_Syntax_Syntax.hd = head;
-                      FStar_Syntax_Syntax.args = args;_}
-                    ->
-                    let stack2 =
-                      FStar_Compiler_List.fold_right
-                        (fun uu___2 ->
-                           fun stack3 ->
-                             match uu___2 with
-                             | (a, aq) ->
-                                 let uu___3 =
-                                   let uu___4 =
-                                     let uu___5 =
-                                       let uu___6 =
-                                         let uu___7 = fresh_memo () in
-                                         (env1, a, uu___7, false) in
-                                       Clos uu___6 in
-                                     (uu___5, aq,
-                                       (t.FStar_Syntax_Syntax.pos)) in
-                                   Arg uu___4 in
-                                 uu___3 :: stack3) args stack1 in
-                    inline_closure_env cfg env1 stack2 head
-                | FStar_Syntax_Syntax.Tm_abs
-                    { FStar_Syntax_Syntax.bs = bs;
-                      FStar_Syntax_Syntax.body = body;
-                      FStar_Syntax_Syntax.rc_opt = lopt;_}
-                    ->
-                    let env' =
-                      FStar_Compiler_List.fold_right
-                        (fun _b ->
-                           fun env2 -> (FStar_Pervasives_Native.None, Dummy)
-                             :: env2) bs env1 in
-                    let stack2 =
-                      (Abs
-                         (env1, bs, env', lopt, (t.FStar_Syntax_Syntax.pos)))
-                      :: stack1 in
-                    inline_closure_env cfg env' stack2 body
-                | FStar_Syntax_Syntax.Tm_arrow
-                    { FStar_Syntax_Syntax.bs1 = bs;
-                      FStar_Syntax_Syntax.comp = c;_}
-                    ->
-                    let uu___2 = close_binders cfg env1 bs in
-                    (match uu___2 with
-                     | (bs1, env') ->
-                         let c1 = close_comp cfg env' c in
-                         let t1 =
-                           FStar_Syntax_Syntax.mk
-                             (FStar_Syntax_Syntax.Tm_arrow
-                                {
-                                  FStar_Syntax_Syntax.bs1 = bs1;
-                                  FStar_Syntax_Syntax.comp = c1
-                                }) t.FStar_Syntax_Syntax.pos in
-                         rebuild_closure cfg env1 stack1 t1)
-                | FStar_Syntax_Syntax.Tm_refine
-                    { FStar_Syntax_Syntax.b = x;
-                      FStar_Syntax_Syntax.phi = uu___2;_}
-                    when
-                    (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.for_extraction
-                      ||
-                      (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unrefine
-                    ->
-                    inline_closure_env cfg env1 stack1
-                      x.FStar_Syntax_Syntax.sort
-                | FStar_Syntax_Syntax.Tm_refine
-                    { FStar_Syntax_Syntax.b = x;
-                      FStar_Syntax_Syntax.phi = phi;_}
-                    ->
-                    let uu___2 =
-                      let uu___3 =
-                        let uu___4 = FStar_Syntax_Syntax.mk_binder x in
-                        [uu___4] in
-                      close_binders cfg env1 uu___3 in
-                    (match uu___2 with
-                     | (x1, env2) ->
-                         let phi1 = non_tail_inline_closure_env cfg env2 phi in
-                         let t1 =
-                           let uu___3 =
-                             let uu___4 =
-                               let uu___5 =
-                                 let uu___6 = FStar_Compiler_List.hd x1 in
-                                 uu___6.FStar_Syntax_Syntax.binder_bv in
-                               {
-                                 FStar_Syntax_Syntax.b = uu___5;
-                                 FStar_Syntax_Syntax.phi = phi1
-                               } in
-                             FStar_Syntax_Syntax.Tm_refine uu___4 in
-                           FStar_Syntax_Syntax.mk uu___3
-                             t.FStar_Syntax_Syntax.pos in
-                         rebuild_closure cfg env2 stack1 t1)
-                | FStar_Syntax_Syntax.Tm_ascribed
-                    { FStar_Syntax_Syntax.tm = t1;
-                      FStar_Syntax_Syntax.asc = asc;
-                      FStar_Syntax_Syntax.eff_opt = lopt;_}
-                    ->
-                    let asc1 = close_ascription cfg env1 asc in
-                    let t2 =
-                      let uu___2 =
-                        let uu___3 =
-                          let uu___4 =
-                            non_tail_inline_closure_env cfg env1 t1 in
-                          {
-                            FStar_Syntax_Syntax.tm = uu___4;
-                            FStar_Syntax_Syntax.asc = asc1;
-                            FStar_Syntax_Syntax.eff_opt = lopt
-                          } in
-                        FStar_Syntax_Syntax.Tm_ascribed uu___3 in
-                      FStar_Syntax_Syntax.mk uu___2 t.FStar_Syntax_Syntax.pos in
-                    rebuild_closure cfg env1 stack1 t2
-                | FStar_Syntax_Syntax.Tm_quoted (t', qi) ->
-                    let t1 =
-                      match qi.FStar_Syntax_Syntax.qkind with
-                      | FStar_Syntax_Syntax.Quote_dynamic ->
-                          let uu___2 =
-                            let uu___3 =
-                              let uu___4 =
-                                non_tail_inline_closure_env cfg env1 t' in
-                              (uu___4, qi) in
-                            FStar_Syntax_Syntax.Tm_quoted uu___3 in
-                          FStar_Syntax_Syntax.mk uu___2
-                            t.FStar_Syntax_Syntax.pos
-                      | FStar_Syntax_Syntax.Quote_static ->
-                          let qi1 =
-                            FStar_Syntax_Syntax.on_antiquoted
-                              (non_tail_inline_closure_env cfg env1) qi in
-                          FStar_Syntax_Syntax.mk
-                            (FStar_Syntax_Syntax.Tm_quoted (t', qi1))
-                            t.FStar_Syntax_Syntax.pos in
-                    rebuild_closure cfg env1 stack1 t1
-                | FStar_Syntax_Syntax.Tm_meta
-                    { FStar_Syntax_Syntax.tm2 = t';
-                      FStar_Syntax_Syntax.meta = m;_}
-                    ->
-                    let stack2 =
-                      (Meta (env1, m, (t.FStar_Syntax_Syntax.pos))) :: stack1 in
-                    inline_closure_env cfg env1 stack2 t'
-                | FStar_Syntax_Syntax.Tm_let
-                    { FStar_Syntax_Syntax.lbs = (false, lb::[]);
-                      FStar_Syntax_Syntax.body1 = body;_}
-                    ->
-                    let env0 = env1 in
-                    let env2 =
-                      FStar_Compiler_List.fold_left
-                        (fun env3 -> fun uu___2 -> dummy :: env3) env1
-                        lb.FStar_Syntax_Syntax.lbunivs in
-                    let typ =
-                      non_tail_inline_closure_env cfg env2
-                        lb.FStar_Syntax_Syntax.lbtyp in
-                    let def =
-                      non_tail_inline_closure_env cfg env2
-                        lb.FStar_Syntax_Syntax.lbdef in
-                    let uu___2 =
-                      let uu___3 = FStar_Syntax_Syntax.is_top_level [lb] in
-                      if uu___3
-                      then ((lb.FStar_Syntax_Syntax.lbname), body)
-                      else
-                        (let x =
-                           FStar_Compiler_Util.left
-                             lb.FStar_Syntax_Syntax.lbname in
-                         let uu___5 =
-                           non_tail_inline_closure_env cfg (dummy :: env0)
-                             body in
-                         ((FStar_Pervasives.Inl
-                             {
-                               FStar_Syntax_Syntax.ppname =
-                                 (x.FStar_Syntax_Syntax.ppname);
-                               FStar_Syntax_Syntax.index =
-                                 (x.FStar_Syntax_Syntax.index);
-                               FStar_Syntax_Syntax.sort = typ
-                             }), uu___5)) in
-                    (match uu___2 with
-                     | (nm, body1) ->
-                         let attrs =
-                           FStar_Compiler_List.map
-                             (non_tail_inline_closure_env cfg env0)
-                             lb.FStar_Syntax_Syntax.lbattrs in
-                         let lb1 =
-                           {
-                             FStar_Syntax_Syntax.lbname = nm;
-                             FStar_Syntax_Syntax.lbunivs =
-                               (lb.FStar_Syntax_Syntax.lbunivs);
-                             FStar_Syntax_Syntax.lbtyp = typ;
-                             FStar_Syntax_Syntax.lbeff =
-                               (lb.FStar_Syntax_Syntax.lbeff);
-                             FStar_Syntax_Syntax.lbdef = def;
-                             FStar_Syntax_Syntax.lbattrs = attrs;
-                             FStar_Syntax_Syntax.lbpos =
-                               (lb.FStar_Syntax_Syntax.lbpos)
-                           } in
-                         let t1 =
-                           FStar_Syntax_Syntax.mk
-                             (FStar_Syntax_Syntax.Tm_let
-                                {
-                                  FStar_Syntax_Syntax.lbs = (false, [lb1]);
-                                  FStar_Syntax_Syntax.body1 = body1
-                                }) t.FStar_Syntax_Syntax.pos in
-                         rebuild_closure cfg env0 stack1 t1)
-                | FStar_Syntax_Syntax.Tm_let
-                    { FStar_Syntax_Syntax.lbs = (uu___2, lbs);
-                      FStar_Syntax_Syntax.body1 = body;_}
-                    ->
-                    let norm_one_lb env2 lb =
-                      let env_univs =
-                        FStar_Compiler_List.fold_right
-                          (fun uu___3 -> fun env3 -> dummy :: env3)
-                          lb.FStar_Syntax_Syntax.lbunivs env2 in
-                      let env3 =
-                        let uu___3 = FStar_Syntax_Syntax.is_top_level lbs in
-                        if uu___3
-                        then env_univs
-                        else
-                          FStar_Compiler_List.fold_right
-                            (fun uu___5 -> fun env4 -> dummy :: env4) lbs
-                            env_univs in
-                      let ty =
-                        non_tail_inline_closure_env cfg env_univs
-                          lb.FStar_Syntax_Syntax.lbtyp in
-                      let nm =
-                        let uu___3 = FStar_Syntax_Syntax.is_top_level lbs in
-                        if uu___3
-                        then lb.FStar_Syntax_Syntax.lbname
-                        else
-                          (let x =
-                             FStar_Compiler_Util.left
-                               lb.FStar_Syntax_Syntax.lbname in
-                           FStar_Pervasives.Inl
-                             {
-                               FStar_Syntax_Syntax.ppname =
-                                 (x.FStar_Syntax_Syntax.ppname);
-                               FStar_Syntax_Syntax.index =
-                                 (x.FStar_Syntax_Syntax.index);
-                               FStar_Syntax_Syntax.sort = ty
-                             }) in
-                      let uu___3 =
-                        non_tail_inline_closure_env cfg env3
-                          lb.FStar_Syntax_Syntax.lbdef in
-                      {
-                        FStar_Syntax_Syntax.lbname = nm;
-                        FStar_Syntax_Syntax.lbunivs =
-                          (lb.FStar_Syntax_Syntax.lbunivs);
-                        FStar_Syntax_Syntax.lbtyp = ty;
-                        FStar_Syntax_Syntax.lbeff =
-                          (lb.FStar_Syntax_Syntax.lbeff);
-                        FStar_Syntax_Syntax.lbdef = uu___3;
-                        FStar_Syntax_Syntax.lbattrs =
-                          (lb.FStar_Syntax_Syntax.lbattrs);
-                        FStar_Syntax_Syntax.lbpos =
-                          (lb.FStar_Syntax_Syntax.lbpos)
-                      } in
-                    let lbs1 = FStar_Compiler_List.map (norm_one_lb env1) lbs in
-                    let body1 =
-                      let body_env =
-                        FStar_Compiler_List.fold_right
-                          (fun uu___3 -> fun env2 -> dummy :: env2) lbs1 env1 in
-                      non_tail_inline_closure_env cfg body_env body in
-                    let t1 =
-                      FStar_Syntax_Syntax.mk
-                        (FStar_Syntax_Syntax.Tm_let
-                           {
-                             FStar_Syntax_Syntax.lbs = (true, lbs1);
-                             FStar_Syntax_Syntax.body1 = body1
-                           }) t.FStar_Syntax_Syntax.pos in
-                    rebuild_closure cfg env1 stack1 t1
-                | FStar_Syntax_Syntax.Tm_match
-                    { FStar_Syntax_Syntax.scrutinee = head;
-                      FStar_Syntax_Syntax.ret_opt = asc_opt;
-                      FStar_Syntax_Syntax.brs = branches1;
-                      FStar_Syntax_Syntax.rc_opt1 = lopt;_}
-                    ->
-                    let stack2 =
-                      (Match
-                         (env1, asc_opt, branches1, lopt, cfg,
-                           (t.FStar_Syntax_Syntax.pos)))
-                      :: stack1 in
-                    inline_closure_env cfg env1 stack2 head))
-and (non_tail_inline_closure_env :
-  FStar_TypeChecker_Cfg.cfg ->
-    env ->
-      FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
-        FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
-  = fun cfg -> fun env1 -> fun t -> inline_closure_env cfg env1 [] t
-and (rebuild_closure :
-  FStar_TypeChecker_Cfg.cfg ->
-    env ->
-      stack_elt Prims.list ->
-        FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
-          FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
-  =
-  fun cfg ->
-    fun env1 ->
-      fun stack1 ->
-        fun t ->
-          FStar_TypeChecker_Cfg.log cfg
-            (fun uu___1 ->
-               let uu___2 = FStar_Syntax_Print.tag_of_term t in
-               let uu___3 =
-                 FStar_Class_Show.show
-                   (FStar_Class_Show.show_list
-                      (FStar_Class_Show.show_tuple2
-                         (FStar_Class_Show.show_option
-                            FStar_Syntax_Print.showable_binder)
-                         showable_closure)) env1 in
-               let uu___4 =
-                 FStar_Class_Show.show
-                   (FStar_Class_Show.show_list showable_stack_elt) stack1 in
-               let uu___5 =
-                 FStar_Class_Show.show FStar_Syntax_Print.showable_term t in
-               FStar_Compiler_Util.print4
-                 ">>> %s (env=%s, stack=%s)\nRebuild closure_as_term %s\n"
-                 uu___2 uu___3 uu___4 uu___5);
-          (match stack1 with
-           | [] -> t
-           | (Arg (Clos (env_arg, tm, uu___1, uu___2), aq, r))::stack2 ->
-               let stack3 = (App (env1, t, aq, r)) :: stack2 in
-               inline_closure_env cfg env_arg stack3 tm
-           | (App (env2, head, aq, r))::stack2 ->
-               let t1 = FStar_Syntax_Syntax.extend_app head (t, aq) r in
-               rebuild_closure cfg env2 stack2 t1
-           | (CBVApp (env2, head, aq, r))::stack2 ->
-               let t1 = FStar_Syntax_Syntax.extend_app head (t, aq) r in
-               rebuild_closure cfg env2 stack2 t1
-           | (Abs (env', bs, env'', lopt, r))::stack2 ->
-               let uu___1 = close_binders cfg env' bs in
-               (match uu___1 with
-                | (bs1, uu___2) ->
-                    let lopt1 = close_lcomp_opt cfg env'' lopt in
-                    let uu___3 =
-                      let uu___4 = FStar_Syntax_Util.abs bs1 t lopt1 in
-                      {
-                        FStar_Syntax_Syntax.n =
-                          (uu___4.FStar_Syntax_Syntax.n);
-                        FStar_Syntax_Syntax.pos = r;
-                        FStar_Syntax_Syntax.vars =
-                          (uu___4.FStar_Syntax_Syntax.vars);
-                        FStar_Syntax_Syntax.hash_code =
-                          (uu___4.FStar_Syntax_Syntax.hash_code)
-                      } in
-                    rebuild_closure cfg env1 stack2 uu___3)
-           | (Match (env2, asc_opt, branches1, lopt, cfg1, r))::stack2 ->
-               let lopt1 = close_lcomp_opt cfg1 env2 lopt in
-               let close_one_branch env3 uu___1 =
-                 match uu___1 with
-                 | (pat, w_opt, tm) ->
-                     let rec norm_pat env4 p =
-                       match p.FStar_Syntax_Syntax.v with
-                       | FStar_Syntax_Syntax.Pat_constant uu___2 -> (p, env4)
-                       | FStar_Syntax_Syntax.Pat_cons (fv, us_opt, pats) ->
-                           let us_opt1 =
-                             if
-                               (cfg1.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.erase_universes
-                             then FStar_Pervasives_Native.None
-                             else
-                               (match us_opt with
-                                | FStar_Pervasives_Native.None ->
-                                    FStar_Pervasives_Native.None
-                                | FStar_Pervasives_Native.Some us ->
-                                    let uu___3 =
-                                      FStar_Compiler_List.map
-                                        (norm_universe cfg1 env4) us in
-                                    FStar_Pervasives_Native.Some uu___3) in
-                           let uu___2 =
-                             FStar_Compiler_List.fold_left
-                               (fun uu___3 ->
-                                  fun uu___4 ->
-                                    match (uu___3, uu___4) with
-                                    | ((pats1, env5), (p1, b)) ->
-                                        let uu___5 = norm_pat env5 p1 in
-                                        (match uu___5 with
-                                         | (p2, env6) ->
-                                             (((p2, b) :: pats1), env6)))
-                               ([], env4) pats in
-                           (match uu___2 with
-                            | (pats1, env5) ->
-                                ({
-                                   FStar_Syntax_Syntax.v =
-                                     (FStar_Syntax_Syntax.Pat_cons
-                                        (fv, us_opt1,
-                                          (FStar_Compiler_List.rev pats1)));
-                                   FStar_Syntax_Syntax.p =
-                                     (p.FStar_Syntax_Syntax.p)
-                                 }, env5))
-                       | FStar_Syntax_Syntax.Pat_var x ->
-                           let x1 =
-                             let uu___2 =
-                               non_tail_inline_closure_env cfg1 env4
-                                 x.FStar_Syntax_Syntax.sort in
-                             {
-                               FStar_Syntax_Syntax.ppname =
-                                 (x.FStar_Syntax_Syntax.ppname);
-                               FStar_Syntax_Syntax.index =
-                                 (x.FStar_Syntax_Syntax.index);
-                               FStar_Syntax_Syntax.sort = uu___2
-                             } in
-                           ({
-                              FStar_Syntax_Syntax.v =
-                                (FStar_Syntax_Syntax.Pat_var x1);
-                              FStar_Syntax_Syntax.p =
-                                (p.FStar_Syntax_Syntax.p)
-                            }, (dummy :: env4))
-                       | FStar_Syntax_Syntax.Pat_dot_term eopt ->
-                           let eopt1 =
-                             FStar_Compiler_Util.map_option
-                               (non_tail_inline_closure_env cfg1 env4) eopt in
-                           ({
-                              FStar_Syntax_Syntax.v =
-                                (FStar_Syntax_Syntax.Pat_dot_term eopt1);
-                              FStar_Syntax_Syntax.p =
-                                (p.FStar_Syntax_Syntax.p)
-                            }, env4) in
-                     let uu___2 = norm_pat env3 pat in
-                     (match uu___2 with
-                      | (pat1, env4) ->
-                          let w_opt1 =
-                            match w_opt with
-                            | FStar_Pervasives_Native.None ->
-                                FStar_Pervasives_Native.None
-                            | FStar_Pervasives_Native.Some w ->
-                                let uu___3 =
-                                  non_tail_inline_closure_env cfg1 env4 w in
-                                FStar_Pervasives_Native.Some uu___3 in
-                          let tm1 = non_tail_inline_closure_env cfg1 env4 tm in
-                          (pat1, w_opt1, tm1)) in
-               let t1 =
-                 let uu___1 =
-                   let uu___2 =
-                     let uu___3 = close_match_returns cfg1 env2 asc_opt in
-                     let uu___4 =
-                       FStar_Compiler_List.map (close_one_branch env2)
-                         branches1 in
-                     {
-                       FStar_Syntax_Syntax.scrutinee = t;
-                       FStar_Syntax_Syntax.ret_opt = uu___3;
-                       FStar_Syntax_Syntax.brs = uu___4;
-                       FStar_Syntax_Syntax.rc_opt1 = lopt1
-                     } in
-                   FStar_Syntax_Syntax.Tm_match uu___2 in
-                 FStar_Syntax_Syntax.mk uu___1 t.FStar_Syntax_Syntax.pos in
-               rebuild_closure cfg1 env2 stack2 t1
-           | (Meta (env_m, m, r))::stack2 ->
-               let m1 =
-                 match m with
-                 | FStar_Syntax_Syntax.Meta_pattern (names, args) ->
-                     let uu___1 =
-                       let uu___2 =
-                         FStar_Compiler_List.map
-                           (non_tail_inline_closure_env cfg env_m) names in
-                       let uu___3 =
-                         FStar_Compiler_List.map
-                           (fun args1 ->
-                              FStar_Compiler_List.map
-                                (fun uu___4 ->
-                                   match uu___4 with
-                                   | (a, q) ->
-                                       let uu___5 =
-                                         non_tail_inline_closure_env cfg
-                                           env_m a in
-                                       (uu___5, q)) args1) args in
-                       (uu___2, uu___3) in
-                     FStar_Syntax_Syntax.Meta_pattern uu___1
-                 | FStar_Syntax_Syntax.Meta_monadic (m2, tbody) ->
-                     let uu___1 =
-                       let uu___2 =
-                         non_tail_inline_closure_env cfg env_m tbody in
-                       (m2, uu___2) in
-                     FStar_Syntax_Syntax.Meta_monadic uu___1
-                 | FStar_Syntax_Syntax.Meta_monadic_lift (m11, m2, tbody) ->
-                     let uu___1 =
-                       let uu___2 =
-                         non_tail_inline_closure_env cfg env_m tbody in
-                       (m11, m2, uu___2) in
-                     FStar_Syntax_Syntax.Meta_monadic_lift uu___1
-                 | uu___1 -> m in
-               let t1 =
-                 FStar_Syntax_Syntax.mk
-                   (FStar_Syntax_Syntax.Tm_meta
-                      {
-                        FStar_Syntax_Syntax.tm2 = t;
-                        FStar_Syntax_Syntax.meta = m1
-                      }) r in
-               rebuild_closure cfg env1 stack2 t1
-           | uu___1 ->
-               FStar_Compiler_Effect.failwith
-                 "Impossible: unexpected stack element")
-and (close_match_returns :
-  FStar_TypeChecker_Cfg.cfg ->
-    env ->
-      FStar_Syntax_Syntax.match_returns_ascription
-        FStar_Pervasives_Native.option ->
-        (FStar_Syntax_Syntax.binder *
-          ((FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax,
-          FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax)
-          FStar_Pervasives.either * FStar_Syntax_Syntax.term'
-          FStar_Syntax_Syntax.syntax FStar_Pervasives_Native.option *
-          Prims.bool)) FStar_Pervasives_Native.option)
-  =
-  fun cfg ->
-    fun env1 ->
-      fun ret_opt ->
-        match ret_opt with
-        | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
-        | FStar_Pervasives_Native.Some (b, asc) ->
-            let uu___ = close_binders cfg env1 [b] in
-            (match uu___ with
-             | (bs, env2) ->
-                 let asc1 = close_ascription cfg env2 asc in
-                 let uu___1 =
-                   let uu___2 = FStar_Compiler_List.hd bs in (uu___2, asc1) in
-                 FStar_Pervasives_Native.Some uu___1)
-and (close_ascription :
-  FStar_TypeChecker_Cfg.cfg ->
-    env ->
-      ((FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax,
-        FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax)
-        FStar_Pervasives.either * FStar_Syntax_Syntax.term'
-        FStar_Syntax_Syntax.syntax FStar_Pervasives_Native.option *
-        Prims.bool) ->
-        ((FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax,
-          FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax)
-          FStar_Pervasives.either * FStar_Syntax_Syntax.term'
-          FStar_Syntax_Syntax.syntax FStar_Pervasives_Native.option *
-          Prims.bool))
-  =
-  fun cfg ->
-    fun env1 ->
-      fun uu___ ->
-        match uu___ with
-        | (annot, tacopt, use_eq) ->
-            let annot1 =
-              match annot with
-              | FStar_Pervasives.Inl t ->
-                  let uu___1 = non_tail_inline_closure_env cfg env1 t in
-                  FStar_Pervasives.Inl uu___1
-              | FStar_Pervasives.Inr c ->
-                  let uu___1 = close_comp cfg env1 c in
-                  FStar_Pervasives.Inr uu___1 in
-            let tacopt1 =
-              FStar_Compiler_Util.map_opt tacopt
-                (non_tail_inline_closure_env cfg env1) in
-            (annot1, tacopt1, use_eq)
-and (close_imp :
-  FStar_TypeChecker_Cfg.cfg ->
-    env ->
-      FStar_Syntax_Syntax.binder_qualifier FStar_Pervasives_Native.option ->
-        FStar_Syntax_Syntax.binder_qualifier FStar_Pervasives_Native.option)
-  =
-  fun cfg ->
-    fun env1 ->
-      fun imp ->
-        match imp with
-        | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Meta t) ->
-            let uu___ =
-              let uu___1 = inline_closure_env cfg env1 [] t in
-              FStar_Syntax_Syntax.Meta uu___1 in
-            FStar_Pervasives_Native.Some uu___
-        | i -> i
-and (close_binders :
-  FStar_TypeChecker_Cfg.cfg ->
-    env ->
-      FStar_Syntax_Syntax.binder Prims.list ->
-        (FStar_Syntax_Syntax.binder Prims.list * env))
-  =
-  fun cfg ->
-    fun env1 ->
-      fun bs ->
-        let uu___ =
-          FStar_Compiler_List.fold_left
-            (fun uu___1 ->
-               fun uu___2 ->
-                 match (uu___1, uu___2) with
-                 | ((env2, out),
-                    { FStar_Syntax_Syntax.binder_bv = b;
-                      FStar_Syntax_Syntax.binder_qual = imp;
-                      FStar_Syntax_Syntax.binder_positivity = pqual;
-                      FStar_Syntax_Syntax.binder_attrs = attrs;_})
-                     ->
-                     let b1 =
-                       let uu___3 =
-                         inline_closure_env cfg env2 []
-                           b.FStar_Syntax_Syntax.sort in
-                       {
-                         FStar_Syntax_Syntax.ppname =
-                           (b.FStar_Syntax_Syntax.ppname);
-                         FStar_Syntax_Syntax.index =
-                           (b.FStar_Syntax_Syntax.index);
-                         FStar_Syntax_Syntax.sort = uu___3
-                       } in
-                     let imp1 = close_imp cfg env2 imp in
-                     let attrs1 =
-                       FStar_Compiler_List.map
-                         (non_tail_inline_closure_env cfg env2) attrs in
-                     let env3 = dummy :: env2 in
-                     let uu___3 =
-                       let uu___4 =
-                         FStar_Syntax_Syntax.mk_binder_with_attrs b1 imp1
-                           pqual attrs1 in
-                       uu___4 :: out in
-                     (env3, uu___3)) (env1, []) bs in
-        match uu___ with
-        | (env2, bs1) -> ((FStar_Compiler_List.rev bs1), env2)
-and (close_comp :
-  FStar_TypeChecker_Cfg.cfg ->
-    env ->
-      FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax ->
-        FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax)
-  =
-  fun cfg ->
-    fun env1 ->
-      fun c ->
-        match env1 with
-        | [] when
-            Prims.op_Negation
-              (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.compress_uvars
-            -> c
-        | uu___ ->
-            (match c.FStar_Syntax_Syntax.n with
-             | FStar_Syntax_Syntax.Total t ->
-                 let uu___1 = inline_closure_env cfg env1 [] t in
-                 FStar_Syntax_Syntax.mk_Total uu___1
-             | FStar_Syntax_Syntax.GTotal t ->
-                 let uu___1 = inline_closure_env cfg env1 [] t in
-                 FStar_Syntax_Syntax.mk_GTotal uu___1
-             | FStar_Syntax_Syntax.Comp c1 ->
-                 let rt =
-                   inline_closure_env cfg env1 []
-                     c1.FStar_Syntax_Syntax.result_typ in
-                 let args =
-                   FStar_Compiler_List.map
-                     (fun uu___1 ->
-                        match uu___1 with
-                        | (a, q) ->
-                            let uu___2 = inline_closure_env cfg env1 [] a in
-                            (uu___2, q)) c1.FStar_Syntax_Syntax.effect_args in
-                 let flags =
-                   FStar_Compiler_List.map
-                     (fun uu___1 ->
-                        match uu___1 with
-                        | FStar_Syntax_Syntax.DECREASES
-                            (FStar_Syntax_Syntax.Decreases_lex l) ->
-                            let uu___2 =
-                              let uu___3 =
-                                FStar_Compiler_List.map
-                                  (inline_closure_env cfg env1 []) l in
-                              FStar_Syntax_Syntax.Decreases_lex uu___3 in
-                            FStar_Syntax_Syntax.DECREASES uu___2
-                        | FStar_Syntax_Syntax.DECREASES
-                            (FStar_Syntax_Syntax.Decreases_wf (rel, e)) ->
-                            let uu___2 =
-                              let uu___3 =
-                                let uu___4 =
-                                  inline_closure_env cfg env1 [] rel in
-                                let uu___5 = inline_closure_env cfg env1 [] e in
-                                (uu___4, uu___5) in
-                              FStar_Syntax_Syntax.Decreases_wf uu___3 in
-                            FStar_Syntax_Syntax.DECREASES uu___2
-                        | f -> f) c1.FStar_Syntax_Syntax.flags in
-                 let uu___1 =
-                   let uu___2 =
-                     FStar_Compiler_List.map (norm_universe cfg env1)
-                       c1.FStar_Syntax_Syntax.comp_univs in
-                   {
-                     FStar_Syntax_Syntax.comp_univs = uu___2;
-                     FStar_Syntax_Syntax.effect_name =
-                       (c1.FStar_Syntax_Syntax.effect_name);
-                     FStar_Syntax_Syntax.result_typ = rt;
-                     FStar_Syntax_Syntax.effect_args = args;
-                     FStar_Syntax_Syntax.flags = flags
-                   } in
-                 FStar_Syntax_Syntax.mk_Comp uu___1)
-and (close_lcomp_opt :
-  FStar_TypeChecker_Cfg.cfg ->
-    env ->
-      FStar_Syntax_Syntax.residual_comp FStar_Pervasives_Native.option ->
-        FStar_Syntax_Syntax.residual_comp FStar_Pervasives_Native.option)
-  =
-  fun cfg ->
-    fun env1 ->
-      fun lopt ->
-        match lopt with
-        | FStar_Pervasives_Native.Some rc ->
-            let flags =
-              FStar_Compiler_List.filter
-                (fun uu___ ->
-                   match uu___ with
-                   | FStar_Syntax_Syntax.DECREASES uu___1 -> false
-                   | uu___1 -> true) rc.FStar_Syntax_Syntax.residual_flags in
-            let rc1 =
-              let uu___ =
-                FStar_Compiler_Util.map_opt
-                  rc.FStar_Syntax_Syntax.residual_typ
-                  (inline_closure_env cfg env1 []) in
-              {
-                FStar_Syntax_Syntax.residual_effect =
-                  (rc.FStar_Syntax_Syntax.residual_effect);
-                FStar_Syntax_Syntax.residual_typ = uu___;
-                FStar_Syntax_Syntax.residual_flags = flags
-              } in
-            FStar_Pervasives_Native.Some rc1
-        | uu___ -> lopt
+let memo_or : 'a . 'a FStar_Syntax_Syntax.memo -> (unit -> 'a) -> 'a =
+  fun m ->
+    fun f ->
+      let uu___ = FStar_Compiler_Effect.op_Bang m in
+      match uu___ with
+      | FStar_Pervasives_Native.Some v -> v
+      | FStar_Pervasives_Native.None ->
+          let v = f () in
+          (FStar_Compiler_Effect.op_Colon_Equals m
+             (FStar_Pervasives_Native.Some v);
+           v)
+let rec (env_subst : env -> FStar_Syntax_Syntax.subst_t) =
+  fun env1 ->
+    let compute uu___ =
+      let uu___1 =
+        FStar_Compiler_List.fold_left
+          (fun uu___2 ->
+             fun uu___3 ->
+               match (uu___2, uu___3) with
+               | ((s, i), (uu___4, c, uu___5)) ->
+                   (match c with
+                    | Clos (e, t, memo, fix) ->
+                        let es = env_subst e in
+                        let t1 =
+                          let uu___6 = FStar_Syntax_Subst.subst es t in
+                          FStar_Syntax_Subst.compress uu___6 in
+                        (((FStar_Syntax_Syntax.DT (i, t1)) :: s),
+                          (i + Prims.int_one))
+                    | Univ u ->
+                        (((FStar_Syntax_Syntax.UN (i, u)) :: s),
+                          (i + Prims.int_one))
+                    | Dummy -> (s, (i + Prims.int_one))))
+          ([], Prims.int_zero) env1 in
+      match uu___1 with | (s, uu___2) -> s in
+    match env1 with
+    | [] -> []
+    | (uu___, uu___1, memo)::uu___2 ->
+        let uu___3 = FStar_Compiler_Effect.op_Bang memo in
+        (match uu___3 with
+         | FStar_Pervasives_Native.Some s -> s
+         | FStar_Pervasives_Native.None ->
+             let s = compute () in
+             (FStar_Compiler_Effect.op_Colon_Equals memo
+                (FStar_Pervasives_Native.Some s);
+              s))
 let (filter_out_lcomp_cflags :
   FStar_Syntax_Syntax.cflag Prims.list ->
     FStar_Syntax_Syntax.cflag Prims.list)
@@ -1294,12 +521,78 @@ let (filter_out_lcomp_cflags :
          match uu___ with
          | FStar_Syntax_Syntax.DECREASES uu___1 -> false
          | uu___1 -> true) flags
+let (default_univ_uvars_to_zero :
+  FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
+  fun t ->
+    let uu___ =
+      FStar_Syntax_Visit.visit_term_univs (fun t1 -> t1)
+        (fun u ->
+           match u with
+           | FStar_Syntax_Syntax.U_unif uu___1 -> FStar_Syntax_Syntax.U_zero
+           | uu___1 -> u) in
+    uu___ t
+let (_erase_universes : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
+  =
+  fun t ->
+    let uu___ =
+      FStar_Syntax_Visit.visit_term_univs (fun t1 -> t1)
+        (fun u -> FStar_Syntax_Syntax.U_unknown) in
+    uu___ t
 let (closure_as_term :
   FStar_TypeChecker_Cfg.cfg ->
-    env ->
-      FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
-        FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
-  = fun cfg -> fun env1 -> fun t -> non_tail_inline_closure_env cfg env1 t
+    env -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
+  =
+  fun cfg ->
+    fun env1 ->
+      fun t ->
+        FStar_TypeChecker_Cfg.log cfg
+          (fun uu___1 ->
+             let uu___2 = FStar_Syntax_Print.tag_of_term t in
+             let uu___3 =
+               FStar_Class_Show.show
+                 (FStar_Class_Show.show_list
+                    (FStar_Class_Show.show_tuple3
+                       (FStar_Class_Show.show_option
+                          FStar_Syntax_Print.showable_binder)
+                       showable_closure
+                       (showable_memo
+                          (FStar_Class_Show.show_list
+                             FStar_Syntax_Print.showable_subst_elt)))) env1 in
+             let uu___4 =
+               FStar_Class_Show.show FStar_Syntax_Print.showable_term t in
+             FStar_Compiler_Util.print3
+               ">>> %s (env=%s)\nClosure_as_term %s\n" uu___2 uu___3 uu___4);
+        (let es = env_subst env1 in
+         let t1 = FStar_Syntax_Subst.subst es t in
+         let t2 =
+           if
+             (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.erase_universes
+           then _erase_universes t1
+           else
+             if
+               (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.default_univs_to_zero
+             then default_univ_uvars_to_zero t1
+             else t1 in
+         let t3 = FStar_Syntax_Subst.compress t2 in
+         FStar_TypeChecker_Cfg.log cfg
+           (fun uu___2 ->
+              let uu___3 = FStar_Syntax_Print.tag_of_term t3 in
+              let uu___4 =
+                FStar_Class_Show.show
+                  (FStar_Class_Show.show_list
+                     (FStar_Class_Show.show_tuple3
+                        (FStar_Class_Show.show_option
+                           FStar_Syntax_Print.showable_binder)
+                        showable_closure
+                        (showable_memo
+                           (FStar_Class_Show.show_list
+                              FStar_Syntax_Print.showable_subst_elt)))) env1 in
+              let uu___5 =
+                FStar_Class_Show.show FStar_Syntax_Print.showable_term t3 in
+              FStar_Compiler_Util.print3
+                ">>> %s (env=%s)\nClosure_as_term RESULT %s\n" uu___3 uu___4
+                uu___5);
+         t3)
 let (unembed_binder_knot :
   FStar_Syntax_Syntax.binder FStar_Syntax_Embeddings_Base.embedding
     FStar_Pervasives_Native.option FStar_Compiler_Effect.ref)
@@ -1321,8 +614,7 @@ let (unembed_binder :
          FStar_Pervasives_Native.None)
 let (mk_psc_subst :
   FStar_TypeChecker_Cfg.cfg ->
-    (FStar_Syntax_Syntax.binder FStar_Pervasives_Native.option * closure)
-      Prims.list -> FStar_Syntax_Syntax.subst_elt Prims.list)
+    env -> FStar_Syntax_Syntax.subst_elt Prims.list)
   =
   fun cfg ->
     fun env1 ->
@@ -1330,28 +622,28 @@ let (mk_psc_subst :
         (fun uu___ ->
            fun subst ->
              match uu___ with
-             | (binder_opt, closure1) ->
+             | (binder_opt, closure1, uu___1) ->
                  (match (binder_opt, closure1) with
                   | (FStar_Pervasives_Native.Some b, Clos
-                     (env2, term, uu___1, uu___2)) ->
+                     (env2, term, uu___2, uu___3)) ->
                       let bv = b.FStar_Syntax_Syntax.binder_bv in
-                      let uu___3 =
-                        let uu___4 =
+                      let uu___4 =
+                        let uu___5 =
                           FStar_Syntax_Util.is_constructed_typ
                             bv.FStar_Syntax_Syntax.sort
                             FStar_Parser_Const.binder_lid in
-                        Prims.op_Negation uu___4 in
-                      if uu___3
+                        Prims.op_Negation uu___5 in
+                      if uu___4
                       then subst
                       else
                         (let term1 = closure_as_term cfg env2 term in
-                         let uu___5 = unembed_binder term1 in
-                         match uu___5 with
+                         let uu___6 = unembed_binder term1 in
+                         match uu___6 with
                          | FStar_Pervasives_Native.None -> subst
                          | FStar_Pervasives_Native.Some x ->
                              let b1 =
-                               let uu___6 =
-                                 let uu___7 =
+                               let uu___7 =
+                                 let uu___8 =
                                    FStar_Syntax_Subst.subst subst
                                      (x.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort in
                                  {
@@ -1359,42 +651,41 @@ let (mk_psc_subst :
                                      (bv.FStar_Syntax_Syntax.ppname);
                                    FStar_Syntax_Syntax.index =
                                      (bv.FStar_Syntax_Syntax.index);
-                                   FStar_Syntax_Syntax.sort = uu___7
+                                   FStar_Syntax_Syntax.sort = uu___8
                                  } in
-                               FStar_Syntax_Syntax.freshen_bv uu___6 in
+                               FStar_Syntax_Syntax.freshen_bv uu___7 in
                              let b_for_x =
-                               let uu___6 =
-                                 let uu___7 =
+                               let uu___7 =
+                                 let uu___8 =
                                    FStar_Syntax_Syntax.bv_to_name b1 in
-                                 ((x.FStar_Syntax_Syntax.binder_bv), uu___7) in
-                               FStar_Syntax_Syntax.NT uu___6 in
+                                 ((x.FStar_Syntax_Syntax.binder_bv), uu___8) in
+                               FStar_Syntax_Syntax.NT uu___7 in
                              let subst1 =
                                FStar_Compiler_List.filter
-                                 (fun uu___6 ->
-                                    match uu___6 with
+                                 (fun uu___7 ->
+                                    match uu___7 with
                                     | FStar_Syntax_Syntax.NT
-                                        (uu___7,
+                                        (uu___8,
                                          {
                                            FStar_Syntax_Syntax.n =
                                              FStar_Syntax_Syntax.Tm_name b';
-                                           FStar_Syntax_Syntax.pos = uu___8;
-                                           FStar_Syntax_Syntax.vars = uu___9;
+                                           FStar_Syntax_Syntax.pos = uu___9;
+                                           FStar_Syntax_Syntax.vars = uu___10;
                                            FStar_Syntax_Syntax.hash_code =
-                                             uu___10;_})
+                                             uu___11;_})
                                         ->
-                                        let uu___11 =
+                                        let uu___12 =
                                           FStar_Ident.ident_equals
                                             b1.FStar_Syntax_Syntax.ppname
                                             b'.FStar_Syntax_Syntax.ppname in
-                                        Prims.op_Negation uu___11
-                                    | uu___7 -> true) subst in
+                                        Prims.op_Negation uu___12
+                                    | uu___8 -> true) subst in
                              b_for_x :: subst1)
-                  | uu___1 -> subst)) env1 []
+                  | uu___2 -> subst)) env1 []
 let (reduce_primops :
   FStar_Syntax_Embeddings_Base.norm_cb ->
     FStar_TypeChecker_Cfg.cfg ->
-      (FStar_Syntax_Syntax.binder FStar_Pervasives_Native.option * closure)
-        Prims.list ->
+      env ->
         FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
           (FStar_Syntax_Syntax.term * Prims.bool))
   =
@@ -1584,8 +875,7 @@ let (reduce_primops :
 let (reduce_equality :
   FStar_Syntax_Embeddings_Base.norm_cb ->
     FStar_TypeChecker_Cfg.cfg ->
-      (FStar_Syntax_Syntax.binder FStar_Pervasives_Native.option * closure)
-        Prims.list ->
+      env ->
         FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
           (FStar_Syntax_Syntax.term * Prims.bool))
   =
@@ -3330,8 +2620,10 @@ let rec (norm :
                     | (bs1, body1, opening) ->
                         let env' =
                           FStar_Compiler_List.fold_left
-                            (fun env2 -> fun uu___5 -> dummy :: env2) env1
-                            bs1 in
+                            (fun env2 ->
+                               fun uu___5 ->
+                                 let uu___6 = dummy () in uu___6 :: env2)
+                            env1 bs1 in
                         let rc_opt1 =
                           Obj.magic
                             (FStar_Class_Monad.op_let_Bang
@@ -3397,44 +2689,50 @@ let rec (norm :
                 | (UnivArgs uu___2)::uu___3 ->
                     FStar_Compiler_Effect.failwith
                       "Ill-typed term: universes cannot be applied to term abstraction"
+                | (Arg (Univ u, uu___2, uu___3))::stack_rest ->
+                    let uu___4 =
+                      let uu___5 =
+                        let uu___6 = fresh_memo () in
+                        (FStar_Pervasives_Native.None, (Univ u), uu___6) in
+                      uu___5 :: env1 in
+                    norm cfg uu___4 stack_rest t1
                 | (Arg (c, uu___2, uu___3))::stack_rest ->
-                    (match c with
-                     | Univ uu___4 ->
-                         norm cfg ((FStar_Pervasives_Native.None, c) :: env1)
-                           stack_rest t1
-                     | uu___4 ->
-                         (match bs with
-                          | [] -> FStar_Compiler_Effect.failwith "Impossible"
-                          | b::[] ->
-                              (FStar_TypeChecker_Cfg.log cfg
-                                 (fun uu___6 ->
-                                    let uu___7 =
-                                      FStar_Class_Show.show showable_closure
-                                        c in
-                                    FStar_Compiler_Util.print1
-                                      "\tShifted %s\n" uu___7);
-                               norm cfg
-                                 (((FStar_Pervasives_Native.Some b), c) ::
-                                 env1) stack_rest body)
-                          | b::tl ->
-                              (FStar_TypeChecker_Cfg.log cfg
-                                 (fun uu___6 ->
-                                    let uu___7 =
-                                      FStar_Class_Show.show showable_closure
-                                        c in
-                                    FStar_Compiler_Util.print1
-                                      "\tShifted %s\n" uu___7);
-                               (let body1 =
-                                  FStar_Syntax_Syntax.mk
-                                    (FStar_Syntax_Syntax.Tm_abs
-                                       {
-                                         FStar_Syntax_Syntax.bs = tl;
-                                         FStar_Syntax_Syntax.body = body;
-                                         FStar_Syntax_Syntax.rc_opt = rc_opt
-                                       }) t1.FStar_Syntax_Syntax.pos in
-                                norm cfg
-                                  (((FStar_Pervasives_Native.Some b), c) ::
-                                  env1) stack_rest body1))))
+                    (match bs with
+                     | [] -> FStar_Compiler_Effect.failwith "Impossible"
+                     | b::[] ->
+                         (FStar_TypeChecker_Cfg.log cfg
+                            (fun uu___5 ->
+                               let uu___6 =
+                                 FStar_Class_Show.show showable_closure c in
+                               FStar_Compiler_Util.print1 "\tShifted %s\n"
+                                 uu___6);
+                          (let uu___5 =
+                             let uu___6 =
+                               let uu___7 = fresh_memo () in
+                               ((FStar_Pervasives_Native.Some b), c, uu___7) in
+                             uu___6 :: env1 in
+                           norm cfg uu___5 stack_rest body))
+                     | b::tl ->
+                         (FStar_TypeChecker_Cfg.log cfg
+                            (fun uu___5 ->
+                               let uu___6 =
+                                 FStar_Class_Show.show showable_closure c in
+                               FStar_Compiler_Util.print1 "\tShifted %s\n"
+                                 uu___6);
+                          (let body1 =
+                             FStar_Syntax_Syntax.mk
+                               (FStar_Syntax_Syntax.Tm_abs
+                                  {
+                                    FStar_Syntax_Syntax.bs = tl;
+                                    FStar_Syntax_Syntax.body = body;
+                                    FStar_Syntax_Syntax.rc_opt = rc_opt
+                                  }) t1.FStar_Syntax_Syntax.pos in
+                           let uu___5 =
+                             let uu___6 =
+                               let uu___7 = fresh_memo () in
+                               ((FStar_Pervasives_Native.Some b), c, uu___7) in
+                             uu___6 :: env1 in
+                           norm cfg uu___5 stack_rest body1)))
                 | (MemoLazy r)::stack3 ->
                     (set_memo cfg r (env1, t1);
                      FStar_TypeChecker_Cfg.log cfg
@@ -3647,7 +2945,9 @@ let rec (norm :
                     FStar_Syntax_Subst.open_term uu___4 f in
                   match uu___3 with
                   | (closing, f1) ->
-                      let f2 = norm cfg (dummy :: env1) [] f1 in
+                      let f2 =
+                        let uu___4 = let uu___5 = dummy () in uu___5 :: env1 in
+                        norm cfg uu___4 [] f1 in
                       let t2 =
                         let uu___4 =
                           let uu___5 =
@@ -3683,16 +2983,18 @@ let rec (norm :
                       let c2 =
                         let uu___4 =
                           FStar_Compiler_List.fold_left
-                            (fun env2 -> fun uu___5 -> dummy :: env2) env1
-                            bs1 in
+                            (fun env2 ->
+                               fun uu___5 ->
+                                 let uu___6 = dummy () in uu___6 :: env2)
+                            env1 bs1 in
                         norm_comp cfg uu___4 c1 in
+                      let close_binders env2 bs2 =
+                        let uu___4 = env_subst env2 in
+                        FStar_Syntax_Subst.subst_binders uu___4 bs2 in
                       let bs2 =
                         if
                           (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.hnf
-                        then
-                          let uu___4 = close_binders cfg env1 bs1 in
-                          FStar_Pervasives_Native.__proj__Mktuple2__item___1
-                            uu___4
+                        then close_binders env1 bs1
                         else norm_binders cfg env1 bs1 in
                       let t2 = FStar_Syntax_Util.arrow bs2 c2 in
                       rebuild cfg env1 stack2 t2)
@@ -3980,7 +3282,8 @@ let rec (norm :
                          let uu___6 = fresh_memo () in
                          (env1, def, uu___6, false) in
                        Clos uu___5 in
-                     ((FStar_Pervasives_Native.Some binder), uu___4) in
+                     let uu___5 = fresh_memo () in
+                     ((FStar_Pervasives_Native.Some binder), uu___4, uu___5) in
                    uu___3 :: env1 in
                  (FStar_TypeChecker_Cfg.log cfg
                     (fun uu___4 ->
@@ -4092,8 +3395,10 @@ let rec (norm :
                                 } in
                               let env' =
                                 FStar_Compiler_List.fold_left
-                                  (fun env2 -> fun uu___10 -> dummy :: env2)
-                                  env1 bs in
+                                  (fun env2 ->
+                                     fun uu___10 ->
+                                       let uu___11 = dummy () in uu___11 ::
+                                         env2) env1 bs in
                               FStar_TypeChecker_Cfg.log cfg
                                 (fun uu___11 ->
                                    FStar_Compiler_Util.print_string
@@ -4172,11 +3477,11 @@ let rec (norm :
                                let env2 =
                                  let uu___4 =
                                    FStar_Compiler_List.map
-                                     (fun uu___5 -> dummy) xs1 in
+                                     (fun uu___5 -> dummy ()) xs1 in
                                  let uu___5 =
                                    let uu___6 =
                                      FStar_Compiler_List.map
-                                       (fun uu___7 -> dummy) lbs1 in
+                                       (fun uu___7 -> dummy ()) lbs1 in
                                    FStar_Compiler_List.op_At uu___6 env1 in
                                  FStar_Compiler_List.op_At uu___4 uu___5 in
                                let def_body1 = norm cfg env2 [] def_body in
@@ -4216,7 +3521,7 @@ let rec (norm :
                                }) lbs1 in
                     let env' =
                       let uu___3 =
-                        FStar_Compiler_List.map (fun uu___4 -> dummy) lbs2 in
+                        FStar_Compiler_List.map (fun uu___4 -> dummy ()) lbs2 in
                       FStar_Compiler_List.op_At uu___3 env1 in
                     let body2 = norm cfg env' [] body1 in
                     let uu___3 = FStar_Syntax_Subst.close_let_rec lbs2 body2 in
@@ -4281,9 +3586,11 @@ let rec (norm :
                                    }) t1.FStar_Syntax_Syntax.pos in
                             let memo = fresh_memo () in
                             let rec_env1 =
-                              (FStar_Pervasives_Native.None,
-                                (Clos (env1, fix_f_i, memo, true)))
-                              :: rec_env in
+                              let uu___4 =
+                                let uu___5 = fresh_memo () in
+                                (FStar_Pervasives_Native.None,
+                                  (Clos (env1, fix_f_i, memo, true)), uu___5) in
+                              uu___4 :: rec_env in
                             (rec_env1, (memo :: memos), (i + Prims.int_one)))
                    (FStar_Pervasives_Native.snd lbs)
                    (env1, [], Prims.int_zero) in
@@ -4309,7 +3616,8 @@ let rec (norm :
                                    (rec_env, (lb.FStar_Syntax_Syntax.lbdef),
                                      uu___8, false) in
                                  Clos uu___7 in
-                               (FStar_Pervasives_Native.None, uu___6) in
+                               let uu___7 = fresh_memo () in
+                               (FStar_Pervasives_Native.None, uu___6, uu___7) in
                              uu___5 :: env2) env1
                         (FStar_Pervasives_Native.snd lbs) in
                     (FStar_TypeChecker_Cfg.log cfg
@@ -4456,23 +3764,26 @@ let rec (norm :
                FStar_Compiler_Effect.failwith
                  "impossible: Tm_delayed on norm"
            | FStar_Syntax_Syntax.Tm_uvar uu___2 ->
-               if
-                 (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.check_no_uvars
-               then
-                 let uu___3 =
-                   let uu___4 =
-                     FStar_Compiler_Range_Ops.string_of_range
-                       t1.FStar_Syntax_Syntax.pos in
-                   let uu___5 =
-                     FStar_Class_Show.show FStar_Syntax_Print.showable_term
-                       t1 in
-                   FStar_Compiler_Util.format2
-                     "(%s) CheckNoUvars: Unexpected unification variable remains: %s"
-                     uu___4 uu___5 in
-                 FStar_Compiler_Effect.failwith uu___3
-               else
-                 (let uu___4 = inline_closure_env cfg env1 [] t1 in
-                  rebuild cfg env1 stack2 uu___4))
+               (if
+                  (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.check_no_uvars
+                then
+                  (let uu___4 =
+                     let uu___5 =
+                       FStar_Class_Show.show
+                         FStar_Compiler_Range_Ops.showable_range
+                         t1.FStar_Syntax_Syntax.pos in
+                     let uu___6 =
+                       FStar_Class_Show.show FStar_Syntax_Print.showable_term
+                         t1 in
+                     FStar_Compiler_Util.format2
+                       "(%s) CheckNoUvars: Unexpected unification variable remains: %s"
+                       uu___5 uu___6 in
+                   FStar_Compiler_Effect.failwith uu___4)
+                else ();
+                (let t2 =
+                   FStar_Errors.with_ctx "inlining"
+                     (fun uu___4 -> closure_as_term cfg env1 t1) in
+                 rebuild cfg env1 stack2 t2)))
 and (do_unfold_fv :
   FStar_TypeChecker_Cfg.cfg ->
     stack_elt Prims.list ->
@@ -4544,8 +3855,11 @@ and (do_unfold_fv :
                             FStar_Compiler_List.fold_left
                               (fun env2 ->
                                  fun u ->
-                                   (FStar_Pervasives_Native.None, (Univ u))
-                                   :: env2) empty_env us' in
+                                   let uu___4 =
+                                     let uu___5 = fresh_memo () in
+                                     (FStar_Pervasives_Native.None, (
+                                       Univ u), uu___5) in
+                                   uu___4 :: env2) empty_env us' in
                           norm cfg env1 stack2 t1))
                     | uu___2 when
                         (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.erase_universes
@@ -5343,8 +4657,7 @@ and (reify_lift :
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
       FStar_Syntax_Syntax.monad_name ->
         FStar_Syntax_Syntax.monad_name ->
-          FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
-            FStar_Syntax_Syntax.term)
+          FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
   =
   fun cfg ->
     fun e ->
@@ -5705,7 +5018,8 @@ and (norm_binders :
                  match uu___1 with
                  | (nbs', env2) ->
                      let b1 = norm_binder cfg env2 b in
-                     ((b1 :: nbs'), (dummy :: env2))) ([], env1) bs in
+                     let uu___2 = let uu___3 = dummy () in uu___3 :: env2 in
+                     ((b1 :: nbs'), uu___2)) ([], env1) bs in
         match uu___ with | (nbs, uu___1) -> FStar_Compiler_List.rev nbs
 and (maybe_simplify :
   FStar_TypeChecker_Cfg.cfg ->
@@ -7706,11 +7020,12 @@ and (do_rebuild :
                                (x.FStar_Syntax_Syntax.index);
                              FStar_Syntax_Syntax.sort = uu___3
                            } in
+                         let uu___3 = let uu___4 = dummy () in uu___4 :: env3 in
                          ({
                             FStar_Syntax_Syntax.v =
                               (FStar_Syntax_Syntax.Pat_var x1);
                             FStar_Syntax_Syntax.p = (p.FStar_Syntax_Syntax.p)
-                          }, (dummy :: env3))
+                          }, uu___3)
                      | FStar_Syntax_Syntax.Pat_dot_term eopt ->
                          let eopt1 =
                            FStar_Compiler_Util.map_option (norm_or_whnf env3)
@@ -8060,7 +7375,8 @@ and (do_rebuild :
                                                          (cfg1, ([], t1))) in
                                                 ([], t1, uu___8, false) in
                                               Clos uu___7 in
-                                            (uu___5, uu___6) in
+                                            let uu___7 = fresh_memo () in
+                                            (uu___5, uu___6, uu___7) in
                                           uu___4 :: env4) env2 s in
                              let uu___3 = guard_when_clause wopt b rest in
                              norm cfg1 env3 stack2 uu___3))) in
@@ -8090,7 +7406,9 @@ and (norm_match_returns :
             let uu___ = FStar_Syntax_Subst.open_ascription [b1] asc in
             (match uu___ with
              | (subst, asc1) ->
-                 let asc2 = norm_ascription cfg (dummy :: env1) asc1 in
+                 let asc2 =
+                   let uu___1 = let uu___2 = dummy () in uu___2 :: env1 in
+                   norm_ascription cfg uu___1 asc1 in
                  let uu___1 =
                    let uu___2 =
                      FStar_Syntax_Subst.close_ascription subst asc2 in
@@ -8255,7 +7573,8 @@ let (normalize_comp :
                (Prims.of_int (10));
              FStar_TypeChecker_Cfg.log_top cfg
                (fun uu___5 ->
-                  let uu___6 = FStar_Syntax_Print.comp_to_string c in
+                  let uu___6 =
+                    FStar_Class_Show.show FStar_Syntax_Print.showable_comp c in
                   FStar_Compiler_Util.print1
                     "Starting normalizer for computation (%s) {\n" uu___6);
              FStar_TypeChecker_Cfg.log_top cfg
@@ -8278,8 +7597,13 @@ let (normalize_comp :
               | (c1, ms) ->
                   (FStar_TypeChecker_Cfg.log_top cfg
                      (fun uu___9 ->
-                        let uu___10 = FStar_Syntax_Print.comp_to_string c1 in
-                        let uu___11 = FStar_Compiler_Util.string_of_int ms in
+                        let uu___10 =
+                          FStar_Class_Show.show
+                            FStar_Syntax_Print.showable_comp c1 in
+                        let uu___11 =
+                          FStar_Class_Show.show
+                            (FStar_Class_Show.printableshow
+                               FStar_Class_Printable.printable_int) ms in
                         FStar_Compiler_Util.print2
                           "}\nNormalization result = (%s) in %s ms\n" uu___10
                           uu___11);
@@ -9793,7 +9117,7 @@ let (get_n_binders :
       FStar_Syntax_Syntax.term ->
         (FStar_Syntax_Syntax.binder Prims.list * FStar_Syntax_Syntax.comp))
   = fun env1 -> fun n -> fun t -> get_n_binders' env1 [] n t
-let (uu___3784 : unit) =
+let (uu___3453 : unit) =
   FStar_Compiler_Effect.op_Colon_Equals __get_n_binders get_n_binders'
 let (maybe_unfold_head_fv :
   FStar_TypeChecker_Env.env ->

--- a/src/syntax/FStar.Syntax.Compress.fst
+++ b/src/syntax/FStar.Syntax.Compress.fst
@@ -72,7 +72,7 @@ makes .checked files more brittle, so we don't do it.
 *)
 let deep_compress (allow_uvars:bool) (allow_names: bool) (tm : term) : term =
   Err.with_ctx ("While deep-compressing a term") (fun () ->
-    Visit.visit_term_univs
+    Visit.visit_term_univs true
       (compress1_t allow_uvars allow_names)
       (compress1_u allow_uvars allow_names)
       tm
@@ -83,7 +83,7 @@ let deep_compress_uvars = deep_compress false true
 let deep_compress_if_no_uvars (tm : term) : option term =
   Err.with_ctx ("While deep-compressing a term") (fun () ->
     try 
-      Some (Visit.visit_term_univs
+      Some (Visit.visit_term_univs true
               (compress1_t false true)
               (compress1_u false true)
               tm)
@@ -93,7 +93,7 @@ let deep_compress_if_no_uvars (tm : term) : option term =
 
 let deep_compress_se (allow_uvars:bool) (allow_names:bool) (se : sigelt) : sigelt =
   Err.with_ctx (format1 "While deep-compressing %s" (Syntax.Print.sigelt_to_string_short se)) (fun () ->
-    Visit.visit_sigelt
+    Visit.visit_sigelt true
       (compress1_t allow_uvars allow_names)
       (compress1_u allow_uvars allow_names)
       se

--- a/src/syntax/FStar.Syntax.Visit.fst
+++ b/src/syntax/FStar.Syntax.Visit.fst
@@ -18,11 +18,11 @@ instance _ : monad id = {
 
 let (<<) f g = fun x -> f (g x)
 
-let visit_term vt t =
-  I?.run (visitM_term (I << vt) t)
+let visit_term pq vt t =
+  I?.run (visitM_term pq (I << vt) t)
 
-let visit_term_univs vt vu t =
-  I?.run (visitM_term_univs (I << vt) (I << vu) t)
+let visit_term_univs pq vt vu t =
+  I?.run (visitM_term_univs pq (I << vt) (I << vu) t)
 
-let visit_sigelt vt vu se =
-  I?.run (visitM_sigelt (I << vt) (I << vu) se)
+let visit_sigelt pq vt vu se =
+  I?.run (visitM_sigelt pq (I << vt) (I << vu) se)

--- a/src/syntax/FStar.Syntax.Visit.fsti
+++ b/src/syntax/FStar.Syntax.Visit.fsti
@@ -34,12 +34,26 @@ operator is applied to anything but constants, and leave everything else
 unchanged. As the traversal is bottom-up, this should fold expressions
 like (1+2)+(3+4) in a single call.
 *)
-val visit_term : (term -> term) -> term -> term
+val visit_term
+  (proc_quotes : bool)
+  (f : term -> term)
+  (t : term)
+  : term
 
 (* As above, but a callback for universes can also be provided that works
 in the same manner. In visit_term, it just defaults to the identity. *)
-val visit_term_univs : (term -> term) -> (universe -> universe) -> (term -> term)
+val visit_term_univs
+  (proc_quotes : bool)
+  (ft : term -> term)
+  (fu : universe -> universe)
+  (t : term)
+  : term
 
 (* As above, but works on any sigelt, visiting all of its underlying
 terms and universes. *)
-val visit_sigelt : (term -> term) -> (universe -> universe) -> (sigelt -> sigelt)
+val visit_sigelt
+  (proc_quotes : bool)
+  (vt : term -> term)
+  (vu : universe -> universe)
+  (t : sigelt)
+  : sigelt

--- a/src/syntax/FStar.Syntax.VisitM.fst
+++ b/src/syntax/FStar.Syntax.VisitM.fst
@@ -179,11 +179,11 @@ let on_sub_term #m {|d : lvm m |} (tm : term) : m term =
     let! t = t |> f_term in
     return <| mk (Tm_let {lbs=(is_rec, lbs); body=t})
 
-  | Tm_quoted (tm, qi) ->
-    let! tm = tm |> f_term in
-    // let! qi = Syntax.on_antiquoted (f_term vfs) qi in
-    // FIXME ^ no monadic variant
-    return <| mk (Tm_quoted (tm, qi))
+  | Tm_quoted (qtm, qi) ->
+    (* NB: We do not do anything on quoted terms. Usually the transformation
+    we want to apply (e.g. erasing universes, compressing, etc) should not
+    be propagated into a quoted term. We could consider a toggle to enable this. *)
+    return tm
 
   | Tm_meta {tm=t; meta=md} ->
     let! t   = t |> f_term in

--- a/src/syntax/FStar.Syntax.VisitM.fst
+++ b/src/syntax/FStar.Syntax.VisitM.fst
@@ -23,6 +23,8 @@ class lvm (m:Type->Type) : Type = {
   f_comp          : endo m comp;
   f_residual_comp : endo m residual_comp;
   f_univ          : endo m universe;
+
+  proc_quotes     : bool;
 }
 
 instance _lvm_monad (#m:_) (_ : lvm m) : Tot (monad m) = lvm_monad
@@ -36,6 +38,8 @@ let novfs (#m:Type->Type) {| monad m |} : lvm m = {
   f_comp          = return;
   f_residual_comp = return;
   f_univ          = return;
+
+  proc_quotes     = false;
 }
 
 let f_aqual #m {|_ : lvm m|} aq : m _ =
@@ -180,10 +184,13 @@ let on_sub_term #m {|d : lvm m |} (tm : term) : m term =
     return <| mk (Tm_let {lbs=(is_rec, lbs); body=t})
 
   | Tm_quoted (qtm, qi) ->
-    (* NB: We do not do anything on quoted terms. Usually the transformation
-    we want to apply (e.g. erasing universes, compressing, etc) should not
-    be propagated into a quoted term. We could consider a toggle to enable this. *)
-    return tm
+    if d.proc_quotes || qi.qkind = Quote_dynamic then
+      let! qtm = qtm |> f_term in
+      // let! qi = Syntax.on_antiquoted (f_term vfs) qi in
+      // FIXME ^ no monadic variant
+      return <| mk (Tm_quoted (qtm, qi))
+    else
+      return tm
 
   | Tm_meta {tm=t; meta=md} ->
     let! t   = t |> f_term in
@@ -491,21 +498,23 @@ let tie_bu (#m : Type -> Type) {| md : monad m |} (d : lvm m) : lvm m =
       f_comp          = (fun x -> f_comp          #_ #d <<| on_sub_comp          #_ #!r x);
       f_residual_comp = (fun x -> f_residual_comp #_ #d <<| on_sub_residual_comp #_ #!r x);
       f_univ          = (fun x -> f_univ          #_ #d <<| on_sub_univ          #_ #!r x);
+
+      proc_quotes     = d.proc_quotes;
     };
   !r
 
-let visitM_term_univs #m {| md : monad m |} vt vu (tm : term) : m term =
+let visitM_term_univs #m {| md : monad m |} (proc_quotes : bool) vt vu (tm : term) : m term =
   let dict : lvm m =
-    tie_bu #m #md { novfs #m #md with f_term = vt; f_univ = vu }
+    tie_bu #m #md { novfs #m #md with f_term = vt; f_univ = vu; proc_quotes = proc_quotes }
   in
   f_term #_ #dict tm
 
-let visitM_term #m {| md : monad m |} vt (tm : term) : m term =
-  visitM_term_univs vt return tm
+let visitM_term #m {| md : monad m |} (proc_quotes : bool) vt (tm : term) : m term =
+  visitM_term_univs true vt return tm
 
-let visitM_sigelt #m {| md : monad m |} vt vu (tm : sigelt) : m sigelt =
+let visitM_sigelt #m {| md : monad m |} (proc_quotes : bool) vt vu (tm : sigelt) : m sigelt =
   let dict : lvm m =
-    tie_bu #m #md { novfs #m #md with f_term = vt; f_univ = vu }
+    tie_bu #m #md { novfs #m #md with f_term = vt; f_univ = vu; proc_quotes = proc_quotes }
   in
   on_sub_sigelt #_ #dict tm
 

--- a/src/syntax/FStar.Syntax.VisitM.fsti
+++ b/src/syntax/FStar.Syntax.VisitM.fsti
@@ -9,12 +9,14 @@ open FStar.Class.Monad
 
 val visitM_term
   (#m:_) {| monad m |}
+  (proc_quotes : bool)
   (v : term -> m term)
   (t : term)
   : m term
 
 val visitM_term_univs
   (#m:_) {| monad m |}
+  (proc_quotes : bool)
   (vt : term -> m term)
   (vu : universe -> m universe)
   (t : term)
@@ -22,6 +24,7 @@ val visitM_term_univs
 
 val visitM_sigelt
   (#m:_) {| monad m |}
+  (proc_quotes : bool)
   (vt : term -> m term)
   (vu : universe -> m universe)
   (t : sigelt)

--- a/src/tactics/FStar.Tactics.Interpreter.fst
+++ b/src/tactics/FStar.Tactics.Interpreter.fst
@@ -167,7 +167,7 @@ let unembed_tactic_0 (eb:embedding 'b) (embedded_tac_b:term) (ncb:norm_cb) : tac
           (* Use the monadic visitor to check whether the reduced head
           contains an admit, which is a common error *)
           let r : option term =
-            Syntax.VisitM.visitM_term (fun t ->
+            Syntax.VisitM.visitM_term false (fun t ->
               match t.n with
               | Tm_fvar fv when fv_eq_lid fv PC.admit_lid -> None
               | _ -> Some t) h_result

--- a/src/tosyntax/FStar.ToSyntax.ToSyntax.fst
+++ b/src/tosyntax/FStar.ToSyntax.ToSyntax.fst
@@ -583,7 +583,7 @@ let rec generalize_annotated_univs (s:sigelt) :sigelt =
 
   (* Visit the sigelt and rely on side effects to capture all
   the names. This goes roughly in left-to-right order. *)
-  let _ = Visit.visit_sigelt
+  let _ = Visit.visit_sigelt false
             (fun t -> t)
             (fun u -> ignore (match u with
                               | U_name nm -> reg nm

--- a/src/typechecker/FStar.TypeChecker.Normalize.fst
+++ b/src/typechecker/FStar.TypeChecker.Normalize.fst
@@ -94,17 +94,23 @@ let cases f d = function
  * exact same object in memory. See read_memo and set_memo below. *)
 type cfg_memo 'a = memo (Cfg.cfg & 'a)
 
-let fresh_memo (#a:Type) () : cfg_memo a = BU.mk_ref None
+let fresh_memo (#a:Type) () : memo a = BU.mk_ref None
 
 type closure =
   | Clos of env & term & cfg_memo (env & term) & bool //memo for lazy evaluation; bool marks whether or not this is a fixpoint
   | Univ of universe                               //universe terms do not have free variables
   | Dummy                                          //Dummy is a placeholder for a binder when doing strong reduction
-and env = list (option binder&closure)
+and env = list (option binder & closure & memo subst_t)
+
+instance showable_memo (a:Type) (_ : showable a) : Tot (showable (memo a)) = {
+  show = (fun m -> match !m with
+                   | None -> "no_memo"
+                   | Some x -> "memo=" ^ show x)
+}
 
 let empty_env : env = []
 
-let dummy : option binder & closure = None,Dummy
+let dummy () : (option binder & closure & memo subst_t) = (None, Dummy, fresh_memo ())
 
 type branches = list (pat & option term & term)
 
@@ -172,7 +178,7 @@ let is_empty = function
     | _ -> false
 
 let lookup_bvar (env : env) x =
-    try snd (List.nth env x.index)
+    try (List.nth env x.index)._2
     with _ -> failwith (BU.format2 "Failed to find %s\nEnv is %s\n" (Print.db_to_string x) (show env))
 
 let downgrade_ghost_effect_name l =
@@ -217,7 +223,7 @@ let norm_universe cfg (env:env) u =
         match u with
           | U_bvar x ->
             begin
-                try match snd (List.nth env x) with
+                try match (List.nth env x)._2 with
                       | Univ u ->
                            if !dbg_univ_norm then
                                BU.print1 "Univ (in norm_universe): %s\n" (Print.univ_to_string u)
@@ -270,361 +276,53 @@ let norm_universe cfg (env:env) u =
         | [u] -> u
         | us -> U_max us
 
+let memo_or (m : memo 'a) (f : unit -> 'a) : 'a =
+  match !m with
+  | Some v -> v
+  | None ->
+    let v = f () in
+    m := Some v;
+    v
 
-(*******************************************************************)
-(* closure_as_term env t --- t is a closure with environment env   *)
-(* closure_as_term env t                                           *)
-(*      is a closed term with all its free variables               *)
-(*      subsituted with their closures in env (recursively closed) *)
-(* This is used when computing WHNFs                               *)
-(*******************************************************************)
-let rec inline_closure_env cfg (env:env) stack t =
-    log cfg (fun () -> BU.print3 ">>> %s (env=%s)\nClosure_as_term %s\n" (Print.tag_of_term t) (show env) (show t));
-    match env with
-    | [] when not <| cfg.steps.compress_uvars ->
-      rebuild_closure cfg env stack t
-
-    | _ ->
-      match t.n with
-      | Tm_delayed _ ->
-        inline_closure_env cfg env stack (compress t)
-
-      | Tm_unknown
-      | Tm_constant _
-      | Tm_name _
-      | Tm_lazy _
-      | Tm_fvar _ ->
-        rebuild_closure cfg env stack t
-
-      | Tm_uvar (uv, s) ->
-        if cfg.steps.check_no_uvars
-        then let t = compress t in
-             match t.n with
-             | Tm_uvar _ ->
-               failwith (BU.format2 "(%s): CheckNoUvars: Unexpected unification variable remains: %s"
-                        (Range.string_of_range t.pos)
-                        (show t))
-             | _ ->
-              inline_closure_env cfg env stack t
-        else
-            let s' = fst s |> List.map (fun s ->
-                    s |> List.map (function
-                | NT(x, t) ->
-                  NT(x, inline_closure_env cfg env [] t)
-                | NM(x, i) ->
-                  let x_i = S.bv_to_tm ({x with index=i}) in
-                  let t = inline_closure_env cfg env [] x_i in
-                  (match t.n with
-                   | Tm_bvar x_j -> NM(x, x_j.index)
-                   | _ -> NT(x, t))
-                | _ -> failwith "Impossible: subst invariant of uvar nodes"))
-             in
-             //let _ = match s with
-             //        | [], _
-             //        | [[]], _ -> ()
-             //        | _::_, _ -> BU.print2 "inline_closure_env\n\tBefore %s\n\t After %s"
-             //                               (List.map Print.subst_to_string (fst s) |> String.concat "@")
-             //                               (List.map Print.subst_to_string s' |> String.concat "@")
-             //        | _ -> () in
-             let t = {t with n=Tm_uvar(uv, (s', snd s))} in
-             rebuild_closure cfg env stack t
-
-      | Tm_type u ->
-        let t = mk (Tm_type (norm_universe cfg env u)) t.pos in
-        rebuild_closure cfg env stack t
-
-      | Tm_uinst(t', us) -> (* head symbol must be an fvar *)
-        let t = mk_Tm_uinst t' (List.map (norm_universe cfg env) us) in
-        rebuild_closure cfg env stack t
-
-      | Tm_bvar x ->
-        begin
-            match lookup_bvar env x with
-            | Univ _ -> failwith "Impossible: term variable is bound to a universe"
-            | Dummy ->
-              let x = {x with sort = S.tun} in
-              let t = mk (Tm_bvar x) t.pos in
-              rebuild_closure cfg env stack t
-            | Clos(env, t0, _, _) ->
-              inline_closure_env cfg env stack t0
-        end
-
-      | Tm_app {hd=head; args} ->
-        let stack =
-            stack |> List.fold_right
-            (fun (a, aq) stack -> Arg (Clos(env, a, fresh_memo (), false),aq,t.pos)::stack)
-            args
-        in
-        inline_closure_env cfg env stack head
-
-      | Tm_abs {bs; body; rc_opt=lopt} ->
-        let env' =
-            env |> List.fold_right
-            (fun _b env -> (None, Dummy)::env)
-            bs
-        in
-        let stack = (Abs(env, bs, env', lopt, t.pos)::stack) in
-        inline_closure_env cfg env' stack body
-
-      | Tm_arrow {bs; comp=c} ->
-        let bs, env' = close_binders cfg env bs in
-        let c = close_comp cfg env' c in
-        let t = mk (Tm_arrow {bs; comp=c}) t.pos in
-        rebuild_closure cfg env stack t
-
-      | Tm_refine {b=x}
-          when cfg.steps.for_extraction
-             || cfg.steps.unrefine ->
-        inline_closure_env cfg env stack x.sort
-
-      | Tm_refine {b=x; phi} ->
-        let x, env = close_binders cfg env [mk_binder x] in
-        let phi = non_tail_inline_closure_env cfg env phi in
-        let t = mk (Tm_refine {b=(List.hd x).binder_bv; phi}) t.pos in
-        rebuild_closure cfg env stack t
-
-      | Tm_ascribed {tm=t1; asc; eff_opt=lopt} ->
-        let asc = close_ascription cfg env asc in
-        let t =
-            mk (Tm_ascribed {tm=non_tail_inline_closure_env cfg env t1;
-                             asc;
-                             eff_opt=lopt}) t.pos
-        in
-        rebuild_closure cfg env stack t
-
-      | Tm_quoted (t', qi) ->
-        let t =
-            match qi.qkind with
-            | Quote_dynamic ->
-              mk (Tm_quoted(non_tail_inline_closure_env cfg env t', qi)) t.pos
-            | Quote_static  ->
-              let qi = S.on_antiquoted (non_tail_inline_closure_env cfg env) qi in
-              mk (Tm_quoted(t', qi)) t.pos
-        in
-        rebuild_closure cfg env stack t
-
-      | Tm_meta {tm=t'; meta=m} ->
-        let stack = Meta(env, m, t.pos)::stack in
-        inline_closure_env cfg env stack t'
-
-      | Tm_let {lbs=(false, [lb]); body} -> //non-recursive let
-        let env0 = env in
-        let env = List.fold_left (fun env _ -> dummy::env) env lb.lbunivs in
-        let typ = non_tail_inline_closure_env cfg env lb.lbtyp in
-        let def = non_tail_inline_closure_env cfg env lb.lbdef in
-        let nm, body =
-            if S.is_top_level [lb]
-            then lb.lbname, body
-            else let x = BU.left lb.lbname in
-                 Inl ({x with sort=typ}),
-                 non_tail_inline_closure_env cfg (dummy::env0) body
-        in
-        let attrs = List.map (non_tail_inline_closure_env cfg env0) lb.lbattrs in
-        let lb = {lb with lbname=nm; lbtyp=typ; lbdef=def; lbattrs=attrs} in
-        let t = mk (Tm_let {lbs=(false, [lb]); body}) t.pos in
-        rebuild_closure cfg env0 stack t
-
-      | Tm_let {lbs=(_,lbs); body} -> //recursive let
-        let norm_one_lb env lb =
-            let env_univs = List.fold_right (fun _ env -> dummy::env) lb.lbunivs env in
-            let env =
-                if S.is_top_level lbs
-                then env_univs
-                else List.fold_right (fun _ env -> dummy::env) lbs env_univs in
-            let ty = non_tail_inline_closure_env cfg env_univs lb.lbtyp in
-            let nm =
-                if S.is_top_level lbs
-                then lb.lbname
-                else let x = BU.left lb.lbname in
-                     Inl ({x with sort=ty})
-            in
-            {lb with lbname=nm;
-                     lbtyp=ty;
-                     lbdef=non_tail_inline_closure_env cfg env lb.lbdef}
-        in
-        let lbs = lbs |> List.map (norm_one_lb env) in
-        let body =
-            let body_env = List.fold_right (fun _ env -> dummy::env) lbs env in
-            non_tail_inline_closure_env cfg body_env body in
-        let t = mk (Tm_let {lbs=(true, lbs); body}) t.pos in
-        rebuild_closure cfg env stack t
-
-      | Tm_match {scrutinee=head; ret_opt=asc_opt; brs=branches; rc_opt=lopt} ->
-        let stack = Match(env, asc_opt, branches, lopt, cfg, t.pos)::stack in
-        inline_closure_env cfg env stack head
-
-and non_tail_inline_closure_env cfg env t =
-    inline_closure_env cfg env [] t
-
-and rebuild_closure cfg env stack t =
-    log cfg (fun () -> BU.print4 ">>> %s (env=%s, stack=%s)\nRebuild closure_as_term %s\n" (Print.tag_of_term t) (show env) (show stack) (show t));
-    match stack with
-    | [] -> t
-
-    | Arg (Clos(env_arg, tm, _, _), aq, r) :: stack ->
-      let stack = App(env, t, aq, r)::stack in
-      inline_closure_env cfg env_arg stack tm
-
-    | App(env, head, aq, r)::stack ->
-      let t = S.extend_app head (t,aq) r in
-      rebuild_closure cfg env stack t
-
-    | CBVApp(env, head, aq, r)::stack ->
-      let t = S.extend_app head (t,aq) r in
-      rebuild_closure cfg env stack t
-
-    | Abs (env', bs, env'', lopt, r)::stack ->
-      let bs, _ = close_binders cfg env' bs in
-      let lopt = close_lcomp_opt cfg env'' lopt in
-      rebuild_closure cfg env stack ({abs bs t lopt with pos=r})
-
-    | Match(env, asc_opt, branches, lopt, cfg, r)::stack ->
-      let lopt = close_lcomp_opt cfg env lopt in
-      let close_one_branch env (pat, w_opt, tm) =
-          let rec norm_pat env p =
-            match p.v with
-            | Pat_constant _ ->
-              p, env
-            | Pat_cons(fv, us_opt, pats) ->
-              let us_opt =
-                if cfg.steps.erase_universes
-                then None
-                else (
-                  match us_opt with
-                  | None -> None
-                  | Some us -> Some (List.map (norm_universe cfg env) us)
-                )
-              in
-              let pats, env =
-                  pats |> List.fold_left
-                  (fun (pats, env) (p, b) ->
-                    let p, env = norm_pat env p in (p,b)::pats, env)
-                  ([], env)
-              in
-              {p with v=Pat_cons(fv, us_opt, List.rev pats)}, env
-            | Pat_var x ->
-              let x = {x with sort=non_tail_inline_closure_env cfg env x.sort} in
-              {p with v=Pat_var x}, dummy::env
-            | Pat_dot_term eopt ->
-              let eopt = BU.map_option (non_tail_inline_closure_env cfg env) eopt in
-              {p with v=Pat_dot_term eopt}, env
-          in
-          let pat, env = norm_pat env pat in
-          let w_opt =
-              match w_opt with
-              | None -> None
-              | Some w -> Some (non_tail_inline_closure_env cfg env w) in
-          let tm = non_tail_inline_closure_env cfg env tm in
-          (pat, w_opt, tm)
-      in
-      let t =
-          mk (Tm_match {scrutinee=t;
-                        ret_opt=close_match_returns cfg env asc_opt;
-                        brs=branches |> List.map (close_one_branch env);
-                        rc_opt=lopt}) t.pos
-      in
-      rebuild_closure cfg env stack t
-
-    | Meta(env_m, m, r)::stack ->
-      let m =
-          match m with
-          | Meta_pattern (names, args) ->
-            Meta_pattern (names |> List.map (non_tail_inline_closure_env cfg env_m),
-                          args |> List.map (fun args ->
-                                            args |> List.map (fun (a, q) ->
-                                            non_tail_inline_closure_env cfg env_m a, q)))
-
-          | Meta_monadic(m, tbody) ->
-            Meta_monadic(m, non_tail_inline_closure_env cfg env_m tbody)
-
-          | Meta_monadic_lift(m1, m2, tbody) ->
-            Meta_monadic_lift(m1, m2, non_tail_inline_closure_env cfg env_m tbody)
-
-          | _ -> //other metadata's do not have any embedded closures
-            m
-      in
-      let t = mk (Tm_meta {tm=t; meta=m}) r in
-      rebuild_closure cfg env stack t
-
-    | _ -> failwith "Impossible: unexpected stack element"
-
-
-and close_match_returns cfg env ret_opt =
-  match ret_opt with
-  | None -> None
-  | Some (b, asc) ->
-    let bs, env = close_binders cfg env [b] in
-    let asc = close_ascription cfg env asc in
-    Some (List.hd bs, asc)
-
-and close_ascription cfg env (annot, tacopt, use_eq) =
-  let annot =
-    match annot with
-    | Inl t -> Inl (non_tail_inline_closure_env cfg env t)
-    | Inr c -> Inr (close_comp cfg env c) in
-  let tacopt = BU.map_opt tacopt (non_tail_inline_closure_env cfg env) in
-  annot, tacopt, use_eq
-
-and close_imp cfg env imp =
-    match imp with
-    | Some (S.Meta t) -> Some (S.Meta (inline_closure_env cfg env [] t))
-    | i -> i
-
-and close_binders cfg env bs =
-    let env, bs = bs |> List.fold_left (fun (env, out) ({binder_bv=b; binder_qual=imp; binder_positivity=pqual; binder_attrs=attrs}) ->
-            let b = {b with sort = inline_closure_env cfg env [] b.sort} in
-            let imp = close_imp cfg env imp in
-            let attrs = List.map (non_tail_inline_closure_env cfg env) attrs in
-            let env = dummy::env in
-            env, ((S.mk_binder_with_attrs b imp pqual attrs)::out)) (env, []) in
-    List.rev bs, env
-
-and close_comp cfg env c =
-    match env with
-    | [] when not <| cfg.steps.compress_uvars -> c
-    | _ ->
-      match c.n with
-      | Total t ->
-        mk_Total (inline_closure_env cfg env [] t)
-
-      | GTotal t ->
-        mk_GTotal (inline_closure_env cfg env [] t)
-
-      | Comp c ->
-        let rt = inline_closure_env cfg env [] c.result_typ in
-        let args =
-            c.effect_args |>
-            List.map (fun (a, q) -> inline_closure_env cfg env [] a, q)
-        in
-        let flags =
-            c.flags |>
-            List.map (function
-                | DECREASES (Decreases_lex l) ->
-                  DECREASES (l |> List.map (inline_closure_env cfg env []) |> Decreases_lex)
-                | DECREASES (Decreases_wf (rel, e)) ->
-                  DECREASES (Decreases_wf (inline_closure_env cfg env [] rel,
-                                           inline_closure_env cfg env [] e))
-                | f -> f)
-        in
-        mk_Comp ({c with comp_univs=List.map (norm_universe cfg env) c.comp_univs;
-                result_typ=rt;
-                effect_args=args;
-                flags=flags})
-
-and close_lcomp_opt cfg env lopt = match lopt with
-    | Some rc ->
-      let flags =
-          rc.residual_flags |>
-          List.filter (function DECREASES _ -> false | _ -> true) in
-      let rc = {rc with residual_flags=flags; residual_typ=BU.map_opt rc.residual_typ (inline_closure_env cfg env [])} in
-      Some rc
-    | _ -> lopt
+let rec env_subst (env:env) : subst_t =
+  let compute () =
+    let (s, _) =
+      List.fold_left (fun (s, i) (_, c, _) ->
+          match c with
+          | Clos (e, t, memo, (* closed_memo, *) fix) ->
+              // let es = memo_or closed_memo (fun () -> env_subst e) in
+              let es = env_subst e in
+              let t = SS.subst es t |> SS.compress in
+              (DT (i, t) :: s, i+1)
+          | Univ u -> (UN (i, u) :: s, i+1)
+          | Dummy -> (s,i+1)
+      ) ([], 0) env
+    in
+    (* NB: The order of the list does not matter, we are building
+      a parallel substitution. *)
+    s
+  in
+  match env with
+  | [] -> []
+  | (_, _, memo) :: _ ->
+    match !memo with
+    | Some s -> s
+    | None ->
+      let s = compute () in
+      memo := Some s;
+      s
 
 let filter_out_lcomp_cflags flags =
     (* TODO : lc.comp might have more cflags than lcomp.cflags *)
     flags |> List.filter (function DECREASES _ -> false | _ -> true)
 
-let closure_as_term cfg env t = non_tail_inline_closure_env cfg env t
+let closure_as_term cfg (env:env) (t:term) : term =
+  log cfg (fun () -> BU.print3 ">>> %s (env=%s)\nClosure_as_term %s\n" (Print.tag_of_term t) (show env) (show t));
+  let es = env_subst env in
+  let t = SS.subst es t in
+  (* Compress the top only since clients expect a compressed term *)
+  let t = SS.compress t in
+  t
 
 (* A hacky knot, set by FStar.Main *)
 let unembed_binder_knot : ref (option (EMB.embedding binder)) = BU.mk_ref None
@@ -635,9 +333,9 @@ let unembed_binder (t : term) : option S.binder =
         Errors.log_issue t.pos (Errors.Warning_UnembedBinderKnot, "unembed_binder_knot is unset!");
         None
 
-let mk_psc_subst cfg env =
+let mk_psc_subst cfg (env:env) =
     List.fold_right
-        (fun (binder_opt, closure) subst ->
+        (fun (binder_opt, closure, _) subst ->
             match binder_opt, closure with
             | Some b, Clos(env, term, _, _) ->
                 // BU.print1 "++++++++++++Name in environment is %s" (Print.binder_to_string b);
@@ -662,7 +360,7 @@ let mk_psc_subst cfg env =
 (* Boolean indicates whether further normalization of the result is
 required. It is usually false, unless we call into a 'renorm' primitive
 step. *)
-let reduce_primops norm_cb cfg env tm : term & bool =
+let reduce_primops norm_cb cfg (env:env) tm : term & bool =
     if not cfg.steps.primops
     then tm, false
     else begin
@@ -1373,7 +1071,7 @@ let rec norm : cfg -> env -> stack -> term -> term =
               then let t = closure_as_term cfg env t in
                    rebuild cfg env stack t
               else let bs, body, opening = open_term' bs body in
-                   let env' = bs |> List.fold_left (fun env _ -> dummy::env) env in
+                   let env' = bs |> List.fold_left (fun env _ -> dummy () ::env) env in
                    let rc_opt =
                      let open FStar.Class.Monad in
                      let! rc = rc_opt in
@@ -1386,49 +1084,49 @@ let rec norm : cfg -> env -> stack -> term -> term =
                    rebuild cfg env stack body_norm
             in
             begin match stack with
-                | UnivArgs _::_ ->
-                  failwith "Ill-typed term: universes cannot be applied to term abstraction"
+            | UnivArgs _::_ ->
+              failwith "Ill-typed term: universes cannot be applied to term abstraction"
 
-                | Arg(c, _, _)::stack_rest ->
-                  begin match c with
-                    | Univ _ -> //universe variables do not have explicit binders
-                      norm cfg ((None,c)::env) stack_rest t
+            | Arg (Univ u, _, _)::stack_rest ->
+              norm cfg ((None, Univ u, fresh_memo ()) :: env) stack_rest t
+              // universe variables do not have explicit binders
 
-                    | _ ->
-                     (* Note: we peel off one application at a time.
-                              An optimization to attempt would be to push n-args are once,
-                              and try to pop all of them at once, in the common case of a full application.
-                      *)
-                      begin match bs with
-                        | [] -> failwith "Impossible"
-                        | [b] ->
-                          log cfg  (fun () -> BU.print1 "\tShifted %s\n" (show c));
-                          norm cfg ((Some b, c) :: env) stack_rest body
-                        | b::tl ->
-                          log cfg  (fun () -> BU.print1 "\tShifted %s\n" (show c));
-                          let body = mk (Tm_abs {bs=tl; body; rc_opt}) t.pos in
-                          norm cfg ((Some b, c) :: env) stack_rest body
-                      end
-                  end
+            | Arg (c, _, _)::stack_rest ->
+              (* Note: we peel off one application at a time.
+                       An optimization to attempt would be to push n-args are once,
+                       and try to pop all of them at once, in the common case of a full application.
+               *)
+              begin match bs with
+              | [] -> failwith "Impossible"
+              | [b] ->
+                log cfg  (fun () -> BU.print1 "\tShifted %s\n" (show c));
+                norm cfg ((Some b, c, fresh_memo()) :: env) stack_rest body
+              | b::tl ->
+                log cfg  (fun () -> BU.print1 "\tShifted %s\n" (show c));
+                let body = mk (Tm_abs {bs=tl; body; rc_opt}) t.pos in
+                norm cfg ((Some b, c, fresh_memo()) :: env) stack_rest body
+              end
 
-                | MemoLazy r :: stack ->
-                  set_memo cfg r (env, t); //We intentionally do not memoize the strong normal form; only the WHNF
-                  log cfg  (fun () -> BU.print1 "\tSet memo %s\n" (show t));
-                  norm cfg env stack t
-                | Meta _::_ ->
-                  //
-                  //Top of the stack is a meta, try stripping meta DIV nodes that
-                  //  may be blocking reduction
-                  //
-                  (match maybe_strip_meta_divs stack with
-                   | None -> fallback ()
-                   | Some stack -> norm cfg env stack t)
-                | Match _::_
-                | Let _ :: _
-                | App _ :: _
-                | CBVApp _ :: _
-                | Abs _ :: _
-                | [] -> fallback ()
+            | MemoLazy r :: stack ->
+              set_memo cfg r (env, t); //We intentionally do not memoize the strong normal form; only the WHNF
+              log cfg  (fun () -> BU.print1 "\tSet memo %s\n" (show t));
+              norm cfg env stack t
+
+            | Meta _::_ ->
+              //
+              //Top of the stack is a meta, try stripping meta DIV nodes that
+              //  may be blocking reduction
+              //
+              (match maybe_strip_meta_divs stack with
+               | None -> fallback ()
+               | Some stack -> norm cfg env stack t)
+            | Match _::_
+            | Let _ :: _
+            | App _ :: _
+            | CBVApp _ :: _
+            | Abs _ :: _
+            | [] ->
+              fallback ()
             end
 
           | Tm_app {hd=head; args} ->
@@ -1518,7 +1216,7 @@ let rec norm : cfg -> env -> stack -> term -> term =
                     | _ -> rebuild cfg env stack (closure_as_term cfg env t)
             else let t_x = norm cfg env [] x.sort in
                  let closing, f = open_term [mk_binder x] f in
-                 let f = norm cfg (dummy::env) [] f in
+                 let f = norm cfg (dummy () ::env) [] f in
                  let t = mk (Tm_refine {b={x with sort=t_x}; phi=close closing f}) t.pos in
                  rebuild cfg env stack t
 
@@ -1526,8 +1224,11 @@ let rec norm : cfg -> env -> stack -> term -> term =
             if cfg.steps.weak
             then rebuild cfg env stack (closure_as_term cfg env t)
             else let bs, c = open_comp bs c in
-                 let c = norm_comp cfg (bs |> List.fold_left (fun env _ -> dummy::env) env) c in
-                 let bs = if cfg.steps.hnf then (close_binders cfg env bs)._1 else norm_binders cfg env bs in
+                 let c = norm_comp cfg (bs |> List.fold_left (fun env _ -> dummy () ::env) env) c in
+                 let close_binders env (bs:binders) : binders =
+                   SS.subst_binders (env_subst env) bs
+                 in
+                 let bs = if cfg.steps.hnf then close_binders env bs else norm_binders cfg env bs in
                  let t = arrow bs c in
                  rebuild cfg env stack t
 
@@ -1597,7 +1298,7 @@ let rec norm : cfg -> env -> stack -> term -> term =
                   * computation. We need to remove it to maintain a proper
                   * term structure. See the discussion in PR #2024. *)
                  let def = U.unmeta_lift lb.lbdef in
-                 let env = (Some binder, Clos(env, def, fresh_memo(), false))::env in
+                 let env = (Some binder, Clos(env, def, fresh_memo(), false), fresh_memo ())::env in
                  log cfg (fun () -> BU.print_string "+++ Reducing Tm_let\n");
                  norm cfg env stack body
 
@@ -1625,7 +1326,7 @@ let rec norm : cfg -> env -> stack -> term -> term =
                                    lbtyp=ty;
                                    lbdef=norm cfg env [] lb.lbdef;
                                    lbattrs=List.map (norm cfg env []) lb.lbattrs} in
-                 let env' = bs |> List.fold_left (fun env _ -> dummy::env) env in
+                 let env' = bs |> List.fold_left (fun env _ -> dummy () ::env) env in
                  log cfg (fun () -> BU.print_string "+++ Normalizing Tm_let -- body\n");
                  let cfg' = { cfg with strong = true } in
                  let body_norm = norm cfg' env' (Let (env, bs, lb, t.pos) :: []) body in
@@ -1642,8 +1343,8 @@ let rec norm : cfg -> env -> stack -> term -> term =
                 let lbname = Inl ({BU.left lb.lbname with sort=ty}) in
                 let xs, def_body, lopt = U.abs_formals lb.lbdef in
                 let xs = norm_binders cfg env xs in
-                let env = List.map (fun _ -> dummy) xs //first the bound vars for the arguments
-                        @ List.map (fun _ -> dummy) lbs //then the recursively bound names
+                let env = List.map (fun _ -> dummy ()) xs //first the bound vars for the arguments
+                        @ List.map (fun _ -> dummy ()) lbs //then the recursively bound names
                         @ env in
                 let def_body = norm cfg env [] def_body in
                 let lopt =
@@ -1654,7 +1355,7 @@ let rec norm : cfg -> env -> stack -> term -> term =
                 { lb with lbname = lbname;
                           lbtyp = ty;
                           lbdef = def}) lbs in
-            let env' = List.map (fun _ -> dummy) lbs @ env in
+            let env' = List.map (fun _ -> dummy ()) lbs @ env in
             let body = norm cfg env' [] body in
             let lbs, body = Subst.close_let_rec lbs body in
             let t = {t with n=Tm_let {lbs=(true, lbs); body}} in
@@ -1679,12 +1380,12 @@ let rec norm : cfg -> env -> stack -> term -> term =
                     let f_i = Syntax.bv_to_tm bv in
                     let fix_f_i = mk (Tm_let {lbs; body=f_i}) t.pos in
                     let memo = fresh_memo () in
-                    let rec_env = (None, Clos(env, fix_f_i, memo, true))::rec_env in
+                    let rec_env = (None, Clos(env, fix_f_i, memo, true), fresh_memo ())::rec_env in
                     rec_env, memo::memos, i + 1) (snd lbs) (env, [], 0) in
             let _ = List.map2 (fun lb memo -> memo := Some (cfg, (rec_env, lb.lbdef))) (snd lbs) memos in //tying the knot
             // NB: fold_left, since the binding structure of lbs is that righmost is closer, while in the env leftmost
             // is closer. In other words, the last element of lbs is index 0 for body, hence needs to be pushed last.
-            let body_env = List.fold_left (fun env lb -> (None, Clos(rec_env, lb.lbdef, fresh_memo(), false))::env)
+            let body_env = List.fold_left (fun env lb -> (None, Clos(rec_env, lb.lbdef, fresh_memo(), false), fresh_memo())::env)
                                env (snd lbs) in
             log cfg (fun () -> BU.print1 "reducing with knot %s\n" "");
             norm cfg body_env stack body
@@ -1770,12 +1471,11 @@ let rec norm : cfg -> env -> stack -> term -> term =
           failwith "impossible: Tm_delayed on norm"
 
         | Tm_uvar _ ->
-          if cfg.steps.check_no_uvars
-          then failwith (BU.format2 "(%s) CheckNoUvars: Unexpected unification variable remains: %s"
-                                  (Range.string_of_range t.pos)
-                                  (show t))
-          else rebuild cfg env stack (inline_closure_env cfg env [] t)
-
+          if cfg.steps.check_no_uvars then
+            failwith (BU.format2 "(%s) CheckNoUvars: Unexpected unification variable remains: %s"
+                                  (show t.pos) (show t));
+          let t = Errors.with_ctx "inlining" (fun () -> closure_as_term cfg env t) in
+          rebuild cfg env stack t
 
 (* NOTE: we do not need any environment here, since an fv does not
  * have any free indices. Hence, we use empty_env as environment when needed. *)
@@ -1805,7 +1505,7 @@ and do_unfold_fv (cfg:Cfg.cfg) stack (t0:term) (qninfo : qninfo) (f:fv) : term =
                   if !dbg_univ_norm then
                       List.iter (fun x -> BU.print1 "Univ (normalizer) %s\n" (Print.univ_to_string x)) us'
                   else ();
-                  let env = us' |> List.fold_left (fun env u -> (None, Univ u)::env) empty_env in
+                  let env = us' |> List.fold_left (fun env u -> (None, Univ u, fresh_memo ())::env) empty_env in
                   norm cfg env stack t
                 | _ when cfg.steps.erase_universes || cfg.steps.allow_unbound_universes ->
                   norm cfg empty_env stack t
@@ -2249,7 +1949,7 @@ and norm_binders : cfg -> env -> binders -> binders =
     fun cfg env bs ->
         let nbs, _ = List.fold_left (fun (nbs', env) b ->
             let b = norm_binder cfg env b in
-            (b::nbs', dummy::env) (* crossing a binder, so shift environment *))
+            (b::nbs', dummy () ::env) (* crossing a binder, so shift environment *))
             ([], env)
             bs in
         List.rev nbs
@@ -2797,7 +2497,7 @@ and do_rebuild (cfg:cfg) (env:env) (stack:stack) (t:term) : term =
               {p with v=Pat_cons(fv, us_opt, List.rev pats)}, env
             | Pat_var x ->
               let x = {x with sort=norm_or_whnf env x.sort} in
-              {p with v=Pat_var x}, dummy::env
+              {p with v=Pat_var x}, dummy () ::env
             | Pat_dot_term eopt ->
               let eopt = BU.map_option (norm_or_whnf env) eopt in
               {p with v=Pat_dot_term eopt}, env
@@ -2976,7 +2676,8 @@ and do_rebuild (cfg:cfg) (env:env) (stack:stack) (t:term) : term =
                 //In that case, do not set the memo reference
                 let env = List.fold_left
                       (fun env (bv, t) -> (Some (S.mk_binder bv),
-                                        Clos([], t, BU.mk_ref (if cfg.steps.hnf then None else Some (cfg, ([], t))), false))::env)
+                                           Clos([], t, BU.mk_ref (if cfg.steps.hnf then None else Some (cfg, ([], t))), false),
+                                           fresh_memo ()) :: env)
                       env s in
                 norm cfg env stack (guard_when_clause wopt b rest)
         in
@@ -2991,7 +2692,7 @@ and norm_match_returns cfg env ret_opt =
   | Some (b, asc) ->
     let b = norm_binder cfg env b in
     let subst, asc = SS.open_ascription [b] asc in
-    let asc = norm_ascription cfg (dummy::env) asc in
+    let asc = norm_ascription cfg (dummy()::env) asc in
     Some (b, SS.close_ascription subst asc)
 
 and norm_ascription cfg env (tc, tacopt, use_eq) =
@@ -3006,7 +2707,7 @@ and norm_residual_comp cfg env (rc:residual_comp) : residual_comp =
 
 let reflection_env_hook = BU.mk_ref None
 
-let normalize_with_primitive_steps ps s e t =
+let normalize_with_primitive_steps ps s e (t:term) =
   let is_nbe = is_nbe_request s in
   let maybe_nbe = if is_nbe then " (NBE)" else "" in
   Errors.with_ctx ("While normalizing a term" ^ maybe_nbe) (fun () ->
@@ -3041,14 +2742,14 @@ let normalize_comp s e c =
     let cfg = config s e in
     reflection_env_hook := Some e;
     plugin_unfold_warn_ctr := 10;
-    log_top cfg (fun () -> BU.print1 "Starting normalizer for computation (%s) {\n" (Print.comp_to_string c));
+    log_top cfg (fun () -> BU.print1 "Starting normalizer for computation (%s) {\n" (show c));
     log_top cfg (fun () -> BU.print1 ">>> cfg = %s\n" (show cfg));
     def_check_scoped c.pos "normalize_comp call" e c;
     let (c, ms) = Errors.with_ctx "While normalizing a computation type" (fun () ->
                     BU.record_time (fun () ->
                       norm_comp cfg [] c))
     in
-    log_top cfg (fun () -> BU.print2 "}\nNormalization result = (%s) in %s ms\n" (Print.comp_to_string c) (string_of_int ms));
+    log_top cfg (fun () -> BU.print2 "}\nNormalization result = (%s) in %s ms\n" (show c) (show ms));
     c)
   (Some (Ident.string_of_lid (Env.current_module e)))
   "FStar.TypeChecker.Normalize.normalize_comp"

--- a/src/typechecker/FStar.TypeChecker.Normalize.fst
+++ b/src/typechecker/FStar.TypeChecker.Normalize.fst
@@ -316,10 +316,21 @@ let filter_out_lcomp_cflags flags =
     (* TODO : lc.comp might have more cflags than lcomp.cflags *)
     flags |> List.filter (function DECREASES _ -> false | _ -> true)
 
+let default_univ_uvars_to_zero (t:term) : term =
+  Visit.visit_term_univs (fun t -> t) (fun u ->
+    match u with
+    | U_unif _ -> U_zero
+    | _ -> u) t
+
 let closure_as_term cfg (env:env) (t:term) : term =
   log cfg (fun () -> BU.print3 ">>> %s (env=%s)\nClosure_as_term %s\n" (Print.tag_of_term t) (show env) (show t));
   let es = env_subst env in
   let t = SS.subst es t in
+  let t =
+     if cfg.steps.default_univs_to_zero
+     then default_univ_uvars_to_zero t
+     else t
+  in
   (* Compress the top only since clients expect a compressed term *)
   let t = SS.compress t in
   t

--- a/src/typechecker/FStar.TypeChecker.Normalize.fst
+++ b/src/typechecker/FStar.TypeChecker.Normalize.fst
@@ -317,13 +317,13 @@ let filter_out_lcomp_cflags flags =
     flags |> List.filter (function DECREASES _ -> false | _ -> true)
 
 let default_univ_uvars_to_zero (t:term) : term =
-  Visit.visit_term_univs (fun t -> t) (fun u ->
+  Visit.visit_term_univs false (fun t -> t) (fun u ->
     match u with
     | U_unif _ -> U_zero
     | _ -> u) t
 
 let _erase_universes (t:term) : term =
-  Visit.visit_term_univs (fun t -> t) (fun u -> U_unknown) t
+  Visit.visit_term_univs false (fun t -> t) (fun u -> U_unknown) t
 
 let closure_as_term cfg (env:env) (t:term) : term =
   log cfg (fun () -> BU.print3 ">>> %s (env=%s)\nClosure_as_term %s\n" (Print.tag_of_term t) (show env) (show t));
@@ -773,7 +773,7 @@ let is_quantified_const cfg (bv:bv) (phi : term) : option term =
     in
     let replace_full_applications_with (bv:S.bv) (arity:int) (s:term) (t:term) : term & bool =
       let chgd = BU.mk_ref false in
-      let t' = t |> Syntax.Visit.visit_term (fun t ->
+      let t' = t |> Syntax.Visit.visit_term false (fun t ->
                       let hd, args = U.head_and_args t in
                       if List.length args = arity && is_bv bv hd then (
                         chgd := true;

--- a/src/typechecker/FStar.TypeChecker.Normalize.fst
+++ b/src/typechecker/FStar.TypeChecker.Normalize.fst
@@ -322,17 +322,23 @@ let default_univ_uvars_to_zero (t:term) : term =
     | U_unif _ -> U_zero
     | _ -> u) t
 
+let _erase_universes (t:term) : term =
+  Visit.visit_term_univs (fun t -> t) (fun u -> U_unknown) t
+
 let closure_as_term cfg (env:env) (t:term) : term =
   log cfg (fun () -> BU.print3 ">>> %s (env=%s)\nClosure_as_term %s\n" (Print.tag_of_term t) (show env) (show t));
   let es = env_subst env in
   let t = SS.subst es t in
   let t =
-     if cfg.steps.default_univs_to_zero
+     if cfg.steps.erase_universes
+     then _erase_universes t
+     else if cfg.steps.default_univs_to_zero
      then default_univ_uvars_to_zero t
      else t
   in
   (* Compress the top only since clients expect a compressed term *)
   let t = SS.compress t in
+  log cfg (fun () -> BU.print3 ">>> %s (env=%s)\nClosure_as_term RESULT %s\n" (Print.tag_of_term t) (show env) (show t));
   t
 
 (* A hacky knot, set by FStar.Main *)

--- a/tests/micro-benchmarks/Misc.Norm2.fst
+++ b/tests/micro-benchmarks/Misc.Norm2.fst
@@ -1,0 +1,18 @@
+module Misc.Norm2
+
+(* During PR https://github.com/FStarLang/FStar/pull/3385, this once
+triggered a failwith in the normalizer due to not respecting erase_universes. *)
+
+open FStar.Mul
+
+type comm_monoid (t:Type) = {
+  one: t;
+}
+
+[@(strict_on_arguments [3])]
+let pow (#t:Type) (k:comm_monoid t) (x:t) (n:nat) : t =
+  x
+
+assume
+val lemma_pow_mul: #t:Type -> k:comm_monoid t -> x:t -> n:nat -> m:nat ->
+  Lemma (pow k x m == pow k x m)

--- a/tests/micro-benchmarks/Misc.Norm3.fst
+++ b/tests/micro-benchmarks/Misc.Norm3.fst
@@ -1,0 +1,36 @@
+module Misc.Norm3
+
+(* This is inspired by a regression in Pulse during the development
+of https://github.com/FStarLang/FStar/pull/3385. If the pass to erase
+universes during SMT encoding operates under the quoted universes, this
+will fail to typecheck. *)
+
+open FStar.Ghost
+open FStar.Tactics
+open FStar.Reflection.Typing
+
+[@@erasable]
+noeq
+type my_erased (a:Type) = | E of a
+
+let test (r_env goal : _) : Tac unit =
+  let u0 = pack_universe Uv_Zero in
+  let goal_typing :
+    my_erased (typing_token r_env goal (E_Total, pack_ln (Tv_Type u0)))
+    = magic()
+  in
+  let goal_typing_tok : squash (typing_token r_env goal (E_Total, pack_ln (Tv_Type u0))) =
+    match goal_typing with E x -> ()
+  in
+  ()
+
+(* This should always work regardless of the comment above. *)
+let test2 (r_env goal u0 : _) : Tac unit =
+  let goal_typing :
+    my_erased (typing_token r_env goal (E_Total, pack_ln (Tv_Type u0)))
+    = magic()
+  in
+  let goal_typing_tok : squash (typing_token r_env goal (E_Total, pack_ln (Tv_Type u0))) =
+    match goal_typing with E x -> ()
+  in
+  ()

--- a/ulib/FStar.ModifiesGen.fst
+++ b/ulib/FStar.ModifiesGen.fst
@@ -1383,7 +1383,7 @@ val modifies_strengthen'
   (requires ((~ (a0 `GSet.mem` addrs_of_loc_weak l r0)) /\  modifies (loc_union l (loc_addresses true r0 (Set.singleton a0))) h h'))
   (ensures (modifies (loc_union l (loc_of_aloc al0)) h h'))
 
-#push-options "--z3rlimit 15 --fuel 0 --ifuel 0"
+#push-options "--z3rlimit 25 --fuel 0 --ifuel 0"
 let modifies_strengthen' #al #c l #r0 #a0 al0 h h' alocs =
   Classical.forall_intro (addrs_of_loc_loc_union_loc_of_aloc_eq_loc_union_loc_addresses_singleton l al0);
   assert (modifies_preserves_regions (loc_union l (loc_of_aloc al0)) h h');


### PR DESCRIPTION
Motivated by a bug report for @karthikbhargavan in which a file was taking excessive memory to typecheck (even if admitting queries). I tracked it down (with some help from #3384) to the normalizer, and particularly the function `inline_closure_env` which closes a term being normalized to not depend on the KAM's environment. This process is really just a substitution of free indices by some well defined values, so this PR:

1- Removes that function altogether.
2- Introduces `env_subst` which computes a substitution given a KAM environment.
3- This substitution is cached, so as to not recompute it for the same environment repeatedly.
4- Reimplements `closure_as_term` by computing the substitution and applying it. This has the enormous benefit of being *lazy*, so it's O(1) if the term happens to not be forced.
5- Finally, this function adds a pass to still respect `DefaultUnivsToZero`.

For the file that triggered this change, it used to blow up in memory to at least 30GB and >2m, while now it finished in 45s with 1.6GB. A[ perf comparison over the F* regressions suite](https://gist.github.com/mtzguido/3ddad71a0b6becfc902cb6e22a78edba) shows that this is somewhat of an improvement (somefiles are 3x faster, like Test.QuickCode). I would like to run an everest comparison too.