### PR TITLE
Move away from deprecated batteries functions.

### DIFF
--- a/ocaml/fstar-lib/FStar_Compiler_Bytes.ml
+++ b/ocaml/fstar-lib/FStar_Compiler_Bytes.ml
@@ -12,7 +12,7 @@ let f_encode f (b:bytes) = String.concat "" (Array.to_list (Array.map f b))
 let length (b:bytes) = BatArray.length b
 let get (b:bytes) n = Z.of_int (BatArray.get b (Z.to_int n))
 let make (f : _ -> Z.t) n = BatArray.init (Z.to_int n) (fun i -> Z.to_int (f (Z.of_int i)))
-let zero_create n : bytes = BatArray.create n 0
+let zero_create n : bytes = BatArray.make n 0
 
 let sub ( b:bytes) s l = BatArray.sub b s l
 let set = BatArray.set

--- a/ocaml/fstar-lib/FStar_Compiler_String.ml
+++ b/ocaml/fstar-lib/FStar_Compiler_String.ml
@@ -29,8 +29,8 @@ let get s i = BatUChar.code (BatUTF8.get s (Z.to_int i))
 let collect f s =
   let r = ref "" in
   BatUTF8.iter (fun c -> r := !r ^ f (BatUChar.code c)) s; !r
-let lowercase = BatString.lowercase
-let uppercase = BatString.uppercase
+let lowercase = BatString.lowercase_ascii
+let uppercase = BatString.uppercase_ascii
 let escaped = BatString.escaped
 let index = get
 exception Found of int

--- a/ocaml/fstar-lib/FStar_String.ml
+++ b/ocaml/fstar-lib/FStar_String.ml
@@ -29,8 +29,8 @@ let get s i = BatUChar.code (BatUTF8.get s (Z.to_int i))
 let collect f s =
   let r = ref "" in
   BatUTF8.iter (fun c -> r := !r ^ f (BatUChar.code c)) s; !r
-let lowercase = BatString.lowercase
-let uppercase = BatString.uppercase
+let lowercase = BatString.lowercase_ascii
+let uppercase = BatString.uppercase_ascii
 let escaped = BatString.escaped
 let index = get
 exception Found of int


### PR DESCRIPTION
This allows F* to build with OCaml 5.2.0.