### PR TITLE
Improvements to `--dep graph` 

### DIFF
--- a/mk/generic.mk
+++ b/mk/generic.mk
@@ -109,6 +109,14 @@ $(DEPSTEM): $(DEPSTEM).touch
 depend: $(DEPSTEM)
 include $(DEPSTEM)
 
+depgraph: $(DEPSTEM).pdf
+$(DEPSTEM).pdf: $(DEPSTEM) .force
+	$(call msg, "DEPEND GRAPH", $(SRC))
+	$(FSTAR) --dep graph $(ROOTS) $(EXTRACT) $(DEPFLAGS) --output_deps_to $(DEPSTEM).graph
+	$(FSTAR_ROOT)/.scripts/simpl_graph.py $(DEPSTEM).graph > $(DEPSTEM).simpl
+	dot -Tpdf -o $@ $(DEPSTEM).simpl
+	echo "Wrote $@"
+
 all-checked: $(ALL_CHECKED_FILES)
 
 all-ml: $(ALL_ML_FILES)

--- a/src/basic/FStarC.Compiler.Util.fsti
+++ b/src/basic/FStarC.Compiler.Util.fsti
@@ -213,7 +213,7 @@ val get_file_extension: string -> string
 val is_path_absolute: string -> bool
 val join_paths: string -> string -> string
 val normalize_file_path: string -> string
-val basename: string -> string
+val basename: string -> string (* name of file without directory *)
 val dirname : string -> string
 val getcwd: unit -> string
 val readdir: string -> list string

--- a/src/basic/FStarC.StringBuffer.fsti
+++ b/src/basic/FStarC.StringBuffer.fsti
@@ -27,7 +27,7 @@ type t
 // sb |> add "hello" |> add " world" |> add "!"
 
 
-val create : FStarC.BigInt.t -> t
+val create : int -> t
 val add: string -> t -> t
 val contents: t -> string
 val clear: t -> t

--- a/src/parser/FStarC.Parser.Dep.fst
+++ b/src/parser/FStarC.Parser.Dep.fst
@@ -443,7 +443,8 @@ let print_graph (outc : out_channel) (fn : string) (graph:dependence_graph)
     List.iter (fun dep ->
       let l = basename k in
       let r = basename <| file_of_dep file_system_map cmd_lined_files dep in
-      pr (Util.format2 "  \"%s\" -> \"%s\"\n" l r)
+      if not <| Options.should_be_already_cached (module_name_of_dep dep) then
+        pr (Util.format2 "  \"%s\" -> \"%s\"\n" l r)
     ) deps
   );
   pr "}\n";

--- a/src/parser/FStarC.Parser.Dep.fst
+++ b/src/parser/FStarC.Parser.Dep.fst
@@ -1764,7 +1764,7 @@ let print_full (outc : out_channel) (deps:deps) : unit =
         aux all_extracted_modules;
         List.rev !order
     in
-    let sb = FStarC.StringBuffer.create (FStarC.BigInt.of_int_fs 10000) in
+    let sb = FStarC.StringBuffer.create 10000 in
     let pr str = ignore <| FStarC.StringBuffer.add str sb in
     let print_entry target first_dep all_deps =
         pr target;

--- a/src/parser/FStarC.Parser.Dep.fst
+++ b/src/parser/FStarC.Parser.Dep.fst
@@ -22,11 +22,10 @@
 *)
 module FStarC.Parser.Dep
 
-open FStar.Pervasives
+open FStarC
+open FStarC.Compiler
 open FStarC.Compiler.Effect   //for ref, failwith etc
 open FStarC.Compiler.List
-open FStar open FStarC
-open FStarC.Compiler
 open FStarC.Parser
 open FStarC.Parser.AST
 open FStarC.Compiler.Util
@@ -808,7 +807,7 @@ let collect_one
   if data_from_cache |> is_some then begin  //we found the parsing data in the checked file
     let deps, has_inline_for_extraction, mo_roots = from_parsing_data (data_from_cache |> must) original_map filename in
     if !dbg then
-      BU.print2 "Reading the parsing data for %s from its checked file .. found [%s]\n" filename (show deps);
+      BU.print2 "Reading the parsing data for %s from its checked file .. found %s\n" filename (show deps);
     data_from_cache |> must,
     deps, has_inline_for_extraction, mo_roots
   end
@@ -1532,7 +1531,7 @@ let collect (all_cmd_line_files: list file_name)
   profile (fun () -> List.iter discover_one all_cmd_line_files) "FStarC.Parser.Dep.discover";
 
   (* At this point, dep_graph has all the (immediate) dependency graph of all the files. *)
-  let cycle_detected dep_graph cycle filename =
+  let cycle_detected (dep_graph:dependence_graph) cycle filename =
       Util.print1 "The cycle contains a subset of the modules in:\n%s \n" (String.concat "\n`used by` " cycle);
 
       (* Write the graph to a file for the user to see. *)
@@ -1599,7 +1598,7 @@ let collect (all_cmd_line_files: list file_name)
             | _ -> [x]) in
         match node.color with
         | Gray ->
-           cycle_detected dep_graph cycle filename
+          cycle_detected dep_graph cycle filename
         | Black ->
             (* If the element has been visited already, then the map contains all its
              * dependencies. Otherwise, the map only contains its direct dependencies. *)


### PR DESCRIPTION
Some work in progress to make dependency graphs more useful. Mostly 1) distinguish between interface and implementation instead of just coallescing the modules, and 2) do not bring into the graph the implementation of modules if they are unneeded.

With this, the dependency graph for `FStar.Tactics.V2.fst` goes from:

![depgraph-FStar Tactics V2 fst](https://github.com/user-attachments/assets/605dd222-1336-4f27-888c-78a4b316eecf)

To:

![depgraph-FStar Tactics V2 fst](https://github.com/user-attachments/assets/b411fc6c-c0ea-48ae-aa5e-15d0818fb10d)

Which allows to distinguish fst/fsti (e.g. we are not depending on `FStar.UInt32.fst`). Marking as WIP since I ripped out the full cycle detection for this.