### PR TITLE
Add a cast from size_t to uint64_t

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_Extraction_Krml.ml
+++ b/ocaml/fstar-lib/generated/FStar_Extraction_Krml.ml
@@ -3249,6 +3249,19 @@ and (translate_expr' : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
           let uu___2 =
             let uu___3 = translate_expr env1 arg in (uu___3, (TInt UInt32)) in
           ECast uu___2
+      | FStar_Extraction_ML_Syntax.MLE_App
+          ({
+             FStar_Extraction_ML_Syntax.expr =
+               FStar_Extraction_ML_Syntax.MLE_Name p;
+             FStar_Extraction_ML_Syntax.mlty = uu___;
+             FStar_Extraction_ML_Syntax.loc = uu___1;_},
+           arg::[])
+          when
+          let uu___2 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+          uu___2 = "FStar.SizeT.sizet_to_uint64" ->
+          let uu___2 =
+            let uu___3 = translate_expr env1 arg in (uu___3, (TInt UInt64)) in
+          ECast uu___2
       | FStar_Extraction_ML_Syntax.MLE_App (head, args) ->
           let uu___ =
             let uu___1 = translate_expr env1 head in
@@ -3990,7 +4003,7 @@ let (translate :
                        "Unable to translate module: %s because:\n  %s\n"
                        m_name uu___3);
                     FStar_Pervasives_Native.None)) modules
-let (uu___2053 : unit) =
+let (uu___2060 : unit) =
   register_post_translate_type_without_decay translate_type_without_decay';
   register_post_translate_type translate_type';
   register_post_translate_type_decl translate_type_decl';

--- a/ocaml/fstar-lib/generated/FStar_SizeT.ml
+++ b/ocaml/fstar-lib/generated/FStar_SizeT.ml
@@ -17,6 +17,7 @@ let (uint64_to_sizet : FStar_UInt64.t -> t) =
   fun x -> uint_to_t (FStar_UInt64.v x)
 let (sizet_to_uint32 : t -> FStar_UInt32.t) =
   fun x -> FStar_Int_Cast.uint64_to_uint32 (__proj__Sz__item__x x)
+let (sizet_to_uint64 : t -> FStar_UInt64.t) = fun x -> __proj__Sz__item__x x
 let (add : t -> t -> t) =
   fun x ->
     fun y ->

--- a/src/extraction/FStar.Extraction.Krml.fst
+++ b/src/extraction/FStar.Extraction.Krml.fst
@@ -1164,6 +1164,10 @@ and translate_expr' env e: expr =
     when string_of_mlpath p = "FStar.SizeT.sizet_to_uint32" ->
       ECast (translate_expr env arg, TInt UInt32)
 
+  | MLE_App ({ expr = MLE_Name p }, [ arg ])
+    when string_of_mlpath p = "FStar.SizeT.sizet_to_uint64" ->
+      ECast (translate_expr env arg, TInt UInt64)
+
   | MLE_App (head, args) ->
       EApp (translate_expr env head, List.map (translate_expr env) args)
 

--- a/ulib/FStar.SizeT.fst
+++ b/ulib/FStar.SizeT.fst
@@ -63,6 +63,7 @@ let uint16_to_sizet x = uint_to_t (U16.v x)
 let uint32_to_sizet x = uint_to_t (U32.v x)
 let uint64_to_sizet x = uint_to_t (U64.v x)
 let sizet_to_uint32 x = FStar.Int.Cast.uint64_to_uint32 (Sz?.x x)
+let sizet_to_uint64 x = (Sz?.x x)
 
 let fits_lte x y = ()
 

--- a/ulib/FStar.SizeT.fsti
+++ b/ulib/FStar.SizeT.fsti
@@ -97,6 +97,10 @@ val sizet_to_uint32 (x:t) : Pure U32.t
   (requires True)
   (ensures fun y -> U32.v y == v x % pow2 32)
 
+val sizet_to_uint64 (x:t) : Pure U64.t
+  (requires True)
+  (ensures fun y -> U64.v y == v x % pow2 64)
+
 val fits_lte (x y: nat) : Lemma
   (requires (x <= y /\ fits y))
   (ensures (fits x))


### PR DESCRIPTION
Just like `FStar.SizeT.sizet_to_uint32` defines a cast from `size_t` to `uint32_t`, this PR adds `FStar.SizeT.sizet_to_uint64` to support casts from `size_t` to `uint64_t`, along with the corresponding Karamel extraction rule.