### PR TITLE
Some makefile fixes

### DIFF
--- a/doc/book/code/exercises/Makefile
+++ b/doc/book/code/exercises/Makefile
@@ -6,7 +6,7 @@ OTHERFLAGS  := --cache_checked_modules $(OTHERFLAGS)
 all: $(addsuffix .checked, $(FSTAR_FILES))
 
 .depend:
-	$(FSTAR) --dep full $(FSTAR_FILES) > .depend
+	$(FSTAR) --dep full $(FSTAR_FILES) --output_deps_to .depend
 
 depend: .depend
 

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -49,7 +49,10 @@ verify: prep $(filter-out $(CACHE_DIR)/Launch.fst.checked $(CACHE_DIR)/FStar.Mod
 
 HAS_OCAML := $(shell which ocamlfind 2>/dev/null)
 
-SPECIAL_CASES += sample_project
+# The makefile here relies on a global fstar.exe and does not read FSTAR_HOME
+# or anything similar, disable for now.
+# SPECIAL_CASES += sample_project
+
 ifneq (,$(HAS_OCAML))
 SPECIAL_CASES += hello
 SPECIAL_CASES += native_tactics

--- a/examples/demos/low-star/Makefile
+++ b/examples/demos/low-star/Makefile
@@ -6,7 +6,7 @@ FSTAR := $(FSTAR) $(FSTAR_FLAGS)
 all: $(addsuffix .checked, $(FSTAR_FILES))
 
 .depend:
-	$(FSTAR) --dep full $(FSTAR_FILES) > .depend
+	$(FSTAR) --dep full $(FSTAR_FILES) --output_deps_to .depend
 
 depend: .depend
 

--- a/examples/hello/multifile/Makefile
+++ b/examples/hello/multifile/Makefile
@@ -31,7 +31,7 @@ all: $(EXECUTABLE)
 
 # generate a dependency graph
 .depend: $(wildcard *.fst *.fsti)
-	$(FSTAR) --dep full $(ROOTS) --extract '* -Prims -FStar' > .depend
+	$(FSTAR) --dep full $(ROOTS) --extract '* -Prims -FStar' --output_deps_to .depend
 
 # this defines the $(ALL_ML_FILES) variable and dependences to produce them
 include .depend

--- a/examples/layeredeffects/Makefile
+++ b/examples/layeredeffects/Makefile
@@ -19,7 +19,7 @@ extraction:
 endif
 
 .depend:
-	$(FSTAR) --dep full $(ROOTS) > .depend
+	$(FSTAR) --dep full $(ROOTS) --output_deps_to .depend
 
 depend: .depend
 

--- a/examples/native_tactics/Makefile
+++ b/examples/native_tactics/Makefile
@@ -42,7 +42,7 @@ OTHERFLAGS +=
 all: $(addsuffix .sep.test, $(TAC_MODULES)) $(addsuffix .test, $(ALL))
 
 # .depend:
-# 	$(FSTAR) --dep full $(addsuffix .Test.fst, $(ALL)) > .depend
+# 	$(FSTAR) --dep full $(addsuffix .Test.fst, $(ALL)) --output_deps_to .depend
 
 # include .depend
 

--- a/examples/sample_project/Makefile
+++ b/examples/sample_project/Makefile
@@ -66,7 +66,7 @@ clean:
 	rm -rf _build $(OUTPUT_DIRECTORY) *~ *.checked $(OCAML_EXE) $(KRML_EXE) .depend
 
 .depend:
-	$(FSTAR) --dep full $(FSTAR_FILES) --extract '* -FStar -Prims' > .depend
+	$(FSTAR) --dep full $(FSTAR_FILES) --extract '* -FStar -Prims' --output_deps_to .depend
 
 depend: .depend
 

--- a/tests/friends/1/Makefile
+++ b/tests/friends/1/Makefile
@@ -9,7 +9,7 @@ verify-all: $(ALL_CHECKED_FILES)
 
 .depend:
 	$(call msg, "DEPEND", $(patsubst $(shell realpath $(FSTAR_HOME))/%,%/,$(shell pwd)))
-	$(Q)$(FSTAR) --dep full $(wildcard *.fst *.fsti) > .depend
+	$(Q)$(FSTAR) --dep full $(wildcard *.fst *.fsti) --output_deps_to .depend
 
 %.checked:
 	$(call msg, "CHECK", $<)

--- a/tests/friends/2/Makefile
+++ b/tests/friends/2/Makefile
@@ -9,7 +9,7 @@ verify-all: $(ALL_CHECKED_FILES)
 
 .depend:
 	$(call msg, "DEPEND", $(patsubst $(shell realpath $(FSTAR_HOME))/%,%/,$(shell pwd)))
-	$(Q)$(FSTAR) --dep full $(wildcard *.fst *.fsti) > .depend
+	$(Q)$(FSTAR) --dep full $(wildcard *.fst *.fsti) --output_deps_to .depend
 
 %.checked:
 	$(call msg, "CHECK", $<)

--- a/tests/friends/3/Makefile
+++ b/tests/friends/3/Makefile
@@ -9,7 +9,7 @@ verify-all: $(ALL_CHECKED_FILES)
 
 .depend:
 	$(call msg, "DEPEND", $(patsubst $(shell realpath $(FSTAR_HOME))/%,%/,$(shell pwd)))
-	$(Q)$(FSTAR) --dep full $(wildcard *.fst *.fsti) > .depend
+	$(Q)$(FSTAR) --dep full $(wildcard *.fst *.fsti) --output_deps_to .depend
 
 %.checked:
 	$(call msg, "CHECK", $<)

--- a/tests/ide/emacs/Makefile
+++ b/tests/ide/emacs/Makefile
@@ -24,5 +24,5 @@ Harness.%.out: Harness.%.in $(FSTAR_HOME)/bin/fstar.exe Harness.fst.checked
 
 .depend:
 	$(call msg, "DEPEND")
-	$(Q)$(FSTAR) --dep full $(wildcard *.fst *.fsti) > .depend
+	$(Q)$(FSTAR) --dep full $(wildcard *.fst *.fsti) --output_deps_to .depend
 include .depend


### PR DESCRIPTION
examples/sample_project is failing in CI but not being detected, because we create `.depend` files by redirection and make (by default, stupidly) will not delete these files in the `--dep` run fails.