### PR TITLE
Revert "UInt128: break dependency on FStar.Int.Cast"

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_UInt128.ml
+++ b/ocaml/fstar-lib/generated/FStar_UInt128.ml
@@ -262,22 +262,21 @@ let (mul32 : FStar_UInt64.t -> FStar_UInt32.t -> t) =
           (u32_combine
              (FStar_UInt64.add
                 (FStar_UInt64.mul (FStar_UInt64.shift_right x u32_32)
-                   (FStar_UInt64.uint_to_t (FStar_UInt32.v y)))
+                   (FStar_Int_Cast.uint32_to_uint64 y))
                 (FStar_UInt64.shift_right
                    (FStar_UInt64.mul (u64_mod_32 x)
-                      (FStar_UInt64.uint_to_t (FStar_UInt32.v y))) u32_32))
+                      (FStar_Int_Cast.uint32_to_uint64 y)) u32_32))
              (u64_mod_32
                 (FStar_UInt64.mul (u64_mod_32 x)
-                   (FStar_UInt64.uint_to_t (FStar_UInt32.v y)))));
+                   (FStar_Int_Cast.uint32_to_uint64 y))));
         high =
           (FStar_UInt64.shift_right
              (FStar_UInt64.add
                 (FStar_UInt64.mul (FStar_UInt64.shift_right x u32_32)
-                   (FStar_UInt64.uint_to_t (FStar_UInt32.v y)))
+                   (FStar_Int_Cast.uint32_to_uint64 y))
                 (FStar_UInt64.shift_right
                    (FStar_UInt64.mul (u64_mod_32 x)
-                      (FStar_UInt64.uint_to_t (FStar_UInt32.v y))) u32_32))
-             u32_32)
+                      (FStar_Int_Cast.uint32_to_uint64 y)) u32_32)) u32_32)
       }
 let (l32 : unit FStar_UInt.uint_t -> unit FStar_UInt.uint_t) =
   fun x -> x mod (Prims.pow2 (Prims.of_int (32)))

--- a/ulib/FStar.UInt128.fst
+++ b/ulib/FStar.UInt128.fst
@@ -945,13 +945,12 @@ let mul32 x y =
   let x0 = u64_mod_32 x in
   let x1 = U64.shift_right x u32_32 in
   u32_product_bound (U64.v x0) (U32.v y);
-  let y64 = U64.uint_to_t (U32.v y) in
-  let x0y = U64.mul x0 y64 in
+  let x0y = U64.mul x0 (FStar.Int.Cast.uint32_to_uint64 y) in
   let x0yl = u64_mod_32 x0y in
   let x0yh = U64.shift_right x0y u32_32 in
   u32_product_bound (U64.v x1) (U32.v y);
   // not in the original C code
-  let x1y' = U64.mul x1 y64 in
+  let x1y' = U64.mul x1 (FStar.Int.Cast.uint32_to_uint64 y) in
   let x1y = U64.add x1y' x0yh in
   // correspondence with C:
   // r0 = r.low


### PR DESCRIPTION
This breaks karamel extraction by somehow triggering the inclusion of a `WindowsWorkaroundSigh.h`. Revert for now as this is definitely not critical.