### PR TITLE
Replace must_erase_during_extraction with erasable.

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_Algebra_Monoid.ml
+++ b/ocaml/fstar-lib/generated/FStar_Algebra_Monoid.ml
@@ -60,10 +60,10 @@ let (embed_nat_int : Prims.nat -> Prims.int) = fun n -> n
 let (uu___0 : (Prims.nat, Prims.int, unit, unit, unit) monoid_morphism) =
   intro_monoid_morphism embed_nat_int nat_plus_monoid int_plus_monoid
 type 'p neg = unit
-let (uu___1 : (unit, unit, unit neg, unit, unit) monoid_morphism) =
+let (uu___1 : (unit, unit, unit, unit, unit) monoid_morphism) =
   intro_monoid_morphism (fun uu___ -> ()) conjunction_monoid
     disjunction_monoid
-let (uu___2 : (unit, unit, unit neg, unit, unit) monoid_morphism) =
+let (uu___2 : (unit, unit, unit, unit, unit) monoid_morphism) =
   intro_monoid_morphism (fun uu___ -> ()) disjunction_monoid
     conjunction_monoid
 type ('m, 'a, 'mult, 'act) mult_act_lemma = unit

--- a/ocaml/fstar-lib/generated/FStar_GSet.ml
+++ b/ocaml/fstar-lib/generated/FStar_GSet.ml
@@ -1,12 +1,5 @@
 open Prims
 type 'a set = unit
 type ('a, 's1, 's2) equal = unit
-
-
-
-
-
-
-
 type ('a, 's1, 's2) disjoint = unit
 type ('a, 's1, 's2) subset = unit

--- a/ocaml/fstar-lib/generated/FStar_Monotonic_HyperHeap.ml
+++ b/ocaml/fstar-lib/generated/FStar_Monotonic_HyperHeap.ml
@@ -1,9 +1,6 @@
 open Prims
 type rid = unit
 type hmap = (unit, FStar_Monotonic_Heap.heap) FStar_Map.t
-
-
-
 let (mod_set : unit FStar_Set.set -> unit FStar_Set.set) =
   fun uu___ -> Prims.magic ()
 type ('s, 'm0, 'm1) modifies = unit
@@ -12,5 +9,3 @@ type ('r, 'm0, 'm1) modifies_one = unit
 type ('s, 'm0, 'm1) equal_on = unit
 type ('s1, 's2) disjoint_regions = unit
 type ('r, 'n, 'c, 'freeable, 's) extend_post = unit
-
-

--- a/ocaml/fstar-lib/generated/FStar_Monotonic_HyperStack.ml
+++ b/ocaml/fstar-lib/generated/FStar_Monotonic_HyperStack.ml
@@ -20,13 +20,11 @@ let (__proj__HS__item__rid_ctr : mem' -> Prims.int) =
   fun projectee -> match projectee with | HS (rid_ctr, h, tip) -> rid_ctr
 let (__proj__HS__item__h : mem' -> FStar_Monotonic_HyperHeap.hmap) =
   fun projectee -> match projectee with | HS (rid_ctr, h, tip) -> h
-
 let (mk_mem : Prims.int -> FStar_Monotonic_HyperHeap.hmap -> unit -> mem') =
   fun rid_ctr -> fun h -> fun tip -> HS (rid_ctr, h, ())
 let (get_hmap : mem' -> FStar_Monotonic_HyperHeap.hmap) =
   fun m -> __proj__HS__item__h m
 let (get_rid_ctr : mem' -> Prims.int) = fun m -> __proj__HS__item__rid_ctr m
-
 type mem = mem'
 let (empty_mem : mem) =
   let empty_map =
@@ -51,12 +49,10 @@ type ('a, 'rel) mreference' =
   | MkRef of unit * ('a, 'rel) FStar_Monotonic_Heap.mref 
 let uu___is_MkRef : 'a 'rel . ('a, 'rel) mreference' -> Prims.bool =
   fun projectee -> true
-
 let __proj__MkRef__item__ref :
   'a 'rel . ('a, 'rel) mreference' -> ('a, 'rel) FStar_Monotonic_Heap.mref =
   fun projectee -> match projectee with | MkRef (frame, ref) -> ref
 type ('a, 'rel) mreference = ('a, 'rel) mreference'
-
 let mk_mreference :
   'a 'rel .
     unit -> ('a, 'rel) FStar_Monotonic_Heap.mref -> ('a, 'rel) mreference
@@ -187,7 +183,6 @@ type ('rs, 'h0, 'h1) mods = unit
 type aref =
   | ARef of unit * FStar_Monotonic_Heap.aref 
 let (uu___is_ARef : aref -> Prims.bool) = fun projectee -> true
-
 let (__proj__ARef__item__aref_aref : aref -> FStar_Monotonic_Heap.aref) =
   fun projectee ->
     match projectee with | ARef (aref_region, aref_aref) -> aref_aref

--- a/ocaml/fstar-lib/generated/FStar_Monotonic_Seq.ml
+++ b/ocaml/fstar-lib/generated/FStar_Monotonic_Seq.ml
@@ -9,15 +9,14 @@ let alloc_mref_seq :
   'a .
     unit ->
       'a FStar_Seq_Base.seq ->
-        (unit, 'a FStar_Seq_Base.seq, ('a, unit, unit) grows)
-          FStar_HyperStack_ST.m_rref
+        (unit, 'a FStar_Seq_Base.seq, unit) FStar_HyperStack_ST.m_rref
   = fun r -> fun init -> FStar_HyperStack_ST.ralloc () init
 type ('a, 'i, 'n, 'x, 'r, 'h) at_least = unit
 let write_at_end :
   'a .
     unit ->
-      (unit, 'a FStar_Seq_Base.seq, ('a, unit, unit) grows)
-        FStar_HyperStack_ST.m_rref -> 'a -> unit
+      (unit, 'a FStar_Seq_Base.seq, unit) FStar_HyperStack_ST.m_rref ->
+        'a -> unit
   =
   fun i ->
     fun r ->
@@ -52,16 +51,15 @@ let i_write_at_end : 'a 'p . unit -> (unit, 'a, 'p) i_seq -> 'a -> unit =
 type 's invariant = unit
 let (test0 :
   unit ->
-    (unit, Prims.nat FStar_Seq_Base.seq, (Prims.nat, unit, unit) grows)
-      FStar_HyperStack_ST.m_rref -> Prims.nat -> unit)
+    (unit, Prims.nat FStar_Seq_Base.seq, unit) FStar_HyperStack_ST.m_rref ->
+      Prims.nat -> unit)
   =
   fun r ->
     fun a ->
       fun k ->
         let h0 = FStar_HyperStack_ST.get () in
         FStar_HyperStack_ST.mr_witness () () () (Obj.magic a) ()
-let (itest :
-  unit -> (unit, Prims.nat, unit invariant) i_seq -> Prims.nat -> unit) =
+let (itest : unit -> (unit, Prims.nat, unit) i_seq -> Prims.nat -> unit) =
   fun r ->
     fun a ->
       fun k ->

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Env.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Env.ml
@@ -4150,7 +4150,15 @@ let (fv_has_erasable_attr : env -> FStar_Syntax_Syntax.fv -> Prims.bool) =
           fv_exists_and_has_attr env1
             (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
             FStar_Parser_Const.erasable_attr in
-        match uu___1 with | (ex, erasable) -> (ex, erasable) in
+        match uu___1 with
+        | (ex, erasable) ->
+            let uu___2 =
+              fv_exists_and_has_attr env1
+                (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
+                FStar_Parser_Const.must_erase_for_extraction_attr in
+            (match uu___2 with
+             | (ex1, must_erase_for_extraction) ->
+                 (ex1, (erasable || must_erase_for_extraction))) in
       cache_in_fv_tab env1.erasable_types_tab fv f
 let (fv_has_strict_args :
   env ->
@@ -4370,6 +4378,10 @@ let rec (non_informative : env -> FStar_Syntax_Syntax.typ -> Prims.bool) =
           { FStar_Syntax_Syntax.hd = head;
             FStar_Syntax_Syntax.args = uu___1;_}
           -> non_informative env1 head
+      | FStar_Syntax_Syntax.Tm_abs
+          { FStar_Syntax_Syntax.bs = uu___1; FStar_Syntax_Syntax.body = body;
+            FStar_Syntax_Syntax.rc_opt = uu___2;_}
+          -> non_informative env1 body
       | FStar_Syntax_Syntax.Tm_uinst (t1, uu___1) -> non_informative env1 t1
       | FStar_Syntax_Syntax.Tm_arrow
           { FStar_Syntax_Syntax.bs1 = uu___1; FStar_Syntax_Syntax.comp = c;_}
@@ -4378,6 +4390,10 @@ let rec (non_informative : env -> FStar_Syntax_Syntax.typ -> Prims.bool) =
              (non_informative env1 (FStar_Syntax_Util.comp_result c)))
             ||
             (is_erasable_effect env1 (FStar_Syntax_Util.comp_effect_name c))
+      | FStar_Syntax_Syntax.Tm_meta
+          { FStar_Syntax_Syntax.tm2 = tm;
+            FStar_Syntax_Syntax.meta = uu___1;_}
+          -> non_informative env1 tm
       | uu___1 -> false
 let (num_effect_indices :
   env -> FStar_Ident.lident -> FStar_Compiler_Range_Type.range -> Prims.int)

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Normalize.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Normalize.ml
@@ -7744,6 +7744,9 @@ let (non_info_norm :
         [FStar_TypeChecker_Env.UnfoldUntil FStar_Syntax_Syntax.delta_constant;
         FStar_TypeChecker_Env.AllowUnboundUniverses;
         FStar_TypeChecker_Env.EraseUniverses;
+        FStar_TypeChecker_Env.Primops;
+        FStar_TypeChecker_Env.Beta;
+        FStar_TypeChecker_Env.Iota;
         FStar_TypeChecker_Env.HNF;
         FStar_TypeChecker_Env.Unascribe;
         FStar_TypeChecker_Env.ForExtraction] in

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Util.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Util.ml
@@ -7302,63 +7302,16 @@ let (must_erase_for_extraction :
   FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.term -> Prims.bool) =
   fun g ->
     fun t ->
-      let rec descend env t1 =
-        let uu___ =
-          let uu___1 = FStar_Syntax_Subst.compress t1 in
-          uu___1.FStar_Syntax_Syntax.n in
-        match uu___ with
-        | FStar_Syntax_Syntax.Tm_arrow uu___1 ->
-            let uu___2 = FStar_Syntax_Util.arrow_formals_comp t1 in
-            (match uu___2 with
-             | (bs, c) ->
-                 let env1 = FStar_TypeChecker_Env.push_binders env bs in
-                 (FStar_TypeChecker_Env.is_erasable_effect env1
-                    (FStar_Syntax_Util.comp_effect_name c))
-                   ||
-                   ((FStar_Syntax_Util.is_pure_or_ghost_comp c) &&
-                      (aux env1 (FStar_Syntax_Util.comp_result c))))
-        | FStar_Syntax_Syntax.Tm_refine
-            {
-              FStar_Syntax_Syntax.b =
-                { FStar_Syntax_Syntax.ppname = uu___1;
-                  FStar_Syntax_Syntax.index = uu___2;
-                  FStar_Syntax_Syntax.sort = t2;_};
-              FStar_Syntax_Syntax.phi = uu___3;_}
-            -> aux env t2
-        | FStar_Syntax_Syntax.Tm_app
-            { FStar_Syntax_Syntax.hd = head;
-              FStar_Syntax_Syntax.args = uu___1;_}
-            -> descend env head
-        | FStar_Syntax_Syntax.Tm_uinst (head, uu___1) -> descend env head
-        | FStar_Syntax_Syntax.Tm_fvar fv ->
-            FStar_TypeChecker_Env.fv_has_attr env fv
-              FStar_Parser_Const.must_erase_for_extraction_attr
-        | uu___1 -> false
-      and aux env t1 =
-        let t2 =
-          FStar_TypeChecker_Normalize.normalize
-            [FStar_TypeChecker_Env.Primops;
-            FStar_TypeChecker_Env.Weak;
-            FStar_TypeChecker_Env.HNF;
-            FStar_TypeChecker_Env.UnfoldUntil
-              FStar_Syntax_Syntax.delta_constant;
-            FStar_TypeChecker_Env.Beta;
-            FStar_TypeChecker_Env.AllowUnboundUniverses;
-            FStar_TypeChecker_Env.Zeta;
-            FStar_TypeChecker_Env.Iota;
-            FStar_TypeChecker_Env.Unascribe] env t1 in
-        let res =
-          (FStar_TypeChecker_Env.non_informative env t2) || (descend env t2) in
-        (let uu___1 = FStar_Compiler_Effect.op_Bang dbg_Extraction in
-         if uu___1
-         then
-           let uu___2 =
-             FStar_Class_Show.show FStar_Syntax_Print.showable_term t2 in
-           FStar_Compiler_Util.print2 "must_erase=%s: %s\n"
-             (if res then "true" else "false") uu___2
-         else ());
-        res in
-      aux g t
+      let res = FStar_TypeChecker_Normalize.non_info_norm g t in
+      (let uu___1 = FStar_Compiler_Effect.op_Bang dbg_Extraction in
+       if uu___1
+       then
+         let uu___2 =
+           FStar_Class_Show.show FStar_Syntax_Print.showable_term t in
+         FStar_Compiler_Util.print2 "must_erase=%s: %s\n"
+           (if res then "true" else "false") uu___2
+       else ());
+      res
 let (effect_extraction_mode :
   FStar_TypeChecker_Env.env ->
     FStar_Ident.lident -> FStar_Syntax_Syntax.eff_extraction_mode)

--- a/ocaml/fstar-lib/generated/FStar_WellFoundedRelation.ml
+++ b/ocaml/fstar-lib/generated/FStar_WellFoundedRelation.ml
@@ -37,8 +37,7 @@ let default_wfr : 'a . unit -> 'a wfr_t =
       proof = ()
     }
 type ('a, 'x1, 'x2) empty_relation = unit
-let rec empty_decreaser :
-  'a . 'a -> ('a, ('a, unit, unit) empty_relation, unit) acc_classical =
+let rec empty_decreaser : 'a . 'a -> ('a, unit, unit) acc_classical =
   fun x -> let smaller y = empty_decreaser y in AccClassicalIntro smaller
 let empty_wfr : 'a . unit -> 'a wfr_t =
   fun uu___ ->
@@ -48,9 +47,7 @@ let empty_wfr : 'a . unit -> 'a wfr_t =
       proof = ()
     }
 type ('a, 'r, 'x1, 'x2) acc_relation = unit
-let rec acc_decreaser :
-  'a 'r .
-    unit -> 'a -> ('a, ('a, 'r, unit, unit) acc_relation, unit) acc_classical
+let rec acc_decreaser : 'a 'r . unit -> 'a -> ('a, unit, unit) acc_classical
   =
   fun f ->
     fun x -> let smaller y = acc_decreaser () y in AccClassicalIntro smaller

--- a/ocaml/fstar-lib/generated/LowStar_Buffer.ml
+++ b/ocaml/fstar-lib/generated/LowStar_Buffer.ml
@@ -8,25 +8,15 @@ type 'a pointer_or_null = 'a buffer
 let sub :
   'a .
     unit ->
-      ('a, ('a, unit, unit) trivial_preorder,
-        ('a, unit, unit) trivial_preorder) LowStar_Monotonic_Buffer.mbuffer
-        ->
+      ('a, unit, unit) LowStar_Monotonic_Buffer.mbuffer ->
         FStar_UInt32.t ->
-          unit ->
-            ('a, ('a, unit, unit) trivial_preorder,
-              ('a, unit, unit) trivial_preorder)
-              LowStar_Monotonic_Buffer.mbuffer
+          unit -> ('a, unit, unit) LowStar_Monotonic_Buffer.mbuffer
   = fun uu___ -> LowStar_Monotonic_Buffer.msub
 let offset :
   'a .
     unit ->
-      ('a, ('a, unit, unit) trivial_preorder,
-        ('a, unit, unit) trivial_preorder) LowStar_Monotonic_Buffer.mbuffer
-        ->
-        FStar_UInt32.t ->
-          ('a, ('a, unit, unit) trivial_preorder,
-            ('a, unit, unit) trivial_preorder)
-            LowStar_Monotonic_Buffer.mbuffer
+      ('a, unit, unit) LowStar_Monotonic_Buffer.mbuffer ->
+        FStar_UInt32.t -> ('a, unit, unit) LowStar_Monotonic_Buffer.mbuffer
   = fun uu___ -> LowStar_Monotonic_Buffer.moffset
 type ('a, 'len) lbuffer = ('a, unit, unit) LowStar_Monotonic_Buffer.mbuffer
 let gcmalloc :
@@ -34,45 +24,31 @@ let gcmalloc :
     unit ->
       unit ->
         'a ->
-          FStar_UInt32.t ->
-            ('a, ('a, unit, unit) trivial_preorder,
-              ('a, unit, unit) trivial_preorder)
-              LowStar_Monotonic_Buffer.mbuffer
+          FStar_UInt32.t -> ('a, unit, unit) LowStar_Monotonic_Buffer.mbuffer
   = fun uu___ -> LowStar_Monotonic_Buffer.mgcmalloc
 let malloc :
   'a .
     unit ->
       unit ->
         'a ->
-          FStar_UInt32.t ->
-            ('a, ('a, unit, unit) trivial_preorder,
-              ('a, unit, unit) trivial_preorder)
-              LowStar_Monotonic_Buffer.mbuffer
+          FStar_UInt32.t -> ('a, unit, unit) LowStar_Monotonic_Buffer.mbuffer
   = fun uu___ -> LowStar_Monotonic_Buffer.mmalloc
 let alloca :
   'a .
     unit ->
       'a ->
-        FStar_UInt32.t ->
-          ('a, ('a, unit, unit) trivial_preorder,
-            ('a, unit, unit) trivial_preorder)
-            LowStar_Monotonic_Buffer.mbuffer
+        FStar_UInt32.t -> ('a, unit, unit) LowStar_Monotonic_Buffer.mbuffer
   = fun uu___ -> LowStar_Monotonic_Buffer.malloca
 let alloca_of_list :
   'a .
     unit ->
-      'a Prims.list ->
-        ('a, ('a, unit, unit) trivial_preorder,
-          ('a, unit, unit) trivial_preorder) LowStar_Monotonic_Buffer.mbuffer
+      'a Prims.list -> ('a, unit, unit) LowStar_Monotonic_Buffer.mbuffer
   = fun uu___ -> LowStar_Monotonic_Buffer.malloca_of_list
 let gcmalloc_of_list :
   'a .
     unit ->
       unit ->
-        'a Prims.list ->
-          ('a, ('a, unit, unit) trivial_preorder,
-            ('a, unit, unit) trivial_preorder)
-            LowStar_Monotonic_Buffer.mbuffer
+        'a Prims.list -> ('a, unit, unit) LowStar_Monotonic_Buffer.mbuffer
   = fun uu___ -> LowStar_Monotonic_Buffer.mgcmalloc_of_list
 type ('a, 'l) assign_list_t = 'a buffer -> unit
 let rec assign_list : 'a . 'a Prims.list -> 'a buffer -> unit =

--- a/ocaml/fstar-lib/generated/LowStar_Monotonic_Buffer.ml
+++ b/ocaml/fstar-lib/generated/LowStar_Monotonic_Buffer.ml
@@ -41,7 +41,6 @@ let mnull :
 type ('uuuuu, 'uuuuu1, 'uuuuu2, 'b, 'h) unused_in = Obj.t
 type ('t, 'rrel, 'rel, 'b) buffer_compatible = Obj.t
 type ('uuuuu, 'rrel, 'rel, 'h, 'b) live = Obj.t
-
 type ('a, 'rrel, 'rel, 'b, 'i, 'len, 'suburel) compatible_sub = unit
 type ubuffer_ =
   {

--- a/ocaml/fstar-lib/generated/LowStar_PrefixFreezableBuffer.ml
+++ b/ocaml/fstar-lib/generated/LowStar_PrefixFreezableBuffer.ml
@@ -14,10 +14,7 @@ type 'len lbuffer = buffer
 type ('r, 'len) malloc_pre = unit
 type ('h0, 'b, 'h1) alloc_post_mem_common = unit
 let (update_frozen_until_alloc :
-  (u8, (unit, unit) prefix_freezable_preorder,
-    (unit, unit) prefix_freezable_preorder) LowStar_Monotonic_Buffer.mbuffer
-    -> unit)
-  =
+  (u8, unit, unit) LowStar_Monotonic_Buffer.mbuffer -> unit) =
   fun b ->
     LowStar_Endianness.store32_le_i b Stdint.Uint32.zero
       (Stdint.Uint32.of_int (4));

--- a/ocaml/fstar-lib/generated/LowStar_UninitializedBuffer.ml
+++ b/ocaml/fstar-lib/generated/LowStar_UninitializedBuffer.ml
@@ -10,28 +10,20 @@ type 'a pointer_or_null = 'a ubuffer
 let usub :
   'a .
     unit ->
-      ('a FStar_Pervasives_Native.option,
-        ('a, unit, unit) initialization_preorder,
-        ('a, unit, unit) initialization_preorder)
+      ('a FStar_Pervasives_Native.option, unit, unit)
         LowStar_Monotonic_Buffer.mbuffer ->
         FStar_UInt32.t ->
           unit ->
-            ('a FStar_Pervasives_Native.option,
-              ('a, unit, unit) initialization_preorder,
-              ('a, unit, unit) initialization_preorder)
+            ('a FStar_Pervasives_Native.option, unit, unit)
               LowStar_Monotonic_Buffer.mbuffer
   = fun uu___ -> LowStar_Monotonic_Buffer.msub
 let uoffset :
   'a .
     unit ->
-      ('a FStar_Pervasives_Native.option,
-        ('a, unit, unit) initialization_preorder,
-        ('a, unit, unit) initialization_preorder)
+      ('a FStar_Pervasives_Native.option, unit, unit)
         LowStar_Monotonic_Buffer.mbuffer ->
         FStar_UInt32.t ->
-          ('a FStar_Pervasives_Native.option,
-            ('a, unit, unit) initialization_preorder,
-            ('a, unit, unit) initialization_preorder)
+          ('a FStar_Pervasives_Native.option, unit, unit)
             LowStar_Monotonic_Buffer.mbuffer
   = fun uu___ -> LowStar_Monotonic_Buffer.moffset
 type ('a, 'i, 's) ipred = unit

--- a/ocaml/fstar-lib/generated/LowStar_Vector.ml
+++ b/ocaml/fstar-lib/generated/LowStar_Vector.ml
@@ -21,7 +21,6 @@ type ('a, 'h, 'vec) live =
   ('a, unit, unit, unit, unit) LowStar_Monotonic_Buffer.live
 type ('a, 'vec) freeable =
   ('a, unit, unit, unit) LowStar_Monotonic_Buffer.freeable
-
 type ('h0, 'h1) hmap_dom_eq = (unit, unit, unit) FStar_Set.equal
 let alloc_empty : 'a . unit -> 'a vector =
   fun uu___ ->

--- a/src/typechecker/FStar.TypeChecker.Env.fst
+++ b/src/typechecker/FStar.TypeChecker.Env.fst
@@ -947,13 +947,8 @@ let cache_in_fv_tab (tab:BU.smap 'a) (fv:fv) (f:unit -> (bool & 'a)) : 'a =
 let fv_has_erasable_attr env fv =
   let f () =
      let ex, erasable = fv_exists_and_has_attr env fv.fv_name.v Const.erasable_attr in
-     ex,erasable
-     //unfortunately, treating the Const.must_erase_for_extraction_attr
-     //in the same way here as erasable_attr leads to regressions in fragile proofs,
-     //notably in FStar.ModifiesGen, since this expands the class of computation types
-     //that can be promoted from ghost to tot. That in turn results in slightly different
-     //smt encodings, leading to breakages. So, sadly, I'm not including must_erase_for_extraction
-     //here. In any case, must_erase_for_extraction is transitionary and should be removed
+     let ex, must_erase_for_extraction = fv_exists_and_has_attr env fv.fv_name.v Const.must_erase_for_extraction_attr in
+     ex, erasable || must_erase_for_extraction
   in
   cache_in_fv_tab env.erasable_types_tab fv f
 
@@ -1049,10 +1044,12 @@ let rec non_informative env t =
       || fv_eq_lid fv Const.erased_lid
       || fv_has_erasable_attr env fv
     | Tm_app {hd=head} -> non_informative env head
+    | Tm_abs {body} -> non_informative env body
     | Tm_uinst (t, _) -> non_informative env t
     | Tm_arrow {comp=c} ->
       (is_pure_or_ghost_comp c && non_informative env (comp_result c))
       || is_erasable_effect env (comp_effect_name c)
+    | Tm_meta {tm} -> non_informative env tm
     | _ -> false
 
 let num_effect_indices env name r =

--- a/src/typechecker/FStar.TypeChecker.Env.fsti
+++ b/src/typechecker/FStar.TypeChecker.Env.fsti
@@ -341,7 +341,11 @@ val fv_with_lid_has_attr   : env -> fv_lid:lid -> attr_lid:lid -> bool
 val fv_has_attr            : env -> fv -> attr_lid:lid -> bool
 val fv_has_strict_args     : env -> fv -> option (list int)
 val fv_has_erasable_attr   : env -> fv -> bool
+
+(* `non_informative env t` is true if the type family `t: (... -> Type) is noninformative,
+   i.e., any `x: t ...` can be erased to `()`. *)
 val non_informative        : env -> typ -> bool
+
 val try_lookup_effect_lid  : env -> lident -> option term
 val lookup_effect_lid      : env -> lident -> term
 val lookup_effect_abbrev   : env -> universes -> lident -> option (binders & comp)

--- a/src/typechecker/FStar.TypeChecker.Normalize.fst
+++ b/src/typechecker/FStar.TypeChecker.Normalize.fst
@@ -2808,6 +2808,8 @@ let non_info_norm env t =
   let steps = [UnfoldUntil delta_constant;
                AllowUnboundUniverses;
                EraseUniverses;
+               Primops;
+               Beta; Iota;
                HNF;
                (* We could use Weak too were it not that we need
                 * to descend in the codomain of arrows. *)

--- a/src/typechecker/FStar.TypeChecker.Quals.fsti
+++ b/src/typechecker/FStar.TypeChecker.Quals.fsti
@@ -29,7 +29,6 @@ after the function is typechecked.
 
 Currently, the only things that must be checked after the function is typechecked are:
 - The erasable attribute, since the defn must be elaborated. See #3253.
-- The must_erase attribute
 - The instance attribute for typeclasses
 *)
 

--- a/src/typechecker/FStar.TypeChecker.Util.fst
+++ b/src/typechecker/FStar.TypeChecker.Util.fst
@@ -3184,40 +3184,9 @@ let maybe_add_implicit_binders (env:env) (bs:binders) : binders =
 
 
 let must_erase_for_extraction (g:env) (t:typ) =
-    let rec descend env t = //t is expected to b in WHNF
-      match (SS.compress t).n with
-      | Tm_arrow _ ->
-           let bs, c = U.arrow_formals_comp t in
-           let env = FStar.TypeChecker.Env.push_binders env bs in
-           (Env.is_erasable_effect env (U.comp_effect_name c))  //includes GHOST
-           || (U.is_pure_or_ghost_comp c && aux env (U.comp_result c))
-      | Tm_refine {b={sort=t}} ->
-           aux env t
-      | Tm_app {hd=head}
-      | Tm_uinst (head, _) ->
-           descend env head
-      | Tm_fvar fv ->
-           //special treatment for must_erase_for_extraction here
-           //See Env.type_is_erasable for more explanations
-           Env.fv_has_attr env fv C.must_erase_for_extraction_attr
-      | _ -> false
-    and aux env t =
-        let t = N.normalize [Env.Primops;
-                             Env.Weak;
-                             Env.HNF;
-                             Env.UnfoldUntil delta_constant;
-                             Env.Beta;
-                             Env.AllowUnboundUniverses;
-                             Env.Zeta;
-                             Env.Iota;
-                             Env.Unascribe] env t in
-//        debug g (fun () -> BU.print1 "aux %s\n" (show t));
-        let res = Env.non_informative env t || descend env t in
-        if !dbg_Extraction
-        then BU.print2 "must_erase=%s: %s\n" (if res then "true" else "false") (show t);
-        res
-    in
-    aux g t
+  let res = N.non_info_norm g t in
+  if !dbg_Extraction then BU.print2 "must_erase=%s: %s\n" (if res then "true" else "false") (show t);
+  res
 
 let effect_extraction_mode env l =
   l |> Env.norm_eff_name env

--- a/tests/micro-benchmarks/MustEraseForExtraction.fst
+++ b/tests/micro-benchmarks/MustEraseForExtraction.fst
@@ -17,7 +17,8 @@ module MustEraseForExtraction
 [@@(expect_failure [318])]
 let t1 = unit
 
+[@@erasable]
 let t2 = unit
 
-[@@(expect_failure [318])]
+[@@(expect_failure [162])]
 let t3 = bool

--- a/tests/micro-benchmarks/MustEraseForExtraction.fsti
+++ b/tests/micro-benchmarks/MustEraseForExtraction.fsti
@@ -17,8 +17,8 @@ module MustEraseForExtraction
 
 val t1 : Type0
 
-[@@must_erase_for_extraction]
+[@@erasable]
 val t2 : Type0
 
-[@@must_erase_for_extraction]
+[@@erasable]
 val t3 : Type0

--- a/ulib/FStar.GSet.fsti
+++ b/ulib/FStar.GSet.fsti
@@ -19,9 +19,9 @@ module FStar.GSet
 #set-options "--initial_fuel 0 --max_fuel 0 --initial_ifuel 0 --max_ifuel 0"
 
 (*
- * AR: mark it must_erase_for_extraction temporarily until CMI comes in
+ * AR: mark it erasable temporarily until CMI comes in
  *)
-[@@must_erase_for_extraction]
+[@@erasable]
 val set (a: Type u#a) : Type u#a
 
 val equal (#a:Type) (s1:set a) (s2:set a) : Type0

--- a/ulib/FStar.GhostSet.fsti
+++ b/ulib/FStar.GhostSet.fsti
@@ -18,7 +18,7 @@ module FStar.GhostSet
 (** Ghost computational sets: membership is a ghost boolean function *)
 #set-options "--initial_fuel 0 --max_fuel 0 --initial_ifuel 0 --max_ifuel 0"
 
-[@@must_erase_for_extraction; erasable]
+[@@erasable]
 val set (a: Type u#a) : Type u#a
 
 let decide_eq a = x:a -> y:a -> GTot (b:bool { b <==> (x==y) })

--- a/ulib/FStar.Monotonic.HyperHeap.fsti
+++ b/ulib/FStar.Monotonic.HyperHeap.fsti
@@ -28,9 +28,9 @@ open FStar.Ghost
  *)
 
 (*
- * AR: mark it must_erase_for_extraction temporarily until CMI comes in
+ * AR: mark it erasable temporarily until CMI comes in
  *)
-[@@must_erase_for_extraction]
+[@@erasable]
 val rid :eqtype
 
 val reveal (r:rid) :GTot (list (int & int))

--- a/ulib/FStar.Pervasives.fsti
+++ b/ulib/FStar.Pervasives.fsti
@@ -867,19 +867,7 @@ val plugin (x: int) : Tot unit
     elaborate and typecheck, but unfold before verification. *)
 val tcnorm : unit
 
-(** We erase all ghost functions and unit-returning pure functions to
-    [()] at extraction. This creates a small issue with abstract
-    types. Consider a module that defines an abstract type [t] whose
-    (internal) definition is [unit] and also defines [f: int -> t]. [f]
-    would be erased to be just [()] inside the module, while the
-    client calls to [f] would not, since [t] is abstract. To get
-    around this, when extracting interfaces, if we encounter an
-    abstract type, we tag it with this attribute, so that
-    extraction can treat it specially.
-
-    Note, since the use of cross-module inlining (the [--cmi] option),
-    this attribute is no longer necessary. We retain it for legacy,
-    but will remove it in the future. *)
+[@@deprecated "use [@@erasable] instead"]
 val must_erase_for_extraction : unit
 
 (** This attribute is used with the Dijkstra Monads for Free

--- a/ulib/FStar.TSet.fst
+++ b/ulib/FStar.TSet.fst
@@ -22,7 +22,7 @@ module P = FStar.PropositionalExtensionality
 module F = FStar.FunctionalExtensionality
 
 (*
- * AR: mark it must_erase_for_extraction temporarily until CMI comes in
+ * AR: mark it erasable temporarily until CMI comes in
  *)
 [@@erasable]
 let set a = F.restricted_t a (fun _ -> prop)

--- a/ulib/FStar.TSet.fsti
+++ b/ulib/FStar.TSet.fsti
@@ -20,9 +20,9 @@ module FStar.TSet
 #set-options "--initial_fuel 0 --max_fuel 0 --initial_ifuel 0 --max_ifuel 0"
 
 (*
- * AR: mark it must_erase_for_extraction temporarily until CMI comes in
+ * AR: mark it erasable temporarily until CMI comes in
  *)
-[@@must_erase_for_extraction; erasable]
+[@@erasable]
 val set (a:Type u#a) : Type u#(max 1 a)
 
 val equal (#a:Type) (s1:set a) (s2:set a) : prop


### PR DESCRIPTION
Right now we have two separate sets of functions which decide whether a type is erasable/noninformative, one which only looks at `erasable` and another which also looks at `must_erase_for_extraction`.

This PR removes the `must_erase_for_extraction` version and treats the `must_erase_for_extraction` attribute as a (deprecated) alias for `erasable`.  This is preparatory work for #3366, so that we only have a single place to change for erasability.

Looking at the ML diff, the old code missed some opportunities to erase types to unit but there are no changes in executable code.  Check world also gives a green.