### PR TITLE
Options: --already_cached should not consider the current module

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_Options.ml
+++ b/ocaml/fstar-lib/generated/FStar_Options.ml
@@ -4962,11 +4962,12 @@ let (should_extract : Prims.string -> codegen_t -> Prims.bool) =
                        (should_extract_module m1))))
 let (should_be_already_cached : Prims.string -> Prims.bool) =
   fun m ->
-    let uu___ = get_already_cached () in
-    match uu___ with
-    | FStar_Pervasives_Native.None -> false
-    | FStar_Pervasives_Native.Some already_cached_setting ->
-        module_matches_namespace_filter m already_cached_setting
+    (let uu___ = should_check m in Prims.op_Negation uu___) &&
+      (let uu___ = get_already_cached () in
+       match uu___ with
+       | FStar_Pervasives_Native.None -> false
+       | FStar_Pervasives_Native.Some already_cached_setting ->
+           module_matches_namespace_filter m already_cached_setting)
 let (profile_enabled :
   Prims.string FStar_Pervasives_Native.option -> Prims.string -> Prims.bool)
   =

--- a/src/basic/FStar.Options.fst
+++ b/src/basic/FStar.Options.fst
@@ -2393,10 +2393,15 @@ let should_extract m tgt =
         | _ -> should_extract_namespace m || should_extract_module m)
 
 let should_be_already_cached m =
-  match get_already_cached() with
-  | None -> false
-  | Some already_cached_setting ->
-    module_matches_namespace_filter m already_cached_setting
+  (* should_check is true for files in the command line,
+  we exclude those from this check since they were explicitly
+  requested. *)
+  not (should_check m) && (
+    match get_already_cached() with
+    | None -> false
+    | Some already_cached_setting ->
+      module_matches_namespace_filter m already_cached_setting
+  )
 
 
 let profile_enabled modul_opt phase =


### PR DESCRIPTION
From the commit message:
```
Options: --already_cached should not consider the current module

If no checked files are present, and we run

    fstar.exe --already_cached '*' A.fst

this will fail, since it could not find a checked file for A itself,
while we (arguably) were stating that all *dependencies* of A should
be checked. This behavior makes it difficult to write Makefiles that
use already cached to make sure we are not inadvertedly checking
dependencies within a given project.

This patch changes the behavior so that, if a file was given in the
command line, it is excluded from the already cached requirement.
This means that `--already_cached '*'` essentially becomes "do not
recursively check any dependencies".
```

I think most Makefiles, especially external ones, should really set `--already_cached '*'`. When we revamp the options there could instead be a `--nonrecursive` flag or similar.

Running check-world here https://github.com/FStarLang/FStar/actions/runs/11195763197