### PR TITLE
Avoid wildcard expansion when making F# builds

### DIFF
--- a/ulib/Makefile.extract.fsharp
+++ b/ulib/Makefile.extract.fsharp
@@ -31,7 +31,7 @@ MY_FSTAR=$(FSTAR) $(OTHERFLAGS) --warn_error @241 --cache_checked_modules --odir
 # And then, in a separate invocation, from each .checked file we
 # extract an .fs file
 $(OUTPUT_DIRECTORY)/%.fs:
-	$(MY_FSTAR) --already_cached '*' $(subst .checked,,$(notdir $<)) --codegen $(CODEGEN) --extract_module $(basename $(notdir $(subst .checked,,$<)))
+	$(MY_FSTAR) --already_cached '*,' $(subst .checked,,$(notdir $<)) --codegen $(CODEGEN) --extract_module $(basename $(notdir $(subst .checked,,$<)))
 
 .depend.extract.fsharp:
 	$(call msg, "DEPEND")


### PR DESCRIPTION
This fixes a regression introduced in https://github.com/FStarLang/FStar/commit/af1b98d3792975a14cec180a851282fbedb33c8f. It was discovered testing Windows CI in https://github.com/FStarLang/FStar/pull/3402 and is a blocker for that PR.

Before the regression there was the term:

    --already_cached '*,'

The regression switched it to:

    --already_cached '*'

which causes:

    Y:/source/FStar/src/ocaml-output/fstar/bin/fstar.exe   --use_hints   --warn_error @241 --cache_checked_modules --odir fs/extracted --cache_dir .cache --already_cached '*' FStar.Pervasives.fst --codegen FSharp --extract_module FStar.Pervasives
    * Error 151:
      - Not a valid FStar file: '..'

    1 error was reported (see above)
    make: *** [Makefile.extract.fsharp:34: fs/extracted/FStar_Pervasives.fs] Error 1

This fix puts back the original trailing comma which inhibits the wildcard expansion.