### PR TITLE
Makefiles: parallelize the extraction of ulib with its verification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,9 @@ FSTAR_CURDIR=$(call maybe_cygwin_path,$(CURDIR))
 
 FSTAR_BUILD_PROFILE ?= release
 
+FSTAR_HOME := $(CURDIR)
+export FSTAR_HOME
+
 .PHONY: fstar
 fstar:
 	$(Q)cp version.txt $(DUNE_SNAPSHOT)/

--- a/src/ocaml-output/Makefile
+++ b/src/ocaml-output/Makefile
@@ -30,7 +30,7 @@ dune-fstar-snapshot:
 dune-verify-ulib:
 	+$(MAKE) -C ../../ulib
 
-dune-stdlib-snapshot: dune-verify-ulib
+dune-stdlib-snapshot:
 	$(MAKE) -C ../../ulib -f Makefile.extract dune-snapshot
 
 dune-snapshot: dune-fstar-snapshot dune-stdlib-snapshot

--- a/ulib/Makefile.extract
+++ b/ulib/Makefile.extract
@@ -64,6 +64,9 @@ include $(DEPEND)
 # so we do not need to extract it.
 all-ml: $(filter-out %/prims.ml, $(ALL_ML_FILES))
 
+%.checked:
+	+$(MAKE) -f Makefile.verify $@
+
 intfiles:
 	+$(MAKE) -C ml intfiles
 

--- a/ulib/Makefile.verify
+++ b/ulib/Makefile.verify
@@ -1,5 +1,7 @@
 .PHONY: verify-core verify-extra
 
+FSTAR_HOME ?= ..
+
 # List the files that should be verified by verify-extra and verify-all
 # NOTE: Only use files that are extracted+linked into the library,
 # or they will anyway be verified when extracting it. Currently, legacy/


### PR DESCRIPTION
There is currently a chokepoint in that all of ulib must verify before we begin extracting. This patch allows the two stages to happen concurrently, while of course respecting the dependencies.