### PR TITLE
Revise the SMT encoding of top-level prop definitions

### DIFF
--- a/examples/rel/Benton2004.RHL.Examples.fst
+++ b/examples/rel/Benton2004.RHL.Examples.fst
@@ -188,7 +188,9 @@ let d_su1'_flip
 #set-options "--z3rlimit 150"
 let sec43
   (i n x y: var)
-  (diffs: squash (List.Tot.noRepeats [i; n; x; y] == true))
+  (diffs: squash (i <> n /\ i <> x /\ i <> y /\
+                  n <> x /\ n <> y /\
+                  x <> y))
 : Lemma
   (ensures (
     exec_equiv
@@ -209,10 +211,8 @@ let sec43
   let rloop = while cond asi in
   let phi1 = gand phi (geq (gvar x Right) (gop op_Addition (gvar y Right) (gconst 1))) in
   let phi2 = gand phi1 (geq (gvar x Left) (gvar x Right)) in
-  assert (x <> i /\ x <> n /\ x <> y); // for the substitutions in phi, phi1
   r_dassr x asx_e phi phi1;
   r_dassl x asx_e phi1 phi2;
-  assert (i <> x /\ i <> n /\ i <> y); // for the substitutions in phi2
   r_ass i i asi_e asi_e phi2 phi2;
   d_su1' asx asi asi phi1 phi2 phi2;
   r_while cond cond lbody asi phi1;

--- a/examples/rel/Makefile
+++ b/examples/rel/Makefile
@@ -26,7 +26,6 @@ all:\
   IfcTypechecker.uver\
   Loops.uver\
   Memo.uver\
-  NetKat.uver\
   OneTimePad.uver\
   Point.uver\
   ProgramEquivalence.uver\

--- a/ocaml/fstar-lib/generated/FStar_CheckedFiles.ml
+++ b/ocaml/fstar-lib/generated/FStar_CheckedFiles.ml
@@ -1,7 +1,7 @@
 open Prims
 let (dbg : Prims.bool FStar_Compiler_Effect.ref) =
   FStar_Compiler_Debug.get_toggle "CheckedFiles"
-let (cache_version_number : Prims.int) = (Prims.of_int (71))
+let (cache_version_number : Prims.int) = (Prims.of_int (72))
 type tc_result =
   {
   checked_module: FStar_Syntax_Syntax.modul ;

--- a/ocaml/fstar-lib/generated/FStar_SMTEncoding_Encode.ml
+++ b/ocaml/fstar-lib/generated/FStar_SMTEncoding_Encode.ml
@@ -2902,6 +2902,10 @@ let (encode_top_level_let :
                                                             env2.FStar_SMTEncoding_Env.tcenv
                                                             fv
                                                             FStar_Parser_Const.smt_theory_symbol_attr_lid in
+                                                        let is_sub_singleton
+                                                          =
+                                                          FStar_Syntax_Util.is_sub_singleton
+                                                            body in
                                                         let should_encode_logical
                                                           =
                                                           (Prims.op_Negation
@@ -2957,27 +2961,97 @@ let (encode_top_level_let :
                                                               "defn_equation"
                                                             else "equation" in
                                                           let uu___16 =
-                                                            let uu___17 =
-                                                              FStar_SMTEncoding_EncodeTerm.encode_term
-                                                                body env'1 in
-                                                            match uu___17
-                                                            with
-                                                            | (body1, decls2)
-                                                                ->
-                                                                let pat =
-                                                                  if
-                                                                    should_encode_logical
-                                                                  then
-                                                                    FStar_SMTEncoding_Term.mk_subtype_of_unit
-                                                                    app
-                                                                  else app in
-                                                                let uu___18 =
-                                                                  make_eqn
+                                                            let app_is_prop =
+                                                              FStar_SMTEncoding_Term.mk_subtype_of_unit
+                                                                app in
+                                                            if
+                                                              should_encode_logical
+                                                            then
+                                                              (if
+                                                                 is_sub_singleton
+                                                               then
+                                                                 let uu___17
+                                                                   =
+                                                                   let uu___18
+                                                                    =
+                                                                    let uu___19
+                                                                    =
+                                                                    let uu___20
+                                                                    =
+                                                                    FStar_Syntax_Syntax.range_of_lbname
+                                                                    lbn in
+                                                                    let uu___21
+                                                                    =
+                                                                    let uu___22
+                                                                    =
+                                                                    FStar_SMTEncoding_Term.mk_Valid
+                                                                    app_is_prop in
+                                                                    ([
+                                                                    [app_is_prop]],
+                                                                    vars1,
+                                                                    uu___22) in
+                                                                    FStar_SMTEncoding_Term.mkForall
+                                                                    uu___20
+                                                                    uu___21 in
+                                                                    let uu___20
+                                                                    =
+                                                                    let uu___21
+                                                                    =
+                                                                    let uu___22
+                                                                    =
+                                                                    FStar_Ident.string_of_lid
+                                                                    flid in
+                                                                    FStar_Compiler_Util.format1
+                                                                    "Prop-typing for %s"
+                                                                    uu___22 in
+                                                                    FStar_Pervasives_Native.Some
+                                                                    uu___21 in
+                                                                    (uu___19,
+                                                                    uu___20,
+                                                                    (Prims.strcat
                                                                     basic_eqn_name
-                                                                    pat app
+                                                                    (Prims.strcat
+                                                                    "_"
+                                                                    fvb.FStar_SMTEncoding_Env.smt_id))) in
+                                                                   FStar_SMTEncoding_Util.mkAssume
+                                                                    uu___18 in
+                                                                 (uu___17,
+                                                                   [])
+                                                               else
+                                                                 (let uu___18
+                                                                    =
+                                                                    FStar_SMTEncoding_EncodeTerm.encode_term
+                                                                    body
+                                                                    env'1 in
+                                                                  match uu___18
+                                                                  with
+                                                                  | (body1,
+                                                                    decls2)
+                                                                    ->
+                                                                    let uu___19
+                                                                    =
+                                                                    make_eqn
+                                                                    basic_eqn_name
+                                                                    app_is_prop
+                                                                    app body1 in
+                                                                    (uu___19,
+                                                                    decls2)))
+                                                            else
+                                                              (let uu___18 =
+                                                                 FStar_SMTEncoding_EncodeTerm.encode_term
+                                                                   body env'1 in
+                                                               match uu___18
+                                                               with
+                                                               | (body1,
+                                                                  decls2) ->
+                                                                   let uu___19
+                                                                    =
+                                                                    make_eqn
+                                                                    basic_eqn_name
+                                                                    app app
                                                                     body1 in
-                                                                (uu___18,
-                                                                  decls2) in
+                                                                   (uu___19,
+                                                                    decls2)) in
                                                           match uu___16 with
                                                           | (basic_eqn,
                                                              decls2) ->

--- a/ocaml/fstar-lib/generated/FStar_SMTEncoding_Encode.ml
+++ b/ocaml/fstar-lib/generated/FStar_SMTEncoding_Encode.ml
@@ -2967,74 +2967,82 @@ let (encode_top_level_let :
                                                             if
                                                               should_encode_logical
                                                             then
-                                                              (if
-                                                                 is_sub_singleton
-                                                               then
-                                                                 let uu___17
-                                                                   =
-                                                                   let uu___18
+                                                              let uu___17 =
+                                                                is_sub_singleton
+                                                                  &&
+                                                                  (let uu___18
                                                                     =
-                                                                    let uu___19
+                                                                    FStar_Options_Ext.get
+                                                                    "retain_old_prop_typing" in
+                                                                   uu___18 =
+                                                                    "") in
+                                                              (if uu___17
+                                                               then
+                                                                 let uu___18
+                                                                   =
+                                                                   let uu___19
                                                                     =
                                                                     let uu___20
                                                                     =
-                                                                    FStar_Syntax_Syntax.range_of_lbname
-                                                                    lbn in
                                                                     let uu___21
                                                                     =
+                                                                    FStar_Syntax_Syntax.range_of_lbname
+                                                                    lbn in
                                                                     let uu___22
+                                                                    =
+                                                                    let uu___23
                                                                     =
                                                                     FStar_SMTEncoding_Term.mk_Valid
                                                                     app_is_prop in
                                                                     ([
                                                                     [app_is_prop]],
                                                                     vars1,
-                                                                    uu___22) in
+                                                                    uu___23) in
                                                                     FStar_SMTEncoding_Term.mkForall
-                                                                    uu___20
-                                                                    uu___21 in
-                                                                    let uu___20
-                                                                    =
+                                                                    uu___21
+                                                                    uu___22 in
                                                                     let uu___21
                                                                     =
                                                                     let uu___22
+                                                                    =
+                                                                    let uu___23
                                                                     =
                                                                     FStar_Ident.string_of_lid
                                                                     flid in
                                                                     FStar_Compiler_Util.format1
                                                                     "Prop-typing for %s"
-                                                                    uu___22 in
+                                                                    uu___23 in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu___21 in
-                                                                    (uu___19,
-                                                                    uu___20,
+                                                                    uu___22 in
+                                                                    (uu___20,
+                                                                    uu___21,
                                                                     (Prims.strcat
                                                                     basic_eqn_name
                                                                     (Prims.strcat
                                                                     "_"
                                                                     fvb.FStar_SMTEncoding_Env.smt_id))) in
                                                                    FStar_SMTEncoding_Util.mkAssume
-                                                                    uu___18 in
-                                                                 (uu___17,
+                                                                    uu___19 in
+                                                                 (uu___18,
                                                                    [])
                                                                else
-                                                                 (let uu___18
+                                                                 (let uu___19
                                                                     =
                                                                     FStar_SMTEncoding_EncodeTerm.encode_term
                                                                     body
                                                                     env'1 in
-                                                                  match uu___18
+                                                                  match uu___19
                                                                   with
                                                                   | (body1,
                                                                     decls2)
                                                                     ->
-                                                                    let uu___19
+                                                                    let uu___20
                                                                     =
                                                                     make_eqn
                                                                     basic_eqn_name
                                                                     app_is_prop
                                                                     app body1 in
-                                                                    (uu___19,
+                                                                    (uu___20,
                                                                     decls2)))
                                                             else
                                                               (let uu___18 =

--- a/ocaml/fstar-lib/generated/FStar_SMTEncoding_Encode.ml
+++ b/ocaml/fstar-lib/generated/FStar_SMTEncoding_Encode.ml
@@ -2840,7 +2840,7 @@ let (encode_top_level_let :
                                                    FStar_Pervasives_Native.None
                                                    binders env' in
                                                match uu___12 with
-                                               | (vars, _guards, env'1,
+                                               | (vars, binder_guards, env'1,
                                                   binder_decls, uu___13) ->
                                                    let uu___14 =
                                                      if
@@ -2992,8 +2992,20 @@ let (encode_top_level_let :
                                                                     =
                                                                     let uu___23
                                                                     =
+                                                                    let uu___24
+                                                                    =
+                                                                    let uu___25
+                                                                    =
+                                                                    FStar_SMTEncoding_Util.mk_and_l
+                                                                    binder_guards in
+                                                                    let uu___26
+                                                                    =
                                                                     FStar_SMTEncoding_Term.mk_Valid
                                                                     app_is_prop in
+                                                                    (uu___25,
+                                                                    uu___26) in
+                                                                    FStar_SMTEncoding_Util.mkImp
+                                                                    uu___24 in
                                                                     ([
                                                                     [app_is_prop]],
                                                                     vars1,

--- a/src/fstar/FStar.CheckedFiles.fst
+++ b/src/fstar/FStar.CheckedFiles.fst
@@ -36,7 +36,7 @@ let dbg = Debug.get_toggle "CheckedFiles"
  * detect when loading the cache that the version number is same
  * It needs to be kept in sync with Prims.fst
  *)
-let cache_version_number = 71
+let cache_version_number = 72
 
 (*
  * Abbreviation for what we store in the checked files (stages as described below)

--- a/src/smtencoding/FStar.SMTEncoding.Encode.fst
+++ b/src/smtencoding/FStar.SMTEncoding.Encode.fst
@@ -821,7 +821,7 @@ let encode_top_level_let :
                     let app_is_prop = Term.mk_subtype_of_unit app in
                     if should_encode_logical
                     then (
-                      if is_sub_singleton
+                      if is_sub_singleton && Options.Ext.get "retain_old_prop_typing" = ""
                       then (
                         Util.mkAssume(mkForall (S.range_of_lbname lbn)
                                             ([[app_is_prop]], vars, mk_Valid <| app_is_prop),

--- a/src/smtencoding/FStar.SMTEncoding.Encode.fst
+++ b/src/smtencoding/FStar.SMTEncoding.Encode.fst
@@ -780,7 +780,7 @@ let encode_top_level_let :
                                 (show binders)
                                 (show body);
                 (* Encode binders *)
-                let vars, _guards, env', binder_decls, _ = encode_binders None binders env' in
+                let vars, binder_guards, env', binder_decls, _ = encode_binders None binders env' in
                 let vars, app =
                     if fvb.fvb_thunked && vars = []
                     then let dummy_var = mk_fv ("@dummy", dummy_sort) in
@@ -824,7 +824,7 @@ let encode_top_level_let :
                       if is_sub_singleton && Options.Ext.get "retain_old_prop_typing" = ""
                       then (
                         Util.mkAssume(mkForall (S.range_of_lbname lbn)
-                                            ([[app_is_prop]], vars, mk_Valid <| app_is_prop),
+                                            ([[app_is_prop]], vars, mkImp(mk_and_l binder_guards, mk_Valid <| app_is_prop)),
                                       Some (BU.format1 "Prop-typing for %s" (string_of_lid flid)),
                                     (basic_eqn_name ^ "_" ^ fvb.smt_id)),
                         []

--- a/src/smtencoding/FStar.SMTEncoding.Pruning.fst
+++ b/src/smtencoding/FStar.SMTEncoding.Pruning.fst
@@ -461,4 +461,8 @@ let prune (p:pruning_state) (roots:list decl)
         | Some a -> [a]) 
       (reached_names@p.ambients)
   in
+  // if Options.Ext.get "debug_context_pruning" <> ""
+  // then (
+  //   BU.print1 "Retained %s assumptions\n" (show (List.length reached_assumptions))
+  // );
   reached_assumptions

--- a/tests/bug-reports/Bug2172.fst
+++ b/tests/bug-reports/Bug2172.fst
@@ -1,14 +1,11 @@
 module Bug2172
 #push-options "--ext context_pruning"
 // one existential quantification over two variables (`p2` below) is
-// different from two extistential quantifications over one variable
+// different from two existential quantifications over one variable
 // each (`p1` below)
 let p1 = exists (x: int). exists (y: int). 0 == x + y
 let p2 = exists (x: int)         (y: int). 0 == x + y
 
 let test0 (witness:nat) = assert p1
-#pop-options
-#push-options "--ext 'context_pruning='"
-let test1 = assert p2
-#pop-options
+let test1 (x:int) = assert (0 == x + (-x)); assert p2
 let _ = assert (p1 <==> p2)

--- a/ulib/Prims.fst
+++ b/ulib/Prims.fst
@@ -729,4 +729,4 @@ val string_of_int: int -> Tot string
 (** THIS IS MEANT TO BE KEPT IN SYNC WITH FStar.CheckedFiles.fs
     Incrementing this forces all .checked files to be invalidated *)
 irreducible
-let __cache_version_number__ = 71
+let __cache_version_number__ = 72


### PR DESCRIPTION
[Following up on #3440]

Say you define:

```
let some_pred (x:t) = forall y. p x y
```

The existing behavior for this in the SMT encoding is to produce something like

```
(forall x. (! (= (some_pred x) (Prims.l_forall (Tm_abs ...)) :pattern ((Prims.subtype_of (some_pred x) Prims.unit)))
```

In other words, with a trigger for proving that `some_pred x : prop`, this axiom introduces an equation in scope defining `some_pred x` in terms of its "deeply embedded" SMT representation as an application of l_forall to a lambda term.

This is overkill in many cases, especially when it can be determined from the head-constructor of the definition that `some_pred x` is trivially a prop.

The interaction of this behavior with context_pruning is especially unfortunate, since it means that as soon as `some_pred` is reachable (and Prims.unit and Prims.subtype_of, but these are almost always reachable), the deep embedding of `some_pred` also becomes reachable and context pruning ends up pulling in a whole bunch of definitions l_quant_interp etc. for the deeply embedded quantifier that are unnecessary.

So, this PR changes the behavior to the following:

When encoding a top-level "logical" definition like `some_pred x`, if the definition is a sub-singleton (syntactically determined from its head constructor), then instead of the axiom above, we now generate

```
(forall x. (! (implies (HasType x t) (Valid (Prims.subtype_of (some_pred x) Prims.unit)) :pattern ((Prims.subtype_of (some_pred x) Prims.unit))))
```

The result is that when context pruning, we no longer needlessly bring deeply embedded quantified facts into scope, just by mentioned top-level logical symbols.

## Impact

I have a green on check-world: https://github.com/FStarLang/FStar/actions/runs/11097438556

Many files that were already using context pruning verify much faster now:
E.g., 

* FStar.Sequence.Base.fst: The context is in some cases half as big as previously, with no l_quant_interp facts retained. I observe a significant end-to-end verification time improvement (4.5s now vs 7.2s previously)

* Kuiper.MatMul.fst: Previously 8.7s now 4.7s

etc.

There were only two meaningful regressions:

1. In F* Bug2172: We were relying on the deeply embedded quantifier to bring some constants into scope which results in instantiating an existential quantifier. This is very unpredictable and not something that one should expect to work. I've changed the test case accordingly.

2. In Pulse: ArraySwap.Proof, the symptom is very similar to Bug2172, where a doubly nested quantifier triggers in an unexpected way to make the proof work. This needed some adjusting. A better fix would be to write a proper pattern on those quantifiers, rather than leaving it to be picked heuristically by Z3.

Note, I've bumped the checked file version, since this changes the SMT encoding and cached declarations in checked files need to be invalidated.

That said, the old behavior is retained with `--ext retain_old_prop_typing`

## Future improvements

If we get rid of the logical type altogether, then the prop-typing of top-level definitions should just follow from regular typing axioms. When that happens, we should be able to remove this special-casing of prop-typing altogether.
