### PR TITLE
prims: bump checked file version

### DIFF
--- a/ulib/prims.fst
+++ b/ulib/prims.fst
@@ -708,4 +708,4 @@ val string_of_int: int -> Tot string
 (** THIS IS MEANT TO BE KEPT IN SYNC WITH FStar.CheckedFiles.fs
     Incrementing this forces all .checked files to be invalidated *)
 irreducible
-let __cache_version_number__ = 67
+let __cache_version_number__ = 68


### PR DESCRIPTION
It was updated in the compiler sources, but not here, causing some weirdness all around.