### PR TITLE
Autoload extension plugins

### DIFF
--- a/src/parser/FStar.Parser.AST.Util.fst
+++ b/src/parser/FStar.Parser.AST.Util.fst
@@ -746,9 +746,30 @@ module BU = FStar.Compiler.Util
 let extension_parser_table : BU.smap extension_parser = FStar.Compiler.Util.smap_create 20
 let register_extension_parser (ext:string) (parser:extension_parser) =
   FStar.Compiler.Util.smap_add extension_parser_table ext parser
-let lookup_extension_parser (ext:string) =
-  FStar.Compiler.Util.smap_try_find extension_parser_table ext
 
+(* Tries to load a plugin named like the extension. Returns true
+if it could find a plugin with the proper name. This will fail hard
+if loading the plugin fails. *)
+let autoload_plugin (ext:string) : bool =
+  if Debug.any () then
+    print1 "Trying to find a plugin for extension %s\n" ext;
+  match Options.find_file (ext ^ ".cmxs") with
+  | Some fn ->
+    if Debug.any () then
+      print1 "Autoloading plugin %s ...\n" fn;
+    Tactics.Load.load_tactics [fn];
+    true
+  | None ->
+    false
+
+let lookup_extension_parser (ext:string) =
+  let r = FStar.Compiler.Util.smap_try_find extension_parser_table ext in
+  match r with
+  | None ->
+    if autoload_plugin ext
+    then FStar.Compiler.Util.smap_try_find extension_parser_table ext
+    else None
+  | _ -> r
 
 let as_open_namespaces_and_abbrevs (ls:list decl)
 : open_namespaces_and_abbreviations
@@ -765,7 +786,13 @@ let extension_lang_parser_table : BU.smap extension_lang_parser = FStar.Compiler
 let register_extension_lang_parser (ext:string) (parser:extension_lang_parser) =
   FStar.Compiler.Util.smap_add extension_lang_parser_table ext parser
 let lookup_extension_lang_parser (ext:string) =
-  FStar.Compiler.Util.smap_try_find extension_lang_parser_table ext
+  let r = FStar.Compiler.Util.smap_try_find extension_lang_parser_table ext in
+  match r with
+  | None ->
+    if autoload_plugin ext
+    then FStar.Compiler.Util.smap_try_find extension_lang_parser_table ext
+    else None
+  | _ -> r
 
 let parse_extension_lang (lang_name:string) (raw_text:string) (raw_text_pos:range)
 : list decl


### PR DESCRIPTION
If we go over a #lang-xyz, and we cannot find an extension xyz in the
internal table, this tries to find a plugin `xyz.cmxs` in the include
path and loading it automatically.

This is extremely convenient for Pulse, where with fstar.include and
this we can now do:

    fstar.exe share/pulse/examples/ArrayTests.fst

and it just works.