### PR TITLE
Represent implicits as a tree instead of a list to make conjoining them constant time

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_Tactics_Hooks.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Hooks.ml
@@ -1582,7 +1582,8 @@ let (synthesize :
                                     FStar_TypeChecker_Common.deferred = [];
                                     FStar_TypeChecker_Common.univ_ineqs =
                                       ([], []);
-                                    FStar_TypeChecker_Common.implicits = []
+                                    FStar_TypeChecker_Common.implicits =
+                                      (FStar_TypeChecker_Common.Flat [])
                                   } in
                                 let uu___6 = FStar_Tactics_Types.goal_env g in
                                 FStar_TypeChecker_Rel.force_trivial_guard
@@ -1663,7 +1664,7 @@ let (solve_implicits :
                                        FStar_TypeChecker_Common.univ_ineqs =
                                          ([], []);
                                        FStar_TypeChecker_Common.implicits =
-                                         []
+                                         (FStar_TypeChecker_Common.Flat [])
                                      } in
                                    FStar_Profiling.profile
                                      (fun uu___8 ->
@@ -2226,7 +2227,9 @@ let (splice :
                                                     FStar_TypeChecker_Common.univ_ineqs
                                                       = ([], []);
                                                     FStar_TypeChecker_Common.implicits
-                                                      = []
+                                                      =
+                                                      (FStar_TypeChecker_Common.Flat
+                                                         [])
                                                   } in
                                                 let uu___11 =
                                                   FStar_Tactics_Types.goal_env
@@ -2518,7 +2521,9 @@ let (postprocess :
                                            FStar_TypeChecker_Common.univ_ineqs
                                              = ([], []);
                                            FStar_TypeChecker_Common.implicits
-                                             = []
+                                             =
+                                             (FStar_TypeChecker_Common.Flat
+                                                [])
                                          } in
                                        let uu___8 =
                                          FStar_Tactics_Types.goal_env g in

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Interpreter.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Interpreter.ml
@@ -1027,7 +1027,8 @@ let run_unembedded_tactic_on_ps :
                                FStar_TypeChecker_Common.univ_ineqs =
                                  (FStar_TypeChecker_Env.trivial_guard.FStar_TypeChecker_Common.univ_ineqs);
                                FStar_TypeChecker_Common.implicits =
-                                 (ps3.FStar_Tactics_Types.all_implicits)
+                                 (FStar_TypeChecker_Common.Flat
+                                    (ps3.FStar_Tactics_Types.all_implicits))
                              } in
                            let g1 =
                              FStar_TypeChecker_Rel.solve_deferred_constraints

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Monad.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Monad.ml
@@ -843,7 +843,10 @@ let (new_uvar :
               match uu___ with
               | (u, ctx_uvar, g_u) ->
                   let uu___1 =
-                    add_implicits g_u.FStar_TypeChecker_Common.implicits in
+                    let uu___2 =
+                      FStar_TypeChecker_Common.as_implicits
+                        g_u.FStar_TypeChecker_Common.implicits in
+                    add_implicits uu___2 in
                   bind uu___1
                     (fun uu___2 ->
                        ret (u, (FStar_Pervasives_Native.fst ctx_uvar)))
@@ -1004,7 +1007,8 @@ let (compress_implicits : unit tac) =
              (FStar_TypeChecker_Env.trivial_guard.FStar_TypeChecker_Common.deferred);
            FStar_TypeChecker_Common.univ_ineqs =
              (FStar_TypeChecker_Env.trivial_guard.FStar_TypeChecker_Common.univ_ineqs);
-           FStar_TypeChecker_Common.implicits = imps
+           FStar_TypeChecker_Common.implicits =
+             (FStar_TypeChecker_Common.Flat imps)
          } in
        let imps1 =
          FStar_TypeChecker_Rel.resolve_implicits_tac

--- a/ocaml/fstar-lib/generated/FStar_Tactics_V1_Basic.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_V1_Basic.ml
@@ -486,6 +486,9 @@ let (proc_guard' :
                    FStar_Compiler_Util.print2 "Processing guard (%s:%s)\n"
                      reason uu___1)
                 (fun uu___ ->
+                   let imps =
+                     FStar_TypeChecker_Common.as_implicits
+                       g.FStar_TypeChecker_Common.implicits in
                    (match sc_opt with
                     | FStar_Pervasives_Native.Some
                         (FStar_Syntax_Syntax.Allow_untyped r) ->
@@ -493,12 +496,9 @@ let (proc_guard' :
                           (fun imp ->
                              mark_uvar_with_should_check_tag
                                imp.FStar_TypeChecker_Common.imp_uvar
-                               (FStar_Syntax_Syntax.Allow_untyped r))
-                          g.FStar_TypeChecker_Common.implicits
+                               (FStar_Syntax_Syntax.Allow_untyped r)) imps
                     | uu___2 -> ());
-                   (let uu___2 =
-                      FStar_Tactics_Monad.add_implicits
-                        g.FStar_TypeChecker_Common.implicits in
+                   (let uu___2 = FStar_Tactics_Monad.add_implicits imps in
                     FStar_Class_Monad.op_let_Bang
                       FStar_Tactics_Monad.monad_tac () () uu___2
                       (fun uu___3 ->
@@ -1055,8 +1055,12 @@ let (__do_unify_wflags :
                                                                     uu___8 in
                                                                     let uu___9
                                                                     =
-                                                                    FStar_Tactics_Monad.add_implicits
+                                                                    let uu___10
+                                                                    =
+                                                                    FStar_TypeChecker_Common.as_implicits
                                                                     g.FStar_TypeChecker_Common.implicits in
+                                                                    FStar_Tactics_Monad.add_implicits
+                                                                    uu___10 in
                                                                     Obj.magic
                                                                     (FStar_Class_Monad.op_let_Bang
                                                                     FStar_Tactics_Monad.monad_tac

--- a/ocaml/fstar-lib/generated/FStar_Tactics_V2_Basic.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_V2_Basic.ml
@@ -774,6 +774,9 @@ let (proc_guard' :
                 (fun uu___1 ->
                    (fun uu___1 ->
                       let uu___1 = Obj.magic uu___1 in
+                      let imps =
+                        FStar_TypeChecker_Common.as_implicits
+                          g.FStar_TypeChecker_Common.implicits in
                       (match sc_opt with
                        | FStar_Pervasives_Native.Some
                            (FStar_Syntax_Syntax.Allow_untyped r) ->
@@ -781,12 +784,9 @@ let (proc_guard' :
                              (fun imp ->
                                 FStar_Tactics_Monad.mark_uvar_with_should_check_tag
                                   imp.FStar_TypeChecker_Common.imp_uvar
-                                  (FStar_Syntax_Syntax.Allow_untyped r))
-                             g.FStar_TypeChecker_Common.implicits
+                                  (FStar_Syntax_Syntax.Allow_untyped r)) imps
                        | uu___3 -> ());
-                      (let uu___3 =
-                         FStar_Tactics_Monad.add_implicits
-                           g.FStar_TypeChecker_Common.implicits in
+                      (let uu___3 = FStar_Tactics_Monad.add_implicits imps in
                        Obj.magic
                          (FStar_Class_Monad.op_let_Bang
                             FStar_Tactics_Monad.monad_tac () () uu___3
@@ -1268,8 +1268,12 @@ let (__do_unify_wflags :
                                                                     uu___7 in
                                                                     let uu___8
                                                                     =
-                                                                    FStar_Tactics_Monad.add_implicits
+                                                                    let uu___9
+                                                                    =
+                                                                    FStar_TypeChecker_Common.as_implicits
                                                                     g.FStar_TypeChecker_Common.implicits in
+                                                                    FStar_Tactics_Monad.add_implicits
+                                                                    uu___9 in
                                                                     Obj.magic
                                                                     (FStar_Class_Monad.op_let_Bang
                                                                     FStar_Tactics_Monad.monad_tac
@@ -11896,10 +11900,12 @@ let (refl_instantiate_implicits :
                                    FStar_TypeChecker_Rel.resolve_implicits g3
                                      uu___5 in
                                  let bvs_and_ts =
-                                   match guard1.FStar_TypeChecker_Common.implicits
-                                   with
+                                   let uu___5 =
+                                     FStar_TypeChecker_Common.as_implicits
+                                       guard1.FStar_TypeChecker_Common.implicits in
+                                   match uu___5 with
                                    | [] -> []
-                                   | uu___5 ->
+                                   | imps ->
                                        let l =
                                          FStar_Compiler_List.map
                                            (fun uu___6 ->
@@ -11926,8 +11932,7 @@ let (refl_instantiate_implicits :
                                                       FStar_Pervasives_Native.None
                                                       uu___12 in
                                                   ((imp_uvar.FStar_Syntax_Syntax.ctx_uvar_head),
-                                                    uu___10, uu___11))
-                                           guard1.FStar_TypeChecker_Common.implicits in
+                                                    uu___10, uu___11)) imps in
                                        (FStar_Compiler_List.iter
                                           (fun uu___7 ->
                                              match uu___7 with
@@ -12364,43 +12369,46 @@ let (refl_try_unify :
                                                   FStar_TypeChecker_Rel.resolve_implicits
                                                     g2 uu___5 in
                                                 let b =
+                                                  let uu___5 =
+                                                    FStar_TypeChecker_Common.as_implicits
+                                                      guard2.FStar_TypeChecker_Common.implicits in
                                                   FStar_Compiler_List.existsb
-                                                    (fun uu___5 ->
-                                                       match uu___5 with
+                                                    (fun uu___6 ->
+                                                       match uu___6 with
                                                        | {
                                                            FStar_TypeChecker_Common.imp_reason
-                                                             = uu___6;
+                                                             = uu___7;
                                                            FStar_TypeChecker_Common.imp_uvar
                                                              =
                                                              {
                                                                FStar_Syntax_Syntax.ctx_uvar_head
                                                                  =
-                                                                 (uv, uu___7,
-                                                                  uu___8);
+                                                                 (uv, uu___8,
+                                                                  uu___9);
                                                                FStar_Syntax_Syntax.ctx_uvar_gamma
-                                                                 = uu___9;
-                                                               FStar_Syntax_Syntax.ctx_uvar_binders
                                                                  = uu___10;
-                                                               FStar_Syntax_Syntax.ctx_uvar_reason
+                                                               FStar_Syntax_Syntax.ctx_uvar_binders
                                                                  = uu___11;
-                                                               FStar_Syntax_Syntax.ctx_uvar_range
+                                                               FStar_Syntax_Syntax.ctx_uvar_reason
                                                                  = uu___12;
+                                                               FStar_Syntax_Syntax.ctx_uvar_range
+                                                                 = uu___13;
                                                                FStar_Syntax_Syntax.ctx_uvar_meta
-                                                                 = uu___13;_};
+                                                                 = uu___14;_};
                                                            FStar_TypeChecker_Common.imp_tm
-                                                             = uu___14;
+                                                             = uu___15;
                                                            FStar_TypeChecker_Common.imp_range
-                                                             = uu___15;_}
+                                                             = uu___16;_}
                                                            ->
-                                                           let uu___16 =
-                                                             let uu___17 =
+                                                           let uu___17 =
+                                                             let uu___18 =
                                                                FStar_Unionfind.puf_unique_id
                                                                  uv in
                                                              FStar_Compiler_Util.pimap_try_find
-                                                               tbl uu___17 in
-                                                           uu___16 =
+                                                               tbl uu___18 in
+                                                           uu___17 =
                                                              FStar_Pervasives_Native.None)
-                                                    guard2.FStar_TypeChecker_Common.implicits in
+                                                    uu___5 in
                                                 if b
                                                 then []
                                                 else
@@ -13354,8 +13362,10 @@ let (proofstate_of_goal_ty :
         match uu___ with
         | (g, g_u) ->
             let ps =
-              proofstate_of_goals rng env3 [g]
-                g_u.FStar_TypeChecker_Common.implicits in
+              let uu___1 =
+                FStar_TypeChecker_Common.as_implicits
+                  g_u.FStar_TypeChecker_Common.implicits in
+              proofstate_of_goals rng env3 [g] uu___1 in
             let uu___1 = FStar_Tactics_Types.goal_witness g in (ps, uu___1)
 let (proofstate_of_all_implicits :
   FStar_Compiler_Range_Type.range ->
@@ -13444,7 +13454,8 @@ let run_unembedded_tactic_on_ps_and_solve_remaining :
                                 FStar_TypeChecker_Common.deferred = [];
                                 FStar_TypeChecker_Common.univ_ineqs =
                                   ([], []);
-                                FStar_TypeChecker_Common.implicits = []
+                                FStar_TypeChecker_Common.implicits =
+                                  (FStar_TypeChecker_Common.Flat [])
                               } in
                             let uu___3 = FStar_Tactics_Types.goal_env g in
                             FStar_TypeChecker_Rel.force_trivial_guard uu___3
@@ -13579,7 +13590,8 @@ let run_tactic_on_ps_and_solve_remaining :
                                FStar_TypeChecker_Common.deferred_to_tac = [];
                                FStar_TypeChecker_Common.deferred = [];
                                FStar_TypeChecker_Common.univ_ineqs = ([], []);
-                               FStar_TypeChecker_Common.implicits = []
+                               FStar_TypeChecker_Common.implicits =
+                                 (FStar_TypeChecker_Common.Flat [])
                              } in
                            let uu___3 = FStar_Tactics_Types.goal_env g in
                            FStar_TypeChecker_Rel.force_trivial_guard uu___3

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Common.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Common.ml
@@ -586,6 +586,30 @@ let (show_implicit : implicit FStar_Class_Show.showable) =
            (i.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_head)
   }
 type implicits = implicit Prims.list
+type implicits_t =
+  | Flat of implicits 
+  | Conj of implicits_t * implicits_t 
+let (uu___is_Flat : implicits_t -> Prims.bool) =
+  fun projectee -> match projectee with | Flat _0 -> true | uu___ -> false
+let (__proj__Flat__item___0 : implicits_t -> implicits) =
+  fun projectee -> match projectee with | Flat _0 -> _0
+let (uu___is_Conj : implicits_t -> Prims.bool) =
+  fun projectee ->
+    match projectee with | Conj (_0, _1) -> true | uu___ -> false
+let (__proj__Conj__item___0 : implicits_t -> implicits_t) =
+  fun projectee -> match projectee with | Conj (_0, _1) -> _0
+let (__proj__Conj__item___1 : implicits_t -> implicits_t) =
+  fun projectee -> match projectee with | Conj (_0, _1) -> _1
+let (as_implicits : implicits_t -> implicits) =
+  fun imps ->
+    let rec aux imps1 out =
+      match imps1 with
+      | Flat i ->
+          (match out with
+           | [] -> i
+           | uu___ -> FStar_Compiler_List.op_At i out)
+      | Conj (imps11, imps2) -> let uu___ = aux imps2 out in aux imps11 uu___ in
+    aux imps []
 let (implicits_to_string : implicits -> Prims.string) =
   fun imps ->
     let imp_to_string i =
@@ -599,7 +623,7 @@ type guard_t =
   deferred: deferred ;
   univ_ineqs:
     (FStar_Syntax_Syntax.universe Prims.list * univ_ineq Prims.list) ;
-  implicits: implicits }
+  implicits: implicits_t }
 let (__proj__Mkguard_t__item__guard_f : guard_t -> guard_formula) =
   fun projectee ->
     match projectee with
@@ -622,7 +646,7 @@ let (__proj__Mkguard_t__item__univ_ineqs :
     match projectee with
     | { guard_f; deferred_to_tac; deferred = deferred1; univ_ineqs;
         implicits = implicits1;_} -> univ_ineqs
-let (__proj__Mkguard_t__item__implicits : guard_t -> implicits) =
+let (__proj__Mkguard_t__item__implicits : guard_t -> implicits_t) =
   fun projectee ->
     match projectee with
     | { guard_f; deferred_to_tac; deferred = deferred1; univ_ineqs;
@@ -633,7 +657,7 @@ let (trivial_guard : guard_t) =
     deferred_to_tac = [];
     deferred = [];
     univ_ineqs = ([], []);
-    implicits = []
+    implicits = (Flat [])
   }
 let (conj_guard_f : guard_formula -> guard_formula -> guard_formula) =
   fun g1 ->
@@ -663,7 +687,7 @@ let (binop_guard :
               (FStar_Compiler_List.op_At
                  (FStar_Pervasives_Native.snd g1.univ_ineqs)
                  (FStar_Pervasives_Native.snd g2.univ_ineqs)));
-          implicits = (FStar_Compiler_List.op_At g1.implicits g2.implicits)
+          implicits = (Conj ((g1.implicits), (g2.implicits)))
         }
 let (conj_guard : guard_t -> guard_t -> guard_t) =
   fun g1 -> fun g2 -> binop_guard conj_guard_f g1 g2

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_DeferredImplicits.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_DeferredImplicits.ml
@@ -694,16 +694,19 @@ let (solve_deferred_to_tactic_goals :
            FStar_Compiler_List.map prob_as_implicit
              g.FStar_TypeChecker_Common.deferred_to_tac in
          let uu___1 =
+           let uu___2 =
+             FStar_TypeChecker_Common.as_implicits
+               g.FStar_TypeChecker_Common.implicits in
            FStar_Compiler_List.fold_right
              (fun imp ->
-                fun uu___2 ->
-                  match uu___2 with
+                fun uu___3 ->
+                  match uu___3 with
                   | (more, imps) ->
-                      let uu___3 =
+                      let uu___4 =
                         FStar_Syntax_Unionfind.find
                           (imp.FStar_TypeChecker_Common.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_head in
-                      (match uu___3 with
-                       | FStar_Pervasives_Native.Some uu___4 ->
+                      (match uu___4 with
+                       | FStar_Pervasives_Native.Some uu___5 ->
                            (more, (imp :: imps))
                        | FStar_Pervasives_Native.None ->
                            let se =
@@ -713,8 +716,8 @@ let (solve_deferred_to_tactic_goals :
                             | FStar_Pervasives_Native.None ->
                                 (more, (imp :: imps))
                             | FStar_Pervasives_Native.Some se1 ->
-                                (((imp, se1) :: more), imps))))
-             g.FStar_TypeChecker_Common.implicits ([], []) in
+                                (((imp, se1) :: more), imps)))) uu___2
+             ([], []) in
          match uu___1 with
          | (more, imps) ->
              let bucketize is =
@@ -756,5 +759,6 @@ let (solve_deferred_to_tactic_goals :
                   (g.FStar_TypeChecker_Common.deferred);
                 FStar_TypeChecker_Common.univ_ineqs =
                   (g.FStar_TypeChecker_Common.univ_ineqs);
-                FStar_TypeChecker_Common.implicits = imps
+                FStar_TypeChecker_Common.implicits =
+                  (FStar_TypeChecker_Common.Flat imps)
               }))

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Env.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Env.ml
@@ -6864,7 +6864,7 @@ let (guard_of_guard_formula :
       FStar_TypeChecker_Common.deferred_to_tac = [];
       FStar_TypeChecker_Common.deferred = [];
       FStar_TypeChecker_Common.univ_ineqs = ([], []);
-      FStar_TypeChecker_Common.implicits = []
+      FStar_TypeChecker_Common.implicits = (FStar_TypeChecker_Common.Flat [])
     }
 let (guard_form : guard_t -> FStar_TypeChecker_Common.guard_formula) =
   fun g -> g.FStar_TypeChecker_Common.guard_f
@@ -6876,18 +6876,19 @@ let (is_trivial : guard_t -> Prims.bool) =
         FStar_TypeChecker_Common.deferred = [];
         FStar_TypeChecker_Common.univ_ineqs = ([], []);
         FStar_TypeChecker_Common.implicits = i;_} ->
+        let uu___1 = FStar_TypeChecker_Common.as_implicits i in
         FStar_Compiler_Util.for_all
           (fun imp ->
-             (let uu___1 =
+             (let uu___2 =
                 FStar_Syntax_Util.ctx_uvar_should_check
                   imp.FStar_TypeChecker_Common.imp_uvar in
-              FStar_Syntax_Syntax.uu___is_Allow_unresolved uu___1) ||
-               (let uu___1 =
+              FStar_Syntax_Syntax.uu___is_Allow_unresolved uu___2) ||
+               (let uu___2 =
                   FStar_Syntax_Unionfind.find
                     (imp.FStar_TypeChecker_Common.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_head in
-                match uu___1 with
-                | FStar_Pervasives_Native.Some uu___2 -> true
-                | FStar_Pervasives_Native.None -> false)) i
+                match uu___2 with
+                | FStar_Pervasives_Native.Some uu___3 -> true
+                | FStar_Pervasives_Native.None -> false)) uu___1
     | uu___ -> false
 let (is_trivial_guard_formula : guard_t -> Prims.bool) =
   fun g ->
@@ -7212,7 +7213,8 @@ let (new_tac_implicit_var :
                           (trivial_guard.FStar_TypeChecker_Common.deferred);
                         FStar_TypeChecker_Common.univ_ineqs =
                           (trivial_guard.FStar_TypeChecker_Common.univ_ineqs);
-                        FStar_TypeChecker_Common.implicits = [imp]
+                        FStar_TypeChecker_Common.implicits =
+                          (FStar_TypeChecker_Common.Flat [imp])
                       } in
                     (t, (ctx_uvar, r), g)))
 let (new_implicit_var_aux :

--- a/src/tactics/FStar.Tactics.Hooks.fst
+++ b/src/tactics/FStar.Tactics.Hooks.fst
@@ -720,7 +720,7 @@ let synthesize (env:Env.env) (typ:typ) (tau:term) : term =
                         ; deferred_to_tac = []
                         ; deferred = []
                         ; univ_ineqs = [], []
-                        ; implicits = [] } in
+                        ; implicits = Flat [] } in
             TcRel.force_trivial_guard (goal_env g) guard
             end
         | None ->
@@ -756,7 +756,7 @@ let solve_implicits (env:Env.env) (tau:term) (imps:Env.implicits) : unit =
                           ; deferred_to_tac = []
                           ; deferred = []
                           ; univ_ineqs = [], []
-                          ; implicits = [] } in
+                          ; implicits = Flat [] } in
               Profiling.profile (fun () ->
                 TcRel.force_trivial_guard (goal_env g) guard)
               None
@@ -938,7 +938,7 @@ let splice
                         ; deferred_to_tac = []
                         ; deferred = []
                         ; univ_ineqs = [], []
-                        ; implicits = [] } in
+                        ; implicits = Flat [] } in
               TcRel.force_trivial_guard (goal_env g) guard
             end
         | None ->
@@ -1030,7 +1030,7 @@ let postprocess (env:Env.env) (tau:term) (typ:term) (tm:term) : term =
                         ; deferred_to_tac = []
                         ; deferred = []
                         ; univ_ineqs = [], []
-                        ; implicits = [] } in
+                        ; implicits = Flat [] } in
             TcRel.force_trivial_guard (goal_env g) guard
             end
         | None ->

--- a/src/tactics/FStar.Tactics.Interpreter.fst
+++ b/src/tactics/FStar.Tactics.Interpreter.fst
@@ -341,7 +341,7 @@ let run_unembedded_tactic_on_ps
                                                                       (fun imp -> show imp.imp_uvar)
                                                                       ps.all_implicits);
 
-          let g = {Env.trivial_guard with TcComm.implicits=ps.all_implicits} in
+          let g = {Env.trivial_guard with TcComm.implicits=Flat ps.all_implicits} in
           let g = TcRel.solve_deferred_constraints env g in
           if !dbg_Tac then
               BU.print2 "Checked %s implicits (1): %s\n"

--- a/src/tactics/FStar.Tactics.Monad.fst
+++ b/src/tactics/FStar.Tactics.Monad.fst
@@ -333,7 +333,7 @@ let new_uvar (reason:string) (env:env) (typ:typ)
     let u, ctx_uvar, g_u =
         Env.new_tac_implicit_var reason rng env typ should_check uvar_typedness_deps None false
     in
-    bind (add_implicits g_u.implicits) (fun _ ->
+    bind (add_implicits (as_implicits g_u.implicits)) (fun _ ->
     ret (u, fst ctx_uvar))
 
 let mk_irrelevant_goal (reason:string) (env:env) (phi:typ) (sc_opt:option should_check_uvar) (rng:Range.range) opts label : tac goal =
@@ -397,7 +397,7 @@ let if_verbose f = if_verbose_tac (fun _ -> f(); ret ())
 let compress_implicits : tac unit =
     bind get (fun ps ->
     let imps = ps.all_implicits in
-    let g = { Env.trivial_guard with implicits = imps } in
+    let g = { Env.trivial_guard with implicits = Flat imps } in
     let imps = Rel.resolve_implicits_tac ps.main_context g in
     let ps' = { ps with all_implicits = List.map fst imps } in
     set ps')

--- a/src/tactics/FStar.Tactics.V1.Basic.fst
+++ b/src/tactics/FStar.Tactics.V1.Basic.fst
@@ -253,15 +253,16 @@ let with_policy pol (t : tac 'a) : tac 'a =
 let proc_guard' (simplify:bool) (reason:string) (e : env) (g : guard_t) (sc_opt:option should_check_uvar) (rng:Range.range) : tac unit =
     mlog (fun () ->
         BU.print2 "Processing guard (%s:%s)\n" reason (Rel.guard_to_string e g)) (fun () ->
+    let imps = as_implicits g.implicits in 
     let _ =
       match sc_opt with
       | Some (Allow_untyped r) ->
         List.iter
           (fun imp -> mark_uvar_with_should_check_tag imp.imp_uvar (Allow_untyped r))
-          g.implicits
+          imps
       | _ -> ()
     in
-    add_implicits g.implicits;!
+    add_implicits imps ;!
     let guard_f =
       if simplify
       then (Rel.simplify_guard e g).guard_f
@@ -413,7 +414,7 @@ let __do_unify_wflags
             ret None
           | Some g ->
             tc_unifier_solved_implicits env must_tot allow_guards all_uvars;!
-            add_implicits g.implicits;!
+            add_implicits (as_implicits g.implicits);!
             ret (Some g)
 
         with | Errors.Error (_, msg, r, _) -> begin

--- a/src/typechecker/FStar.TypeChecker.Common.fst
+++ b/src/typechecker/FStar.TypeChecker.Common.fst
@@ -211,6 +211,14 @@ instance show_implicit : showable implicit = {
   show = (fun i -> show i.imp_uvar.ctx_uvar_head);
 }
 
+let as_implicits imps =
+  let rec aux imps out =
+    match imps with
+    | Flat i -> (match out with | [] -> i | _ -> i@out)
+    | Conj imps1 imps2 -> aux imps1 (aux imps2 out)
+  in
+  aux imps []
+
 let implicits_to_string imps =
     let imp_to_string i = show i.imp_uvar.ctx_uvar_head in
     FStar.Common.string_of_list imp_to_string imps
@@ -220,7 +228,7 @@ let trivial_guard = {
   deferred_to_tac=[];
   deferred=[];
   univ_ineqs=([], []);
-  implicits=[]
+  implicits=Flat []
 }
 
 let conj_guard_f g1 g2 = match g1, g2 with
@@ -234,7 +242,7 @@ let binop_guard f g1 g2 = {
   deferred=g1.deferred@g2.deferred;
   univ_ineqs=(fst g1.univ_ineqs@fst g2.univ_ineqs,
               snd g1.univ_ineqs@snd g2.univ_ineqs);
-  implicits=g1.implicits@g2.implicits
+  implicits=Conj g1.implicits g2.implicits
 }
 let conj_guard g1 g2 = binop_guard conj_guard_f g1 g2
 

--- a/src/typechecker/FStar.TypeChecker.Common.fsti
+++ b/src/typechecker/FStar.TypeChecker.Common.fsti
@@ -155,7 +155,10 @@ type implicit = {
 instance val show_implicit : showable implicit
 
 type implicits = list implicit
-
+type implicits_t =
+| Flat of implicits
+| Conj : implicits_t -> implicits_t -> implicits_t
+val as_implicits : implicits_t -> implicits
 val implicits_to_string : implicits -> string
 
 type guard_t = {
@@ -164,7 +167,7 @@ type guard_t = {
                              //They are never attempted by the unification engine in Rel
   deferred:   deferred;
   univ_ineqs: list universe & list univ_ineq;
-  implicits:  implicits;
+  implicits:  implicits_t;
 }
 
 val trivial_guard : guard_t

--- a/src/typechecker/FStar.TypeChecker.DeferredImplicits.fst
+++ b/src/typechecker/FStar.TypeChecker.DeferredImplicits.fst
@@ -274,7 +274,7 @@ let solve_deferred_to_tactic_goals env g =
                    more, imp::imps
                  | Some se ->
                    (imp, se)::more, imps)
-            g.implicits
+            (as_implicits g.implicits)
             ([], [])
     in
     (** Each implicit is associated with a sigelt.
@@ -299,4 +299,4 @@ let solve_deferred_to_tactic_goals env g =
     let buckets = bucketize (eqs@more) in
     // Dispatch each bucket of implicits to their respective tactic
     List.iter (fun (imps, sigel) -> solve_goals_with_tac env g imps sigel) buckets;
-    { g with deferred_to_tac=[]; implicits = imps}
+    { g with deferred_to_tac=[]; implicits = Flat imps}

--- a/src/typechecker/FStar.TypeChecker.Env.fst
+++ b/src/typechecker/FStar.TypeChecker.Env.fst
@@ -1888,14 +1888,14 @@ let guard_of_guard_formula g = {
   deferred=[];
   deferred_to_tac=[];
   univ_ineqs=([], []);
-  implicits=[]
+  implicits=Flat []
 }
 
 let guard_form g = g.guard_f
 
 let is_trivial g = match g with
     | {guard_f=Trivial; deferred=[]; univ_ineqs=([], []); implicits=i} ->
-      i |> BU.for_all (fun imp ->
+      as_implicits i |> BU.for_all (fun imp ->
            (Allow_unresolved? (U.ctx_uvar_should_check imp.imp_uvar))
            || (match Unionfind.find imp.imp_uvar.ctx_uvar_head with
                | Some _ -> true
@@ -2025,7 +2025,7 @@ let new_tac_implicit_var
             } in
   if !dbg_ImplicitTrace then
     BU.print1 "Just created uvar for implicit {%s}\n" (show ctx_uvar.ctx_uvar_head);
-  let g = {trivial_guard with implicits=[imp]} in
+  let g = {trivial_guard with implicits=Flat [imp]} in
   t, (ctx_uvar, r), g
 
 let new_implicit_var_aux reason r env k should_check meta unrefine =


### PR DESCRIPTION
With @mtzguido, we noticed that concatenating implicit argument lists makes type checking large expressions quadratic, as reported by @jaylorch  and @LukeXuan 

This PR represents implicits as a tree, enabling a constant time operation to conjoin them, coercing them to a list only when needed eventually to iterate over all implicits.