### PR TITLE
Introduce an attribute to unrefine type arguments

### DIFF
--- a/doc/old/tutorial/code/solutions/EtM.CPA.fst
+++ b/doc/old/tutorial/code/solutions/EtM.CPA.fst
@@ -37,6 +37,7 @@ let ivsize = blockSize AES_128_CBC
 let keysize = 16
 type aes_key = lbytes keysize (* = b:bytes{B.length b = keysize} *)
 type msg = plain
+[@@do_not_unrefine]
 type cipher = b:bytes{B.length b >= ivsize}
 (* MK: minimal cipher length twice blocksize? *)
 

--- a/examples/crypto/HyE.AE.fsti
+++ b/examples/crypto/HyE.AE.fsti
@@ -32,6 +32,7 @@ let ivsize = aeadRealIVSize AES_128_GCM
 let keysize = aeadKeySize AES_128_GCM
 type aes_key = lbytes keysize (* = b:bytes{B.length b = keysize} *)
 type msg = Plain.t
+[@@do_not_unrefine]
 type cipher = b:bytes{B.length b >= ivsize}
 (* MK: minimal cipher length twice blocksize? *)
 

--- a/ocaml/fstar-lib/generated/FStar_InteractiveHelpers_Base.ml
+++ b/ocaml/fstar-lib/generated/FStar_InteractiveHelpers_Base.ml
@@ -94,8 +94,8 @@ let option_to_string :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "prims.fst"
-                                (Prims.of_int (595)) (Prims.of_int (19))
-                                (Prims.of_int (595)) (Prims.of_int (31)))))
+                                (Prims.of_int (611)) (Prims.of_int (19))
+                                (Prims.of_int (611)) (Prims.of_int (31)))))
                        (Obj.magic
                           (FStar_Tactics_Effect.tac_bind
                              (FStar_Sealed.seal
@@ -107,9 +107,9 @@ let option_to_string :
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range "prims.fst"
-                                      (Prims.of_int (595))
+                                      (Prims.of_int (611))
                                       (Prims.of_int (19))
-                                      (Prims.of_int (595))
+                                      (Prims.of_int (611))
                                       (Prims.of_int (31)))))
                              (Obj.magic (f x'))
                              (fun uu___ ->
@@ -141,8 +141,8 @@ let list_to_string :
                  (Prims.of_int (68)))))
         (FStar_Sealed.seal
            (Obj.magic
-              (FStar_Range.mk_range "prims.fst" (Prims.of_int (595))
-                 (Prims.of_int (19)) (Prims.of_int (595)) (Prims.of_int (31)))))
+              (FStar_Range.mk_range "prims.fst" (Prims.of_int (611))
+                 (Prims.of_int (19)) (Prims.of_int (611)) (Prims.of_int (31)))))
         (Obj.magic
            (FStar_Tactics_Util.fold_left
               (fun s ->
@@ -157,8 +157,8 @@ let list_to_string :
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "prims.fst"
-                              (Prims.of_int (595)) (Prims.of_int (19))
-                              (Prims.of_int (595)) (Prims.of_int (31)))))
+                              (Prims.of_int (611)) (Prims.of_int (19))
+                              (Prims.of_int (611)) (Prims.of_int (31)))))
                      (Obj.magic
                         (FStar_Tactics_Effect.tac_bind
                            (FStar_Sealed.seal
@@ -170,8 +170,8 @@ let list_to_string :
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range "prims.fst"
-                                    (Prims.of_int (595)) (Prims.of_int (19))
-                                    (Prims.of_int (595)) (Prims.of_int (31)))))
+                                    (Prims.of_int (611)) (Prims.of_int (19))
+                                    (Prims.of_int (611)) (Prims.of_int (31)))))
                            (Obj.magic
                               (FStar_Tactics_Effect.tac_bind
                                  (FStar_Sealed.seal
@@ -185,9 +185,9 @@ let list_to_string :
                                  (FStar_Sealed.seal
                                     (Obj.magic
                                        (FStar_Range.mk_range "prims.fst"
-                                          (Prims.of_int (595))
+                                          (Prims.of_int (611))
                                           (Prims.of_int (19))
-                                          (Prims.of_int (595))
+                                          (Prims.of_int (611))
                                           (Prims.of_int (31)))))
                                  (Obj.magic (f x))
                                  (fun uu___ ->
@@ -293,8 +293,8 @@ let (abv_to_string :
                           (Prims.of_int (85)) (Prims.of_int (15)))))
                  (FStar_Sealed.seal
                     (Obj.magic
-                       (FStar_Range.mk_range "prims.fst" (Prims.of_int (595))
-                          (Prims.of_int (19)) (Prims.of_int (595))
+                       (FStar_Range.mk_range "prims.fst" (Prims.of_int (611))
+                          (Prims.of_int (19)) (Prims.of_int (611))
                           (Prims.of_int (31)))))
                  (Obj.magic (FStar_Tactics_V1_Derived.name_of_bv bv))
                  (fun uu___ ->
@@ -353,8 +353,8 @@ let (print_binder_info :
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range "prims.fst"
-                                  (Prims.of_int (595)) (Prims.of_int (19))
-                                  (Prims.of_int (595)) (Prims.of_int (31)))))
+                                  (Prims.of_int (611)) (Prims.of_int (19))
+                                  (Prims.of_int (611)) (Prims.of_int (31)))))
                          (Obj.magic
                             (FStar_Tactics_V1_Builtins.term_to_string t))
                          (fun uu___ ->
@@ -416,9 +416,9 @@ let (print_binder_info :
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "prims.fst"
-                                                   (Prims.of_int (595))
+                                                   (Prims.of_int (611))
                                                    (Prims.of_int (19))
-                                                   (Prims.of_int (595))
+                                                   (Prims.of_int (611))
                                                    (Prims.of_int (31)))))
                                           (Obj.magic
                                              (FStar_Tactics_Effect.tac_bind
@@ -434,9 +434,9 @@ let (print_binder_info :
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "prims.fst"
-                                                         (Prims.of_int (595))
+                                                         (Prims.of_int (611))
                                                          (Prims.of_int (19))
-                                                         (Prims.of_int (595))
+                                                         (Prims.of_int (611))
                                                          (Prims.of_int (31)))))
                                                 (Obj.magic
                                                    (FStar_Tactics_Effect.tac_bind
@@ -477,9 +477,9 @@ let (print_binder_info :
                                                                     Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                  (Obj.magic
                                                                     (
@@ -496,9 +496,9 @@ let (print_binder_info :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -539,9 +539,9 @@ let (print_binder_info :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -557,9 +557,9 @@ let (print_binder_info :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -575,9 +575,9 @@ let (print_binder_info :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -593,9 +593,9 @@ let (print_binder_info :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -636,9 +636,9 @@ let (print_binder_info :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -654,9 +654,9 @@ let (print_binder_info :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -672,9 +672,9 @@ let (print_binder_info :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -690,9 +690,9 @@ let (print_binder_info :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V1_Builtins.term_to_string
@@ -848,8 +848,8 @@ let (acomp_to_string :
                    (Prims.of_int (113)) (Prims.of_int (42)))))
           (FStar_Sealed.seal
              (Obj.magic
-                (FStar_Range.mk_range "prims.fst" (Prims.of_int (595))
-                   (Prims.of_int (19)) (Prims.of_int (595))
+                (FStar_Range.mk_range "prims.fst" (Prims.of_int (611))
+                   (Prims.of_int (19)) (Prims.of_int (611))
                    (Prims.of_int (31)))))
           (Obj.magic
              (FStar_Tactics_Effect.tac_bind
@@ -861,8 +861,8 @@ let (acomp_to_string :
                          (Prims.of_int (113)) (Prims.of_int (36)))))
                 (FStar_Sealed.seal
                    (Obj.magic
-                      (FStar_Range.mk_range "prims.fst" (Prims.of_int (595))
-                         (Prims.of_int (19)) (Prims.of_int (595))
+                      (FStar_Range.mk_range "prims.fst" (Prims.of_int (611))
+                         (Prims.of_int (19)) (Prims.of_int (611))
                          (Prims.of_int (31)))))
                 (Obj.magic (FStar_Tactics_V1_Builtins.term_to_string ret))
                 (fun uu___ ->
@@ -880,8 +880,8 @@ let (acomp_to_string :
                    (Prims.of_int (115)) (Prims.of_int (43)))))
           (FStar_Sealed.seal
              (Obj.magic
-                (FStar_Range.mk_range "prims.fst" (Prims.of_int (595))
-                   (Prims.of_int (19)) (Prims.of_int (595))
+                (FStar_Range.mk_range "prims.fst" (Prims.of_int (611))
+                   (Prims.of_int (19)) (Prims.of_int (611))
                    (Prims.of_int (31)))))
           (Obj.magic
              (FStar_Tactics_Effect.tac_bind
@@ -893,8 +893,8 @@ let (acomp_to_string :
                          (Prims.of_int (115)) (Prims.of_int (37)))))
                 (FStar_Sealed.seal
                    (Obj.magic
-                      (FStar_Range.mk_range "prims.fst" (Prims.of_int (595))
-                         (Prims.of_int (19)) (Prims.of_int (595))
+                      (FStar_Range.mk_range "prims.fst" (Prims.of_int (611))
+                         (Prims.of_int (19)) (Prims.of_int (611))
                          (Prims.of_int (31)))))
                 (Obj.magic (FStar_Tactics_V1_Builtins.term_to_string ret))
                 (fun uu___ ->
@@ -912,8 +912,8 @@ let (acomp_to_string :
                    (Prims.of_int (117)) (Prims.of_int (72)))))
           (FStar_Sealed.seal
              (Obj.magic
-                (FStar_Range.mk_range "prims.fst" (Prims.of_int (595))
-                   (Prims.of_int (19)) (Prims.of_int (595))
+                (FStar_Range.mk_range "prims.fst" (Prims.of_int (611))
+                   (Prims.of_int (19)) (Prims.of_int (611))
                    (Prims.of_int (31)))))
           (Obj.magic
              (FStar_Tactics_Effect.tac_bind
@@ -943,8 +943,8 @@ let (acomp_to_string :
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range "prims.fst"
-                                    (Prims.of_int (595)) (Prims.of_int (19))
-                                    (Prims.of_int (595)) (Prims.of_int (31)))))
+                                    (Prims.of_int (611)) (Prims.of_int (19))
+                                    (Prims.of_int (611)) (Prims.of_int (31)))))
                            (Obj.magic
                               (FStar_Tactics_Effect.tac_bind
                                  (FStar_Sealed.seal
@@ -958,9 +958,9 @@ let (acomp_to_string :
                                  (FStar_Sealed.seal
                                     (Obj.magic
                                        (FStar_Range.mk_range "prims.fst"
-                                          (Prims.of_int (595))
+                                          (Prims.of_int (611))
                                           (Prims.of_int (19))
-                                          (Prims.of_int (595))
+                                          (Prims.of_int (611))
                                           (Prims.of_int (31)))))
                                  (Obj.magic
                                     (FStar_Tactics_Effect.tac_bind
@@ -976,9 +976,9 @@ let (acomp_to_string :
                                           (Obj.magic
                                              (FStar_Range.mk_range
                                                 "prims.fst"
-                                                (Prims.of_int (595))
+                                                (Prims.of_int (611))
                                                 (Prims.of_int (19))
-                                                (Prims.of_int (595))
+                                                (Prims.of_int (611))
                                                 (Prims.of_int (31)))))
                                        (Obj.magic
                                           (FStar_Tactics_V1_Builtins.term_to_string
@@ -1024,8 +1024,8 @@ let (acomp_to_string :
                     (FStar_Sealed.seal
                        (Obj.magic
                           (FStar_Range.mk_range "prims.fst"
-                             (Prims.of_int (595)) (Prims.of_int (19))
-                             (Prims.of_int (595)) (Prims.of_int (31)))))
+                             (Prims.of_int (611)) (Prims.of_int (19))
+                             (Prims.of_int (611)) (Prims.of_int (31)))))
                     (Obj.magic
                        (FStar_Tactics_Effect.tac_bind
                           (FStar_Sealed.seal
@@ -1037,8 +1037,8 @@ let (acomp_to_string :
                           (FStar_Sealed.seal
                              (Obj.magic
                                 (FStar_Range.mk_range "prims.fst"
-                                   (Prims.of_int (595)) (Prims.of_int (19))
-                                   (Prims.of_int (595)) (Prims.of_int (31)))))
+                                   (Prims.of_int (611)) (Prims.of_int (19))
+                                   (Prims.of_int (611)) (Prims.of_int (31)))))
                           (Obj.magic
                              (FStar_Tactics_V1_Builtins.term_to_string a))
                           (fun uu___2 ->
@@ -1109,9 +1109,9 @@ let (acomp_to_string :
                                               (Obj.magic
                                                  (FStar_Range.mk_range
                                                     "prims.fst"
-                                                    (Prims.of_int (595))
+                                                    (Prims.of_int (611))
                                                     (Prims.of_int (19))
-                                                    (Prims.of_int (595))
+                                                    (Prims.of_int (611))
                                                     (Prims.of_int (31)))))
                                            (Obj.magic
                                               (FStar_Tactics_Effect.tac_bind
@@ -1127,9 +1127,9 @@ let (acomp_to_string :
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "prims.fst"
-                                                          (Prims.of_int (595))
+                                                          (Prims.of_int (611))
                                                           (Prims.of_int (19))
-                                                          (Prims.of_int (595))
+                                                          (Prims.of_int (611))
                                                           (Prims.of_int (31)))))
                                                  (Obj.magic
                                                     (FStar_Tactics_Effect.tac_bind
@@ -1145,9 +1145,9 @@ let (acomp_to_string :
                                                           (Obj.magic
                                                              (FStar_Range.mk_range
                                                                 "prims.fst"
-                                                                (Prims.of_int (595))
+                                                                (Prims.of_int (611))
                                                                 (Prims.of_int (19))
-                                                                (Prims.of_int (595))
+                                                                (Prims.of_int (611))
                                                                 (Prims.of_int (31)))))
                                                        (Obj.magic
                                                           (FStar_Tactics_Effect.tac_bind
@@ -1163,9 +1163,9 @@ let (acomp_to_string :
                                                                 (Obj.magic
                                                                    (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                              (Obj.magic
                                                                 (FStar_Tactics_V1_Builtins.term_to_string
@@ -1324,8 +1324,8 @@ let (filter_ascriptions :
                     (FStar_Sealed.seal
                        (Obj.magic
                           (FStar_Range.mk_range "prims.fst"
-                             (Prims.of_int (595)) (Prims.of_int (19))
-                             (Prims.of_int (595)) (Prims.of_int (31)))))
+                             (Prims.of_int (611)) (Prims.of_int (19))
+                             (Prims.of_int (611)) (Prims.of_int (31)))))
                     (Obj.magic
                        (FStar_Tactics_Effect.tac_bind
                           (FStar_Sealed.seal
@@ -1379,9 +1379,9 @@ let (filter_ascriptions :
                                      (FStar_Sealed.seal
                                         (Obj.magic
                                            (FStar_Range.mk_range "prims.fst"
-                                              (Prims.of_int (595))
+                                              (Prims.of_int (611))
                                               (Prims.of_int (19))
-                                              (Prims.of_int (595))
+                                              (Prims.of_int (611))
                                               (Prims.of_int (31)))))
                                      (Obj.magic
                                         (FStar_Tactics_Effect.tac_bind
@@ -1397,9 +1397,9 @@ let (filter_ascriptions :
                                               (Obj.magic
                                                  (FStar_Range.mk_range
                                                     "prims.fst"
-                                                    (Prims.of_int (595))
+                                                    (Prims.of_int (611))
                                                     (Prims.of_int (19))
-                                                    (Prims.of_int (595))
+                                                    (Prims.of_int (611))
                                                     (Prims.of_int (31)))))
                                            (Obj.magic
                                               (FStar_Tactics_V1_Builtins.term_to_string
@@ -1627,8 +1627,8 @@ let (genv_to_string :
                          (Prims.of_int (248)) (Prims.of_int (34)))))
                 (FStar_Sealed.seal
                    (Obj.magic
-                      (FStar_Range.mk_range "prims.fst" (Prims.of_int (595))
-                         (Prims.of_int (19)) (Prims.of_int (595))
+                      (FStar_Range.mk_range "prims.fst" (Prims.of_int (611))
+                         (Prims.of_int (19)) (Prims.of_int (611))
                          (Prims.of_int (31)))))
                 (Obj.magic
                    (abv_to_string
@@ -1711,9 +1711,9 @@ let (genv_to_string :
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "prims.fst"
-                                                              (Prims.of_int (595))
+                                                              (Prims.of_int (611))
                                                               (Prims.of_int (19))
-                                                              (Prims.of_int (595))
+                                                              (Prims.of_int (611))
                                                               (Prims.of_int (31)))))
                                                      (Obj.magic
                                                         (FStar_Tactics_Effect.tac_bind
@@ -1752,9 +1752,9 @@ let (genv_to_string :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1770,9 +1770,9 @@ let (genv_to_string :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1788,9 +1788,9 @@ let (genv_to_string :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1806,9 +1806,9 @@ let (genv_to_string :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1824,9 +1824,9 @@ let (genv_to_string :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V1_Builtins.term_to_string
@@ -1918,9 +1918,9 @@ let (genv_to_string :
                                                      (Obj.magic
                                                         (FStar_Range.mk_range
                                                            "prims.fst"
-                                                           (Prims.of_int (595))
+                                                           (Prims.of_int (611))
                                                            (Prims.of_int (19))
-                                                           (Prims.of_int (595))
+                                                           (Prims.of_int (611))
                                                            (Prims.of_int (31)))))
                                                   (Obj.magic
                                                      (FStar_Tactics_Util.map
@@ -1942,9 +1942,9 @@ let (genv_to_string :
                                                                     Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                  (Obj.magic
                                                                     (

--- a/ocaml/fstar-lib/generated/FStar_InteractiveHelpers_Effectful.ml
+++ b/ocaml/fstar-lib/generated/FStar_InteractiveHelpers_Effectful.ml
@@ -44,8 +44,8 @@ let (cast_info_to_string :
                (Prims.of_int (56)))))
       (FStar_Sealed.seal
          (Obj.magic
-            (FStar_Range.mk_range "prims.fst" (Prims.of_int (595))
-               (Prims.of_int (19)) (Prims.of_int (595)) (Prims.of_int (31)))))
+            (FStar_Range.mk_range "prims.fst" (Prims.of_int (611))
+               (Prims.of_int (19)) (Prims.of_int (611)) (Prims.of_int (31)))))
       (Obj.magic
          (FStar_Tactics_Effect.tac_bind
             (FStar_Sealed.seal
@@ -74,8 +74,8 @@ let (cast_info_to_string :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "prims.fst"
-                                (Prims.of_int (595)) (Prims.of_int (19))
-                                (Prims.of_int (595)) (Prims.of_int (31)))))
+                                (Prims.of_int (611)) (Prims.of_int (19))
+                                (Prims.of_int (611)) (Prims.of_int (31)))))
                        (Obj.magic
                           (FStar_Tactics_Effect.tac_bind
                              (FStar_Sealed.seal
@@ -87,9 +87,9 @@ let (cast_info_to_string :
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range "prims.fst"
-                                      (Prims.of_int (595))
+                                      (Prims.of_int (611))
                                       (Prims.of_int (19))
-                                      (Prims.of_int (595))
+                                      (Prims.of_int (611))
                                       (Prims.of_int (31)))))
                              (Obj.magic
                                 (FStar_Tactics_Effect.tac_bind
@@ -129,9 +129,9 @@ let (cast_info_to_string :
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "prims.fst"
-                                                       (Prims.of_int (595))
+                                                       (Prims.of_int (611))
                                                        (Prims.of_int (19))
-                                                       (Prims.of_int (595))
+                                                       (Prims.of_int (611))
                                                        (Prims.of_int (31)))))
                                               (Obj.magic
                                                  (FStar_Tactics_Effect.tac_bind
@@ -147,9 +147,9 @@ let (cast_info_to_string :
                                                        (Obj.magic
                                                           (FStar_Range.mk_range
                                                              "prims.fst"
-                                                             (Prims.of_int (595))
+                                                             (Prims.of_int (611))
                                                              (Prims.of_int (19))
-                                                             (Prims.of_int (595))
+                                                             (Prims.of_int (611))
                                                              (Prims.of_int (31)))))
                                                     (Obj.magic
                                                        (FStar_Tactics_Effect.tac_bind
@@ -165,9 +165,9 @@ let (cast_info_to_string :
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "prims.fst"
-                                                                   (Prims.of_int (595))
+                                                                   (Prims.of_int (611))
                                                                    (Prims.of_int (19))
-                                                                   (Prims.of_int (595))
+                                                                   (Prims.of_int (611))
                                                                    (Prims.of_int (31)))))
                                                           (Obj.magic
                                                              (FStar_InteractiveHelpers_Base.option_to_string
@@ -255,8 +255,8 @@ let (effect_info_to_string :
                (Prims.of_int (49)))))
       (FStar_Sealed.seal
          (Obj.magic
-            (FStar_Range.mk_range "prims.fst" (Prims.of_int (595))
-               (Prims.of_int (19)) (Prims.of_int (595)) (Prims.of_int (31)))))
+            (FStar_Range.mk_range "prims.fst" (Prims.of_int (611))
+               (Prims.of_int (19)) (Prims.of_int (611)) (Prims.of_int (31)))))
       (Obj.magic
          (FStar_Tactics_Effect.tac_bind
             (FStar_Sealed.seal
@@ -267,8 +267,8 @@ let (effect_info_to_string :
                      (Prims.of_int (54)) (Prims.of_int (49)))))
             (FStar_Sealed.seal
                (Obj.magic
-                  (FStar_Range.mk_range "prims.fst" (Prims.of_int (595))
-                     (Prims.of_int (19)) (Prims.of_int (595))
+                  (FStar_Range.mk_range "prims.fst" (Prims.of_int (611))
+                     (Prims.of_int (19)) (Prims.of_int (611))
                      (Prims.of_int (31)))))
             (Obj.magic
                (FStar_Tactics_Effect.tac_bind
@@ -281,8 +281,8 @@ let (effect_info_to_string :
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range "prims.fst"
-                           (Prims.of_int (595)) (Prims.of_int (19))
-                           (Prims.of_int (595)) (Prims.of_int (31)))))
+                           (Prims.of_int (611)) (Prims.of_int (19))
+                           (Prims.of_int (611)) (Prims.of_int (31)))))
                   (Obj.magic
                      (FStar_Tactics_Effect.tac_bind
                         (FStar_Sealed.seal
@@ -316,9 +316,9 @@ let (effect_info_to_string :
                                    (FStar_Sealed.seal
                                       (Obj.magic
                                          (FStar_Range.mk_range "prims.fst"
-                                            (Prims.of_int (595))
+                                            (Prims.of_int (611))
                                             (Prims.of_int (19))
-                                            (Prims.of_int (595))
+                                            (Prims.of_int (611))
                                             (Prims.of_int (31)))))
                                    (Obj.magic
                                       (FStar_Tactics_Effect.tac_bind
@@ -334,9 +334,9 @@ let (effect_info_to_string :
                                             (Obj.magic
                                                (FStar_Range.mk_range
                                                   "prims.fst"
-                                                  (Prims.of_int (595))
+                                                  (Prims.of_int (611))
                                                   (Prims.of_int (19))
-                                                  (Prims.of_int (595))
+                                                  (Prims.of_int (611))
                                                   (Prims.of_int (31)))))
                                          (Obj.magic
                                             (FStar_Tactics_Effect.tac_bind
@@ -375,9 +375,9 @@ let (effect_info_to_string :
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "prims.fst"
-                                                                   (Prims.of_int (595))
+                                                                   (Prims.of_int (611))
                                                                    (Prims.of_int (19))
-                                                                   (Prims.of_int (595))
+                                                                   (Prims.of_int (611))
                                                                    (Prims.of_int (31)))))
                                                           (Obj.magic
                                                              (FStar_Tactics_Effect.tac_bind
@@ -393,9 +393,9 @@ let (effect_info_to_string :
                                                                    (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                 (Obj.magic
                                                                    (FStar_Tactics_Effect.tac_bind
@@ -411,9 +411,9 @@ let (effect_info_to_string :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_InteractiveHelpers_Base.option_to_string
@@ -505,8 +505,8 @@ let (eterm_info_to_string :
                           (Prims.of_int (66)) (Prims.of_int (67)))))
                  (FStar_Sealed.seal
                     (Obj.magic
-                       (FStar_Range.mk_range "prims.fst" (Prims.of_int (595))
-                          (Prims.of_int (19)) (Prims.of_int (595))
+                       (FStar_Range.mk_range "prims.fst" (Prims.of_int (611))
+                          (Prims.of_int (19)) (Prims.of_int (611))
                           (Prims.of_int (31)))))
                  (Obj.magic
                     (FStar_Tactics_Effect.tac_bind
@@ -519,8 +519,8 @@ let (eterm_info_to_string :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "prims.fst"
-                                (Prims.of_int (595)) (Prims.of_int (19))
-                                (Prims.of_int (595)) (Prims.of_int (31)))))
+                                (Prims.of_int (611)) (Prims.of_int (19))
+                                (Prims.of_int (611)) (Prims.of_int (31)))))
                        (Obj.magic (cast_info_to_string x))
                        (fun uu___ ->
                           FStar_Tactics_Effect.lift_div_tac
@@ -562,8 +562,8 @@ let (eterm_info_to_string :
                             (FStar_Sealed.seal
                                (Obj.magic
                                   (FStar_Range.mk_range "prims.fst"
-                                     (Prims.of_int (595)) (Prims.of_int (19))
-                                     (Prims.of_int (595)) (Prims.of_int (31)))))
+                                     (Prims.of_int (611)) (Prims.of_int (19))
+                                     (Prims.of_int (611)) (Prims.of_int (31)))))
                             (Obj.magic
                                (FStar_Tactics_Effect.tac_bind
                                   (FStar_Sealed.seal
@@ -600,9 +600,9 @@ let (eterm_info_to_string :
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "prims.fst"
-                                                      (Prims.of_int (595))
+                                                      (Prims.of_int (611))
                                                       (Prims.of_int (19))
-                                                      (Prims.of_int (595))
+                                                      (Prims.of_int (611))
                                                       (Prims.of_int (31)))))
                                              (Obj.magic
                                                 (FStar_Tactics_Effect.tac_bind
@@ -618,9 +618,9 @@ let (eterm_info_to_string :
                                                       (Obj.magic
                                                          (FStar_Range.mk_range
                                                             "prims.fst"
-                                                            (Prims.of_int (595))
+                                                            (Prims.of_int (611))
                                                             (Prims.of_int (19))
-                                                            (Prims.of_int (595))
+                                                            (Prims.of_int (611))
                                                             (Prims.of_int (31)))))
                                                    (Obj.magic
                                                       (FStar_Tactics_Effect.tac_bind
@@ -636,9 +636,9 @@ let (eterm_info_to_string :
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "prims.fst"
-                                                                  (Prims.of_int (595))
+                                                                  (Prims.of_int (611))
                                                                   (Prims.of_int (19))
-                                                                  (Prims.of_int (595))
+                                                                  (Prims.of_int (611))
                                                                   (Prims.of_int (31)))))
                                                          (Obj.magic
                                                             (FStar_Tactics_V1_Builtins.term_to_string
@@ -1427,9 +1427,9 @@ let (typ_or_comp_to_effect_info :
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "prims.fst"
-                                                          (Prims.of_int (595))
+                                                          (Prims.of_int (611))
                                                           (Prims.of_int (19))
-                                                          (Prims.of_int (595))
+                                                          (Prims.of_int (611))
                                                           (Prims.of_int (31)))))
                                                  (Obj.magic
                                                     (FStar_InteractiveHelpers_Base.acomp_to_string
@@ -1634,9 +1634,9 @@ let (compute_eterm_info :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V1_Builtins.term_to_string
@@ -2087,8 +2087,8 @@ let (cast_info_to_propositions :
                       (FStar_Sealed.seal
                          (Obj.magic
                             (FStar_Range.mk_range "prims.fst"
-                               (Prims.of_int (595)) (Prims.of_int (19))
-                               (Prims.of_int (595)) (Prims.of_int (31)))))
+                               (Prims.of_int (611)) (Prims.of_int (19))
+                               (Prims.of_int (611)) (Prims.of_int (31)))))
                       (Obj.magic (cast_info_to_string ci))
                       (fun uu___ ->
                          FStar_Tactics_Effect.lift_div_tac
@@ -2729,9 +2729,9 @@ let (compute_pre_type :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V1_Builtins.term_to_string
@@ -3266,9 +3266,9 @@ let (compute_post_type :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -3309,9 +3309,9 @@ let (compute_post_type :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -3327,9 +3327,9 @@ let (compute_post_type :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V1_Builtins.term_to_string
@@ -3422,9 +3422,9 @@ let (compute_post_type :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -3465,9 +3465,9 @@ let (compute_post_type :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -3483,9 +3483,9 @@ let (compute_post_type :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V1_Builtins.term_to_string
@@ -3641,9 +3641,9 @@ let (compute_post_type :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V1_Builtins.term_to_string
@@ -4198,9 +4198,9 @@ let rec (_introduce_variables_for_abs :
                                       (FStar_Sealed.seal
                                          (Obj.magic
                                             (FStar_Range.mk_range "prims.fst"
-                                               (Prims.of_int (595))
+                                               (Prims.of_int (611))
                                                (Prims.of_int (19))
-                                               (Prims.of_int (595))
+                                               (Prims.of_int (611))
                                                (Prims.of_int (31)))))
                                       (Obj.magic
                                          (FStar_Tactics_V1_Derived.name_of_binder
@@ -4435,8 +4435,8 @@ let (is_st_get :
                     (FStar_Sealed.seal
                        (Obj.magic
                           (FStar_Range.mk_range "prims.fst"
-                             (Prims.of_int (595)) (Prims.of_int (19))
-                             (Prims.of_int (595)) (Prims.of_int (31)))))
+                             (Prims.of_int (611)) (Prims.of_int (19))
+                             (Prims.of_int (611)) (Prims.of_int (31)))))
                     (Obj.magic (FStar_Tactics_V1_Builtins.term_to_string t))
                     (fun uu___ ->
                        FStar_Tactics_Effect.lift_div_tac
@@ -4650,8 +4650,8 @@ let (is_let_st_get :
                     (FStar_Sealed.seal
                        (Obj.magic
                           (FStar_Range.mk_range "prims.fst"
-                             (Prims.of_int (595)) (Prims.of_int (19))
-                             (Prims.of_int (595)) (Prims.of_int (31)))))
+                             (Prims.of_int (611)) (Prims.of_int (19))
+                             (Prims.of_int (611)) (Prims.of_int (31)))))
                     (Obj.magic
                        (FStar_Tactics_Effect.tac_bind
                           (FStar_Sealed.seal
@@ -5048,9 +5048,9 @@ let rec (find_mem_in_related :
                                           (Obj.magic
                                              (FStar_Range.mk_range
                                                 "prims.fst"
-                                                (Prims.of_int (595))
+                                                (Prims.of_int (611))
                                                 (Prims.of_int (19))
-                                                (Prims.of_int (595))
+                                                (Prims.of_int (611))
                                                 (Prims.of_int (31)))))
                                        (Obj.magic
                                           (FStar_Tactics_Effect.tac_bind
@@ -5509,9 +5509,9 @@ let (pre_post_to_propositions :
                                                   (Obj.magic
                                                      (FStar_Range.mk_range
                                                         "prims.fst"
-                                                        (Prims.of_int (595))
+                                                        (Prims.of_int (611))
                                                         (Prims.of_int (19))
-                                                        (Prims.of_int (595))
+                                                        (Prims.of_int (611))
                                                         (Prims.of_int (31)))))
                                                (Obj.magic
                                                   (FStar_InteractiveHelpers_Base.option_to_string
@@ -5580,9 +5580,9 @@ let (pre_post_to_propositions :
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "prims.fst"
-                                                                   (Prims.of_int (595))
+                                                                   (Prims.of_int (611))
                                                                    (Prims.of_int (19))
-                                                                   (Prims.of_int (595))
+                                                                   (Prims.of_int (611))
                                                                    (Prims.of_int (31)))))
                                                           (Obj.magic
                                                              (FStar_InteractiveHelpers_Base.option_to_string
@@ -7262,9 +7262,9 @@ let (eterm_info_to_assertions :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_InteractiveHelpers_Base.option_to_string
@@ -7341,9 +7341,9 @@ let (eterm_info_to_assertions :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_InteractiveHelpers_Base.option_to_string
@@ -7545,9 +7545,9 @@ let (eterm_info_to_assertions :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (effect_info_to_string
@@ -7623,9 +7623,9 @@ let (eterm_info_to_assertions :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_InteractiveHelpers_Base.option_to_string
@@ -7702,9 +7702,9 @@ let (eterm_info_to_assertions :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_InteractiveHelpers_Base.option_to_string
@@ -7831,9 +7831,9 @@ let (eterm_info_to_assertions :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_InteractiveHelpers_Base.genv_to_string
@@ -7961,9 +7961,9 @@ let (eterm_info_to_assertions :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -7979,9 +7979,9 @@ let (eterm_info_to_assertions :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -7997,9 +7997,9 @@ let (eterm_info_to_assertions :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V1_Derived.binder_to_string
@@ -8235,9 +8235,9 @@ let (eterm_info_to_assertions :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V1_Derived.binder_to_string
@@ -8856,9 +8856,9 @@ let (eterm_info_to_assertions :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_InteractiveHelpers_ExploreTerm.type_info_to_string
@@ -8940,9 +8940,9 @@ let (eterm_info_to_assertions :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_InteractiveHelpers_ExploreTerm.type_info_to_string
@@ -9393,9 +9393,9 @@ let (eterm_info_to_assertions :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_InteractiveHelpers_Base.option_to_string
@@ -9478,9 +9478,9 @@ let (eterm_info_to_assertions :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_InteractiveHelpers_Base.option_to_string

--- a/ocaml/fstar-lib/generated/FStar_InteractiveHelpers_ExploreTerm.ml
+++ b/ocaml/fstar-lib/generated/FStar_InteractiveHelpers_ExploreTerm.ml
@@ -103,8 +103,8 @@ let (type_info_to_string :
                (Prims.of_int (50)))))
       (FStar_Sealed.seal
          (Obj.magic
-            (FStar_Range.mk_range "prims.fst" (Prims.of_int (595))
-               (Prims.of_int (19)) (Prims.of_int (595)) (Prims.of_int (31)))))
+            (FStar_Range.mk_range "prims.fst" (Prims.of_int (611))
+               (Prims.of_int (19)) (Prims.of_int (611)) (Prims.of_int (31)))))
       (Obj.magic
          (FStar_Tactics_Effect.tac_bind
             (FStar_Sealed.seal
@@ -133,8 +133,8 @@ let (type_info_to_string :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "prims.fst"
-                                (Prims.of_int (595)) (Prims.of_int (19))
-                                (Prims.of_int (595)) (Prims.of_int (31)))))
+                                (Prims.of_int (611)) (Prims.of_int (19))
+                                (Prims.of_int (611)) (Prims.of_int (31)))))
                        (Obj.magic
                           (FStar_Tactics_Effect.tac_bind
                              (FStar_Sealed.seal
@@ -146,9 +146,9 @@ let (type_info_to_string :
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range "prims.fst"
-                                      (Prims.of_int (595))
+                                      (Prims.of_int (611))
                                       (Prims.of_int (19))
-                                      (Prims.of_int (595))
+                                      (Prims.of_int (611))
                                       (Prims.of_int (31)))))
                              (Obj.magic
                                 (FStar_Tactics_Effect.tac_bind
@@ -163,9 +163,9 @@ let (type_info_to_string :
                                    (FStar_Sealed.seal
                                       (Obj.magic
                                          (FStar_Range.mk_range "prims.fst"
-                                            (Prims.of_int (595))
+                                            (Prims.of_int (611))
                                             (Prims.of_int (19))
-                                            (Prims.of_int (595))
+                                            (Prims.of_int (611))
                                             (Prims.of_int (31)))))
                                    (Obj.magic
                                       (FStar_InteractiveHelpers_Base.option_to_string
@@ -546,8 +546,8 @@ let (typ_or_comp_to_string :
                    (Prims.of_int (164)) (Prims.of_int (37)))))
           (FStar_Sealed.seal
              (Obj.magic
-                (FStar_Range.mk_range "prims.fst" (Prims.of_int (595))
-                   (Prims.of_int (19)) (Prims.of_int (595))
+                (FStar_Range.mk_range "prims.fst" (Prims.of_int (611))
+                   (Prims.of_int (19)) (Prims.of_int (611))
                    (Prims.of_int (31)))))
           (Obj.magic
              (FStar_Tactics_Effect.tac_bind
@@ -577,8 +577,8 @@ let (typ_or_comp_to_string :
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range "prims.fst"
-                                    (Prims.of_int (595)) (Prims.of_int (19))
-                                    (Prims.of_int (595)) (Prims.of_int (31)))))
+                                    (Prims.of_int (611)) (Prims.of_int (19))
+                                    (Prims.of_int (611)) (Prims.of_int (31)))))
                            (Obj.magic
                               (FStar_Tactics_Effect.tac_bind
                                  (FStar_Sealed.seal
@@ -592,9 +592,9 @@ let (typ_or_comp_to_string :
                                  (FStar_Sealed.seal
                                     (Obj.magic
                                        (FStar_Range.mk_range "prims.fst"
-                                          (Prims.of_int (595))
+                                          (Prims.of_int (611))
                                           (Prims.of_int (19))
-                                          (Prims.of_int (595))
+                                          (Prims.of_int (611))
                                           (Prims.of_int (31)))))
                                  (Obj.magic
                                     (FStar_Tactics_Effect.tac_bind
@@ -610,9 +610,9 @@ let (typ_or_comp_to_string :
                                           (Obj.magic
                                              (FStar_Range.mk_range
                                                 "prims.fst"
-                                                (Prims.of_int (595))
+                                                (Prims.of_int (611))
                                                 (Prims.of_int (19))
-                                                (Prims.of_int (595))
+                                                (Prims.of_int (611))
                                                 (Prims.of_int (31)))))
                                        (Obj.magic
                                           (FStar_InteractiveHelpers_Base.list_to_string
@@ -646,8 +646,8 @@ let (typ_or_comp_to_string :
                    (Prims.of_int (167)) (Prims.of_int (37)))))
           (FStar_Sealed.seal
              (Obj.magic
-                (FStar_Range.mk_range "prims.fst" (Prims.of_int (595))
-                   (Prims.of_int (19)) (Prims.of_int (595))
+                (FStar_Range.mk_range "prims.fst" (Prims.of_int (611))
+                   (Prims.of_int (19)) (Prims.of_int (611))
                    (Prims.of_int (31)))))
           (Obj.magic
              (FStar_Tactics_Effect.tac_bind
@@ -677,8 +677,8 @@ let (typ_or_comp_to_string :
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range "prims.fst"
-                                    (Prims.of_int (595)) (Prims.of_int (19))
-                                    (Prims.of_int (595)) (Prims.of_int (31)))))
+                                    (Prims.of_int (611)) (Prims.of_int (19))
+                                    (Prims.of_int (611)) (Prims.of_int (31)))))
                            (Obj.magic
                               (FStar_Tactics_Effect.tac_bind
                                  (FStar_Sealed.seal
@@ -692,9 +692,9 @@ let (typ_or_comp_to_string :
                                  (FStar_Sealed.seal
                                     (Obj.magic
                                        (FStar_Range.mk_range "prims.fst"
-                                          (Prims.of_int (595))
+                                          (Prims.of_int (611))
                                           (Prims.of_int (19))
-                                          (Prims.of_int (595))
+                                          (Prims.of_int (611))
                                           (Prims.of_int (31)))))
                                  (Obj.magic
                                     (FStar_Tactics_Effect.tac_bind
@@ -710,9 +710,9 @@ let (typ_or_comp_to_string :
                                           (Obj.magic
                                              (FStar_Range.mk_range
                                                 "prims.fst"
-                                                (Prims.of_int (595))
+                                                (Prims.of_int (611))
                                                 (Prims.of_int (19))
-                                                (Prims.of_int (595))
+                                                (Prims.of_int (611))
                                                 (Prims.of_int (31)))))
                                        (Obj.magic
                                           (FStar_InteractiveHelpers_Base.list_to_string
@@ -820,9 +820,9 @@ let (safe_typ_or_comp :
                                      (FStar_Sealed.seal
                                         (Obj.magic
                                            (FStar_Range.mk_range "prims.fst"
-                                              (Prims.of_int (595))
+                                              (Prims.of_int (611))
                                               (Prims.of_int (19))
-                                              (Prims.of_int (595))
+                                              (Prims.of_int (611))
                                               (Prims.of_int (31)))))
                                      (Obj.magic
                                         (FStar_Tactics_Effect.tac_bind
@@ -838,9 +838,9 @@ let (safe_typ_or_comp :
                                               (Obj.magic
                                                  (FStar_Range.mk_range
                                                     "prims.fst"
-                                                    (Prims.of_int (595))
+                                                    (Prims.of_int (611))
                                                     (Prims.of_int (19))
-                                                    (Prims.of_int (595))
+                                                    (Prims.of_int (611))
                                                     (Prims.of_int (31)))))
                                            (Obj.magic
                                               (FStar_Tactics_Effect.tac_bind
@@ -856,9 +856,9 @@ let (safe_typ_or_comp :
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "prims.fst"
-                                                          (Prims.of_int (595))
+                                                          (Prims.of_int (611))
                                                           (Prims.of_int (19))
-                                                          (Prims.of_int (595))
+                                                          (Prims.of_int (611))
                                                           (Prims.of_int (31)))))
                                                  (Obj.magic
                                                     (FStar_Tactics_V1_Builtins.term_to_string
@@ -932,9 +932,9 @@ let (safe_typ_or_comp :
                                      (FStar_Sealed.seal
                                         (Obj.magic
                                            (FStar_Range.mk_range "prims.fst"
-                                              (Prims.of_int (595))
+                                              (Prims.of_int (611))
                                               (Prims.of_int (19))
-                                              (Prims.of_int (595))
+                                              (Prims.of_int (611))
                                               (Prims.of_int (31)))))
                                      (Obj.magic
                                         (FStar_Tactics_Effect.tac_bind
@@ -950,9 +950,9 @@ let (safe_typ_or_comp :
                                               (Obj.magic
                                                  (FStar_Range.mk_range
                                                     "prims.fst"
-                                                    (Prims.of_int (595))
+                                                    (Prims.of_int (611))
                                                     (Prims.of_int (19))
-                                                    (Prims.of_int (595))
+                                                    (Prims.of_int (611))
                                                     (Prims.of_int (31)))))
                                            (Obj.magic
                                               (FStar_Tactics_Effect.tac_bind
@@ -991,9 +991,9 @@ let (safe_typ_or_comp :
                                                                (Obj.magic
                                                                   (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                             (Obj.magic
                                                                (FStar_Tactics_Effect.tac_bind
@@ -1009,9 +1009,9 @@ let (safe_typ_or_comp :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                   (Obj.magic
                                                                     (FStar_InteractiveHelpers_Base.acomp_to_string
@@ -1333,9 +1333,9 @@ let rec (unfold_until_arrow :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V1_Builtins.term_to_string
@@ -1592,9 +1592,9 @@ let rec (unfold_until_arrow :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V1_Builtins.term_to_string
@@ -1673,9 +1673,9 @@ let rec (unfold_until_arrow :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V1_Builtins.term_to_string
@@ -2036,9 +2036,9 @@ let (_abs_update_typ :
                                                          (Obj.magic
                                                             (FStar_Range.mk_range
                                                                "prims.fst"
-                                                               (Prims.of_int (595))
+                                                               (Prims.of_int (611))
                                                                (Prims.of_int (19))
-                                                               (Prims.of_int (595))
+                                                               (Prims.of_int (611))
                                                                (Prims.of_int (31)))))
                                                       (Obj.magic
                                                          (FStar_Tactics_V1_Builtins.term_to_string
@@ -2561,9 +2561,9 @@ let rec (_flush_typ_or_comp_comp :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2579,9 +2579,9 @@ let rec (_flush_typ_or_comp_comp :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2622,9 +2622,9 @@ let rec (_flush_typ_or_comp_comp :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2640,9 +2640,9 @@ let rec (_flush_typ_or_comp_comp :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_InteractiveHelpers_Base.list_to_string
@@ -2916,9 +2916,9 @@ let (flush_typ_or_comp :
                                                                   (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                (Obj.magic
                                                                   (typ_or_comp_to_string
@@ -3002,8 +3002,8 @@ let (safe_arg_typ_or_comp :
                       (FStar_Sealed.seal
                          (Obj.magic
                             (FStar_Range.mk_range "prims.fst"
-                               (Prims.of_int (595)) (Prims.of_int (19))
-                               (Prims.of_int (595)) (Prims.of_int (31)))))
+                               (Prims.of_int (611)) (Prims.of_int (19))
+                               (Prims.of_int (611)) (Prims.of_int (31)))))
                       (Obj.magic
                          (FStar_Tactics_V1_Builtins.term_to_string hd))
                       (fun uu___ ->
@@ -3093,9 +3093,9 @@ let (safe_arg_typ_or_comp :
                                                       (Obj.magic
                                                          (FStar_Range.mk_range
                                                             "prims.fst"
-                                                            (Prims.of_int (595))
+                                                            (Prims.of_int (611))
                                                             (Prims.of_int (19))
-                                                            (Prims.of_int (595))
+                                                            (Prims.of_int (611))
                                                             (Prims.of_int (31)))))
                                                    (Obj.magic
                                                       (FStar_Tactics_V1_Builtins.term_to_string
@@ -3312,9 +3312,9 @@ let (safe_arg_typ_or_comp :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V1_Builtins.term_to_string
@@ -3509,9 +3509,9 @@ let rec (explore_term :
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range "prims.fst"
-                                           (Prims.of_int (595))
+                                           (Prims.of_int (611))
                                            (Prims.of_int (19))
-                                           (Prims.of_int (595))
+                                           (Prims.of_int (611))
                                            (Prims.of_int (31)))))
                                   (Obj.magic
                                      (FStar_Tactics_Effect.tac_bind
@@ -3550,9 +3550,9 @@ let rec (explore_term :
                                                       (Obj.magic
                                                          (FStar_Range.mk_range
                                                             "prims.fst"
-                                                            (Prims.of_int (595))
+                                                            (Prims.of_int (611))
                                                             (Prims.of_int (19))
-                                                            (Prims.of_int (595))
+                                                            (Prims.of_int (611))
                                                             (Prims.of_int (31)))))
                                                    (Obj.magic
                                                       (FStar_Tactics_Effect.tac_bind
@@ -3568,9 +3568,9 @@ let rec (explore_term :
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "prims.fst"
-                                                                  (Prims.of_int (595))
+                                                                  (Prims.of_int (611))
                                                                   (Prims.of_int (19))
-                                                                  (Prims.of_int (595))
+                                                                  (Prims.of_int (611))
                                                                   (Prims.of_int (31)))))
                                                          (Obj.magic
                                                             (FStar_Tactics_V1_Builtins.term_to_string
@@ -3784,9 +3784,9 @@ let rec (explore_term :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_InteractiveHelpers_Base.option_to_string

--- a/ocaml/fstar-lib/generated/FStar_InteractiveHelpers_Output.ml
+++ b/ocaml/fstar-lib/generated/FStar_InteractiveHelpers_Output.ml
@@ -65,8 +65,8 @@ let (subst_shadowed_with_abs_in_assertions :
                         (FStar_Sealed.seal
                            (Obj.magic
                               (FStar_Range.mk_range "prims.fst"
-                                 (Prims.of_int (595)) (Prims.of_int (19))
-                                 (Prims.of_int (595)) (Prims.of_int (31)))))
+                                 (Prims.of_int (611)) (Prims.of_int (19))
+                                 (Prims.of_int (611)) (Prims.of_int (31)))))
                         (Obj.magic
                            (FStar_InteractiveHelpers_Base.genv_to_string ge))
                         (fun uu___ ->
@@ -249,9 +249,9 @@ let (subst_shadowed_with_abs_in_assertions :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -292,9 +292,9 @@ let (subst_shadowed_with_abs_in_assertions :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -310,9 +310,9 @@ let (subst_shadowed_with_abs_in_assertions :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -328,9 +328,9 @@ let (subst_shadowed_with_abs_in_assertions :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V1_Builtins.term_to_string
@@ -483,9 +483,9 @@ let (subst_shadowed_with_abs_in_assertions :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (subst_to_string
@@ -543,9 +543,9 @@ let (subst_shadowed_with_abs_in_assertions :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (subst_to_string
@@ -1007,9 +1007,9 @@ let (propositions_to_printout :
                                                                     Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                  (Obj.magic
                                                                     (
@@ -1244,9 +1244,9 @@ let (result_to_printout :
                                                       (Obj.magic
                                                          (FStar_Range.mk_range
                                                             "prims.fst"
-                                                            (Prims.of_int (595))
+                                                            (Prims.of_int (611))
                                                             (Prims.of_int (19))
-                                                            (Prims.of_int (595))
+                                                            (Prims.of_int (611))
                                                             (Prims.of_int (31)))))
                                                    (Obj.magic
                                                       (propositions_to_printout
@@ -1274,9 +1274,9 @@ let (result_to_printout :
                                                            (Obj.magic
                                                               (FStar_Range.mk_range
                                                                  "prims.fst"
-                                                                 (Prims.of_int (595))
+                                                                 (Prims.of_int (611))
                                                                  (Prims.of_int (19))
-                                                                 (Prims.of_int (595))
+                                                                 (Prims.of_int (611))
                                                                  (Prims.of_int (31)))))
                                                         (Obj.magic
                                                            (FStar_Tactics_Effect.tac_bind
@@ -1294,9 +1294,9 @@ let (result_to_printout :
                                                                     (
                                                                     FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                               (Obj.magic
                                                                  (propositions_to_printout
@@ -1396,8 +1396,8 @@ let (_debug_print_var :
                     (FStar_Sealed.seal
                        (Obj.magic
                           (FStar_Range.mk_range "prims.fst"
-                             (Prims.of_int (595)) (Prims.of_int (19))
-                             (Prims.of_int (595)) (Prims.of_int (31)))))
+                             (Prims.of_int (611)) (Prims.of_int (19))
+                             (Prims.of_int (611)) (Prims.of_int (31)))))
                     (Obj.magic
                        (FStar_Tactics_Effect.tac_bind
                           (FStar_Sealed.seal
@@ -1409,8 +1409,8 @@ let (_debug_print_var :
                           (FStar_Sealed.seal
                              (Obj.magic
                                 (FStar_Range.mk_range "prims.fst"
-                                   (Prims.of_int (595)) (Prims.of_int (19))
-                                   (Prims.of_int (595)) (Prims.of_int (31)))))
+                                   (Prims.of_int (611)) (Prims.of_int (19))
+                                   (Prims.of_int (611)) (Prims.of_int (31)))))
                           (Obj.magic
                              (FStar_Tactics_Effect.tac_bind
                                 (FStar_Sealed.seal
@@ -1424,9 +1424,9 @@ let (_debug_print_var :
                                 (FStar_Sealed.seal
                                    (Obj.magic
                                       (FStar_Range.mk_range "prims.fst"
-                                         (Prims.of_int (595))
+                                         (Prims.of_int (611))
                                          (Prims.of_int (19))
-                                         (Prims.of_int (595))
+                                         (Prims.of_int (611))
                                          (Prims.of_int (31)))))
                                 (Obj.magic
                                    (FStar_Tactics_V1_Builtins.term_to_string
@@ -1536,9 +1536,9 @@ let (_debug_print_var :
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "prims.fst"
-                                                          (Prims.of_int (595))
+                                                          (Prims.of_int (611))
                                                           (Prims.of_int (19))
-                                                          (Prims.of_int (595))
+                                                          (Prims.of_int (611))
                                                           (Prims.of_int (31)))))
                                                  (Obj.magic
                                                     (FStar_Tactics_V1_Builtins.term_to_string
@@ -1610,9 +1610,9 @@ let (_debug_print_var :
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "prims.fst"
-                                                   (Prims.of_int (595))
+                                                   (Prims.of_int (611))
                                                    (Prims.of_int (19))
-                                                   (Prims.of_int (595))
+                                                   (Prims.of_int (611))
                                                    (Prims.of_int (31)))))
                                           (Obj.magic
                                              (FStar_InteractiveHelpers_Base.term_construct
@@ -1735,9 +1735,9 @@ let (_debug_print_var :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1753,9 +1753,9 @@ let (_debug_print_var :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V1_Derived.name_of_bv
@@ -1848,8 +1848,8 @@ let (pp_tac : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                   (FStar_Sealed.seal
                      (Obj.magic
                         (FStar_Range.mk_range "prims.fst"
-                           (Prims.of_int (595)) (Prims.of_int (19))
-                           (Prims.of_int (595)) (Prims.of_int (31)))))
+                           (Prims.of_int (611)) (Prims.of_int (19))
+                           (Prims.of_int (611)) (Prims.of_int (31)))))
                   (Obj.magic
                      (FStar_Tactics_Effect.tac_bind
                         (FStar_Sealed.seal

--- a/ocaml/fstar-lib/generated/FStar_InteractiveHelpers_PostProcess.ml
+++ b/ocaml/fstar-lib/generated/FStar_InteractiveHelpers_PostProcess.ml
@@ -129,9 +129,9 @@ let (pp_explore :
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "prims.fst"
-                                                         (Prims.of_int (595))
+                                                         (Prims.of_int (611))
                                                          (Prims.of_int (19))
-                                                         (Prims.of_int (595))
+                                                         (Prims.of_int (611))
                                                          (Prims.of_int (31)))))
                                                 (Obj.magic
                                                    (FStar_Tactics_V1_Builtins.term_to_string
@@ -276,9 +276,9 @@ let (pp_explore :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V1_Builtins.term_to_string
@@ -607,9 +607,9 @@ let find_predicated_term_explorer :
                                                  (Obj.magic
                                                     (FStar_Range.mk_range
                                                        "prims.fst"
-                                                       (Prims.of_int (595))
+                                                       (Prims.of_int (611))
                                                        (Prims.of_int (19))
-                                                       (Prims.of_int (595))
+                                                       (Prims.of_int (611))
                                                        (Prims.of_int (31)))))
                                               (Obj.magic
                                                  (FStar_Tactics_Effect.tac_bind
@@ -648,9 +648,9 @@ let find_predicated_term_explorer :
                                                                   (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                (Obj.magic
                                                                   (FStar_Tactics_Effect.tac_bind
@@ -666,9 +666,9 @@ let find_predicated_term_explorer :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -918,9 +918,9 @@ let (find_focused_term_in_current_goal :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "prims.fst"
-                                                 (Prims.of_int (595))
+                                                 (Prims.of_int (611))
                                                  (Prims.of_int (19))
-                                                 (Prims.of_int (595))
+                                                 (Prims.of_int (611))
                                                  (Prims.of_int (31)))))
                                         (Obj.magic
                                            (FStar_Tactics_V1_Builtins.term_to_string
@@ -1065,9 +1065,9 @@ let (find_focused_term_in_current_goal :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V1_Builtins.term_to_string
@@ -1174,9 +1174,9 @@ let (find_focused_term_in_current_goal :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V1_Builtins.term_to_string
@@ -1239,9 +1239,9 @@ let (find_focused_term_in_current_goal :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V1_Builtins.term_to_string
@@ -1356,9 +1356,9 @@ let (find_focused_assert_in_current_goal :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "prims.fst"
-                                                 (Prims.of_int (595))
+                                                 (Prims.of_int (611))
                                                  (Prims.of_int (19))
-                                                 (Prims.of_int (595))
+                                                 (Prims.of_int (611))
                                                  (Prims.of_int (31)))))
                                         (Obj.magic
                                            (FStar_Tactics_V1_Builtins.term_to_string
@@ -1533,9 +1533,9 @@ let (find_focused_assert_in_current_goal :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V1_Builtins.term_to_string
@@ -1718,9 +1718,9 @@ let (analyze_effectful_term :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                    (Obj.magic
                                                                     (FStar_Tactics_V1_Builtins.term_to_string
@@ -1954,9 +1954,9 @@ let (analyze_effectful_term :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_InteractiveHelpers_Base.abv_to_string
@@ -2214,9 +2214,9 @@ let (analyze_effectful_term :
                                                                 (Obj.magic
                                                                    (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                              (Obj.magic
                                                                 (FStar_InteractiveHelpers_Base.term_construct
@@ -2286,9 +2286,9 @@ let (analyze_effectful_term :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_InteractiveHelpers_Base.genv_to_string
@@ -2964,9 +2964,9 @@ let (split_conjunctions_under_match :
                                (FStar_Sealed.seal
                                   (Obj.magic
                                      (FStar_Range.mk_range "prims.fst"
-                                        (Prims.of_int (595))
+                                        (Prims.of_int (611))
                                         (Prims.of_int (19))
-                                        (Prims.of_int (595))
+                                        (Prims.of_int (611))
                                         (Prims.of_int (31)))))
                                (Obj.magic
                                   (FStar_InteractiveHelpers_Base.term_construct
@@ -3341,9 +3341,9 @@ let (is_eq :
                                (FStar_Sealed.seal
                                   (Obj.magic
                                      (FStar_Range.mk_range "prims.fst"
-                                        (Prims.of_int (595))
+                                        (Prims.of_int (611))
                                         (Prims.of_int (19))
-                                        (Prims.of_int (595))
+                                        (Prims.of_int (611))
                                         (Prims.of_int (31)))))
                                (Obj.magic
                                   (FStar_Tactics_V1_Builtins.term_to_string
@@ -3434,9 +3434,9 @@ let (is_eq :
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "prims.fst"
-                                                                  (Prims.of_int (595))
+                                                                  (Prims.of_int (611))
                                                                   (Prims.of_int (19))
-                                                                  (Prims.of_int (595))
+                                                                  (Prims.of_int (611))
                                                                   (Prims.of_int (31)))))
                                                          (Obj.magic
                                                             (FStar_Tactics_V1_Builtins.term_to_string
@@ -3509,9 +3509,9 @@ let (is_eq :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (
                                                                     Obj.magic
@@ -3749,8 +3749,8 @@ let (is_equality_for_term :
                       (FStar_Sealed.seal
                          (Obj.magic
                             (FStar_Range.mk_range "prims.fst"
-                               (Prims.of_int (595)) (Prims.of_int (19))
-                               (Prims.of_int (595)) (Prims.of_int (31)))))
+                               (Prims.of_int (611)) (Prims.of_int (19))
+                               (Prims.of_int (611)) (Prims.of_int (31)))))
                       (Obj.magic
                          (FStar_Tactics_Effect.tac_bind
                             (FStar_Sealed.seal
@@ -3762,8 +3762,8 @@ let (is_equality_for_term :
                             (FStar_Sealed.seal
                                (Obj.magic
                                   (FStar_Range.mk_range "prims.fst"
-                                     (Prims.of_int (595)) (Prims.of_int (19))
-                                     (Prims.of_int (595)) (Prims.of_int (31)))))
+                                     (Prims.of_int (611)) (Prims.of_int (19))
+                                     (Prims.of_int (611)) (Prims.of_int (31)))))
                             (Obj.magic
                                (FStar_Tactics_Effect.tac_bind
                                   (FStar_Sealed.seal
@@ -3801,9 +3801,9 @@ let (is_equality_for_term :
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "prims.fst"
-                                                      (Prims.of_int (595))
+                                                      (Prims.of_int (611))
                                                       (Prims.of_int (19))
-                                                      (Prims.of_int (595))
+                                                      (Prims.of_int (611))
                                                       (Prims.of_int (31)))))
                                              (Obj.magic
                                                 (FStar_Tactics_Effect.tac_bind
@@ -3819,9 +3819,9 @@ let (is_equality_for_term :
                                                       (Obj.magic
                                                          (FStar_Range.mk_range
                                                             "prims.fst"
-                                                            (Prims.of_int (595))
+                                                            (Prims.of_int (611))
                                                             (Prims.of_int (19))
-                                                            (Prims.of_int (595))
+                                                            (Prims.of_int (611))
                                                             (Prims.of_int (31)))))
                                                    (Obj.magic
                                                       (FStar_Tactics_V1_Builtins.term_to_string
@@ -4008,9 +4008,9 @@ let (is_equality_for_term :
                                                               (Obj.magic
                                                                  (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                            (Obj.magic
                                                               (FStar_Tactics_Effect.tac_bind
@@ -4054,9 +4054,9 @@ let (is_equality_for_term :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -4072,9 +4072,9 @@ let (is_equality_for_term :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V1_Builtins.term_to_string
@@ -4285,8 +4285,8 @@ let (find_subequality :
                       (FStar_Sealed.seal
                          (Obj.magic
                             (FStar_Range.mk_range "prims.fst"
-                               (Prims.of_int (595)) (Prims.of_int (19))
-                               (Prims.of_int (595)) (Prims.of_int (31)))))
+                               (Prims.of_int (611)) (Prims.of_int (19))
+                               (Prims.of_int (611)) (Prims.of_int (31)))))
                       (Obj.magic
                          (FStar_Tactics_Effect.tac_bind
                             (FStar_Sealed.seal
@@ -4298,8 +4298,8 @@ let (find_subequality :
                             (FStar_Sealed.seal
                                (Obj.magic
                                   (FStar_Range.mk_range "prims.fst"
-                                     (Prims.of_int (595)) (Prims.of_int (19))
-                                     (Prims.of_int (595)) (Prims.of_int (31)))))
+                                     (Prims.of_int (611)) (Prims.of_int (19))
+                                     (Prims.of_int (611)) (Prims.of_int (31)))))
                             (Obj.magic
                                (FStar_Tactics_Effect.tac_bind
                                   (FStar_Sealed.seal
@@ -4337,9 +4337,9 @@ let (find_subequality :
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "prims.fst"
-                                                      (Prims.of_int (595))
+                                                      (Prims.of_int (611))
                                                       (Prims.of_int (19))
-                                                      (Prims.of_int (595))
+                                                      (Prims.of_int (611))
                                                       (Prims.of_int (31)))))
                                              (Obj.magic
                                                 (FStar_Tactics_Effect.tac_bind
@@ -4355,9 +4355,9 @@ let (find_subequality :
                                                       (Obj.magic
                                                          (FStar_Range.mk_range
                                                             "prims.fst"
-                                                            (Prims.of_int (595))
+                                                            (Prims.of_int (611))
                                                             (Prims.of_int (19))
-                                                            (Prims.of_int (595))
+                                                            (Prims.of_int (611))
                                                             (Prims.of_int (31)))))
                                                    (Obj.magic
                                                       (FStar_Tactics_V1_Builtins.term_to_string
@@ -4455,9 +4455,9 @@ let (find_subequality :
                                                (Obj.magic
                                                   (FStar_Range.mk_range
                                                      "prims.fst"
-                                                     (Prims.of_int (595))
+                                                     (Prims.of_int (611))
                                                      (Prims.of_int (19))
-                                                     (Prims.of_int (595))
+                                                     (Prims.of_int (611))
                                                      (Prims.of_int (31)))))
                                             (Obj.magic
                                                (FStar_InteractiveHelpers_Base.list_to_string
@@ -4633,9 +4633,9 @@ let (find_equality_from_post :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_InteractiveHelpers_Base.option_to_string
@@ -4798,9 +4798,9 @@ let rec (find_context_equality_aux :
                                                       (Obj.magic
                                                          (FStar_Range.mk_range
                                                             "prims.fst"
-                                                            (Prims.of_int (595))
+                                                            (Prims.of_int (611))
                                                             (Prims.of_int (19))
-                                                            (Prims.of_int (595))
+                                                            (Prims.of_int (611))
                                                             (Prims.of_int (31)))))
                                                    (Obj.magic
                                                       (FStar_Tactics_Effect.tac_bind
@@ -4816,9 +4816,9 @@ let rec (find_context_equality_aux :
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "prims.fst"
-                                                                  (Prims.of_int (595))
+                                                                  (Prims.of_int (611))
                                                                   (Prims.of_int (19))
-                                                                  (Prims.of_int (595))
+                                                                  (Prims.of_int (611))
                                                                   (Prims.of_int (31)))))
                                                          (Obj.magic
                                                             (FStar_Tactics_Effect.tac_bind
@@ -4858,9 +4858,9 @@ let rec (find_context_equality_aux :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -4876,9 +4876,9 @@ let rec (find_context_equality_aux :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -4894,9 +4894,9 @@ let rec (find_context_equality_aux :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -5871,8 +5871,8 @@ let (unfold_in_assert_or_assume :
                     (FStar_Sealed.seal
                        (Obj.magic
                           (FStar_Range.mk_range "prims.fst"
-                             (Prims.of_int (595)) (Prims.of_int (19))
-                             (Prims.of_int (595)) (Prims.of_int (31)))))
+                             (Prims.of_int (611)) (Prims.of_int (19))
+                             (Prims.of_int (611)) (Prims.of_int (31)))))
                     (Obj.magic
                        (FStar_Tactics_V1_Builtins.term_to_string ares.res))
                     (fun uu___ ->
@@ -6045,9 +6045,9 @@ let (unfold_in_assert_or_assume :
                                                               (Obj.magic
                                                                  (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                            (Obj.magic
                                                               (FStar_Tactics_V1_Builtins.term_to_string
@@ -6201,9 +6201,9 @@ let (unfold_in_assert_or_assume :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -6219,9 +6219,9 @@ let (unfold_in_assert_or_assume :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -6262,9 +6262,9 @@ let (unfold_in_assert_or_assume :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -6280,9 +6280,9 @@ let (unfold_in_assert_or_assume :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -6323,9 +6323,9 @@ let (unfold_in_assert_or_assume :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -6341,9 +6341,9 @@ let (unfold_in_assert_or_assume :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V1_Builtins.term_to_string
@@ -6507,9 +6507,9 @@ let (unfold_in_assert_or_assume :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -6525,9 +6525,9 @@ let (unfold_in_assert_or_assume :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -6568,9 +6568,9 @@ let (unfold_in_assert_or_assume :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -6586,9 +6586,9 @@ let (unfold_in_assert_or_assume :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -6629,9 +6629,9 @@ let (unfold_in_assert_or_assume :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -6647,9 +6647,9 @@ let (unfold_in_assert_or_assume :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V1_Builtins.term_to_string
@@ -6851,9 +6851,9 @@ let (unfold_in_assert_or_assume :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -6869,9 +6869,9 @@ let (unfold_in_assert_or_assume :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -6912,9 +6912,9 @@ let (unfold_in_assert_or_assume :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -6930,9 +6930,9 @@ let (unfold_in_assert_or_assume :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -6948,9 +6948,9 @@ let (unfold_in_assert_or_assume :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V1_Builtins.term_to_string
@@ -7196,9 +7196,9 @@ let (unfold_in_assert_or_assume :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V1_Builtins.term_to_string
@@ -7335,9 +7335,9 @@ let (unfold_in_assert_or_assume :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V1_Derived.bv_to_string
@@ -7461,9 +7461,9 @@ let (unfold_in_assert_or_assume :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V1_Builtins.term_to_string
@@ -7922,9 +7922,9 @@ let (unfold_in_assert_or_assume :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V1_Builtins.term_to_string
@@ -7990,9 +7990,9 @@ let (unfold_in_assert_or_assume :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -8008,9 +8008,9 @@ let (unfold_in_assert_or_assume :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V1_Builtins.term_to_string
@@ -8153,9 +8153,9 @@ let (unfold_in_assert_or_assume :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V1_Builtins.term_to_string

--- a/ocaml/fstar-lib/generated/FStar_Options.ml
+++ b/ocaml/fstar-lib/generated/FStar_Options.ml
@@ -4102,6 +4102,8 @@ let (dep : unit -> Prims.string FStar_Pervasives_Native.option) =
 let (detail_errors : unit -> Prims.bool) = fun uu___ -> get_detail_errors ()
 let (detail_hint_replay : unit -> Prims.bool) =
   fun uu___ -> get_detail_hint_replay ()
+let (any_dump_module : unit -> Prims.bool) =
+  fun uu___ -> let uu___1 = get_dump_module () in Prims.uu___is_Cons uu___1
 let (dump_module : Prims.string -> Prims.bool) =
   fun s ->
     let uu___ = get_dump_module () in

--- a/ocaml/fstar-lib/generated/FStar_Parser_Const.ml
+++ b/ocaml/fstar-lib/generated/FStar_Parser_Const.ml
@@ -348,6 +348,8 @@ let (no_auto_projectors_attr : FStar_Ident.lident) =
 let (no_subtping_attr_lid : FStar_Ident.lident) = psconst "no_subtyping"
 let (admit_termination_lid : FStar_Ident.lident) =
   psconst "admit_termination"
+let (unrefine_binder_attr : FStar_Ident.lident) = pconst "unrefine"
+let (do_not_unrefine_attr : FStar_Ident.lident) = pconst "do_not_unrefine"
 let (attr_substitute_lid : FStar_Ident.lident) =
   p2l ["FStar"; "Pervasives"; "Substitute"]
 let (desugar_of_variant_record_lid : FStar_Ident.lident) =

--- a/ocaml/fstar-lib/generated/FStar_Reflection_V1_Formula.ml
+++ b/ocaml/fstar-lib/generated/FStar_Reflection_V1_Formula.ml
@@ -857,8 +857,8 @@ let (formula_to_string :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "prims.fst"
-                            (Prims.of_int (595)) (Prims.of_int (19))
-                            (Prims.of_int (595)) (Prims.of_int (31)))))
+                            (Prims.of_int (611)) (Prims.of_int (19))
+                            (Prims.of_int (611)) (Prims.of_int (31)))))
                    (Obj.magic
                       (FStar_Tactics_Effect.tac_bind
                          (FStar_Sealed.seal
@@ -894,9 +894,9 @@ let (formula_to_string :
                                       (FStar_Sealed.seal
                                          (Obj.magic
                                             (FStar_Range.mk_range "prims.fst"
-                                               (Prims.of_int (595))
+                                               (Prims.of_int (611))
                                                (Prims.of_int (19))
-                                               (Prims.of_int (595))
+                                               (Prims.of_int (611))
                                                (Prims.of_int (31)))))
                                       (Obj.magic
                                          (FStar_Tactics_Effect.tac_bind
@@ -912,9 +912,9 @@ let (formula_to_string :
                                                (Obj.magic
                                                   (FStar_Range.mk_range
                                                      "prims.fst"
-                                                     (Prims.of_int (595))
+                                                     (Prims.of_int (611))
                                                      (Prims.of_int (19))
-                                                     (Prims.of_int (595))
+                                                     (Prims.of_int (611))
                                                      (Prims.of_int (31)))))
                                             (Obj.magic
                                                (FStar_Tactics_V1_Builtins.term_to_string
@@ -942,9 +942,9 @@ let (formula_to_string :
                                     (FStar_Sealed.seal
                                        (Obj.magic
                                           (FStar_Range.mk_range "prims.fst"
-                                             (Prims.of_int (595))
+                                             (Prims.of_int (611))
                                              (Prims.of_int (19))
-                                             (Prims.of_int (595))
+                                             (Prims.of_int (611))
                                              (Prims.of_int (31)))))
                                     (Obj.magic
                                        (FStar_Tactics_Effect.tac_bind
@@ -960,9 +960,9 @@ let (formula_to_string :
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "prims.fst"
-                                                   (Prims.of_int (595))
+                                                   (Prims.of_int (611))
                                                    (Prims.of_int (19))
-                                                   (Prims.of_int (595))
+                                                   (Prims.of_int (611))
                                                    (Prims.of_int (31)))))
                                           (Obj.magic
                                              (FStar_Tactics_Effect.tac_bind
@@ -1001,9 +1001,9 @@ let (formula_to_string :
                                                               (Obj.magic
                                                                  (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                            (Obj.magic
                                                               (FStar_Tactics_Effect.tac_bind
@@ -1021,9 +1021,9 @@ let (formula_to_string :
                                                                     Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                  (Obj.magic
                                                                     (
@@ -1040,9 +1040,9 @@ let (formula_to_string :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V1_Builtins.term_to_string
@@ -1096,8 +1096,8 @@ let (formula_to_string :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "prims.fst"
-                            (Prims.of_int (595)) (Prims.of_int (19))
-                            (Prims.of_int (595)) (Prims.of_int (31)))))
+                            (Prims.of_int (611)) (Prims.of_int (19))
+                            (Prims.of_int (611)) (Prims.of_int (31)))))
                    (Obj.magic
                       (FStar_Tactics_Effect.tac_bind
                          (FStar_Sealed.seal
@@ -1133,9 +1133,9 @@ let (formula_to_string :
                                       (FStar_Sealed.seal
                                          (Obj.magic
                                             (FStar_Range.mk_range "prims.fst"
-                                               (Prims.of_int (595))
+                                               (Prims.of_int (611))
                                                (Prims.of_int (19))
-                                               (Prims.of_int (595))
+                                               (Prims.of_int (611))
                                                (Prims.of_int (31)))))
                                       (Obj.magic
                                          (FStar_Tactics_Effect.tac_bind
@@ -1151,9 +1151,9 @@ let (formula_to_string :
                                                (Obj.magic
                                                   (FStar_Range.mk_range
                                                      "prims.fst"
-                                                     (Prims.of_int (595))
+                                                     (Prims.of_int (611))
                                                      (Prims.of_int (19))
-                                                     (Prims.of_int (595))
+                                                     (Prims.of_int (611))
                                                      (Prims.of_int (31)))))
                                             (Obj.magic
                                                (FStar_Tactics_V1_Builtins.term_to_string
@@ -1181,9 +1181,9 @@ let (formula_to_string :
                                     (FStar_Sealed.seal
                                        (Obj.magic
                                           (FStar_Range.mk_range "prims.fst"
-                                             (Prims.of_int (595))
+                                             (Prims.of_int (611))
                                              (Prims.of_int (19))
-                                             (Prims.of_int (595))
+                                             (Prims.of_int (611))
                                              (Prims.of_int (31)))))
                                     (Obj.magic
                                        (FStar_Tactics_Effect.tac_bind
@@ -1199,9 +1199,9 @@ let (formula_to_string :
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "prims.fst"
-                                                   (Prims.of_int (595))
+                                                   (Prims.of_int (611))
                                                    (Prims.of_int (19))
-                                                   (Prims.of_int (595))
+                                                   (Prims.of_int (611))
                                                    (Prims.of_int (31)))))
                                           (Obj.magic
                                              (FStar_Tactics_Effect.tac_bind
@@ -1240,9 +1240,9 @@ let (formula_to_string :
                                                               (Obj.magic
                                                                  (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                            (Obj.magic
                                                               (FStar_Tactics_Effect.tac_bind
@@ -1260,9 +1260,9 @@ let (formula_to_string :
                                                                     Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                  (Obj.magic
                                                                     (
@@ -1279,9 +1279,9 @@ let (formula_to_string :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V1_Builtins.term_to_string
@@ -1335,8 +1335,8 @@ let (formula_to_string :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "prims.fst"
-                            (Prims.of_int (595)) (Prims.of_int (19))
-                            (Prims.of_int (595)) (Prims.of_int (31)))))
+                            (Prims.of_int (611)) (Prims.of_int (19))
+                            (Prims.of_int (611)) (Prims.of_int (31)))))
                    (Obj.magic
                       (FStar_Tactics_Effect.tac_bind
                          (FStar_Sealed.seal
@@ -1368,9 +1368,9 @@ let (formula_to_string :
                                     (FStar_Sealed.seal
                                        (Obj.magic
                                           (FStar_Range.mk_range "prims.fst"
-                                             (Prims.of_int (595))
+                                             (Prims.of_int (611))
                                              (Prims.of_int (19))
-                                             (Prims.of_int (595))
+                                             (Prims.of_int (611))
                                              (Prims.of_int (31)))))
                                     (Obj.magic
                                        (FStar_Tactics_Effect.tac_bind
@@ -1386,9 +1386,9 @@ let (formula_to_string :
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "prims.fst"
-                                                   (Prims.of_int (595))
+                                                   (Prims.of_int (611))
                                                    (Prims.of_int (19))
-                                                   (Prims.of_int (595))
+                                                   (Prims.of_int (611))
                                                    (Prims.of_int (31)))))
                                           (Obj.magic
                                              (FStar_Tactics_Effect.tac_bind
@@ -1404,9 +1404,9 @@ let (formula_to_string :
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "prims.fst"
-                                                         (Prims.of_int (595))
+                                                         (Prims.of_int (611))
                                                          (Prims.of_int (19))
-                                                         (Prims.of_int (595))
+                                                         (Prims.of_int (611))
                                                          (Prims.of_int (31)))))
                                                 (Obj.magic
                                                    (FStar_Tactics_V1_Builtins.term_to_string
@@ -1441,8 +1441,8 @@ let (formula_to_string :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "prims.fst"
-                            (Prims.of_int (595)) (Prims.of_int (19))
-                            (Prims.of_int (595)) (Prims.of_int (31)))))
+                            (Prims.of_int (611)) (Prims.of_int (19))
+                            (Prims.of_int (611)) (Prims.of_int (31)))))
                    (Obj.magic
                       (FStar_Tactics_Effect.tac_bind
                          (FStar_Sealed.seal
@@ -1474,9 +1474,9 @@ let (formula_to_string :
                                     (FStar_Sealed.seal
                                        (Obj.magic
                                           (FStar_Range.mk_range "prims.fst"
-                                             (Prims.of_int (595))
+                                             (Prims.of_int (611))
                                              (Prims.of_int (19))
-                                             (Prims.of_int (595))
+                                             (Prims.of_int (611))
                                              (Prims.of_int (31)))))
                                     (Obj.magic
                                        (FStar_Tactics_Effect.tac_bind
@@ -1492,9 +1492,9 @@ let (formula_to_string :
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "prims.fst"
-                                                   (Prims.of_int (595))
+                                                   (Prims.of_int (611))
                                                    (Prims.of_int (19))
-                                                   (Prims.of_int (595))
+                                                   (Prims.of_int (611))
                                                    (Prims.of_int (31)))))
                                           (Obj.magic
                                              (FStar_Tactics_Effect.tac_bind
@@ -1510,9 +1510,9 @@ let (formula_to_string :
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "prims.fst"
-                                                         (Prims.of_int (595))
+                                                         (Prims.of_int (611))
                                                          (Prims.of_int (19))
-                                                         (Prims.of_int (595))
+                                                         (Prims.of_int (611))
                                                          (Prims.of_int (31)))))
                                                 (Obj.magic
                                                    (FStar_Tactics_V1_Builtins.term_to_string
@@ -1547,8 +1547,8 @@ let (formula_to_string :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "prims.fst"
-                            (Prims.of_int (595)) (Prims.of_int (19))
-                            (Prims.of_int (595)) (Prims.of_int (31)))))
+                            (Prims.of_int (611)) (Prims.of_int (19))
+                            (Prims.of_int (611)) (Prims.of_int (31)))))
                    (Obj.magic
                       (FStar_Tactics_Effect.tac_bind
                          (FStar_Sealed.seal
@@ -1580,9 +1580,9 @@ let (formula_to_string :
                                     (FStar_Sealed.seal
                                        (Obj.magic
                                           (FStar_Range.mk_range "prims.fst"
-                                             (Prims.of_int (595))
+                                             (Prims.of_int (611))
                                              (Prims.of_int (19))
-                                             (Prims.of_int (595))
+                                             (Prims.of_int (611))
                                              (Prims.of_int (31)))))
                                     (Obj.magic
                                        (FStar_Tactics_Effect.tac_bind
@@ -1598,9 +1598,9 @@ let (formula_to_string :
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "prims.fst"
-                                                   (Prims.of_int (595))
+                                                   (Prims.of_int (611))
                                                    (Prims.of_int (19))
-                                                   (Prims.of_int (595))
+                                                   (Prims.of_int (611))
                                                    (Prims.of_int (31)))))
                                           (Obj.magic
                                              (FStar_Tactics_Effect.tac_bind
@@ -1616,9 +1616,9 @@ let (formula_to_string :
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "prims.fst"
-                                                         (Prims.of_int (595))
+                                                         (Prims.of_int (611))
                                                          (Prims.of_int (19))
-                                                         (Prims.of_int (595))
+                                                         (Prims.of_int (611))
                                                          (Prims.of_int (31)))))
                                                 (Obj.magic
                                                    (FStar_Tactics_V1_Builtins.term_to_string
@@ -1653,8 +1653,8 @@ let (formula_to_string :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "prims.fst"
-                            (Prims.of_int (595)) (Prims.of_int (19))
-                            (Prims.of_int (595)) (Prims.of_int (31)))))
+                            (Prims.of_int (611)) (Prims.of_int (19))
+                            (Prims.of_int (611)) (Prims.of_int (31)))))
                    (Obj.magic
                       (FStar_Tactics_Effect.tac_bind
                          (FStar_Sealed.seal
@@ -1686,9 +1686,9 @@ let (formula_to_string :
                                     (FStar_Sealed.seal
                                        (Obj.magic
                                           (FStar_Range.mk_range "prims.fst"
-                                             (Prims.of_int (595))
+                                             (Prims.of_int (611))
                                              (Prims.of_int (19))
-                                             (Prims.of_int (595))
+                                             (Prims.of_int (611))
                                              (Prims.of_int (31)))))
                                     (Obj.magic
                                        (FStar_Tactics_Effect.tac_bind
@@ -1704,9 +1704,9 @@ let (formula_to_string :
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "prims.fst"
-                                                   (Prims.of_int (595))
+                                                   (Prims.of_int (611))
                                                    (Prims.of_int (19))
-                                                   (Prims.of_int (595))
+                                                   (Prims.of_int (611))
                                                    (Prims.of_int (31)))))
                                           (Obj.magic
                                              (FStar_Tactics_Effect.tac_bind
@@ -1722,9 +1722,9 @@ let (formula_to_string :
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "prims.fst"
-                                                         (Prims.of_int (595))
+                                                         (Prims.of_int (611))
                                                          (Prims.of_int (19))
-                                                         (Prims.of_int (595))
+                                                         (Prims.of_int (611))
                                                          (Prims.of_int (31)))))
                                                 (Obj.magic
                                                    (FStar_Tactics_V1_Builtins.term_to_string
@@ -1759,8 +1759,8 @@ let (formula_to_string :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "prims.fst"
-                            (Prims.of_int (595)) (Prims.of_int (19))
-                            (Prims.of_int (595)) (Prims.of_int (31)))))
+                            (Prims.of_int (611)) (Prims.of_int (19))
+                            (Prims.of_int (611)) (Prims.of_int (31)))))
                    (Obj.magic
                       (FStar_Tactics_Effect.tac_bind
                          (FStar_Sealed.seal
@@ -1792,9 +1792,9 @@ let (formula_to_string :
                                     (FStar_Sealed.seal
                                        (Obj.magic
                                           (FStar_Range.mk_range "prims.fst"
-                                             (Prims.of_int (595))
+                                             (Prims.of_int (611))
                                              (Prims.of_int (19))
-                                             (Prims.of_int (595))
+                                             (Prims.of_int (611))
                                              (Prims.of_int (31)))))
                                     (Obj.magic
                                        (FStar_Tactics_Effect.tac_bind
@@ -1810,9 +1810,9 @@ let (formula_to_string :
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "prims.fst"
-                                                   (Prims.of_int (595))
+                                                   (Prims.of_int (611))
                                                    (Prims.of_int (19))
-                                                   (Prims.of_int (595))
+                                                   (Prims.of_int (611))
                                                    (Prims.of_int (31)))))
                                           (Obj.magic
                                              (FStar_Tactics_Effect.tac_bind
@@ -1828,9 +1828,9 @@ let (formula_to_string :
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "prims.fst"
-                                                         (Prims.of_int (595))
+                                                         (Prims.of_int (611))
                                                          (Prims.of_int (19))
-                                                         (Prims.of_int (595))
+                                                         (Prims.of_int (611))
                                                          (Prims.of_int (31)))))
                                                 (Obj.magic
                                                    (FStar_Tactics_V1_Builtins.term_to_string
@@ -1865,8 +1865,8 @@ let (formula_to_string :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "prims.fst"
-                            (Prims.of_int (595)) (Prims.of_int (19))
-                            (Prims.of_int (595)) (Prims.of_int (31)))))
+                            (Prims.of_int (611)) (Prims.of_int (19))
+                            (Prims.of_int (611)) (Prims.of_int (31)))))
                    (Obj.magic
                       (FStar_Tactics_Effect.tac_bind
                          (FStar_Sealed.seal
@@ -1898,9 +1898,9 @@ let (formula_to_string :
                                     (FStar_Sealed.seal
                                        (Obj.magic
                                           (FStar_Range.mk_range "prims.fst"
-                                             (Prims.of_int (595))
+                                             (Prims.of_int (611))
                                              (Prims.of_int (19))
-                                             (Prims.of_int (595))
+                                             (Prims.of_int (611))
                                              (Prims.of_int (31)))))
                                     (Obj.magic
                                        (FStar_Tactics_Effect.tac_bind
@@ -1916,9 +1916,9 @@ let (formula_to_string :
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "prims.fst"
-                                                   (Prims.of_int (595))
+                                                   (Prims.of_int (611))
                                                    (Prims.of_int (19))
-                                                   (Prims.of_int (595))
+                                                   (Prims.of_int (611))
                                                    (Prims.of_int (31)))))
                                           (Obj.magic
                                              (FStar_Tactics_Effect.tac_bind
@@ -1934,9 +1934,9 @@ let (formula_to_string :
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "prims.fst"
-                                                         (Prims.of_int (595))
+                                                         (Prims.of_int (611))
                                                          (Prims.of_int (19))
-                                                         (Prims.of_int (595))
+                                                         (Prims.of_int (611))
                                                          (Prims.of_int (31)))))
                                                 (Obj.magic
                                                    (FStar_Tactics_V1_Builtins.term_to_string
@@ -1971,8 +1971,8 @@ let (formula_to_string :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "prims.fst"
-                            (Prims.of_int (595)) (Prims.of_int (19))
-                            (Prims.of_int (595)) (Prims.of_int (31)))))
+                            (Prims.of_int (611)) (Prims.of_int (19))
+                            (Prims.of_int (611)) (Prims.of_int (31)))))
                    (Obj.magic
                       (FStar_Tactics_Effect.tac_bind
                          (FStar_Sealed.seal
@@ -2004,9 +2004,9 @@ let (formula_to_string :
                                     (FStar_Sealed.seal
                                        (Obj.magic
                                           (FStar_Range.mk_range "prims.fst"
-                                             (Prims.of_int (595))
+                                             (Prims.of_int (611))
                                              (Prims.of_int (19))
-                                             (Prims.of_int (595))
+                                             (Prims.of_int (611))
                                              (Prims.of_int (31)))))
                                     (Obj.magic
                                        (FStar_Tactics_Effect.tac_bind
@@ -2022,9 +2022,9 @@ let (formula_to_string :
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "prims.fst"
-                                                   (Prims.of_int (595))
+                                                   (Prims.of_int (611))
                                                    (Prims.of_int (19))
-                                                   (Prims.of_int (595))
+                                                   (Prims.of_int (611))
                                                    (Prims.of_int (31)))))
                                           (Obj.magic
                                              (FStar_Tactics_Effect.tac_bind
@@ -2040,9 +2040,9 @@ let (formula_to_string :
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "prims.fst"
-                                                         (Prims.of_int (595))
+                                                         (Prims.of_int (611))
                                                          (Prims.of_int (19))
-                                                         (Prims.of_int (595))
+                                                         (Prims.of_int (611))
                                                          (Prims.of_int (31)))))
                                                 (Obj.magic
                                                    (FStar_Tactics_V1_Builtins.term_to_string
@@ -2077,8 +2077,8 @@ let (formula_to_string :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "prims.fst"
-                            (Prims.of_int (595)) (Prims.of_int (19))
-                            (Prims.of_int (595)) (Prims.of_int (31)))))
+                            (Prims.of_int (611)) (Prims.of_int (19))
+                            (Prims.of_int (611)) (Prims.of_int (31)))))
                    (Obj.magic
                       (FStar_Tactics_Effect.tac_bind
                          (FStar_Sealed.seal
@@ -2090,8 +2090,8 @@ let (formula_to_string :
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range "prims.fst"
-                                  (Prims.of_int (595)) (Prims.of_int (19))
-                                  (Prims.of_int (595)) (Prims.of_int (31)))))
+                                  (Prims.of_int (611)) (Prims.of_int (19))
+                                  (Prims.of_int (611)) (Prims.of_int (31)))))
                          (Obj.magic
                             (FStar_Tactics_V1_Builtins.term_to_string p))
                          (fun uu___ ->
@@ -2113,8 +2113,8 @@ let (formula_to_string :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "prims.fst"
-                            (Prims.of_int (595)) (Prims.of_int (19))
-                            (Prims.of_int (595)) (Prims.of_int (31)))))
+                            (Prims.of_int (611)) (Prims.of_int (19))
+                            (Prims.of_int (611)) (Prims.of_int (31)))))
                    (Obj.magic
                       (FStar_Tactics_Effect.tac_bind
                          (FStar_Sealed.seal
@@ -2146,9 +2146,9 @@ let (formula_to_string :
                                     (FStar_Sealed.seal
                                        (Obj.magic
                                           (FStar_Range.mk_range "prims.fst"
-                                             (Prims.of_int (595))
+                                             (Prims.of_int (611))
                                              (Prims.of_int (19))
-                                             (Prims.of_int (595))
+                                             (Prims.of_int (611))
                                              (Prims.of_int (31)))))
                                     (Obj.magic
                                        (FStar_Tactics_Effect.tac_bind
@@ -2164,9 +2164,9 @@ let (formula_to_string :
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "prims.fst"
-                                                   (Prims.of_int (595))
+                                                   (Prims.of_int (611))
                                                    (Prims.of_int (19))
-                                                   (Prims.of_int (595))
+                                                   (Prims.of_int (611))
                                                    (Prims.of_int (31)))))
                                           (Obj.magic
                                              (FStar_Tactics_Effect.tac_bind
@@ -2182,9 +2182,9 @@ let (formula_to_string :
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "prims.fst"
-                                                         (Prims.of_int (595))
+                                                         (Prims.of_int (611))
                                                          (Prims.of_int (19))
-                                                         (Prims.of_int (595))
+                                                         (Prims.of_int (611))
                                                          (Prims.of_int (31)))))
                                                 (Obj.magic
                                                    (FStar_Tactics_V1_Builtins.term_to_string
@@ -2219,8 +2219,8 @@ let (formula_to_string :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "prims.fst"
-                            (Prims.of_int (595)) (Prims.of_int (19))
-                            (Prims.of_int (595)) (Prims.of_int (31)))))
+                            (Prims.of_int (611)) (Prims.of_int (19))
+                            (Prims.of_int (611)) (Prims.of_int (31)))))
                    (Obj.magic
                       (FStar_Tactics_Effect.tac_bind
                          (FStar_Sealed.seal
@@ -2232,8 +2232,8 @@ let (formula_to_string :
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range "prims.fst"
-                                  (Prims.of_int (595)) (Prims.of_int (19))
-                                  (Prims.of_int (595)) (Prims.of_int (31)))))
+                                  (Prims.of_int (611)) (Prims.of_int (19))
+                                  (Prims.of_int (611)) (Prims.of_int (31)))))
                          (Obj.magic
                             (FStar_Tactics_V1_Builtins.term_to_string t))
                          (fun uu___ ->
@@ -2255,8 +2255,8 @@ let (formula_to_string :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "prims.fst"
-                            (Prims.of_int (595)) (Prims.of_int (19))
-                            (Prims.of_int (595)) (Prims.of_int (31)))))
+                            (Prims.of_int (611)) (Prims.of_int (19))
+                            (Prims.of_int (611)) (Prims.of_int (31)))))
                    (Obj.magic
                       (FStar_Tactics_Effect.tac_bind
                          (FStar_Sealed.seal
@@ -2268,8 +2268,8 @@ let (formula_to_string :
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range "prims.fst"
-                                  (Prims.of_int (595)) (Prims.of_int (19))
-                                  (Prims.of_int (595)) (Prims.of_int (31)))))
+                                  (Prims.of_int (611)) (Prims.of_int (19))
+                                  (Prims.of_int (611)) (Prims.of_int (31)))))
                          (Obj.magic
                             (FStar_Tactics_V1_Builtins.term_to_string t))
                          (fun uu___ ->
@@ -2291,8 +2291,8 @@ let (formula_to_string :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "prims.fst"
-                            (Prims.of_int (595)) (Prims.of_int (19))
-                            (Prims.of_int (595)) (Prims.of_int (31)))))
+                            (Prims.of_int (611)) (Prims.of_int (19))
+                            (Prims.of_int (611)) (Prims.of_int (31)))))
                    (Obj.magic
                       (FStar_Tactics_Effect.tac_bind
                          (FStar_Sealed.seal
@@ -2324,9 +2324,9 @@ let (formula_to_string :
                                     (FStar_Sealed.seal
                                        (Obj.magic
                                           (FStar_Range.mk_range "prims.fst"
-                                             (Prims.of_int (595))
+                                             (Prims.of_int (611))
                                              (Prims.of_int (19))
-                                             (Prims.of_int (595))
+                                             (Prims.of_int (611))
                                              (Prims.of_int (31)))))
                                     (Obj.magic
                                        (FStar_Tactics_Effect.tac_bind
@@ -2342,9 +2342,9 @@ let (formula_to_string :
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "prims.fst"
-                                                   (Prims.of_int (595))
+                                                   (Prims.of_int (611))
                                                    (Prims.of_int (19))
-                                                   (Prims.of_int (595))
+                                                   (Prims.of_int (611))
                                                    (Prims.of_int (31)))))
                                           (Obj.magic
                                              (FStar_Tactics_Effect.tac_bind
@@ -2360,9 +2360,9 @@ let (formula_to_string :
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "prims.fst"
-                                                         (Prims.of_int (595))
+                                                         (Prims.of_int (611))
                                                          (Prims.of_int (19))
-                                                         (Prims.of_int (595))
+                                                         (Prims.of_int (611))
                                                          (Prims.of_int (31)))))
                                                 (Obj.magic
                                                    (FStar_Tactics_V1_Builtins.term_to_string
@@ -2397,8 +2397,8 @@ let (formula_to_string :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "prims.fst"
-                            (Prims.of_int (595)) (Prims.of_int (19))
-                            (Prims.of_int (595)) (Prims.of_int (31)))))
+                            (Prims.of_int (611)) (Prims.of_int (19))
+                            (Prims.of_int (611)) (Prims.of_int (31)))))
                    (Obj.magic
                       (FStar_Tactics_Effect.tac_bind
                          (FStar_Sealed.seal
@@ -2410,8 +2410,8 @@ let (formula_to_string :
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range "prims.fst"
-                                  (Prims.of_int (595)) (Prims.of_int (19))
-                                  (Prims.of_int (595)) (Prims.of_int (31)))))
+                                  (Prims.of_int (611)) (Prims.of_int (19))
+                                  (Prims.of_int (611)) (Prims.of_int (31)))))
                          (Obj.magic (bv_to_string bv))
                          (fun uu___ ->
                             FStar_Tactics_Effect.lift_div_tac

--- a/ocaml/fstar-lib/generated/FStar_Reflection_V2_Formula.ml
+++ b/ocaml/fstar-lib/generated/FStar_Reflection_V2_Formula.ml
@@ -1166,8 +1166,8 @@ let (formula_to_string :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "prims.fst"
-                            (Prims.of_int (595)) (Prims.of_int (19))
-                            (Prims.of_int (595)) (Prims.of_int (31)))))
+                            (Prims.of_int (611)) (Prims.of_int (19))
+                            (Prims.of_int (611)) (Prims.of_int (31)))))
                    (Obj.magic
                       (FStar_Tactics_Effect.tac_bind
                          (FStar_Sealed.seal
@@ -1203,9 +1203,9 @@ let (formula_to_string :
                                       (FStar_Sealed.seal
                                          (Obj.magic
                                             (FStar_Range.mk_range "prims.fst"
-                                               (Prims.of_int (595))
+                                               (Prims.of_int (611))
                                                (Prims.of_int (19))
-                                               (Prims.of_int (595))
+                                               (Prims.of_int (611))
                                                (Prims.of_int (31)))))
                                       (Obj.magic
                                          (FStar_Tactics_Effect.tac_bind
@@ -1221,9 +1221,9 @@ let (formula_to_string :
                                                (Obj.magic
                                                   (FStar_Range.mk_range
                                                      "prims.fst"
-                                                     (Prims.of_int (595))
+                                                     (Prims.of_int (611))
                                                      (Prims.of_int (19))
-                                                     (Prims.of_int (595))
+                                                     (Prims.of_int (611))
                                                      (Prims.of_int (31)))))
                                             (Obj.magic
                                                (FStar_Tactics_V2_Builtins.term_to_string
@@ -1251,9 +1251,9 @@ let (formula_to_string :
                                     (FStar_Sealed.seal
                                        (Obj.magic
                                           (FStar_Range.mk_range "prims.fst"
-                                             (Prims.of_int (595))
+                                             (Prims.of_int (611))
                                              (Prims.of_int (19))
-                                             (Prims.of_int (595))
+                                             (Prims.of_int (611))
                                              (Prims.of_int (31)))))
                                     (Obj.magic
                                        (FStar_Tactics_Effect.tac_bind
@@ -1269,9 +1269,9 @@ let (formula_to_string :
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "prims.fst"
-                                                   (Prims.of_int (595))
+                                                   (Prims.of_int (611))
                                                    (Prims.of_int (19))
-                                                   (Prims.of_int (595))
+                                                   (Prims.of_int (611))
                                                    (Prims.of_int (31)))))
                                           (Obj.magic
                                              (FStar_Tactics_Effect.tac_bind
@@ -1310,9 +1310,9 @@ let (formula_to_string :
                                                               (Obj.magic
                                                                  (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                            (Obj.magic
                                                               (FStar_Tactics_Effect.tac_bind
@@ -1330,9 +1330,9 @@ let (formula_to_string :
                                                                     Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                  (Obj.magic
                                                                     (
@@ -1349,9 +1349,9 @@ let (formula_to_string :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Builtins.term_to_string
@@ -1405,8 +1405,8 @@ let (formula_to_string :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "prims.fst"
-                            (Prims.of_int (595)) (Prims.of_int (19))
-                            (Prims.of_int (595)) (Prims.of_int (31)))))
+                            (Prims.of_int (611)) (Prims.of_int (19))
+                            (Prims.of_int (611)) (Prims.of_int (31)))))
                    (Obj.magic
                       (FStar_Tactics_Effect.tac_bind
                          (FStar_Sealed.seal
@@ -1442,9 +1442,9 @@ let (formula_to_string :
                                       (FStar_Sealed.seal
                                          (Obj.magic
                                             (FStar_Range.mk_range "prims.fst"
-                                               (Prims.of_int (595))
+                                               (Prims.of_int (611))
                                                (Prims.of_int (19))
-                                               (Prims.of_int (595))
+                                               (Prims.of_int (611))
                                                (Prims.of_int (31)))))
                                       (Obj.magic
                                          (FStar_Tactics_Effect.tac_bind
@@ -1460,9 +1460,9 @@ let (formula_to_string :
                                                (Obj.magic
                                                   (FStar_Range.mk_range
                                                      "prims.fst"
-                                                     (Prims.of_int (595))
+                                                     (Prims.of_int (611))
                                                      (Prims.of_int (19))
-                                                     (Prims.of_int (595))
+                                                     (Prims.of_int (611))
                                                      (Prims.of_int (31)))))
                                             (Obj.magic
                                                (FStar_Tactics_V2_Builtins.term_to_string
@@ -1490,9 +1490,9 @@ let (formula_to_string :
                                     (FStar_Sealed.seal
                                        (Obj.magic
                                           (FStar_Range.mk_range "prims.fst"
-                                             (Prims.of_int (595))
+                                             (Prims.of_int (611))
                                              (Prims.of_int (19))
-                                             (Prims.of_int (595))
+                                             (Prims.of_int (611))
                                              (Prims.of_int (31)))))
                                     (Obj.magic
                                        (FStar_Tactics_Effect.tac_bind
@@ -1508,9 +1508,9 @@ let (formula_to_string :
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "prims.fst"
-                                                   (Prims.of_int (595))
+                                                   (Prims.of_int (611))
                                                    (Prims.of_int (19))
-                                                   (Prims.of_int (595))
+                                                   (Prims.of_int (611))
                                                    (Prims.of_int (31)))))
                                           (Obj.magic
                                              (FStar_Tactics_Effect.tac_bind
@@ -1549,9 +1549,9 @@ let (formula_to_string :
                                                               (Obj.magic
                                                                  (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                            (Obj.magic
                                                               (FStar_Tactics_Effect.tac_bind
@@ -1569,9 +1569,9 @@ let (formula_to_string :
                                                                     Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                  (Obj.magic
                                                                     (
@@ -1588,9 +1588,9 @@ let (formula_to_string :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Builtins.term_to_string
@@ -1644,8 +1644,8 @@ let (formula_to_string :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "prims.fst"
-                            (Prims.of_int (595)) (Prims.of_int (19))
-                            (Prims.of_int (595)) (Prims.of_int (31)))))
+                            (Prims.of_int (611)) (Prims.of_int (19))
+                            (Prims.of_int (611)) (Prims.of_int (31)))))
                    (Obj.magic
                       (FStar_Tactics_Effect.tac_bind
                          (FStar_Sealed.seal
@@ -1677,9 +1677,9 @@ let (formula_to_string :
                                     (FStar_Sealed.seal
                                        (Obj.magic
                                           (FStar_Range.mk_range "prims.fst"
-                                             (Prims.of_int (595))
+                                             (Prims.of_int (611))
                                              (Prims.of_int (19))
-                                             (Prims.of_int (595))
+                                             (Prims.of_int (611))
                                              (Prims.of_int (31)))))
                                     (Obj.magic
                                        (FStar_Tactics_Effect.tac_bind
@@ -1695,9 +1695,9 @@ let (formula_to_string :
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "prims.fst"
-                                                   (Prims.of_int (595))
+                                                   (Prims.of_int (611))
                                                    (Prims.of_int (19))
-                                                   (Prims.of_int (595))
+                                                   (Prims.of_int (611))
                                                    (Prims.of_int (31)))))
                                           (Obj.magic
                                              (FStar_Tactics_Effect.tac_bind
@@ -1713,9 +1713,9 @@ let (formula_to_string :
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "prims.fst"
-                                                         (Prims.of_int (595))
+                                                         (Prims.of_int (611))
                                                          (Prims.of_int (19))
-                                                         (Prims.of_int (595))
+                                                         (Prims.of_int (611))
                                                          (Prims.of_int (31)))))
                                                 (Obj.magic
                                                    (FStar_Tactics_V2_Builtins.term_to_string
@@ -1750,8 +1750,8 @@ let (formula_to_string :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "prims.fst"
-                            (Prims.of_int (595)) (Prims.of_int (19))
-                            (Prims.of_int (595)) (Prims.of_int (31)))))
+                            (Prims.of_int (611)) (Prims.of_int (19))
+                            (Prims.of_int (611)) (Prims.of_int (31)))))
                    (Obj.magic
                       (FStar_Tactics_Effect.tac_bind
                          (FStar_Sealed.seal
@@ -1783,9 +1783,9 @@ let (formula_to_string :
                                     (FStar_Sealed.seal
                                        (Obj.magic
                                           (FStar_Range.mk_range "prims.fst"
-                                             (Prims.of_int (595))
+                                             (Prims.of_int (611))
                                              (Prims.of_int (19))
-                                             (Prims.of_int (595))
+                                             (Prims.of_int (611))
                                              (Prims.of_int (31)))))
                                     (Obj.magic
                                        (FStar_Tactics_Effect.tac_bind
@@ -1801,9 +1801,9 @@ let (formula_to_string :
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "prims.fst"
-                                                   (Prims.of_int (595))
+                                                   (Prims.of_int (611))
                                                    (Prims.of_int (19))
-                                                   (Prims.of_int (595))
+                                                   (Prims.of_int (611))
                                                    (Prims.of_int (31)))))
                                           (Obj.magic
                                              (FStar_Tactics_Effect.tac_bind
@@ -1819,9 +1819,9 @@ let (formula_to_string :
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "prims.fst"
-                                                         (Prims.of_int (595))
+                                                         (Prims.of_int (611))
                                                          (Prims.of_int (19))
-                                                         (Prims.of_int (595))
+                                                         (Prims.of_int (611))
                                                          (Prims.of_int (31)))))
                                                 (Obj.magic
                                                    (FStar_Tactics_V2_Builtins.term_to_string
@@ -1856,8 +1856,8 @@ let (formula_to_string :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "prims.fst"
-                            (Prims.of_int (595)) (Prims.of_int (19))
-                            (Prims.of_int (595)) (Prims.of_int (31)))))
+                            (Prims.of_int (611)) (Prims.of_int (19))
+                            (Prims.of_int (611)) (Prims.of_int (31)))))
                    (Obj.magic
                       (FStar_Tactics_Effect.tac_bind
                          (FStar_Sealed.seal
@@ -1889,9 +1889,9 @@ let (formula_to_string :
                                     (FStar_Sealed.seal
                                        (Obj.magic
                                           (FStar_Range.mk_range "prims.fst"
-                                             (Prims.of_int (595))
+                                             (Prims.of_int (611))
                                              (Prims.of_int (19))
-                                             (Prims.of_int (595))
+                                             (Prims.of_int (611))
                                              (Prims.of_int (31)))))
                                     (Obj.magic
                                        (FStar_Tactics_Effect.tac_bind
@@ -1907,9 +1907,9 @@ let (formula_to_string :
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "prims.fst"
-                                                   (Prims.of_int (595))
+                                                   (Prims.of_int (611))
                                                    (Prims.of_int (19))
-                                                   (Prims.of_int (595))
+                                                   (Prims.of_int (611))
                                                    (Prims.of_int (31)))))
                                           (Obj.magic
                                              (FStar_Tactics_Effect.tac_bind
@@ -1925,9 +1925,9 @@ let (formula_to_string :
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "prims.fst"
-                                                         (Prims.of_int (595))
+                                                         (Prims.of_int (611))
                                                          (Prims.of_int (19))
-                                                         (Prims.of_int (595))
+                                                         (Prims.of_int (611))
                                                          (Prims.of_int (31)))))
                                                 (Obj.magic
                                                    (FStar_Tactics_V2_Builtins.term_to_string
@@ -1962,8 +1962,8 @@ let (formula_to_string :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "prims.fst"
-                            (Prims.of_int (595)) (Prims.of_int (19))
-                            (Prims.of_int (595)) (Prims.of_int (31)))))
+                            (Prims.of_int (611)) (Prims.of_int (19))
+                            (Prims.of_int (611)) (Prims.of_int (31)))))
                    (Obj.magic
                       (FStar_Tactics_Effect.tac_bind
                          (FStar_Sealed.seal
@@ -1995,9 +1995,9 @@ let (formula_to_string :
                                     (FStar_Sealed.seal
                                        (Obj.magic
                                           (FStar_Range.mk_range "prims.fst"
-                                             (Prims.of_int (595))
+                                             (Prims.of_int (611))
                                              (Prims.of_int (19))
-                                             (Prims.of_int (595))
+                                             (Prims.of_int (611))
                                              (Prims.of_int (31)))))
                                     (Obj.magic
                                        (FStar_Tactics_Effect.tac_bind
@@ -2013,9 +2013,9 @@ let (formula_to_string :
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "prims.fst"
-                                                   (Prims.of_int (595))
+                                                   (Prims.of_int (611))
                                                    (Prims.of_int (19))
-                                                   (Prims.of_int (595))
+                                                   (Prims.of_int (611))
                                                    (Prims.of_int (31)))))
                                           (Obj.magic
                                              (FStar_Tactics_Effect.tac_bind
@@ -2031,9 +2031,9 @@ let (formula_to_string :
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "prims.fst"
-                                                         (Prims.of_int (595))
+                                                         (Prims.of_int (611))
                                                          (Prims.of_int (19))
-                                                         (Prims.of_int (595))
+                                                         (Prims.of_int (611))
                                                          (Prims.of_int (31)))))
                                                 (Obj.magic
                                                    (FStar_Tactics_V2_Builtins.term_to_string
@@ -2068,8 +2068,8 @@ let (formula_to_string :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "prims.fst"
-                            (Prims.of_int (595)) (Prims.of_int (19))
-                            (Prims.of_int (595)) (Prims.of_int (31)))))
+                            (Prims.of_int (611)) (Prims.of_int (19))
+                            (Prims.of_int (611)) (Prims.of_int (31)))))
                    (Obj.magic
                       (FStar_Tactics_Effect.tac_bind
                          (FStar_Sealed.seal
@@ -2101,9 +2101,9 @@ let (formula_to_string :
                                     (FStar_Sealed.seal
                                        (Obj.magic
                                           (FStar_Range.mk_range "prims.fst"
-                                             (Prims.of_int (595))
+                                             (Prims.of_int (611))
                                              (Prims.of_int (19))
-                                             (Prims.of_int (595))
+                                             (Prims.of_int (611))
                                              (Prims.of_int (31)))))
                                     (Obj.magic
                                        (FStar_Tactics_Effect.tac_bind
@@ -2119,9 +2119,9 @@ let (formula_to_string :
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "prims.fst"
-                                                   (Prims.of_int (595))
+                                                   (Prims.of_int (611))
                                                    (Prims.of_int (19))
-                                                   (Prims.of_int (595))
+                                                   (Prims.of_int (611))
                                                    (Prims.of_int (31)))))
                                           (Obj.magic
                                              (FStar_Tactics_Effect.tac_bind
@@ -2137,9 +2137,9 @@ let (formula_to_string :
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "prims.fst"
-                                                         (Prims.of_int (595))
+                                                         (Prims.of_int (611))
                                                          (Prims.of_int (19))
-                                                         (Prims.of_int (595))
+                                                         (Prims.of_int (611))
                                                          (Prims.of_int (31)))))
                                                 (Obj.magic
                                                    (FStar_Tactics_V2_Builtins.term_to_string
@@ -2174,8 +2174,8 @@ let (formula_to_string :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "prims.fst"
-                            (Prims.of_int (595)) (Prims.of_int (19))
-                            (Prims.of_int (595)) (Prims.of_int (31)))))
+                            (Prims.of_int (611)) (Prims.of_int (19))
+                            (Prims.of_int (611)) (Prims.of_int (31)))))
                    (Obj.magic
                       (FStar_Tactics_Effect.tac_bind
                          (FStar_Sealed.seal
@@ -2207,9 +2207,9 @@ let (formula_to_string :
                                     (FStar_Sealed.seal
                                        (Obj.magic
                                           (FStar_Range.mk_range "prims.fst"
-                                             (Prims.of_int (595))
+                                             (Prims.of_int (611))
                                              (Prims.of_int (19))
-                                             (Prims.of_int (595))
+                                             (Prims.of_int (611))
                                              (Prims.of_int (31)))))
                                     (Obj.magic
                                        (FStar_Tactics_Effect.tac_bind
@@ -2225,9 +2225,9 @@ let (formula_to_string :
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "prims.fst"
-                                                   (Prims.of_int (595))
+                                                   (Prims.of_int (611))
                                                    (Prims.of_int (19))
-                                                   (Prims.of_int (595))
+                                                   (Prims.of_int (611))
                                                    (Prims.of_int (31)))))
                                           (Obj.magic
                                              (FStar_Tactics_Effect.tac_bind
@@ -2243,9 +2243,9 @@ let (formula_to_string :
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "prims.fst"
-                                                         (Prims.of_int (595))
+                                                         (Prims.of_int (611))
                                                          (Prims.of_int (19))
-                                                         (Prims.of_int (595))
+                                                         (Prims.of_int (611))
                                                          (Prims.of_int (31)))))
                                                 (Obj.magic
                                                    (FStar_Tactics_V2_Builtins.term_to_string
@@ -2280,8 +2280,8 @@ let (formula_to_string :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "prims.fst"
-                            (Prims.of_int (595)) (Prims.of_int (19))
-                            (Prims.of_int (595)) (Prims.of_int (31)))))
+                            (Prims.of_int (611)) (Prims.of_int (19))
+                            (Prims.of_int (611)) (Prims.of_int (31)))))
                    (Obj.magic
                       (FStar_Tactics_Effect.tac_bind
                          (FStar_Sealed.seal
@@ -2313,9 +2313,9 @@ let (formula_to_string :
                                     (FStar_Sealed.seal
                                        (Obj.magic
                                           (FStar_Range.mk_range "prims.fst"
-                                             (Prims.of_int (595))
+                                             (Prims.of_int (611))
                                              (Prims.of_int (19))
-                                             (Prims.of_int (595))
+                                             (Prims.of_int (611))
                                              (Prims.of_int (31)))))
                                     (Obj.magic
                                        (FStar_Tactics_Effect.tac_bind
@@ -2331,9 +2331,9 @@ let (formula_to_string :
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "prims.fst"
-                                                   (Prims.of_int (595))
+                                                   (Prims.of_int (611))
                                                    (Prims.of_int (19))
-                                                   (Prims.of_int (595))
+                                                   (Prims.of_int (611))
                                                    (Prims.of_int (31)))))
                                           (Obj.magic
                                              (FStar_Tactics_Effect.tac_bind
@@ -2349,9 +2349,9 @@ let (formula_to_string :
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "prims.fst"
-                                                         (Prims.of_int (595))
+                                                         (Prims.of_int (611))
                                                          (Prims.of_int (19))
-                                                         (Prims.of_int (595))
+                                                         (Prims.of_int (611))
                                                          (Prims.of_int (31)))))
                                                 (Obj.magic
                                                    (FStar_Tactics_V2_Builtins.term_to_string
@@ -2386,8 +2386,8 @@ let (formula_to_string :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "prims.fst"
-                            (Prims.of_int (595)) (Prims.of_int (19))
-                            (Prims.of_int (595)) (Prims.of_int (31)))))
+                            (Prims.of_int (611)) (Prims.of_int (19))
+                            (Prims.of_int (611)) (Prims.of_int (31)))))
                    (Obj.magic
                       (FStar_Tactics_Effect.tac_bind
                          (FStar_Sealed.seal
@@ -2399,8 +2399,8 @@ let (formula_to_string :
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range "prims.fst"
-                                  (Prims.of_int (595)) (Prims.of_int (19))
-                                  (Prims.of_int (595)) (Prims.of_int (31)))))
+                                  (Prims.of_int (611)) (Prims.of_int (19))
+                                  (Prims.of_int (611)) (Prims.of_int (31)))))
                          (Obj.magic
                             (FStar_Tactics_V2_Builtins.term_to_string p))
                          (fun uu___ ->
@@ -2422,8 +2422,8 @@ let (formula_to_string :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "prims.fst"
-                            (Prims.of_int (595)) (Prims.of_int (19))
-                            (Prims.of_int (595)) (Prims.of_int (31)))))
+                            (Prims.of_int (611)) (Prims.of_int (19))
+                            (Prims.of_int (611)) (Prims.of_int (31)))))
                    (Obj.magic
                       (FStar_Tactics_Effect.tac_bind
                          (FStar_Sealed.seal
@@ -2455,9 +2455,9 @@ let (formula_to_string :
                                     (FStar_Sealed.seal
                                        (Obj.magic
                                           (FStar_Range.mk_range "prims.fst"
-                                             (Prims.of_int (595))
+                                             (Prims.of_int (611))
                                              (Prims.of_int (19))
-                                             (Prims.of_int (595))
+                                             (Prims.of_int (611))
                                              (Prims.of_int (31)))))
                                     (Obj.magic
                                        (FStar_Tactics_Effect.tac_bind
@@ -2473,9 +2473,9 @@ let (formula_to_string :
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "prims.fst"
-                                                   (Prims.of_int (595))
+                                                   (Prims.of_int (611))
                                                    (Prims.of_int (19))
-                                                   (Prims.of_int (595))
+                                                   (Prims.of_int (611))
                                                    (Prims.of_int (31)))))
                                           (Obj.magic
                                              (FStar_Tactics_Effect.tac_bind
@@ -2491,9 +2491,9 @@ let (formula_to_string :
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "prims.fst"
-                                                         (Prims.of_int (595))
+                                                         (Prims.of_int (611))
                                                          (Prims.of_int (19))
-                                                         (Prims.of_int (595))
+                                                         (Prims.of_int (611))
                                                          (Prims.of_int (31)))))
                                                 (Obj.magic
                                                    (FStar_Tactics_V2_Builtins.term_to_string
@@ -2528,8 +2528,8 @@ let (formula_to_string :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "prims.fst"
-                            (Prims.of_int (595)) (Prims.of_int (19))
-                            (Prims.of_int (595)) (Prims.of_int (31)))))
+                            (Prims.of_int (611)) (Prims.of_int (19))
+                            (Prims.of_int (611)) (Prims.of_int (31)))))
                    (Obj.magic
                       (FStar_Tactics_Effect.tac_bind
                          (FStar_Sealed.seal
@@ -2541,8 +2541,8 @@ let (formula_to_string :
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range "prims.fst"
-                                  (Prims.of_int (595)) (Prims.of_int (19))
-                                  (Prims.of_int (595)) (Prims.of_int (31)))))
+                                  (Prims.of_int (611)) (Prims.of_int (19))
+                                  (Prims.of_int (611)) (Prims.of_int (31)))))
                          (Obj.magic
                             (FStar_Tactics_V2_Builtins.term_to_string t))
                          (fun uu___ ->
@@ -2564,8 +2564,8 @@ let (formula_to_string :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "prims.fst"
-                            (Prims.of_int (595)) (Prims.of_int (19))
-                            (Prims.of_int (595)) (Prims.of_int (31)))))
+                            (Prims.of_int (611)) (Prims.of_int (19))
+                            (Prims.of_int (611)) (Prims.of_int (31)))))
                    (Obj.magic
                       (FStar_Tactics_Effect.tac_bind
                          (FStar_Sealed.seal
@@ -2577,8 +2577,8 @@ let (formula_to_string :
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range "prims.fst"
-                                  (Prims.of_int (595)) (Prims.of_int (19))
-                                  (Prims.of_int (595)) (Prims.of_int (31)))))
+                                  (Prims.of_int (611)) (Prims.of_int (19))
+                                  (Prims.of_int (611)) (Prims.of_int (31)))))
                          (Obj.magic
                             (FStar_Tactics_V2_Builtins.term_to_string t))
                          (fun uu___ ->
@@ -2600,8 +2600,8 @@ let (formula_to_string :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "prims.fst"
-                            (Prims.of_int (595)) (Prims.of_int (19))
-                            (Prims.of_int (595)) (Prims.of_int (31)))))
+                            (Prims.of_int (611)) (Prims.of_int (19))
+                            (Prims.of_int (611)) (Prims.of_int (31)))))
                    (Obj.magic
                       (FStar_Tactics_Effect.tac_bind
                          (FStar_Sealed.seal
@@ -2633,9 +2633,9 @@ let (formula_to_string :
                                     (FStar_Sealed.seal
                                        (Obj.magic
                                           (FStar_Range.mk_range "prims.fst"
-                                             (Prims.of_int (595))
+                                             (Prims.of_int (611))
                                              (Prims.of_int (19))
-                                             (Prims.of_int (595))
+                                             (Prims.of_int (611))
                                              (Prims.of_int (31)))))
                                     (Obj.magic
                                        (FStar_Tactics_Effect.tac_bind
@@ -2651,9 +2651,9 @@ let (formula_to_string :
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "prims.fst"
-                                                   (Prims.of_int (595))
+                                                   (Prims.of_int (611))
                                                    (Prims.of_int (19))
-                                                   (Prims.of_int (595))
+                                                   (Prims.of_int (611))
                                                    (Prims.of_int (31)))))
                                           (Obj.magic
                                              (FStar_Tactics_Effect.tac_bind
@@ -2669,9 +2669,9 @@ let (formula_to_string :
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "prims.fst"
-                                                         (Prims.of_int (595))
+                                                         (Prims.of_int (611))
                                                          (Prims.of_int (19))
-                                                         (Prims.of_int (595))
+                                                         (Prims.of_int (611))
                                                          (Prims.of_int (31)))))
                                                 (Obj.magic
                                                    (FStar_Tactics_V2_Builtins.term_to_string
@@ -2706,8 +2706,8 @@ let (formula_to_string :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "prims.fst"
-                            (Prims.of_int (595)) (Prims.of_int (19))
-                            (Prims.of_int (595)) (Prims.of_int (31)))))
+                            (Prims.of_int (611)) (Prims.of_int (19))
+                            (Prims.of_int (611)) (Prims.of_int (31)))))
                    (Obj.magic
                       (FStar_Tactics_Effect.tac_bind
                          (FStar_Sealed.seal
@@ -2719,8 +2719,8 @@ let (formula_to_string :
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range "prims.fst"
-                                  (Prims.of_int (595)) (Prims.of_int (19))
-                                  (Prims.of_int (595)) (Prims.of_int (31)))))
+                                  (Prims.of_int (611)) (Prims.of_int (19))
+                                  (Prims.of_int (611)) (Prims.of_int (31)))))
                          (Obj.magic (namedv_to_string bv))
                          (fun uu___ ->
                             FStar_Tactics_Effect.lift_div_tac

--- a/ocaml/fstar-lib/generated/FStar_SMTEncoding_EncodeTerm.ml
+++ b/ocaml/fstar-lib/generated/FStar_SMTEncoding_EncodeTerm.ml
@@ -2705,7 +2705,7 @@ and (encode_term :
                            FStar_TypeChecker_Util.new_implicit_var
                              "SMTEncoding codomain" uu___4
                              env.FStar_SMTEncoding_Env.tcenv
-                             FStar_Syntax_Util.ktype0 in
+                             FStar_Syntax_Util.ktype0 false in
                          (match uu___3 with | (t2, uu___4, uu___5) -> t2)
                      | FStar_Pervasives_Native.Some t2 -> t2 in
                    let uu___3 =

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Print.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Print.ml
@@ -821,6 +821,21 @@ and (attrs_to_string :
               (fun t -> let uu___3 = term_to_string t in paren uu___3) tms in
           FStar_Compiler_String.concat "; " uu___2 in
         FStar_Compiler_Util.format1 "[@ %s]" uu___1
+and (binder_attrs_to_string :
+  FStar_Syntax_Syntax.term Prims.list -> Prims.string) =
+  fun uu___ ->
+    if FStar_Options.any_dump_module ()
+    then ""
+    else
+      (match uu___ with
+       | [] -> ""
+       | tms ->
+           let uu___1 =
+             let uu___2 =
+               FStar_Compiler_List.map
+                 (fun t -> let uu___3 = term_to_string t in paren uu___3) tms in
+             FStar_Compiler_String.concat "; " uu___2 in
+           FStar_Compiler_Util.format1 "[@@@ %s]" uu___1)
 and (bqual_to_string' :
   Prims.string ->
     FStar_Syntax_Syntax.binder_qualifier FStar_Pervasives_Native.option ->
@@ -866,7 +881,8 @@ and (binder_to_string' :
       if uu___
       then FStar_Syntax_Print_Pretty.binder_to_string' is_arrow b
       else
-        (let attrs = attrs_to_string b.FStar_Syntax_Syntax.binder_attrs in
+        (let attrs =
+           binder_attrs_to_string b.FStar_Syntax_Syntax.binder_attrs in
          let uu___2 = FStar_Syntax_Syntax.is_null_binder b in
          if uu___2
          then

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Syntax.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Syntax.ml
@@ -281,7 +281,8 @@ and uvar_decoration =
   {
   uvar_decoration_typ: term' syntax ;
   uvar_decoration_typedness_depends_on: ctx_uvar Prims.list ;
-  uvar_decoration_should_check: should_check_uvar }
+  uvar_decoration_should_check: should_check_uvar ;
+  uvar_decoration_should_unrefine: Prims.bool }
 and pat' =
   | Pat_constant of sconst 
   | Pat_cons of (fv * universes FStar_Pervasives_Native.option * (pat'
@@ -653,20 +654,29 @@ let (__proj__Mkuvar_decoration__item__uvar_decoration_typ :
   fun projectee ->
     match projectee with
     | { uvar_decoration_typ; uvar_decoration_typedness_depends_on;
-        uvar_decoration_should_check;_} -> uvar_decoration_typ
+        uvar_decoration_should_check; uvar_decoration_should_unrefine;_} ->
+        uvar_decoration_typ
 let (__proj__Mkuvar_decoration__item__uvar_decoration_typedness_depends_on :
   uvar_decoration -> ctx_uvar Prims.list) =
   fun projectee ->
     match projectee with
     | { uvar_decoration_typ; uvar_decoration_typedness_depends_on;
-        uvar_decoration_should_check;_} ->
+        uvar_decoration_should_check; uvar_decoration_should_unrefine;_} ->
         uvar_decoration_typedness_depends_on
 let (__proj__Mkuvar_decoration__item__uvar_decoration_should_check :
   uvar_decoration -> should_check_uvar) =
   fun projectee ->
     match projectee with
     | { uvar_decoration_typ; uvar_decoration_typedness_depends_on;
-        uvar_decoration_should_check;_} -> uvar_decoration_should_check
+        uvar_decoration_should_check; uvar_decoration_should_unrefine;_} ->
+        uvar_decoration_should_check
+let (__proj__Mkuvar_decoration__item__uvar_decoration_should_unrefine :
+  uvar_decoration -> Prims.bool) =
+  fun projectee ->
+    match projectee with
+    | { uvar_decoration_typ; uvar_decoration_typedness_depends_on;
+        uvar_decoration_should_check; uvar_decoration_should_unrefine;_} ->
+        uvar_decoration_should_unrefine
 let (uu___is_Pat_constant : pat' -> Prims.bool) =
   fun projectee ->
     match projectee with | Pat_constant _0 -> true | uu___ -> false

--- a/ocaml/fstar-lib/generated/FStar_Tactics_BV.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_BV.ml
@@ -1296,9 +1296,9 @@ let (arith_to_bv_tac : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                          (Obj.magic
                                                             (FStar_Range.mk_range
                                                                "prims.fst"
-                                                               (Prims.of_int (595))
+                                                               (Prims.of_int (611))
                                                                (Prims.of_int (19))
-                                                               (Prims.of_int (595))
+                                                               (Prims.of_int (611))
                                                                (Prims.of_int (31)))))
                                                       (Obj.magic
                                                          (FStar_Tactics_V2_Builtins.term_to_string

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Canon.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Canon.ml
@@ -1355,9 +1355,9 @@ let (canon_point_entry : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr)
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "prims.fst"
-                                                          (Prims.of_int (595))
+                                                          (Prims.of_int (611))
                                                           (Prims.of_int (19))
-                                                          (Prims.of_int (595))
+                                                          (Prims.of_int (611))
                                                           (Prims.of_int (31)))))
                                                  (Obj.magic
                                                     (FStar_Tactics_V2_Builtins.term_to_string

--- a/ocaml/fstar-lib/generated/FStar_Tactics_CanonCommMonoidSimple.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_CanonCommMonoidSimple.ml
@@ -867,9 +867,9 @@ let canon_monoid :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind

--- a/ocaml/fstar-lib/generated/FStar_Tactics_CtrlRewrite.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_CtrlRewrite.ml
@@ -217,6 +217,36 @@ let (__do_rewrite :
                                FStar_TypeChecker_Rel.solve_deferred_constraints
                                  env g in
                              let typ = lcomp.FStar_TypeChecker_Common.res_typ in
+                             let typ1 =
+                               let uu___4 =
+                                 let uu___5 =
+                                   FStar_Options_Ext.get "__unrefine" in
+                                 uu___5 <> "" in
+                               if uu___4
+                               then
+                                 let typ_norm =
+                                   FStar_TypeChecker_Normalize.unfold_whnf'
+                                     [FStar_TypeChecker_Env.DontUnfoldAttr
+                                        [FStar_Parser_Const.do_not_unrefine_attr]]
+                                     env typ in
+                                 let uu___5 =
+                                   let uu___6 =
+                                     let uu___7 =
+                                       FStar_Syntax_Subst.compress typ_norm in
+                                     uu___7.FStar_Syntax_Syntax.n in
+                                   FStar_Syntax_Syntax.uu___is_Tm_refine
+                                     uu___6 in
+                                 (if uu___5
+                                  then
+                                    let typ' =
+                                      FStar_TypeChecker_Normalize.unfold_whnf'
+                                        [FStar_TypeChecker_Env.DontUnfoldAttr
+                                           [FStar_Parser_Const.do_not_unrefine_attr];
+                                        FStar_TypeChecker_Env.Unrefine] env
+                                        typ_norm in
+                                    typ'
+                                  else typ)
+                               else typ in
                              let should_check =
                                let uu___4 =
                                  FStar_TypeChecker_Common.is_total_lcomp
@@ -231,7 +261,7 @@ let (__do_rewrite :
                                let uu___5 =
                                  FStar_Tactics_Monad.goal_typedness_deps g0 in
                                FStar_Tactics_Monad.new_uvar "do_rewrite.rhs"
-                                 env typ should_check uu___5 (rangeof g0) in
+                                 env typ1 should_check uu___5 (rangeof g0) in
                              Obj.magic
                                (FStar_Class_Monad.op_let_Bang
                                   FStar_Tactics_Monad.monad_tac () ()
@@ -267,9 +297,9 @@ let (__do_rewrite :
                                                          let uu___9 =
                                                            let uu___10 =
                                                              env.FStar_TypeChecker_Env.universe_of
-                                                               env typ in
+                                                               env typ1 in
                                                            FStar_Syntax_Util.mk_eq2
-                                                             uu___10 typ tm
+                                                             uu___10 typ1 tm
                                                              ut in
                                                          FStar_Tactics_Monad.add_irrelevant_goal
                                                            g0 "do_rewrite.eq"

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Hooks.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Hooks.ml
@@ -208,7 +208,7 @@ let (by_tactic_interp :
                    FStar_TypeChecker_Env.new_implicit_var_aux
                      "rewrite_with_tactic RHS" tm.FStar_Syntax_Syntax.pos e
                      typ FStar_Syntax_Syntax.Strict
-                     FStar_Pervasives_Native.None in
+                     FStar_Pervasives_Native.None false in
                  (match uu___3 with
                   | (uvtm, uu___4, g_imp) ->
                       let u = e.FStar_TypeChecker_Env.universe_of e typ in
@@ -2369,7 +2369,7 @@ let (postprocess :
                     FStar_TypeChecker_Env.new_implicit_var_aux
                       "postprocess RHS" tm.FStar_Syntax_Syntax.pos env typ
                       (FStar_Syntax_Syntax.Allow_untyped "postprocess")
-                      FStar_Pervasives_Native.None in
+                      FStar_Pervasives_Native.None false in
                   match uu___2 with
                   | (uvtm, uu___3, g_imp) ->
                       let u = env.FStar_TypeChecker_Env.universe_of env typ in

--- a/ocaml/fstar-lib/generated/FStar_Tactics_MkProjectors.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_MkProjectors.ml
@@ -685,9 +685,9 @@ let (mk_proj_decl :
                                  (FStar_Sealed.seal
                                     (Obj.magic
                                        (FStar_Range.mk_range "prims.fst"
-                                          (Prims.of_int (595))
+                                          (Prims.of_int (611))
                                           (Prims.of_int (19))
-                                          (Prims.of_int (595))
+                                          (Prims.of_int (611))
                                           (Prims.of_int (31)))))
                                  (Obj.magic
                                     (FStar_Tactics_Unseal.unseal
@@ -733,9 +733,9 @@ let (mk_proj_decl :
                                                (Obj.magic
                                                   (FStar_Range.mk_range
                                                      "prims.fst"
-                                                     (Prims.of_int (595))
+                                                     (Prims.of_int (611))
                                                      (Prims.of_int (19))
-                                                     (Prims.of_int (595))
+                                                     (Prims.of_int (611))
                                                      (Prims.of_int (31)))))
                                             (Obj.magic
                                                (FStar_Tactics_V2_Builtins.term_to_string
@@ -888,9 +888,9 @@ let (mk_proj_decl :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -931,9 +931,9 @@ let (mk_proj_decl :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -949,9 +949,9 @@ let (mk_proj_decl :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Unseal.unseal
@@ -1185,9 +1185,9 @@ let (mk_proj_decl :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Builtins.term_to_string

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Monad.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Monad.ml
@@ -843,19 +843,14 @@ let (new_uvar :
               let uu___ =
                 FStar_TypeChecker_Env.new_tac_implicit_var reason rng env typ
                   should_check uvar_typedness_deps
-                  FStar_Pervasives_Native.None in
+                  FStar_Pervasives_Native.None false in
               match uu___ with
               | (u, ctx_uvar, g_u) ->
                   let uu___1 =
                     add_implicits g_u.FStar_TypeChecker_Common.implicits in
                   bind uu___1
                     (fun uu___2 ->
-                       let uu___3 =
-                         let uu___4 =
-                           let uu___5 = FStar_Compiler_List.hd ctx_uvar in
-                           FStar_Pervasives_Native.fst uu___5 in
-                         (u, uu___4) in
-                       ret uu___3)
+                       ret (u, (FStar_Pervasives_Native.fst ctx_uvar)))
 let (mk_irrelevant_goal :
   Prims.string ->
     FStar_TypeChecker_Env.env ->
@@ -1073,7 +1068,9 @@ let (set_uvar_expected_typ :
           FStar_Syntax_Syntax.uvar_decoration_typedness_depends_on =
             (dec.FStar_Syntax_Syntax.uvar_decoration_typedness_depends_on);
           FStar_Syntax_Syntax.uvar_decoration_should_check =
-            (dec.FStar_Syntax_Syntax.uvar_decoration_should_check)
+            (dec.FStar_Syntax_Syntax.uvar_decoration_should_check);
+          FStar_Syntax_Syntax.uvar_decoration_should_unrefine =
+            (dec.FStar_Syntax_Syntax.uvar_decoration_should_unrefine)
         }
 let (mark_uvar_with_should_check_tag :
   FStar_Syntax_Syntax.ctx_uvar ->
@@ -1091,7 +1088,9 @@ let (mark_uvar_with_should_check_tag :
             (dec.FStar_Syntax_Syntax.uvar_decoration_typ);
           FStar_Syntax_Syntax.uvar_decoration_typedness_depends_on =
             (dec.FStar_Syntax_Syntax.uvar_decoration_typedness_depends_on);
-          FStar_Syntax_Syntax.uvar_decoration_should_check = sc
+          FStar_Syntax_Syntax.uvar_decoration_should_check = sc;
+          FStar_Syntax_Syntax.uvar_decoration_should_unrefine =
+            (dec.FStar_Syntax_Syntax.uvar_decoration_should_unrefine)
         }
 let (mark_uvar_as_already_checked : FStar_Syntax_Syntax.ctx_uvar -> unit) =
   fun u ->

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Parametricity.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Parametricity.ml
@@ -1524,9 +1524,9 @@ and (param_fv :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (last
@@ -1719,9 +1719,9 @@ and (param_fv :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (last
@@ -2909,9 +2909,9 @@ let (param_ctor :
                                                          (Obj.magic
                                                             (FStar_Range.mk_range
                                                                "prims.fst"
-                                                               (Prims.of_int (595))
+                                                               (Prims.of_int (611))
                                                                (Prims.of_int (19))
-                                                               (Prims.of_int (595))
+                                                               (Prims.of_int (611))
                                                                (Prims.of_int (31)))))
                                                       (Obj.magic (last nm))
                                                       (fun uu___2 ->
@@ -4244,9 +4244,9 @@ let (paramd :
                                             (Obj.magic
                                                (FStar_Range.mk_range
                                                   "prims.fst"
-                                                  (Prims.of_int (595))
+                                                  (Prims.of_int (611))
                                                   (Prims.of_int (19))
-                                                  (Prims.of_int (595))
+                                                  (Prims.of_int (611))
                                                   (Prims.of_int (31)))))
                                          (Obj.magic
                                             (last

--- a/ocaml/fstar-lib/generated/FStar_Tactics_PatternMatching.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_PatternMatching.ml
@@ -746,8 +746,8 @@ let (string_of_match_exception :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "prims.fst"
-                            (Prims.of_int (595)) (Prims.of_int (19))
-                            (Prims.of_int (595)) (Prims.of_int (31)))))
+                            (Prims.of_int (611)) (Prims.of_int (19))
+                            (Prims.of_int (611)) (Prims.of_int (31)))))
                    (Obj.magic
                       (FStar_Tactics_Effect.tac_bind
                          (FStar_Sealed.seal
@@ -759,8 +759,8 @@ let (string_of_match_exception :
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range "prims.fst"
-                                  (Prims.of_int (595)) (Prims.of_int (19))
-                                  (Prims.of_int (595)) (Prims.of_int (31)))))
+                                  (Prims.of_int (611)) (Prims.of_int (19))
+                                  (Prims.of_int (611)) (Prims.of_int (31)))))
                          (Obj.magic
                             (FStar_Tactics_Effect.tac_bind
                                (FStar_Sealed.seal
@@ -774,9 +774,9 @@ let (string_of_match_exception :
                                (FStar_Sealed.seal
                                   (Obj.magic
                                      (FStar_Range.mk_range "prims.fst"
-                                        (Prims.of_int (595))
+                                        (Prims.of_int (611))
                                         (Prims.of_int (19))
-                                        (Prims.of_int (595))
+                                        (Prims.of_int (611))
                                         (Prims.of_int (31)))))
                                (Obj.magic
                                   (FStar_Tactics_V2_Builtins.term_to_string
@@ -808,8 +808,8 @@ let (string_of_match_exception :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "prims.fst"
-                            (Prims.of_int (595)) (Prims.of_int (19))
-                            (Prims.of_int (595)) (Prims.of_int (31)))))
+                            (Prims.of_int (611)) (Prims.of_int (19))
+                            (Prims.of_int (611)) (Prims.of_int (31)))))
                    (Obj.magic
                       (FStar_Tactics_Effect.tac_bind
                          (FStar_Sealed.seal
@@ -821,8 +821,8 @@ let (string_of_match_exception :
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range "prims.fst"
-                                  (Prims.of_int (595)) (Prims.of_int (19))
-                                  (Prims.of_int (595)) (Prims.of_int (31)))))
+                                  (Prims.of_int (611)) (Prims.of_int (19))
+                                  (Prims.of_int (611)) (Prims.of_int (31)))))
                          (Obj.magic
                             (FStar_Tactics_Effect.tac_bind
                                (FStar_Sealed.seal
@@ -836,9 +836,9 @@ let (string_of_match_exception :
                                (FStar_Sealed.seal
                                   (Obj.magic
                                      (FStar_Range.mk_range "prims.fst"
-                                        (Prims.of_int (595))
+                                        (Prims.of_int (611))
                                         (Prims.of_int (19))
-                                        (Prims.of_int (595))
+                                        (Prims.of_int (611))
                                         (Prims.of_int (31)))))
                                (Obj.magic
                                   (FStar_Tactics_Effect.tac_bind
@@ -877,9 +877,9 @@ let (string_of_match_exception :
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "prims.fst"
-                                                         (Prims.of_int (595))
+                                                         (Prims.of_int (611))
                                                          (Prims.of_int (19))
-                                                         (Prims.of_int (595))
+                                                         (Prims.of_int (611))
                                                          (Prims.of_int (31)))))
                                                 (Obj.magic
                                                    (FStar_Tactics_Effect.tac_bind
@@ -895,9 +895,9 @@ let (string_of_match_exception :
                                                          (Obj.magic
                                                             (FStar_Range.mk_range
                                                                "prims.fst"
-                                                               (Prims.of_int (595))
+                                                               (Prims.of_int (611))
                                                                (Prims.of_int (19))
-                                                               (Prims.of_int (595))
+                                                               (Prims.of_int (611))
                                                                (Prims.of_int (31)))))
                                                       (Obj.magic
                                                          (FStar_Tactics_V2_Builtins.term_to_string
@@ -940,8 +940,8 @@ let (string_of_match_exception :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "prims.fst"
-                            (Prims.of_int (595)) (Prims.of_int (19))
-                            (Prims.of_int (595)) (Prims.of_int (31)))))
+                            (Prims.of_int (611)) (Prims.of_int (19))
+                            (Prims.of_int (611)) (Prims.of_int (31)))))
                    (Obj.magic
                       (FStar_Tactics_Effect.tac_bind
                          (FStar_Sealed.seal
@@ -973,9 +973,9 @@ let (string_of_match_exception :
                                     (FStar_Sealed.seal
                                        (Obj.magic
                                           (FStar_Range.mk_range "prims.fst"
-                                             (Prims.of_int (595))
+                                             (Prims.of_int (611))
                                              (Prims.of_int (19))
-                                             (Prims.of_int (595))
+                                             (Prims.of_int (611))
                                              (Prims.of_int (31)))))
                                     (Obj.magic
                                        (FStar_Tactics_Effect.tac_bind
@@ -991,9 +991,9 @@ let (string_of_match_exception :
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "prims.fst"
-                                                   (Prims.of_int (595))
+                                                   (Prims.of_int (611))
                                                    (Prims.of_int (19))
-                                                   (Prims.of_int (595))
+                                                   (Prims.of_int (611))
                                                    (Prims.of_int (31)))))
                                           (Obj.magic
                                              (FStar_Tactics_Effect.tac_bind
@@ -1009,9 +1009,9 @@ let (string_of_match_exception :
                                                    (Obj.magic
                                                       (FStar_Range.mk_range
                                                          "prims.fst"
-                                                         (Prims.of_int (595))
+                                                         (Prims.of_int (611))
                                                          (Prims.of_int (19))
-                                                         (Prims.of_int (595))
+                                                         (Prims.of_int (611))
                                                          (Prims.of_int (31)))))
                                                 (Obj.magic (term_head tm))
                                                 (fun uu___2 ->
@@ -1047,8 +1047,8 @@ let (string_of_match_exception :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "prims.fst"
-                            (Prims.of_int (595)) (Prims.of_int (19))
-                            (Prims.of_int (595)) (Prims.of_int (31)))))
+                            (Prims.of_int (611)) (Prims.of_int (19))
+                            (Prims.of_int (611)) (Prims.of_int (31)))))
                    (Obj.magic
                       (FStar_Tactics_Effect.tac_bind
                          (FStar_Sealed.seal
@@ -1060,8 +1060,8 @@ let (string_of_match_exception :
                          (FStar_Sealed.seal
                             (Obj.magic
                                (FStar_Range.mk_range "prims.fst"
-                                  (Prims.of_int (595)) (Prims.of_int (19))
-                                  (Prims.of_int (595)) (Prims.of_int (31)))))
+                                  (Prims.of_int (611)) (Prims.of_int (19))
+                                  (Prims.of_int (611)) (Prims.of_int (31)))))
                          (Obj.magic
                             (FStar_Tactics_V2_Builtins.term_to_string typ))
                          (fun uu___1 ->
@@ -1199,8 +1199,8 @@ let (string_of_bindings :
                      (FStar_Sealed.seal
                         (Obj.magic
                            (FStar_Range.mk_range "prims.fst"
-                              (Prims.of_int (595)) (Prims.of_int (19))
-                              (Prims.of_int (595)) (Prims.of_int (31)))))
+                              (Prims.of_int (611)) (Prims.of_int (19))
+                              (Prims.of_int (611)) (Prims.of_int (31)))))
                      (Obj.magic
                         (FStar_Tactics_Effect.tac_bind
                            (FStar_Sealed.seal
@@ -1212,8 +1212,8 @@ let (string_of_bindings :
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range "prims.fst"
-                                    (Prims.of_int (595)) (Prims.of_int (19))
-                                    (Prims.of_int (595)) (Prims.of_int (31)))))
+                                    (Prims.of_int (611)) (Prims.of_int (19))
+                                    (Prims.of_int (611)) (Prims.of_int (31)))))
                            (Obj.magic
                               (FStar_Tactics_Effect.tac_bind
                                  (FStar_Sealed.seal
@@ -1227,9 +1227,9 @@ let (string_of_bindings :
                                  (FStar_Sealed.seal
                                     (Obj.magic
                                        (FStar_Range.mk_range "prims.fst"
-                                          (Prims.of_int (595))
+                                          (Prims.of_int (611))
                                           (Prims.of_int (19))
-                                          (Prims.of_int (595))
+                                          (Prims.of_int (611))
                                           (Prims.of_int (31)))))
                                  (Obj.magic
                                     (FStar_Tactics_V2_Builtins.term_to_string
@@ -1766,8 +1766,8 @@ let (string_of_matching_solution :
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range "prims.fst"
-                                    (Prims.of_int (595)) (Prims.of_int (19))
-                                    (Prims.of_int (595)) (Prims.of_int (31)))))
+                                    (Prims.of_int (611)) (Prims.of_int (19))
+                                    (Prims.of_int (611)) (Prims.of_int (31)))))
                            (Obj.magic
                               (FStar_Tactics_Effect.tac_bind
                                  (FStar_Sealed.seal
@@ -1781,9 +1781,9 @@ let (string_of_matching_solution :
                                  (FStar_Sealed.seal
                                     (Obj.magic
                                        (FStar_Range.mk_range "prims.fst"
-                                          (Prims.of_int (595))
+                                          (Prims.of_int (611))
                                           (Prims.of_int (19))
-                                          (Prims.of_int (595))
+                                          (Prims.of_int (611))
                                           (Prims.of_int (31)))))
                                  (Obj.magic
                                     (FStar_Tactics_V2_Builtins.term_to_string
@@ -1810,8 +1810,8 @@ let (string_of_matching_solution :
                           (Prims.of_int (389)) (Prims.of_int (60)))))
                  (FStar_Sealed.seal
                     (Obj.magic
-                       (FStar_Range.mk_range "prims.fst" (Prims.of_int (595))
-                          (Prims.of_int (19)) (Prims.of_int (595))
+                       (FStar_Range.mk_range "prims.fst" (Prims.of_int (611))
+                          (Prims.of_int (19)) (Prims.of_int (611))
                           (Prims.of_int (31)))))
                  (Obj.magic
                     (FStar_Tactics_Effect.tac_bind
@@ -1844,9 +1844,9 @@ let (string_of_matching_solution :
                                       (FStar_Sealed.seal
                                          (Obj.magic
                                             (FStar_Range.mk_range "prims.fst"
-                                               (Prims.of_int (595))
+                                               (Prims.of_int (611))
                                                (Prims.of_int (19))
-                                               (Prims.of_int (595))
+                                               (Prims.of_int (611))
                                                (Prims.of_int (31)))))
                                       (Obj.magic
                                          (FStar_Tactics_Effect.tac_bind
@@ -1862,9 +1862,9 @@ let (string_of_matching_solution :
                                                (Obj.magic
                                                   (FStar_Range.mk_range
                                                      "prims.fst"
-                                                     (Prims.of_int (595))
+                                                     (Prims.of_int (611))
                                                      (Prims.of_int (19))
-                                                     (Prims.of_int (595))
+                                                     (Prims.of_int (611))
                                                      (Prims.of_int (31)))))
                                             (Obj.magic
                                                (FStar_Tactics_V2_Derived.binding_to_string
@@ -2030,9 +2030,9 @@ let rec solve_mp_for_single_hyp :
                                                                 (Obj.magic
                                                                    (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                              (Obj.magic
                                                                 (string_of_match_exception
@@ -2183,9 +2183,9 @@ let solve_mp :
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "prims.fst"
-                                                          (Prims.of_int (595))
+                                                          (Prims.of_int (611))
                                                           (Prims.of_int (19))
-                                                          (Prims.of_int (595))
+                                                          (Prims.of_int (611))
                                                           (Prims.of_int (31)))))
                                                  (Obj.magic
                                                     (string_of_match_exception
@@ -2759,9 +2759,9 @@ let (matching_problem_of_abs :
                                  (FStar_Sealed.seal
                                     (Obj.magic
                                        (FStar_Range.mk_range "prims.fst"
-                                          (Prims.of_int (595))
+                                          (Prims.of_int (611))
                                           (Prims.of_int (19))
-                                          (Prims.of_int (595))
+                                          (Prims.of_int (611))
                                           (Prims.of_int (31)))))
                                  (Obj.magic
                                     (FStar_Tactics_Effect.tac_bind
@@ -2890,9 +2890,9 @@ let (matching_problem_of_abs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                   (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2908,9 +2908,9 @@ let (matching_problem_of_abs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2926,9 +2926,9 @@ let (matching_problem_of_abs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Builtins.term_to_string
@@ -3083,9 +3083,9 @@ let (matching_problem_of_abs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -3126,9 +3126,9 @@ let (matching_problem_of_abs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -3144,9 +3144,9 @@ let (matching_problem_of_abs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -3162,9 +3162,9 @@ let (matching_problem_of_abs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -3180,9 +3180,9 @@ let (matching_problem_of_abs :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Builtins.term_to_string
@@ -4185,9 +4185,9 @@ let (specialize_abspat_continuation :
                                                                     (
                                                                     FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                               (Obj.magic
                                                                  (FStar_Tactics_V2_Builtins.term_to_string
@@ -4281,9 +4281,9 @@ let (specialize_abspat_continuation :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Builtins.term_to_string

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Print.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Print.ml
@@ -12,8 +12,8 @@ let (namedv_to_string :
                (Prims.of_int (17)))))
       (FStar_Sealed.seal
          (Obj.magic
-            (FStar_Range.mk_range "prims.fst" (Prims.of_int (595))
-               (Prims.of_int (19)) (Prims.of_int (595)) (Prims.of_int (31)))))
+            (FStar_Range.mk_range "prims.fst" (Prims.of_int (611))
+               (Prims.of_int (19)) (Prims.of_int (611)) (Prims.of_int (31)))))
       (Obj.magic
          (FStar_Tactics_Unseal.unseal x.FStar_Reflection_V2_Data.ppname))
       (fun uu___ ->
@@ -81,9 +81,9 @@ let rec print_list_aux :
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range "prims.fst"
-                                           (Prims.of_int (595))
+                                           (Prims.of_int (611))
                                            (Prims.of_int (19))
-                                           (Prims.of_int (595))
+                                           (Prims.of_int (611))
                                            (Prims.of_int (31)))))
                                   (Obj.magic
                                      (FStar_Tactics_Effect.tac_bind
@@ -99,9 +99,9 @@ let rec print_list_aux :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "prims.fst"
-                                                 (Prims.of_int (595))
+                                                 (Prims.of_int (611))
                                                  (Prims.of_int (19))
-                                                 (Prims.of_int (595))
+                                                 (Prims.of_int (611))
                                                  (Prims.of_int (31)))))
                                         (Obj.magic (print_list_aux f xs1))
                                         (fun uu___1 ->
@@ -128,8 +128,8 @@ let print_list :
                  (Prims.of_int (33)))))
         (FStar_Sealed.seal
            (Obj.magic
-              (FStar_Range.mk_range "prims.fst" (Prims.of_int (595))
-                 (Prims.of_int (19)) (Prims.of_int (595)) (Prims.of_int (31)))))
+              (FStar_Range.mk_range "prims.fst" (Prims.of_int (611))
+                 (Prims.of_int (19)) (Prims.of_int (611)) (Prims.of_int (31)))))
         (Obj.magic
            (FStar_Tactics_Effect.tac_bind
               (FStar_Sealed.seal
@@ -139,8 +139,8 @@ let print_list :
                        (Prims.of_int (25)) (Prims.of_int (27)))))
               (FStar_Sealed.seal
                  (Obj.magic
-                    (FStar_Range.mk_range "prims.fst" (Prims.of_int (595))
-                       (Prims.of_int (19)) (Prims.of_int (595))
+                    (FStar_Range.mk_range "prims.fst" (Prims.of_int (611))
+                       (Prims.of_int (19)) (Prims.of_int (611))
                        (Prims.of_int (31)))))
               (Obj.magic (print_list_aux f l))
               (fun uu___ ->
@@ -172,8 +172,8 @@ let rec (universe_to_ast_string :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "prims.fst"
-                            (Prims.of_int (595)) (Prims.of_int (19))
-                            (Prims.of_int (595)) (Prims.of_int (31)))))
+                            (Prims.of_int (611)) (Prims.of_int (19))
+                            (Prims.of_int (611)) (Prims.of_int (31)))))
                    (Obj.magic
                       (FStar_Tactics_Effect.tac_bind
                          (FStar_Sealed.seal
@@ -207,8 +207,8 @@ let rec (universe_to_ast_string :
                    (FStar_Sealed.seal
                       (Obj.magic
                          (FStar_Range.mk_range "prims.fst"
-                            (Prims.of_int (595)) (Prims.of_int (19))
-                            (Prims.of_int (595)) (Prims.of_int (31)))))
+                            (Prims.of_int (611)) (Prims.of_int (19))
+                            (Prims.of_int (611)) (Prims.of_int (31)))))
                    (Obj.magic (print_list universe_to_ast_string us))
                    (fun uu___ ->
                       FStar_Tactics_Effect.lift_div_tac
@@ -296,8 +296,8 @@ let rec (term_to_ast_string :
                         (FStar_Sealed.seal
                            (Obj.magic
                               (FStar_Range.mk_range "prims.fst"
-                                 (Prims.of_int (595)) (Prims.of_int (19))
-                                 (Prims.of_int (595)) (Prims.of_int (31)))))
+                                 (Prims.of_int (611)) (Prims.of_int (19))
+                                 (Prims.of_int (611)) (Prims.of_int (31)))))
                         (Obj.magic (namedv_to_string bv))
                         (fun uu___1 ->
                            FStar_Tactics_Effect.lift_div_tac
@@ -314,8 +314,8 @@ let rec (term_to_ast_string :
                         (FStar_Sealed.seal
                            (Obj.magic
                               (FStar_Range.mk_range "prims.fst"
-                                 (Prims.of_int (595)) (Prims.of_int (19))
-                                 (Prims.of_int (595)) (Prims.of_int (31)))))
+                                 (Prims.of_int (611)) (Prims.of_int (19))
+                                 (Prims.of_int (611)) (Prims.of_int (31)))))
                         (Obj.magic (FStar_Tactics_V2_Derived.bv_to_string bv))
                         (fun uu___1 ->
                            FStar_Tactics_Effect.lift_div_tac
@@ -339,8 +339,8 @@ let rec (term_to_ast_string :
                         (FStar_Sealed.seal
                            (Obj.magic
                               (FStar_Range.mk_range "prims.fst"
-                                 (Prims.of_int (595)) (Prims.of_int (19))
-                                 (Prims.of_int (595)) (Prims.of_int (31)))))
+                                 (Prims.of_int (611)) (Prims.of_int (19))
+                                 (Prims.of_int (611)) (Prims.of_int (31)))))
                         (Obj.magic
                            (FStar_Tactics_Effect.tac_bind
                               (FStar_Sealed.seal
@@ -372,9 +372,9 @@ let rec (term_to_ast_string :
                                     (FStar_Sealed.seal
                                        (Obj.magic
                                           (FStar_Range.mk_range "prims.fst"
-                                             (Prims.of_int (595))
+                                             (Prims.of_int (611))
                                              (Prims.of_int (19))
-                                             (Prims.of_int (595))
+                                             (Prims.of_int (611))
                                              (Prims.of_int (31)))))
                                     (Obj.magic
                                        (FStar_Tactics_Effect.tac_bind
@@ -390,9 +390,9 @@ let rec (term_to_ast_string :
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "prims.fst"
-                                                   (Prims.of_int (595))
+                                                   (Prims.of_int (611))
                                                    (Prims.of_int (19))
-                                                   (Prims.of_int (595))
+                                                   (Prims.of_int (611))
                                                    (Prims.of_int (31)))))
                                           (Obj.magic
                                              (universes_to_ast_string us))
@@ -424,8 +424,8 @@ let rec (term_to_ast_string :
                         (FStar_Sealed.seal
                            (Obj.magic
                               (FStar_Range.mk_range "prims.fst"
-                                 (Prims.of_int (595)) (Prims.of_int (19))
-                                 (Prims.of_int (595)) (Prims.of_int (31)))))
+                                 (Prims.of_int (611)) (Prims.of_int (19))
+                                 (Prims.of_int (611)) (Prims.of_int (31)))))
                         (Obj.magic
                            (FStar_Tactics_Effect.tac_bind
                               (FStar_Sealed.seal
@@ -479,9 +479,9 @@ let rec (term_to_ast_string :
                                                   (Obj.magic
                                                      (FStar_Range.mk_range
                                                         "prims.fst"
-                                                        (Prims.of_int (595))
+                                                        (Prims.of_int (611))
                                                         (Prims.of_int (19))
-                                                        (Prims.of_int (595))
+                                                        (Prims.of_int (611))
                                                         (Prims.of_int (31)))))
                                                (Obj.magic
                                                   (FStar_Tactics_Effect.tac_bind
@@ -497,9 +497,9 @@ let rec (term_to_ast_string :
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "prims.fst"
-                                                              (Prims.of_int (595))
+                                                              (Prims.of_int (611))
                                                               (Prims.of_int (19))
-                                                              (Prims.of_int (595))
+                                                              (Prims.of_int (611))
                                                               (Prims.of_int (31)))))
                                                      (Obj.magic
                                                         (term_to_ast_string a))
@@ -531,8 +531,8 @@ let rec (term_to_ast_string :
                         (FStar_Sealed.seal
                            (Obj.magic
                               (FStar_Range.mk_range "prims.fst"
-                                 (Prims.of_int (595)) (Prims.of_int (19))
-                                 (Prims.of_int (595)) (Prims.of_int (31)))))
+                                 (Prims.of_int (611)) (Prims.of_int (19))
+                                 (Prims.of_int (611)) (Prims.of_int (31)))))
                         (Obj.magic
                            (FStar_Tactics_Effect.tac_bind
                               (FStar_Sealed.seal
@@ -588,9 +588,9 @@ let rec (term_to_ast_string :
                                                   (Obj.magic
                                                      (FStar_Range.mk_range
                                                         "prims.fst"
-                                                        (Prims.of_int (595))
+                                                        (Prims.of_int (611))
                                                         (Prims.of_int (19))
-                                                        (Prims.of_int (595))
+                                                        (Prims.of_int (611))
                                                         (Prims.of_int (31)))))
                                                (Obj.magic
                                                   (FStar_Tactics_Effect.tac_bind
@@ -606,9 +606,9 @@ let rec (term_to_ast_string :
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "prims.fst"
-                                                              (Prims.of_int (595))
+                                                              (Prims.of_int (611))
                                                               (Prims.of_int (19))
-                                                              (Prims.of_int (595))
+                                                              (Prims.of_int (611))
                                                               (Prims.of_int (31)))))
                                                      (Obj.magic
                                                         (term_to_ast_string e))
@@ -640,8 +640,8 @@ let rec (term_to_ast_string :
                         (FStar_Sealed.seal
                            (Obj.magic
                               (FStar_Range.mk_range "prims.fst"
-                                 (Prims.of_int (595)) (Prims.of_int (19))
-                                 (Prims.of_int (595)) (Prims.of_int (31)))))
+                                 (Prims.of_int (611)) (Prims.of_int (19))
+                                 (Prims.of_int (611)) (Prims.of_int (31)))))
                         (Obj.magic
                            (FStar_Tactics_Effect.tac_bind
                               (FStar_Sealed.seal
@@ -697,9 +697,9 @@ let rec (term_to_ast_string :
                                                   (Obj.magic
                                                      (FStar_Range.mk_range
                                                         "prims.fst"
-                                                        (Prims.of_int (595))
+                                                        (Prims.of_int (611))
                                                         (Prims.of_int (19))
-                                                        (Prims.of_int (595))
+                                                        (Prims.of_int (611))
                                                         (Prims.of_int (31)))))
                                                (Obj.magic
                                                   (FStar_Tactics_Effect.tac_bind
@@ -715,9 +715,9 @@ let rec (term_to_ast_string :
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "prims.fst"
-                                                              (Prims.of_int (595))
+                                                              (Prims.of_int (611))
                                                               (Prims.of_int (19))
-                                                              (Prims.of_int (595))
+                                                              (Prims.of_int (611))
                                                               (Prims.of_int (31)))))
                                                      (Obj.magic
                                                         (comp_to_ast_string c))
@@ -749,8 +749,8 @@ let rec (term_to_ast_string :
                         (FStar_Sealed.seal
                            (Obj.magic
                               (FStar_Range.mk_range "prims.fst"
-                                 (Prims.of_int (595)) (Prims.of_int (19))
-                                 (Prims.of_int (595)) (Prims.of_int (31)))))
+                                 (Prims.of_int (611)) (Prims.of_int (19))
+                                 (Prims.of_int (611)) (Prims.of_int (31)))))
                         (Obj.magic
                            (FStar_Tactics_Effect.tac_bind
                               (FStar_Sealed.seal
@@ -788,8 +788,8 @@ let rec (term_to_ast_string :
                         (FStar_Sealed.seal
                            (Obj.magic
                               (FStar_Range.mk_range "prims.fst"
-                                 (Prims.of_int (595)) (Prims.of_int (19))
-                                 (Prims.of_int (595)) (Prims.of_int (31)))))
+                                 (Prims.of_int (611)) (Prims.of_int (19))
+                                 (Prims.of_int (611)) (Prims.of_int (31)))))
                         (Obj.magic
                            (FStar_Tactics_Effect.tac_bind
                               (FStar_Sealed.seal
@@ -845,9 +845,9 @@ let rec (term_to_ast_string :
                                                   (Obj.magic
                                                      (FStar_Range.mk_range
                                                         "prims.fst"
-                                                        (Prims.of_int (595))
+                                                        (Prims.of_int (611))
                                                         (Prims.of_int (19))
-                                                        (Prims.of_int (595))
+                                                        (Prims.of_int (611))
                                                         (Prims.of_int (31)))))
                                                (Obj.magic
                                                   (FStar_Tactics_Effect.tac_bind
@@ -863,9 +863,9 @@ let rec (term_to_ast_string :
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "prims.fst"
-                                                              (Prims.of_int (595))
+                                                              (Prims.of_int (611))
                                                               (Prims.of_int (19))
-                                                              (Prims.of_int (595))
+                                                              (Prims.of_int (611))
                                                               (Prims.of_int (31)))))
                                                      (Obj.magic
                                                         (term_to_ast_string e))
@@ -905,8 +905,8 @@ let rec (term_to_ast_string :
                         (FStar_Sealed.seal
                            (Obj.magic
                               (FStar_Range.mk_range "prims.fst"
-                                 (Prims.of_int (595)) (Prims.of_int (19))
-                                 (Prims.of_int (595)) (Prims.of_int (31)))))
+                                 (Prims.of_int (611)) (Prims.of_int (19))
+                                 (Prims.of_int (611)) (Prims.of_int (31)))))
                         (Obj.magic
                            (FStar_Tactics_Effect.tac_bind
                               (FStar_Sealed.seal
@@ -938,9 +938,9 @@ let rec (term_to_ast_string :
                                     (FStar_Sealed.seal
                                        (Obj.magic
                                           (FStar_Range.mk_range "prims.fst"
-                                             (Prims.of_int (595))
+                                             (Prims.of_int (611))
                                              (Prims.of_int (19))
-                                             (Prims.of_int (595))
+                                             (Prims.of_int (611))
                                              (Prims.of_int (31)))))
                                     (Obj.magic
                                        (FStar_Tactics_Effect.tac_bind
@@ -956,9 +956,9 @@ let rec (term_to_ast_string :
                                              (Obj.magic
                                                 (FStar_Range.mk_range
                                                    "prims.fst"
-                                                   (Prims.of_int (595))
+                                                   (Prims.of_int (611))
                                                    (Prims.of_int (19))
-                                                   (Prims.of_int (595))
+                                                   (Prims.of_int (611))
                                                    (Prims.of_int (31)))))
                                           (Obj.magic
                                              (FStar_Tactics_Effect.tac_bind
@@ -997,9 +997,9 @@ let rec (term_to_ast_string :
                                                               (Obj.magic
                                                                  (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                            (Obj.magic
                                                               (FStar_Tactics_Effect.tac_bind
@@ -1017,9 +1017,9 @@ let rec (term_to_ast_string :
                                                                     Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                  (Obj.magic
                                                                     (
@@ -1061,9 +1061,9 @@ let rec (term_to_ast_string :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1079,9 +1079,9 @@ let rec (term_to_ast_string :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (term_to_ast_string
@@ -1147,8 +1147,8 @@ let rec (term_to_ast_string :
                         (FStar_Sealed.seal
                            (Obj.magic
                               (FStar_Range.mk_range "prims.fst"
-                                 (Prims.of_int (595)) (Prims.of_int (19))
-                                 (Prims.of_int (595)) (Prims.of_int (31)))))
+                                 (Prims.of_int (611)) (Prims.of_int (19))
+                                 (Prims.of_int (611)) (Prims.of_int (31)))))
                         (Obj.magic
                            (FStar_Tactics_Effect.tac_bind
                               (FStar_Sealed.seal
@@ -1201,9 +1201,9 @@ let rec (term_to_ast_string :
                                                   (Obj.magic
                                                      (FStar_Range.mk_range
                                                         "prims.fst"
-                                                        (Prims.of_int (595))
+                                                        (Prims.of_int (611))
                                                         (Prims.of_int (19))
-                                                        (Prims.of_int (595))
+                                                        (Prims.of_int (611))
                                                         (Prims.of_int (31)))))
                                                (Obj.magic
                                                   (FStar_Tactics_Effect.tac_bind
@@ -1219,9 +1219,9 @@ let rec (term_to_ast_string :
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "prims.fst"
-                                                              (Prims.of_int (595))
+                                                              (Prims.of_int (611))
                                                               (Prims.of_int (19))
-                                                              (Prims.of_int (595))
+                                                              (Prims.of_int (611))
                                                               (Prims.of_int (31)))))
                                                      (Obj.magic
                                                         (FStar_Tactics_Effect.tac_bind
@@ -1260,9 +1260,9 @@ let rec (term_to_ast_string :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -1278,9 +1278,9 @@ let rec (term_to_ast_string :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (branches_to_ast_string
@@ -1330,8 +1330,8 @@ let rec (term_to_ast_string :
                         (FStar_Sealed.seal
                            (Obj.magic
                               (FStar_Range.mk_range "prims.fst"
-                                 (Prims.of_int (595)) (Prims.of_int (19))
-                                 (Prims.of_int (595)) (Prims.of_int (31)))))
+                                 (Prims.of_int (611)) (Prims.of_int (19))
+                                 (Prims.of_int (611)) (Prims.of_int (31)))))
                         (Obj.magic
                            (FStar_Tactics_Effect.tac_bind
                               (FStar_Sealed.seal
@@ -1385,9 +1385,9 @@ let rec (term_to_ast_string :
                                                   (Obj.magic
                                                      (FStar_Range.mk_range
                                                         "prims.fst"
-                                                        (Prims.of_int (595))
+                                                        (Prims.of_int (611))
                                                         (Prims.of_int (19))
-                                                        (Prims.of_int (595))
+                                                        (Prims.of_int (611))
                                                         (Prims.of_int (31)))))
                                                (Obj.magic
                                                   (FStar_Tactics_Effect.tac_bind
@@ -1403,9 +1403,9 @@ let rec (term_to_ast_string :
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "prims.fst"
-                                                              (Prims.of_int (595))
+                                                              (Prims.of_int (611))
                                                               (Prims.of_int (19))
-                                                              (Prims.of_int (595))
+                                                              (Prims.of_int (611))
                                                               (Prims.of_int (31)))))
                                                      (Obj.magic
                                                         (FStar_Tactics_Effect.tac_bind
@@ -1421,9 +1421,9 @@ let rec (term_to_ast_string :
                                                               (Obj.magic
                                                                  (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                            (Obj.magic
                                                               (term_to_ast_string
@@ -1467,8 +1467,8 @@ let rec (term_to_ast_string :
                         (FStar_Sealed.seal
                            (Obj.magic
                               (FStar_Range.mk_range "prims.fst"
-                                 (Prims.of_int (595)) (Prims.of_int (19))
-                                 (Prims.of_int (595)) (Prims.of_int (31)))))
+                                 (Prims.of_int (611)) (Prims.of_int (19))
+                                 (Prims.of_int (611)) (Prims.of_int (31)))))
                         (Obj.magic
                            (FStar_Tactics_Effect.tac_bind
                               (FStar_Sealed.seal
@@ -1522,9 +1522,9 @@ let rec (term_to_ast_string :
                                                   (Obj.magic
                                                      (FStar_Range.mk_range
                                                         "prims.fst"
-                                                        (Prims.of_int (595))
+                                                        (Prims.of_int (611))
                                                         (Prims.of_int (19))
-                                                        (Prims.of_int (595))
+                                                        (Prims.of_int (611))
                                                         (Prims.of_int (31)))))
                                                (Obj.magic
                                                   (FStar_Tactics_Effect.tac_bind
@@ -1540,9 +1540,9 @@ let rec (term_to_ast_string :
                                                         (Obj.magic
                                                            (FStar_Range.mk_range
                                                               "prims.fst"
-                                                              (Prims.of_int (595))
+                                                              (Prims.of_int (611))
                                                               (Prims.of_int (19))
-                                                              (Prims.of_int (595))
+                                                              (Prims.of_int (611))
                                                               (Prims.of_int (31)))))
                                                      (Obj.magic
                                                         (FStar_Tactics_Effect.tac_bind
@@ -1558,9 +1558,9 @@ let rec (term_to_ast_string :
                                                               (Obj.magic
                                                                  (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                            (Obj.magic
                                                               (comp_to_ast_string
@@ -1644,9 +1644,9 @@ and (match_returns_to_string :
                                (FStar_Sealed.seal
                                   (Obj.magic
                                      (FStar_Range.mk_range "prims.fst"
-                                        (Prims.of_int (595))
+                                        (Prims.of_int (611))
                                         (Prims.of_int (19))
-                                        (Prims.of_int (595))
+                                        (Prims.of_int (611))
                                         (Prims.of_int (31)))))
                                (Obj.magic (term_to_ast_string tac))
                                (fun uu___1 ->
@@ -1686,9 +1686,9 @@ and (match_returns_to_string :
                               (FStar_Sealed.seal
                                  (Obj.magic
                                     (FStar_Range.mk_range "prims.fst"
-                                       (Prims.of_int (595))
+                                       (Prims.of_int (611))
                                        (Prims.of_int (19))
-                                       (Prims.of_int (595))
+                                       (Prims.of_int (611))
                                        (Prims.of_int (31)))))
                               (Obj.magic
                                  (FStar_Tactics_V2_Derived.binder_to_string b))
@@ -1710,9 +1710,9 @@ and (match_returns_to_string :
                                    (FStar_Sealed.seal
                                       (Obj.magic
                                          (FStar_Range.mk_range "prims.fst"
-                                            (Prims.of_int (595))
+                                            (Prims.of_int (611))
                                             (Prims.of_int (19))
-                                            (Prims.of_int (595))
+                                            (Prims.of_int (611))
                                             (Prims.of_int (31)))))
                                    (match asc with
                                     | (FStar_Pervasives.Inl t, tacopt,
@@ -1753,9 +1753,9 @@ and (match_returns_to_string :
                                                            (Obj.magic
                                                               (FStar_Range.mk_range
                                                                  "prims.fst"
-                                                                 (Prims.of_int (595))
+                                                                 (Prims.of_int (611))
                                                                  (Prims.of_int (19))
-                                                                 (Prims.of_int (595))
+                                                                 (Prims.of_int (611))
                                                                  (Prims.of_int (31)))))
                                                         (Obj.magic
                                                            (tacopt_to_string
@@ -1805,9 +1805,9 @@ and (match_returns_to_string :
                                                            (Obj.magic
                                                               (FStar_Range.mk_range
                                                                  "prims.fst"
-                                                                 (Prims.of_int (595))
+                                                                 (Prims.of_int (611))
                                                                  (Prims.of_int (19))
-                                                                 (Prims.of_int (595))
+                                                                 (Prims.of_int (611))
                                                                  (Prims.of_int (31)))))
                                                         (Obj.magic
                                                            (tacopt_to_string
@@ -1872,8 +1872,8 @@ and (branch_to_ast_string :
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range "prims.fst"
-                                    (Prims.of_int (595)) (Prims.of_int (19))
-                                    (Prims.of_int (595)) (Prims.of_int (31)))))
+                                    (Prims.of_int (611)) (Prims.of_int (19))
+                                    (Prims.of_int (611)) (Prims.of_int (31)))))
                            (Obj.magic (term_to_ast_string e))
                            (fun uu___1 ->
                               FStar_Tactics_Effect.lift_div_tac
@@ -1896,8 +1896,8 @@ and (comp_to_ast_string :
                    (Prims.of_int (95)) (Prims.of_int (46)))))
           (FStar_Sealed.seal
              (Obj.magic
-                (FStar_Range.mk_range "prims.fst" (Prims.of_int (595))
-                   (Prims.of_int (19)) (Prims.of_int (595))
+                (FStar_Range.mk_range "prims.fst" (Prims.of_int (611))
+                   (Prims.of_int (19)) (Prims.of_int (611))
                    (Prims.of_int (31))))) (Obj.magic (term_to_ast_string t))
           (fun uu___ ->
              FStar_Tactics_Effect.lift_div_tac
@@ -1911,8 +1911,8 @@ and (comp_to_ast_string :
                    (Prims.of_int (96)) (Prims.of_int (48)))))
           (FStar_Sealed.seal
              (Obj.magic
-                (FStar_Range.mk_range "prims.fst" (Prims.of_int (595))
-                   (Prims.of_int (19)) (Prims.of_int (595))
+                (FStar_Range.mk_range "prims.fst" (Prims.of_int (611))
+                   (Prims.of_int (19)) (Prims.of_int (611))
                    (Prims.of_int (31))))) (Obj.magic (term_to_ast_string t))
           (fun uu___ ->
              FStar_Tactics_Effect.lift_div_tac
@@ -1926,8 +1926,8 @@ and (comp_to_ast_string :
                    (Prims.of_int (97)) (Prims.of_int (91)))))
           (FStar_Sealed.seal
              (Obj.magic
-                (FStar_Range.mk_range "prims.fst" (Prims.of_int (595))
-                   (Prims.of_int (19)) (Prims.of_int (595))
+                (FStar_Range.mk_range "prims.fst" (Prims.of_int (611))
+                   (Prims.of_int (19)) (Prims.of_int (611))
                    (Prims.of_int (31)))))
           (Obj.magic
              (FStar_Tactics_Effect.tac_bind
@@ -1955,8 +1955,8 @@ and (comp_to_ast_string :
                            (FStar_Sealed.seal
                               (Obj.magic
                                  (FStar_Range.mk_range "prims.fst"
-                                    (Prims.of_int (595)) (Prims.of_int (19))
-                                    (Prims.of_int (595)) (Prims.of_int (31)))))
+                                    (Prims.of_int (611)) (Prims.of_int (19))
+                                    (Prims.of_int (611)) (Prims.of_int (31)))))
                            (Obj.magic
                               (FStar_Tactics_Effect.tac_bind
                                  (FStar_Sealed.seal
@@ -1970,9 +1970,9 @@ and (comp_to_ast_string :
                                  (FStar_Sealed.seal
                                     (Obj.magic
                                        (FStar_Range.mk_range "prims.fst"
-                                          (Prims.of_int (595))
+                                          (Prims.of_int (611))
                                           (Prims.of_int (19))
-                                          (Prims.of_int (595))
+                                          (Prims.of_int (611))
                                           (Prims.of_int (31)))))
                                  (Obj.magic (term_to_ast_string post))
                                  (fun uu___2 ->
@@ -1994,8 +1994,8 @@ and (comp_to_ast_string :
                    (Prims.of_int (99)) (Prims.of_int (111)))))
           (FStar_Sealed.seal
              (Obj.magic
-                (FStar_Range.mk_range "prims.fst" (Prims.of_int (595))
-                   (Prims.of_int (19)) (Prims.of_int (595))
+                (FStar_Range.mk_range "prims.fst" (Prims.of_int (611))
+                   (Prims.of_int (19)) (Prims.of_int (611))
                    (Prims.of_int (31)))))
           (Obj.magic
              (FStar_Tactics_Effect.tac_bind
@@ -2006,8 +2006,8 @@ and (comp_to_ast_string :
                          (Prims.of_int (99)) (Prims.of_int (111)))))
                 (FStar_Sealed.seal
                    (Obj.magic
-                      (FStar_Range.mk_range "prims.fst" (Prims.of_int (595))
-                         (Prims.of_int (19)) (Prims.of_int (595))
+                      (FStar_Range.mk_range "prims.fst" (Prims.of_int (611))
+                         (Prims.of_int (19)) (Prims.of_int (611))
                          (Prims.of_int (31)))))
                 (Obj.magic
                    (FStar_Tactics_Effect.tac_bind
@@ -2037,9 +2037,9 @@ and (comp_to_ast_string :
                                  (FStar_Sealed.seal
                                     (Obj.magic
                                        (FStar_Range.mk_range "prims.fst"
-                                          (Prims.of_int (595))
+                                          (Prims.of_int (611))
                                           (Prims.of_int (19))
-                                          (Prims.of_int (595))
+                                          (Prims.of_int (611))
                                           (Prims.of_int (31)))))
                                  (Obj.magic
                                     (FStar_Tactics_Effect.tac_bind
@@ -2055,9 +2055,9 @@ and (comp_to_ast_string :
                                           (Obj.magic
                                              (FStar_Range.mk_range
                                                 "prims.fst"
-                                                (Prims.of_int (595))
+                                                (Prims.of_int (611))
                                                 (Prims.of_int (19))
-                                                (Prims.of_int (595))
+                                                (Prims.of_int (611))
                                                 (Prims.of_int (31)))))
                                        (Obj.magic
                                           (FStar_Tactics_Effect.tac_bind
@@ -2091,9 +2091,9 @@ and (comp_to_ast_string :
                                                       (Obj.magic
                                                          (FStar_Range.mk_range
                                                             "prims.fst"
-                                                            (Prims.of_int (595))
+                                                            (Prims.of_int (611))
                                                             (Prims.of_int (19))
-                                                            (Prims.of_int (595))
+                                                            (Prims.of_int (611))
                                                             (Prims.of_int (31)))))
                                                    (Obj.magic
                                                       (FStar_Tactics_Effect.tac_bind
@@ -2109,9 +2109,9 @@ and (comp_to_ast_string :
                                                             (Obj.magic
                                                                (FStar_Range.mk_range
                                                                   "prims.fst"
-                                                                  (Prims.of_int (595))
+                                                                  (Prims.of_int (611))
                                                                   (Prims.of_int (19))
-                                                                  (Prims.of_int (595))
+                                                                  (Prims.of_int (611))
                                                                   (Prims.of_int (31)))))
                                                          (Obj.magic
                                                             (term_to_ast_string

--- a/ocaml/fstar-lib/generated/FStar_Tactics_TypeRepr.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_TypeRepr.ml
@@ -726,9 +726,9 @@ let rec (get_apply_tuple :
                                                   (Obj.magic
                                                      (FStar_Range.mk_range
                                                         "prims.fst"
-                                                        (Prims.of_int (595))
+                                                        (Prims.of_int (611))
                                                         (Prims.of_int (19))
-                                                        (Prims.of_int (595))
+                                                        (Prims.of_int (611))
                                                         (Prims.of_int (31)))))
                                                (Obj.magic
                                                   (FStar_Tactics_V2_Builtins.term_to_string
@@ -957,9 +957,9 @@ let rec (get_apply_tuple :
                                                   (Obj.magic
                                                      (FStar_Range.mk_range
                                                         "prims.fst"
-                                                        (Prims.of_int (595))
+                                                        (Prims.of_int (611))
                                                         (Prims.of_int (19))
-                                                        (Prims.of_int (595))
+                                                        (Prims.of_int (611))
                                                         (Prims.of_int (31)))))
                                                (Obj.magic
                                                   (FStar_Tactics_V2_Builtins.term_to_string
@@ -1017,9 +1017,9 @@ let rec (get_apply_tuple :
                                                      (Obj.magic
                                                         (FStar_Range.mk_range
                                                            "prims.fst"
-                                                           (Prims.of_int (595))
+                                                           (Prims.of_int (611))
                                                            (Prims.of_int (19))
-                                                           (Prims.of_int (595))
+                                                           (Prims.of_int (611))
                                                            (Prims.of_int (31)))))
                                                   (Obj.magic
                                                      (FStar_Tactics_V2_Builtins.term_to_string
@@ -1067,9 +1067,9 @@ let rec (get_apply_tuple :
                                                 (Obj.magic
                                                    (FStar_Range.mk_range
                                                       "prims.fst"
-                                                      (Prims.of_int (595))
+                                                      (Prims.of_int (611))
                                                       (Prims.of_int (19))
-                                                      (Prims.of_int (595))
+                                                      (Prims.of_int (611))
                                                       (Prims.of_int (31)))))
                                              (Obj.magic
                                                 (FStar_Tactics_V2_Builtins.term_to_string

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Typeclasses.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Typeclasses.ml
@@ -647,9 +647,9 @@ let (trywith :
                                                       (Obj.magic
                                                          (FStar_Range.mk_range
                                                             "prims.fst"
-                                                            (Prims.of_int (595))
+                                                            (Prims.of_int (611))
                                                             (Prims.of_int (19))
-                                                            (Prims.of_int (595))
+                                                            (Prims.of_int (611))
                                                             (Prims.of_int (31)))))
                                                    (Obj.magic
                                                       (FStar_Tactics_Effect.tac_bind
@@ -690,9 +690,9 @@ let (trywith :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (
                                                                     Obj.magic
@@ -709,9 +709,9 @@ let (trywith :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Builtins.term_to_string
@@ -807,9 +807,9 @@ let (trywith :
                                                                     (
                                                                     FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                               (Obj.magic
                                                                  (FStar_Tactics_V2_Builtins.term_to_string
@@ -1091,8 +1091,8 @@ let (local :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "prims.fst"
-                                (Prims.of_int (595)) (Prims.of_int (19))
-                                (Prims.of_int (595)) (Prims.of_int (31)))))
+                                (Prims.of_int (611)) (Prims.of_int (19))
+                                (Prims.of_int (611)) (Prims.of_int (31)))))
                        (Obj.magic
                           (FStar_Tactics_V2_Builtins.term_to_string g.g))
                        (fun uu___2 ->
@@ -1185,8 +1185,8 @@ let (global :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "prims.fst"
-                                (Prims.of_int (595)) (Prims.of_int (19))
-                                (Prims.of_int (595)) (Prims.of_int (31)))))
+                                (Prims.of_int (611)) (Prims.of_int (19))
+                                (Prims.of_int (611)) (Prims.of_int (31)))))
                        (Obj.magic
                           (FStar_Tactics_V2_Builtins.term_to_string g.g))
                        (fun uu___2 ->
@@ -2131,9 +2131,9 @@ let (tcresolve : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Builtins.term_to_string
@@ -2680,9 +2680,9 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Util.string_of_list
@@ -2772,9 +2772,9 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Builtins.term_to_string
@@ -2911,9 +2911,9 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2929,9 +2929,9 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Effect.tac_bind
@@ -2947,9 +2947,9 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Builtins.term_to_string
@@ -3147,9 +3147,9 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_Util.string_of_list
@@ -3293,9 +3293,9 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Builtins.term_to_string
@@ -4153,9 +4153,9 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Builtins.term_to_string
@@ -4212,9 +4212,9 @@ let (mk_class :
                                                                     (Obj.magic
                                                                     (FStar_Range.mk_range
                                                                     "prims.fst"
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (19))
-                                                                    (Prims.of_int (595))
+                                                                    (Prims.of_int (611))
                                                                     (Prims.of_int (31)))))
                                                                     (Obj.magic
                                                                     (FStar_Tactics_V2_Builtins.term_to_string

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Types.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Types.ml
@@ -235,16 +235,13 @@ let (goal_of_goal_ty :
       let uu___ =
         FStar_TypeChecker_Env.new_implicit_var_aux "proofstate_of_goal_ty"
           typ.FStar_Syntax_Syntax.pos env typ FStar_Syntax_Syntax.Strict
-          FStar_Pervasives_Native.None in
+          FStar_Pervasives_Native.None false in
       match uu___ with
-      | (u, ctx_uvars, g_u) ->
-          let uu___1 = FStar_Compiler_List.hd ctx_uvars in
-          (match uu___1 with
-           | (ctx_uvar, uu___2) ->
-               let g =
-                 let uu___3 = FStar_Options.peek () in
-                 mk_goal env ctx_uvar uu___3 false "" in
-               (g, g_u))
+      | (u, (ctx_uvar, uu___1), g_u) ->
+          let g =
+            let uu___2 = FStar_Options.peek () in
+            mk_goal env ctx_uvar uu___2 false "" in
+          (g, g_u)
 let (goal_of_implicit :
   FStar_TypeChecker_Env.env -> FStar_TypeChecker_Common.implicit -> goal) =
   fun env ->

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Util.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Util.ml
@@ -678,9 +678,9 @@ let rec string_of_list :
                                   (FStar_Sealed.seal
                                      (Obj.magic
                                         (FStar_Range.mk_range "prims.fst"
-                                           (Prims.of_int (595))
+                                           (Prims.of_int (611))
                                            (Prims.of_int (19))
-                                           (Prims.of_int (595))
+                                           (Prims.of_int (611))
                                            (Prims.of_int (31)))))
                                   (Obj.magic
                                      (FStar_Tactics_Effect.tac_bind
@@ -696,9 +696,9 @@ let rec string_of_list :
                                            (Obj.magic
                                               (FStar_Range.mk_range
                                                  "prims.fst"
-                                                 (Prims.of_int (595))
+                                                 (Prims.of_int (611))
                                                  (Prims.of_int (19))
-                                                 (Prims.of_int (595))
+                                                 (Prims.of_int (611))
                                                  (Prims.of_int (31)))))
                                         (Obj.magic (string_of_list f xs))
                                         (fun uu___1 ->
@@ -733,8 +733,8 @@ let string_of_option :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "prims.fst"
-                                (Prims.of_int (595)) (Prims.of_int (19))
-                                (Prims.of_int (595)) (Prims.of_int (31)))))
+                                (Prims.of_int (611)) (Prims.of_int (19))
+                                (Prims.of_int (611)) (Prims.of_int (31)))))
                        (Obj.magic (f x))
                        (fun uu___ ->
                           FStar_Tactics_Effect.lift_div_tac

--- a/ocaml/fstar-lib/generated/FStar_Tactics_V1_Basic.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_V1_Basic.ml
@@ -127,7 +127,9 @@ let (set_uvar_expected_typ :
           FStar_Syntax_Syntax.uvar_decoration_typedness_depends_on =
             (dec.FStar_Syntax_Syntax.uvar_decoration_typedness_depends_on);
           FStar_Syntax_Syntax.uvar_decoration_should_check =
-            (dec.FStar_Syntax_Syntax.uvar_decoration_should_check)
+            (dec.FStar_Syntax_Syntax.uvar_decoration_should_check);
+          FStar_Syntax_Syntax.uvar_decoration_should_unrefine =
+            (dec.FStar_Syntax_Syntax.uvar_decoration_should_unrefine)
         }
 let (mark_uvar_with_should_check_tag :
   FStar_Syntax_Syntax.ctx_uvar ->
@@ -145,7 +147,9 @@ let (mark_uvar_with_should_check_tag :
             (dec.FStar_Syntax_Syntax.uvar_decoration_typ);
           FStar_Syntax_Syntax.uvar_decoration_typedness_depends_on =
             (dec.FStar_Syntax_Syntax.uvar_decoration_typedness_depends_on);
-          FStar_Syntax_Syntax.uvar_decoration_should_check = sc
+          FStar_Syntax_Syntax.uvar_decoration_should_check = sc;
+          FStar_Syntax_Syntax.uvar_decoration_should_unrefine =
+            (dec.FStar_Syntax_Syntax.uvar_decoration_should_unrefine)
         }
 let (mark_uvar_as_already_checked : FStar_Syntax_Syntax.ctx_uvar -> unit) =
   fun u ->

--- a/ocaml/fstar-lib/generated/FStar_Tactics_V2_Basic.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_V2_Basic.ml
@@ -11925,9 +11925,10 @@ let (refl_try_unify :
                                                   reason
                                                   t0.FStar_Syntax_Syntax.pos
                                                   g1 t2 should_check_uvar
-                                                  FStar_Pervasives_Native.None in
+                                                  FStar_Pervasives_Native.None
+                                                  false in
                                               (match uu___7 with
-                                               | (uv_t, (ctx_u, uu___8)::[],
+                                               | (uv_t, (ctx_u, uu___8),
                                                   guard_uv) ->
                                                    let uv_id =
                                                      FStar_Syntax_Unionfind.uvar_unique_id

--- a/ocaml/fstar-lib/generated/FStar_Tactics_V2_Derived.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_V2_Derived.ml
@@ -48,8 +48,8 @@ let (binder_to_string :
                           (Prims.of_int (50)) (Prims.of_int (86)))))
                  (FStar_Sealed.seal
                     (Obj.magic
-                       (FStar_Range.mk_range "prims.fst" (Prims.of_int (595))
-                          (Prims.of_int (19)) (Prims.of_int (595))
+                       (FStar_Range.mk_range "prims.fst" (Prims.of_int (611))
+                          (Prims.of_int (19)) (Prims.of_int (611))
                           (Prims.of_int (31)))))
                  (Obj.magic
                     (FStar_Tactics_Effect.tac_bind
@@ -62,8 +62,8 @@ let (binder_to_string :
                        (FStar_Sealed.seal
                           (Obj.magic
                              (FStar_Range.mk_range "prims.fst"
-                                (Prims.of_int (595)) (Prims.of_int (19))
-                                (Prims.of_int (595)) (Prims.of_int (31)))))
+                                (Prims.of_int (611)) (Prims.of_int (19))
+                                (Prims.of_int (611)) (Prims.of_int (31)))))
                        (Obj.magic
                           (FStar_Tactics_Effect.tac_bind
                              (FStar_Sealed.seal
@@ -75,9 +75,9 @@ let (binder_to_string :
                              (FStar_Sealed.seal
                                 (Obj.magic
                                    (FStar_Range.mk_range "prims.fst"
-                                      (Prims.of_int (595))
+                                      (Prims.of_int (611))
                                       (Prims.of_int (19))
-                                      (Prims.of_int (595))
+                                      (Prims.of_int (611))
                                       (Prims.of_int (31)))))
                              (Obj.magic
                                 (FStar_Tactics_Effect.tac_bind
@@ -92,9 +92,9 @@ let (binder_to_string :
                                    (FStar_Sealed.seal
                                       (Obj.magic
                                          (FStar_Range.mk_range "prims.fst"
-                                            (Prims.of_int (595))
+                                            (Prims.of_int (611))
                                             (Prims.of_int (19))
-                                            (Prims.of_int (595))
+                                            (Prims.of_int (611))
                                             (Prims.of_int (31)))))
                                    (Obj.magic
                                       (FStar_Tactics_Effect.tac_bind
@@ -110,9 +110,9 @@ let (binder_to_string :
                                             (Obj.magic
                                                (FStar_Range.mk_range
                                                   "prims.fst"
-                                                  (Prims.of_int (595))
+                                                  (Prims.of_int (611))
                                                   (Prims.of_int (19))
-                                                  (Prims.of_int (595))
+                                                  (Prims.of_int (611))
                                                   (Prims.of_int (31)))))
                                          (Obj.magic
                                             (FStar_Tactics_V2_Builtins.term_to_string

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_DeferredImplicits.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_DeferredImplicits.ml
@@ -630,19 +630,16 @@ let (solve_deferred_to_tactic_goals :
                                   reason
                                   (tp.FStar_TypeChecker_Common.lhs).FStar_Syntax_Syntax.pos
                                   env2 goal_ty FStar_Syntax_Syntax.Strict
-                                  FStar_Pervasives_Native.None in
+                                  FStar_Pervasives_Native.None false in
                               (match uu___8 with
                                | (goal, ctx_uvar, uu___9) ->
                                    let imp =
-                                     let uu___10 =
-                                       let uu___11 =
-                                         FStar_Compiler_List.hd ctx_uvar in
-                                       FStar_Pervasives_Native.fst uu___11 in
                                      {
                                        FStar_TypeChecker_Common.imp_reason =
                                          "";
                                        FStar_TypeChecker_Common.imp_uvar =
-                                         uu___10;
+                                         (FStar_Pervasives_Native.fst
+                                            ctx_uvar);
                                        FStar_TypeChecker_Common.imp_tm = goal;
                                        FStar_TypeChecker_Common.imp_range =
                                          ((tp.FStar_TypeChecker_Common.lhs).FStar_Syntax_Syntax.pos)

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Env.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Env.ml
@@ -7120,72 +7120,76 @@ let (new_tac_implicit_var :
             FStar_Syntax_Syntax.ctx_uvar Prims.list ->
               FStar_Syntax_Syntax.ctx_uvar_meta_t
                 FStar_Pervasives_Native.option ->
-                (FStar_Syntax_Syntax.term * (FStar_Syntax_Syntax.ctx_uvar *
-                  FStar_Compiler_Range_Type.range) Prims.list * guard_t))
+                Prims.bool ->
+                  (FStar_Syntax_Syntax.term * (FStar_Syntax_Syntax.ctx_uvar *
+                    FStar_Compiler_Range_Type.range) * guard_t))
   =
   fun reason ->
     fun r ->
       fun env1 ->
-        fun k ->
+        fun uvar_typ ->
           fun should_check ->
             fun uvar_typedness_deps ->
               fun meta ->
-                let binders = all_binders env1 in
-                let gamma = env1.gamma in
-                let decoration =
-                  {
-                    FStar_Syntax_Syntax.uvar_decoration_typ = k;
-                    FStar_Syntax_Syntax.uvar_decoration_typedness_depends_on
-                      = uvar_typedness_deps;
-                    FStar_Syntax_Syntax.uvar_decoration_should_check =
-                      should_check
-                  } in
-                let ctx_uvar =
-                  let uu___ = FStar_Syntax_Unionfind.fresh decoration r in
-                  {
-                    FStar_Syntax_Syntax.ctx_uvar_head = uu___;
-                    FStar_Syntax_Syntax.ctx_uvar_gamma = gamma;
-                    FStar_Syntax_Syntax.ctx_uvar_binders = binders;
-                    FStar_Syntax_Syntax.ctx_uvar_reason = reason;
-                    FStar_Syntax_Syntax.ctx_uvar_range = r;
-                    FStar_Syntax_Syntax.ctx_uvar_meta = meta
-                  } in
-                FStar_TypeChecker_Common.check_uvar_ctx_invariant reason r
-                  true gamma binders;
-                (let t =
-                   FStar_Syntax_Syntax.mk
-                     (FStar_Syntax_Syntax.Tm_uvar
-                        (ctx_uvar, ([], FStar_Syntax_Syntax.NoUseRange))) r in
-                 let imp =
-                   {
-                     FStar_TypeChecker_Common.imp_reason = reason;
-                     FStar_TypeChecker_Common.imp_uvar = ctx_uvar;
-                     FStar_TypeChecker_Common.imp_tm = t;
-                     FStar_TypeChecker_Common.imp_range = r
-                   } in
-                 (let uu___2 =
-                    FStar_Compiler_Effect.op_Bang dbg_ImplicitTrace in
-                  if uu___2
-                  then
-                    let uu___3 =
-                      FStar_Syntax_Print.uvar_to_string
-                        ctx_uvar.FStar_Syntax_Syntax.ctx_uvar_head in
-                    FStar_Compiler_Util.print1
-                      "Just created uvar for implicit {%s}\n" uu___3
-                  else ());
-                 (let g =
+                fun unrefine ->
+                  let binders = all_binders env1 in
+                  let gamma = env1.gamma in
+                  let decoration =
                     {
-                      FStar_TypeChecker_Common.guard_f =
-                        (trivial_guard.FStar_TypeChecker_Common.guard_f);
-                      FStar_TypeChecker_Common.deferred_to_tac =
-                        (trivial_guard.FStar_TypeChecker_Common.deferred_to_tac);
-                      FStar_TypeChecker_Common.deferred =
-                        (trivial_guard.FStar_TypeChecker_Common.deferred);
-                      FStar_TypeChecker_Common.univ_ineqs =
-                        (trivial_guard.FStar_TypeChecker_Common.univ_ineqs);
-                      FStar_TypeChecker_Common.implicits = [imp]
+                      FStar_Syntax_Syntax.uvar_decoration_typ = uvar_typ;
+                      FStar_Syntax_Syntax.uvar_decoration_typedness_depends_on
+                        = uvar_typedness_deps;
+                      FStar_Syntax_Syntax.uvar_decoration_should_check =
+                        should_check;
+                      FStar_Syntax_Syntax.uvar_decoration_should_unrefine =
+                        unrefine
                     } in
-                  (t, [(ctx_uvar, r)], g)))
+                  let ctx_uvar =
+                    let uu___ = FStar_Syntax_Unionfind.fresh decoration r in
+                    {
+                      FStar_Syntax_Syntax.ctx_uvar_head = uu___;
+                      FStar_Syntax_Syntax.ctx_uvar_gamma = gamma;
+                      FStar_Syntax_Syntax.ctx_uvar_binders = binders;
+                      FStar_Syntax_Syntax.ctx_uvar_reason = reason;
+                      FStar_Syntax_Syntax.ctx_uvar_range = r;
+                      FStar_Syntax_Syntax.ctx_uvar_meta = meta
+                    } in
+                  FStar_TypeChecker_Common.check_uvar_ctx_invariant reason r
+                    true gamma binders;
+                  (let t =
+                     FStar_Syntax_Syntax.mk
+                       (FStar_Syntax_Syntax.Tm_uvar
+                          (ctx_uvar, ([], FStar_Syntax_Syntax.NoUseRange))) r in
+                   let imp =
+                     {
+                       FStar_TypeChecker_Common.imp_reason = reason;
+                       FStar_TypeChecker_Common.imp_uvar = ctx_uvar;
+                       FStar_TypeChecker_Common.imp_tm = t;
+                       FStar_TypeChecker_Common.imp_range = r
+                     } in
+                   (let uu___2 =
+                      FStar_Compiler_Effect.op_Bang dbg_ImplicitTrace in
+                    if uu___2
+                    then
+                      let uu___3 =
+                        FStar_Syntax_Print.uvar_to_string
+                          ctx_uvar.FStar_Syntax_Syntax.ctx_uvar_head in
+                      FStar_Compiler_Util.print1
+                        "Just created uvar for implicit {%s}\n" uu___3
+                    else ());
+                   (let g =
+                      {
+                        FStar_TypeChecker_Common.guard_f =
+                          (trivial_guard.FStar_TypeChecker_Common.guard_f);
+                        FStar_TypeChecker_Common.deferred_to_tac =
+                          (trivial_guard.FStar_TypeChecker_Common.deferred_to_tac);
+                        FStar_TypeChecker_Common.deferred =
+                          (trivial_guard.FStar_TypeChecker_Common.deferred);
+                        FStar_TypeChecker_Common.univ_ineqs =
+                          (trivial_guard.FStar_TypeChecker_Common.univ_ineqs);
+                        FStar_TypeChecker_Common.implicits = [imp]
+                      } in
+                    (t, (ctx_uvar, r), g)))
 let (new_implicit_var_aux :
   Prims.string ->
     FStar_Compiler_Range_Type.range ->
@@ -7194,8 +7198,9 @@ let (new_implicit_var_aux :
           FStar_Syntax_Syntax.should_check_uvar ->
             FStar_Syntax_Syntax.ctx_uvar_meta_t
               FStar_Pervasives_Native.option ->
-              (FStar_Syntax_Syntax.term * (FStar_Syntax_Syntax.ctx_uvar *
-                FStar_Compiler_Range_Type.range) Prims.list * guard_t))
+              Prims.bool ->
+                (FStar_Syntax_Syntax.term * (FStar_Syntax_Syntax.ctx_uvar *
+                  FStar_Compiler_Range_Type.range) * guard_t))
   =
   fun reason ->
     fun r ->
@@ -7203,45 +7208,53 @@ let (new_implicit_var_aux :
         fun k ->
           fun should_check ->
             fun meta ->
-              new_tac_implicit_var reason r env1 k should_check [] meta
+              fun unrefine ->
+                new_tac_implicit_var reason r env1 k should_check [] meta
+                  unrefine
 let (uvar_meta_for_binder :
   FStar_Syntax_Syntax.binder ->
-    FStar_Syntax_Syntax.ctx_uvar_meta_t FStar_Pervasives_Native.option)
+    (FStar_Syntax_Syntax.ctx_uvar_meta_t FStar_Pervasives_Native.option *
+      Prims.bool))
   =
   fun b ->
-    match b.FStar_Syntax_Syntax.binder_qual with
-    | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Meta tau) ->
-        FStar_Pervasives_Native.Some
-          (FStar_Syntax_Syntax.Ctx_uvar_meta_tac tau)
-    | uu___ ->
-        let is_unification_tag t =
-          let uu___1 = FStar_Syntax_Util.head_and_args t in
-          match uu___1 with
-          | (hd, args) ->
-              let hd1 = FStar_Syntax_Util.un_uinst hd in
-              let uu___2 =
-                let uu___3 =
-                  let uu___4 = FStar_Syntax_Subst.compress hd1 in
-                  uu___4.FStar_Syntax_Syntax.n in
-                (uu___3, args) in
-              (match uu___2 with
-               | (FStar_Syntax_Syntax.Tm_fvar fv,
-                  (uu___3, FStar_Pervasives_Native.Some
-                   { FStar_Syntax_Syntax.aqual_implicit = true;
-                     FStar_Syntax_Syntax.aqual_attributes = uu___4;_})::
-                  (a, FStar_Pervasives_Native.None)::[]) when
-                   FStar_Syntax_Syntax.fv_eq_lid fv
-                     FStar_Parser_Const.unification_tag_lid
-                   -> FStar_Pervasives_Native.Some a
-               | uu___3 -> FStar_Pervasives_Native.None) in
-        let uu___1 =
-          FStar_Compiler_List.tryPick is_unification_tag
-            b.FStar_Syntax_Syntax.binder_attrs in
-        (match uu___1 with
-         | FStar_Pervasives_Native.Some tag ->
-             FStar_Pervasives_Native.Some
-               (FStar_Syntax_Syntax.Ctx_uvar_meta_attr tag)
-         | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None)
+    let should_unrefine =
+      FStar_Syntax_Util.has_attribute b.FStar_Syntax_Syntax.binder_attrs
+        FStar_Parser_Const.unrefine_binder_attr in
+    let meta =
+      match b.FStar_Syntax_Syntax.binder_qual with
+      | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Meta tau) ->
+          FStar_Pervasives_Native.Some
+            (FStar_Syntax_Syntax.Ctx_uvar_meta_tac tau)
+      | uu___ ->
+          let is_unification_tag t =
+            let uu___1 = FStar_Syntax_Util.head_and_args t in
+            match uu___1 with
+            | (hd, args) ->
+                let hd1 = FStar_Syntax_Util.un_uinst hd in
+                let uu___2 =
+                  let uu___3 =
+                    let uu___4 = FStar_Syntax_Subst.compress hd1 in
+                    uu___4.FStar_Syntax_Syntax.n in
+                  (uu___3, args) in
+                (match uu___2 with
+                 | (FStar_Syntax_Syntax.Tm_fvar fv,
+                    (uu___3, FStar_Pervasives_Native.Some
+                     { FStar_Syntax_Syntax.aqual_implicit = true;
+                       FStar_Syntax_Syntax.aqual_attributes = uu___4;_})::
+                    (a, FStar_Pervasives_Native.None)::[]) when
+                     FStar_Syntax_Syntax.fv_eq_lid fv
+                       FStar_Parser_Const.unification_tag_lid
+                     -> FStar_Pervasives_Native.Some a
+                 | uu___3 -> FStar_Pervasives_Native.None) in
+          let uu___1 =
+            FStar_Compiler_List.tryPick is_unification_tag
+              b.FStar_Syntax_Syntax.binder_attrs in
+          (match uu___1 with
+           | FStar_Pervasives_Native.Some tag ->
+               FStar_Pervasives_Native.Some
+                 (FStar_Syntax_Syntax.Ctx_uvar_meta_attr tag)
+           | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None) in
+    (meta, should_unrefine)
 let (uvars_for_binders :
   env ->
     FStar_Syntax_Syntax.binders ->
@@ -7264,44 +7277,46 @@ let (uvars_for_binders :
                          let sort =
                            FStar_Syntax_Subst.subst substs1
                              (b.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort in
-                         let ctx_uvar_meta = uvar_meta_for_binder b in
-                         let uu___2 =
-                           let uu___3 = reason b in
-                           let uu___4 =
-                             let uu___5 =
-                               FStar_Options.compat_pre_typed_indexed_effects
-                                 () in
-                             if uu___5
-                             then
-                               FStar_Syntax_Syntax.Allow_untyped
-                                 "indexed effect uvar in compat mode"
-                             else FStar_Syntax_Syntax.Strict in
-                           new_implicit_var_aux uu___3 r env1 sort uu___4
-                             ctx_uvar_meta in
+                         let uu___2 = uvar_meta_for_binder b in
                          (match uu___2 with
-                          | (t, l_ctx_uvars, g_t) ->
-                              ((let uu___4 =
-                                  FStar_Compiler_Effect.op_Bang
-                                    dbg_LayeredEffectsEqns in
-                                if uu___4
-                                then
-                                  FStar_Compiler_List.iter
-                                    (fun uu___5 ->
-                                       match uu___5 with
-                                       | (ctx_uvar, uu___6) ->
-                                           let uu___7 =
-                                             FStar_Syntax_Print.ctx_uvar_to_string
-                                               ctx_uvar in
-                                           FStar_Compiler_Util.print1
-                                             "Layered Effect uvar : %s\n"
-                                             uu___7) l_ctx_uvars
-                                else ());
-                               (let uu___4 = conj_guards [g; g_t] in
-                                ((FStar_Compiler_List.op_At substs1
-                                    [FStar_Syntax_Syntax.NT
-                                       ((b.FStar_Syntax_Syntax.binder_bv), t)]),
-                                  (FStar_Compiler_List.op_At uvars [t]),
-                                  uu___4))))) (substs, [], trivial_guard) bs in
+                          | (ctx_uvar_meta, should_unrefine) ->
+                              let uu___3 =
+                                let uu___4 = reason b in
+                                let uu___5 =
+                                  let uu___6 =
+                                    FStar_Options.compat_pre_typed_indexed_effects
+                                      () in
+                                  if uu___6
+                                  then
+                                    FStar_Syntax_Syntax.Allow_untyped
+                                      "indexed effect uvar in compat mode"
+                                  else FStar_Syntax_Syntax.Strict in
+                                new_implicit_var_aux uu___4 r env1 sort
+                                  uu___5 ctx_uvar_meta should_unrefine in
+                              (match uu___3 with
+                               | (t, l_ctx_uvars, g_t) ->
+                                   ((let uu___5 =
+                                       FStar_Compiler_Effect.op_Bang
+                                         dbg_LayeredEffectsEqns in
+                                     if uu___5
+                                     then
+                                       let uu___6 =
+                                         FStar_Class_Show.show
+                                           (FStar_Class_Show.show_tuple2
+                                              FStar_Syntax_Print.showable_ctxu
+                                              FStar_Compiler_Range_Ops.showable_range)
+                                           l_ctx_uvars in
+                                       FStar_Compiler_Util.print1
+                                         "Layered Effect uvar: %s\n" uu___6
+                                     else ());
+                                    (let uu___5 = conj_guards [g; g_t] in
+                                     ((FStar_Compiler_List.op_At substs1
+                                         [FStar_Syntax_Syntax.NT
+                                            ((b.FStar_Syntax_Syntax.binder_bv),
+                                              t)]),
+                                       (FStar_Compiler_List.op_At uvars [t]),
+                                       uu___5))))))
+                (substs, [], trivial_guard) bs in
             match uu___ with | (uu___1, uvars, g) -> (uvars, g)
 let (pure_precondition_for_trivial_post :
   env ->

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_PatternUtils.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_PatternUtils.ml
@@ -270,7 +270,7 @@ let (pat_as_exp :
                      FStar_TypeChecker_Env.new_implicit_var_aux
                        "pattern bv type" uu___4 env1 t
                        (FStar_Syntax_Syntax.Allow_untyped "pattern bv type")
-                       FStar_Pervasives_Native.None in
+                       FStar_Pervasives_Native.None false in
                    (match uu___3 with
                     | (t_x, uu___4, guard) ->
                         let x1 =
@@ -325,7 +325,7 @@ let (pat_as_exp :
                                env1 k
                                (FStar_Syntax_Syntax.Allow_ghost
                                   "pat dot term type")
-                               FStar_Pervasives_Native.None in
+                               FStar_Pervasives_Native.None false in
                            (match uu___3 with
                             | (t, uu___4, g) ->
                                 let uu___5 =
@@ -334,7 +334,7 @@ let (pat_as_exp :
                                     env1 t
                                     (FStar_Syntax_Syntax.Allow_ghost
                                        "pat dot term")
-                                    FStar_Pervasives_Native.None in
+                                    FStar_Pervasives_Native.None false in
                                 (match uu___5 with
                                  | (e, uu___6, g') ->
                                      let p2 =

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_TcEffect.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_TcEffect.ml
@@ -148,7 +148,7 @@ let (pure_wp_uvar :
                 FStar_Syntax_Syntax.mk_Tm_app pure_wp_t1 uu___2 r in
           let uu___ =
             FStar_TypeChecker_Env.new_implicit_var_aux reason r env pure_wp_t
-              FStar_Syntax_Syntax.Strict FStar_Pervasives_Native.None in
+              FStar_Syntax_Syntax.Strict FStar_Pervasives_Native.None false in
           match uu___ with
           | (pure_wp_uvar1, uu___1, guard_wp) -> (pure_wp_uvar1, guard_wp)
 let op_let_Question :
@@ -4867,7 +4867,8 @@ let (tc_layered_eff_decl :
                                                                     uu___24 r
                                                                     env1 sort
                                                                     FStar_Syntax_Syntax.Strict
-                                                                    ctx_uvar_meta in
+                                                                    ctx_uvar_meta
+                                                                    false in
                                                                     (match uu___23
                                                                     with
                                                                     | 
@@ -4969,7 +4970,8 @@ let (tc_layered_eff_decl :
                                                                     FStar_Syntax_Syntax.Strict
                                                                     (FStar_Pervasives_Native.Some
                                                                     (FStar_Syntax_Syntax.Ctx_uvar_meta_attr
-                                                                    attr)) in
+                                                                    attr))
+                                                                    false in
                                                                     (match uu___21
                                                                     with
                                                                     | 
@@ -5819,7 +5821,8 @@ let (tc_layered_eff_decl :
                                                                     =
                                                                     FStar_TypeChecker_Util.new_implicit_var
                                                                     reason r
-                                                                    env2 t in
+                                                                    env2 t
+                                                                    false in
                                                                     (match uu___25
                                                                     with
                                                                     | 

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_TcTerm.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_TcTerm.ml
@@ -321,7 +321,7 @@ let (check_no_escape :
                                            FStar_Syntax_Util.type_u () in
                                          FStar_Pervasives_Native.fst uu___8 in
                                        FStar_TypeChecker_Util.new_implicit_var
-                                         "no escape" uu___6 env uu___7 in
+                                         "no escape" uu___6 env uu___7 false in
                                      (match uu___5 with
                                       | (s, uu___6, g0) ->
                                           let uu___7 =
@@ -3254,7 +3254,7 @@ and (tc_maybe_toplevel_term :
                                          FStar_TypeChecker_Util.new_implicit_var
                                            "tc_term reflect"
                                            e2.FStar_Syntax_Syntax.pos
-                                           env_no_ex a in
+                                           env_no_ex a false in
                                        (match uu___15 with
                                         | (a_uvar, uu___16, g_a) ->
                                             let uu___17 =
@@ -3908,7 +3908,8 @@ and (tc_match :
                                     let uu___8 =
                                       FStar_TypeChecker_Util.new_implicit_var
                                         "match result"
-                                        e12.FStar_Syntax_Syntax.pos env k in
+                                        e12.FStar_Syntax_Syntax.pos env k
+                                        false in
                                     (match uu___8 with
                                      | (res_t, uu___9, g) ->
                                          let uu___10 =
@@ -4717,41 +4718,52 @@ and (tc_value :
                 let uu___2 = FStar_Syntax_Util.type_u () in
                 (match uu___2 with
                  | (k, u) ->
-                     FStar_TypeChecker_Util.new_implicit_var
-                       "type of user-provided implicit term" r env1 k)
-            | FStar_Pervasives_Native.Some (t, use_eq) ->
-                (if use_eq
-                 then
-                   (let uu___3 =
-                      let uu___4 =
-                        let uu___5 =
+                     let uu___3 =
+                       FStar_TypeChecker_Util.new_implicit_var
+                         "type of user-provided implicit term" r env1 k false in
+                     (match uu___3 with | (t, uu___4, g0) -> (t, g0)))
+            | FStar_Pervasives_Native.Some (t, use_eq) when use_eq ->
+                let uu___2 =
+                  let uu___3 =
+                    let uu___4 =
+                      let uu___5 =
+                        let uu___6 =
                           FStar_Class_Show.show
                             FStar_Syntax_Print.showable_term t in
                         FStar_Compiler_Util.format1
-                          "Equality ascription as an expected type for unk (:%s) is not yet supported, please use subtyping"
-                          uu___5 in
-                      (FStar_Errors_Codes.Fatal_NotSupported, uu___4) in
-                    FStar_Errors.raise_error uu___3 e.FStar_Syntax_Syntax.pos)
-                 else ();
-                 (t, [],
-                   (FStar_Class_Monoid.mzero
-                      FStar_TypeChecker_Common.monoid_guard_t))) in
-          (match uu___ with
-           | (t, uu___1, g0) ->
-               let uu___2 =
-                 let uu___3 =
-                   let uu___4 = FStar_Compiler_Range_Ops.string_of_range r in
-                   Prims.strcat "user-provided implicit term at " uu___4 in
-                 FStar_TypeChecker_Util.new_implicit_var uu___3 r env1 t in
-               (match uu___2 with
-                | (e1, uu___3, g1) ->
-                    let uu___4 =
-                      let uu___5 = FStar_Syntax_Syntax.mk_Total t in
-                      FStar_TypeChecker_Common.lcomp_of_comp uu___5 in
+                          "Equality ascription as an expected type for unk (:%s) is not yet supported."
+                          uu___6 in
+                      FStar_Errors_Msg.text uu___5 in
                     let uu___5 =
+                      let uu___6 =
+                        FStar_Errors_Msg.text "Please use subtyping." in
+                      [uu___6] in
+                    uu___4 :: uu___5 in
+                  (FStar_Errors_Codes.Fatal_NotSupported, uu___3) in
+                FStar_Errors.raise_error_doc uu___2 e.FStar_Syntax_Syntax.pos
+            | FStar_Pervasives_Native.Some (t, uu___2) ->
+                (t,
+                  (FStar_Class_Monoid.mzero
+                     FStar_TypeChecker_Common.monoid_guard_t)) in
+          (match uu___ with
+           | (t, g0) ->
+               let uu___1 =
+                 let uu___2 =
+                   let uu___3 =
+                     FStar_Class_Show.show
+                       FStar_Compiler_Range_Ops.showable_range r in
+                   Prims.strcat "user-provided implicit term at " uu___3 in
+                 FStar_TypeChecker_Util.new_implicit_var uu___2 r env1 t
+                   false in
+               (match uu___1 with
+                | (e1, uu___2, g1) ->
+                    let uu___3 =
+                      let uu___4 = FStar_Syntax_Syntax.mk_Total t in
+                      FStar_TypeChecker_Common.lcomp_of_comp uu___4 in
+                    let uu___4 =
                       FStar_Class_Monoid.op_Plus_Plus
                         FStar_TypeChecker_Common.monoid_guard_t g0 g1 in
-                    (e1, uu___4, uu___5)))
+                    (e1, uu___3, uu___4)))
       | FStar_Syntax_Syntax.Tm_name x ->
           let uu___ = FStar_TypeChecker_Env.lookup_bv env1 x in
           (match uu___ with
@@ -5416,7 +5428,7 @@ and (tc_comp :
                                                        FStar_TypeChecker_Util.new_implicit_var
                                                          "implicit for type of the well-founded relation in decreases clause"
                                                          rel.FStar_Syntax_Syntax.pos
-                                                         env1 t in
+                                                         env1 t false in
                                                      (match uu___12 with
                                                       | (a, uu___13, g_a) ->
                                                           let wf_t =
@@ -7985,7 +7997,8 @@ and (check_application_args :
                                       FStar_Pervasives_Native.fst uu___8 in
                                     FStar_TypeChecker_Util.new_implicit_var
                                       "formal parameter"
-                                      tf1.FStar_Syntax_Syntax.pos env uu___7 in
+                                      tf1.FStar_Syntax_Syntax.pos env uu___7
+                                      false in
                                   (match uu___6 with
                                    | (t, uu___7, g) ->
                                        let uu___8 =
@@ -8006,7 +8019,7 @@ and (check_application_args :
                                 FStar_Pervasives_Native.fst uu___7 in
                               FStar_TypeChecker_Util.new_implicit_var
                                 "result type" tf1.FStar_Syntax_Syntax.pos env
-                                uu___6 in
+                                uu___6 false in
                             match uu___5 with
                             | (t, uu___6, g) ->
                                 let uu___7 = FStar_Options.ml_ish () in
@@ -8081,7 +8094,8 @@ and (check_application_args :
                                       FStar_Pervasives_Native.fst uu___12 in
                                     FStar_TypeChecker_Util.new_implicit_var
                                       "formal parameter"
-                                      tf1.FStar_Syntax_Syntax.pos env uu___11 in
+                                      tf1.FStar_Syntax_Syntax.pos env uu___11
+                                      false in
                                   (match uu___10 with
                                    | (t, uu___11, g) ->
                                        let uu___12 =
@@ -8102,7 +8116,7 @@ and (check_application_args :
                                 FStar_Pervasives_Native.fst uu___11 in
                               FStar_TypeChecker_Util.new_implicit_var
                                 "result type" tf1.FStar_Syntax_Syntax.pos env
-                                uu___10 in
+                                uu___10 false in
                             match uu___9 with
                             | (t, uu___10, g) ->
                                 let uu___11 = FStar_Options.ml_ish () in

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Util.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Util.ml
@@ -37,16 +37,19 @@ let (new_implicit_var :
     FStar_Compiler_Range_Type.range ->
       FStar_TypeChecker_Env.env ->
         FStar_Syntax_Syntax.typ ->
-          (FStar_Syntax_Syntax.term * (FStar_Syntax_Syntax.ctx_uvar *
-            FStar_Compiler_Range_Type.range) Prims.list *
-            FStar_TypeChecker_Env.guard_t))
+          Prims.bool ->
+            (FStar_Syntax_Syntax.term * (FStar_Syntax_Syntax.ctx_uvar *
+              FStar_Compiler_Range_Type.range) *
+              FStar_TypeChecker_Env.guard_t))
   =
   fun reason ->
     fun r ->
       fun env ->
         fun k ->
-          FStar_TypeChecker_Env.new_implicit_var_aux reason r env k
-            FStar_Syntax_Syntax.Strict FStar_Pervasives_Native.None
+          fun unrefine ->
+            FStar_TypeChecker_Env.new_implicit_var_aux reason r env k
+              FStar_Syntax_Syntax.Strict FStar_Pervasives_Native.None
+              unrefine
 let (close_guard_implicits :
   FStar_TypeChecker_Env.env ->
     Prims.bool ->
@@ -6489,46 +6492,49 @@ let (instantiate_one_binder :
              FStar_Syntax_Syntax.binder_qual = uu___2;
              FStar_Syntax_Syntax.binder_positivity = uu___3;
              FStar_Syntax_Syntax.binder_attrs = uu___4;_} ->
-             let ctx_uvar_meta = FStar_TypeChecker_Env.uvar_meta_for_binder b in
-             let t = x.FStar_Syntax_Syntax.sort in
-             let uu___5 =
-               let msg =
-                 let is_typeclass =
-                   match ctx_uvar_meta with
-                   | FStar_Pervasives_Native.Some
-                       (FStar_Syntax_Syntax.Ctx_uvar_meta_tac tau) ->
-                       FStar_Syntax_Util.is_fvar
-                         FStar_Parser_Const.tcresolve_lid tau
-                   | uu___6 -> false in
-                 if is_typeclass
-                 then "Typeclass constraint argument"
-                 else
-                   if FStar_Pervasives_Native.uu___is_Some ctx_uvar_meta
-                   then "Instantiating meta argument"
-                   else "Instantiating implicit argument" in
-               FStar_TypeChecker_Env.new_implicit_var_aux msg r env t
-                 FStar_Syntax_Syntax.Strict ctx_uvar_meta in
+             let uu___5 = FStar_TypeChecker_Env.uvar_meta_for_binder b in
              (match uu___5 with
-              | (varg, uu___6, implicits) ->
-                  let aq = FStar_Syntax_Util.aqual_of_binder b in
-                  let arg = (varg, aq) in
-                  let r1 = (varg, t, aq, implicits) in
-                  ((let uu___8 = FStar_Compiler_Debug.high () in
-                    if uu___8
-                    then
-                      let uu___9 =
-                        FStar_Class_Show.show
-                          (FStar_Class_Show.show_tuple2
-                             FStar_Syntax_Print.showable_term
-                             FStar_Syntax_Print.showable_term)
-                          ((FStar_Pervasives_Native.__proj__Mktuple4__item___1
-                              r1),
-                            (FStar_Pervasives_Native.__proj__Mktuple4__item___2
-                               r1)) in
-                      FStar_Compiler_Util.print1
-                        "instantiate_one_binder: result = %s\n" uu___9
-                    else ());
-                   r1)))
+              | (ctx_uvar_meta, should_unrefine) ->
+                  let t = x.FStar_Syntax_Syntax.sort in
+                  let uu___6 =
+                    let msg =
+                      let is_typeclass =
+                        match ctx_uvar_meta with
+                        | FStar_Pervasives_Native.Some
+                            (FStar_Syntax_Syntax.Ctx_uvar_meta_tac tau) ->
+                            FStar_Syntax_Util.is_fvar
+                              FStar_Parser_Const.tcresolve_lid tau
+                        | uu___7 -> false in
+                      if is_typeclass
+                      then "Typeclass constraint argument"
+                      else
+                        if FStar_Pervasives_Native.uu___is_Some ctx_uvar_meta
+                        then "Instantiating meta argument"
+                        else "Instantiating implicit argument" in
+                    FStar_TypeChecker_Env.new_implicit_var_aux msg r env t
+                      FStar_Syntax_Syntax.Strict ctx_uvar_meta
+                      should_unrefine in
+                  (match uu___6 with
+                   | (varg, uu___7, implicits) ->
+                       let aq = FStar_Syntax_Util.aqual_of_binder b in
+                       let arg = (varg, aq) in
+                       let r1 = (varg, t, aq, implicits) in
+                       ((let uu___9 = FStar_Compiler_Debug.high () in
+                         if uu___9
+                         then
+                           let uu___10 =
+                             FStar_Class_Show.show
+                               (FStar_Class_Show.show_tuple2
+                                  FStar_Syntax_Print.showable_term
+                                  FStar_Syntax_Print.showable_term)
+                               ((FStar_Pervasives_Native.__proj__Mktuple4__item___1
+                                   r1),
+                                 (FStar_Pervasives_Native.__proj__Mktuple4__item___2
+                                    r1)) in
+                           FStar_Compiler_Util.print1
+                             "instantiate_one_binder: result = %s\n" uu___10
+                         else ());
+                        r1))))
 let (maybe_instantiate :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->

--- a/ocaml/fstar-tests/generated/FStar_Tests_Unif.ml
+++ b/ocaml/fstar-tests/generated/FStar_Tests_Unif.ml
@@ -217,13 +217,13 @@ let (inst :
              let uu___2 = FStar_Tests_Pars.init () in
              FStar_TypeChecker_Util.new_implicit_var ""
                FStar_Compiler_Range_Type.dummyRange uu___2
-               FStar_Syntax_Util.ktype0 in
+               FStar_Syntax_Util.ktype0 false in
            match uu___1 with
            | (t, uu___2, uu___3) ->
                let uu___4 =
                  let uu___5 = FStar_Tests_Pars.init () in
                  FStar_TypeChecker_Util.new_implicit_var ""
-                   FStar_Compiler_Range_Type.dummyRange uu___5 t in
+                   FStar_Compiler_Range_Type.dummyRange uu___5 t false in
                (match uu___4 with
                 | (u, uu___5, uu___6) -> aux (u :: out) (n1 - Prims.int_one))) in
       let us = aux [] n in
@@ -367,7 +367,8 @@ let (run_all : unit -> Prims.bool) =
                            FStar_TypeChecker_Env.push_binders uu___20 uu___21 in
                          let uu___20 =
                            FStar_TypeChecker_Util.new_implicit_var ""
-                             FStar_Compiler_Range_Type.dummyRange env typ in
+                             FStar_Compiler_Range_Type.dummyRange env typ
+                             false in
                          match uu___20 with
                          | (u_p, uu___21, uu___22) ->
                              let tm22 =
@@ -419,7 +420,7 @@ let (run_all : unit -> Prims.bool) =
                                let uu___22 =
                                  FStar_TypeChecker_Util.new_implicit_var ""
                                    FStar_Compiler_Range_Type.dummyRange env
-                                   typ in
+                                   typ false in
                                match uu___22 with
                                | (u_p, uu___23, uu___24) ->
                                    let tm23 =

--- a/src/basic/FStar.Options.fst
+++ b/src/basic/FStar.Options.fst
@@ -1903,6 +1903,7 @@ let defensive_abort              () = get_defensive () = "abort"
 let dep                          () = get_dep                         ()
 let detail_errors                () = get_detail_errors               ()
 let detail_hint_replay           () = get_detail_hint_replay          ()
+let any_dump_module              () = Cons? (get_dump_module())
 let dump_module                  s  = get_dump_module() |> List.existsb (module_name_eq s)
 let eager_subtyping              () = get_eager_subtyping()
 let error_contexts               () = get_error_contexts              ()

--- a/src/basic/FStar.Options.fsti
+++ b/src/basic/FStar.Options.fsti
@@ -119,6 +119,7 @@ val dep                         : unit    -> option string
 val detail_errors               : unit    -> bool
 val detail_hint_replay          : unit    -> bool
 val display_usage               : unit    -> unit
+val any_dump_module             : unit    -> bool
 val dump_module                 : string  -> bool
 val eager_subtyping             : unit    -> bool
 val error_contexts              : unit    -> bool

--- a/src/parser/FStar.Parser.Const.fst
+++ b/src/parser/FStar.Parser.Const.fst
@@ -384,6 +384,8 @@ let no_auto_projectors_decls_attr = psconst "no_auto_projectors_decls"
 let no_auto_projectors_attr = psconst "no_auto_projectors"
 let no_subtping_attr_lid = psconst "no_subtyping"
 let admit_termination_lid = psconst "admit_termination"
+let unrefine_binder_attr = pconst "unrefine"
+let do_not_unrefine_attr = pconst "do_not_unrefine"
 let attr_substitute_lid = p2l ["FStar"; "Pervasives"; "Substitute"]
 let desugar_of_variant_record_lid = psconst "desugar_of_variant_record"
 

--- a/src/smtencoding/FStar.SMTEncoding.EncodeTerm.fst
+++ b/src/smtencoding/FStar.SMTEncoding.EncodeTerm.fst
@@ -1250,7 +1250,9 @@ and encode_term (t:typ) (env:env_t) : (term         (* encoding of t, expects t 
                                               "SMTEncoding codomain"
                                               (Env.get_range env.tcenv)
                                               env.tcenv
-                                              U.ktype0 in
+                                              U.ktype0
+                                              false
+                                              in
                   t
                 | Some t -> t
               in

--- a/src/syntax/FStar.Syntax.Print.fst
+++ b/src/syntax/FStar.Syntax.Print.fst
@@ -424,6 +424,14 @@ and attrs_to_string = function
     | [] -> ""
     | tms -> U.format1 "[@ %s]" (List.map (fun t -> paren (term_to_string t)) tms |> String.concat "; ")
 
+and binder_attrs_to_string = function
+    | _ when Options.any_dump_module () -> ""
+    (* ^ VALE HACK: Vale does not properly parse attributes on binders (yet).
+    Just don't print them. *)
+
+    | [] -> ""
+    | tms -> U.format1 "[@@@ %s]" (List.map (fun t -> paren (term_to_string t)) tms |> String.concat "; ")
+
 //and uvar_t_to_string (uv, k) =
 //   if false && (Options.print_real_names())
 //   then
@@ -448,7 +456,7 @@ and binder_to_string' is_arrow b =
   if not (Options.ugly()) then
     Pretty.binder_to_string' is_arrow b
   else
-    let attrs = attrs_to_string b.binder_attrs in
+    let attrs = binder_attrs_to_string b.binder_attrs in
     if is_null_binder b
     then (attrs ^ "_:" ^ term_to_string b.binder_bv.sort)
     else if not is_arrow && not (Options.print_bound_var_types())

--- a/src/syntax/FStar.Syntax.Syntax.fsti
+++ b/src/syntax/FStar.Syntax.Syntax.fsti
@@ -199,6 +199,7 @@ and uvar_decoration = {
   uvar_decoration_typ:typ;
   uvar_decoration_typedness_depends_on:list ctx_uvar;
   uvar_decoration_should_check:should_check_uvar;
+  uvar_decoration_should_unrefine:bool;
 }
 
 and uvar = Unionfind.p_uvar (option term & uvar_decoration) & version & Range.range

--- a/src/tactics/FStar.Tactics.CtrlRewrite.fst
+++ b/src/tactics/FStar.Tactics.CtrlRewrite.fst
@@ -106,6 +106,21 @@ let __do_rewrite
     else
     let g = FStar.TypeChecker.Rel.solve_deferred_constraints env g in
     let typ = lcomp.res_typ in
+
+    (* unrefine typ as is done for the type arg of eq2 *)
+    let typ =
+      if Options.Ext.get "__unrefine" <> "" then
+        let typ_norm = N.unfold_whnf' [Env.DontUnfoldAttr [Parser.Const.do_not_unrefine_attr]] env typ in
+        if Tm_refine? (SS.compress typ_norm).n then
+          (* It is indeed a refinement, normalize again to remove them. *)
+          let typ' = N.unfold_whnf' [Env.DontUnfoldAttr [Parser.Const.do_not_unrefine_attr]; Env.Unrefine] env typ_norm in
+          typ'
+        else
+          typ
+      else
+        typ
+    in
+
     let should_check =
       if FStar.TypeChecker.Common.is_total_lcomp lcomp 
       then None

--- a/src/tactics/FStar.Tactics.Hooks.fst
+++ b/src/tactics/FStar.Tactics.Hooks.fst
@@ -160,7 +160,7 @@ let by_tactic_interp (pol:pol) (e:Env.env) (t:term) : tres =
             when S.fv_eq_lid fv PC.rewrite_by_tactic_lid ->
 
         // Create a new uvar that must be equal to the initial term
-        let uvtm, _, g_imp = Env.new_implicit_var_aux "rewrite_with_tactic RHS" tm.pos e typ Strict None in
+        let uvtm, _, g_imp = Env.new_implicit_var_aux "rewrite_with_tactic RHS" tm.pos e typ Strict None false in
 
         let u = e.universe_of e typ in
         // eq2 is squashed already, so it's in Type0
@@ -1011,7 +1011,7 @@ let postprocess (env:Env.env) (tau:term) (typ:term) (tm:term) : term =
     //we know that tm:typ
     //and we have a goal that u == tm
     //so if we solve that equality, we don't need to retype the solution of `u : typ`
-    let uvtm, _, g_imp = Env.new_implicit_var_aux "postprocess RHS" tm.pos env typ (Allow_untyped "postprocess") None in
+    let uvtm, _, g_imp = Env.new_implicit_var_aux "postprocess RHS" tm.pos env typ (Allow_untyped "postprocess") None false in
 
     let u = env.universe_of env typ in
     // eq2 is squashed already, so it's in Type0

--- a/src/tactics/FStar.Tactics.Monad.fst
+++ b/src/tactics/FStar.Tactics.Monad.fst
@@ -334,10 +334,10 @@ let new_uvar (reason:string) (env:env) (typ:typ)
       | _ -> Strict
     in
     let u, ctx_uvar, g_u =
-        Env.new_tac_implicit_var reason rng env typ should_check uvar_typedness_deps None
+        Env.new_tac_implicit_var reason rng env typ should_check uvar_typedness_deps None false
     in
     bind (add_implicits g_u.implicits) (fun _ ->
-    ret (u, fst (List.hd ctx_uvar)))
+    ret (u, fst ctx_uvar))
 
 let mk_irrelevant_goal (reason:string) (env:env) (phi:typ) (sc_opt:option should_check_uvar) (rng:Range.range) opts label : tac goal =
     let typ = U.mk_squash (env.universe_of env phi) phi in

--- a/src/tactics/FStar.Tactics.Types.fst
+++ b/src/tactics/FStar.Tactics.Types.fst
@@ -52,12 +52,11 @@ let mk_goal env u o b l = {
 }
 
 let goal_of_goal_ty env typ : goal & guard_t =
-    let u, ctx_uvars, g_u =
-        Env.new_implicit_var_aux "proofstate_of_goal_ty" typ.pos env typ Strict None
-    in
-    let ctx_uvar, _ = List.hd ctx_uvars in
-    let g = mk_goal env ctx_uvar (FStar.Options.peek()) false "" in
-    g, g_u
+  let u, (ctx_uvar, _) , g_u =
+    Env.new_implicit_var_aux "proofstate_of_goal_ty" typ.pos env typ Strict None false
+  in
+  let g = mk_goal env ctx_uvar (FStar.Options.peek()) false "" in
+  g, g_u
 
 let goal_of_implicit env (i:Env.implicit) : goal =
   mk_goal ({env with gamma=i.imp_uvar.ctx_uvar_gamma}) i.imp_uvar (FStar.Options.peek()) false i.imp_reason

--- a/src/tactics/FStar.Tactics.V2.Basic.fst
+++ b/src/tactics/FStar.Tactics.V2.Basic.fst
@@ -2682,11 +2682,12 @@ let refl_try_unify (g:env) (uvs:list (bv & typ)) (t0 t1:term)
     //
     let guard_uvs, ss, tbl = List.fold_left (fun (guard_uvs, ss, tbl) (bv, t) ->
       let t = SS.subst ss t in
-      let uv_t, [ctx_u, _], guard_uv =
+      let uv_t, (ctx_u, _), guard_uv =
         // the API doesn't promise well-typedness of the solutions
         let reason = BU.format1 "refl_try_unify for %s" (show bv) in
         let should_check_uvar = Allow_untyped "refl_try_unify" in
-        Env.new_implicit_var_aux reason t0.pos g t should_check_uvar None in
+        Env.new_implicit_var_aux reason t0.pos g t should_check_uvar None false
+      in
       let uv_id = Syntax.Unionfind.uvar_unique_id ctx_u.ctx_uvar_head in
       Env.conj_guard guard_uvs guard_uv,
       (NT (bv, uv_t))::ss,

--- a/src/tests/FStar.Tests.Unif.fst
+++ b/src/tests/FStar.Tests.Unif.fst
@@ -132,8 +132,8 @@ let check_core_typing i e t =
 let inst n tm =
    let rec aux out n =
     if n=0 then out
-    else let t, _, _ = FStar.TypeChecker.Util.new_implicit_var "" dummyRange (init()) U.ktype0 in
-         let u, _, _ = FStar.TypeChecker.Util.new_implicit_var "" dummyRange (init()) t in
+    else let t, _, _ = FStar.TypeChecker.Util.new_implicit_var "" dummyRange (init()) U.ktype0 false in
+         let u, _, _ = FStar.TypeChecker.Util.new_implicit_var "" dummyRange (init()) t false in
          aux (u::out) (n - 1) in
    let us = aux [] n in
    norm (app tm us), us
@@ -235,7 +235,7 @@ let run_all () =
         let l = tc ("fun (p:unit -> Type0) -> p") in
         let unit = tc "()" in
         let env = Env.push_binders (init()) [S.mk_binder x; S.mk_binder q] in
-        let u_p, _, _ = FStar.TypeChecker.Util.new_implicit_var "" dummyRange env typ in
+        let u_p, _, _ = FStar.TypeChecker.Util.new_implicit_var "" dummyRange env typ false in
         let tm2 = app (norm (app l [u_p])) [unit] in
         tm1, tm2, [x;q]
     in
@@ -254,7 +254,7 @@ let run_all () =
         let l = tc ("fun (p:pure_post unit) -> p") in
         let unit = tc "()" in
         let env = Env.push_binders (init()) [S.mk_binder x; S.mk_binder q] in
-        let u_p, _, _ = FStar.TypeChecker.Util.new_implicit_var "" dummyRange env typ in
+        let u_p, _, _ = FStar.TypeChecker.Util.new_implicit_var "" dummyRange env typ false in
         let tm2 = app (norm (app l [u_p])) [unit] in
         tm1, tm2, [x;q]
     in

--- a/src/typechecker/FStar.TypeChecker.DeferredImplicits.fst
+++ b/src/typechecker/FStar.TypeChecker.DeferredImplicits.fst
@@ -227,11 +227,11 @@ let solve_deferred_to_tactic_goals env g =
         in
         let goal_ty = U.mk_eq2 (env.universe_of env_lax t_eq) t_eq tp.lhs tp.rhs in
         let goal, ctx_uvar, _ =
-            Env.new_implicit_var_aux reason tp.lhs.pos env goal_ty Strict None
+            Env.new_implicit_var_aux reason tp.lhs.pos env goal_ty Strict None false
         in
         let imp =
             { imp_reason = "";
-              imp_uvar = fst (List.hd ctx_uvar);
+              imp_uvar = fst ctx_uvar;
               imp_tm = goal;
               imp_range = tp.lhs.pos
             }

--- a/src/typechecker/FStar.TypeChecker.Env.fsti
+++ b/src/typechecker/FStar.TypeChecker.Env.fsti
@@ -495,24 +495,29 @@ val too_early_in_prims : env -> bool
 
 val close_forall              : env -> binders -> term -> term
 
-val new_tac_implicit_var (reason: string)
-                         (r: Range.range)
-                         (env:env)
-                         (uvar_typ:typ)
-                         (should_check:should_check_uvar)
-                         (uvar_typedness_deps:list ctx_uvar)
-                         (meta:option ctx_uvar_meta_t)
-  : (term & list (ctx_uvar & Range.range) & guard_t)
+val new_tac_implicit_var
+  (reason: string)
+  (r: Range.range)
+  (env:env)
+  (uvar_typ:typ)
+  (should_check:should_check_uvar)
+  (uvar_typedness_deps:list ctx_uvar)
+  (meta:option ctx_uvar_meta_t)
+  (unrefine:bool)
+: term & (ctx_uvar & Range.range) & guard_t
 
-val new_implicit_var_aux : string ->
-                           Range.range ->
-                           env ->
-                           typ ->
-                           should_check_uvar ->
-                           option ctx_uvar_meta_t ->
-                           (term & list (ctx_uvar & Range.range) & guard_t)
+val new_implicit_var_aux
+  (reason: string)
+  (r: Range.range)
+  (env:env)
+  (uvar_typ:typ)
+  (should_check:should_check_uvar)
+  (meta:option ctx_uvar_meta_t)
+  (unrefine:bool)
+: term & (ctx_uvar & Range.range) & guard_t
 
-val uvar_meta_for_binder (b:binder) : option ctx_uvar_meta_t
+
+val uvar_meta_for_binder (b:binder) : option ctx_uvar_meta_t & (*should_unrefine:*)bool
 
 (* layered effect utils *)
 

--- a/src/typechecker/FStar.TypeChecker.PatternUtils.fst
+++ b/src/typechecker/FStar.TypeChecker.PatternUtils.fst
@@ -183,7 +183,7 @@ let pat_as_exp (introduce_bv_uvars:bool)
         if not introduce_bv_uvars
         then {x with sort=S.tun}, Env.trivial_guard, env
         else let t, _ = U.type_u() in
-             let t_x, _, guard = new_implicit_var_aux "pattern bv type" (S.range_of_bv x) env t (Allow_untyped "pattern bv type") None in
+             let t_x, _, guard = new_implicit_var_aux "pattern bv type" (S.range_of_bv x) env t (Allow_untyped "pattern bv type") None false in
              let x = {x with sort=t_x} in
              x, guard, Env.push_bv env x
     in
@@ -217,8 +217,8 @@ let pat_as_exp (introduce_bv_uvars:bool)
                          (Print.pat_to_string p)
                 end;
                 let k, _ = U.type_u () in
-                let t, _, g = new_implicit_var_aux "pat_dot_term type" p.p env k (Allow_ghost "pat dot term type") None in
-                let e, _,  g' = new_implicit_var_aux "pat_dot_term" p.p env t (Allow_ghost "pat dot term") None in
+                let t, _, g = new_implicit_var_aux "pat_dot_term type" p.p env k (Allow_ghost "pat dot term type") None false in
+                let e, _,  g' = new_implicit_var_aux "pat_dot_term" p.p env t (Allow_ghost "pat dot term") None false in
                 let p = {p with v=Pat_dot_term (Some e)} in
                 [], [], [], env, e, conj_guard g g', p
               | Some e -> [], [], [], env, e, Env.trivial_guard, p)

--- a/src/typechecker/FStar.TypeChecker.Util.fst
+++ b/src/typechecker/FStar.TypeChecker.Util.fst
@@ -71,8 +71,8 @@ let report env errs =
 (************************************************************************)
 (* Unification variables *)
 (************************************************************************)
-let new_implicit_var reason r env k =
-  Env.new_implicit_var_aux reason r env k Strict None
+let new_implicit_var reason r env k unrefine =
+  Env.new_implicit_var_aux reason r env k Strict None unrefine
 
 let close_guard_implicits env solve_deferred (xs:binders) (g:guard_t) : guard_t =
   if Options.eager_subtyping ()
@@ -2847,7 +2847,7 @@ let instantiate_one_binder (env:env_t) (r:Range.range) (b:binder) : term & typ &
     BU.print1 "instantiate_one_binder: Instantiating implicit binder %s\n" (show b);
   let (++) = Env.conj_guard in
   let { binder_bv=x } = b in
-  let ctx_uvar_meta = uvar_meta_for_binder b in (* meta/attrs computed here *)
+  let ctx_uvar_meta, should_unrefine = uvar_meta_for_binder b in (* meta/attrs computed here *)
   let t = x.sort in
   let varg, _, implicits =
     let msg =
@@ -2860,7 +2860,7 @@ let instantiate_one_binder (env:env_t) (r:Range.range) (b:binder) : term & typ &
       else if Some? ctx_uvar_meta then "Instantiating meta argument"
       else "Instantiating implicit argument"
     in
-    Env.new_implicit_var_aux msg r env t Strict ctx_uvar_meta
+    Env.new_implicit_var_aux msg r env t Strict ctx_uvar_meta should_unrefine
   in
   let aq = U.aqual_of_binder b in
   let arg = varg, aq in

--- a/src/typechecker/FStar.TypeChecker.Util.fsti
+++ b/src/typechecker/FStar.TypeChecker.Util.fsti
@@ -33,7 +33,7 @@ type lcomp_with_binder = option bv & lcomp
 val report: env -> list string -> unit
 
 //unification variables
-val new_implicit_var : string -> Range.range -> env -> typ -> (term & list (ctx_uvar & Range.range) & guard_t)
+val new_implicit_var : string -> Range.range -> env -> typ -> unrefine:bool -> term & (ctx_uvar & Range.range) & guard_t
 val check_uvars: Range.range -> typ -> unit
 
 //caller can set the boolean to true if they want to solve the deferred constraints involving this binder now (best case)

--- a/tests/error-messages/ArrowRanges.fst.expected
+++ b/tests/error-messages/ArrowRanges.fst.expected
@@ -4,7 +4,7 @@
   - Expected type Prims.eqtype got type Type0
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
-  - See also prims.fst(57,23-57,30)
+  - See also prims.fst(73,23-73,30)
 
 >>]
 >> Got issues: [

--- a/tests/error-messages/Basic.fst.expected
+++ b/tests/error-messages/Basic.fst.expected
@@ -72,7 +72,7 @@
   - Assertion failed
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
-  - See also prims.fst(435,90-435,102)
+  - See also prims.fst(451,90-451,102)
 
 >>]
 >> Got issues: [
@@ -80,7 +80,7 @@
   - Assertion failed
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
-  - See also prims.fst(435,90-435,102)
+  - See also prims.fst(451,90-451,102)
 
 >>]
 >> Got issues: [
@@ -88,7 +88,7 @@
   - Assertion failed
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
-  - See also prims.fst(435,90-435,102)
+  - See also prims.fst(451,90-451,102)
 
 >>]
 Verified module: Basic

--- a/tests/error-messages/Coercions.fst.expected
+++ b/tests/error-messages/Coercions.fst.expected
@@ -20,7 +20,7 @@
   - Expected type Prims.nat got type Prims.int
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
-  - See also prims.fst(664,18-664,24)
+  - See also prims.fst(680,18-680,24)
 
 >>]
 >> Got issues: [
@@ -29,7 +29,7 @@
   - Expected type Prims.nat got type Prims.int
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
-  - See also prims.fst(664,18-664,24)
+  - See also prims.fst(680,18-680,24)
 
 >>]
 >> Got issues: [
@@ -38,7 +38,7 @@
   - Expected type Prims.nat got type Prims.int
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
-  - See also prims.fst(664,18-664,24)
+  - See also prims.fst(680,18-680,24)
 
 >>]
 >> Got issues: [
@@ -47,7 +47,7 @@
   - Expected type Prims.nat got type Prims.int
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
-  - See also prims.fst(664,18-664,24)
+  - See also prims.fst(680,18-680,24)
 
 >>]
 >> Got issues: [
@@ -56,7 +56,7 @@
   - Expected type Prims.nat got type Prims.int
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
-  - See also prims.fst(664,18-664,24)
+  - See also prims.fst(680,18-680,24)
 
 >>]
 Verified module: Coercions

--- a/tests/error-messages/Inference.fst.expected
+++ b/tests/error-messages/Inference.fst.expected
@@ -4,14 +4,14 @@
   - Expected type Prims.eqtype got type Type0
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
-  - See also prims.fst(57,23-57,30)
+  - See also prims.fst(73,23-73,30)
 
 * Error 19 at Inference.fst(20,14-20,15):
   - Subtyping check failed
   - Expected type Prims.eqtype got type Type0
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
-  - See also prims.fst(57,23-57,30)
+  - See also prims.fst(73,23-73,30)
 
 >>]
 Verified module: Inference

--- a/tests/error-messages/NegativeTests.False.fst.expected
+++ b/tests/error-messages/NegativeTests.False.fst.expected
@@ -3,7 +3,7 @@
   - Assertion failed
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
-  - See also prims.fst(443,77-443,89)
+  - See also prims.fst(459,77-459,89)
 
 >>]
 >> Got issues: [

--- a/tests/error-messages/NegativeTests.Neg.fst.expected
+++ b/tests/error-messages/NegativeTests.Neg.fst.expected
@@ -4,7 +4,7 @@
   - Expected type Prims.nat got type Prims.int
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
-  - See also prims.fst(664,18-664,24)
+  - See also prims.fst(680,18-680,24)
 
 >>]
 >> Got issues: [
@@ -13,7 +13,7 @@
   - Expected type Prims.nat got type Prims.int
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
-  - See also prims.fst(664,18-664,24)
+  - See also prims.fst(680,18-680,24)
 
 >>]
 >> Got issues: [
@@ -72,7 +72,7 @@
   - Expected type Prims.nat got type Prims.int
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
-  - See also prims.fst(664,18-664,24)
+  - See also prims.fst(680,18-680,24)
 
 >>]
 >> Got issues: [

--- a/tests/error-messages/NegativeTests.ShortCircuiting.fst.expected
+++ b/tests/error-messages/NegativeTests.ShortCircuiting.fst.expected
@@ -12,7 +12,7 @@
   - Assertion failed
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
-  - See also prims.fst(435,90-435,102)
+  - See also prims.fst(451,90-451,102)
 
 >>]
 * Warning 240 at NegativeTests.ShortCircuiting.fst(19,4-19,7):

--- a/tests/error-messages/NegativeTests.ZZImplicitFalse.fst.expected
+++ b/tests/error-messages/NegativeTests.ZZImplicitFalse.fst.expected
@@ -4,7 +4,7 @@
   - Expected type Prims.l_False got type Prims.unit
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
-  - See also prims.fst(143,29-143,34)
+  - See also prims.fst(159,29-159,34)
 
 >>]
 * Warning 240 at NegativeTests.ZZImplicitFalse.fst(18,4-18,8):

--- a/tests/error-messages/PatAnnot.fst.expected
+++ b/tests/error-messages/PatAnnot.fst.expected
@@ -12,7 +12,7 @@
   - Assertion failed
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
-  - Also see: prims.fst(443,77-443,89)
+  - Also see: prims.fst(459,77-459,89)
 
 >>]
 >> Got issues: [
@@ -20,7 +20,7 @@
   - Assertion failed
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
-  - Also see: prims.fst(443,77-443,89)
+  - Also see: prims.fst(459,77-459,89)
 
 >>]
 >> Got issues: [
@@ -38,7 +38,7 @@
   - Expected type Prims.nat got type Prims.int
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
-  - See also prims.fst(664,18-664,24)
+  - See also prims.fst(680,18-680,24)
 
 >>]
 >> Got issues: [
@@ -46,7 +46,7 @@
   - Type annotation on parameter incompatible with the expected type
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
-  - See also prims.fst(664,18-664,24)
+  - See also prims.fst(680,18-680,24)
 
 >>]
 Verified module: PatAnnot

--- a/tests/error-messages/Test.FunctionalExtensionality.fst.expected
+++ b/tests/error-messages/Test.FunctionalExtensionality.fst.expected
@@ -21,7 +21,7 @@
   - Expected type _: Prims.int -> Prims.int got type Prims.nat ^-> Prims.int
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
-  - See also prims.fst(664,18-664,24)
+  - See also prims.fst(680,18-680,24)
 
 >>]
 >> Got issues: [

--- a/tests/error-messages/TestErrorLocations.fst.expected
+++ b/tests/error-messages/TestErrorLocations.fst.expected
@@ -34,7 +34,7 @@
   - Expected type Prims.nat got type Prims.int
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
-  - See also prims.fst(664,18-664,24)
+  - See also prims.fst(680,18-680,24)
 
 >>]
 >> Got issues: [
@@ -50,7 +50,7 @@
   - Assertion failed
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
-  - See also prims.fst(435,90-435,102)
+  - See also prims.fst(451,90-451,102)
 
 >>]
 >> Got issues: [
@@ -58,7 +58,7 @@
   - Assertion failed
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
-  - See also prims.fst(435,90-435,102)
+  - See also prims.fst(451,90-451,102)
 
 >>]
 >> Got issues: [
@@ -67,7 +67,7 @@
   - Expected type Prims.nat got type Prims.int
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
-  - See also prims.fst(664,18-664,24)
+  - See also prims.fst(680,18-680,24)
 
 >>]
 >> Got issues: [

--- a/tests/error-messages/WPExtensionality.fst.expected
+++ b/tests/error-messages/WPExtensionality.fst.expected
@@ -3,7 +3,7 @@
   - Assertion failed
   - The SMT solver could not prove the query. Use --query_stats for more
     details.
-  - See also prims.fst(435,90-435,102)
+  - See also prims.fst(451,90-451,102)
 
 >>]
 Verified module: WPExtensionality

--- a/tests/ide/emacs/fstarmode_gh73.out.expected
+++ b/tests/ide/emacs/fstarmode_gh73.out.expected
@@ -1,5 +1,5 @@
 {"kind": "protocol-info", "rest": "[...]"}
-{"kind": "response", "query-id": "1", "response": [{"level": "warning", "message": "- Pattern uses these theory symbols or terms that should not be in an SMT\n  pattern:\n    Prims.op_Subtraction\n", "number": 271, "ranges": [{"beg": [434, 8], "end": [434, 51], "fname": "FStar.UInt.fsti"}]}], "status": "success"}
+{"kind": "response", "query-id": "1", "response": [{"level": "warning", "message": "- Pattern uses these theory symbols or terms that should not be in an SMT\n  pattern:\n    Prims.op_Subtraction\n", "number": 271, "ranges": [{"beg": [435, 8], "end": [435, 51], "fname": "FStar.UInt.fsti"}]}], "status": "success"}
 {"kind": "response", "query-id": "2", "response": [{"level": "error", "message": "- Expected expression of type int got expression \"A\" of type string\n", "number": 189, "ranges": [{"beg": [4, 48], "end": [4, 51], "fname": "<input>"}]}], "status": "success"}
 {"kind": "response", "query-id": "3", "response": [{"level": "error", "message": "- Expected expression of type int got expression \"A\" of type string\n", "number": 189, "ranges": [{"beg": [4, 48], "end": [4, 51], "fname": "<input>"}]}], "status": "failure"}
 {"kind": "response", "query-id": "4", "response": [], "status": "success"}

--- a/tests/ide/emacs/integration.push-pop.out.expected
+++ b/tests/ide/emacs/integration.push-pop.out.expected
@@ -78,17 +78,17 @@
 {"kind": "response", "query-id": "80", "response": [], "status": "success"}
 {"kind": "response", "query-id": "91", "response": [{"level": "error", "message": "- Syntax error\n", "number": 168, "ranges": [{"beg": [12, 0], "end": [12, 0], "fname": "<input>"}]}], "status": "success"}
 {"kind": "response", "query-id": "98", "response": [], "status": "success"}
-{"kind": "response", "query-id": "101", "response": [{"level": "error", "message": "- Subtyping check failed\n- Expected type nat got type int\n- The SMT solver could not prove the query. Use --query_stats for more details.\n- See also prims.fst(664,18-664,24)\n", "number": 19, "ranges": [{"beg": [11, 15], "end": [11, 17], "fname": "<input>"}, {"beg": [664, 18], "end": [664, 24], "fname": "prims.fst"}]}], "status": "failure"}
+{"kind": "response", "query-id": "101", "response": [{"level": "error", "message": "- Subtyping check failed\n- Expected type nat got type int\n- The SMT solver could not prove the query. Use --query_stats for more details.\n- See also prims.fst(680,18-680,24)\n", "number": 19, "ranges": [{"beg": [11, 15], "end": [11, 17], "fname": "<input>"}, {"beg": [680, 18], "end": [680, 24], "fname": "prims.fst"}]}], "status": "failure"}
 {"kind": "response", "query-id": "107", "response": [], "status": "success"}
 {"kind": "response", "query-id": "108", "response": [], "status": "success"}
 {"kind": "response", "query-id": "112", "response": null, "status": "success"}
 {"kind": "response", "query-id": "114", "response": [], "status": "success"}
-{"kind": "response", "query-id": "116", "response": [{"level": "error", "message": "- Subtyping check failed\n- Expected type nat got type int\n- The SMT solver could not prove the query. Use --query_stats for more details.\n- See also prims.fst(664,18-664,24)\n", "number": 19, "ranges": [{"beg": [11, 15], "end": [11, 17], "fname": "<input>"}, {"beg": [664, 18], "end": [664, 24], "fname": "prims.fst"}]}], "status": "failure"}
+{"kind": "response", "query-id": "116", "response": [{"level": "error", "message": "- Subtyping check failed\n- Expected type nat got type int\n- The SMT solver could not prove the query. Use --query_stats for more details.\n- See also prims.fst(680,18-680,24)\n", "number": 19, "ranges": [{"beg": [11, 15], "end": [11, 17], "fname": "<input>"}, {"beg": [680, 18], "end": [680, 24], "fname": "prims.fst"}]}], "status": "failure"}
 {"kind": "response", "query-id": "118", "response": [], "status": "success"}
 {"kind": "response", "query-id": "119", "response": [], "status": "success"}
 {"kind": "response", "query-id": "122", "response": null, "status": "success"}
 {"kind": "response", "query-id": "124", "response": [], "status": "success"}
-{"kind": "response", "query-id": "126", "response": [{"level": "error", "message": "- Subtyping check failed\n- Expected type nat got type int\n- The SMT solver could not prove the query. Use --query_stats for more details.\n- See also prims.fst(664,18-664,24)\n", "number": 19, "ranges": [{"beg": [11, 15], "end": [11, 17], "fname": "<input>"}, {"beg": [664, 18], "end": [664, 24], "fname": "prims.fst"}]}], "status": "failure"}
+{"kind": "response", "query-id": "126", "response": [{"level": "error", "message": "- Subtyping check failed\n- Expected type nat got type int\n- The SMT solver could not prove the query. Use --query_stats for more details.\n- See also prims.fst(680,18-680,24)\n", "number": 19, "ranges": [{"beg": [11, 15], "end": [11, 17], "fname": "<input>"}, {"beg": [680, 18], "end": [680, 24], "fname": "prims.fst"}]}], "status": "failure"}
 {"kind": "response", "query-id": "128", "response": [], "status": "success"}
 {"kind": "response", "query-id": "130", "response": [], "status": "success"}
 {"kind": "response", "query-id": "133", "response": [], "status": "success"}
@@ -106,7 +106,7 @@
 {"kind": "response", "query-id": "191", "response": null, "status": "success"}
 {"kind": "response", "query-id": "192", "response": null, "status": "success"}
 {"kind": "response", "query-id": "194", "response": [], "status": "success"}
-{"kind": "response", "query-id": "198", "response": [{"level": "error", "message": "- Subtyping check failed\n- Expected type nat got type int\n- The SMT solver could not prove the query. Use --query_stats for more details.\n- See also prims.fst(664,18-664,24)\n", "number": 19, "ranges": [{"beg": [11, 15], "end": [11, 17], "fname": "<input>"}, {"beg": [664, 18], "end": [664, 24], "fname": "prims.fst"}]}], "status": "failure"}
+{"kind": "response", "query-id": "198", "response": [{"level": "error", "message": "- Subtyping check failed\n- Expected type nat got type int\n- The SMT solver could not prove the query. Use --query_stats for more details.\n- See also prims.fst(680,18-680,24)\n", "number": 19, "ranges": [{"beg": [11, 15], "end": [11, 17], "fname": "<input>"}, {"beg": [680, 18], "end": [680, 24], "fname": "prims.fst"}]}], "status": "failure"}
 {"kind": "response", "query-id": "200", "response": [], "status": "success"}
 {"kind": "response", "query-id": "204", "response": [], "status": "success"}
 {"kind": "response", "query-id": "205", "response": [{"level": "error", "message": "- Assertion failed\n- The SMT solver could not prove the query. Use --query_stats for more details.\n- See also <input>(13,15-13,23)\n", "number": 19, "ranges": [{"beg": [13, 8], "end": [13, 14], "fname": "<input>"}, {"beg": [13, 15], "end": [13, 23], "fname": "<input>"}]}], "status": "failure"}

--- a/tests/ide/emacs/tutorial.push.out.expected
+++ b/tests/ide/emacs/tutorial.push.out.expected
@@ -1,5 +1,5 @@
 {"kind": "protocol-info", "rest": "[...]"}
-{"kind": "response", "query-id": "1", "response": [{"level": "warning", "message": "- Pattern uses these theory symbols or terms that should not be in an SMT\n  pattern:\n    Prims.op_Subtraction\n", "number": 271, "ranges": [{"beg": [434, 8], "end": [434, 51], "fname": "FStar.UInt.fsti"}]}], "status": "success"}
+{"kind": "response", "query-id": "1", "response": [{"level": "warning", "message": "- Pattern uses these theory symbols or terms that should not be in an SMT\n  pattern:\n    Prims.op_Subtraction\n", "number": 271, "ranges": [{"beg": [435, 8], "end": [435, 51], "fname": "FStar.UInt.fsti"}]}], "status": "success"}
 {"kind": "response", "query-id": "2", "response": [], "status": "success"}
 {"kind": "response", "query-id": "3", "response": [], "status": "success"}
 {"kind": "response", "query-id": "4", "response": [], "status": "success"}

--- a/tests/micro-benchmarks/UnrefineAttr.fst
+++ b/tests/micro-benchmarks/UnrefineAttr.fst
@@ -1,0 +1,15 @@
+module UnrefineAttr
+
+assume val eq2 (#[@@@unrefine] a:Type) (x y : a) : Type0
+
+(* Actually enable it. *)
+#set-options "--ext __unrefine"
+
+let test0 (x y : nat) = eq2 #int x y
+let test1 (x y : nat) = eq2 x y (* this implicit should be solved to int *)
+let test2 (x y : int) = eq2 x y
+
+let _ = assert (forall x y. test0 x y == test2 x y)
+let _ = assert (forall x y. test1 x y == test2 x y)
+let _ = assert_norm (forall x y. test0 x y == test2 x y)
+let _ = assert_norm (forall x y. test1 x y == test2 x y)

--- a/ulib/FStar.BitVector.fsti
+++ b/ulib/FStar.BitVector.fsti
@@ -28,6 +28,7 @@ open FStar.Mul
 open FStar.Seq.Base
 
 (** [bv_t n] is just a sequence of booleans of length [n] *)
+[@@do_not_unrefine]
 type bv_t (n: nat) = vec: seq bool {length vec = n}
 
 (**** Common constants *)

--- a/ulib/FStar.ModifiesGen.fst
+++ b/ulib/FStar.ModifiesGen.fst
@@ -1498,7 +1498,7 @@ let loc_addresses_unused_in #al c r a h = ()
 
 let loc_addresses_not_unused_in #al c r a h = ()
 
-#push-options "--z3rlimit 25"
+#push-options "--z3rlimit 35"
 let loc_unused_in_not_unused_in_disjoint #al c h =
   assert (Ghost.reveal (Loc?.aux (loc_unused_in c h)) `loc_aux_disjoint` Ghost.reveal (Loc?.aux (loc_not_unused_in c h)));
   assert_spinoff (loc_disjoint #al #c (loc_unused_in #al c h)

--- a/ulib/FStar.UInt.fsti
+++ b/ulib/FStar.UInt.fsti
@@ -50,6 +50,7 @@ let fits (x:int) (n:nat) : Tot bool = min_int n <= x && x <= max_int n
 let size (x:int) (n:nat) : Tot Type0 = b2t(fits x n)
 
 (* Machine integer type *)
+[@@do_not_unrefine]
 type uint_t (n:nat) = x:int{size x n}
 
 /// Constants

--- a/ulib/experimental/FStar.OrdSet.fst
+++ b/ulib/experimental/FStar.OrdSet.fst
@@ -15,6 +15,7 @@
 *)
 module FStar.OrdSet
 
+[@@do_not_unrefine]
 type ordset a f = l:(list a){sorted f l}
 
 let hasEq_ordset _ _ = ()

--- a/ulib/prims.fst
+++ b/ulib/prims.fst
@@ -47,6 +47,22 @@ val cps:attribute
 assume
 val tac_opaque : attribute
 
+(** This attribute can be used on type binders to make unifier attempt
+    to unrefine them before instantiating them. This is useful in polymorphic
+    definitions where the type does not change the result type, for example
+    eq2 below. Using the attribute, an equality between two nats will happen
+    at type int, which is more canonical.
+
+    This feature is experimental and only enabled with "--ext __unrefine" *)
+assume
+val unrefine : attribute
+
+(** This attribute can be attached to a type definition to partly counter the
+    behavior of the `unrefine` attribute. It will cause the definition marked
+    `do_not_unrefine` to not be unfolded during the unrefining process. *)
+assume
+val do_not_unrefine : attribute
+
 (** A predicate to express when a type supports decidable equality
     The type-checker emits axioms for [hasEq] for each inductive type *)
 assume

--- a/ulib/prims.fst
+++ b/ulib/prims.fst
@@ -172,7 +172,7 @@ type equals (#a: Type) (x: a) : a -> Type = | Refl : equals x x
          we should just rename eq2 to op_Equals_Equals
 *)
 [@@ tac_opaque; smt_theory_symbol]
-type eq2 (#a: Type) (x: a) (y: a) : logical = squash (equals x y)
+type eq2 (#[@@@unrefine] a: Type) (x: a) (y: a) : logical = squash (equals x y)
 
 (** bool-to-type coercion: This is often automatically inserted type,
     when using a boolean in context expecting a type. But,
@@ -585,13 +585,13 @@ val op_LessThan: int -> int -> Tot bool
 
 [@@ smt_theory_symbol]
 assume
-val op_Equality: #a: eqtype -> a -> a -> Tot bool
+val op_Equality: #[@@@unrefine]a: eqtype -> a -> a -> Tot bool
 
 (** [<>] decidable dis-equality on [eqtype] *)
 
 [@@ smt_theory_symbol]
 assume
-val op_disEquality: #a: eqtype -> a -> a -> Tot bool
+val op_disEquality: #[@@@unrefine]a: eqtype -> a -> a -> Tot bool
 
 (** The extensible open inductive type of exceptions *)
 assume new


### PR DESCRIPTION
This PR allows to tag certain type implicits with the `@@@unrefine` attribute, causing the unifier to attempt to peel away all refinements of the type before instantiating the uvar. With this, if `x` is `nat`, the equality `x == x` will happen at type `int` instead of `nat` as currently happens. This can be desirable if we try to relate this fact to, say, `0 == 0`, which defaults to `int` as `0` is an int literal.

This is potentially controversial and can break some code, see also the `do_not_unrefine` attribute to fix some regressions. Hence, this logic is only enabled if `--debug __unrefine` is passed (I will turn this into an extension flag `--ext`, but the extension mechanism is currently inefficient and I don't want to slow down F*).