### PR TITLE
Parser: introduce `seq![1;2;3]` for sequence literals

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,11 +134,20 @@ bench:
 # Regenerate and accept expected output tests. Should be manually
 # reviewed before checking in.
 .PHONY: output
-output: output-error-messages output-ide-emacs output-ide-lsp output-bug-reports
+output:				\
+	output-error-messages	\
+	output-pretty-printing	\
+	output-ide-emacs	\
+	output-ide-lsp		\
+	output-bug-reports
 
 .PHONY: output-error-messages
 output-error-messages:
 	+$(Q)$(MAKE) -C tests/error-messages accept
+
+.PHONY: output-pretty-printing
+output-pretty-printing:
+	+$(Q)$(MAKE) -C tests/prettyprinting accept
 
 .PHONY: output-ide-emacs
 output-ide-emacs:

--- a/ocaml/fstar-lib/FStar_Parser_LexFStar.ml
+++ b/ocaml/fstar-lib/FStar_Parser_LexFStar.ml
@@ -462,6 +462,8 @@ match%sedlex lexbuf with
    use_lang_blob snap lang_name pos use_lang_buffer lexbuf
  )
 
+ | "seq![" -> SEQ_BANG_LBRACK
+
  | "#set-options" -> PRAGMA_SET_OPTIONS
  | "#reset-options" -> PRAGMA_RESET_OPTIONS
  | "#push-options" -> PRAGMA_PUSH_OPTIONS

--- a/ocaml/fstar-lib/FStar_Parser_Parse.mly
+++ b/ocaml/fstar-lib/FStar_Parser_Parse.mly
@@ -124,6 +124,7 @@ let parse_use_lang_blob (extension_name:string)
 %token EQUALS PERCENT_LBRACK LBRACK_AT LBRACK_AT_AT LBRACK_AT_AT_AT DOT_LBRACK
 %token DOT_LENS_PAREN_LEFT DOT_LPAREN DOT_LBRACK_BAR LBRACK LBRACK_BAR LBRACE_BAR LBRACE BANG_LBRACE
 %token BAR_RBRACK BAR_RBRACE UNDERSCORE LENS_PAREN_LEFT LENS_PAREN_RIGHT
+%token SEQ_BANG_LBRACK
 %token BAR RBRACK RBRACE DOLLAR
 %token PRIVATE REIFIABLE REFLECTABLE REIFY RANGE_OF SET_RANGE_OF LBRACE_COLON_PATTERN
 %token PIPE_LEFT PIPE_RIGHT
@@ -1474,7 +1475,9 @@ projectionLHS:
         in mk_term (Paren e1) (rr2 $loc($1) $loc($4)) (e.level)
       }
   | LBRACK es=semiColonTermList RBRACK
-      { mkConsList (rr2 $loc($1) $loc($3)) es }
+      { mkListLit (rr2 $loc($1) $loc($3)) es }
+  | SEQ_BANG_LBRACK es=semiColonTermList RBRACK
+      { mkSeqLit (rr2 $loc($1) $loc($3)) es }
   | PERCENT_LBRACK es=semiColonTermList RBRACK
       { mk_term (LexList es) (rr2 $loc($1) $loc($3)) Type_level }
   | BANG_LBRACE es=separated_list(COMMA, appTerm) RBRACE

--- a/ocaml/fstar-lib/generated/FStar_Parser_AST.ml
+++ b/ocaml/fstar-lib/generated/FStar_Parser_AST.ml
@@ -1192,41 +1192,6 @@ let (un_function :
             (uu___2, body) in
           FStar_Pervasives_Native.Some uu___1
       | uu___ -> FStar_Pervasives_Native.None
-let (consPat :
-  FStar_Compiler_Range_Type.range -> pattern -> pattern -> pattern') =
-  fun r ->
-    fun hd ->
-      fun tl ->
-        let uu___ =
-          let uu___1 = mk_pattern (PatName FStar_Parser_Const.cons_lid) r in
-          (uu___1, [hd; tl]) in
-        PatApp uu___
-let (consTerm : FStar_Compiler_Range_Type.range -> term -> term -> term) =
-  fun r ->
-    fun hd ->
-      fun tl ->
-        mk_term
-          (Construct
-             (FStar_Parser_Const.cons_lid, [(hd, Nothing); (tl, Nothing)])) r
-          Expr
-let (mkConsList : FStar_Compiler_Range_Type.range -> term Prims.list -> term)
-  =
-  fun r ->
-    fun elts ->
-      let nil = mk_term (Construct (FStar_Parser_Const.nil_lid, [])) r Expr in
-      FStar_Compiler_List.fold_right (fun e -> fun tl -> consTerm r e tl)
-        elts nil
-let (unit_const : FStar_Compiler_Range_Type.range -> term) =
-  fun r -> mk_term (Const FStar_Const.Const_unit) r Expr
-let (ml_comp : term -> term) =
-  fun t ->
-    let lid = FStar_Parser_Const.effect_ML_lid () in
-    let ml = mk_term (Name lid) t.range Expr in
-    let t1 = mk_term (App (ml, t, Nothing)) t.range Expr in t1
-let (tot_comp : term -> term) =
-  fun t ->
-    let ml = mk_term (Name FStar_Parser_Const.effect_Tot_lid) t.range Expr in
-    let t1 = mk_term (App (ml, t, Nothing)) t.range Expr in t1
 let (mkApp :
   term -> (term * imp) Prims.list -> FStar_Compiler_Range_Type.range -> term)
   =
@@ -1245,6 +1210,53 @@ let (mkApp :
                         match uu___2 with
                         | (a, imp1) -> mk_term (App (t1, a, imp1)) r Un) t
                    args)
+let (consPat :
+  FStar_Compiler_Range_Type.range -> pattern -> pattern -> pattern') =
+  fun r ->
+    fun hd ->
+      fun tl ->
+        let uu___ =
+          let uu___1 = mk_pattern (PatName FStar_Parser_Const.cons_lid) r in
+          (uu___1, [hd; tl]) in
+        PatApp uu___
+let (consTerm : FStar_Compiler_Range_Type.range -> term -> term -> term) =
+  fun r ->
+    fun hd ->
+      fun tl ->
+        mk_term
+          (Construct
+             (FStar_Parser_Const.cons_lid, [(hd, Nothing); (tl, Nothing)])) r
+          Expr
+let (mkListLit : FStar_Compiler_Range_Type.range -> term Prims.list -> term)
+  =
+  fun r ->
+    fun elts ->
+      let nil = mk_term (Construct (FStar_Parser_Const.nil_lid, [])) r Expr in
+      FStar_Compiler_List.fold_right (fun e -> fun tl -> consTerm r e tl)
+        elts nil
+let (seqConsTerm : FStar_Compiler_Range_Type.range -> term -> term -> term) =
+  fun r ->
+    fun hd ->
+      fun tl ->
+        let cons = mk_term (Var FStar_Parser_Const.seq_cons_lid) r Expr in
+        mkApp cons [(hd, Nothing); (tl, Nothing)] r
+let (mkSeqLit : FStar_Compiler_Range_Type.range -> term Prims.list -> term) =
+  fun r ->
+    fun elts ->
+      let nil = mk_term (Var FStar_Parser_Const.seq_empty_lid) r Expr in
+      FStar_Compiler_List.fold_right (fun e -> fun tl -> seqConsTerm r e tl)
+        elts nil
+let (unit_const : FStar_Compiler_Range_Type.range -> term) =
+  fun r -> mk_term (Const FStar_Const.Const_unit) r Expr
+let (ml_comp : term -> term) =
+  fun t ->
+    let lid = FStar_Parser_Const.effect_ML_lid () in
+    let ml = mk_term (Name lid) t.range Expr in
+    let t1 = mk_term (App (ml, t, Nothing)) t.range Expr in t1
+let (tot_comp : term -> term) =
+  fun t ->
+    let ml = mk_term (Name FStar_Parser_Const.effect_Tot_lid) t.range Expr in
+    let t1 = mk_term (App (ml, t, Nothing)) t.range Expr in t1
 let (mkRefSet : FStar_Compiler_Range_Type.range -> term Prims.list -> term) =
   fun r ->
     fun elts ->

--- a/ocaml/fstar-lib/generated/FStar_Parser_AST.ml
+++ b/ocaml/fstar-lib/generated/FStar_Parser_AST.ml
@@ -96,6 +96,8 @@ type term' =
   | ElimImplies of (term * term * term) 
   | ElimOr of (term * term * term * binder * term * binder * term) 
   | ElimAnd of (term * term * term * binder * binder * term) 
+  | ListLiteral of term Prims.list 
+  | SeqLiteral of term Prims.list 
 and term = {
   tm: term' ;
   range: FStar_Compiler_Range_Type.range ;
@@ -417,6 +419,16 @@ let (uu___is_ElimAnd : term' -> Prims.bool) =
 let (__proj__ElimAnd__item___0 :
   term' -> (term * term * term * binder * binder * term)) =
   fun projectee -> match projectee with | ElimAnd _0 -> _0
+let (uu___is_ListLiteral : term' -> Prims.bool) =
+  fun projectee ->
+    match projectee with | ListLiteral _0 -> true | uu___ -> false
+let (__proj__ListLiteral__item___0 : term' -> term Prims.list) =
+  fun projectee -> match projectee with | ListLiteral _0 -> _0
+let (uu___is_SeqLiteral : term' -> Prims.bool) =
+  fun projectee ->
+    match projectee with | SeqLiteral _0 -> true | uu___ -> false
+let (__proj__SeqLiteral__item___0 : term' -> term Prims.list) =
+  fun projectee -> match projectee with | SeqLiteral _0 -> _0
 let (__proj__Mkterm__item__tm : term -> term') =
   fun projectee ->
     match projectee with | { tm; range; level = level1;_} -> tm
@@ -1228,24 +1240,9 @@ let (consTerm : FStar_Compiler_Range_Type.range -> term -> term -> term) =
              (FStar_Parser_Const.cons_lid, [(hd, Nothing); (tl, Nothing)])) r
           Expr
 let (mkListLit : FStar_Compiler_Range_Type.range -> term Prims.list -> term)
-  =
-  fun r ->
-    fun elts ->
-      let nil = mk_term (Construct (FStar_Parser_Const.nil_lid, [])) r Expr in
-      FStar_Compiler_List.fold_right (fun e -> fun tl -> consTerm r e tl)
-        elts nil
-let (seqConsTerm : FStar_Compiler_Range_Type.range -> term -> term -> term) =
-  fun r ->
-    fun hd ->
-      fun tl ->
-        let cons = mk_term (Var FStar_Parser_Const.seq_cons_lid) r Expr in
-        mkApp cons [(hd, Nothing); (tl, Nothing)] r
+  = fun r -> fun elts -> mk_term (ListLiteral elts) r Expr
 let (mkSeqLit : FStar_Compiler_Range_Type.range -> term Prims.list -> term) =
-  fun r ->
-    fun elts ->
-      let nil = mk_term (Var FStar_Parser_Const.seq_empty_lid) r Expr in
-      FStar_Compiler_List.fold_right (fun e -> fun tl -> seqConsTerm r e tl)
-        elts nil
+  fun r -> fun elts -> mk_term (SeqLiteral elts) r Expr
 let (unit_const : FStar_Compiler_Range_Type.range -> term) =
   fun r -> mk_term (Const FStar_Const.Const_unit) r Expr
 let (ml_comp : term -> term) =
@@ -2254,6 +2251,12 @@ let rec (term_to_string : term -> Prims.string) =
         let uu___3 = term_to_string e2 in
         FStar_Compiler_Util.format4 "_intro_ %s /\\ %s with %s and %s" uu___
           uu___1 uu___2 uu___3
+    | ListLiteral ts ->
+        let uu___ = to_string_l "; " term_to_string ts in
+        FStar_Compiler_Util.format1 "[%s]" uu___
+    | SeqLiteral ts ->
+        let uu___ = to_string_l "; " term_to_string ts in
+        FStar_Compiler_Util.format1 "seq![%s]" uu___
 and (binders_to_string : Prims.string -> binder Prims.list -> Prims.string) =
   fun sep ->
     fun bs ->

--- a/ocaml/fstar-lib/generated/FStar_Parser_AST_Util.ml
+++ b/ocaml/fstar-lib/generated/FStar_Parser_AST_Util.ml
@@ -884,6 +884,8 @@ and (lidents_of_term' :
             FStar_Compiler_List.op_At uu___4 uu___5 in
           FStar_Compiler_List.op_At uu___2 uu___3 in
         FStar_Compiler_List.op_At uu___ uu___1
+    | FStar_Parser_AST.ListLiteral ts -> (concat_map ()) lidents_of_term ts
+    | FStar_Parser_AST.SeqLiteral ts -> (concat_map ()) lidents_of_term ts
 and (lidents_of_branch :
   (FStar_Parser_AST.pattern * FStar_Parser_AST.term
     FStar_Pervasives_Native.option * FStar_Parser_AST.term) ->

--- a/ocaml/fstar-lib/generated/FStar_Parser_Const.ml
+++ b/ocaml/fstar-lib/generated/FStar_Parser_Const.ml
@@ -105,6 +105,10 @@ let (list_append_lid : FStar_Ident.lident) = p2l ["FStar"; "List"; "append"]
 let (list_tot_append_lid : FStar_Ident.lident) =
   p2l ["FStar"; "List"; "Tot"; "Base"; "append"]
 let (id_lid : FStar_Ident.lident) = psconst "id"
+let (seq_cons_lid : FStar_Ident.lident) =
+  p2l ["FStar"; "Seq"; "Base"; "cons"]
+let (seq_empty_lid : FStar_Ident.lident) =
+  p2l ["FStar"; "Seq"; "Base"; "empty"]
 let (c2l : Prims.string -> FStar_Ident.lident) =
   fun s -> p2l ["FStar"; "Char"; s]
 let (char_u32_of_char : FStar_Ident.lident) = c2l "u32_of_char"

--- a/ocaml/fstar-lib/generated/FStar_Parser_Dep.ml
+++ b/ocaml/fstar-lib/generated/FStar_Parser_Dep.ml
@@ -1821,6 +1821,16 @@ let (collect_one :
                   collect_binder y;
                   collect_term e;
                   collect_term e')
+             | FStar_Parser_AST.ListLiteral ts ->
+                 FStar_Compiler_List.iter collect_term ts
+             | FStar_Parser_AST.SeqLiteral ts ->
+                 ((let uu___3 =
+                     let uu___4 =
+                       let uu___5 = FStar_Ident.lid_of_str "FStar.Seq.Base" in
+                       (false, uu___5) in
+                     P_dep uu___4 in
+                   add_to_parsing_data uu___3);
+                  FStar_Compiler_List.iter collect_term ts)
            and collect_patterns ps =
              FStar_Compiler_List.iter collect_pattern ps
            and collect_pattern p = collect_pattern' p.FStar_Parser_AST.pat

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Resugar.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Resugar.ml
@@ -459,6 +459,66 @@ let (resugar_machine_integer :
                  (FStar_Const.Const_int
                     (i, (FStar_Pervasives_Native.Some sw)))) pos
               FStar_Parser_AST.Un
+let rec (__is_list_literal :
+  FStar_Ident.lident ->
+    FStar_Ident.lident ->
+      FStar_Syntax_Syntax.term ->
+        FStar_Syntax_Syntax.term Prims.list FStar_Pervasives_Native.option)
+  =
+  fun uu___2 ->
+    fun uu___1 ->
+      fun uu___ ->
+        (fun cons_lid ->
+           fun nil_lid ->
+             fun t ->
+               let uu___ = FStar_Syntax_Util.head_and_args_full t in
+               match uu___ with
+               | (hd, args) ->
+                   let hd1 =
+                     let uu___1 = FStar_Syntax_Util.un_uinst hd in
+                     FStar_Syntax_Subst.compress uu___1 in
+                   let args1 =
+                     let uu___1 = FStar_Options.print_implicits () in
+                     if uu___1 then args else filter_imp_args args in
+                   (match ((hd1.FStar_Syntax_Syntax.n), args1) with
+                    | (FStar_Syntax_Syntax.Tm_fvar fv,
+                       (hd2, FStar_Pervasives_Native.None)::(tl,
+                                                             FStar_Pervasives_Native.None)::[])
+                        when FStar_Syntax_Syntax.fv_eq_lid fv cons_lid ->
+                        Obj.magic
+                          (Obj.repr
+                             (let uu___1 =
+                                __is_list_literal cons_lid nil_lid tl in
+                              FStar_Class_Monad.op_let_Bang
+                                FStar_Class_Monad.monad_option () ()
+                                (Obj.magic uu___1)
+                                (fun uu___2 ->
+                                   (fun tl1 ->
+                                      let tl1 = Obj.magic tl1 in
+                                      Obj.magic
+                                        (FStar_Class_Monad.return
+                                           FStar_Class_Monad.monad_option ()
+                                           (Obj.magic (hd2 :: tl1)))) uu___2)))
+                    | (FStar_Syntax_Syntax.Tm_fvar fv, []) when
+                        FStar_Syntax_Syntax.fv_eq_lid fv nil_lid ->
+                        Obj.magic
+                          (Obj.repr
+                             (FStar_Class_Monad.return
+                                FStar_Class_Monad.monad_option ()
+                                (Obj.magic [])))
+                    | (uu___1, uu___2) ->
+                        Obj.magic (Obj.repr FStar_Pervasives_Native.None)))
+          uu___2 uu___1 uu___
+let (is_list_literal :
+  FStar_Syntax_Syntax.term ->
+    FStar_Syntax_Syntax.term Prims.list FStar_Pervasives_Native.option)
+  = __is_list_literal FStar_Parser_Const.cons_lid FStar_Parser_Const.nil_lid
+let (is_seq_literal :
+  FStar_Syntax_Syntax.term ->
+    FStar_Syntax_Syntax.term Prims.list FStar_Pervasives_Native.option)
+  =
+  __is_list_literal FStar_Parser_Const.seq_cons_lid
+    FStar_Parser_Const.seq_empty_lid
 let rec (resugar_term' :
   FStar_Syntax_DsEnv.env -> FStar_Syntax_Syntax.term -> FStar_Parser_AST.term)
   =
@@ -1110,393 +1170,484 @@ let rec (resugar_term' :
                     match uu___5 with
                     | FStar_Pervasives_Native.Some r -> r
                     | FStar_Pervasives_Native.None -> resugar_as_app hd args2 in
-                  let uu___5 = resugar_term_as_op e in
+                  let uu___5 = is_list_literal t1 in
                   match uu___5 with
-                  | FStar_Pervasives_Native.None -> resugar_as_app e args1
-                  | FStar_Pervasives_Native.Some ("calc_finish", uu___6) ->
-                      let uu___7 = resugar_calc env t1 in
-                      (match uu___7 with
-                       | FStar_Pervasives_Native.Some r -> r
-                       | uu___8 -> resugar_as_app e args1)
-                  | FStar_Pervasives_Native.Some ("tuple", n) when
-                      (FStar_Pervasives_Native.Some
-                         (FStar_Compiler_List.length args1))
-                        = n
-                      -> resugar_tuple_type env args1
-                  | FStar_Pervasives_Native.Some ("dtuple", n) when
-                      (FStar_Pervasives_Native.Some
-                         (FStar_Compiler_List.length args1))
-                        = n
-                      -> resugar_dtuple_type env e args1
-                  | FStar_Pervasives_Native.Some (ref_read, uu___6) when
-                      let uu___7 =
-                        FStar_Ident.string_of_lid
-                          FStar_Parser_Const.sread_lid in
-                      ref_read = uu___7 ->
-                      let uu___7 = FStar_Compiler_List.hd args1 in
-                      (match uu___7 with
-                       | (t2, uu___8) ->
-                           let uu___9 =
-                             let uu___10 = FStar_Syntax_Subst.compress t2 in
-                             uu___10.FStar_Syntax_Syntax.n in
-                           (match uu___9 with
-                            | FStar_Syntax_Syntax.Tm_fvar fv when
-                                let uu___10 =
-                                  FStar_Ident.string_of_lid
-                                    (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                                FStar_Syntax_Util.field_projector_contains_constructor
-                                  uu___10
-                                ->
-                                let f =
-                                  let uu___10 =
-                                    let uu___11 =
-                                      FStar_Ident.string_of_lid
-                                        (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                                    [uu___11] in
-                                  FStar_Ident.lid_of_path uu___10
-                                    t2.FStar_Syntax_Syntax.pos in
-                                let uu___10 =
-                                  let uu___11 =
-                                    let uu___12 = resugar_term' env t2 in
-                                    (uu___12, f) in
-                                  FStar_Parser_AST.Project uu___11 in
-                                mk uu___10
-                            | uu___10 -> resugar_term' env t2))
-                  | FStar_Pervasives_Native.Some ("try_with", uu___6) when
-                      (FStar_Compiler_List.length args1) > Prims.int_one ->
-                      (try
-                         (fun uu___7 ->
-                            match () with
-                            | () ->
-                                let new_args = first_two_explicit args1 in
-                                let uu___8 =
-                                  match new_args with
-                                  | (a1, uu___9)::(a2, uu___10)::[] ->
-                                      (a1, a2)
-                                  | uu___9 ->
-                                      FStar_Compiler_Effect.failwith
-                                        "wrong arguments to try_with" in
-                                (match uu___8 with
-                                 | (body, handler) ->
-                                     let decomp term =
-                                       let uu___9 =
-                                         let uu___10 =
-                                           FStar_Syntax_Subst.compress term in
-                                         uu___10.FStar_Syntax_Syntax.n in
-                                       match uu___9 with
-                                       | FStar_Syntax_Syntax.Tm_abs
-                                           { FStar_Syntax_Syntax.bs = x;
-                                             FStar_Syntax_Syntax.body = e1;
-                                             FStar_Syntax_Syntax.rc_opt =
-                                               uu___10;_}
-                                           ->
-                                           let uu___11 =
-                                             FStar_Syntax_Subst.open_term x
-                                               e1 in
-                                           (match uu___11 with
-                                            | (x1, e2) -> e2)
-                                       | uu___10 ->
-                                           let uu___11 =
-                                             let uu___12 =
-                                               let uu___13 =
-                                                 resugar_term' env term in
-                                               FStar_Parser_AST.term_to_string
-                                                 uu___13 in
-                                             Prims.strcat
-                                               "wrong argument format to try_with: "
-                                               uu___12 in
-                                           FStar_Compiler_Effect.failwith
-                                             uu___11 in
-                                     let body1 =
-                                       let uu___9 = decomp body in
-                                       resugar_term' env uu___9 in
-                                     let handler1 =
-                                       let uu___9 = decomp handler in
-                                       resugar_term' env uu___9 in
-                                     let rec resugar_body t2 =
-                                       match t2.FStar_Parser_AST.tm with
-                                       | FStar_Parser_AST.Match
-                                           (e1, FStar_Pervasives_Native.None,
-                                            FStar_Pervasives_Native.None,
-                                            (uu___9, uu___10, b)::[])
-                                           -> b
-                                       | FStar_Parser_AST.Let
-                                           (uu___9, uu___10, b) -> b
-                                       | FStar_Parser_AST.Ascribed
-                                           (t11, t21, t3, use_eq) ->
-                                           let uu___9 =
-                                             let uu___10 =
-                                               let uu___11 = resugar_body t11 in
-                                               (uu___11, t21, t3, use_eq) in
-                                             FStar_Parser_AST.Ascribed
-                                               uu___10 in
-                                           mk uu___9
-                                       | uu___9 ->
-                                           FStar_Compiler_Effect.failwith
-                                             "unexpected body format to try_with" in
-                                     let e1 = resugar_body body1 in
-                                     let rec resugar_branches t2 =
-                                       match t2.FStar_Parser_AST.tm with
-                                       | FStar_Parser_AST.Match
-                                           (e2, FStar_Pervasives_Native.None,
-                                            FStar_Pervasives_Native.None,
-                                            branches)
-                                           -> branches
-                                       | FStar_Parser_AST.Ascribed
-                                           (t11, t21, t3, uu___9) ->
-                                           resugar_branches t11
-                                       | uu___9 -> [] in
-                                     let branches = resugar_branches handler1 in
-                                     mk
-                                       (FStar_Parser_AST.TryWith
-                                          (e1, branches)))) ()
-                       with | uu___7 -> resugar_as_app e args1)
-                  | FStar_Pervasives_Native.Some ("try_with", uu___6) ->
-                      resugar_as_app e args1
-                  | FStar_Pervasives_Native.Some (op, uu___6) when
-                      (((((((op = "=") || (op = "==")) || (op = "===")) ||
-                            (op = "@"))
-                           || (op = ":="))
-                          || (op = "|>"))
-                         || (op = "<<"))
-                        && (FStar_Options.print_implicits ())
-                      -> resugar_as_app e args1
-                  | FStar_Pervasives_Native.Some (op, uu___6) when
-                      (FStar_Compiler_Util.starts_with op "forall") ||
-                        (FStar_Compiler_Util.starts_with op "exists")
-                      ->
-                      let rec uncurry xs pats t2 flavor_matches =
-                        match t2.FStar_Parser_AST.tm with
-                        | FStar_Parser_AST.QExists
-                            (xs', (uu___7, pats'), body) when
-                            flavor_matches t2 ->
-                            uncurry (FStar_Compiler_List.op_At xs xs')
-                              (FStar_Compiler_List.op_At pats pats') body
-                              flavor_matches
-                        | FStar_Parser_AST.QForall
-                            (xs', (uu___7, pats'), body) when
-                            flavor_matches t2 ->
-                            uncurry (FStar_Compiler_List.op_At xs xs')
-                              (FStar_Compiler_List.op_At pats pats') body
-                              flavor_matches
-                        | FStar_Parser_AST.QuantOp
-                            (uu___7, xs', (uu___8, pats'), body) when
-                            flavor_matches t2 ->
-                            uncurry (FStar_Compiler_List.op_At xs xs')
-                              (FStar_Compiler_List.op_At pats pats') body
-                              flavor_matches
-                        | uu___7 -> (xs, pats, t2) in
-                      let resugar_forall_body body =
+                  | FStar_Pervasives_Native.Some ts ->
+                      let uu___6 =
                         let uu___7 =
-                          let uu___8 = FStar_Syntax_Subst.compress body in
-                          uu___8.FStar_Syntax_Syntax.n in
-                        match uu___7 with
-                        | FStar_Syntax_Syntax.Tm_abs
-                            { FStar_Syntax_Syntax.bs = xs;
-                              FStar_Syntax_Syntax.body = body1;
-                              FStar_Syntax_Syntax.rc_opt = uu___8;_}
-                            ->
-                            let uu___9 =
-                              FStar_Syntax_Subst.open_term xs body1 in
-                            (match uu___9 with
-                             | (xs1, body2) ->
-                                 let xs2 =
-                                   let uu___10 =
-                                     FStar_Options.print_implicits () in
-                                   if uu___10 then xs1 else filter_imp_bs xs1 in
-                                 let xs3 =
-                                   (map_opt ())
-                                     (fun b ->
-                                        resugar_binder' env b
-                                          t1.FStar_Syntax_Syntax.pos) xs2 in
-                                 let uu___10 =
-                                   let uu___11 =
-                                     let uu___12 =
-                                       FStar_Syntax_Subst.compress body2 in
-                                     uu___12.FStar_Syntax_Syntax.n in
-                                   match uu___11 with
-                                   | FStar_Syntax_Syntax.Tm_meta
-                                       { FStar_Syntax_Syntax.tm2 = e1;
-                                         FStar_Syntax_Syntax.meta = m;_}
-                                       ->
-                                       let body3 = resugar_term' env e1 in
+                          FStar_Compiler_List.map (resugar_term' env) ts in
+                        FStar_Parser_AST.ListLiteral uu___7 in
+                      mk uu___6
+                  | FStar_Pervasives_Native.None ->
+                      let uu___6 = is_seq_literal t1 in
+                      (match uu___6 with
+                       | FStar_Pervasives_Native.Some ts ->
+                           let uu___7 =
+                             let uu___8 =
+                               FStar_Compiler_List.map (resugar_term' env) ts in
+                             FStar_Parser_AST.SeqLiteral uu___8 in
+                           mk uu___7
+                       | FStar_Pervasives_Native.None ->
+                           let uu___7 = resugar_term_as_op e in
+                           (match uu___7 with
+                            | FStar_Pervasives_Native.None ->
+                                resugar_as_app e args1
+                            | FStar_Pervasives_Native.Some
+                                ("calc_finish", uu___8) ->
+                                let uu___9 = resugar_calc env t1 in
+                                (match uu___9 with
+                                 | FStar_Pervasives_Native.Some r -> r
+                                 | uu___10 -> resugar_as_app e args1)
+                            | FStar_Pervasives_Native.Some ("tuple", n) when
+                                (FStar_Pervasives_Native.Some
+                                   (FStar_Compiler_List.length args1))
+                                  = n
+                                -> resugar_tuple_type env args1
+                            | FStar_Pervasives_Native.Some ("dtuple", n) when
+                                (FStar_Pervasives_Native.Some
+                                   (FStar_Compiler_List.length args1))
+                                  = n
+                                -> resugar_dtuple_type env e args1
+                            | FStar_Pervasives_Native.Some (ref_read, uu___8)
+                                when
+                                let uu___9 =
+                                  FStar_Ident.string_of_lid
+                                    FStar_Parser_Const.sread_lid in
+                                ref_read = uu___9 ->
+                                let uu___9 = FStar_Compiler_List.hd args1 in
+                                (match uu___9 with
+                                 | (t2, uu___10) ->
+                                     let uu___11 =
                                        let uu___12 =
-                                         match m with
-                                         | FStar_Syntax_Syntax.Meta_pattern
-                                             (uu___13, pats) ->
-                                             let uu___14 =
-                                               FStar_Compiler_List.map
-                                                 (fun es ->
-                                                    FStar_Compiler_List.map
-                                                      (fun uu___15 ->
-                                                         match uu___15 with
-                                                         | (e2, uu___16) ->
-                                                             resugar_term'
-                                                               env e2) es)
-                                                 pats in
-                                             (uu___14, body3)
-                                         | FStar_Syntax_Syntax.Meta_labeled
-                                             (s, r, p) ->
+                                         FStar_Syntax_Subst.compress t2 in
+                                       uu___12.FStar_Syntax_Syntax.n in
+                                     (match uu___11 with
+                                      | FStar_Syntax_Syntax.Tm_fvar fv when
+                                          let uu___12 =
+                                            FStar_Ident.string_of_lid
+                                              (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
+                                          FStar_Syntax_Util.field_projector_contains_constructor
+                                            uu___12
+                                          ->
+                                          let f =
+                                            let uu___12 =
+                                              let uu___13 =
+                                                FStar_Ident.string_of_lid
+                                                  (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
+                                              [uu___13] in
+                                            FStar_Ident.lid_of_path uu___12
+                                              t2.FStar_Syntax_Syntax.pos in
+                                          let uu___12 =
+                                            let uu___13 =
+                                              let uu___14 =
+                                                resugar_term' env t2 in
+                                              (uu___14, f) in
+                                            FStar_Parser_AST.Project uu___13 in
+                                          mk uu___12
+                                      | uu___12 -> resugar_term' env t2))
+                            | FStar_Pervasives_Native.Some
+                                ("try_with", uu___8) when
+                                (FStar_Compiler_List.length args1) >
+                                  Prims.int_one
+                                ->
+                                (try
+                                   (fun uu___9 ->
+                                      match () with
+                                      | () ->
+                                          let new_args =
+                                            first_two_explicit args1 in
+                                          let uu___10 =
+                                            match new_args with
+                                            | (a1, uu___11)::(a2, uu___12)::[]
+                                                -> (a1, a2)
+                                            | uu___11 ->
+                                                FStar_Compiler_Effect.failwith
+                                                  "wrong arguments to try_with" in
+                                          (match uu___10 with
+                                           | (body, handler) ->
+                                               let decomp term =
+                                                 let uu___11 =
+                                                   let uu___12 =
+                                                     FStar_Syntax_Subst.compress
+                                                       term in
+                                                   uu___12.FStar_Syntax_Syntax.n in
+                                                 match uu___11 with
+                                                 | FStar_Syntax_Syntax.Tm_abs
+                                                     {
+                                                       FStar_Syntax_Syntax.bs
+                                                         = x;
+                                                       FStar_Syntax_Syntax.body
+                                                         = e1;
+                                                       FStar_Syntax_Syntax.rc_opt
+                                                         = uu___12;_}
+                                                     ->
+                                                     let uu___13 =
+                                                       FStar_Syntax_Subst.open_term
+                                                         x e1 in
+                                                     (match uu___13 with
+                                                      | (x1, e2) -> e2)
+                                                 | uu___12 ->
+                                                     let uu___13 =
+                                                       let uu___14 =
+                                                         let uu___15 =
+                                                           resugar_term' env
+                                                             term in
+                                                         FStar_Parser_AST.term_to_string
+                                                           uu___15 in
+                                                       Prims.strcat
+                                                         "wrong argument format to try_with: "
+                                                         uu___14 in
+                                                     FStar_Compiler_Effect.failwith
+                                                       uu___13 in
+                                               let body1 =
+                                                 let uu___11 = decomp body in
+                                                 resugar_term' env uu___11 in
+                                               let handler1 =
+                                                 let uu___11 = decomp handler in
+                                                 resugar_term' env uu___11 in
+                                               let rec resugar_body t2 =
+                                                 match t2.FStar_Parser_AST.tm
+                                                 with
+                                                 | FStar_Parser_AST.Match
+                                                     (e1,
+                                                      FStar_Pervasives_Native.None,
+                                                      FStar_Pervasives_Native.None,
+                                                      (uu___11, uu___12, b)::[])
+                                                     -> b
+                                                 | FStar_Parser_AST.Let
+                                                     (uu___11, uu___12, b) ->
+                                                     b
+                                                 | FStar_Parser_AST.Ascribed
+                                                     (t11, t21, t3, use_eq)
+                                                     ->
+                                                     let uu___11 =
+                                                       let uu___12 =
+                                                         let uu___13 =
+                                                           resugar_body t11 in
+                                                         (uu___13, t21, t3,
+                                                           use_eq) in
+                                                       FStar_Parser_AST.Ascribed
+                                                         uu___12 in
+                                                     mk uu___11
+                                                 | uu___11 ->
+                                                     FStar_Compiler_Effect.failwith
+                                                       "unexpected body format to try_with" in
+                                               let e1 = resugar_body body1 in
+                                               let rec resugar_branches t2 =
+                                                 match t2.FStar_Parser_AST.tm
+                                                 with
+                                                 | FStar_Parser_AST.Match
+                                                     (e2,
+                                                      FStar_Pervasives_Native.None,
+                                                      FStar_Pervasives_Native.None,
+                                                      branches)
+                                                     -> branches
+                                                 | FStar_Parser_AST.Ascribed
+                                                     (t11, t21, t3, uu___11)
+                                                     -> resugar_branches t11
+                                                 | uu___11 -> [] in
+                                               let branches =
+                                                 resugar_branches handler1 in
+                                               mk
+                                                 (FStar_Parser_AST.TryWith
+                                                    (e1, branches)))) ()
+                                 with | uu___9 -> resugar_as_app e args1)
+                            | FStar_Pervasives_Native.Some
+                                ("try_with", uu___8) ->
+                                resugar_as_app e args1
+                            | FStar_Pervasives_Native.Some (op, uu___8) when
+                                (((((((op = "=") || (op = "==")) ||
+                                       (op = "==="))
+                                      || (op = "@"))
+                                     || (op = ":="))
+                                    || (op = "|>"))
+                                   || (op = "<<"))
+                                  && (FStar_Options.print_implicits ())
+                                -> resugar_as_app e args1
+                            | FStar_Pervasives_Native.Some (op, uu___8) when
+                                (FStar_Compiler_Util.starts_with op "forall")
+                                  ||
+                                  (FStar_Compiler_Util.starts_with op
+                                     "exists")
+                                ->
+                                let rec uncurry xs pats t2 flavor_matches =
+                                  match t2.FStar_Parser_AST.tm with
+                                  | FStar_Parser_AST.QExists
+                                      (xs', (uu___9, pats'), body) when
+                                      flavor_matches t2 ->
+                                      uncurry
+                                        (FStar_Compiler_List.op_At xs xs')
+                                        (FStar_Compiler_List.op_At pats pats')
+                                        body flavor_matches
+                                  | FStar_Parser_AST.QForall
+                                      (xs', (uu___9, pats'), body) when
+                                      flavor_matches t2 ->
+                                      uncurry
+                                        (FStar_Compiler_List.op_At xs xs')
+                                        (FStar_Compiler_List.op_At pats pats')
+                                        body flavor_matches
+                                  | FStar_Parser_AST.QuantOp
+                                      (uu___9, xs', (uu___10, pats'), body)
+                                      when flavor_matches t2 ->
+                                      uncurry
+                                        (FStar_Compiler_List.op_At xs xs')
+                                        (FStar_Compiler_List.op_At pats pats')
+                                        body flavor_matches
+                                  | uu___9 -> (xs, pats, t2) in
+                                let resugar_forall_body body =
+                                  let uu___9 =
+                                    let uu___10 =
+                                      FStar_Syntax_Subst.compress body in
+                                    uu___10.FStar_Syntax_Syntax.n in
+                                  match uu___9 with
+                                  | FStar_Syntax_Syntax.Tm_abs
+                                      { FStar_Syntax_Syntax.bs = xs;
+                                        FStar_Syntax_Syntax.body = body1;
+                                        FStar_Syntax_Syntax.rc_opt = uu___10;_}
+                                      ->
+                                      let uu___11 =
+                                        FStar_Syntax_Subst.open_term xs body1 in
+                                      (match uu___11 with
+                                       | (xs1, body2) ->
+                                           let xs2 =
+                                             let uu___12 =
+                                               FStar_Options.print_implicits
+                                                 () in
+                                             if uu___12
+                                             then xs1
+                                             else filter_imp_bs xs1 in
+                                           let xs3 =
+                                             (map_opt ())
+                                               (fun b ->
+                                                  resugar_binder' env b
+                                                    t1.FStar_Syntax_Syntax.pos)
+                                               xs2 in
+                                           let uu___12 =
                                              let uu___13 =
                                                let uu___14 =
+                                                 FStar_Syntax_Subst.compress
+                                                   body2 in
+                                               uu___14.FStar_Syntax_Syntax.n in
+                                             match uu___13 with
+                                             | FStar_Syntax_Syntax.Tm_meta
+                                                 {
+                                                   FStar_Syntax_Syntax.tm2 =
+                                                     e1;
+                                                   FStar_Syntax_Syntax.meta =
+                                                     m;_}
+                                                 ->
+                                                 let body3 =
+                                                   resugar_term' env e1 in
+                                                 let uu___14 =
+                                                   match m with
+                                                   | FStar_Syntax_Syntax.Meta_pattern
+                                                       (uu___15, pats) ->
+                                                       let uu___16 =
+                                                         FStar_Compiler_List.map
+                                                           (fun es ->
+                                                              FStar_Compiler_List.map
+                                                                (fun uu___17
+                                                                   ->
+                                                                   match uu___17
+                                                                   with
+                                                                   | 
+                                                                   (e2,
+                                                                    uu___18)
+                                                                    ->
+                                                                    resugar_term'
+                                                                    env e2)
+                                                                es) pats in
+                                                       (uu___16, body3)
+                                                   | FStar_Syntax_Syntax.Meta_labeled
+                                                       (s, r, p) ->
+                                                       let uu___15 =
+                                                         let uu___16 =
+                                                           let uu___17 =
+                                                             let uu___18 =
+                                                               FStar_Errors_Msg.rendermsg
+                                                                 s in
+                                                             (body3, uu___18,
+                                                               p) in
+                                                           FStar_Parser_AST.Labeled
+                                                             uu___17 in
+                                                         mk uu___16 in
+                                                       ([], uu___15)
+                                                   | uu___15 ->
+                                                       FStar_Compiler_Effect.failwith
+                                                         "wrong pattern format for QForall/QExists" in
+                                                 (match uu___14 with
+                                                  | (pats, body4) ->
+                                                      (pats, body4))
+                                             | uu___14 ->
                                                  let uu___15 =
-                                                   let uu___16 =
-                                                     FStar_Errors_Msg.rendermsg
-                                                       s in
-                                                   (body3, uu___16, p) in
-                                                 FStar_Parser_AST.Labeled
-                                                   uu___15 in
-                                               mk uu___14 in
-                                             ([], uu___13)
-                                         | uu___13 ->
-                                             FStar_Compiler_Effect.failwith
-                                               "wrong pattern format for QForall/QExists" in
-                                       (match uu___12 with
-                                        | (pats, body4) -> (pats, body4))
-                                   | uu___12 ->
-                                       let uu___13 = resugar_term' env body2 in
-                                       ([], uu___13) in
-                                 (match uu___10 with
-                                  | (pats, body3) ->
-                                      let decompile_op op1 =
+                                                   resugar_term' env body2 in
+                                                 ([], uu___15) in
+                                           (match uu___12 with
+                                            | (pats, body3) ->
+                                                let decompile_op op1 =
+                                                  let uu___13 =
+                                                    FStar_Parser_AST.string_to_op
+                                                      op1 in
+                                                  match uu___13 with
+                                                  | FStar_Pervasives_Native.None
+                                                      -> op1
+                                                  | FStar_Pervasives_Native.Some
+                                                      (op2, uu___14) -> op2 in
+                                                let flavor_matches t2 =
+                                                  match ((t2.FStar_Parser_AST.tm),
+                                                          op)
+                                                  with
+                                                  | (FStar_Parser_AST.QExists
+                                                     uu___13, "exists") ->
+                                                      true
+                                                  | (FStar_Parser_AST.QForall
+                                                     uu___13, "forall") ->
+                                                      true
+                                                  | (FStar_Parser_AST.QuantOp
+                                                     (id, uu___13, uu___14,
+                                                      uu___15),
+                                                     uu___16) ->
+                                                      let uu___17 =
+                                                        FStar_Ident.string_of_id
+                                                          id in
+                                                      uu___17 = op
+                                                  | uu___13 -> false in
+                                                let uu___13 =
+                                                  uncurry xs3 pats body3
+                                                    flavor_matches in
+                                                (match uu___13 with
+                                                 | (xs4, pats1, body4) ->
+                                                     let binders =
+                                                       FStar_Parser_AST.idents_of_binders
+                                                         xs4
+                                                         t1.FStar_Syntax_Syntax.pos in
+                                                     if op = "forall"
+                                                     then
+                                                       mk
+                                                         (FStar_Parser_AST.QForall
+                                                            (xs4,
+                                                              (binders,
+                                                                pats1),
+                                                              body4))
+                                                     else
+                                                       if op = "exists"
+                                                       then
+                                                         mk
+                                                           (FStar_Parser_AST.QExists
+                                                              (xs4,
+                                                                (binders,
+                                                                  pats1),
+                                                                body4))
+                                                       else
+                                                         (let uu___16 =
+                                                            let uu___17 =
+                                                              let uu___18 =
+                                                                FStar_Ident.id_of_text
+                                                                  op in
+                                                              (uu___18, xs4,
+                                                                (binders,
+                                                                  pats1),
+                                                                body4) in
+                                                            FStar_Parser_AST.QuantOp
+                                                              uu___17 in
+                                                          mk uu___16))))
+                                  | uu___10 ->
+                                      if op = "forall"
+                                      then
                                         let uu___11 =
-                                          FStar_Parser_AST.string_to_op op1 in
-                                        match uu___11 with
-                                        | FStar_Pervasives_Native.None -> op1
-                                        | FStar_Pervasives_Native.Some
-                                            (op2, uu___12) -> op2 in
-                                      let flavor_matches t2 =
-                                        match ((t2.FStar_Parser_AST.tm), op)
-                                        with
-                                        | (FStar_Parser_AST.QExists uu___11,
-                                           "exists") -> true
-                                        | (FStar_Parser_AST.QForall uu___11,
-                                           "forall") -> true
-                                        | (FStar_Parser_AST.QuantOp
-                                           (id, uu___11, uu___12, uu___13),
-                                           uu___14) ->
-                                            let uu___15 =
-                                              FStar_Ident.string_of_id id in
-                                            uu___15 = op
-                                        | uu___11 -> false in
-                                      let uu___11 =
-                                        uncurry xs3 pats body3 flavor_matches in
-                                      (match uu___11 with
-                                       | (xs4, pats1, body4) ->
-                                           let binders =
-                                             FStar_Parser_AST.idents_of_binders
-                                               xs4 t1.FStar_Syntax_Syntax.pos in
-                                           if op = "forall"
-                                           then
-                                             mk
-                                               (FStar_Parser_AST.QForall
-                                                  (xs4, (binders, pats1),
-                                                    body4))
-                                           else
-                                             if op = "exists"
-                                             then
-                                               mk
-                                                 (FStar_Parser_AST.QExists
-                                                    (xs4, (binders, pats1),
-                                                      body4))
-                                             else
-                                               (let uu___14 =
-                                                  let uu___15 =
-                                                    let uu___16 =
-                                                      FStar_Ident.id_of_text
-                                                        op in
-                                                    (uu___16, xs4,
-                                                      (binders, pats1),
-                                                      body4) in
-                                                  FStar_Parser_AST.QuantOp
-                                                    uu___15 in
-                                                mk uu___14))))
-                        | uu___8 ->
-                            if op = "forall"
-                            then
-                              let uu___9 =
-                                let uu___10 =
-                                  let uu___11 = resugar_term' env body in
-                                  ([], ([], []), uu___11) in
-                                FStar_Parser_AST.QForall uu___10 in
-                              mk uu___9
-                            else
-                              (let uu___10 =
-                                 let uu___11 =
-                                   let uu___12 = resugar_term' env body in
-                                   ([], ([], []), uu___12) in
-                                 FStar_Parser_AST.QExists uu___11 in
-                               mk uu___10) in
-                      if (FStar_Compiler_List.length args1) > Prims.int_zero
-                      then
-                        let args2 = last args1 in
-                        (match args2 with
-                         | (b, uu___7)::[] -> resugar_forall_body b
-                         | uu___7 ->
-                             FStar_Compiler_Effect.failwith
-                               "wrong args format to QForall")
-                      else resugar_as_app e args1
-                  | FStar_Pervasives_Native.Some ("alloc", uu___6) ->
-                      let uu___7 = FStar_Compiler_List.hd args1 in
-                      (match uu___7 with
-                       | (e1, uu___8) -> resugar_term' env e1)
-                  | FStar_Pervasives_Native.Some (op, expected_arity1) ->
-                      let op1 = FStar_Ident.id_of_text op in
-                      let resugar args2 =
-                        FStar_Compiler_List.map
-                          (fun uu___6 ->
-                             match uu___6 with
-                             | (e1, qual) ->
-                                 let uu___7 = resugar_term' env e1 in
-                                 let uu___8 = resugar_aqual env qual in
-                                 (uu___7, uu___8)) args2 in
-                      (match expected_arity1 with
-                       | FStar_Pervasives_Native.None ->
-                           let resugared_args = resugar args1 in
-                           let expect_n =
-                             FStar_Parser_ToDocument.handleable_args_length
-                               op1 in
-                           if
-                             (FStar_Compiler_List.length resugared_args) >=
-                               expect_n
-                           then
-                             let uu___6 =
-                               FStar_Compiler_Util.first_N expect_n
-                                 resugared_args in
-                             (match uu___6 with
-                              | (op_args, rest) ->
-                                  let head =
-                                    let uu___7 =
-                                      let uu___8 =
-                                        let uu___9 =
-                                          FStar_Compiler_List.map
-                                            FStar_Pervasives_Native.fst
-                                            op_args in
-                                        (op1, uu___9) in
-                                      FStar_Parser_AST.Op uu___8 in
-                                    mk uu___7 in
-                                  FStar_Compiler_List.fold_left
-                                    (fun head1 ->
-                                       fun uu___7 ->
-                                         match uu___7 with
-                                         | (arg, qual) ->
-                                             mk
-                                               (FStar_Parser_AST.App
-                                                  (head1, arg, qual))) head
-                                    rest)
-                           else resugar_as_app e args1
-                       | FStar_Pervasives_Native.Some n when
-                           (FStar_Compiler_List.length args1) = n ->
-                           let uu___6 =
-                             let uu___7 =
-                               let uu___8 =
-                                 let uu___9 = resugar args1 in
-                                 FStar_Compiler_List.map
-                                   FStar_Pervasives_Native.fst uu___9 in
-                               (op1, uu___8) in
-                             FStar_Parser_AST.Op uu___7 in
-                           mk uu___6
-                       | uu___6 -> resugar_as_app e args1)))
+                                          let uu___12 =
+                                            let uu___13 =
+                                              resugar_term' env body in
+                                            ([], ([], []), uu___13) in
+                                          FStar_Parser_AST.QForall uu___12 in
+                                        mk uu___11
+                                      else
+                                        (let uu___12 =
+                                           let uu___13 =
+                                             let uu___14 =
+                                               resugar_term' env body in
+                                             ([], ([], []), uu___14) in
+                                           FStar_Parser_AST.QExists uu___13 in
+                                         mk uu___12) in
+                                if
+                                  (FStar_Compiler_List.length args1) >
+                                    Prims.int_zero
+                                then
+                                  let args2 = last args1 in
+                                  (match args2 with
+                                   | (b, uu___9)::[] -> resugar_forall_body b
+                                   | uu___9 ->
+                                       FStar_Compiler_Effect.failwith
+                                         "wrong args format to QForall")
+                                else resugar_as_app e args1
+                            | FStar_Pervasives_Native.Some ("alloc", uu___8)
+                                ->
+                                let uu___9 = FStar_Compiler_List.hd args1 in
+                                (match uu___9 with
+                                 | (e1, uu___10) -> resugar_term' env e1)
+                            | FStar_Pervasives_Native.Some
+                                (op, expected_arity1) ->
+                                let op1 = FStar_Ident.id_of_text op in
+                                let resugar args2 =
+                                  FStar_Compiler_List.map
+                                    (fun uu___8 ->
+                                       match uu___8 with
+                                       | (e1, qual) ->
+                                           let uu___9 = resugar_term' env e1 in
+                                           let uu___10 =
+                                             resugar_aqual env qual in
+                                           (uu___9, uu___10)) args2 in
+                                (match expected_arity1 with
+                                 | FStar_Pervasives_Native.None ->
+                                     let resugared_args = resugar args1 in
+                                     let expect_n =
+                                       FStar_Parser_ToDocument.handleable_args_length
+                                         op1 in
+                                     if
+                                       (FStar_Compiler_List.length
+                                          resugared_args)
+                                         >= expect_n
+                                     then
+                                       let uu___8 =
+                                         FStar_Compiler_Util.first_N expect_n
+                                           resugared_args in
+                                       (match uu___8 with
+                                        | (op_args, rest) ->
+                                            let head =
+                                              let uu___9 =
+                                                let uu___10 =
+                                                  let uu___11 =
+                                                    FStar_Compiler_List.map
+                                                      FStar_Pervasives_Native.fst
+                                                      op_args in
+                                                  (op1, uu___11) in
+                                                FStar_Parser_AST.Op uu___10 in
+                                              mk uu___9 in
+                                            FStar_Compiler_List.fold_left
+                                              (fun head1 ->
+                                                 fun uu___9 ->
+                                                   match uu___9 with
+                                                   | (arg, qual) ->
+                                                       mk
+                                                         (FStar_Parser_AST.App
+                                                            (head1, arg,
+                                                              qual))) head
+                                              rest)
+                                     else resugar_as_app e args1
+                                 | FStar_Pervasives_Native.Some n when
+                                     (FStar_Compiler_List.length args1) = n
+                                     ->
+                                     let uu___8 =
+                                       let uu___9 =
+                                         let uu___10 =
+                                           let uu___11 = resugar args1 in
+                                           FStar_Compiler_List.map
+                                             FStar_Pervasives_Native.fst
+                                             uu___11 in
+                                         (op1, uu___10) in
+                                       FStar_Parser_AST.Op uu___9 in
+                                     mk uu___8
+                                 | uu___8 -> resugar_as_app e args1)))))
       | FStar_Syntax_Syntax.Tm_match
           { FStar_Syntax_Syntax.scrutinee = e;
             FStar_Syntax_Syntax.ret_opt = FStar_Pervasives_Native.None;

--- a/src/parser/FStar.Parser.AST.Util.fst
+++ b/src/parser/FStar.Parser.AST.Util.fst
@@ -640,6 +640,8 @@ and lidents_of_term' (t:term')
   | ElimImplies (t1, t2, t3) -> lidents_of_term t1 @ lidents_of_term t2 @ lidents_of_term t3
   | ElimOr (t1, t2, t3, b1, t4, b2, t5) -> lidents_of_term t1 @ lidents_of_term t2 @ lidents_of_term t3 @ lidents_of_term t4 @ lidents_of_term t5
   | ElimAnd (t1, t2, t3, b1, b2, t4) -> lidents_of_term t1 @ lidents_of_term t2 @ lidents_of_term t3 @ lidents_of_term t4
+  | ListLiteral ts -> concat_map lidents_of_term ts
+  | SeqLiteral ts -> concat_map lidents_of_term ts
 and lidents_of_branch (p, _, t) = lidents_of_pattern p @ lidents_of_term t
 and lidents_of_calc_step = function
   | CalcStep (t1, t2, t3) -> lidents_of_term t1 @ lidents_of_term t2 @ lidents_of_term t3

--- a/src/parser/FStar.Parser.AST.fst
+++ b/src/parser/FStar.Parser.AST.fst
@@ -79,16 +79,10 @@ let consPat r hd tl = PatApp(mk_pattern (PatName C.cons_lid) r, [hd;tl])
 let consTerm r hd tl = mk_term (Construct(C.cons_lid, [(hd, Nothing);(tl, Nothing)])) r Expr
 
 let mkListLit r elts =
-  let nil = mk_term (Construct(C.nil_lid, [])) r Expr in
-  List.fold_right (fun e tl -> consTerm r e tl) elts nil
+  mk_term (ListLiteral elts) r Expr
 
-let seqConsTerm r hd tl =
-  let cons = mk_term (Var (C.seq_cons_lid)) r Expr in
-  mkApp cons [(hd, Nothing); (tl, Nothing)] r
-
-let mkSeqLit  r elts =
-  let nil = mk_term (Var (C.seq_empty_lid)) r Expr in
-  List.fold_right (fun e tl -> seqConsTerm r e tl) elts nil
+let mkSeqLit r elts =
+  mk_term (SeqLiteral elts) r Expr
 
 let unit_const r = mk_term(Const Const_unit) r Expr
 
@@ -620,6 +614,12 @@ let rec term_to_string (x:term) = match x.tm with
       (term_to_string q)
       (term_to_string e1)
       (term_to_string e2)
+
+  | ListLiteral ts ->
+    Util.format1 "[%s]" (to_string_l "; " term_to_string ts)
+
+  | SeqLiteral ts ->
+    Util.format1 "seq![%s]" (to_string_l "; " term_to_string ts)
     
 and binders_to_string sep bs =
     List.map binder_to_string bs |> String.concat sep

--- a/src/parser/FStar.Parser.AST.fsti
+++ b/src/parser/FStar.Parser.AST.fsti
@@ -300,7 +300,9 @@ val un_function : pattern -> term -> option (pattern & term)
 
 val consPat : range -> pattern -> pattern -> pattern'
 val consTerm : range -> term -> term -> term
-val mkConsList : range -> list term -> term
+
+val mkListLit  : range -> list term -> term (* a list literal *)
+val mkSeqLit   : range -> list term -> term (* a sequence literal *)
 
 val unit_const : range -> term
 val ml_comp : term -> term

--- a/src/parser/FStar.Parser.AST.fsti
+++ b/src/parser/FStar.Parser.AST.fsti
@@ -96,6 +96,9 @@ type term' =
   | ElimImplies of term & term & term                             (* elim_implies P Q with e *)
   | ElimOr of term & term & term & binder & term & binder & term  (* elim_or P Q to R with x.e1 and y.e2 *)
   | ElimAnd of term & term & term & binder & binder & term        (* elim_and P Q to R with x y. e *)
+  | ListLiteral of list term
+  | SeqLiteral of list term
+
 
 and term = {tm:term'; range:range; level:level}
 
@@ -300,9 +303,6 @@ val un_function : pattern -> term -> option (pattern & term)
 
 val consPat : range -> pattern -> pattern -> pattern'
 val consTerm : range -> term -> term -> term
-
-val mkListLit  : range -> list term -> term (* a list literal *)
-val mkSeqLit   : range -> list term -> term (* a sequence literal *)
 
 val unit_const : range -> term
 val ml_comp : term -> term

--- a/src/parser/FStar.Parser.Const.fst
+++ b/src/parser/FStar.Parser.Const.fst
@@ -139,6 +139,9 @@ let list_append_lid       = p2l ["FStar"; "List"; "append"]
 let list_tot_append_lid   = p2l ["FStar"; "List"; "Tot"; "Base"; "append"]
 let id_lid                = psconst "id"
 
+let seq_cons_lid              = p2l ["FStar"; "Seq"; "Base"; "cons"]
+let seq_empty_lid             = p2l ["FStar"; "Seq"; "Base"; "empty"]
+
 /// Constants from FStar.Char
 let c2l s = p2l ["FStar"; "Char"; s]
 let char_u32_of_char = c2l "u32_of_char"

--- a/src/parser/FStar.Parser.Dep.fst
+++ b/src/parser/FStar.Parser.Dep.fst
@@ -1147,6 +1147,13 @@ let collect_one
           collect_binder y;
           collect_term e;
           collect_term e'
+
+        | ListLiteral ts ->
+          List.iter collect_term ts
+
+        | SeqLiteral ts ->
+          add_to_parsing_data (P_dep (false, (Ident.lid_of_str "FStar.Seq.Base")));
+          List.iter collect_term ts
         
       and collect_patterns ps =
         List.iter collect_pattern ps

--- a/src/tosyntax/FStar.ToSyntax.ToSyntax.fst
+++ b/src/tosyntax/FStar.ToSyntax.ToSyntax.fst
@@ -432,6 +432,12 @@ and free_vars tvars_only env t = match (unparen t).tm with
     (let env', free = free_vars_bs tvars_only env [x;y] in
      free@free_vars tvars_only env' e)
 
+  | ListLiteral ts ->
+    List.collect (free_vars tvars_only env) ts
+
+  | SeqLiteral ts ->
+    List.collect (free_vars tvars_only env) ts
+
   | Abs _  (* not closing implicitly over free vars in all these forms: TODO: Fixme! *)
   | Let _
   | LetOpen _
@@ -2306,6 +2312,18 @@ and desugar_term_maybe_top (top_level:bool) (env:env_t) (top:term) : S.term & an
                   (U.abs [x;y] e None, None)] in
       mk_Tm_app head args top.range, noaqs
 
+    | ListLiteral ts ->
+      let nil r = mk_term (Construct (C.nil_lid, [])) r Expr in
+      let cons r hd tl= mk_term (Construct (C.cons_lid, [ (hd, Nothing); (tl, Nothing)])) r Expr in
+      let t' = List.fold_right (cons top.range) ts (nil top.range) in
+      desugar_term_aq env t'
+
+    | SeqLiteral ts ->
+      let nil r = mk_term (Var C.seq_empty_lid) r Expr in
+      let cons r hd tl = mkApp (mk_term (Var C.seq_cons_lid) r Expr) [ (hd, Nothing); (tl, Nothing)] r in
+      let t' = List.fold_right (cons top.range) ts (nil top.range) in
+      desugar_term_aq env t'
+
     | _ when (top.level=Formula) -> desugar_formula env top, noaqs
 
     | _ ->
@@ -2368,22 +2386,26 @@ and desugar_comp r (allow_type_promotion:bool) env t =
       | Decreases _ -> true
       | _ -> false
     in
-    let is_smt_pat (t,_) =
+    let is_smt_pat1 (t:term) : bool =
       match (unparen t).tm with
       // TODO: remove this first match once we fully migrate
-      | Construct (cons, [{tm=Construct (smtpat, _)}, _; _]) ->
-        Ident.lid_equals cons C.cons_lid &&
+      | Construct (smtpat, _) ->
         BU.for_some (fun s -> (string_of_lid smtpat) = s)
           (* the smt pattern does not seem to be disambiguated yet at this point *)
           ["SMTPat"; "SMTPatT"; "SMTPatOr"]
           (* [C.smtpat_lid ; C.smtpatT_lid ; C.smtpatOr_lid] *)
 
-      | Construct (cons, [{tm=Var smtpat}, _; _]) ->
-        Ident.lid_equals cons C.cons_lid &&
+      | Var smtpat ->
         BU.for_some (fun s -> (string_of_lid smtpat) = s)
           (* the smt pattern does not seem to be disambiguated yet at this point *)
           ["smt_pat" ; "smt_pat_or"]
           (* [C.smtpat_lid ; C.smtpatT_lid ; C.smtpatOr_lid] *)
+
+      | _ -> false
+    in
+    let is_smt_pat (t,_) : bool =
+      match (unparen t).tm with
+      | ListLiteral ts -> BU.for_all is_smt_pat1 ts
       | _ -> false
     in
     let pre_process_comp_typ (t:AST.term) =

--- a/tests/error-messages/Makefile
+++ b/tests/error-messages/Makefile
@@ -30,6 +30,7 @@ Bug3227.fst.output: OTHERFLAGS+=--dump_module Bug3227
 Bug3292.fst.output: OTHERFLAGS+=--dump_module Bug3292
 CalcImpl.fst.output: OTHERFLAGS+=--dump_module CalcImpl
 DTuples.fst.output: OTHERFLAGS+=--dump_module DTuples
+SeqLit.fst.output: OTHERFLAGS+=--dump_module SeqLit
 
 include $(FSTAR_HOME)/examples/Makefile.common
 

--- a/tests/error-messages/SeqLit.fst
+++ b/tests/error-messages/SeqLit.fst
@@ -1,0 +1,16 @@
+module SeqLit
+
+let x = seq![1; 2; 3]
+let y = [1; 2; 3]
+
+let _ = assert (FStar.Seq.seq_to_list x == y)
+
+let _ = 1 :: [2] @ [3]
+let _ = 1 :: 2 :: [3]
+let _ = 1 :: 2 :: 3 :: []
+let _ = 1 :: 2 :: 3 :: []
+
+let _ = 1 `Seq.cons` seq![2] `Seq.append` seq![3]
+let _ = 1 `Seq.cons` (2 `Seq.cons` seq![3])
+let _ = 1 `Seq.cons` (2 `Seq.cons` (3 `Seq.cons` seq![]))
+let _ = 1 `Seq.cons` (2 `Seq.cons` (3 `Seq.cons` seq![]))

--- a/tests/error-messages/SeqLit.fst.expected
+++ b/tests/error-messages/SeqLit.fst.expected
@@ -1,0 +1,148 @@
+Module after desugaring:
+module SeqLit
+Declarations: [
+let x = seq![1; 2; 3]
+let y = [1; 2; 3]
+private
+let _ = assert (FStar.Seq.Base.seq_to_list SeqLit.x == SeqLit.y)
+private
+let _ = [1; 2] @ [3]
+private
+let _ = [1; 2; 3]
+private
+let _ = [1; 2; 3]
+private
+let _ = [1; 2; 3]
+private
+let _ = FStar.Seq.Base.append seq![1; 2] seq![3]
+private
+let _ = seq![1; 2; 3]
+private
+let _ = seq![1; 2; 3]
+private
+let _ = seq![1; 2; 3]
+]
+Exports: [
+let x = seq![1; 2; 3]
+let y = [1; 2; 3]
+private
+let _ = assert (FStar.Seq.Base.seq_to_list SeqLit.x == SeqLit.y)
+private
+let _ = [1; 2] @ [3]
+private
+let _ = [1; 2; 3]
+private
+let _ = [1; 2; 3]
+private
+let _ = [1; 2; 3]
+private
+let _ = FStar.Seq.Base.append seq![1; 2] seq![3]
+private
+let _ = seq![1; 2; 3]
+private
+let _ = seq![1; 2; 3]
+private
+let _ = seq![1; 2; 3]
+]
+
+Module before type checking:
+module SeqLit
+Declarations: [
+let x = seq![1; 2; 3]
+let y = [1; 2; 3]
+private
+let _ = assert (FStar.Seq.Base.seq_to_list SeqLit.x == SeqLit.y)
+private
+let _ = [1; 2] @ [3]
+private
+let _ = [1; 2; 3]
+private
+let _ = [1; 2; 3]
+private
+let _ = [1; 2; 3]
+private
+let _ = FStar.Seq.Base.append seq![1; 2] seq![3]
+private
+let _ = seq![1; 2; 3]
+private
+let _ = seq![1; 2; 3]
+private
+let _ = seq![1; 2; 3]
+]
+Exports: [
+let x = seq![1; 2; 3]
+let y = [1; 2; 3]
+private
+let _ = assert (FStar.Seq.Base.seq_to_list SeqLit.x == SeqLit.y)
+private
+let _ = [1; 2] @ [3]
+private
+let _ = [1; 2; 3]
+private
+let _ = [1; 2; 3]
+private
+let _ = [1; 2; 3]
+private
+let _ = FStar.Seq.Base.append seq![1; 2] seq![3]
+private
+let _ = seq![1; 2; 3]
+private
+let _ = seq![1; 2; 3]
+private
+let _ = seq![1; 2; 3]
+]
+
+Module after type checking:
+module SeqLit
+Declarations: [
+let x = seq![1; 2; 3]
+let y = [1; 2; 3]
+private
+let _ = assert (FStar.Seq.Base.seq_to_list SeqLit.x == SeqLit.y)
+private
+let _ = [1; 2] @ [3]
+private
+let _ = [1; 2; 3]
+private
+let _ = [1; 2; 3]
+private
+let _ = [1; 2; 3]
+private
+let _ = FStar.Seq.Base.append seq![1; 2] seq![3]
+private
+let _ = seq![1; 2; 3]
+private
+let _ = seq![1; 2; 3]
+private
+let _ = seq![1; 2; 3]
+]
+Exports: [
+let x = seq![1; 2; 3]
+let y = [1; 2; 3]
+private
+let _ = assert (FStar.Seq.Base.seq_to_list SeqLit.x == SeqLit.y)
+private
+let _ = [1; 2] @ [3]
+private
+let _ = [1; 2; 3]
+private
+let _ = [1; 2; 3]
+private
+let _ = [1; 2; 3]
+private
+let _ = FStar.Seq.Base.append seq![1; 2] seq![3]
+private
+let _ = seq![1; 2; 3]
+private
+let _ = seq![1; 2; 3]
+private
+let _ = seq![1; 2; 3]
+]
+
+* Warning 337 at SeqLit.fst(8,17-8,18):
+  - The operator '@' has been resolved to FStar.List.Tot.append even though
+    FStar.List.Tot is not in scope. Please add an 'open FStar.List.Tot' to stop
+    relying on this deprecated, special treatment of '@'.
+
+Verified module: SeqLit
+All verification conditions discharged successfully

--- a/tests/ide/test-incremental.py
+++ b/tests/ide/test-incremental.py
@@ -261,8 +261,8 @@ def test_file(filepath):
     # Check that fstar exited with code 0
     if p.returncode != 0:
         print("F* returned non-zero exit code")
-        print(p.stderr.read())
-        print(p.stdout.read())
+        print(p.stderr)
+        print(p.stdout)
         return False
     # Parse the response into a list of lines
     # lines = response.splitlines()

--- a/tests/prettyprinting/SeqLit.fst
+++ b/tests/prettyprinting/SeqLit.fst
@@ -1,0 +1,16 @@
+module SeqLit
+
+let x = seq![1; 2; 3]
+let y = [1; 2; 3]
+
+let _ = assert (FStar.Seq.seq_to_list x == y)
+
+let _ = 1 :: [2] @ [3]
+let _ = 1 :: 2 :: [3]
+let _ = 1 :: 2 :: 3 :: []
+let _ = 1 :: 2 :: 3 :: []
+
+let _ = 1 `Seq.cons` seq![2] `Seq.append` seq![3]
+let _ = 1 `Seq.cons` (2 `Seq.cons` seq![3])
+let _ = 1 `Seq.cons` (2 `Seq.cons` (3 `Seq.cons` seq![]))
+let _ = 1 `Seq.cons` (2 `Seq.cons` (3 `Seq.cons` seq![]))

--- a/tests/prettyprinting/SeqLit.fst.expected
+++ b/tests/prettyprinting/SeqLit.fst.expected
@@ -1,0 +1,17 @@
+module SeqLit
+
+let x = seq![1; 2; 3]
+let y = [1; 2; 3]
+
+let _ = assert (FStar.Seq.seq_to_list x == y)
+
+let _ = 1 :: [2] @ [3]
+let _ = 1 :: 2 :: [3]
+let _ = 1 :: 2 :: 3 :: []
+let _ = 1 :: 2 :: 3 :: []
+
+let _ = (1 `Seq.cons` seq![2]) `Seq.append` seq![3]
+let _ = 1 `Seq.cons` (2 `Seq.cons` seq![3])
+let _ = 1 `Seq.cons` (2 `Seq.cons` (3 `Seq.cons` seq![]))
+let _ = 1 `Seq.cons` (2 `Seq.cons` (3 `Seq.cons` seq![]))
+


### PR DESCRIPTION
This introduces some syntax for literal sequences. I want to rework this a bit still to obtain resugaring, but posting for comments.