### PR TITLE
Restore bytecode fstarlib

### DIFF
--- a/ocaml/fstar-lib/dune
+++ b/ocaml/fstar-lib/dune
@@ -14,7 +14,7 @@
     process
     sedlex
  )
- (modes native)
+ (modes native byte)
  (wrapped false)
  (preprocess (pps ppx_deriving.show ppx_deriving_yojson sedlex.ppx))
 )


### PR DESCRIPTION
This breaks MLS* and its compilation to JS via js_of_ocaml, which consumes bytecode