### PR TITLE
Main: adding --locate, --locate_lib, --locate_ocaml

### DIFF
--- a/examples/hello/multifile/output/Makefile
+++ b/examples/hello/multifile/output/Makefile
@@ -1,12 +1,14 @@
 
-ifdef FSTAR_HOME
-  ifeq ($(OS),Windows_NT)
-    OCAMLPATH := $(shell cygpath -m $(FSTAR_HOME)/lib);$(OCAMLPATH)
-  else
-    OCAMLPATH := $(FSTAR_HOME)/lib:$(OCAMLPATH)
-  endif
-endif
+# ifdef FSTAR_HOME
+#   ifeq ($(OS),Windows_NT)
+#     OCAMLPATH := $(shell cygpath -m $(FSTAR_HOME)/lib);$(OCAMLPATH)
+#   else
+#     OCAMLPATH := $(FSTAR_HOME)/stage2/lib:$(OCAMLPATH)
+#   endif
+# endif
 
+FSTAR_OCAML := $(shell $(FSTAR_HOME)/bin/fstar.exe --locate_ocaml)
+OCAMLPATH := $(FSTAR_OCAML):$(OCAMLPATH)
 # with dune
 Main.exe: $(wildcard *.ml)
 	OCAMLPATH="$(OCAMLPATH)" dune build

--- a/ocaml/fstar-lib/FStar_Compiler_Util.ml
+++ b/ocaml/fstar-lib/FStar_Compiler_Util.ml
@@ -901,6 +901,7 @@ let incr r = FStar_ST.(Z.(write r (read r + one)))
 let decr r = FStar_ST.(Z.(write r (read r - one)))
 let geq (i:int) (j:int) = i >= j
 
+let exec_name = Sys.executable_name
 let get_exec_dir () = Filename.dirname (Sys.executable_name)
 let expand_environment_variable x = try Some (Sys.getenv x) with Not_found -> None
 

--- a/ocaml/fstar-lib/generated/FStar_Common.ml
+++ b/ocaml/fstar-lib/generated/FStar_Common.ml
@@ -176,3 +176,9 @@ let psmap_values :
   'uuuuu . 'uuuuu FStar_Compiler_Util.psmap -> 'uuuuu Prims.list =
   fun m ->
     FStar_Compiler_Util.psmap_fold m (fun k -> fun v -> fun a -> v :: a) []
+let option_to_list :
+  'uuuuu . 'uuuuu FStar_Pervasives_Native.option -> 'uuuuu Prims.list =
+  fun uu___ ->
+    match uu___ with
+    | FStar_Pervasives_Native.None -> []
+    | FStar_Pervasives_Native.Some x -> [x]

--- a/ocaml/fstar-lib/generated/FStar_Main.ml
+++ b/ocaml/fstar-lib/generated/FStar_Main.ml
@@ -285,135 +285,197 @@ let go : 'uuuuu . 'uuuuu -> unit =
                              FStar_Compiler_Util.print1
                                "Registered tactic plugins:\n%s\n" uu___16))
                          else
-                           (let uu___15 =
-                              let uu___16 = FStar_Options.read_krml_file () in
-                              FStar_Pervasives_Native.uu___is_Some uu___16 in
+                           (let uu___15 = FStar_Options.locate () in
                             if uu___15
                             then
-                              let path =
-                                let uu___16 = FStar_Options.read_krml_file () in
-                                FStar_Pervasives_Native.__proj__Some__item__v
-                                  uu___16 in
-                              let uu___16 =
-                                FStar_Compiler_Util.load_value_from_file path in
-                              match uu___16 with
-                              | FStar_Pervasives_Native.None ->
-                                  let uu___17 =
-                                    let uu___18 =
-                                      let uu___19 =
-                                        FStar_Errors_Msg.text
-                                          "Could not read krml file:" in
-                                      let uu___20 =
-                                        FStar_Pprint.doc_of_string path in
-                                      FStar_Pprint.op_Hat_Slash_Hat uu___19
-                                        uu___20 in
-                                    [uu___18] in
-                                  FStar_Errors.raise_error0
-                                    FStar_Errors_Codes.Fatal_ModuleOrFileNotFound
-                                    ()
-                                    (Obj.magic
-                                       FStar_Errors_Msg.is_error_message_list_doc)
-                                    (Obj.magic uu___17)
-                              | FStar_Pervasives_Native.Some (version, files)
-                                  ->
-                                  ((let uu___18 =
-                                      FStar_Class_Show.show
-                                        (FStar_Class_Show.printableshow
-                                           FStar_Class_Printable.printable_int)
-                                        version in
-                                    FStar_Compiler_Util.print1
-                                      "Karamel format version: %s\n" uu___18);
-                                   FStar_Compiler_List.iter
-                                     (fun uu___18 ->
-                                        match uu___18 with
-                                        | (name, decls) ->
-                                            (FStar_Compiler_Util.print1
-                                               "%s:\n" name;
-                                             FStar_Compiler_List.iter
-                                               (fun d ->
-                                                  let uu___20 =
-                                                    FStar_Class_Show.show
-                                                      FStar_Extraction_Krml.showable_decl
-                                                      d in
-                                                  FStar_Compiler_Util.print1
-                                                    "  %s\n" uu___20) decls))
-                                     files)
+                              ((let uu___17 =
+                                  let uu___18 =
+                                    FStar_Compiler_Util.get_exec_dir () in
+                                  FStar_Compiler_Util.normalize_file_path
+                                    uu___18 in
+                                FStar_Compiler_Util.print1 "%s\n" uu___17);
+                               FStar_Compiler_Effect.exit Prims.int_zero)
                             else
-                              (let uu___17 = FStar_Options.lsp_server () in
+                              (let uu___17 = FStar_Options.locate_lib () in
                                if uu___17
-                               then FStar_Interactive_Lsp.start_server ()
+                               then
+                                 let uu___18 = FStar_Options.lib_root () in
+                                 match uu___18 with
+                                 | FStar_Pervasives_Native.None ->
+                                     (FStar_Compiler_Util.print_error
+                                        "No library found (is --no_default_includes set?)\n";
+                                      FStar_Compiler_Effect.exit
+                                        Prims.int_one)
+                                 | FStar_Pervasives_Native.Some s ->
+                                     ((let uu___20 =
+                                         FStar_Compiler_Util.normalize_file_path
+                                           s in
+                                       FStar_Compiler_Util.print1 "%s\n"
+                                         uu___20);
+                                      FStar_Compiler_Effect.exit
+                                        Prims.int_zero)
                                else
-                                 (let uu___19 = FStar_Options.interactive () in
+                                 (let uu___19 = FStar_Options.locate_ocaml () in
                                   if uu___19
                                   then
-                                    (FStar_Syntax_Unionfind.set_rw ();
-                                     (match filenames with
-                                      | [] ->
-                                          (FStar_Errors.log_issue0
-                                             FStar_Errors_Codes.Error_MissingFileName
-                                             ()
-                                             (Obj.magic
-                                                FStar_Errors_Msg.is_error_message_string)
-                                             (Obj.magic
-                                                "--ide: Name of current file missing in command line invocation\n");
-                                           FStar_Compiler_Effect.exit
-                                             Prims.int_one)
-                                      | uu___21::uu___22::uu___23 ->
-                                          (FStar_Errors.log_issue0
-                                             FStar_Errors_Codes.Error_TooManyFiles
-                                             ()
-                                             (Obj.magic
-                                                FStar_Errors_Msg.is_error_message_string)
-                                             (Obj.magic
-                                                "--ide: Too many files in command line invocation\n");
-                                           FStar_Compiler_Effect.exit
-                                             Prims.int_one)
-                                      | filename::[] ->
-                                          let uu___21 =
-                                            FStar_Options.legacy_interactive
+                                    ((let uu___21 =
+                                        let uu___22 =
+                                          let uu___23 =
+                                            FStar_Compiler_Util.get_exec_dir
                                               () in
-                                          if uu___21
-                                          then
-                                            FStar_Interactive_Legacy.interactive_mode
-                                              filename
-                                          else
-                                            FStar_Interactive_Ide.interactive_mode
-                                              filename))
+                                          Prims.strcat uu___23 "/../lib" in
+                                        FStar_Compiler_Util.normalize_file_path
+                                          uu___22 in
+                                      FStar_Compiler_Util.print1 "%s\n"
+                                        uu___21);
+                                     FStar_Compiler_Effect.exit
+                                       Prims.int_zero)
                                   else
-                                    if
-                                      (FStar_Compiler_List.length filenames)
-                                        >= Prims.int_one
-                                    then
-                                      (let uu___21 =
-                                         FStar_Dependencies.find_deps_if_needed
-                                           filenames
-                                           FStar_CheckedFiles.load_parsing_data_from_cache in
-                                       match uu___21 with
-                                       | (filenames1, dep_graph) ->
-                                           let uu___22 =
-                                             FStar_Universal.batch_mode_tc
-                                               filenames1 dep_graph in
-                                           (match uu___22 with
-                                            | (tcrs, env, cleanup1) ->
-                                                ((let uu___24 = cleanup1 env in
-                                                  ());
-                                                 (let module_names =
-                                                    FStar_Compiler_List.map
-                                                      (fun tcr ->
-                                                         FStar_Universal.module_or_interface_name
-                                                           tcr.FStar_CheckedFiles.checked_module)
-                                                      tcrs in
-                                                  report_errors module_names;
-                                                  finished_message
-                                                    module_names
-                                                    Prims.int_zero))))
-                                    else
-                                      FStar_Errors.raise_error0
-                                        FStar_Errors_Codes.Error_MissingFileName
-                                        ()
-                                        (Obj.magic
-                                           FStar_Errors_Msg.is_error_message_string)
-                                        (Obj.magic "No file provided")))))))))))
+                                    (let uu___21 =
+                                       let uu___22 =
+                                         FStar_Options.read_krml_file () in
+                                       FStar_Pervasives_Native.uu___is_Some
+                                         uu___22 in
+                                     if uu___21
+                                     then
+                                       let path =
+                                         let uu___22 =
+                                           FStar_Options.read_krml_file () in
+                                         FStar_Pervasives_Native.__proj__Some__item__v
+                                           uu___22 in
+                                       let uu___22 =
+                                         FStar_Compiler_Util.load_value_from_file
+                                           path in
+                                       match uu___22 with
+                                       | FStar_Pervasives_Native.None ->
+                                           let uu___23 =
+                                             let uu___24 =
+                                               let uu___25 =
+                                                 FStar_Errors_Msg.text
+                                                   "Could not read krml file:" in
+                                               let uu___26 =
+                                                 FStar_Pprint.doc_of_string
+                                                   path in
+                                               FStar_Pprint.op_Hat_Slash_Hat
+                                                 uu___25 uu___26 in
+                                             [uu___24] in
+                                           FStar_Errors.raise_error0
+                                             FStar_Errors_Codes.Fatal_ModuleOrFileNotFound
+                                             ()
+                                             (Obj.magic
+                                                FStar_Errors_Msg.is_error_message_list_doc)
+                                             (Obj.magic uu___23)
+                                       | FStar_Pervasives_Native.Some
+                                           (version, files) ->
+                                           ((let uu___24 =
+                                               FStar_Class_Show.show
+                                                 (FStar_Class_Show.printableshow
+                                                    FStar_Class_Printable.printable_int)
+                                                 version in
+                                             FStar_Compiler_Util.print1
+                                               "Karamel format version: %s\n"
+                                               uu___24);
+                                            FStar_Compiler_List.iter
+                                              (fun uu___24 ->
+                                                 match uu___24 with
+                                                 | (name, decls) ->
+                                                     (FStar_Compiler_Util.print1
+                                                        "%s:\n" name;
+                                                      FStar_Compiler_List.iter
+                                                        (fun d ->
+                                                           let uu___26 =
+                                                             FStar_Class_Show.show
+                                                               FStar_Extraction_Krml.showable_decl
+                                                               d in
+                                                           FStar_Compiler_Util.print1
+                                                             "  %s\n" uu___26)
+                                                        decls)) files)
+                                     else
+                                       (let uu___23 =
+                                          FStar_Options.lsp_server () in
+                                        if uu___23
+                                        then
+                                          FStar_Interactive_Lsp.start_server
+                                            ()
+                                        else
+                                          (let uu___25 =
+                                             FStar_Options.interactive () in
+                                           if uu___25
+                                           then
+                                             (FStar_Syntax_Unionfind.set_rw
+                                                ();
+                                              (match filenames with
+                                               | [] ->
+                                                   (FStar_Errors.log_issue0
+                                                      FStar_Errors_Codes.Error_MissingFileName
+                                                      ()
+                                                      (Obj.magic
+                                                         FStar_Errors_Msg.is_error_message_string)
+                                                      (Obj.magic
+                                                         "--ide: Name of current file missing in command line invocation\n");
+                                                    FStar_Compiler_Effect.exit
+                                                      Prims.int_one)
+                                               | uu___27::uu___28::uu___29 ->
+                                                   (FStar_Errors.log_issue0
+                                                      FStar_Errors_Codes.Error_TooManyFiles
+                                                      ()
+                                                      (Obj.magic
+                                                         FStar_Errors_Msg.is_error_message_string)
+                                                      (Obj.magic
+                                                         "--ide: Too many files in command line invocation\n");
+                                                    FStar_Compiler_Effect.exit
+                                                      Prims.int_one)
+                                               | filename::[] ->
+                                                   let uu___27 =
+                                                     FStar_Options.legacy_interactive
+                                                       () in
+                                                   if uu___27
+                                                   then
+                                                     FStar_Interactive_Legacy.interactive_mode
+                                                       filename
+                                                   else
+                                                     FStar_Interactive_Ide.interactive_mode
+                                                       filename))
+                                           else
+                                             if
+                                               (FStar_Compiler_List.length
+                                                  filenames)
+                                                 >= Prims.int_one
+                                             then
+                                               (let uu___27 =
+                                                  FStar_Dependencies.find_deps_if_needed
+                                                    filenames
+                                                    FStar_CheckedFiles.load_parsing_data_from_cache in
+                                                match uu___27 with
+                                                | (filenames1, dep_graph) ->
+                                                    let uu___28 =
+                                                      FStar_Universal.batch_mode_tc
+                                                        filenames1 dep_graph in
+                                                    (match uu___28 with
+                                                     | (tcrs, env, cleanup1)
+                                                         ->
+                                                         ((let uu___30 =
+                                                             cleanup1 env in
+                                                           ());
+                                                          (let module_names =
+                                                             FStar_Compiler_List.map
+                                                               (fun tcr ->
+                                                                  FStar_Universal.module_or_interface_name
+                                                                    tcr.FStar_CheckedFiles.checked_module)
+                                                               tcrs in
+                                                           report_errors
+                                                             module_names;
+                                                           finished_message
+                                                             module_names
+                                                             Prims.int_zero))))
+                                             else
+                                               FStar_Errors.raise_error0
+                                                 FStar_Errors_Codes.Error_MissingFileName
+                                                 ()
+                                                 (Obj.magic
+                                                    FStar_Errors_Msg.is_error_message_string)
+                                                 (Obj.magic
+                                                    "No file provided"))))))))))))))
 let (lazy_chooser :
   FStar_Syntax_Syntax.lazy_kind ->
     FStar_Syntax_Syntax.lazyinfo -> FStar_Syntax_Syntax.term)

--- a/ocaml/fstar-lib/generated/FStar_Main.ml
+++ b/ocaml/fstar-lib/generated/FStar_Main.ml
@@ -177,14 +177,24 @@ let go : 'uuuuu . 'uuuuu -> unit =
                (let uu___5 = FStar_Compiler_Debug.any () in
                 if uu___5
                 then
-                  let uu___6 =
-                    let uu___7 = FStar_Options.include_path () in
-                    FStar_Class_Show.show
-                      (FStar_Class_Show.show_list
-                         (FStar_Class_Show.printableshow
-                            FStar_Class_Printable.printable_string)) uu___7 in
-                  FStar_Compiler_Util.print1 "Full include path = %s\n"
-                    uu___6
+                  (FStar_Compiler_Util.print1 "- F* executable: %s\n"
+                     FStar_Compiler_Util.exec_name;
+                   FStar_Compiler_Util.print1 "- F* exec dir: %s\n"
+                     FStar_Options.fstar_bin_directory;
+                   (let uu___9 =
+                      let uu___10 = FStar_Options.lib_root () in
+                      FStar_Compiler_Util.dflt "<none>" uu___10 in
+                    FStar_Compiler_Util.print1 "- Library root: %s\n" uu___9);
+                   (let uu___10 =
+                      let uu___11 = FStar_Options.include_path () in
+                      FStar_Class_Show.show
+                        (FStar_Class_Show.show_list
+                           (FStar_Class_Show.printableshow
+                              FStar_Class_Printable.printable_string))
+                        uu___11 in
+                    FStar_Compiler_Util.print1 "- Full include path: %s\n"
+                      uu___10);
+                   FStar_Compiler_Util.print_string "\n")
                 else ());
                load_native_tactics ();
                FStar_Syntax_Unionfind.set_ro ();

--- a/ocaml/fstar-lib/generated/FStar_Options.ml
+++ b/ocaml/fstar-lib/generated/FStar_Options.ml
@@ -362,6 +362,9 @@ let (defaults : (Prims.string * option_val) Prims.list) =
   ("query_stats", (Bool false));
   ("read_checked_file", Unset);
   ("list_plugins", (Bool false));
+  ("locate", (Bool false));
+  ("locate_lib", (Bool false));
+  ("locate_ocaml", (Bool false));
   ("read_krml_file", Unset);
   ("record_hints", (Bool false));
   ("record_options", (Bool false));
@@ -745,6 +748,12 @@ let (get_read_krml_file :
   fun uu___ -> lookup_opt "read_krml_file" (as_option as_string)
 let (get_list_plugins : unit -> Prims.bool) =
   fun uu___ -> lookup_opt "list_plugins" as_bool
+let (get_locate : unit -> Prims.bool) =
+  fun uu___ -> lookup_opt "locate" as_bool
+let (get_locate_lib : unit -> Prims.bool) =
+  fun uu___ -> lookup_opt "locate_lib" as_bool
+let (get_locate_ocaml : unit -> Prims.bool) =
+  fun uu___ -> lookup_opt "locate_ocaml" as_bool
 let (get_record_hints : unit -> Prims.bool) =
   fun uu___ -> lookup_opt "record_hints" as_bool
 let (get_record_options : unit -> Prims.bool) =
@@ -847,16 +856,6 @@ let (get_profile_group_by_decl : unit -> Prims.bool) =
 let (get_profile_component :
   unit -> Prims.string Prims.list FStar_Pervasives_Native.option) =
   fun uu___ -> lookup_opt "profile_component" (as_option (as_list as_string))
-let (universe_include_path_base_dirs : Prims.string Prims.list) =
-  let sub_dirs = ["legacy"; "experimental"; ".cache"] in
-  FStar_Compiler_List.collect
-    (fun d ->
-       let uu___ =
-         FStar_Compiler_List.map
-           (fun s ->
-              let uu___1 = FStar_Compiler_String.op_Hat "/" s in
-              FStar_Compiler_String.op_Hat d uu___1) sub_dirs in
-       d :: uu___) ["/ulib"; "/lib/fstar"]
 let (_version : Prims.string FStar_Compiler_Effect.ref) =
   FStar_Compiler_Util.mk_ref ""
 let (_platform : Prims.string FStar_Compiler_Effect.ref) =
@@ -3419,7 +3418,58 @@ let rec (specs_with_types :
                                                                     (Bool
                                                                     true)),
                                                                     uu___268) in
-                                                                    [uu___267] in
+                                                                    let uu___268
+                                                                    =
+                                                                    let uu___269
+                                                                    =
+                                                                    let uu___270
+                                                                    =
+                                                                    text
+                                                                    "Print the root of the F* installation and exit" in
+                                                                    (FStar_Getopt.noshort,
+                                                                    "locate",
+                                                                    (Const
+                                                                    (Bool
+                                                                    true)),
+                                                                    uu___270) in
+                                                                    let uu___270
+                                                                    =
+                                                                    let uu___271
+                                                                    =
+                                                                    let uu___272
+                                                                    =
+                                                                    text
+                                                                    "Print the root of the F* library and exit" in
+                                                                    (FStar_Getopt.noshort,
+                                                                    "locate_lib",
+                                                                    (Const
+                                                                    (Bool
+                                                                    true)),
+                                                                    uu___272) in
+                                                                    let uu___272
+                                                                    =
+                                                                    let uu___273
+                                                                    =
+                                                                    let uu___274
+                                                                    =
+                                                                    text
+                                                                    "Print the root of the built OCaml F* library and exit" in
+                                                                    (FStar_Getopt.noshort,
+                                                                    "locate_ocaml",
+                                                                    (Const
+                                                                    (Bool
+                                                                    true)),
+                                                                    uu___274) in
+                                                                    [uu___273] in
+                                                                    uu___271
+                                                                    ::
+                                                                    uu___272 in
+                                                                    uu___269
+                                                                    ::
+                                                                    uu___270 in
+                                                                    uu___267
+                                                                    ::
+                                                                    uu___268 in
                                                                     uu___265
                                                                     ::
                                                                     uu___266 in
@@ -4042,6 +4092,25 @@ let rec (expand_include_d : Prims.string -> Prims.string Prims.list) =
     else [dirname]
 let (expand_include_ds : Prims.string Prims.list -> Prims.string Prims.list)
   = fun dirnames -> FStar_Compiler_List.collect expand_include_d dirnames
+let (lib_root : unit -> Prims.string FStar_Pervasives_Native.option) =
+  fun uu___ ->
+    let uu___1 = get_no_default_includes () in
+    if uu___1
+    then FStar_Pervasives_Native.None
+    else
+      (let uu___3 =
+         FStar_Compiler_Util.expand_environment_variable "FSTAR_LIB" in
+       match uu___3 with
+       | FStar_Pervasives_Native.Some s -> FStar_Pervasives_Native.Some s
+       | FStar_Pervasives_Native.None ->
+           let uu___4 =
+             FStar_Compiler_String.op_Hat fstar_bin_directory "/../ulib" in
+           FStar_Pervasives_Native.Some uu___4)
+let (lib_paths : unit -> Prims.string Prims.list) =
+  fun uu___ ->
+    let uu___1 =
+      let uu___2 = lib_root () in FStar_Common.option_to_list uu___2 in
+    expand_include_ds uu___1
 let (include_path : unit -> Prims.string Prims.list) =
   fun uu___ ->
     let cache_dir =
@@ -4049,33 +4118,14 @@ let (include_path : unit -> Prims.string Prims.list) =
       match uu___1 with
       | FStar_Pervasives_Native.None -> []
       | FStar_Pervasives_Native.Some c -> [c] in
-    let lib_paths =
-      let uu___1 = get_no_default_includes () in
-      if uu___1
-      then []
-      else
-        (let uu___3 =
-           FStar_Compiler_Util.expand_environment_variable "FSTAR_LIB" in
-         match uu___3 with
-         | FStar_Pervasives_Native.None ->
-             let fstar_home =
-               FStar_Compiler_String.op_Hat fstar_bin_directory "/.." in
-             let defs = universe_include_path_base_dirs in
-             let uu___4 =
-               let uu___5 =
-                 FStar_Compiler_List.map
-                   (fun x -> FStar_Compiler_String.op_Hat fstar_home x) defs in
-               FStar_Compiler_List.filter FStar_Compiler_Util.file_exists
-                 uu___5 in
-             expand_include_ds uu___4
-         | FStar_Pervasives_Native.Some s -> [s]) in
     let include_paths =
       let uu___1 = get_include () in expand_include_ds uu___1 in
     let uu___1 =
-      let uu___2 =
-        let uu___3 = expand_include_d "." in
-        FStar_Compiler_List.op_At include_paths uu___3 in
-      FStar_Compiler_List.op_At lib_paths uu___2 in
+      let uu___2 = lib_paths () in
+      let uu___3 =
+        let uu___4 = expand_include_d "." in
+        FStar_Compiler_List.op_At include_paths uu___4 in
+      FStar_Compiler_List.op_At uu___2 uu___3 in
     FStar_Compiler_List.op_At cache_dir uu___1
 let (find_file : Prims.string -> Prims.string FStar_Pervasives_Native.option)
   =
@@ -4450,6 +4500,9 @@ let (query_stats : unit -> Prims.bool) = fun uu___ -> get_query_stats ()
 let (read_checked_file : unit -> Prims.string FStar_Pervasives_Native.option)
   = fun uu___ -> get_read_checked_file ()
 let (list_plugins : unit -> Prims.bool) = fun uu___ -> get_list_plugins ()
+let (locate : unit -> Prims.bool) = fun uu___ -> get_locate ()
+let (locate_lib : unit -> Prims.bool) = fun uu___ -> get_locate_lib ()
+let (locate_ocaml : unit -> Prims.bool) = fun uu___ -> get_locate_ocaml ()
 let (read_krml_file : unit -> Prims.string FStar_Pervasives_Native.option) =
   fun uu___ -> get_read_krml_file ()
 let (record_hints : unit -> Prims.bool) = fun uu___ -> get_record_hints ()

--- a/src/basic/FStar.Common.fst
+++ b/src/basic/FStar.Common.fst
@@ -150,3 +150,7 @@ let psmap_keys m =
   BU.psmap_fold m (fun k v a -> k::a) []
 let psmap_values m =
   BU.psmap_fold m (fun k v a -> v::a) []
+
+let option_to_list = function
+  | None -> []
+  | Some x -> [x]

--- a/src/basic/FStar.Compiler.Util.fsti
+++ b/src/basic/FStar.Compiler.Util.fsti
@@ -306,6 +306,7 @@ val for_range: int -> int -> (int -> unit) -> unit
 
 val mk_ref: 'a -> ref 'a
 
+val exec_name : string
 val get_exec_dir: unit -> string
 val expand_environment_variable: string -> option string
 

--- a/src/basic/FStar.Options.fst
+++ b/src/basic/FStar.Options.fst
@@ -1832,6 +1832,8 @@ let rec expand_include_d (dirname : string) : list string =
 let expand_include_ds (dirnames : list string) : list string =
   List.collect expand_include_d dirnames
 
+(* TODO: normalize these paths. This will probably affect makefiles since
+make does not normalize the paths itself. *)
 let lib_root () : option string =
   if get_no_default_includes() then
     None

--- a/src/basic/FStar.Options.fst
+++ b/src/basic/FStar.Options.fst
@@ -269,6 +269,9 @@ let defaults =
       ("query_stats"                  , Bool false);
       ("read_checked_file"            , Unset);
       ("list_plugins"                 , Bool false);
+      ("locate"                       , Bool false);
+      ("locate_lib"                   , Bool false);
+      ("locate_ocaml"                 , Bool false);
       ("read_krml_file"               , Unset);
       ("record_hints"                 , Bool false);
       ("record_options"               , Bool false);
@@ -526,6 +529,9 @@ let get_query_stats             ()      = lookup_opt "query_stats"              
 let get_read_checked_file       ()      = lookup_opt "read_checked_file"        (as_option as_string)
 let get_read_krml_file          ()      = lookup_opt "read_krml_file"           (as_option as_string)
 let get_list_plugins            ()      = lookup_opt "list_plugins"             as_bool
+let get_locate                  ()      = lookup_opt "locate"                   as_bool
+let get_locate_lib              ()      = lookup_opt "locate_lib"               as_bool
+let get_locate_ocaml            ()      = lookup_opt "locate_ocaml"             as_bool
 let get_record_hints            ()      = lookup_opt "record_hints"             as_bool
 let get_record_options          ()      = lookup_opt "record_options"           as_bool
 let get_retry                   ()      = lookup_opt "retry"                    as_bool
@@ -1589,6 +1595,18 @@ let rec specs_with_types warn_unsafe : list (char & string & opt_type & Pprint.d
     "list_plugins",
      Const (Bool true),
     text "List all registered plugins and exit");
+  ( noshort,
+    "locate",
+     Const (Bool true),
+    text "Print the root of the F* installation and exit");
+  ( noshort,
+    "locate_lib",
+    Const (Bool true),
+    text "Print the root of the F* library and exit");
+  ( noshort,
+    "locate_ocaml",
+    Const (Bool true),
+    text "Print the root of the built OCaml F* library and exit");
   ]
 
 and specs (warn_unsafe:bool) : list (FStar.Getopt.opt & Pprint.document) =
@@ -2083,6 +2101,9 @@ let query_cache                  () = get_query_cache                 ()
 let query_stats                  () = get_query_stats                 ()
 let read_checked_file            () = get_read_checked_file           ()
 let list_plugins                 () = get_list_plugins                ()
+let locate                       () = get_locate                      ()
+let locate_lib                   () = get_locate_lib                  ()
+let locate_ocaml                 () = get_locate_ocaml                ()
 let read_krml_file               () = get_read_krml_file              ()
 let record_hints                 () = get_record_hints                ()
 let record_options               () = get_record_options              ()

--- a/src/basic/FStar.Options.fsti
+++ b/src/basic/FStar.Options.fsti
@@ -145,6 +145,8 @@ val ide                         : unit    -> bool
 val ide_id_info_off             : unit    -> bool
 val set_ide_filename            : string -> unit
 val ide_filename                : unit -> option string
+val lib_root                    : unit    -> option string
+val lib_paths                   : unit    -> list string
 val include_path                : unit    -> list string
 val print                       : unit    -> bool
 val print_in_place              : unit    -> bool

--- a/src/basic/FStar.Options.fsti
+++ b/src/basic/FStar.Options.fsti
@@ -175,6 +175,9 @@ val normalize_pure_terms_for_extraction
                                 : unit    -> bool
 val krmloutput                  : unit    -> option string
 val list_plugins                : unit    -> bool
+val locate                      : unit    -> bool
+val locate_lib                  : unit    -> bool
+val locate_ocaml                : unit    -> bool
 val output_deps_to              : unit    -> option string
 val output_dir                  : unit    -> option string
 val prepend_cache_dir           : string  -> string

--- a/src/fstar/FStar.Main.fst
+++ b/src/fstar/FStar.Main.fst
@@ -149,8 +149,14 @@ let go _ =
     | Success ->
         fstar_files := Some filenames;
 
-        if Debug.any () then
-          Util.print1 "Full include path = %s\n" (show (Options.include_path ()));
+        if Debug.any () then (
+          Util.print1 "- F* executable: %s\n" (Util.exec_name);
+          Util.print1 "- F* exec dir: %s\n" (Options.fstar_bin_directory);
+          Util.print1 "- Library root: %s\n" ((Util.dflt "<none>" (Options.lib_root ())));
+          Util.print1 "- Full include path: %s\n" (show (Options.include_path ()));
+          Util.print_string "\n";
+          ()
+        );
 
         load_native_tactics ();
 

--- a/src/fstar/FStar.Main.fst
+++ b/src/fstar/FStar.Main.fst
@@ -201,7 +201,25 @@ let go _ =
           Util.print1 "Registered tactic plugins:\n%s\n" (String.concat "\n" (List.map (fun p -> "  " ^ show p.FStar.TypeChecker.Primops.Base.name) ts));
           ()
 
-        else if Some? (Options.read_krml_file ()) then
+        else if Options.locate () then (
+          Util.print1 "%s\n" (Util.get_exec_dir () |> Util.normalize_file_path);
+          exit 0
+
+        ) else if Options.locate_lib () then (
+          match Options.lib_root () with
+          | None ->
+            Util.print_error "No library found (is --no_default_includes set?)\n";
+            exit 1
+          | Some s ->
+            Util.print1 "%s\n" (Util.normalize_file_path s);
+            exit 0
+
+        ) else if Options.locate_ocaml () then (
+          // This is correct right now, but probably should change.
+          Util.print1 "%s\n" (Util.get_exec_dir () ^ "/../lib" |> Util.normalize_file_path);
+          exit 0
+
+        ) else if Some? (Options.read_krml_file ()) then
           let path = Some?.v <| Options.read_krml_file () in
           match load_value_from_file path <: option FStar.Extraction.Krml.binary_format with
           | None ->

--- a/ulib/fstar.include
+++ b/ulib/fstar.include
@@ -1,0 +1,3 @@
+legacy
+experimental
+.cache


### PR DESCRIPTION
These options allow to programatically query F* for the path to its executable, library, and ocaml-built library. This simplifies writing makefiles and other build automation by avoiding manual path computation, which are really annoying and brittle.