### PR TITLE
Fix encoding of primitive operators with refined domains

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_CheckedFiles.ml
+++ b/ocaml/fstar-lib/generated/FStar_CheckedFiles.ml
@@ -1,7 +1,7 @@
 open Prims
 let (dbg : Prims.bool FStar_Compiler_Effect.ref) =
   FStar_Compiler_Debug.get_toggle "CheckedFiles"
-let (cache_version_number : Prims.int) = (Prims.of_int (68))
+let (cache_version_number : Prims.int) = (Prims.of_int (69))
 type tc_result =
   {
   checked_module: FStar_Syntax_Syntax.modul ;

--- a/ocaml/fstar-lib/generated/FStar_SMTEncoding_Encode.ml
+++ b/ocaml/fstar-lib/generated/FStar_SMTEncoding_Encode.ml
@@ -143,7 +143,7 @@ let (prims : prims_t) =
                FStar_SMTEncoding_Term.Term_sort in
            (match uu___2 with
             | (ysym, y) ->
-                let quant rel vars body rng x1 =
+                let quant_with_pre rel vars precondition body rng x1 =
                   let xname_decl =
                     let uu___3 =
                       let uu___4 =
@@ -214,7 +214,12 @@ let (prims : prims_t) =
                                  (uu___5, app1, vars2))
                         ([tot_fun_axiom_for_x], xtok1, []) all_vars_but_one in
                     match uu___3 with | (axioms, uu___4, uu___5) -> axioms in
-                  let rel_body = rel_type_f rel (xapp, body) in
+                  let rel_body =
+                    let rel_body1 = rel_type_f rel (xapp, body) in
+                    match precondition with
+                    | FStar_Pervasives_Native.None -> rel_body1
+                    | FStar_Pervasives_Native.Some pre ->
+                        FStar_SMTEncoding_Util.mkImp (pre, rel_body1) in
                   let uu___3 =
                     let uu___4 =
                       let uu___5 =
@@ -250,6 +255,8 @@ let (prims : prims_t) =
                       FStar_Compiler_List.op_At tot_fun_axioms uu___6 in
                     FStar_Compiler_List.op_At uu___4 uu___5 in
                   (xtok1, (FStar_Compiler_List.length vars), uu___3) in
+                let quant rel vars body =
+                  quant_with_pre rel vars FStar_Pervasives_Native.None body in
                 let axy =
                   FStar_Compiler_List.map FStar_SMTEncoding_Term.mk_fv
                     [(asym, FStar_SMTEncoding_Term.Term_sort);
@@ -467,17 +474,35 @@ let (prims : prims_t) =
                                                   let uu___32 =
                                                     let uu___33 =
                                                       let uu___34 =
-                                                        FStar_SMTEncoding_Term.unboxInt
-                                                          x in
+                                                        let uu___35 =
+                                                          FStar_SMTEncoding_Term.unboxInt
+                                                            y in
+                                                        let uu___36 =
+                                                          FStar_SMTEncoding_Util.mkInteger
+                                                            "0" in
+                                                        (uu___35, uu___36) in
+                                                      FStar_SMTEncoding_Util.mkEq
+                                                        uu___34 in
+                                                    FStar_SMTEncoding_Util.mkNot
+                                                      uu___33 in
+                                                  FStar_Pervasives_Native.Some
+                                                    uu___32 in
+                                                let uu___32 =
+                                                  let uu___33 =
+                                                    let uu___34 =
                                                       let uu___35 =
                                                         FStar_SMTEncoding_Term.unboxInt
+                                                          x in
+                                                      let uu___36 =
+                                                        FStar_SMTEncoding_Term.unboxInt
                                                           y in
-                                                      (uu___34, uu___35) in
+                                                      (uu___35, uu___36) in
                                                     FStar_SMTEncoding_Util.mkDiv
-                                                      uu___33 in
+                                                      uu___34 in
                                                   FStar_SMTEncoding_Term.boxInt
-                                                    uu___32 in
-                                                quant Eq xy uu___31 in
+                                                    uu___33 in
+                                                quant_with_pre Eq xy uu___31
+                                                  uu___32 in
                                               (FStar_Parser_Const.op_Division,
                                                 uu___30) in
                                             let uu___30 =
@@ -487,17 +512,35 @@ let (prims : prims_t) =
                                                     let uu___34 =
                                                       let uu___35 =
                                                         let uu___36 =
-                                                          FStar_SMTEncoding_Term.unboxInt
-                                                            x in
+                                                          let uu___37 =
+                                                            FStar_SMTEncoding_Term.unboxInt
+                                                              y in
+                                                          let uu___38 =
+                                                            FStar_SMTEncoding_Util.mkInteger
+                                                              "0" in
+                                                          (uu___37, uu___38) in
+                                                        FStar_SMTEncoding_Util.mkEq
+                                                          uu___36 in
+                                                      FStar_SMTEncoding_Util.mkNot
+                                                        uu___35 in
+                                                    FStar_Pervasives_Native.Some
+                                                      uu___34 in
+                                                  let uu___34 =
+                                                    let uu___35 =
+                                                      let uu___36 =
                                                         let uu___37 =
                                                           FStar_SMTEncoding_Term.unboxInt
+                                                            x in
+                                                        let uu___38 =
+                                                          FStar_SMTEncoding_Term.unboxInt
                                                             y in
-                                                        (uu___36, uu___37) in
+                                                        (uu___37, uu___38) in
                                                       FStar_SMTEncoding_Util.mkMod
-                                                        uu___35 in
+                                                        uu___36 in
                                                     FStar_SMTEncoding_Term.boxInt
-                                                      uu___34 in
-                                                  quant Eq xy uu___33 in
+                                                      uu___35 in
+                                                  quant_with_pre Eq xy
+                                                    uu___33 uu___34 in
                                                 (FStar_Parser_Const.op_Modulus,
                                                   uu___32) in
                                               let uu___32 =
@@ -659,20 +702,46 @@ let (prims : prims_t) =
                                                                     =
                                                                     let uu___52
                                                                     =
-                                                                    FStar_SMTEncoding_Term.unboxReal
-                                                                    x in
+                                                                    let uu___53
+                                                                    =
+                                                                    FStar_SMTEncoding_Term.unboxInt
+                                                                    y in
+                                                                    let uu___54
+                                                                    =
+                                                                    FStar_SMTEncoding_Util.mkReal
+                                                                    "0" in
+                                                                    (uu___53,
+                                                                    uu___54) in
+                                                                    FStar_SMTEncoding_Util.mkEq
+                                                                    uu___52 in
+                                                                    FStar_SMTEncoding_Util.mkNot
+                                                                    uu___51 in
+                                                                    FStar_Pervasives_Native.Some
+                                                                    uu___50 in
+                                                                  let uu___50
+                                                                    =
+                                                                    let uu___51
+                                                                    =
+                                                                    let uu___52
+                                                                    =
                                                                     let uu___53
                                                                     =
                                                                     FStar_SMTEncoding_Term.unboxReal
+                                                                    x in
+                                                                    let uu___54
+                                                                    =
+                                                                    FStar_SMTEncoding_Term.unboxReal
                                                                     y in
-                                                                    (uu___52,
-                                                                    uu___53) in
+                                                                    (uu___53,
+                                                                    uu___54) in
                                                                     FStar_SMTEncoding_Util.mkRealDiv
-                                                                    uu___51 in
+                                                                    uu___52 in
                                                                     FStar_SMTEncoding_Term.boxReal
+                                                                    uu___51 in
+                                                                  quant_with_pre
+                                                                    Eq xy
+                                                                    uu___49
                                                                     uu___50 in
-                                                                  quant Eq xy
-                                                                    uu___49 in
                                                                 (FStar_Parser_Const.real_op_Division,
                                                                   uu___48) in
                                                               let uu___48 =

--- a/ocaml/fstar-lib/generated/FStar_SMTEncoding_Encode.ml
+++ b/ocaml/fstar-lib/generated/FStar_SMTEncoding_Encode.ml
@@ -704,7 +704,7 @@ let (prims : prims_t) =
                                                                     =
                                                                     let uu___53
                                                                     =
-                                                                    FStar_SMTEncoding_Term.unboxInt
+                                                                    FStar_SMTEncoding_Term.unboxReal
                                                                     y in
                                                                     let uu___54
                                                                     =

--- a/src/fstar/FStar.CheckedFiles.fst
+++ b/src/fstar/FStar.CheckedFiles.fst
@@ -36,7 +36,7 @@ let dbg = Debug.get_toggle "CheckedFiles"
  * detect when loading the cache that the version number is same
  * It needs to be kept in sync with prims.fst
  *)
-let cache_version_number = 68
+let cache_version_number = 69
 
 (*
  * Abbreviation for what we store in the checked files (stages as described below)

--- a/src/smtencoding/FStar.SMTEncoding.Encode.fst
+++ b/src/smtencoding/FStar.SMTEncoding.Encode.fst
@@ -89,7 +89,7 @@ let prims =
     let asym, a = fresh_fvar module_name "a" Term_sort in
     let xsym, x = fresh_fvar module_name "x" Term_sort in
     let ysym, y = fresh_fvar module_name "y" Term_sort in
-    let quant (rel:defn_rel_type) vars body : Range.range -> string -> term & int & list decl = fun rng x ->
+    let quant_with_pre (rel:defn_rel_type) vars precondition body : Range.range -> string -> term & int & list decl = fun rng x ->
         let xname_decl = Term.DeclFun(x, vars |> List.map fv_sort, Term_sort, None) in
         let xtok = x ^ "@tok" in
         let xtok_decl = Term.DeclFun(xtok, [], Term_sort, None) in
@@ -120,7 +120,12 @@ let prims =
           axioms
         in
 
-        let rel_body = (rel_type_f rel) (xapp, body) in
+        let rel_body =
+          let rel_body = (rel_type_f rel) (xapp, body) in
+          match precondition with
+          | None -> rel_body
+          | Some pre -> mkImp(pre, rel_body)
+        in
 
         xtok,
         List.length vars,
@@ -134,6 +139,7 @@ let prims =
                         Some "Name-token correspondence",
                         "token_correspondence_"^x)])
     in
+    let quant rel vars body = quant_with_pre rel vars None body in
     let axy = List.map mk_fv [(asym, Term_sort); (xsym, Term_sort); (ysym, Term_sort)] in
     let xy = List.map mk_fv [(xsym, Term_sort); (ysym, Term_sort)] in
     let qx = List.map mk_fv [(xsym, Term_sort)] in
@@ -154,8 +160,8 @@ let prims =
         (Const.op_Minus,       (quant Eq qx  (boxInt  <| mkMinus(unboxInt x))));
         (Const.op_Addition,    (quant Eq xy  (boxInt  <| mkAdd(unboxInt x, unboxInt y))));
         (Const.op_Multiply,    (quant Eq xy  (boxInt  <| mkMul(unboxInt x, unboxInt y))));
-        (Const.op_Division,    (quant Eq xy  (boxInt  <| mkDiv(unboxInt x, unboxInt y))));
-        (Const.op_Modulus,     (quant Eq xy  (boxInt  <| mkMod(unboxInt x, unboxInt y))));
+        (Const.op_Division,    (quant_with_pre Eq xy (Some (mkNot (mkEq (unboxInt y, mkInteger "0")))) (boxInt  <| mkDiv(unboxInt x, unboxInt y))));
+        (Const.op_Modulus,     (quant_with_pre Eq xy (Some (mkNot (mkEq (unboxInt y, mkInteger "0")))) (boxInt  <| mkMod(unboxInt x, unboxInt y))));
         //real ops
         (Const.real_op_LT,          (quant ValidIff xy  (mkLT(unboxReal x, unboxReal y))));
         (Const.real_op_LTE,         (quant ValidIff xy  (mkLTE(unboxReal x, unboxReal y))));
@@ -164,7 +170,7 @@ let prims =
         (Const.real_op_Subtraction, (quant Eq xy  (boxReal <| mkSub(unboxReal x, unboxReal y))));
         (Const.real_op_Addition,    (quant Eq xy  (boxReal <| mkAdd(unboxReal x, unboxReal y))));
         (Const.real_op_Multiply,    (quant Eq xy  (boxReal <| mkMul(unboxReal x, unboxReal y))));
-        (Const.real_op_Division,    (quant Eq xy  (boxReal <| mkRealDiv(unboxReal x, unboxReal y))));
+        (Const.real_op_Division,    (quant_with_pre Eq xy (Some (mkNot (mkEq (unboxInt y, mkReal "0")))) (boxReal <| mkRealDiv(unboxReal x, unboxReal y))));
         (Const.real_of_int,         (quant Eq qx  (boxReal <| mkRealOfInt (unboxInt x) Range.dummyRange)))
         ]
     in

--- a/src/smtencoding/FStar.SMTEncoding.Encode.fst
+++ b/src/smtencoding/FStar.SMTEncoding.Encode.fst
@@ -170,7 +170,7 @@ let prims =
         (Const.real_op_Subtraction, (quant Eq xy  (boxReal <| mkSub(unboxReal x, unboxReal y))));
         (Const.real_op_Addition,    (quant Eq xy  (boxReal <| mkAdd(unboxReal x, unboxReal y))));
         (Const.real_op_Multiply,    (quant Eq xy  (boxReal <| mkMul(unboxReal x, unboxReal y))));
-        (Const.real_op_Division,    (quant_with_pre Eq xy (Some (mkNot (mkEq (unboxInt y, mkReal "0")))) (boxReal <| mkRealDiv(unboxReal x, unboxReal y))));
+        (Const.real_op_Division,    (quant_with_pre Eq xy (Some (mkNot (mkEq (unboxReal y, mkReal "0")))) (boxReal <| mkRealDiv(unboxReal x, unboxReal y))));
         (Const.real_of_int,         (quant Eq qx  (boxReal <| mkRealOfInt (unboxInt x) Range.dummyRange)))
         ]
     in

--- a/tests/bug-reports/Bug3426.fst
+++ b/tests/bug-reports/Bug3426.fst
@@ -1,0 +1,21 @@
+module Bug3426
+open FStar.Real
+let prim_arith_ty (p: unit): Type0 =
+  let () = p in
+  int -> int -> int
+
+[@@expect_failure]
+let prim_arith_sem (p: unit): (prim_arith_ty p) =
+  fun x y -> x / y
+
+[@@expect_failure]
+let prim_arith_sem_mod (p: unit): (prim_arith_ty p) =
+  fun x y -> x % y
+
+let prim_arith_ty_real (p: unit): Type0 =
+  let () = p in
+  real -> real -> real
+
+[@@expect_failure]
+let prim_arith_sem_real (p: unit): (prim_arith_ty_real p) =
+  fun x y -> x /. y

--- a/tests/bug-reports/Makefile
+++ b/tests/bug-reports/Makefile
@@ -80,7 +80,7 @@ SHOULD_VERIFY_CLOSED=\
 	Bug2155.fst Bug3224a.fst Bug3224b.fst Bug3236.fst Bug3252.fst \
 	BugBoxInjectivity.fst BugTypeParamProjector.fst Bug2172.fst Bug3266.fst		\
 	Bug3264a.fst Bug3264b.fst Bug3286a.fst Bug3286b.fst Bug3320.fst Bug2583.fst \
-	Bug2419.fst Bug3353.fst
+	Bug2419.fst Bug3353.fst Bug3426.fst
 
 
 SHOULD_VERIFY_INTERFACE_CLOSED=Bug771.fsti Bug771b.fsti

--- a/ulib/FStar.UInt.fst
+++ b/ulib/FStar.UInt.fst
@@ -584,7 +584,7 @@ let lemma_lognot_value_zero #n a =
 private
 val lemma_mod_variation: #n:pos -> a:uint_t n ->
   Lemma (a <> 0 ==> ((-a) % pow2 n) - 1 % pow2 n = (((-a) % pow2 n) - 1) % pow2 n)
-let lemma_mod_variation #n a = ()
+let lemma_mod_variation #n a = assert (pow2 n =!= 0)
 #pop-options
 
 let lemma_one_mod_pow2 #n = ()

--- a/ulib/prims.fst
+++ b/ulib/prims.fst
@@ -729,4 +729,4 @@ val string_of_int: int -> Tot string
 (** THIS IS MEANT TO BE KEPT IN SYNC WITH FStar.CheckedFiles.fs
     Incrementing this forces all .checked files to be invalidated *)
 irreducible
-let __cache_version_number__ = 68
+let __cache_version_number__ = 69


### PR DESCRIPTION
Fixes #3426 

This adds preconditions in the SMT encoding to Prims.op_Modulus, op_Division, and Real.op_Slash_dot.

I also had an everest run with no meaningful regressions---one brittle proof in Hacl.Spec.Chacha.Equiv needed a restart-solver to go through.