### PR TITLE
check-world: add mls-star

### DIFF
--- a/.github/workflows/check-world.yml
+++ b/.github/workflows/check-world.yml
@@ -689,3 +689,72 @@ jobs:
 
       - name: Build
         run: make -C mitls-fstar/src/tls -skj$(nproc) test
+
+
+  ### Nix jobs, for some Inria projects
+  #
+  # NOTE: these jobs are not containerized
+  # 1- it should not be needed since Nix takes care of isolating the environment
+  # 2- it would actually fail to setup Nix due to permissions in the container, and I haven't
+  #    found a clear reference on what the permissions/uids should be.
+  #
+  # The fstar-nix job is here to
+  # 1- Test the nix build in this workflow too
+  # 2- Reuse the built F* in the following projects, via the magic-nix-cache (note the 'needs')
+
+  fstar-nix:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: DeterminateSystems/nix-installer-action@main
+    - uses: DeterminateSystems/magic-nix-cache-action@main
+    - name: Build
+      run: nix build -L
+
+  comparse:
+    needs: fstar-nix
+    runs-on: ubuntu-latest
+    steps:
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+
+      - uses: actions/checkout@master
+        with:
+          repository: TWal/comparse
+
+      - name: Update fstar flake and check
+        run: |
+          nix flake update --override-input fstar-flake "github:${{github.repository}}?rev=${{github.sha}}"
+          nix flake check
+
+  dy-star:
+    needs: fstar-nix
+    runs-on: ubuntu-latest
+    steps:
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+
+      - uses: actions/checkout@master
+        with:
+          repository: REPROSEC/dolev-yao-star-extrinsic
+
+      - name: Update fstar flake and check
+        run: |
+          nix flake update --override-input fstar-flake "github:${{github.repository}}?rev=${{github.sha}}"
+          nix flake check
+
+  mls-star:
+    needs: fstar-nix
+    runs-on: ubuntu-latest
+    steps:
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+
+      - uses: actions/checkout@master
+        with:
+          repository: Inria-Prosecco/mls-star
+
+      - name: Update fstar flake and check
+        run: |
+          nix flake update --override-input fstar-flake "github:${{github.repository}}?rev=${{github.sha}}"
+          nix flake check


### PR DESCRIPTION
cc @TWal, this adds mls-star to the check-world workflow. It starts from scratch in Nix, so it does not depend on the jobs to build F* or other projects. It picks up the F* commit from the branch being tested and updates the Nix flake to use it (thanks for the command to do that).

It also uses the magic-cache which saves about 10 minutes of setup.

Some questions I have are:
1- Would it make sense to add separate jobs for its dependencies (comparse, dolev-yao)? They are being built here, of course, but maybe it'd be nicer to have them in separated jobs as dependencies to this one for better visibility in the actions run page. Given the magic-cache I think this should also be just as fast.
2- We should document what to do on a failure here, since I think not everyone has Nix set up.
3- Maybe set --proof_recovery too?