### PR TITLE
Tweaks to default pretty instances.

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_Class_PP.ml
+++ b/ocaml/fstar-lib/generated/FStar_Class_PP.ml
@@ -6,6 +6,18 @@ let __proj__Mkpretty__item__pp :
   fun projectee -> match projectee with | { pp;_} -> pp
 let pp : 'a . 'a pretty -> 'a -> FStar_Pprint.document =
   fun projectee -> match projectee with | { pp = pp1;_} -> pp1
+let (gparens : FStar_Pprint.document -> FStar_Pprint.document) =
+  fun a ->
+    let uu___ =
+      let uu___1 = FStar_Pprint.parens a in
+      FStar_Pprint.nest (Prims.of_int (2)) uu___1 in
+    FStar_Pprint.group uu___
+let (gbrackets : FStar_Pprint.document -> FStar_Pprint.document) =
+  fun a ->
+    let uu___ =
+      let uu___1 = FStar_Pprint.brackets a in
+      FStar_Pprint.nest (Prims.of_int (2)) uu___1 in
+    FStar_Pprint.group uu___
 let (pp_unit : unit pretty) =
   { pp = (fun uu___ -> FStar_Pprint.doc_of_string "()") }
 let (pp_int : Prims.int pretty) =
@@ -17,8 +29,11 @@ let pp_list : 'a . 'a pretty -> 'a Prims.list pretty =
       pp =
         (fun l ->
            let uu___1 =
-             FStar_Pprint.separate_map FStar_Pprint.semi (pp uu___) l in
-           FStar_Pprint.brackets uu___1)
+             let uu___2 =
+               let uu___3 = FStar_Pprint.break_ Prims.int_one in
+               FStar_Pprint.op_Hat_Hat FStar_Pprint.semi uu___3 in
+             FStar_Pprint.flow_map uu___2 (pp uu___) l in
+           gbrackets uu___1)
     }
 let pp_option : 'a . 'a pretty -> 'a FStar_Pervasives_Native.option pretty =
   fun uu___ ->
@@ -27,9 +42,13 @@ let pp_option : 'a . 'a pretty -> 'a FStar_Pervasives_Native.option pretty =
         (fun o ->
            match o with
            | FStar_Pervasives_Native.Some v ->
-               let uu___1 = FStar_Pprint.doc_of_string "Some" in
-               let uu___2 = pp uu___ v in
-               FStar_Pprint.op_Hat_Slash_Hat uu___1 uu___2
+               let uu___1 =
+                 let uu___2 =
+                   let uu___3 = FStar_Pprint.doc_of_string "Some" in
+                   let uu___4 = pp uu___ v in
+                   FStar_Pprint.op_Hat_Slash_Hat uu___3 uu___4 in
+                 FStar_Pprint.nest (Prims.of_int (2)) uu___2 in
+               FStar_Pprint.group uu___1
            | FStar_Pervasives_Native.None ->
                FStar_Pprint.doc_of_string "None")
     }
@@ -40,16 +59,23 @@ let pp_either :
       {
         pp =
           (fun e ->
-             match e with
-             | FStar_Pervasives.Inl x ->
-                 let uu___2 = FStar_Pprint.doc_of_string "Inl" in
-                 let uu___3 = pp uu___ x in
-                 FStar_Pprint.op_Hat_Slash_Hat uu___2 uu___3
-             | FStar_Pervasives.Inr x ->
-                 let uu___2 = FStar_Pprint.doc_of_string "Inr" in
-                 let uu___3 = pp uu___1 x in
-                 FStar_Pprint.op_Hat_Slash_Hat uu___2 uu___3)
+             let uu___2 =
+               let uu___3 =
+                 match e with
+                 | FStar_Pervasives.Inl x ->
+                     let uu___4 = FStar_Pprint.doc_of_string "Inl" in
+                     let uu___5 = pp uu___ x in
+                     FStar_Pprint.op_Hat_Slash_Hat uu___4 uu___5
+                 | FStar_Pervasives.Inr x ->
+                     let uu___4 = FStar_Pprint.doc_of_string "Inr" in
+                     let uu___5 = pp uu___1 x in
+                     FStar_Pprint.op_Hat_Slash_Hat uu___4 uu___5 in
+               FStar_Pprint.nest (Prims.of_int (2)) uu___3 in
+             FStar_Pprint.group uu___2)
       }
+let (comma_space : FStar_Pprint.document) =
+  let uu___ = FStar_Pprint.break_ Prims.int_one in
+  FStar_Pprint.op_Hat_Hat FStar_Pprint.comma uu___
 let pp_tuple2 : 'a 'b . 'a pretty -> 'b pretty -> ('a * 'b) pretty =
   fun uu___ ->
     fun uu___1 ->
@@ -63,8 +89,8 @@ let pp_tuple2 : 'a 'b . 'a pretty -> 'b pretty -> ('a * 'b) pretty =
                      let uu___5 = pp uu___ x1 in
                      let uu___6 = let uu___7 = pp uu___1 x2 in [uu___7] in
                      uu___5 :: uu___6 in
-                   FStar_Pprint.separate FStar_Pprint.comma uu___4 in
-                 FStar_Pprint.parens uu___3)
+                   FStar_Pprint.separate comma_space uu___4 in
+                 gparens uu___3)
       }
 let pp_tuple3 :
   'a 'b 'c . 'a pretty -> 'b pretty -> 'c pretty -> ('a * 'b * 'c) pretty =
@@ -84,8 +110,8 @@ let pp_tuple3 :
                          let uu___9 = let uu___10 = pp uu___2 x3 in [uu___10] in
                          uu___8 :: uu___9 in
                        uu___6 :: uu___7 in
-                     FStar_Pprint.separate FStar_Pprint.comma uu___5 in
-                   FStar_Pprint.parens uu___4)
+                     FStar_Pprint.separate comma_space uu___5 in
+                   gparens uu___4)
         }
 let pp_tuple4 :
   'a 'b 'c 'd .
@@ -113,8 +139,8 @@ let pp_tuple4 :
                              uu___11 :: uu___12 in
                            uu___9 :: uu___10 in
                          uu___7 :: uu___8 in
-                       FStar_Pprint.separate FStar_Pprint.comma uu___6 in
-                     FStar_Pprint.parens uu___5)
+                       FStar_Pprint.separate comma_space uu___6 in
+                     gparens uu___5)
           }
 let pp_tuple5 :
   'a 'b 'c 'd 'e .
@@ -148,8 +174,8 @@ let pp_tuple5 :
                                uu___12 :: uu___13 in
                              uu___10 :: uu___11 in
                            uu___8 :: uu___9 in
-                         FStar_Pprint.separate FStar_Pprint.comma uu___7 in
-                       FStar_Pprint.parens uu___6)
+                         FStar_Pprint.separate comma_space uu___7 in
+                       gparens uu___6)
             }
 let pp_tuple6 :
   'a 'b 'c 'd 'e 'f .
@@ -189,8 +215,8 @@ let pp_tuple6 :
                                  uu___13 :: uu___14 in
                                uu___11 :: uu___12 in
                              uu___9 :: uu___10 in
-                           FStar_Pprint.separate FStar_Pprint.comma uu___8 in
-                         FStar_Pprint.parens uu___7)
+                           FStar_Pprint.separate comma_space uu___8 in
+                         gparens uu___7)
               }
 let pretty_from_showable : 'a . 'a FStar_Class_Show.showable -> 'a pretty =
   fun uu___ ->

--- a/src/class/FStar.Class.PP.fst
+++ b/src/class/FStar.Class.PP.fst
@@ -3,6 +3,9 @@ module FStar.Class.PP
 open FStar.Compiler.Effect
 open FStar.Pprint
 
+let gparens a = group (nest 2 (parens a))
+let gbrackets a = group (nest 2 (brackets a))
+
 instance pp_unit = {
    pp = (fun _ -> doc_of_string "()");
 }
@@ -16,27 +19,29 @@ instance pp_bool = {
 }
 
 instance pp_list (a:Type) (_ : pretty a) : Tot (pretty (list a)) = {
-  pp = (fun l -> brackets (separate_map semi pp l));
+  pp = (fun l -> gbrackets (flow_map (semi ^^ break_ 1) pp l));
 }
 
 instance pp_option (a:Type) (_ : pretty a) : Tot (pretty (option a)) = {
   pp = (fun o -> match o with
-                 | Some v -> doc_of_string "Some" ^/^ pp v
+                 | Some v -> group (nest 2 (doc_of_string "Some" ^/^ pp v))
                  | None -> doc_of_string "None");
 }
 
 instance pp_either (_ : pretty 'a) (_ : pretty 'b) = {
-  pp = (fun e -> match e with
+  pp = (fun e -> group (nest 2 (match e with
                  | Inl x -> doc_of_string "Inl" ^/^ pp x
-                 | Inr x -> doc_of_string "Inr" ^/^ pp x);
+                 | Inr x -> doc_of_string "Inr" ^/^ pp x)));
 }
+
+let comma_space = comma ^^ break_ 1
 
 instance pp_tuple2
    (_ : pretty 'a)
    (_ : pretty 'b)
 = {
   pp = (fun (x1, x2) ->
-            parens (separate comma [pp x1; pp x2]));
+            gparens (separate comma_space [pp x1; pp x2]));
 }
 
 instance pp_tuple3
@@ -45,7 +50,7 @@ instance pp_tuple3
    (_ : pretty 'c)
 = {
   pp = (fun (x1, x2, x3) ->
-            parens (separate comma [pp x1; pp x2; pp x3]));
+            gparens (separate comma_space [pp x1; pp x2; pp x3]));
 }
 
 instance pp_tuple4
@@ -55,7 +60,7 @@ instance pp_tuple4
    (_ : pretty 'd)
 = {
   pp = (fun (x1, x2, x3, x4) ->
-            parens (separate comma [pp x1; pp x2; pp x3; pp x4]));
+            gparens (separate comma_space [pp x1; pp x2; pp x3; pp x4]));
 }
 
 instance pp_tuple5
@@ -66,7 +71,7 @@ instance pp_tuple5
    (_ : pretty 'e)
 = {
   pp = (fun (x1, x2, x3, x4, x5) ->
-            parens (separate comma [pp x1; pp x2; pp x3; pp x4; pp x5]));
+            gparens (separate comma_space [pp x1; pp x2; pp x3; pp x4; pp x5]));
 }
 
 instance pp_tuple6
@@ -78,7 +83,7 @@ instance pp_tuple6
    (_ : pretty 'f)
 = {
   pp = (fun (x1, x2, x3, x4, x5, x6) ->
-            parens (separate comma [pp x1; pp x2; pp x3; pp x4; pp x5; pp x6]));
+            gparens (separate comma_space [pp x1; pp x2; pp x3; pp x4; pp x5; pp x6]));
 }
 
 let pretty_from_showable (#a:Type) {| _ : Class.Show.showable a |} : Tot (pretty a) = {


### PR DESCRIPTION
Before:
```
  (ELet
    { 
      name = "s";
      typ = (TQualified (["DPE"], "session_state"));
      mut = false;
      meta = []
      }
    (EApp (EQualified (["DPE"],"replace_session"))
      [(EBound 4);EUnit;(ECons (TQualified (["DPE"], "session_state")) "InUse"
        []);EUnit])
    (EMatch (EBound 0) [iou:branch;iou:branch;iou:branch;iou:branch;iou:branch])))
  (DFunction None [Private] 0 (TQualified (["DPETypes"], "profile_descriptor_t"))
  (["DPE"],"get_profile")
  [{ name = "uu___"; typ = TUnit; mut = false; meta = [] }]
  (EApp (EQualified (["DPETypes"],"mk_profile_descriptor"))
    [(EString "");(EConstant (UInt32,"1"));(EConstant (UInt32,"0"));(EBool false);(EBool
      false);(EBool false);(EBool false);(EConstant (SizeT,"0"));(EString "");(EBool
      false);(EString "");(EString "");(EBool false);(EBool true);(EConstant
      (SizeT,"1"));(EConstant (SizeT,"16"));(EBool false);(EBool false);(EBool
      false);(EBool false);(EBool true);(EBool false);(EBool false);(EBool false);(EBool
      false);(EBool false);(EBool true);(EBool false);(EBool false);(EBool false);(EBool
      false);(EBool false);(EBool true);(EString "");(EString "");(EString "");(EBool
      false);(EString "");(EString "");(EString "");(EBool false);(EBool false);(EBool
      false);(EString "");(EString "");(EString "");(EBool false);(EConstant
      (SizeT,"0"));(EConstant (SizeT,"0"));(EBool false);(EBool false);(EBool
      false);(EBool false);(EBool false);(EBool false);(EBool false);(EBool
      false);(EString "");(EBool false);(EString "");(EString "");(EString "");(EBool
      false);(EString "");(EString "");(EBool false);(EBool false);(EBool false);(EString
      "")]))
```

After:
```
  (ELet
    {
      name = "s";
      typ = (TQualified (["DPE"], "session_state"));
      mut = false;
      meta = []
      }
    (EApp (EQualified (["DPE"], "replace_session"))
      [(EBound 4); EUnit;
        (ECons (TQualified (["DPE"], "session_state")) "InUse" []); EUnit])
    (EMatch (EBound 0)
      [iou:branch; iou:branch; iou:branch; iou:branch; iou:branch])))
  (DFunction None [Private] 0 (TQualified (["DPETypes"], "profile_descriptor_t"))
  (["DPE"], "get_profile")
  [{ name = "uu___"; typ = TUnit; mut = false; meta = [] }]
  (EApp (EQualified (["DPETypes"], "mk_profile_descriptor"))
    [(EString ""); (EConstant (UInt32, "1")); (EConstant (UInt32, "0"));
      (EBool false); (EBool false); (EBool false); (EBool false);
      (EConstant (SizeT, "0")); (EString ""); (EBool false); (EString "");
      (EString ""); (EBool false); (EBool true); (EConstant (SizeT, "1"));
      (EConstant (SizeT, "16")); (EBool false); (EBool false); (EBool false);
      (EBool false); (EBool true); (EBool false); (EBool false); (EBool false);
      (EBool false); (EBool false); (EBool true); (EBool false); (EBool false);
      (EBool false); (EBool false); (EBool false); (EBool true); (EString "");
      (EString ""); (EString ""); (EBool false); (EString ""); (EString "");
      (EString ""); (EBool false); (EBool false); (EBool false); (EString "");
      (EString ""); (EString ""); (EBool false); (EConstant (SizeT, "0"));
      (EConstant (SizeT, "0")); (EBool false); (EBool false); (EBool false);
      (EBool false); (EBool false); (EBool false); (EBool false); (EBool false);
      (EString ""); (EBool false); (EString ""); (EString ""); (EString "");
      (EBool false); (EString ""); (EString ""); (EBool false); (EBool false);
      (EBool false); (EString "")]))
```