### PR TITLE
Parser.Dep: interpret inline_for_extraction on *any* decl, not just Vals

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_Parser_Dep.ml
+++ b/ocaml/fstar-lib/generated/FStar_Parser_Dep.ml
@@ -1305,13 +1305,12 @@ let (collect_one :
                   collect_decl x.FStar_Parser_AST.d;
                   FStar_Compiler_List.iter collect_term
                     x.FStar_Parser_AST.attrs;
-                  (match x.FStar_Parser_AST.d with
-                   | FStar_Parser_AST.Val uu___3 when
-                       FStar_Compiler_List.contains
-                         FStar_Parser_AST.Inline_for_extraction
-                         x.FStar_Parser_AST.quals
-                       -> add_to_parsing_data P_inline_for_extraction
-                   | uu___3 -> ())) decls
+                  if
+                    FStar_Compiler_List.contains
+                      FStar_Parser_AST.Inline_for_extraction
+                      x.FStar_Parser_AST.quals
+                  then add_to_parsing_data P_inline_for_extraction
+                  else ()) decls
            and collect_decl d =
              match d with
              | FStar_Parser_AST.Include (lid, uu___1) ->

--- a/src/parser/FStar.Parser.Dep.fst
+++ b/src/parser/FStar.Parser.Dep.fst
@@ -810,7 +810,7 @@ let collect_one
         List.iter (fun x -> collect_decl x.d;
                             List.iter collect_term x.attrs;
                             match x.d with
-                            | Val _ when List.contains Inline_for_extraction x.quals ->
+                            | _ when List.contains Inline_for_extraction x.quals ->
                                 add_to_parsing_data P_inline_for_extraction
                             | _ -> ()
                             ) decls


### PR DESCRIPTION

This is relevant for Pulse, which uses %splice to generate Vals during
typechecking time, so the parser will miss the qualifier and mess up
the dependency analysis.