### PR TITLE
Main: introduce --read_krml_file mode

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_Extraction_Krml.ml
+++ b/ocaml/fstar-lib/generated/FStar_Extraction_Krml.ml
@@ -624,6 +624,897 @@ type branches = (pattern * expr) Prims.list
 type constant = (width * Prims.string)
 type var = Prims.int
 type lident = (Prims.string Prims.list * Prims.string)
+let (showable_width : width FStar_Class_Show.showable) =
+  {
+    FStar_Class_Show.show =
+      (fun uu___ ->
+         match uu___ with
+         | UInt8 -> "UInt8"
+         | UInt16 -> "UInt16"
+         | UInt32 -> "UInt32"
+         | UInt64 -> "UInt64"
+         | Int8 -> "Int8"
+         | Int16 -> "Int16"
+         | Int32 -> "Int32"
+         | Int64 -> "Int64"
+         | Bool -> "Bool"
+         | CInt -> "CInt"
+         | SizeT -> "SizeT"
+         | PtrdiffT -> "PtrdiffT")
+  }
+let rec (typ_to_string : typ -> Prims.string) =
+  fun t ->
+    match t with
+    | TInt w ->
+        let uu___ = FStar_Class_Show.show showable_width w in
+        Prims.strcat "TInt " uu___
+    | TBuf t1 -> let uu___ = typ_to_string t1 in Prims.strcat "TBuf " uu___
+    | TUnit -> "TUnit"
+    | TQualified x ->
+        let uu___ =
+          FStar_Class_Show.show
+            (FStar_Class_Show.show_tuple2
+               (FStar_Class_Show.show_list
+                  (FStar_Class_Show.printableshow
+                     FStar_Class_Printable.printable_string))
+               (FStar_Class_Show.printableshow
+                  FStar_Class_Printable.printable_string)) x in
+        Prims.strcat "TQualified " uu___
+    | TBool -> "TBool"
+    | TAny -> "TAny"
+    | TArrow (t1, t2) ->
+        let uu___ =
+          let uu___1 = typ_to_string t1 in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 = typ_to_string t2 in Prims.strcat uu___4 ")" in
+            Prims.strcat ", " uu___3 in
+          Prims.strcat uu___1 uu___2 in
+        Prims.strcat "TArrow (" uu___
+    | TBound x ->
+        let uu___ =
+          FStar_Class_Show.show
+            (FStar_Class_Show.printableshow
+               FStar_Class_Printable.printable_int) x in
+        Prims.strcat "TBound " uu___
+    | TApp (x, xs) ->
+        let uu___ =
+          let uu___1 =
+            FStar_Class_Show.show
+              (FStar_Class_Show.show_tuple2
+                 (FStar_Class_Show.show_list
+                    (FStar_Class_Show.printableshow
+                       FStar_Class_Printable.printable_string))
+                 (FStar_Class_Show.printableshow
+                    FStar_Class_Printable.printable_string)) x in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 = (FStar_Common.string_of_list ()) typ_to_string xs in
+              Prims.strcat uu___4 ")" in
+            Prims.strcat ", " uu___3 in
+          Prims.strcat uu___1 uu___2 in
+        Prims.strcat "TApp (" uu___
+    | TTuple ts ->
+        let uu___ = (FStar_Common.string_of_list ()) typ_to_string ts in
+        Prims.strcat "TTuple " uu___
+    | TConstBuf t1 ->
+        let uu___ = typ_to_string t1 in Prims.strcat "TConstBuf " uu___
+    | TArray (t1, c) ->
+        let uu___ =
+          let uu___1 = typ_to_string t1 in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 =
+                FStar_Class_Show.show
+                  (FStar_Class_Show.show_tuple2 showable_width
+                     (FStar_Class_Show.printableshow
+                        FStar_Class_Printable.printable_string)) c in
+              Prims.strcat uu___4 ")" in
+            Prims.strcat ", " uu___3 in
+          Prims.strcat uu___1 uu___2 in
+        Prims.strcat "TArray (" uu___
+let (showable_typ : typ FStar_Class_Show.showable) =
+  { FStar_Class_Show.show = typ_to_string }
+let (showable_binder : binder FStar_Class_Show.showable) =
+  {
+    FStar_Class_Show.show =
+      (fun uu___ ->
+         match uu___ with
+         | { name; typ = typ1; mut;_} ->
+             let uu___1 =
+               let uu___2 =
+                 let uu___3 =
+                   let uu___4 = typ_to_string typ1 in
+                   let uu___5 =
+                     let uu___6 =
+                       let uu___7 =
+                         FStar_Class_Show.show
+                           (FStar_Class_Show.printableshow
+                              FStar_Class_Printable.printable_bool) mut in
+                       Prims.strcat uu___7 "; }" in
+                     Prims.strcat "; mut = " uu___6 in
+                   Prims.strcat uu___4 uu___5 in
+                 Prims.strcat "; typ = " uu___3 in
+               Prims.strcat name uu___2 in
+             Prims.strcat "binder{ name = " uu___1)
+  }
+let (showable_flag : flag FStar_Class_Show.showable) =
+  {
+    FStar_Class_Show.show =
+      (fun uu___ ->
+         match uu___ with
+         | Private -> "Private"
+         | WipeBody -> "WipeBody"
+         | CInline -> "CInline"
+         | Substitute -> "Substitute"
+         | GCType -> "GCType"
+         | Comment s -> Prims.strcat "Comment " s
+         | MustDisappear -> "MustDisappear"
+         | Const s -> Prims.strcat "Const " s
+         | Prologue s -> Prims.strcat "Prologue " s
+         | Epilogue s -> Prims.strcat "Epilogue " s
+         | Abstract -> "Abstract"
+         | IfDef -> "IfDef"
+         | Macro -> "Macro"
+         | Deprecated s -> Prims.strcat "Deprecated " s
+         | CNoInline -> "CNoInline")
+  }
+let (showable_lifetime : lifetime FStar_Class_Show.showable) =
+  {
+    FStar_Class_Show.show =
+      (fun uu___ ->
+         match uu___ with
+         | Eternal -> "Eternal"
+         | Stack -> "Stack"
+         | ManuallyManaged -> "ManuallyManaged")
+  }
+let (showable_op : op FStar_Class_Show.showable) =
+  {
+    FStar_Class_Show.show =
+      (fun uu___ ->
+         match uu___ with
+         | Add -> "Add"
+         | AddW -> "AddW"
+         | Sub -> "Sub"
+         | SubW -> "SubW"
+         | Div -> "Div"
+         | DivW -> "DivW"
+         | Mult -> "Mult"
+         | MultW -> "MultW"
+         | Mod -> "Mod"
+         | BOr -> "BOr"
+         | BAnd -> "BAnd"
+         | BXor -> "BXor"
+         | BShiftL -> "BShiftL"
+         | BShiftR -> "BShiftR"
+         | BNot -> "BNot"
+         | Eq -> "Eq"
+         | Neq -> "Neq"
+         | Lt -> "Lt"
+         | Lte -> "Lte"
+         | Gt -> "Gt"
+         | Gte -> "Gte"
+         | And -> "And"
+         | Or -> "Or"
+         | Xor -> "Xor"
+         | Not -> "Not")
+  }
+let (showable_cc : cc FStar_Class_Show.showable) =
+  {
+    FStar_Class_Show.show =
+      (fun uu___ ->
+         match uu___ with
+         | StdCall -> "StdCall"
+         | CDecl -> "CDecl"
+         | FastCall -> "FastCall")
+  }
+let rec (decl_to_string : decl -> Prims.string) =
+  fun d ->
+    match d with
+    | DGlobal (fs, x, i, t, e) ->
+        let uu___ =
+          let uu___1 =
+            FStar_Class_Show.show (FStar_Class_Show.show_list showable_flag)
+              fs in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 =
+                FStar_Class_Show.show
+                  (FStar_Class_Show.show_tuple2
+                     (FStar_Class_Show.show_list
+                        (FStar_Class_Show.printableshow
+                           FStar_Class_Printable.printable_string))
+                     (FStar_Class_Show.printableshow
+                        FStar_Class_Printable.printable_string)) x in
+              let uu___5 =
+                let uu___6 =
+                  let uu___7 =
+                    FStar_Class_Show.show
+                      (FStar_Class_Show.printableshow
+                         FStar_Class_Printable.printable_int) i in
+                  let uu___8 =
+                    let uu___9 =
+                      let uu___10 = typ_to_string t in
+                      let uu___11 =
+                        let uu___12 =
+                          let uu___13 = expr_to_string e in
+                          Prims.strcat uu___13 ")" in
+                        Prims.strcat ", " uu___12 in
+                      Prims.strcat uu___10 uu___11 in
+                    Prims.strcat ", " uu___9 in
+                  Prims.strcat uu___7 uu___8 in
+                Prims.strcat ", " uu___6 in
+              Prims.strcat uu___4 uu___5 in
+            Prims.strcat ", " uu___3 in
+          Prims.strcat uu___1 uu___2 in
+        Prims.strcat "DGlobal (" uu___
+    | DFunction (cc1, fs, i, t, x, bs, e) ->
+        let uu___ =
+          let uu___1 =
+            FStar_Class_Show.show (FStar_Class_Show.show_option showable_cc)
+              cc1 in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 =
+                FStar_Class_Show.show
+                  (FStar_Class_Show.show_list showable_flag) fs in
+              let uu___5 =
+                let uu___6 =
+                  let uu___7 =
+                    FStar_Class_Show.show
+                      (FStar_Class_Show.printableshow
+                         FStar_Class_Printable.printable_int) i in
+                  let uu___8 =
+                    let uu___9 =
+                      let uu___10 = typ_to_string t in
+                      let uu___11 =
+                        let uu___12 =
+                          let uu___13 =
+                            FStar_Class_Show.show
+                              (FStar_Class_Show.show_tuple2
+                                 (FStar_Class_Show.show_list
+                                    (FStar_Class_Show.printableshow
+                                       FStar_Class_Printable.printable_string))
+                                 (FStar_Class_Show.printableshow
+                                    FStar_Class_Printable.printable_string))
+                              x in
+                          let uu___14 =
+                            let uu___15 =
+                              let uu___16 =
+                                (FStar_Common.string_of_list ())
+                                  (FStar_Class_Show.show showable_binder) bs in
+                              let uu___17 =
+                                let uu___18 =
+                                  let uu___19 = expr_to_string e in
+                                  Prims.strcat uu___19 ")" in
+                                Prims.strcat ", " uu___18 in
+                              Prims.strcat uu___16 uu___17 in
+                            Prims.strcat ", " uu___15 in
+                          Prims.strcat uu___13 uu___14 in
+                        Prims.strcat ", " uu___12 in
+                      Prims.strcat uu___10 uu___11 in
+                    Prims.strcat ", " uu___9 in
+                  Prims.strcat uu___7 uu___8 in
+                Prims.strcat ", " uu___6 in
+              Prims.strcat uu___4 uu___5 in
+            Prims.strcat ", " uu___3 in
+          Prims.strcat uu___1 uu___2 in
+        Prims.strcat "DFunction (" uu___
+    | DTypeAlias (x, fs, i, t) ->
+        let uu___ =
+          let uu___1 =
+            FStar_Class_Show.show
+              (FStar_Class_Show.show_tuple2
+                 (FStar_Class_Show.show_list
+                    (FStar_Class_Show.printableshow
+                       FStar_Class_Printable.printable_string))
+                 (FStar_Class_Show.printableshow
+                    FStar_Class_Printable.printable_string)) x in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 =
+                FStar_Class_Show.show
+                  (FStar_Class_Show.show_list showable_flag) fs in
+              let uu___5 =
+                let uu___6 =
+                  let uu___7 =
+                    FStar_Class_Show.show
+                      (FStar_Class_Show.printableshow
+                         FStar_Class_Printable.printable_int) i in
+                  let uu___8 =
+                    let uu___9 =
+                      let uu___10 = typ_to_string t in
+                      Prims.strcat uu___10 ")" in
+                    Prims.strcat ", " uu___9 in
+                  Prims.strcat uu___7 uu___8 in
+                Prims.strcat ", " uu___6 in
+              Prims.strcat uu___4 uu___5 in
+            Prims.strcat ", " uu___3 in
+          Prims.strcat uu___1 uu___2 in
+        Prims.strcat "DTypeAlias (" uu___
+    | DTypeFlat (x, fs, i, f) ->
+        let uu___ =
+          let uu___1 =
+            FStar_Class_Show.show
+              (FStar_Class_Show.show_tuple2
+                 (FStar_Class_Show.show_list
+                    (FStar_Class_Show.printableshow
+                       FStar_Class_Printable.printable_string))
+                 (FStar_Class_Show.printableshow
+                    FStar_Class_Printable.printable_string)) x in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 =
+                FStar_Class_Show.show
+                  (FStar_Class_Show.show_list showable_flag) fs in
+              let uu___5 =
+                let uu___6 =
+                  let uu___7 =
+                    FStar_Class_Show.show
+                      (FStar_Class_Show.printableshow
+                         FStar_Class_Printable.printable_int) i in
+                  let uu___8 =
+                    let uu___9 =
+                      let uu___10 =
+                        FStar_Class_Show.show
+                          (FStar_Class_Show.show_list
+                             (FStar_Class_Show.show_tuple2
+                                (FStar_Class_Show.printableshow
+                                   FStar_Class_Printable.printable_string)
+                                (FStar_Class_Show.show_tuple2 showable_typ
+                                   (FStar_Class_Show.printableshow
+                                      FStar_Class_Printable.printable_bool))))
+                          f in
+                      Prims.strcat uu___10 ")" in
+                    Prims.strcat ", " uu___9 in
+                  Prims.strcat uu___7 uu___8 in
+                Prims.strcat ", " uu___6 in
+              Prims.strcat uu___4 uu___5 in
+            Prims.strcat ", " uu___3 in
+          Prims.strcat uu___1 uu___2 in
+        Prims.strcat "DTypeFlat (" uu___
+    | DUnusedRetainedForBackwardsCompat (cc1, fs, x, t) ->
+        let uu___ =
+          let uu___1 =
+            FStar_Class_Show.show (FStar_Class_Show.show_option showable_cc)
+              cc1 in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 =
+                FStar_Class_Show.show
+                  (FStar_Class_Show.show_list showable_flag) fs in
+              let uu___5 =
+                let uu___6 =
+                  let uu___7 =
+                    FStar_Class_Show.show
+                      (FStar_Class_Show.show_tuple2
+                         (FStar_Class_Show.show_list
+                            (FStar_Class_Show.printableshow
+                               FStar_Class_Printable.printable_string))
+                         (FStar_Class_Show.printableshow
+                            FStar_Class_Printable.printable_string)) x in
+                  let uu___8 =
+                    let uu___9 =
+                      let uu___10 = typ_to_string t in
+                      Prims.strcat uu___10 ")" in
+                    Prims.strcat ", " uu___9 in
+                  Prims.strcat uu___7 uu___8 in
+                Prims.strcat ", " uu___6 in
+              Prims.strcat uu___4 uu___5 in
+            Prims.strcat ", " uu___3 in
+          Prims.strcat uu___1 uu___2 in
+        Prims.strcat "DUnusedRetainedForBackwardsCompat (" uu___
+    | DTypeVariant (x, fs, i, bs) ->
+        let uu___ =
+          let uu___1 =
+            FStar_Class_Show.show
+              (FStar_Class_Show.show_tuple2
+                 (FStar_Class_Show.show_list
+                    (FStar_Class_Show.printableshow
+                       FStar_Class_Printable.printable_string))
+                 (FStar_Class_Show.printableshow
+                    FStar_Class_Printable.printable_string)) x in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 =
+                FStar_Class_Show.show
+                  (FStar_Class_Show.show_list showable_flag) fs in
+              let uu___5 =
+                let uu___6 =
+                  let uu___7 =
+                    FStar_Class_Show.show
+                      (FStar_Class_Show.printableshow
+                         FStar_Class_Printable.printable_int) i in
+                  let uu___8 =
+                    let uu___9 =
+                      let uu___10 =
+                        FStar_Class_Show.show
+                          (FStar_Class_Show.show_list
+                             (FStar_Class_Show.show_tuple2
+                                (FStar_Class_Show.printableshow
+                                   FStar_Class_Printable.printable_string)
+                                (FStar_Class_Show.show_list
+                                   (FStar_Class_Show.show_tuple2
+                                      (FStar_Class_Show.printableshow
+                                         FStar_Class_Printable.printable_string)
+                                      (FStar_Class_Show.show_tuple2
+                                         showable_typ
+                                         (FStar_Class_Show.printableshow
+                                            FStar_Class_Printable.printable_bool))))))
+                          bs in
+                      Prims.strcat uu___10 ")" in
+                    Prims.strcat ", " uu___9 in
+                  Prims.strcat uu___7 uu___8 in
+                Prims.strcat ", " uu___6 in
+              Prims.strcat uu___4 uu___5 in
+            Prims.strcat ", " uu___3 in
+          Prims.strcat uu___1 uu___2 in
+        Prims.strcat "DTypeVariant (" uu___
+    | DTypeAbstractStruct x ->
+        let uu___ =
+          FStar_Class_Show.show
+            (FStar_Class_Show.show_tuple2
+               (FStar_Class_Show.show_list
+                  (FStar_Class_Show.printableshow
+                     FStar_Class_Printable.printable_string))
+               (FStar_Class_Show.printableshow
+                  FStar_Class_Printable.printable_string)) x in
+        Prims.strcat "DTypeAbstractStruct " uu___
+    | DExternal (cc1, fs, x, t, xs) ->
+        let uu___ =
+          let uu___1 =
+            FStar_Class_Show.show (FStar_Class_Show.show_option showable_cc)
+              cc1 in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 =
+                FStar_Class_Show.show
+                  (FStar_Class_Show.show_list showable_flag) fs in
+              let uu___5 =
+                let uu___6 =
+                  let uu___7 =
+                    FStar_Class_Show.show
+                      (FStar_Class_Show.show_tuple2
+                         (FStar_Class_Show.show_list
+                            (FStar_Class_Show.printableshow
+                               FStar_Class_Printable.printable_string))
+                         (FStar_Class_Show.printableshow
+                            FStar_Class_Printable.printable_string)) x in
+                  let uu___8 =
+                    let uu___9 =
+                      let uu___10 = typ_to_string t in
+                      let uu___11 =
+                        let uu___12 =
+                          let uu___13 =
+                            (FStar_Common.string_of_list ())
+                              (FStar_Class_Show.show
+                                 (FStar_Class_Show.printableshow
+                                    FStar_Class_Printable.printable_string))
+                              xs in
+                          Prims.strcat uu___13 ")" in
+                        Prims.strcat ", " uu___12 in
+                      Prims.strcat uu___10 uu___11 in
+                    Prims.strcat ", " uu___9 in
+                  Prims.strcat uu___7 uu___8 in
+                Prims.strcat ", " uu___6 in
+              Prims.strcat uu___4 uu___5 in
+            Prims.strcat ", " uu___3 in
+          Prims.strcat uu___1 uu___2 in
+        Prims.strcat "DExternal (" uu___
+    | DUntaggedUnion (x, fs, i, xs) ->
+        let uu___ =
+          let uu___1 =
+            FStar_Class_Show.show
+              (FStar_Class_Show.show_tuple2
+                 (FStar_Class_Show.show_list
+                    (FStar_Class_Show.printableshow
+                       FStar_Class_Printable.printable_string))
+                 (FStar_Class_Show.printableshow
+                    FStar_Class_Printable.printable_string)) x in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 =
+                FStar_Class_Show.show
+                  (FStar_Class_Show.show_list showable_flag) fs in
+              let uu___5 =
+                let uu___6 =
+                  let uu___7 =
+                    FStar_Class_Show.show
+                      (FStar_Class_Show.printableshow
+                         FStar_Class_Printable.printable_int) i in
+                  let uu___8 =
+                    let uu___9 =
+                      let uu___10 =
+                        FStar_Class_Show.show
+                          (FStar_Class_Show.show_list
+                             (FStar_Class_Show.show_tuple2
+                                (FStar_Class_Show.printableshow
+                                   FStar_Class_Printable.printable_string)
+                                showable_typ)) xs in
+                      Prims.strcat uu___10 ")" in
+                    Prims.strcat ", " uu___9 in
+                  Prims.strcat uu___7 uu___8 in
+                Prims.strcat ", " uu___6 in
+              Prims.strcat uu___4 uu___5 in
+            Prims.strcat ", " uu___3 in
+          Prims.strcat uu___1 uu___2 in
+        Prims.strcat "DUntaggedUnion (" uu___
+and (expr_to_string : expr -> Prims.string) =
+  fun e ->
+    match e with
+    | EBound x ->
+        let uu___ =
+          FStar_Class_Show.show
+            (FStar_Class_Show.printableshow
+               FStar_Class_Printable.printable_int) x in
+        Prims.strcat "EBound " uu___
+    | EQualified x ->
+        let uu___ =
+          FStar_Class_Show.show
+            (FStar_Class_Show.show_tuple2
+               (FStar_Class_Show.show_list
+                  (FStar_Class_Show.printableshow
+                     FStar_Class_Printable.printable_string))
+               (FStar_Class_Show.printableshow
+                  FStar_Class_Printable.printable_string)) x in
+        Prims.strcat "EQualified " uu___
+    | EConstant x ->
+        let uu___ =
+          FStar_Class_Show.show
+            (FStar_Class_Show.show_tuple2 showable_width
+               (FStar_Class_Show.printableshow
+                  FStar_Class_Printable.printable_string)) x in
+        Prims.strcat "EConstant " uu___
+    | EUnit -> "EUnit"
+    | EApp (x, xs) ->
+        let uu___ =
+          let uu___1 = expr_to_string x in
+          let uu___2 = (FStar_Common.string_of_list ()) expr_to_string xs in
+          Prims.strcat uu___1 uu___2 in
+        Prims.strcat "EApp " uu___
+    | ETypApp (x, xs) ->
+        let uu___ = expr_to_string x in Prims.strcat "ETypApp " uu___
+    | ELet (x, y, z) ->
+        let uu___ =
+          let uu___1 = FStar_Class_Show.show showable_binder x in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 = expr_to_string y in
+              let uu___5 =
+                let uu___6 =
+                  let uu___7 = expr_to_string z in Prims.strcat uu___7 ")" in
+                Prims.strcat ", " uu___6 in
+              Prims.strcat uu___4 uu___5 in
+            Prims.strcat ", " uu___3 in
+          Prims.strcat uu___1 uu___2 in
+        Prims.strcat "ELet (" uu___
+    | EIfThenElse (x, y, z) ->
+        let uu___ =
+          let uu___1 = expr_to_string x in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 = expr_to_string y in
+              let uu___5 =
+                let uu___6 =
+                  let uu___7 = expr_to_string z in Prims.strcat uu___7 ")" in
+                Prims.strcat ", " uu___6 in
+              Prims.strcat uu___4 uu___5 in
+            Prims.strcat ", " uu___3 in
+          Prims.strcat uu___1 uu___2 in
+        Prims.strcat "EIfThenElse (" uu___
+    | ESequence xs ->
+        let uu___ = (FStar_Common.string_of_list ()) expr_to_string xs in
+        Prims.strcat "ESequence " uu___
+    | EAssign (x, y) ->
+        let uu___ =
+          let uu___1 = expr_to_string x in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 = expr_to_string y in Prims.strcat uu___4 ")" in
+            Prims.strcat ", " uu___3 in
+          Prims.strcat uu___1 uu___2 in
+        Prims.strcat "EAssign (" uu___
+    | EBufCreate (x, y, z) ->
+        let uu___ =
+          let uu___1 = FStar_Class_Show.show showable_lifetime x in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 = expr_to_string y in
+              let uu___5 =
+                let uu___6 =
+                  let uu___7 = expr_to_string z in Prims.strcat uu___7 ")" in
+                Prims.strcat ", " uu___6 in
+              Prims.strcat uu___4 uu___5 in
+            Prims.strcat ", " uu___3 in
+          Prims.strcat uu___1 uu___2 in
+        Prims.strcat "EBufCreate (" uu___
+    | EBufRead (x, y) ->
+        let uu___ =
+          let uu___1 = expr_to_string x in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 = expr_to_string y in Prims.strcat uu___4 ")" in
+            Prims.strcat ", " uu___3 in
+          Prims.strcat uu___1 uu___2 in
+        Prims.strcat "EBufRead (" uu___
+    | EBufWrite (x, y, z) ->
+        let uu___ =
+          let uu___1 = expr_to_string x in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 = expr_to_string y in
+              let uu___5 =
+                let uu___6 =
+                  let uu___7 = expr_to_string z in Prims.strcat uu___7 ")" in
+                Prims.strcat ", " uu___6 in
+              Prims.strcat uu___4 uu___5 in
+            Prims.strcat ", " uu___3 in
+          Prims.strcat uu___1 uu___2 in
+        Prims.strcat "EBufWrite (" uu___
+    | EBufSub (x, y) ->
+        let uu___ =
+          let uu___1 = expr_to_string x in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 = expr_to_string y in Prims.strcat uu___4 ")" in
+            Prims.strcat ", " uu___3 in
+          Prims.strcat uu___1 uu___2 in
+        Prims.strcat "EBufSub (" uu___
+    | EBufBlit (x, y, z, a, b) ->
+        let uu___ =
+          let uu___1 = expr_to_string x in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 = expr_to_string y in
+              let uu___5 =
+                let uu___6 =
+                  let uu___7 = expr_to_string z in
+                  let uu___8 =
+                    let uu___9 =
+                      let uu___10 = expr_to_string a in
+                      let uu___11 =
+                        let uu___12 =
+                          let uu___13 = expr_to_string b in
+                          Prims.strcat uu___13 ")" in
+                        Prims.strcat ", " uu___12 in
+                      Prims.strcat uu___10 uu___11 in
+                    Prims.strcat ", " uu___9 in
+                  Prims.strcat uu___7 uu___8 in
+                Prims.strcat ", " uu___6 in
+              Prims.strcat uu___4 uu___5 in
+            Prims.strcat ", " uu___3 in
+          Prims.strcat uu___1 uu___2 in
+        Prims.strcat "EBufBlit (" uu___
+    | EMatch (x, bs) ->
+        let uu___ =
+          let uu___1 = expr_to_string x in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 =
+                (FStar_Common.string_of_list ()) (fun uu___5 -> "iou") bs in
+              Prims.strcat uu___4 ")" in
+            Prims.strcat ", " uu___3 in
+          Prims.strcat uu___1 uu___2 in
+        Prims.strcat "EMatch (" uu___
+    | EOp (x, y) ->
+        let uu___ =
+          let uu___1 = FStar_Class_Show.show showable_op x in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 = FStar_Class_Show.show showable_width y in
+              Prims.strcat uu___4 ")" in
+            Prims.strcat ", " uu___3 in
+          Prims.strcat uu___1 uu___2 in
+        Prims.strcat "EOp (" uu___
+    | ECast (x, y) ->
+        let uu___ =
+          let uu___1 = expr_to_string x in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 = typ_to_string y in Prims.strcat uu___4 ")" in
+            Prims.strcat ", " uu___3 in
+          Prims.strcat uu___1 uu___2 in
+        Prims.strcat "ECast (" uu___
+    | EPushFrame -> "EPushFrame"
+    | EPopFrame -> "EPopFrame"
+    | EBool x ->
+        let uu___ =
+          FStar_Class_Show.show
+            (FStar_Class_Show.printableshow
+               FStar_Class_Printable.printable_bool) x in
+        Prims.strcat "EBool " uu___
+    | EAny -> "EAny"
+    | EAbort -> "EAbort"
+    | EReturn x ->
+        let uu___ = expr_to_string x in Prims.strcat "EReturn " uu___
+    | EFlat (x, xs) ->
+        let uu___ =
+          let uu___1 = typ_to_string x in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 =
+                (FStar_Common.string_of_list ())
+                  (fun uu___5 ->
+                     match uu___5 with
+                     | (s, e1) ->
+                         let uu___6 =
+                           let uu___7 =
+                             let uu___8 =
+                               let uu___9 = expr_to_string e1 in
+                               Prims.strcat uu___9 ")" in
+                             Prims.strcat ", " uu___8 in
+                           Prims.strcat s uu___7 in
+                         Prims.strcat "(" uu___6) xs in
+              Prims.strcat uu___4 ")" in
+            Prims.strcat ", " uu___3 in
+          Prims.strcat uu___1 uu___2 in
+        Prims.strcat "EFlat (" uu___
+    | EField (x, y, z) ->
+        let uu___ =
+          let uu___1 = typ_to_string x in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 = expr_to_string y in
+              let uu___5 =
+                let uu___6 =
+                  let uu___7 =
+                    FStar_Class_Show.show
+                      (FStar_Class_Show.printableshow
+                         FStar_Class_Printable.printable_string) z in
+                  Prims.strcat uu___7 ")" in
+                Prims.strcat ", " uu___6 in
+              Prims.strcat uu___4 uu___5 in
+            Prims.strcat ", " uu___3 in
+          Prims.strcat uu___1 uu___2 in
+        Prims.strcat "EField (" uu___
+    | EWhile (x, y) ->
+        let uu___ =
+          let uu___1 = expr_to_string x in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 = expr_to_string y in Prims.strcat uu___4 ")" in
+            Prims.strcat ", " uu___3 in
+          Prims.strcat uu___1 uu___2 in
+        Prims.strcat "EWhile (" uu___
+    | EBufCreateL (x, xs) ->
+        let uu___ =
+          let uu___1 = FStar_Class_Show.show showable_lifetime x in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 = (FStar_Common.string_of_list ()) expr_to_string xs in
+              Prims.strcat uu___4 ")" in
+            Prims.strcat ", " uu___3 in
+          Prims.strcat uu___1 uu___2 in
+        Prims.strcat "EBufCreateL (" uu___
+    | ETuple xs ->
+        let uu___ = (FStar_Common.string_of_list ()) expr_to_string xs in
+        Prims.strcat "ETuple " uu___
+    | ECons (x, y, xs) ->
+        let uu___ =
+          let uu___1 = typ_to_string x in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 =
+                FStar_Class_Show.show
+                  (FStar_Class_Show.printableshow
+                     FStar_Class_Printable.printable_string) y in
+              let uu___5 =
+                let uu___6 =
+                  let uu___7 =
+                    (FStar_Common.string_of_list ()) expr_to_string xs in
+                  Prims.strcat uu___7 ")" in
+                Prims.strcat ", " uu___6 in
+              Prims.strcat uu___4 uu___5 in
+            Prims.strcat ", " uu___3 in
+          Prims.strcat uu___1 uu___2 in
+        Prims.strcat "ECons (" uu___
+    | EBufFill (x, y, z) ->
+        let uu___ =
+          let uu___1 = expr_to_string x in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 = expr_to_string y in
+              let uu___5 =
+                let uu___6 =
+                  let uu___7 = expr_to_string z in Prims.strcat uu___7 ")" in
+                Prims.strcat ", " uu___6 in
+              Prims.strcat uu___4 uu___5 in
+            Prims.strcat ", " uu___3 in
+          Prims.strcat uu___1 uu___2 in
+        Prims.strcat "EBufFill (" uu___
+    | EString x ->
+        let uu___ =
+          FStar_Class_Show.show
+            (FStar_Class_Show.printableshow
+               FStar_Class_Printable.printable_string) x in
+        Prims.strcat "EString " uu___
+    | EFun (xs, y, z) ->
+        let uu___ =
+          let uu___1 =
+            (FStar_Common.string_of_list ())
+              (FStar_Class_Show.show showable_binder) xs in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 = expr_to_string y in
+              let uu___5 =
+                let uu___6 =
+                  let uu___7 = typ_to_string z in Prims.strcat uu___7 ")" in
+                Prims.strcat ", " uu___6 in
+              Prims.strcat uu___4 uu___5 in
+            Prims.strcat ", " uu___3 in
+          Prims.strcat uu___1 uu___2 in
+        Prims.strcat "EFun (" uu___
+    | EAbortS x ->
+        let uu___ =
+          FStar_Class_Show.show
+            (FStar_Class_Show.printableshow
+               FStar_Class_Printable.printable_string) x in
+        Prims.strcat "EAbortS " uu___
+    | EBufFree x ->
+        let uu___ = expr_to_string x in Prims.strcat "EBufFree " uu___
+    | EBufCreateNoInit (x, y) ->
+        let uu___ =
+          let uu___1 = FStar_Class_Show.show showable_lifetime x in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 = expr_to_string y in Prims.strcat uu___4 ")" in
+            Prims.strcat ", " uu___3 in
+          Prims.strcat uu___1 uu___2 in
+        Prims.strcat "EBufCreateNoInit (" uu___
+    | EAbortT (x, y) ->
+        let uu___ =
+          let uu___1 =
+            FStar_Class_Show.show
+              (FStar_Class_Show.printableshow
+                 FStar_Class_Printable.printable_string) x in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 = typ_to_string y in Prims.strcat uu___4 ")" in
+            Prims.strcat ", " uu___3 in
+          Prims.strcat uu___1 uu___2 in
+        Prims.strcat "EAbortT (" uu___
+    | EComment (x, y, z) ->
+        let uu___ =
+          let uu___1 =
+            FStar_Class_Show.show
+              (FStar_Class_Show.printableshow
+                 FStar_Class_Printable.printable_string) x in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 = expr_to_string y in
+              let uu___5 =
+                let uu___6 =
+                  let uu___7 =
+                    FStar_Class_Show.show
+                      (FStar_Class_Show.printableshow
+                         FStar_Class_Printable.printable_string) z in
+                  Prims.strcat uu___7 ")" in
+                Prims.strcat ", " uu___6 in
+              Prims.strcat uu___4 uu___5 in
+            Prims.strcat ", " uu___3 in
+          Prims.strcat uu___1 uu___2 in
+        Prims.strcat "EComment (" uu___
+    | EStandaloneComment x ->
+        let uu___ =
+          FStar_Class_Show.show
+            (FStar_Class_Show.printableshow
+               FStar_Class_Printable.printable_string) x in
+        Prims.strcat "EStandaloneComment " uu___
+    | EAddrOf x ->
+        let uu___ = expr_to_string x in Prims.strcat "EAddrOf " uu___
+    | EBufNull x ->
+        let uu___ = typ_to_string x in Prims.strcat "EBufNull " uu___
+    | EBufDiff (x, y) ->
+        let uu___ =
+          let uu___1 = expr_to_string x in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 = expr_to_string y in Prims.strcat uu___4 ")" in
+            Prims.strcat ", " uu___3 in
+          Prims.strcat uu___1 uu___2 in
+        Prims.strcat "EBufDiff (" uu___
+let (showable_decl : decl FStar_Class_Show.showable) =
+  { FStar_Class_Show.show = decl_to_string }
 type program = decl Prims.list
 type file = (Prims.string * program)
 type version = Prims.int
@@ -3194,7 +4085,7 @@ let (translate :
                        "Unable to translate module: %s because:\n  %s\n"
                        m_name uu___3);
                     FStar_Pervasives_Native.None)) modules
-let (uu___1711 : unit) =
+let (uu___2016 : unit) =
   register_post_translate_type_without_decay translate_type_without_decay';
   register_post_translate_type translate_type';
   register_post_translate_type_decl translate_type_decl';

--- a/ocaml/fstar-lib/generated/FStar_Main.ml
+++ b/ocaml/fstar-lib/generated/FStar_Main.ml
@@ -237,68 +237,122 @@ let go : 'uuuuu . 'uuuuu -> unit =
                                 tcr.FStar_CheckedFiles.checked_module in
                             FStar_Compiler_Util.print1 "%s\n" uu___12
                       else
-                        (let uu___12 = FStar_Options.lsp_server () in
+                        (let uu___12 =
+                           let uu___13 = FStar_Options.read_krml_file () in
+                           FStar_Pervasives_Native.uu___is_Some uu___13 in
                          if uu___12
-                         then FStar_Interactive_Lsp.start_server ()
-                         else
-                           (let uu___14 = FStar_Options.interactive () in
-                            if uu___14
-                            then
-                              (FStar_Syntax_Unionfind.set_rw ();
-                               (match filenames with
-                                | [] ->
-                                    (FStar_Errors.log_issue
-                                       FStar_Compiler_Range_Type.dummyRange
-                                       (FStar_Errors_Codes.Error_MissingFileName,
-                                         "--ide: Name of current file missing in command line invocation\n");
-                                     FStar_Compiler_Effect.exit Prims.int_one)
-                                | uu___16::uu___17::uu___18 ->
-                                    (FStar_Errors.log_issue
-                                       FStar_Compiler_Range_Type.dummyRange
-                                       (FStar_Errors_Codes.Error_TooManyFiles,
-                                         "--ide: Too many files in command line invocation\n");
-                                     FStar_Compiler_Effect.exit Prims.int_one)
-                                | filename::[] ->
-                                    let uu___16 =
-                                      FStar_Options.legacy_interactive () in
-                                    if uu___16
-                                    then
-                                      FStar_Interactive_Legacy.interactive_mode
-                                        filename
-                                    else
-                                      FStar_Interactive_Ide.interactive_mode
-                                        filename))
-                            else
-                              if
-                                (FStar_Compiler_List.length filenames) >=
-                                  Prims.int_one
-                              then
-                                (let uu___16 =
-                                   FStar_Dependencies.find_deps_if_needed
-                                     filenames
-                                     FStar_CheckedFiles.load_parsing_data_from_cache in
-                                 match uu___16 with
-                                 | (filenames1, dep_graph) ->
+                         then
+                           let path =
+                             let uu___13 = FStar_Options.read_krml_file () in
+                             FStar_Pervasives_Native.__proj__Some__item__v
+                               uu___13 in
+                           let uu___13 =
+                             FStar_Compiler_Util.load_value_from_file path in
+                           match uu___13 with
+                           | FStar_Pervasives_Native.None ->
+                               let uu___14 =
+                                 let uu___15 =
+                                   let uu___16 =
                                      let uu___17 =
-                                       FStar_Universal.batch_mode_tc
-                                         filenames1 dep_graph in
-                                     (match uu___17 with
-                                      | (tcrs, env, cleanup1) ->
-                                          ((let uu___19 = cleanup1 env in ());
-                                           (let module_names =
-                                              FStar_Compiler_List.map
-                                                (fun tcr ->
-                                                   FStar_Universal.module_or_interface_name
-                                                     tcr.FStar_CheckedFiles.checked_module)
-                                                tcrs in
-                                            report_errors module_names;
-                                            finished_message module_names
-                                              Prims.int_zero))))
-                              else
-                                FStar_Errors.raise_error
-                                  (FStar_Errors_Codes.Error_MissingFileName,
-                                    "No file provided")
-                                  FStar_Compiler_Range_Type.dummyRange))))))))
+                                       FStar_Errors_Msg.text
+                                         "Could not read krml file:" in
+                                     let uu___18 =
+                                       FStar_Pprint.doc_of_string path in
+                                     FStar_Pprint.op_Hat_Slash_Hat uu___17
+                                       uu___18 in
+                                   [uu___16] in
+                                 (FStar_Errors_Codes.Fatal_ModuleOrFileNotFound,
+                                   uu___15) in
+                               FStar_Errors.raise_err_doc uu___14
+                           | FStar_Pervasives_Native.Some (version, files) ->
+                               ((let uu___15 =
+                                   FStar_Class_Show.show
+                                     (FStar_Class_Show.printableshow
+                                        FStar_Class_Printable.printable_int)
+                                     version in
+                                 FStar_Compiler_Util.print1
+                                   "Karamel format version: %s\n" uu___15);
+                                FStar_Compiler_List.iter
+                                  (fun uu___15 ->
+                                     match uu___15 with
+                                     | (name, decls) ->
+                                         (FStar_Compiler_Util.print1 "%s:\n"
+                                            name;
+                                          FStar_Compiler_List.iter
+                                            (fun d ->
+                                               let uu___17 =
+                                                 FStar_Class_Show.show
+                                                   FStar_Extraction_Krml.showable_decl
+                                                   d in
+                                               FStar_Compiler_Util.print1
+                                                 "  %s\n" uu___17) decls))
+                                  files)
+                         else
+                           (let uu___14 = FStar_Options.lsp_server () in
+                            if uu___14
+                            then FStar_Interactive_Lsp.start_server ()
+                            else
+                              (let uu___16 = FStar_Options.interactive () in
+                               if uu___16
+                               then
+                                 (FStar_Syntax_Unionfind.set_rw ();
+                                  (match filenames with
+                                   | [] ->
+                                       (FStar_Errors.log_issue
+                                          FStar_Compiler_Range_Type.dummyRange
+                                          (FStar_Errors_Codes.Error_MissingFileName,
+                                            "--ide: Name of current file missing in command line invocation\n");
+                                        FStar_Compiler_Effect.exit
+                                          Prims.int_one)
+                                   | uu___18::uu___19::uu___20 ->
+                                       (FStar_Errors.log_issue
+                                          FStar_Compiler_Range_Type.dummyRange
+                                          (FStar_Errors_Codes.Error_TooManyFiles,
+                                            "--ide: Too many files in command line invocation\n");
+                                        FStar_Compiler_Effect.exit
+                                          Prims.int_one)
+                                   | filename::[] ->
+                                       let uu___18 =
+                                         FStar_Options.legacy_interactive () in
+                                       if uu___18
+                                       then
+                                         FStar_Interactive_Legacy.interactive_mode
+                                           filename
+                                       else
+                                         FStar_Interactive_Ide.interactive_mode
+                                           filename))
+                               else
+                                 if
+                                   (FStar_Compiler_List.length filenames) >=
+                                     Prims.int_one
+                                 then
+                                   (let uu___18 =
+                                      FStar_Dependencies.find_deps_if_needed
+                                        filenames
+                                        FStar_CheckedFiles.load_parsing_data_from_cache in
+                                    match uu___18 with
+                                    | (filenames1, dep_graph) ->
+                                        let uu___19 =
+                                          FStar_Universal.batch_mode_tc
+                                            filenames1 dep_graph in
+                                        (match uu___19 with
+                                         | (tcrs, env, cleanup1) ->
+                                             ((let uu___21 = cleanup1 env in
+                                               ());
+                                              (let module_names =
+                                                 FStar_Compiler_List.map
+                                                   (fun tcr ->
+                                                      FStar_Universal.module_or_interface_name
+                                                        tcr.FStar_CheckedFiles.checked_module)
+                                                   tcrs in
+                                               report_errors module_names;
+                                               finished_message module_names
+                                                 Prims.int_zero))))
+                                 else
+                                   FStar_Errors.raise_error
+                                     (FStar_Errors_Codes.Error_MissingFileName,
+                                       "No file provided")
+                                     FStar_Compiler_Range_Type.dummyRange)))))))))
 let (lazy_chooser :
   FStar_Syntax_Syntax.lazy_kind ->
     FStar_Syntax_Syntax.lazyinfo ->

--- a/ocaml/fstar-lib/generated/FStar_Options.ml
+++ b/ocaml/fstar-lib/generated/FStar_Options.ml
@@ -360,6 +360,7 @@ let (defaults : (Prims.string * option_val) Prims.list) =
   ("query_cache", (Bool false));
   ("query_stats", (Bool false));
   ("read_checked_file", Unset);
+  ("read_krml_file", Unset);
   ("record_hints", (Bool false));
   ("record_options", (Bool false));
   ("report_assumes", Unset);
@@ -624,6 +625,9 @@ let (get_query_stats : unit -> Prims.bool) =
 let (get_read_checked_file :
   unit -> Prims.string FStar_Pervasives_Native.option) =
   fun uu___ -> lookup_opt "read_checked_file" (as_option as_string)
+let (get_read_krml_file :
+  unit -> Prims.string FStar_Pervasives_Native.option) =
+  fun uu___ -> lookup_opt "read_krml_file" (as_option as_string)
 let (get_record_hints : unit -> Prims.bool) =
   fun uu___ -> lookup_opt "record_hints" as_bool
 let (get_record_options : unit -> Prims.bool) =
@@ -1015,7 +1019,7 @@ let (interp_quake_arg : Prims.string -> (Prims.int * Prims.int * Prims.bool))
           let uu___ = ios f1 in let uu___1 = ios f2 in (uu___, uu___1, true)
         else FStar_Compiler_Effect.failwith "unexpected value for --quake"
     | uu___ -> FStar_Compiler_Effect.failwith "unexpected value for --quake"
-let (uu___453 : (((Prims.string -> unit) -> unit) * (Prims.string -> unit)))
+let (uu___454 : (((Prims.string -> unit) -> unit) * (Prims.string -> unit)))
   =
   let cb = FStar_Compiler_Util.mk_ref FStar_Pervasives_Native.None in
   let set1 f =
@@ -1027,11 +1031,11 @@ let (uu___453 : (((Prims.string -> unit) -> unit) * (Prims.string -> unit)))
     | FStar_Pervasives_Native.Some f -> f msg in
   (set1, call)
 let (set_option_warning_callback_aux : (Prims.string -> unit) -> unit) =
-  match uu___453 with
+  match uu___454 with
   | (set_option_warning_callback_aux1, option_warning_callback) ->
       set_option_warning_callback_aux1
 let (option_warning_callback : Prims.string -> unit) =
-  match uu___453 with
+  match uu___454 with
   | (set_option_warning_callback_aux1, option_warning_callback1) ->
       option_warning_callback1
 let (set_option_warning_callback : (Prims.string -> unit) -> unit) =
@@ -2263,12 +2267,11 @@ let rec (specs_with_types :
                                                                     let uu___157
                                                                     =
                                                                     text
-                                                                    "Record a database of hints for efficient proof replay" in
+                                                                    "Read a Karamel binary file and dump it to standard output." in
                                                                     (FStar_Getopt.noshort,
-                                                                    "record_hints",
-                                                                    (Const
-                                                                    (Bool
-                                                                    true)),
+                                                                    "read_krml_file",
+                                                                    (PathStr
+                                                                    "path"),
                                                                     uu___157) in
                                                                     let uu___157
                                                                     =
@@ -2277,9 +2280,9 @@ let rec (specs_with_types :
                                                                     let uu___159
                                                                     =
                                                                     text
-                                                                    "Record the state of options used to check each sigelt, useful for the `check_with` attribute and metaprogramming. Note that this implies a performance hit and increases the size of checked files." in
+                                                                    "Record a database of hints for efficient proof replay" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "record_options",
+                                                                    "record_hints",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2291,14 +2294,28 @@ let rec (specs_with_types :
                                                                     let uu___161
                                                                     =
                                                                     text
+                                                                    "Record the state of options used to check each sigelt, useful for the `check_with` attribute and metaprogramming. Note that this implies a performance hit and increases the size of checked files." in
+                                                                    (FStar_Getopt.noshort,
+                                                                    "record_options",
+                                                                    (Const
+                                                                    (Bool
+                                                                    true)),
+                                                                    uu___161) in
+                                                                    let uu___161
+                                                                    =
+                                                                    let uu___162
+                                                                    =
+                                                                    let uu___163
+                                                                    =
+                                                                    text
                                                                     "Retry each SMT query N times and succeed on the first try. Using --retry disables --quake." in
                                                                     (FStar_Getopt.noshort,
                                                                     "retry",
                                                                     (PostProcessed
                                                                     ((fun
-                                                                    uu___162
+                                                                    uu___164
                                                                     ->
-                                                                    match uu___162
+                                                                    match uu___164
                                                                     with
                                                                     | 
                                                                     Int i ->
@@ -2319,25 +2336,12 @@ let rec (specs_with_types :
                                                                     true);
                                                                     Bool true)
                                                                     | 
-                                                                    uu___163
+                                                                    uu___165
                                                                     ->
                                                                     FStar_Compiler_Effect.failwith
                                                                     "impos"),
                                                                     (IntStr
                                                                     "positive integer"))),
-                                                                    uu___161) in
-                                                                    let uu___161
-                                                                    =
-                                                                    let uu___162
-                                                                    =
-                                                                    let uu___163
-                                                                    =
-                                                                    text
-                                                                    "Optimistically, attempt using the recorded hint for  toplevel_name (a top-level name in the current module) when trying to verify some other term 'g'" in
-                                                                    (FStar_Getopt.noshort,
-                                                                    "reuse_hint_for",
-                                                                    (SimpleStr
-                                                                    "toplevel_name"),
                                                                     uu___163) in
                                                                     let uu___163
                                                                     =
@@ -2346,12 +2350,11 @@ let rec (specs_with_types :
                                                                     let uu___165
                                                                     =
                                                                     text
-                                                                    "Report every use of an escape hatch, include assume, admit, etc." in
+                                                                    "Optimistically, attempt using the recorded hint for  toplevel_name (a top-level name in the current module) when trying to verify some other term 'g'" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "report_assumes",
-                                                                    (EnumStr
-                                                                    ["warn";
-                                                                    "error"]),
+                                                                    "reuse_hint_for",
+                                                                    (SimpleStr
+                                                                    "toplevel_name"),
                                                                     uu___165) in
                                                                     let uu___165
                                                                     =
@@ -2360,12 +2363,12 @@ let rec (specs_with_types :
                                                                     let uu___167
                                                                     =
                                                                     text
-                                                                    "Disable all non-critical output" in
+                                                                    "Report every use of an escape hatch, include assume, admit, etc." in
                                                                     (FStar_Getopt.noshort,
-                                                                    "silent",
-                                                                    (Const
-                                                                    (Bool
-                                                                    true)),
+                                                                    "report_assumes",
+                                                                    (EnumStr
+                                                                    ["warn";
+                                                                    "error"]),
                                                                     uu___167) in
                                                                     let uu___167
                                                                     =
@@ -2374,11 +2377,12 @@ let rec (specs_with_types :
                                                                     let uu___169
                                                                     =
                                                                     text
-                                                                    "Path to the Z3 SMT solver (we could eventually support other solvers)" in
+                                                                    "Disable all non-critical output" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "smt",
-                                                                    (PathStr
-                                                                    "path"),
+                                                                    "silent",
+                                                                    (Const
+                                                                    (Bool
+                                                                    true)),
                                                                     uu___169) in
                                                                     let uu___169
                                                                     =
@@ -2387,10 +2391,11 @@ let rec (specs_with_types :
                                                                     let uu___171
                                                                     =
                                                                     text
-                                                                    "Toggle a peephole optimization that eliminates redundant uses of boxing/unboxing in the SMT encoding (default 'false')" in
+                                                                    "Path to the Z3 SMT solver (we could eventually support other solvers)" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "smtencoding.elim_box",
-                                                                    BoolStr,
+                                                                    "smt",
+                                                                    (PathStr
+                                                                    "path"),
                                                                     uu___171) in
                                                                     let uu___171
                                                                     =
@@ -2398,57 +2403,11 @@ let rec (specs_with_types :
                                                                     =
                                                                     let uu___173
                                                                     =
-                                                                    let uu___174
-                                                                    =
                                                                     text
-                                                                    "Control the representation of non-linear arithmetic functions in the SMT encoding:" in
-                                                                    let uu___175
-                                                                    =
-                                                                    let uu___176
-                                                                    =
-                                                                    let uu___177
-                                                                    =
-                                                                    let uu___178
-                                                                    =
-                                                                    text
-                                                                    "if 'boxwrap' use 'Prims.op_Multiply, Prims.op_Division, Prims.op_Modulus'" in
-                                                                    let uu___179
-                                                                    =
-                                                                    let uu___180
-                                                                    =
-                                                                    text
-                                                                    "if 'native' use '*, div, mod'" in
-                                                                    let uu___181
-                                                                    =
-                                                                    let uu___182
-                                                                    =
-                                                                    text
-                                                                    "if 'wrapped' use '_mul, _div, _mod : Int*Int -> Int'" in
-                                                                    [uu___182] in
-                                                                    uu___180
-                                                                    ::
-                                                                    uu___181 in
-                                                                    uu___178
-                                                                    ::
-                                                                    uu___179 in
-                                                                    FStar_Errors_Msg.bulleted
-                                                                    uu___177 in
-                                                                    let uu___177
-                                                                    =
-                                                                    text
-                                                                    "(default 'boxwrap')" in
-                                                                    FStar_Pprint.op_Hat_Hat
-                                                                    uu___176
-                                                                    uu___177 in
-                                                                    FStar_Pprint.op_Hat_Hat
-                                                                    uu___174
-                                                                    uu___175 in
+                                                                    "Toggle a peephole optimization that eliminates redundant uses of boxing/unboxing in the SMT encoding (default 'false')" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "smtencoding.nl_arith_repr",
-                                                                    (EnumStr
-                                                                    ["native";
-                                                                    "wrapped";
-                                                                    "boxwrap"]),
+                                                                    "smtencoding.elim_box",
+                                                                    BoolStr,
                                                                     uu___173) in
                                                                     let uu___173
                                                                     =
@@ -2459,7 +2418,7 @@ let rec (specs_with_types :
                                                                     let uu___176
                                                                     =
                                                                     text
-                                                                    "Toggle the representation of linear arithmetic functions in the SMT encoding:" in
+                                                                    "Control the representation of non-linear arithmetic functions in the SMT encoding:" in
                                                                     let uu___177
                                                                     =
                                                                     let uu___178
@@ -2469,14 +2428,23 @@ let rec (specs_with_types :
                                                                     let uu___180
                                                                     =
                                                                     text
-                                                                    "if 'boxwrap', use 'Prims.op_Addition, Prims.op_Subtraction, Prims.op_Minus'" in
+                                                                    "if 'boxwrap' use 'Prims.op_Multiply, Prims.op_Division, Prims.op_Modulus'" in
                                                                     let uu___181
                                                                     =
                                                                     let uu___182
                                                                     =
                                                                     text
-                                                                    "if 'native', use '+, -, -'" in
-                                                                    [uu___182] in
+                                                                    "if 'native' use '*, div, mod'" in
+                                                                    let uu___183
+                                                                    =
+                                                                    let uu___184
+                                                                    =
+                                                                    text
+                                                                    "if 'wrapped' use '_mul, _div, _mod : Int*Int -> Int'" in
+                                                                    [uu___184] in
+                                                                    uu___182
+                                                                    ::
+                                                                    uu___183 in
                                                                     uu___180
                                                                     ::
                                                                     uu___181 in
@@ -2493,9 +2461,10 @@ let rec (specs_with_types :
                                                                     uu___176
                                                                     uu___177 in
                                                                     (FStar_Getopt.noshort,
-                                                                    "smtencoding.l_arith_repr",
+                                                                    "smtencoding.nl_arith_repr",
                                                                     (EnumStr
                                                                     ["native";
+                                                                    "wrapped";
                                                                     "boxwrap"]),
                                                                     uu___175) in
                                                                     let uu___175
@@ -2504,24 +2473,10 @@ let rec (specs_with_types :
                                                                     =
                                                                     let uu___177
                                                                     =
-                                                                    text
-                                                                    "Include an axiom in the SMT encoding to introduce proof-irrelevance from a constructive proof" in
-                                                                    (FStar_Getopt.noshort,
-                                                                    "smtencoding.valid_intro",
-                                                                    BoolStr,
-                                                                    uu___177) in
-                                                                    let uu___177
-                                                                    =
                                                                     let uu___178
                                                                     =
-                                                                    let uu___179
-                                                                    =
                                                                     text
-                                                                    "Include an axiom in the SMT encoding to eliminate proof-irrelevance into the existence of a proof witness" in
-                                                                    (FStar_Getopt.noshort,
-                                                                    "smtencoding.valid_elim",
-                                                                    BoolStr,
-                                                                    uu___179) in
+                                                                    "Toggle the representation of linear arithmetic functions in the SMT encoding:" in
                                                                     let uu___179
                                                                     =
                                                                     let uu___180
@@ -2531,45 +2486,58 @@ let rec (specs_with_types :
                                                                     let uu___182
                                                                     =
                                                                     text
-                                                                    "Split SMT verification conditions into several separate queries, one per goal. Helps with localizing errors." in
+                                                                    "if 'boxwrap', use 'Prims.op_Addition, Prims.op_Subtraction, Prims.op_Minus'" in
                                                                     let uu___183
                                                                     =
                                                                     let uu___184
                                                                     =
-                                                                    let uu___185
-                                                                    =
                                                                     text
-                                                                    "Use 'no' to disable (this may reduce the quality of error messages)." in
-                                                                    let uu___186
-                                                                    =
-                                                                    let uu___187
-                                                                    =
-                                                                    text
-                                                                    "Use 'on_failure' to split queries and retry when discharging fails (the default)" in
-                                                                    let uu___188
-                                                                    =
-                                                                    let uu___189
-                                                                    =
-                                                                    text
-                                                                    "Use 'yes' to always split." in
-                                                                    [uu___189] in
-                                                                    uu___187
-                                                                    ::
-                                                                    uu___188 in
-                                                                    uu___185
-                                                                    ::
-                                                                    uu___186 in
-                                                                    FStar_Errors_Msg.bulleted
-                                                                    uu___184 in
-                                                                    FStar_Pprint.op_Hat_Hat
+                                                                    "if 'native', use '+, -, -'" in
+                                                                    [uu___184] in
                                                                     uu___182
+                                                                    ::
                                                                     uu___183 in
+                                                                    FStar_Errors_Msg.bulleted
+                                                                    uu___181 in
+                                                                    let uu___181
+                                                                    =
+                                                                    text
+                                                                    "(default 'boxwrap')" in
+                                                                    FStar_Pprint.op_Hat_Hat
+                                                                    uu___180
+                                                                    uu___181 in
+                                                                    FStar_Pprint.op_Hat_Hat
+                                                                    uu___178
+                                                                    uu___179 in
                                                                     (FStar_Getopt.noshort,
-                                                                    "split_queries",
+                                                                    "smtencoding.l_arith_repr",
                                                                     (EnumStr
-                                                                    ["no";
-                                                                    "on_failure";
-                                                                    "always"]),
+                                                                    ["native";
+                                                                    "boxwrap"]),
+                                                                    uu___177) in
+                                                                    let uu___177
+                                                                    =
+                                                                    let uu___178
+                                                                    =
+                                                                    let uu___179
+                                                                    =
+                                                                    text
+                                                                    "Include an axiom in the SMT encoding to introduce proof-irrelevance from a constructive proof" in
+                                                                    (FStar_Getopt.noshort,
+                                                                    "smtencoding.valid_intro",
+                                                                    BoolStr,
+                                                                    uu___179) in
+                                                                    let uu___179
+                                                                    =
+                                                                    let uu___180
+                                                                    =
+                                                                    let uu___181
+                                                                    =
+                                                                    text
+                                                                    "Include an axiom in the SMT encoding to eliminate proof-irrelevance into the existence of a proof witness" in
+                                                                    (FStar_Getopt.noshort,
+                                                                    "smtencoding.valid_elim",
+                                                                    BoolStr,
                                                                     uu___181) in
                                                                     let uu___181
                                                                     =
@@ -2577,13 +2545,48 @@ let rec (specs_with_types :
                                                                     =
                                                                     let uu___183
                                                                     =
+                                                                    let uu___184
+                                                                    =
                                                                     text
-                                                                    "Do not use the lexical scope of tactics to improve binder names" in
+                                                                    "Split SMT verification conditions into several separate queries, one per goal. Helps with localizing errors." in
+                                                                    let uu___185
+                                                                    =
+                                                                    let uu___186
+                                                                    =
+                                                                    let uu___187
+                                                                    =
+                                                                    text
+                                                                    "Use 'no' to disable (this may reduce the quality of error messages)." in
+                                                                    let uu___188
+                                                                    =
+                                                                    let uu___189
+                                                                    =
+                                                                    text
+                                                                    "Use 'on_failure' to split queries and retry when discharging fails (the default)" in
+                                                                    let uu___190
+                                                                    =
+                                                                    let uu___191
+                                                                    =
+                                                                    text
+                                                                    "Use 'yes' to always split." in
+                                                                    [uu___191] in
+                                                                    uu___189
+                                                                    ::
+                                                                    uu___190 in
+                                                                    uu___187
+                                                                    ::
+                                                                    uu___188 in
+                                                                    FStar_Errors_Msg.bulleted
+                                                                    uu___186 in
+                                                                    FStar_Pprint.op_Hat_Hat
+                                                                    uu___184
+                                                                    uu___185 in
                                                                     (FStar_Getopt.noshort,
-                                                                    "tactic_raw_binders",
-                                                                    (Const
-                                                                    (Bool
-                                                                    true)),
+                                                                    "split_queries",
+                                                                    (EnumStr
+                                                                    ["no";
+                                                                    "on_failure";
+                                                                    "always"]),
                                                                     uu___183) in
                                                                     let uu___183
                                                                     =
@@ -2592,9 +2595,9 @@ let rec (specs_with_types :
                                                                     let uu___185
                                                                     =
                                                                     text
-                                                                    "Do not recover from metaprogramming errors, and abort if one occurs" in
+                                                                    "Do not use the lexical scope of tactics to improve binder names" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "tactics_failhard",
+                                                                    "tactic_raw_binders",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2606,9 +2609,9 @@ let rec (specs_with_types :
                                                                     let uu___187
                                                                     =
                                                                     text
-                                                                    "Print some rough information on tactics, such as the time they take to run" in
+                                                                    "Do not recover from metaprogramming errors, and abort if one occurs" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "tactics_info",
+                                                                    "tactics_failhard",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2620,9 +2623,9 @@ let rec (specs_with_types :
                                                                     let uu___189
                                                                     =
                                                                     text
-                                                                    "Print a depth-indexed trace of tactic execution (Warning: very verbose)" in
+                                                                    "Print some rough information on tactics, such as the time they take to run" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "tactic_trace",
+                                                                    "tactics_info",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2634,11 +2637,12 @@ let rec (specs_with_types :
                                                                     let uu___191
                                                                     =
                                                                     text
-                                                                    "Trace tactics up to a certain binding depth" in
+                                                                    "Print a depth-indexed trace of tactic execution (Warning: very verbose)" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "tactic_trace_d",
-                                                                    (IntStr
-                                                                    "positive_integer"),
+                                                                    "tactic_trace",
+                                                                    (Const
+                                                                    (Bool
+                                                                    true)),
                                                                     uu___191) in
                                                                     let uu___191
                                                                     =
@@ -2647,12 +2651,11 @@ let rec (specs_with_types :
                                                                     let uu___193
                                                                     =
                                                                     text
-                                                                    "Use NBE to evaluate metaprograms (experimental)" in
+                                                                    "Trace tactics up to a certain binding depth" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "__tactics_nbe",
-                                                                    (Const
-                                                                    (Bool
-                                                                    true)),
+                                                                    "tactic_trace_d",
+                                                                    (IntStr
+                                                                    "positive_integer"),
                                                                     uu___193) in
                                                                     let uu___193
                                                                     =
@@ -2661,10 +2664,12 @@ let rec (specs_with_types :
                                                                     let uu___195
                                                                     =
                                                                     text
-                                                                    "Attempt to normalize definitions marked as tcnorm (default 'true')" in
+                                                                    "Use NBE to evaluate metaprograms (experimental)" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "tcnorm",
-                                                                    BoolStr,
+                                                                    "__tactics_nbe",
+                                                                    (Const
+                                                                    (Bool
+                                                                    true)),
                                                                     uu___195) in
                                                                     let uu___195
                                                                     =
@@ -2673,12 +2678,10 @@ let rec (specs_with_types :
                                                                     let uu___197
                                                                     =
                                                                     text
-                                                                    "Print the time it takes to verify each top-level definition. This is just an alias for an invocation of the profiler, so it may not work well if combined with --profile. In particular, it implies --profile_group_by_decl." in
+                                                                    "Attempt to normalize definitions marked as tcnorm (default 'true')" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "timing",
-                                                                    (Const
-                                                                    (Bool
-                                                                    true)),
+                                                                    "tcnorm",
+                                                                    BoolStr,
                                                                     uu___197) in
                                                                     let uu___197
                                                                     =
@@ -2687,9 +2690,9 @@ let rec (specs_with_types :
                                                                     let uu___199
                                                                     =
                                                                     text
-                                                                    "Attach stack traces on errors" in
+                                                                    "Print the time it takes to verify each top-level definition. This is just an alias for an invocation of the profiler, so it may not work well if combined with --profile. In particular, it implies --profile_group_by_decl." in
                                                                     (FStar_Getopt.noshort,
-                                                                    "trace_error",
+                                                                    "timing",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2701,9 +2704,9 @@ let rec (specs_with_types :
                                                                     let uu___201
                                                                     =
                                                                     text
-                                                                    "Emit output formatted for debugging" in
+                                                                    "Attach stack traces on errors" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "ugly",
+                                                                    "trace_error",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2715,9 +2718,9 @@ let rec (specs_with_types :
                                                                     let uu___203
                                                                     =
                                                                     text
-                                                                    "Let the SMT solver unfold inductive types to arbitrary depths (may affect verifier performance)" in
+                                                                    "Emit output formatted for debugging" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "unthrottle_inductives",
+                                                                    "ugly",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2729,9 +2732,9 @@ let rec (specs_with_types :
                                                                     let uu___205
                                                                     =
                                                                     text
-                                                                    "Allow tactics to run external processes. WARNING: checking an untrusted F* file while using this option can have disastrous effects." in
+                                                                    "Let the SMT solver unfold inductive types to arbitrary depths (may affect verifier performance)" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "unsafe_tactic_exec",
+                                                                    "unthrottle_inductives",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2743,9 +2746,9 @@ let rec (specs_with_types :
                                                                     let uu___207
                                                                     =
                                                                     text
-                                                                    "Use equality constraints when comparing higher-order types (Temporary)" in
+                                                                    "Allow tactics to run external processes. WARNING: checking an untrusted F* file while using this option can have disastrous effects." in
                                                                     (FStar_Getopt.noshort,
-                                                                    "use_eq_at_higher_order",
+                                                                    "unsafe_tactic_exec",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2757,9 +2760,9 @@ let rec (specs_with_types :
                                                                     let uu___209
                                                                     =
                                                                     text
-                                                                    "Use a previously recorded hints database for proof replay" in
+                                                                    "Use equality constraints when comparing higher-order types (Temporary)" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "use_hints",
+                                                                    "use_eq_at_higher_order",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2771,9 +2774,9 @@ let rec (specs_with_types :
                                                                     let uu___211
                                                                     =
                                                                     text
-                                                                    "Admit queries if their hash matches the hash recorded in the hints database" in
+                                                                    "Use a previously recorded hints database for proof replay" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "use_hint_hashes",
+                                                                    "use_hints",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2785,11 +2788,12 @@ let rec (specs_with_types :
                                                                     let uu___213
                                                                     =
                                                                     text
-                                                                    "Use compiled tactics from  path" in
+                                                                    "Admit queries if their hash matches the hash recorded in the hints database" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "use_native_tactics",
-                                                                    (PathStr
-                                                                    "path"),
+                                                                    "use_hint_hashes",
+                                                                    (Const
+                                                                    (Bool
+                                                                    true)),
                                                                     uu___213) in
                                                                     let uu___213
                                                                     =
@@ -2798,12 +2802,11 @@ let rec (specs_with_types :
                                                                     let uu___215
                                                                     =
                                                                     text
-                                                                    "Do not run plugins natively and interpret them as usual instead" in
+                                                                    "Use compiled tactics from  path" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "no_plugins",
-                                                                    (Const
-                                                                    (Bool
-                                                                    true)),
+                                                                    "use_native_tactics",
+                                                                    (PathStr
+                                                                    "path"),
                                                                     uu___215) in
                                                                     let uu___215
                                                                     =
@@ -2812,9 +2815,9 @@ let rec (specs_with_types :
                                                                     let uu___217
                                                                     =
                                                                     text
-                                                                    "Do not run the tactic engine before discharging a VC" in
+                                                                    "Do not run plugins natively and interpret them as usual instead" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "no_tactics",
+                                                                    "no_plugins",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2826,12 +2829,12 @@ let rec (specs_with_types :
                                                                     let uu___219
                                                                     =
                                                                     text
-                                                                    "Prunes the context to include only the facts from the given namespace or fact id. Facts can be include or excluded using the [+|-] qualifier. For example --using_facts_from '* -FStar.Reflection +FStar.Compiler.List -FStar.Compiler.List.Tot' will remove all facts from FStar.Compiler.List.Tot.*, retain all remaining facts from FStar.Compiler.List.*, remove all facts from FStar.Reflection.*, and retain all the rest. Note, the '+' is optional: --using_facts_from 'FStar.Compiler.List' is equivalent to --using_facts_from '+FStar.Compiler.List'. Multiple uses of this option accumulate, e.g., --using_facts_from A --using_facts_from B is interpreted as --using_facts_from A^B." in
+                                                                    "Do not run the tactic engine before discharging a VC" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "using_facts_from",
-                                                                    (ReverseAccumulated
-                                                                    (SimpleStr
-                                                                    "One or more space-separated occurrences of '[+|-]( * | namespace | fact id)'")),
+                                                                    "no_tactics",
+                                                                    (Const
+                                                                    (Bool
+                                                                    true)),
                                                                     uu___219) in
                                                                     let uu___219
                                                                     =
@@ -2840,12 +2843,12 @@ let rec (specs_with_types :
                                                                     let uu___221
                                                                     =
                                                                     text
-                                                                    "This does nothing and will be removed" in
+                                                                    "Prunes the context to include only the facts from the given namespace or fact id. Facts can be include or excluded using the [+|-] qualifier. For example --using_facts_from '* -FStar.Reflection +FStar.Compiler.List -FStar.Compiler.List.Tot' will remove all facts from FStar.Compiler.List.Tot.*, retain all remaining facts from FStar.Compiler.List.*, remove all facts from FStar.Reflection.*, and retain all the rest. Note, the '+' is optional: --using_facts_from 'FStar.Compiler.List' is equivalent to --using_facts_from '+FStar.Compiler.List'. Multiple uses of this option accumulate, e.g., --using_facts_from A --using_facts_from B is interpreted as --using_facts_from A^B." in
                                                                     (FStar_Getopt.noshort,
-                                                                    "__temp_fast_implicits",
-                                                                    (Const
-                                                                    (Bool
-                                                                    true)),
+                                                                    "using_facts_from",
+                                                                    (ReverseAccumulated
+                                                                    (SimpleStr
+                                                                    "One or more space-separated occurrences of '[+|-]( * | namespace | fact id)'")),
                                                                     uu___221) in
                                                                     let uu___221
                                                                     =
@@ -2854,20 +2857,12 @@ let rec (specs_with_types :
                                                                     let uu___223
                                                                     =
                                                                     text
-                                                                    "Display version number" in
-                                                                    (118,
-                                                                    "version",
-                                                                    (WithSideEffect
-                                                                    ((fun
-                                                                    uu___224
-                                                                    ->
-                                                                    display_version
-                                                                    ();
-                                                                    FStar_Compiler_Effect.exit
-                                                                    Prims.int_zero),
+                                                                    "This does nothing and will be removed" in
+                                                                    (FStar_Getopt.noshort,
+                                                                    "__temp_fast_implicits",
                                                                     (Const
                                                                     (Bool
-                                                                    true)))),
+                                                                    true)),
                                                                     uu___223) in
                                                                     let uu___223
                                                                     =
@@ -2876,12 +2871,20 @@ let rec (specs_with_types :
                                                                     let uu___225
                                                                     =
                                                                     text
-                                                                    "Warn when (a -> b) is desugared to (a -> Tot b)" in
-                                                                    (FStar_Getopt.noshort,
-                                                                    "warn_default_effects",
+                                                                    "Display version number" in
+                                                                    (118,
+                                                                    "version",
+                                                                    (WithSideEffect
+                                                                    ((fun
+                                                                    uu___226
+                                                                    ->
+                                                                    display_version
+                                                                    ();
+                                                                    FStar_Compiler_Effect.exit
+                                                                    Prims.int_zero),
                                                                     (Const
                                                                     (Bool
-                                                                    true)),
+                                                                    true)))),
                                                                     uu___225) in
                                                                     let uu___225
                                                                     =
@@ -2890,12 +2893,12 @@ let rec (specs_with_types :
                                                                     let uu___227
                                                                     =
                                                                     text
-                                                                    "Z3 command line options" in
+                                                                    "Warn when (a -> b) is desugared to (a -> Tot b)" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "z3cliopt",
-                                                                    (ReverseAccumulated
-                                                                    (SimpleStr
-                                                                    "option")),
+                                                                    "warn_default_effects",
+                                                                    (Const
+                                                                    (Bool
+                                                                    true)),
                                                                     uu___227) in
                                                                     let uu___227
                                                                     =
@@ -2904,9 +2907,9 @@ let rec (specs_with_types :
                                                                     let uu___229
                                                                     =
                                                                     text
-                                                                    "Z3 options in smt2 format" in
+                                                                    "Z3 command line options" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "z3smtopt",
+                                                                    "z3cliopt",
                                                                     (ReverseAccumulated
                                                                     (SimpleStr
                                                                     "option")),
@@ -2918,12 +2921,12 @@ let rec (specs_with_types :
                                                                     let uu___231
                                                                     =
                                                                     text
-                                                                    "Restart Z3 after each query; useful for ensuring proof robustness" in
+                                                                    "Z3 options in smt2 format" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "z3refresh",
-                                                                    (Const
-                                                                    (Bool
-                                                                    true)),
+                                                                    "z3smtopt",
+                                                                    (ReverseAccumulated
+                                                                    (SimpleStr
+                                                                    "option")),
                                                                     uu___231) in
                                                                     let uu___231
                                                                     =
@@ -2932,11 +2935,12 @@ let rec (specs_with_types :
                                                                     let uu___233
                                                                     =
                                                                     text
-                                                                    "Set the Z3 per-query resource limit (default 5 units, taking roughtly 5s)" in
+                                                                    "Restart Z3 after each query; useful for ensuring proof robustness" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "z3rlimit",
-                                                                    (IntStr
-                                                                    "positive_integer"),
+                                                                    "z3refresh",
+                                                                    (Const
+                                                                    (Bool
+                                                                    true)),
                                                                     uu___233) in
                                                                     let uu___233
                                                                     =
@@ -2945,9 +2949,9 @@ let rec (specs_with_types :
                                                                     let uu___235
                                                                     =
                                                                     text
-                                                                    "Set the Z3 per-query resource limit multiplier. This is useful when, say, regenerating hints and you want to be more lax. (default 1)" in
+                                                                    "Set the Z3 per-query resource limit (default 5 units, taking roughtly 5s)" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "z3rlimit_factor",
+                                                                    "z3rlimit",
                                                                     (IntStr
                                                                     "positive_integer"),
                                                                     uu___235) in
@@ -2958,9 +2962,9 @@ let rec (specs_with_types :
                                                                     let uu___237
                                                                     =
                                                                     text
-                                                                    "Set the Z3 random seed (default 0)" in
+                                                                    "Set the Z3 per-query resource limit multiplier. This is useful when, say, regenerating hints and you want to be more lax. (default 1)" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "z3seed",
+                                                                    "z3rlimit_factor",
                                                                     (IntStr
                                                                     "positive_integer"),
                                                                     uu___237) in
@@ -2971,11 +2975,11 @@ let rec (specs_with_types :
                                                                     let uu___239
                                                                     =
                                                                     text
-                                                                    "Set the version of Z3 that is to be used. Default: 4.8.5" in
+                                                                    "Set the Z3 random seed (default 0)" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "z3version",
-                                                                    (SimpleStr
-                                                                    "version"),
+                                                                    "z3seed",
+                                                                    (IntStr
+                                                                    "positive_integer"),
                                                                     uu___239) in
                                                                     let uu___239
                                                                     =
@@ -2984,12 +2988,25 @@ let rec (specs_with_types :
                                                                     let uu___241
                                                                     =
                                                                     text
+                                                                    "Set the version of Z3 that is to be used. Default: 4.8.5" in
+                                                                    (FStar_Getopt.noshort,
+                                                                    "z3version",
+                                                                    (SimpleStr
+                                                                    "version"),
+                                                                    uu___241) in
+                                                                    let uu___241
+                                                                    =
+                                                                    let uu___242
+                                                                    =
+                                                                    let uu___243
+                                                                    =
+                                                                    text
                                                                     "Don't check positivity of inductive types" in
                                                                     (FStar_Getopt.noshort,
                                                                     "__no_positivity",
                                                                     (WithSideEffect
                                                                     ((fun
-                                                                    uu___242
+                                                                    uu___244
                                                                     ->
                                                                     if
                                                                     warn_unsafe
@@ -3000,63 +3017,6 @@ let rec (specs_with_types :
                                                                     (Const
                                                                     (Bool
                                                                     true)))),
-                                                                    uu___241) in
-                                                                    let uu___241
-                                                                    =
-                                                                    let uu___242
-                                                                    =
-                                                                    let uu___243
-                                                                    =
-                                                                    let uu___244
-                                                                    =
-                                                                    text
-                                                                    "The [-warn_error] option follows the OCaml syntax, namely:" in
-                                                                    let uu___245
-                                                                    =
-                                                                    let uu___246
-                                                                    =
-                                                                    let uu___247
-                                                                    =
-                                                                    text
-                                                                    "[r] is a range of warnings (either a number [n], or a range [n..n])" in
-                                                                    let uu___248
-                                                                    =
-                                                                    let uu___249
-                                                                    =
-                                                                    text
-                                                                    "[-r] silences range [r]" in
-                                                                    let uu___250
-                                                                    =
-                                                                    let uu___251
-                                                                    =
-                                                                    text
-                                                                    "[+r] enables range [r] as warnings (NOTE: \"enabling\" an error will downgrade it to a warning)" in
-                                                                    let uu___252
-                                                                    =
-                                                                    let uu___253
-                                                                    =
-                                                                    text
-                                                                    "[@r] makes range [r] fatal." in
-                                                                    [uu___253] in
-                                                                    uu___251
-                                                                    ::
-                                                                    uu___252 in
-                                                                    uu___249
-                                                                    ::
-                                                                    uu___250 in
-                                                                    uu___247
-                                                                    ::
-                                                                    uu___248 in
-                                                                    FStar_Errors_Msg.bulleted
-                                                                    uu___246 in
-                                                                    FStar_Pprint.op_Hat_Hat
-                                                                    uu___244
-                                                                    uu___245 in
-                                                                    (FStar_Getopt.noshort,
-                                                                    "warn_error",
-                                                                    (ReverseAccumulated
-                                                                    (SimpleStr
-                                                                    "")),
                                                                     uu___243) in
                                                                     let uu___243
                                                                     =
@@ -3064,11 +3024,56 @@ let rec (specs_with_types :
                                                                     =
                                                                     let uu___245
                                                                     =
+                                                                    let uu___246
+                                                                    =
                                                                     text
-                                                                    "Use normalization by evaluation as the default normalization strategy (default 'false')" in
+                                                                    "The [-warn_error] option follows the OCaml syntax, namely:" in
+                                                                    let uu___247
+                                                                    =
+                                                                    let uu___248
+                                                                    =
+                                                                    let uu___249
+                                                                    =
+                                                                    text
+                                                                    "[r] is a range of warnings (either a number [n], or a range [n..n])" in
+                                                                    let uu___250
+                                                                    =
+                                                                    let uu___251
+                                                                    =
+                                                                    text
+                                                                    "[-r] silences range [r]" in
+                                                                    let uu___252
+                                                                    =
+                                                                    let uu___253
+                                                                    =
+                                                                    text
+                                                                    "[+r] enables range [r] as warnings (NOTE: \"enabling\" an error will downgrade it to a warning)" in
+                                                                    let uu___254
+                                                                    =
+                                                                    let uu___255
+                                                                    =
+                                                                    text
+                                                                    "[@r] makes range [r] fatal." in
+                                                                    [uu___255] in
+                                                                    uu___253
+                                                                    ::
+                                                                    uu___254 in
+                                                                    uu___251
+                                                                    ::
+                                                                    uu___252 in
+                                                                    uu___249
+                                                                    ::
+                                                                    uu___250 in
+                                                                    FStar_Errors_Msg.bulleted
+                                                                    uu___248 in
+                                                                    FStar_Pprint.op_Hat_Hat
+                                                                    uu___246
+                                                                    uu___247 in
                                                                     (FStar_Getopt.noshort,
-                                                                    "use_nbe",
-                                                                    BoolStr,
+                                                                    "warn_error",
+                                                                    (ReverseAccumulated
+                                                                    (SimpleStr
+                                                                    "")),
                                                                     uu___245) in
                                                                     let uu___245
                                                                     =
@@ -3077,9 +3082,9 @@ let rec (specs_with_types :
                                                                     let uu___247
                                                                     =
                                                                     text
-                                                                    "Use normalization by evaluation for normalizing terms before extraction (default 'false')" in
+                                                                    "Use normalization by evaluation as the default normalization strategy (default 'false')" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "use_nbe_for_extraction",
+                                                                    "use_nbe",
                                                                     BoolStr,
                                                                     uu___247) in
                                                                     let uu___247
@@ -3089,9 +3094,9 @@ let rec (specs_with_types :
                                                                     let uu___249
                                                                     =
                                                                     text
-                                                                    "Enforce trivial preconditions for unannotated effectful functions (default 'true')" in
+                                                                    "Use normalization by evaluation for normalizing terms before extraction (default 'false')" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "trivial_pre_for_unannotated_effectful_fns",
+                                                                    "use_nbe_for_extraction",
                                                                     BoolStr,
                                                                     uu___249) in
                                                                     let uu___249
@@ -3101,19 +3106,10 @@ let rec (specs_with_types :
                                                                     let uu___251
                                                                     =
                                                                     text
-                                                                    "Debug messages for embeddings/unembeddings of natively compiled terms" in
+                                                                    "Enforce trivial preconditions for unannotated effectful functions (default 'true')" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "__debug_embedding",
-                                                                    (WithSideEffect
-                                                                    ((fun
-                                                                    uu___252
-                                                                    ->
-                                                                    FStar_Compiler_Effect.op_Colon_Equals
-                                                                    debug_embedding
-                                                                    true),
-                                                                    (Const
-                                                                    (Bool
-                                                                    true)))),
+                                                                    "trivial_pre_for_unannotated_effectful_fns",
+                                                                    BoolStr,
                                                                     uu___251) in
                                                                     let uu___251
                                                                     =
@@ -3122,15 +3118,15 @@ let rec (specs_with_types :
                                                                     let uu___253
                                                                     =
                                                                     text
-                                                                    "Eagerly embed and unembed terms to primitive operations and plugins: not recommended except for benchmarking" in
+                                                                    "Debug messages for embeddings/unembeddings of natively compiled terms" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "eager_embedding",
+                                                                    "__debug_embedding",
                                                                     (WithSideEffect
                                                                     ((fun
                                                                     uu___254
                                                                     ->
                                                                     FStar_Compiler_Effect.op_Colon_Equals
-                                                                    eager_embedding
+                                                                    debug_embedding
                                                                     true),
                                                                     (Const
                                                                     (Bool
@@ -3143,12 +3139,19 @@ let rec (specs_with_types :
                                                                     let uu___255
                                                                     =
                                                                     text
-                                                                    "Emit profiles grouped by declaration rather than by module" in
+                                                                    "Eagerly embed and unembed terms to primitive operations and plugins: not recommended except for benchmarking" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "profile_group_by_decl",
+                                                                    "eager_embedding",
+                                                                    (WithSideEffect
+                                                                    ((fun
+                                                                    uu___256
+                                                                    ->
+                                                                    FStar_Compiler_Effect.op_Colon_Equals
+                                                                    eager_embedding
+                                                                    true),
                                                                     (Const
                                                                     (Bool
-                                                                    true)),
+                                                                    true)))),
                                                                     uu___255) in
                                                                     let uu___255
                                                                     =
@@ -3157,12 +3160,12 @@ let rec (specs_with_types :
                                                                     let uu___257
                                                                     =
                                                                     text
-                                                                    "Specific source locations in the compiler are instrumented with profiling counters. Pass `--profile_component FStar.TypeChecker` to enable all counters in the FStar.TypeChecker namespace. This option is a module or namespace selector, like many other options (e.g., `--extract`)" in
+                                                                    "Emit profiles grouped by declaration rather than by module" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "profile_component",
-                                                                    (Accumulated
-                                                                    (SimpleStr
-                                                                    "One or more space-separated occurrences of '[+|-]( * | namespace | module | identifier)'")),
+                                                                    "profile_group_by_decl",
+                                                                    (Const
+                                                                    (Bool
+                                                                    true)),
                                                                     uu___257) in
                                                                     let uu___257
                                                                     =
@@ -3171,12 +3174,12 @@ let rec (specs_with_types :
                                                                     let uu___259
                                                                     =
                                                                     text
-                                                                    "Profiling can be enabled when the compiler is processing a given set of source modules. Pass `--profile FStar.Pervasives` to enable profiling when the compiler is processing any module in FStar.Pervasives. This option is a module or namespace selector, like many other options (e.g., `--extract`)" in
+                                                                    "Specific source locations in the compiler are instrumented with profiling counters. Pass `--profile_component FStar.TypeChecker` to enable all counters in the FStar.TypeChecker namespace. This option is a module or namespace selector, like many other options (e.g., `--extract`)" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "profile",
+                                                                    "profile_component",
                                                                     (Accumulated
                                                                     (SimpleStr
-                                                                    "One or more space-separated occurrences of '[+|-]( * | namespace | module)'")),
+                                                                    "One or more space-separated occurrences of '[+|-]( * | namespace | module | identifier)'")),
                                                                     uu___259) in
                                                                     let uu___259
                                                                     =
@@ -3185,25 +3188,12 @@ let rec (specs_with_types :
                                                                     let uu___261
                                                                     =
                                                                     text
-                                                                    "Display this information" in
-                                                                    (104,
-                                                                    "help",
-                                                                    (WithSideEffect
-                                                                    ((fun
-                                                                    uu___262
-                                                                    ->
-                                                                    (
-                                                                    let uu___264
-                                                                    =
-                                                                    specs
-                                                                    warn_unsafe in
-                                                                    display_usage_aux
-                                                                    uu___264);
-                                                                    FStar_Compiler_Effect.exit
-                                                                    Prims.int_zero),
-                                                                    (Const
-                                                                    (Bool
-                                                                    true)))),
+                                                                    "Profiling can be enabled when the compiler is processing a given set of source modules. Pass `--profile FStar.Pervasives` to enable profiling when the compiler is processing any module in FStar.Pervasives. This option is a module or namespace selector, like many other options (e.g., `--extract`)" in
+                                                                    (FStar_Getopt.noshort,
+                                                                    "profile",
+                                                                    (Accumulated
+                                                                    (SimpleStr
+                                                                    "One or more space-separated occurrences of '[+|-]( * | namespace | module)'")),
                                                                     uu___261) in
                                                                     let uu___261
                                                                     =
@@ -3212,12 +3202,39 @@ let rec (specs_with_types :
                                                                     let uu___263
                                                                     =
                                                                     text
+                                                                    "Display this information" in
+                                                                    (104,
+                                                                    "help",
+                                                                    (WithSideEffect
+                                                                    ((fun
+                                                                    uu___264
+                                                                    ->
+                                                                    (
+                                                                    let uu___266
+                                                                    =
+                                                                    specs
+                                                                    warn_unsafe in
+                                                                    display_usage_aux
+                                                                    uu___266);
+                                                                    FStar_Compiler_Effect.exit
+                                                                    Prims.int_zero),
+                                                                    (Const
+                                                                    (Bool
+                                                                    true)))),
+                                                                    uu___263) in
+                                                                    let uu___263
+                                                                    =
+                                                                    let uu___264
+                                                                    =
+                                                                    let uu___265
+                                                                    =
+                                                                    text
                                                                     "List all debug keys and exit" in
                                                                     (FStar_Getopt.noshort,
                                                                     "list_debug_keys",
                                                                     (WithSideEffect
                                                                     ((fun
-                                                                    uu___264
+                                                                    uu___266
                                                                     ->
                                                                     display_debug_keys
                                                                     ();
@@ -3226,8 +3243,11 @@ let rec (specs_with_types :
                                                                     (Const
                                                                     (Bool
                                                                     true)))),
-                                                                    uu___263) in
-                                                                    [uu___262] in
+                                                                    uu___265) in
+                                                                    [uu___264] in
+                                                                    uu___262
+                                                                    ::
+                                                                    uu___263 in
                                                                     uu___260
                                                                     ::
                                                                     uu___261 in
@@ -3683,7 +3703,7 @@ let (settable_specs :
     (fun uu___ ->
        match uu___ with | ((uu___1, x, uu___2), uu___3) -> settable x)
     all_specs
-let (uu___661 :
+let (uu___662 :
   (((unit -> FStar_Getopt.parse_cmdline_res) -> unit) *
     (unit -> FStar_Getopt.parse_cmdline_res)))
   =
@@ -3700,11 +3720,11 @@ let (uu___661 :
   (set1, call)
 let (set_error_flags_callback_aux :
   (unit -> FStar_Getopt.parse_cmdline_res) -> unit) =
-  match uu___661 with
+  match uu___662 with
   | (set_error_flags_callback_aux1, set_error_flags) ->
       set_error_flags_callback_aux1
 let (set_error_flags : unit -> FStar_Getopt.parse_cmdline_res) =
-  match uu___661 with
+  match uu___662 with
   | (set_error_flags_callback_aux1, set_error_flags1) -> set_error_flags1
 let (set_error_flags_callback :
   (unit -> FStar_Getopt.parse_cmdline_res) -> unit) =
@@ -4207,6 +4227,8 @@ let (query_cache : unit -> Prims.bool) = fun uu___ -> get_query_cache ()
 let (query_stats : unit -> Prims.bool) = fun uu___ -> get_query_stats ()
 let (read_checked_file : unit -> Prims.string FStar_Pervasives_Native.option)
   = fun uu___ -> get_read_checked_file ()
+let (read_krml_file : unit -> Prims.string FStar_Pervasives_Native.option) =
+  fun uu___ -> get_read_krml_file ()
 let (record_hints : unit -> Prims.bool) = fun uu___ -> get_record_hints ()
 let (record_options : unit -> Prims.bool) =
   fun uu___ -> get_record_options ()

--- a/src/basic/FStar.Options.fst
+++ b/src/basic/FStar.Options.fst
@@ -239,6 +239,7 @@ let defaults =
       ("query_cache"                  , Bool false);
       ("query_stats"                  , Bool false);
       ("read_checked_file"            , Unset);
+      ("read_krml_file"               , Unset);
       ("record_hints"                 , Bool false);
       ("record_options"               , Bool false);
       ("report_assumes"               , Unset);
@@ -427,6 +428,7 @@ let get_quake_keep              ()      = lookup_opt "quake_keep"               
 let get_query_cache             ()      = lookup_opt "query_cache"              as_bool
 let get_query_stats             ()      = lookup_opt "query_stats"              as_bool
 let get_read_checked_file       ()      = lookup_opt "read_checked_file"        (as_option as_string)
+let get_read_krml_file          ()      = lookup_opt "read_krml_file"           (as_option as_string)
 let get_record_hints            ()      = lookup_opt "record_hints"             as_bool
 let get_record_options          ()      = lookup_opt "record_options"           as_bool
 let get_retry                   ()      = lookup_opt "retry"                    as_bool
@@ -1158,6 +1160,11 @@ let rec specs_with_types warn_unsafe : list (char & string & opt_type & Pprint.d
     "read_checked_file",
     PathStr "path",
     text "Read a checked file and dump it to standard output.");
+
+  ( noshort,
+    "read_krml_file",
+    PathStr "path",
+    text "Read a Karamel binary file and dump it to standard output.");
 
   ( noshort,
     "record_hints",
@@ -1945,6 +1952,7 @@ let quake_keep                   () = get_quake_keep                  ()
 let query_cache                  () = get_query_cache                 ()
 let query_stats                  () = get_query_stats                 ()
 let read_checked_file            () = get_read_checked_file           ()
+let read_krml_file               () = get_read_krml_file              ()
 let record_hints                 () = get_record_hints                ()
 let record_options               () = get_record_options              ()
 let retry                        () = get_retry                       ()

--- a/src/basic/FStar.Options.fsti
+++ b/src/basic/FStar.Options.fsti
@@ -186,6 +186,7 @@ val quake_keep                  : unit    -> bool
 val query_cache                 : unit    -> bool
 val query_stats                 : unit    -> bool
 val read_checked_file           : unit    -> option string
+val read_krml_file              : unit    -> option string
 val record_hints                : unit    -> bool
 val record_options              : unit    -> bool
 val retry                       : unit    -> bool

--- a/src/extraction/FStar.Extraction.Krml.fst
+++ b/src/extraction/FStar.Extraction.Krml.fst
@@ -195,6 +195,158 @@ and typ =
   | TConstBuf of typ
   | TArray of typ & constant
 
+instance showable_width = { show = function
+  | UInt8 -> "UInt8"
+  | UInt16 -> "UInt16"
+  | UInt32 -> "UInt32"
+  | UInt64 -> "UInt64"
+  | Int8 -> "Int8"
+  | Int16 -> "Int16"
+  | Int32 -> "Int32"
+  | Int64 -> "Int64"
+  | Bool -> "Bool"
+  | CInt -> "CInt"
+  | SizeT -> "SizeT"
+  | PtrdiffT -> "PtrdiffT"
+}
+
+let rec typ_to_string (t:typ) : string =
+  match t with
+  | TInt w -> "TInt " ^ show w
+  | TBuf t -> "TBuf " ^ typ_to_string t
+  | TUnit -> "TUnit"
+  | TQualified x -> "TQualified " ^ show x
+  | TBool -> "TBool"
+  | TAny -> "TAny"
+  | TArrow (t1, t2) -> "TArrow (" ^ typ_to_string t1 ^ ", " ^ typ_to_string t2 ^ ")"
+  | TBound x -> "TBound " ^ show x
+  | TApp (x, xs) -> "TApp (" ^ show x ^ ", " ^ Common.string_of_list typ_to_string xs ^ ")"
+  | TTuple ts -> "TTuple " ^ Common.string_of_list typ_to_string ts
+  | TConstBuf t -> "TConstBuf " ^ typ_to_string t
+  | TArray (t, c) -> "TArray (" ^ typ_to_string t ^ ", " ^ show c ^ ")"
+  
+instance showable_typ = { show = typ_to_string }
+
+instance showable_binder = { show = fun {name; typ; mut} ->
+  "binder{ name = " ^ name ^ "; typ = " ^ typ_to_string typ ^ "; mut = " ^ show mut ^ "; }"
+}
+
+instance showable_flag = { show = function
+  | Private -> "Private"
+  | WipeBody -> "WipeBody"
+  | CInline -> "CInline"
+  | Substitute -> "Substitute"
+  | GCType -> "GCType"
+  | Comment s -> "Comment " ^ s
+  | MustDisappear -> "MustDisappear"
+  | Const s -> "Const " ^ s
+  | Prologue s -> "Prologue " ^ s
+  | Epilogue s -> "Epilogue " ^ s
+  | Abstract -> "Abstract"
+  | IfDef -> "IfDef"
+  | Macro -> "Macro"
+  | Deprecated s -> "Deprecated " ^ s
+  | CNoInline -> "CNoInline"
+}
+
+instance showable_lifetime : showable lifetime = { show = function
+  | Eternal -> "Eternal"
+  | Stack -> "Stack"
+  | ManuallyManaged -> "ManuallyManaged"
+}
+
+instance showable_op = { show = function
+  | Add -> "Add"
+  | AddW -> "AddW"
+  | Sub -> "Sub"
+  | SubW -> "SubW"
+  | Div -> "Div"
+  | DivW -> "DivW"
+  | Mult -> "Mult"
+  | MultW -> "MultW"
+  | Mod -> "Mod"
+  | BOr -> "BOr"
+  | BAnd -> "BAnd"
+  | BXor -> "BXor"
+  | BShiftL -> "BShiftL"
+  | BShiftR -> "BShiftR"
+  | BNot -> "BNot"
+  | Eq -> "Eq"
+  | Neq -> "Neq"
+  | Lt -> "Lt"
+  | Lte -> "Lte"
+  | Gt -> "Gt"
+  | Gte -> "Gte"
+  | And -> "And"
+  | Or -> "Or"
+  | Xor -> "Xor"
+  | Not -> "Not"
+}
+
+instance showable_cc = { show = function
+  | StdCall -> "StdCall"
+  | CDecl -> "CDecl"
+  | FastCall -> "FastCall"
+}
+
+let rec decl_to_string (d:decl) : string =
+  match d with
+  | DGlobal (fs, x, i, t, e) -> "DGlobal (" ^ show fs ^ ", " ^ show x ^ ", " ^ show i ^ ", " ^ typ_to_string t ^ ", " ^ expr_to_string e ^ ")"
+  | DFunction (cc, fs, i, t, x, bs, e) -> "DFunction (" ^ show cc ^ ", " ^ show fs ^ ", " ^ show i ^ ", " ^ typ_to_string t ^ ", " ^ show x ^ ", " ^ Common.string_of_list show bs ^ ", " ^ expr_to_string e ^ ")"
+  | DTypeAlias (x, fs, i, t) -> "DTypeAlias (" ^ show x ^ ", " ^ show fs ^ ", " ^ show i ^ ", " ^ typ_to_string t ^ ")"
+  | DTypeFlat (x, fs, i, f) -> "DTypeFlat (" ^ show x ^ ", " ^ show fs ^ ", " ^ show i ^ ", " ^ show f ^ ")"
+  | DUnusedRetainedForBackwardsCompat (cc, fs, x, t) -> "DUnusedRetainedForBackwardsCompat (" ^ show cc ^ ", " ^ show fs ^ ", " ^ show x ^ ", " ^ typ_to_string t ^ ")"
+  | DTypeVariant (x, fs, i, bs) -> "DTypeVariant (" ^ show x ^ ", " ^ show fs ^ ", " ^ show i ^ ", " ^ show bs ^ ")"
+  | DTypeAbstractStruct x -> "DTypeAbstractStruct " ^ show x
+  | DExternal (cc, fs, x, t, xs) -> "DExternal (" ^ show cc ^ ", " ^ show fs ^ ", " ^ show x ^ ", " ^ typ_to_string t ^ ", " ^ Common.string_of_list show xs ^ ")"
+  | DUntaggedUnion (x, fs, i, xs) -> "DUntaggedUnion (" ^ show x ^ ", " ^ show fs ^ ", " ^ show i ^ ", " ^ show xs ^ ")"
+  
+and expr_to_string (e:expr) : string =
+  match e with
+  | EBound x -> "EBound " ^ show x
+  | EQualified x -> "EQualified " ^ show x
+  | EConstant x -> "EConstant " ^ show x
+  | EUnit -> "EUnit"
+  | EApp (x, xs) -> "EApp " ^ expr_to_string x ^ Common.string_of_list expr_to_string xs
+  | ETypApp (x, xs) -> "ETypApp " ^ expr_to_string x // ^ Common.string_of_list expr_to_string xs
+  | ELet (x, y, z) -> "ELet (" ^ show x ^ ", " ^ expr_to_string y ^ ", " ^ expr_to_string z ^ ")"
+  | EIfThenElse (x, y, z) -> "EIfThenElse (" ^ expr_to_string x ^ ", " ^ expr_to_string y ^ ", " ^ expr_to_string z ^ ")"
+  | ESequence xs -> "ESequence " ^ Common.string_of_list expr_to_string xs
+  | EAssign (x, y) -> "EAssign (" ^ expr_to_string x ^ ", " ^ expr_to_string y ^ ")"
+  | EBufCreate (x, y, z) -> "EBufCreate (" ^ show x ^ ", " ^ expr_to_string y ^ ", " ^ expr_to_string z ^ ")"
+  | EBufRead (x, y) -> "EBufRead (" ^ expr_to_string x ^ ", " ^ expr_to_string y ^ ")"
+  | EBufWrite (x, y, z) -> "EBufWrite (" ^ expr_to_string x ^ ", " ^ expr_to_string y ^ ", " ^ expr_to_string z ^ ")"
+  | EBufSub (x, y) -> "EBufSub (" ^ expr_to_string x ^ ", " ^ expr_to_string y ^ ")"
+  | EBufBlit (x, y, z, a, b) -> "EBufBlit (" ^ expr_to_string x ^ ", " ^ expr_to_string y ^ ", " ^ expr_to_string z ^ ", " ^ expr_to_string a ^ ", " ^ expr_to_string b ^ ")"
+  | EMatch (x, bs) -> "EMatch (" ^ expr_to_string x ^ ", " ^ Common.string_of_list (fun _ -> "iou") bs ^ ")"
+  | EOp (x, y) -> "EOp (" ^ show x ^ ", " ^ show y ^ ")"
+  | ECast (x, y) -> "ECast (" ^ expr_to_string x ^ ", " ^ typ_to_string y ^ ")"
+  | EPushFrame -> "EPushFrame"
+  | EPopFrame -> "EPopFrame"
+  | EBool x -> "EBool " ^ show x
+  | EAny -> "EAny"
+  | EAbort -> "EAbort"
+  | EReturn x -> "EReturn " ^ expr_to_string x
+  | EFlat (x, xs) -> "EFlat (" ^ typ_to_string x ^ ", " ^ Common.string_of_list (fun (s,e) -> "(" ^ s ^ ", " ^ expr_to_string e ^ ")") xs ^ ")"
+  | EField (x, y, z) -> "EField (" ^ typ_to_string x ^ ", " ^ expr_to_string y ^ ", " ^ show z ^ ")"
+  | EWhile (x, y) -> "EWhile (" ^ expr_to_string x ^ ", " ^ expr_to_string y ^ ")"
+  | EBufCreateL (x, xs) -> "EBufCreateL (" ^ show x ^ ", " ^ Common.string_of_list expr_to_string xs ^ ")"
+  | ETuple xs -> "ETuple " ^ Common.string_of_list expr_to_string xs
+  | ECons (x, y, xs) -> "ECons (" ^ typ_to_string x ^ ", " ^ show y ^ ", " ^ Common.string_of_list expr_to_string xs ^ ")"
+  | EBufFill (x, y, z) -> "EBufFill (" ^ expr_to_string x ^ ", " ^ expr_to_string y ^ ", " ^ expr_to_string z ^ ")"
+  | EString x -> "EString " ^ show x
+  | EFun (xs, y, z) -> "EFun (" ^ Common.string_of_list show xs ^ ", " ^ expr_to_string y ^ ", " ^ typ_to_string z ^ ")"
+  | EAbortS x -> "EAbortS " ^ show x
+  | EBufFree x -> "EBufFree " ^ expr_to_string x
+  | EBufCreateNoInit (x, y) -> "EBufCreateNoInit (" ^ show x ^ ", " ^ expr_to_string y ^ ")"
+  | EAbortT (x, y) -> "EAbortT (" ^ show x ^ ", " ^ typ_to_string y ^ ")"
+  | EComment (x, y, z) -> "EComment (" ^ show x ^ ", " ^ expr_to_string y ^ ", " ^ show z ^ ")"
+  | EStandaloneComment x -> "EStandaloneComment " ^ show x
+  | EAddrOf x -> "EAddrOf " ^ expr_to_string x
+  | EBufNull x -> "EBufNull " ^ typ_to_string x
+  | EBufDiff (x, y) -> "EBufDiff (" ^ expr_to_string x ^ ", " ^ expr_to_string y ^ ")"
+
+instance showable_decl = { show = decl_to_string }
 
 let current_version: version = 28
 

--- a/src/extraction/FStar.Extraction.Krml.fsti
+++ b/src/extraction/FStar.Extraction.Krml.fsti
@@ -16,7 +16,12 @@
 (* -------------------------------------------------------------------- *)
 module FStar.Extraction.Krml
 
+open FStar.Class.Show
+
 val decl : Type0
+
+instance val showable_decl : showable decl
+
 type program = list decl
 type file = string & program
 

--- a/src/fstar/FStar.Main.fst
+++ b/src/fstar/FStar.Main.fst
@@ -191,6 +191,23 @@ let go _ =
 
           | Some (_, tcr) ->
             print1 "%s\n" (show tcr.checked_module)
+
+        else if Some? (Options.read_krml_file ()) then
+          let path = Some?.v <| Options.read_krml_file () in
+          match load_value_from_file path <: option FStar.Extraction.Krml.binary_format with
+          | None ->
+            let open FStar.Pprint in
+            Errors.raise_err_doc (Errors.Fatal_ModuleOrFileNotFound, [
+                Errors.Msg.text "Could not read krml file:" ^/^ doc_of_string path
+              ])
+          | Some (version, files) ->
+            print1 "Karamel format version: %s\n" (show version);
+            (* Just "show decls" would print it, we just format this a bit *)
+            files |> List.iter (fun (name, decls) ->
+              print1 "%s:\n" name;
+              decls |> List.iter (fun d -> print1 "  %s\n" (show d))
+            )
+
         (* --lsp *)
         else if Options.lsp_server () then
           FStar.Interactive.Lsp.start_server ()


### PR DESCRIPTION
cc @msprotz , you may find this useful too.

```
$ cat A.fst
module A

let x = 123ul
$ ./bin/fstar.exe A.fst --codegen krml
[...]
$ ./bin/fstar.exe --read_krml_file out.krml | tail
  DGlobal ([], (["FStar", "UInt32"], "op_Greater_Equals_Hat"), 0, TArrow (TInt UInt32, TArrow (TInt UInt32, TBool)), EOp (Gte, UInt32))
  DGlobal ([], (["FStar", "UInt32"], "op_Less_Hat"), 0, TArrow (TInt UInt32, TArrow (TInt UInt32, TBool)), EOp (Lt, UInt32))
  DGlobal ([], (["FStar", "UInt32"], "op_Less_Equals_Hat"), 0, TArrow (TInt UInt32, TArrow (TInt UInt32, TBool)), EOp (Lte, UInt32))
  DExternal (None, [], (["FStar", "UInt32"], "to_string"), TArrow (TInt UInt32, TQualified (["Prims"], "string")), ["uu___"])
  DExternal (None, [], (["FStar", "UInt32"], "to_string_hex"), TArrow (TInt UInt32, TQualified (["Prims"], "string")), ["uu___"])
  DExternal (None, [], (["FStar", "UInt32"], "to_string_hex_pad"), TArrow (TInt UInt32, TQualified (["Prims"], "string")), ["uu___"])
  DExternal (None, [], (["FStar", "UInt32"], "of_string"), TArrow (TQualified (["Prims"], "string"), TInt UInt32), ["uu___"])
  DFunction (None, [Private], 0, TInt UInt32, (["FStar", "UInt32"], "__uint_to_t"), [binder{ name = x; typ = TQualified (["Prims"], "int"); mut = false; }], EApp EQualified (["FStar", "UInt32"], "uint_to_t")[EBound 0])
A:
  DGlobal ([], (["A"], "x"), 0, TInt UInt32, EConstant (UInt32, "123"))
```

It tries to print absolutely everything, no fancy formatting.