### PR TITLE
Add extract_as attribute.

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_ExtractAs.ml
+++ b/ocaml/fstar-lib/generated/FStar_ExtractAs.ml
@@ -1,0 +1,1 @@
+open Prims

--- a/ocaml/fstar-lib/generated/FStar_Parser_Const.ml
+++ b/ocaml/fstar-lib/generated/FStar_Parser_Const.ml
@@ -661,5 +661,7 @@ let (tref_lid : FStar_Ident.lident) =
 let (document_lid : FStar_Ident.lident) =
   p2l ["FStar"; "Stubs"; "Pprint"; "document"]
 let (issue_lid : FStar_Ident.lident) = p2l ["FStar"; "Issue"; "issue"]
+let (extract_as_lid : FStar_Ident.lident) =
+  p2l ["FStar"; "ExtractAs"; "extract_as"]
 let (extract_as_impure_effect_lid : FStar_Ident.lident) =
   p2l ["FStar"; "Pervasives"; "extract_as_impure_effect"]

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Env.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Env.ml
@@ -3795,6 +3795,15 @@ let (num_datacon_non_injective_ty_params :
           then FStar_Pervasives_Native.Some Prims.int_zero
           else FStar_Pervasives_Native.Some num_ty_params
       | uu___1 -> FStar_Pervasives_Native.None
+let (visible_with :
+  delta_level Prims.list ->
+    FStar_Syntax_Syntax.qualifier Prims.list -> Prims.bool)
+  =
+  fun delta_levels ->
+    fun quals ->
+      FStar_Compiler_Util.for_some
+        (fun dl -> FStar_Compiler_Util.for_some (visible_at dl) quals)
+        delta_levels
 let (lookup_definition_qninfo_aux :
   Prims.bool ->
     delta_level Prims.list ->
@@ -3808,10 +3817,6 @@ let (lookup_definition_qninfo_aux :
     fun delta_levels ->
       fun lid ->
         fun qninfo1 ->
-          let visible quals =
-            FStar_Compiler_Util.for_some
-              (fun dl -> FStar_Compiler_Util.for_some (visible_at dl) quals)
-              delta_levels in
           match qninfo1 with
           | FStar_Pervasives_Native.Some
               (FStar_Pervasives.Inr (se, FStar_Pervasives_Native.None),
@@ -3822,8 +3827,8 @@ let (lookup_definition_qninfo_aux :
                    { FStar_Syntax_Syntax.lbs1 = (is_rec, lbs);
                      FStar_Syntax_Syntax.lids1 = uu___1;_}
                    when
-                   (visible se.FStar_Syntax_Syntax.sigquals) &&
-                     ((Prims.op_Negation is_rec) || rec_ok)
+                   (visible_with delta_levels se.FStar_Syntax_Syntax.sigquals)
+                     && ((Prims.op_Negation is_rec) || rec_ok)
                    ->
                    FStar_Compiler_Util.find_map lbs
                      (fun lb ->

--- a/src/extraction/FStar.Extraction.ML.Modul.fst
+++ b/src/extraction/FStar.Extraction.ML.Modul.fst
@@ -756,6 +756,8 @@ let mark_sigelt_erased (se:sigelt) (g:uenv) : uenv =
 let fixup_sigelt_extract_as se =
   match se.sigel, find_map se.sigattrs N.is_extract_as_attr with
   | Sig_let {lids; lbs=(_, [lb])}, Some impl ->
+    // The specified implementation can be recursive,
+    // to be on the safe side we always mark the replaced sigelt as recursive.
     {se with sigel = Sig_let {lids; lbs=(true, [{lb with lbdef = impl}])}}
   | _ -> se
 

--- a/src/parser/FStar.Parser.Const.fst
+++ b/src/parser/FStar.Parser.Const.fst
@@ -598,4 +598,5 @@ let tref_lid        = p2l ["FStar"; "Stubs"; "Tactics"; "Types"; "tref"]
 let document_lid = p2l ["FStar"; "Stubs"; "Pprint"; "document"]
 let issue_lid = p2l ["FStar"; "Issue"; "issue"]
 
+let extract_as_lid = p2l ["FStar"; "ExtractAs"; "extract_as"]
 let extract_as_impure_effect_lid = p2l ["FStar"; "Pervasives"; "extract_as_impure_effect"]

--- a/src/syntax/FStar.Syntax.Resugar.fst
+++ b/src/syntax/FStar.Syntax.Resugar.fst
@@ -1389,8 +1389,7 @@ let mk_decl r q d' =
     d = d' ;
     drange = r ;
     quals = List.choose resugar_qualifier q ;
-    (* TODO : are these stocked up somewhere ? *)
-    attrs = [] ;
+    attrs = [] ; // We fill in the attrs in resugar_sigelt'
     interleaved = false;
   }
 
@@ -1481,7 +1480,7 @@ let resugar_eff_decl' env ed =
   mk_decl r q (A.NewEffect(DefineEffect(eff_name, eff_binders, eff_typ, decls)))
 
 let resugar_sigelt' env se : option A.decl =
-  match se.sigel with
+  let d = (match se.sigel with
   | Sig_bundle {ses} ->
     let decl_typ_ses, datacon_ses = ses |> List.partition
       (fun se -> match se.sigel with
@@ -1601,7 +1600,11 @@ let resugar_sigelt' env se : option A.decl =
     Some (decl'_to_decl se (A.Polymonadic_bind (m, n, p, resugar_term' env t)))
 
   | Sig_polymonadic_subcomp {m_lid=m; n_lid=n; tm=(_, t)} ->
-    Some (decl'_to_decl se (A.Polymonadic_subcomp (m, n, resugar_term' env t)))
+    Some (decl'_to_decl se (A.Polymonadic_subcomp (m, n, resugar_term' env t)))) in
+
+  match d with
+  | Some d -> Some { d with attrs = List.map (resugar_term' env) se.sigattrs }
+  | None -> None
 
 (* Old interface: no envs *)
 

--- a/src/typechecker/FStar.TypeChecker.Env.fst
+++ b/src/typechecker/FStar.TypeChecker.Env.fst
@@ -768,15 +768,15 @@ let num_datacon_non_injective_ty_params env lid =
       if injective_type_params then Some 0 else Some num_ty_params
     | _ -> None
 
+let visible_with delta_levels quals =
+  delta_levels |> BU.for_some (fun dl -> quals |> BU.for_some (visible_at dl))
+
 let lookup_definition_qninfo_aux rec_ok delta_levels lid (qninfo : qninfo) =
-  let visible quals =
-      delta_levels |> BU.for_some (fun dl -> quals |> BU.for_some (visible_at dl))
-  in
   match qninfo with
   | Some (Inr (se, None), _) ->
     begin match se.sigel with
       | Sig_let {lbs=(is_rec, lbs)}
-        when visible se.sigquals
+        when visible_with delta_levels se.sigquals
           && (not is_rec || rec_ok) ->
           BU.find_map lbs (fun lb ->
               let fv = right lb.lbname in

--- a/src/typechecker/FStar.TypeChecker.Env.fsti
+++ b/src/typechecker/FStar.TypeChecker.Env.fsti
@@ -330,6 +330,7 @@ val lookup_and_inst_datacon: env -> universes -> lident -> typ
 (* the boolean tells if the lident was actually a inductive *)
 val datacons_of_typ        : env -> lident -> (bool & list lident)
 val typ_of_datacon         : env -> lident -> lident
+val visible_with           : list delta_level -> list qualifier -> bool
 val lookup_definition_qninfo : list delta_level -> lident -> qninfo -> option (univ_names & term)
 val lookup_definition      : list delta_level -> env -> lident -> option (univ_names & term)
 val lookup_nonrec_definition: list delta_level -> env -> lident -> option (univ_names & term)

--- a/src/typechecker/FStar.TypeChecker.Normalize.fsti
+++ b/src/typechecker/FStar.TypeChecker.Normalize.fsti
@@ -66,6 +66,9 @@ val remove_uvar_solutions: Env.env -> term -> term
 val unfold_head_once: Env.env -> term -> option term
 val unembed_binder_knot : ref (option (FStar.Syntax.Embeddings.embedding binder))
 
+val is_extract_as_attr : attribute -> option term
+val has_extract_as_attr : Env.env -> Ident.lid -> option term
+
 val reflection_env_hook : ref (option Env.env)
 
 (* Destructs the term as an arrow type and returns its binders and

--- a/tests/extraction/ExtractAs.fst
+++ b/tests/extraction/ExtractAs.fst
@@ -1,0 +1,18 @@
+module ExtractAs
+open FStar.ExtractAs
+let fail_unless (b: bool) = if b then "ok" else magic ()
+
+// Test that extract_as works when extracting the definition itself.
+
+[@@extract_as (`(fun (x: nat) -> x + 10))]
+let frob y = 2 + y
+
+let _ = fail_unless (frob 1 = 11)
+
+// Test that extract_as works when inlining the definition.
+
+inline_for_extraction noextract [@@extract_as (`(fun (x: nat) -> x + 10))]
+let bar_2 y = 2 + y
+let bar z = bar_2 z
+
+let _ = fail_unless (bar 1 = 11)

--- a/tests/extraction/Makefile
+++ b/tests/extraction/Makefile
@@ -2,7 +2,7 @@ FSTAR_EXAMPLES=$(realpath ../../examples)
 include $(FSTAR_EXAMPLES)/Makefile.include
 include $(FSTAR_ULIB)/ml/Makefile.include
 
-all: inline_let all_cmi Eta_expand.test Div.test
+all: inline_let all_cmi Eta_expand.test Div.test ExtractAs.test
 
 %.exe: %.fst | out
 	$(FSTAR) $(FSTAR_DEFAULT_ARGS) --odir out --codegen OCaml $<

--- a/ulib/FStar.ExtractAs.fst
+++ b/ulib/FStar.ExtractAs.fst
@@ -31,5 +31,7 @@ open FStar.Stubs.Reflection.Types
     and most likely cause the extracted program to crash.
 
     Note that the argument needs to be a literal quotation.
+    The implementation can be recursive,
+    but then you need to construct the attribute via a tactic.
  *)
 let extract_as (impl: term) = ()

--- a/ulib/FStar.ExtractAs.fst
+++ b/ulib/FStar.ExtractAs.fst
@@ -1,0 +1,35 @@
+(*
+   Copyright 2024 Microsoft Research
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*)
+
+module FStar.ExtractAs
+open FStar.Stubs.Reflection.Types
+
+(** Replaces the annotated definition
+    by the specified implementation during extraction.
+    There are no checks whether the implementation
+    has the same semantics, or even the same type.
+
+    For example, if you have:
+
+    [@@extract_as (`(fun (x: nat) -> "not a number"))]
+    let add_one (x: nat) : nat = x + 42
+
+    Then `add_one` will extract to `let add_one x = "not a number"`,
+    and most likely cause the extracted program to crash.
+
+    Note that the argument needs to be a literal quotation.
+ *)
+let extract_as (impl: term) = ()

--- a/ulib/LowStar.Monotonic.Buffer.fst
+++ b/ulib/LowStar.Monotonic.Buffer.fst
@@ -1877,7 +1877,8 @@ let blit #a #rrel1 #rrel2 #rel1 #rel2 src idx_src dst idx_dst len =
       g_upd_seq_as_seq dst (Seq.slice s2' 0 (U32.v length2)) h  //for modifies clause
   | _, _ -> ()
 
-#push-options "--z3rlimit 128 --max_fuel 0 --max_ifuel 1 --initial_ifuel 1 --z3cliopt smt.qi.EAGER_THRESHOLD=4"
+#restart-solver
+#push-options "--z3rlimit 256 --max_fuel 0 --max_ifuel 1 --initial_ifuel 1 --z3cliopt smt.qi.EAGER_THRESHOLD=4"
 let fill' (#t:Type) (#rrel #rel: srel t)
   (b: mbuffer t rrel rel)
   (z:t)


### PR DESCRIPTION
To quote the documentation for the attribute:
```fstar
(** Replaces the annotated definition
    by the specified implementation during extraction.
    There are no checks whether the implementation
    has the same semantics, or even the same type.

    For example, if you have:

    [@@extract_as (`(fun (x: nat) -> "not a number"))]
    let add_one (x: nat) : nat = x + 42

    Then `add_one` will extract to `let add_one x = "not a number"`,
    and most likely cause the extracted program to crash.

    Note that the argument needs to be a literal quotation.
 *)
```

