### PR TITLE
feat(syntax): any terms in meta arguments

### DIFF
--- a/ocaml/fstar-lib/FStar_Parser_Parse.mly
+++ b/ocaml/fstar-lib/FStar_Parser_Parse.mly
@@ -658,7 +658,7 @@ letqualifier:
  *     note that in the [@@ case, we choose the Implicit aqual
  *)
 aqual:
-  | HASH LBRACK t=thunk(tmNoEq) RBRACK { mk_meta_tac t }
+  | HASH LBRACK t=thunk(term) RBRACK { mk_meta_tac t }
   | HASH      { Implicit }
   | DOLLAR    { Equality }
 


### PR DESCRIPTION
This PR makes the following code typecheck. Before we had to add parenthesis. That's a super simple change and that's causing no regression in the parser! :)

```
let this_is_now_accepted
    (#[let _ = 1 in FStar.Tactics.exact ()]arg: unit)
    = ()

let before_you_had_to_write
    (#[(let _ = 1 in FStar.Tactics.exact ())]arg: unit)
    = ()
```