### PR TITLE
Fix library finding in binary package

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_Options.ml
+++ b/ocaml/fstar-lib/generated/FStar_Options.ml
@@ -4104,8 +4104,27 @@ let (lib_root : unit -> Prims.string FStar_Pervasives_Native.option) =
        | FStar_Pervasives_Native.Some s -> FStar_Pervasives_Native.Some s
        | FStar_Pervasives_Native.None ->
            let uu___4 =
-             FStar_Compiler_String.op_Hat fstar_bin_directory "/../ulib" in
-           FStar_Pervasives_Native.Some uu___4)
+             let uu___5 =
+               FStar_Compiler_String.op_Hat fstar_bin_directory "/../ulib" in
+             FStar_Compiler_Util.file_exists uu___5 in
+           if uu___4
+           then
+             let uu___5 =
+               FStar_Compiler_String.op_Hat fstar_bin_directory "/../ulib" in
+             FStar_Pervasives_Native.Some uu___5
+           else
+             (let uu___6 =
+                let uu___7 =
+                  FStar_Compiler_String.op_Hat fstar_bin_directory
+                    "/../lib/fstar" in
+                FStar_Compiler_Util.file_exists uu___7 in
+              if uu___6
+              then
+                let uu___7 =
+                  FStar_Compiler_String.op_Hat fstar_bin_directory
+                    "/../lib/fstar" in
+                FStar_Pervasives_Native.Some uu___7
+              else FStar_Pervasives_Native.None))
 let (lib_paths : unit -> Prims.string Prims.list) =
   fun uu___ ->
     let uu___1 =

--- a/ulib/install-ulib.sh
+++ b/ulib/install-ulib.sh
@@ -2,7 +2,7 @@
 set -e
 set -x
 
-for f in *.fst *.fsti experimental/*.fst experimental/*.fsti .cache/*.checked ml/Makefile.realized ml/Makefile.include gmake/* legacy/*.fst legacy/*.fsti Makefile.extract.fsharp fs/* fs/VS/* ; do
+for f in fstar.include *.fst *.fsti experimental/*.fst experimental/*.fsti .cache/*.checked ml/Makefile.realized ml/Makefile.include gmake/* legacy/*.fst legacy/*.fsti Makefile.extract.fsharp fs/* fs/VS/* ; do
     if [[ -f $f ]] ; then
         "$INSTALL_EXEC" -m 644 -D -p $f $PREFIX/lib/fstar/$f
     fi


### PR DESCRIPTION
I broke the binary package pretty badly in https://github.com/FStarLang/FStar/pull/3509 by removing a default include of `lib/fstar/`, this restores it. Also, the binary package should get the fstar.include in ulib for it to work.