### PR TITLE
Errors: implementing error bound

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_Compiler_Range_Ops.ml
+++ b/ocaml/fstar-lib/generated/FStar_Compiler_Range_Ops.ml
@@ -255,6 +255,53 @@ let (json_of_def_range : FStar_Compiler_Range_Type.range -> FStar_Json.json)
     let uu___ = file_of_range r in
     let uu___1 = start_of_range r in
     let uu___2 = end_of_range r in json_of_range_fields uu___ uu___1 uu___2
+let (intersect_rng :
+  FStar_Compiler_Range_Type.rng ->
+    FStar_Compiler_Range_Type.rng -> FStar_Compiler_Range_Type.rng)
+  =
+  fun r1 ->
+    fun r2 ->
+      if
+        r1.FStar_Compiler_Range_Type.file_name <>
+          r2.FStar_Compiler_Range_Type.file_name
+      then r2
+      else
+        (let start_pos =
+           if
+             FStar_Compiler_Range_Type.pos_geq
+               r1.FStar_Compiler_Range_Type.start_pos
+               r2.FStar_Compiler_Range_Type.start_pos
+           then r1.FStar_Compiler_Range_Type.start_pos
+           else r2.FStar_Compiler_Range_Type.start_pos in
+         let end_pos =
+           if
+             FStar_Compiler_Range_Type.pos_geq
+               r1.FStar_Compiler_Range_Type.end_pos
+               r2.FStar_Compiler_Range_Type.end_pos
+           then r2.FStar_Compiler_Range_Type.end_pos
+           else r1.FStar_Compiler_Range_Type.end_pos in
+         FStar_Compiler_Range_Type.mk_rng
+           r1.FStar_Compiler_Range_Type.file_name start_pos end_pos)
+let (intersect_ranges :
+  FStar_Compiler_Range_Type.range ->
+    FStar_Compiler_Range_Type.range -> FStar_Compiler_Range_Type.range)
+  =
+  fun r1 ->
+    fun r2 ->
+      let uu___ =
+        intersect_rng r1.FStar_Compiler_Range_Type.def_range
+          r2.FStar_Compiler_Range_Type.def_range in
+      let uu___1 =
+        intersect_rng r1.FStar_Compiler_Range_Type.use_range
+          r2.FStar_Compiler_Range_Type.use_range in
+      {
+        FStar_Compiler_Range_Type.def_range = uu___;
+        FStar_Compiler_Range_Type.use_range = uu___1
+      }
+let (bound_range :
+  FStar_Compiler_Range_Type.range ->
+    FStar_Compiler_Range_Type.range -> FStar_Compiler_Range_Type.range)
+  = fun r -> fun bound -> intersect_ranges r bound
 let (showable_range :
   FStar_Compiler_Range_Type.range FStar_Class_Show.showable) =
   { FStar_Class_Show.show = string_of_range }

--- a/ocaml/fstar-lib/generated/FStar_Errors.ml
+++ b/ocaml/fstar-lib/generated/FStar_Errors.ml
@@ -3,6 +3,19 @@ let (fallback_range :
   FStar_Compiler_Range_Type.range FStar_Pervasives_Native.option
     FStar_Compiler_Effect.ref)
   = FStar_Compiler_Util.mk_ref FStar_Pervasives_Native.None
+let (error_range_bound :
+  FStar_Compiler_Range_Type.range FStar_Pervasives_Native.option
+    FStar_Compiler_Effect.ref)
+  = FStar_Compiler_Util.mk_ref FStar_Pervasives_Native.None
+let with_error_bound :
+  'a . FStar_Compiler_Range_Type.range -> (unit -> 'a) -> 'a =
+  fun r ->
+    fun f ->
+      let old = FStar_Compiler_Effect.op_Bang error_range_bound in
+      FStar_Compiler_Effect.op_Colon_Equals error_range_bound
+        (FStar_Pervasives_Native.Some r);
+      (let res = f () in
+       FStar_Compiler_Effect.op_Colon_Equals error_range_bound old; res)
 exception Invalid_warn_error_setting of Prims.string 
 let (uu___is_Invalid_warn_error_setting : Prims.exn -> Prims.bool) =
   fun projectee ->
@@ -436,6 +449,14 @@ let (dummy_ide_rng : FStar_Compiler_Range_Type.rng) =
   let uu___ = FStar_Compiler_Range_Type.mk_pos Prims.int_one Prims.int_zero in
   let uu___1 = FStar_Compiler_Range_Type.mk_pos Prims.int_one Prims.int_zero in
   FStar_Compiler_Range_Type.mk_rng "<input>" uu___ uu___1
+let (maybe_bound_rng :
+  FStar_Compiler_Range_Type.range -> FStar_Compiler_Range_Type.range) =
+  fun r ->
+    let uu___ = FStar_Compiler_Effect.op_Bang error_range_bound in
+    match uu___ with
+    | FStar_Pervasives_Native.Some r' ->
+        FStar_Compiler_Range_Ops.bound_range r r'
+    | FStar_Pervasives_Native.None -> r
 let (fixup_issue_range : issue -> issue) =
   fun i ->
     let rng =
@@ -462,10 +483,11 @@ let (fixup_issue_range : issue -> issue) =
                else use_rng) in
           let uu___ = FStar_Compiler_Range_Type.set_use_range range use_rng' in
           FStar_Pervasives_Native.Some uu___ in
+    let uu___ = FStar_Compiler_Util.map_opt rng maybe_bound_rng in
     {
       issue_msg = (i.issue_msg);
       issue_level = (i.issue_level);
-      issue_range = rng;
+      issue_range = uu___;
       issue_number = (i.issue_number);
       issue_ctx = (i.issue_ctx)
     }
@@ -681,7 +703,7 @@ let (set_option_warning_callback_range :
   FStar_Compiler_Range_Type.range FStar_Pervasives_Native.option -> unit) =
   fun ropt ->
     FStar_Options.set_option_warning_callback (warn_unsafe_options ropt)
-let (uu___341 :
+let (uu___357 :
   (((Prims.string -> FStar_Errors_Codes.error_setting Prims.list) -> unit) *
     (unit -> FStar_Errors_Codes.error_setting Prims.list)))
   =
@@ -727,10 +749,10 @@ let (uu___341 :
   (set_callbacks, get_error_flags)
 let (t_set_parse_warn_error :
   (Prims.string -> FStar_Errors_Codes.error_setting Prims.list) -> unit) =
-  match uu___341 with
+  match uu___357 with
   | (t_set_parse_warn_error1, error_flags) -> t_set_parse_warn_error1
 let (error_flags : unit -> FStar_Errors_Codes.error_setting Prims.list) =
-  match uu___341 with
+  match uu___357 with
   | (t_set_parse_warn_error1, error_flags1) -> error_flags1
 let (set_parse_warn_error :
   (Prims.string -> FStar_Errors_Codes.error_setting Prims.list) -> unit) =

--- a/src/basic/FStar.Compiler.Range.Ops.fst
+++ b/src/basic/FStar.Compiler.Range.Ops.fst
@@ -121,6 +121,25 @@ let json_of_def_range r =
             (start_of_range r)
             (end_of_range r)
 
+let intersect_rng r1 r2 =
+  if r1.file_name <> r2.file_name then r2
+  else let start_pos =
+           if pos_geq r1.start_pos r2.start_pos then
+             r1.start_pos
+           else r2.start_pos in
+       let end_pos =
+           if pos_geq r1.end_pos r2.end_pos then
+             r2.end_pos
+           else r1.end_pos in
+       mk_rng r1.file_name start_pos end_pos
+let intersect_ranges r1 r2 = {
+  def_range=intersect_rng r1.def_range r2.def_range;
+  use_range=intersect_rng r1.use_range r2.use_range
+}
+
+let bound_range (r bound : range) : range =
+  intersect_ranges r bound
+
 instance showable_range = {
   show = string_of_range;
 }

--- a/src/basic/FStar.Compiler.Range.Ops.fsti
+++ b/src/basic/FStar.Compiler.Range.Ops.fsti
@@ -48,5 +48,10 @@ val json_of_pos : pos -> Json.json
 val json_of_use_range : range -> Json.json
 val json_of_def_range : range -> Json.json
 
+(** Bounds the range [r] by [bound]. Essentially, this is an intersection,
+making sure that whatever we report is within the bound. If the ranges
+are from different files, or there is no overlap, we return [bound]. *)
+val bound_range (r : range) (bound : range) : range
+
 instance val showable_range : showable range
 instance val pretty_range : pretty range

--- a/src/basic/FStar.Errors.fsti
+++ b/src/basic/FStar.Errors.fsti
@@ -28,6 +28,14 @@ with a dummy range. It is set by TypeChecker.Tc.process_one_decl to
 the range of the sigelt being checked. *)
 val fallback_range : FStar.Compiler.Effect.ref (option Range.range)
 
+(* This range, if set, will be used to limit the range of every
+issue that is logged/raised. This is set, e.g. when checking a top-level
+definition, to the range of the definition, so no error can be reported
+outside of it. *)
+val error_range_bound : FStar.Compiler.Effect.ref (option Range.range)
+
+val with_error_bound (r:Range.range) (f : unit -> 'a) : 'a
+
 (* Get the error number for a particular code. Useful for creating error
 messages mentioning --warn_error. *)
 val errno : error_code -> int


### PR DESCRIPTION
As discussed last meeting, this allows to set a "bound" for the ranges in error reports, so that a wrongly-computed range cannot just escape to anywhere in the file, or even worse to other files.

This is not currently set by F*, but will be used by Pulse.