### PR TITLE
Bump dune version dependency.

### DIFF
--- a/fstar.opam
+++ b/fstar.opam
@@ -10,7 +10,7 @@ depends: [
   "zarith"
   "stdint"
   "yojson"
-  "dune" {build & >= "3.2.0"}
+  "dune" {build & >= "3.8.0"}
   "memtrace"
   "menhirLib"
   "menhir" {build & >= "2.1"}


### PR DESCRIPTION
Commit 7e20a5cab6e5451e178c486dcd0a80db39c35b22 requires dune >= 3.8.0 to build, this adds the dependency to the opam file.