### PR TITLE
Arrow one

### DIFF
--- a/.github/workflows/check-world.yml
+++ b/.github/workflows/check-world.yml
@@ -327,8 +327,14 @@ jobs:
         run: make -C pulse -skj$(nproc) test
 
   build-hacl:
-    runs-on: [self-hosted, linux, big] # using a faster runner
-    # runs-on: ubuntu-latest
+    # runs-on: [self-hosted, linux, big] # using a faster runner
+    # NOTE: To use a self-hosted runner, we must make sure that
+    # the runner is executing as UID 1001 (which is the one the
+    # docker container uses) or it will be unable to write to its
+    # workspace. This is simply a terrible design by github actions.
+    # Somehow the cloud runners work regardless of the uid in
+    # the container.
+    runs-on: ubuntu-latest
     container: mtzguido/fstar-base-testing
     needs:
       - build-fstar

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Util.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Util.ml
@@ -2823,11 +2823,21 @@ let (arrow_one_ln :
         FStar_Pervasives_Native.Some (b, c)
     | FStar_Syntax_Syntax.Tm_arrow
         { FStar_Syntax_Syntax.bs1 = b::bs; FStar_Syntax_Syntax.comp = c;_} ->
-        let uu___1 =
-          let uu___2 =
-            let uu___3 = arrow bs c in FStar_Syntax_Syntax.mk_Total uu___3 in
-          (b, uu___2) in
-        FStar_Pervasives_Native.Some uu___1
+        let rng' =
+          FStar_Compiler_List.fold_left
+            (fun a ->
+               fun b1 ->
+                 FStar_Compiler_Range_Ops.union_ranges a
+                   ((b1.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort).FStar_Syntax_Syntax.pos)
+            c.FStar_Syntax_Syntax.pos bs in
+        let c' =
+          let uu___1 =
+            FStar_Syntax_Syntax.mk
+              (FStar_Syntax_Syntax.Tm_arrow
+                 { FStar_Syntax_Syntax.bs1 = bs; FStar_Syntax_Syntax.comp = c
+                 }) rng' in
+          FStar_Syntax_Syntax.mk_Total uu___1 in
+        FStar_Pervasives_Native.Some (b, c')
     | uu___1 -> FStar_Pervasives_Native.None
 let (arrow_one :
   FStar_Syntax_Syntax.typ ->

--- a/src/syntax/FStar.Syntax.Util.fst
+++ b/src/syntax/FStar.Syntax.Util.fst
@@ -1226,7 +1226,10 @@ let arrow_one_ln (t:typ) : option (binder & comp) =
     | Tm_arrow {bs=[b]; comp=c} ->
         Some (b, c)
     | Tm_arrow {bs=b::bs; comp=c} ->
-        Some (b, mk_Total (arrow bs c))
+        (* NB: bs are closed, so we just repackage the node *)
+        let rng' = List.fold_left (fun a b -> Range.union_ranges a b.binder_bv.sort.pos) c.pos bs in
+        let c' = mk_Total (mk (Tm_arrow {bs; comp=c}) rng') in
+        Some (b, c')
     | _ ->
         None
 


### PR DESCRIPTION
`arrow_one_ln` was needlessly closing over the binders again, even though they were already closed. This is a no-op, but it makes some programs quadratic instead of linear, for instance if calling `arrow_one_ln` repeatedly from a tactic, which happens for `collect_arr_bs`, and others.

For an arrow with 500 binders and the `mk_projectors` tactics, this reduced the startup time from ~3s to 180ms. There's other bottlenecks probably.