### PR TITLE
Introducing a generic catenable list

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_Class_Listlike.ml
+++ b/ocaml/fstar-lib/generated/FStar_Class_Listlike.ml
@@ -1,0 +1,70 @@
+open Prims
+type ('e, 's) view_t =
+  | VNil 
+  | VCons of 'e * 's 
+let uu___is_VNil : 'e 's . ('e, 's) view_t -> Prims.bool =
+  fun projectee -> match projectee with | VNil -> true | uu___ -> false
+let uu___is_VCons : 'e 's . ('e, 's) view_t -> Prims.bool =
+  fun projectee ->
+    match projectee with | VCons (_0, _1) -> true | uu___ -> false
+let __proj__VCons__item___0 : 'e 's . ('e, 's) view_t -> 'e =
+  fun projectee -> match projectee with | VCons (_0, _1) -> _0
+let __proj__VCons__item___1 : 'e 's . ('e, 's) view_t -> 's =
+  fun projectee -> match projectee with | VCons (_0, _1) -> _1
+type ('e, 's) listlike =
+  {
+  empty: 's ;
+  cons: 'e -> 's -> 's ;
+  view: 's -> ('e, 's) view_t }
+let __proj__Mklistlike__item__empty : 'e 's . ('e, 's) listlike -> 's =
+  fun projectee -> match projectee with | { empty; cons; view;_} -> empty
+let __proj__Mklistlike__item__cons :
+  'e 's . ('e, 's) listlike -> 'e -> 's -> 's =
+  fun projectee -> match projectee with | { empty; cons; view;_} -> cons
+let __proj__Mklistlike__item__view :
+  'e 's . ('e, 's) listlike -> 's -> ('e, 's) view_t =
+  fun projectee -> match projectee with | { empty; cons; view;_} -> view
+let empty : 'e . unit -> ('e, Obj.t) listlike -> Obj.t =
+  fun s ->
+    fun projectee ->
+      match projectee with | { empty = empty1; cons; view;_} -> empty1
+let cons : 'e . unit -> ('e, Obj.t) listlike -> 'e -> Obj.t -> Obj.t =
+  fun s ->
+    fun projectee ->
+      match projectee with | { empty = empty1; cons = cons1; view;_} -> cons1
+let view : 'e . unit -> ('e, Obj.t) listlike -> Obj.t -> ('e, Obj.t) view_t =
+  fun s ->
+    fun projectee ->
+      match projectee with
+      | { empty = empty1; cons = cons1; view = view1;_} -> view1
+let is_empty : 'e 's . ('e, 's) listlike -> 's -> Prims.bool =
+  fun uu___ ->
+    fun l ->
+      let uu___1 = Obj.magic (view () (Obj.magic uu___) (Obj.magic l)) in
+      match uu___1 with | VNil -> true | VCons (uu___2, uu___3) -> false
+let singleton : 'e 's . ('e, 's) listlike -> 'e -> 's =
+  fun uu___1 ->
+    fun uu___ ->
+      (fun uu___ ->
+         fun x ->
+           Obj.magic
+             (cons () (Obj.magic uu___) x (empty () (Obj.magic uu___))))
+        uu___1 uu___
+let rec to_list : 'e 's . ('e, 's) listlike -> 's -> 'e Prims.list =
+  fun uu___ ->
+    fun l ->
+      let uu___1 = Obj.magic (view () (Obj.magic uu___) (Obj.magic l)) in
+      match uu___1 with
+      | VNil -> []
+      | VCons (x, xs) -> let uu___2 = to_list uu___ xs in x :: uu___2
+let rec from_list : 'e 's . ('e, 's) listlike -> 'e Prims.list -> 's =
+  fun uu___1 ->
+    fun uu___ ->
+      (fun uu___ ->
+         fun l ->
+           match l with
+           | [] -> Obj.magic (empty () (Obj.magic uu___))
+           | x::xs ->
+               let uu___1 = from_list uu___ xs in
+               Obj.magic (cons () (Obj.magic uu___) x (Obj.magic uu___1)))
+        uu___1 uu___

--- a/ocaml/fstar-lib/generated/FStar_Compiler_CList.ml
+++ b/ocaml/fstar-lib/generated/FStar_Compiler_CList.ml
@@ -1,0 +1,138 @@
+open Prims
+type 'a clist =
+  | CNil 
+  | CCons of 'a * 'a clist 
+  | CCat of 'a clist * 'a clist 
+let uu___is_CNil : 'a . 'a clist -> Prims.bool =
+  fun projectee -> match projectee with | CNil -> true | uu___ -> false
+let uu___is_CCons : 'a . 'a clist -> Prims.bool =
+  fun projectee ->
+    match projectee with | CCons (_0, _1) -> true | uu___ -> false
+let __proj__CCons__item___0 : 'a . 'a clist -> 'a =
+  fun projectee -> match projectee with | CCons (_0, _1) -> _0
+let __proj__CCons__item___1 : 'a . 'a clist -> 'a clist =
+  fun projectee -> match projectee with | CCons (_0, _1) -> _1
+let uu___is_CCat : 'a . 'a clist -> Prims.bool =
+  fun projectee ->
+    match projectee with | CCat (_0, _1) -> true | uu___ -> false
+let __proj__CCat__item___0 : 'a . 'a clist -> 'a clist =
+  fun projectee -> match projectee with | CCat (_0, _1) -> _0
+let __proj__CCat__item___1 : 'a . 'a clist -> 'a clist =
+  fun projectee -> match projectee with | CCat (_0, _1) -> _1
+type 'a t = 'a clist
+let ccat : 'a . 'a clist -> 'a clist -> 'a clist =
+  fun xs ->
+    fun ys ->
+      match (xs, ys) with
+      | (CNil, uu___) -> ys
+      | (uu___, CNil) -> xs
+      | uu___ -> CCat (xs, ys)
+let rec view : 'a . 'a clist -> ('a, 'a clist) FStar_Class_Listlike.view_t =
+  fun l ->
+    match l with
+    | CNil -> FStar_Class_Listlike.VNil
+    | CCons (x, xs) -> FStar_Class_Listlike.VCons (x, xs)
+    | CCat (CCat (xs, ys), zs) -> view (CCat (xs, (CCat (ys, zs))))
+    | CCat (xs, ys) ->
+        (match view xs with
+         | FStar_Class_Listlike.VNil -> view ys
+         | FStar_Class_Listlike.VCons (x, xs') ->
+             FStar_Class_Listlike.VCons (x, (CCat (xs', ys))))
+let listlike_clist : 'a . unit -> ('a, 'a t) FStar_Class_Listlike.listlike =
+  fun uu___ ->
+    {
+      FStar_Class_Listlike.empty = CNil;
+      FStar_Class_Listlike.cons =
+        (fun uu___1 -> fun uu___2 -> CCons (uu___1, uu___2));
+      FStar_Class_Listlike.view = view
+    }
+let monoid_clist : 'a . unit -> 'a t FStar_Class_Monoid.monoid =
+  fun uu___ ->
+    { FStar_Class_Monoid.mzero = CNil; FStar_Class_Monoid.mplus = ccat }
+let showable_clist :
+  'a . 'a FStar_Class_Show.showable -> 'a t FStar_Class_Show.showable =
+  fun uu___ ->
+    {
+      FStar_Class_Show.show =
+        (fun l ->
+           let uu___1 = FStar_Class_Listlike.to_list (listlike_clist ()) l in
+           FStar_Class_Show.show (FStar_Class_Show.show_list uu___) uu___1)
+    }
+let eq_clist : 'a . 'a FStar_Class_Deq.deq -> 'a t FStar_Class_Deq.deq =
+  fun d ->
+    {
+      FStar_Class_Deq.op_Equals_Question =
+        (fun l1 ->
+           fun l2 ->
+             let uu___ = FStar_Class_Listlike.to_list (listlike_clist ()) l1 in
+             let uu___1 = FStar_Class_Listlike.to_list (listlike_clist ()) l2 in
+             FStar_Class_Deq.op_Equals_Question (FStar_Class_Deq.deq_list d)
+               uu___ uu___1)
+    }
+let ord_clist : 'a . 'a FStar_Class_Ord.ord -> 'a t FStar_Class_Ord.ord =
+  fun d ->
+    {
+      FStar_Class_Ord.super = (eq_clist (FStar_Class_Ord.ord_eq d));
+      FStar_Class_Ord.cmp =
+        (fun l1 ->
+           fun l2 ->
+             let uu___ = FStar_Class_Listlike.to_list (listlike_clist ()) l1 in
+             let uu___1 = FStar_Class_Listlike.to_list (listlike_clist ()) l2 in
+             FStar_Class_Ord.cmp (FStar_Class_Ord.ord_list d) uu___ uu___1)
+    }
+let rec map : 'a 'b . ('a -> 'b) -> 'a clist -> 'b clist =
+  fun f ->
+    fun l ->
+      match l with
+      | CNil -> CNil
+      | CCons (x, xs) ->
+          let uu___ = f x in let uu___1 = map f xs in CCons (uu___, uu___1)
+      | CCat (xs, ys) ->
+          let uu___ = map f xs in let uu___1 = map f ys in ccat uu___ uu___1
+let rec existsb : 'a . ('a -> Prims.bool) -> 'a clist -> Prims.bool =
+  fun p ->
+    fun l ->
+      match l with
+      | CNil -> false
+      | CCons (x, xs) -> (p x) || (existsb p xs)
+      | CCat (xs, ys) -> (existsb p xs) || (existsb p ys)
+let rec for_all : 'a . ('a -> Prims.bool) -> 'a clist -> Prims.bool =
+  fun p ->
+    fun l ->
+      match l with
+      | CNil -> true
+      | CCons (x, xs) -> (p x) && (for_all p xs)
+      | CCat (xs, ys) -> (for_all p xs) && (for_all p ys)
+let rec partition :
+  'a . ('a -> Prims.bool) -> 'a clist -> ('a clist * 'a clist) =
+  fun p ->
+    fun l ->
+      match l with
+      | CNil -> (CNil, CNil)
+      | CCons (x, xs) ->
+          let uu___ = partition p xs in
+          (match uu___ with
+           | (ys, zs) ->
+               let uu___1 = p x in
+               if uu___1
+               then ((CCons (x, ys)), zs)
+               else (ys, (CCons (x, zs))))
+      | CCat (xs, ys) ->
+          let uu___ = partition p xs in
+          (match uu___ with
+           | (ys1, zs) ->
+               let uu___1 = partition p ys1 in
+               (match uu___1 with
+                | (us, vs) ->
+                    let uu___2 = ccat ys1 us in
+                    let uu___3 = ccat zs vs in (uu___2, uu___3)))
+let rec collect : 'a 'b . ('a -> 'b clist) -> 'a clist -> 'b clist =
+  fun f ->
+    fun l ->
+      match l with
+      | CNil -> CNil
+      | CCons (x, xs) ->
+          let uu___ = f x in let uu___1 = collect f xs in ccat uu___ uu___1
+      | CCat (xs, ys) ->
+          let uu___ = collect f xs in
+          let uu___1 = collect f ys in ccat uu___ uu___1

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Hooks.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Hooks.ml
@@ -1574,17 +1574,8 @@ let (synthesize :
                                     "Synthesis left a goal: %s\n" uu___7
                                 else ());
                                (let guard =
-                                  {
-                                    FStar_TypeChecker_Common.guard_f =
-                                      (FStar_TypeChecker_Common.NonTrivial vc);
-                                    FStar_TypeChecker_Common.deferred_to_tac
-                                      = [];
-                                    FStar_TypeChecker_Common.deferred = [];
-                                    FStar_TypeChecker_Common.univ_ineqs =
-                                      ([], []);
-                                    FStar_TypeChecker_Common.implicits =
-                                      (FStar_TypeChecker_Common.Flat [])
-                                  } in
+                                  FStar_TypeChecker_Env.guard_of_guard_formula
+                                    (FStar_TypeChecker_Common.NonTrivial vc) in
                                 let uu___6 = FStar_Tactics_Types.goal_env g in
                                 FStar_TypeChecker_Rel.force_trivial_guard
                                   uu___6 guard))
@@ -1654,18 +1645,9 @@ let (solve_implicits :
                                     env.FStar_TypeChecker_Env.admit
                                 then
                                   (let guard =
-                                     {
-                                       FStar_TypeChecker_Common.guard_f =
-                                         (FStar_TypeChecker_Common.NonTrivial
-                                            vc);
-                                       FStar_TypeChecker_Common.deferred_to_tac
-                                         = [];
-                                       FStar_TypeChecker_Common.deferred = [];
-                                       FStar_TypeChecker_Common.univ_ineqs =
-                                         ([], []);
-                                       FStar_TypeChecker_Common.implicits =
-                                         (FStar_TypeChecker_Common.Flat [])
-                                     } in
+                                     FStar_TypeChecker_Env.guard_of_guard_formula
+                                       (FStar_TypeChecker_Common.NonTrivial
+                                          vc) in
                                    FStar_Profiling.profile
                                      (fun uu___8 ->
                                         let uu___9 =
@@ -2215,22 +2197,9 @@ let (splice :
                                                     uu___12
                                                 else ());
                                                (let guard =
-                                                  {
-                                                    FStar_TypeChecker_Common.guard_f
-                                                      =
-                                                      (FStar_TypeChecker_Common.NonTrivial
-                                                         vc);
-                                                    FStar_TypeChecker_Common.deferred_to_tac
-                                                      = [];
-                                                    FStar_TypeChecker_Common.deferred
-                                                      = [];
-                                                    FStar_TypeChecker_Common.univ_ineqs
-                                                      = ([], []);
-                                                    FStar_TypeChecker_Common.implicits
-                                                      =
-                                                      (FStar_TypeChecker_Common.Flat
-                                                         [])
-                                                  } in
+                                                  FStar_TypeChecker_Env.guard_of_guard_formula
+                                                    (FStar_TypeChecker_Common.NonTrivial
+                                                       vc) in
                                                 let uu___11 =
                                                   FStar_Tactics_Types.goal_env
                                                     g1 in
@@ -2510,21 +2479,9 @@ let (postprocess :
                                            uu___9
                                        else ());
                                       (let guard =
-                                         {
-                                           FStar_TypeChecker_Common.guard_f =
-                                             (FStar_TypeChecker_Common.NonTrivial
-                                                vc);
-                                           FStar_TypeChecker_Common.deferred_to_tac
-                                             = [];
-                                           FStar_TypeChecker_Common.deferred
-                                             = [];
-                                           FStar_TypeChecker_Common.univ_ineqs
-                                             = ([], []);
-                                           FStar_TypeChecker_Common.implicits
-                                             =
-                                             (FStar_TypeChecker_Common.Flat
-                                                [])
-                                         } in
+                                         FStar_TypeChecker_Env.guard_of_guard_formula
+                                           (FStar_TypeChecker_Common.NonTrivial
+                                              vc) in
                                        let uu___8 =
                                          FStar_Tactics_Types.goal_env g in
                                        FStar_TypeChecker_Rel.force_trivial_guard

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Interpreter.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Interpreter.ml
@@ -1017,6 +1017,10 @@ let run_unembedded_tactic_on_ps :
                                "About to check tactic implicits: %s\n" uu___7
                            else ());
                           (let g =
+                             let uu___6 =
+                               FStar_Class_Listlike.from_list
+                                 (FStar_Compiler_CList.listlike_clist ())
+                                 ps3.FStar_Tactics_Types.all_implicits in
                              {
                                FStar_TypeChecker_Common.guard_f =
                                  (FStar_TypeChecker_Env.trivial_guard.FStar_TypeChecker_Common.guard_f);
@@ -1026,9 +1030,7 @@ let run_unembedded_tactic_on_ps :
                                  (FStar_TypeChecker_Env.trivial_guard.FStar_TypeChecker_Common.deferred);
                                FStar_TypeChecker_Common.univ_ineqs =
                                  (FStar_TypeChecker_Env.trivial_guard.FStar_TypeChecker_Common.univ_ineqs);
-                               FStar_TypeChecker_Common.implicits =
-                                 (FStar_TypeChecker_Common.Flat
-                                    (ps3.FStar_Tactics_Types.all_implicits))
+                               FStar_TypeChecker_Common.implicits = uu___6
                              } in
                            let g1 =
                              FStar_TypeChecker_Rel.solve_deferred_constraints
@@ -1046,7 +1048,7 @@ let run_unembedded_tactic_on_ps :
                               let uu___9 =
                                 FStar_Class_Show.show
                                   (FStar_Class_Show.show_list
-                                     FStar_TypeChecker_Common.show_implicit)
+                                     FStar_TypeChecker_Common.showable_implicit)
                                   ps3.FStar_Tactics_Types.all_implicits in
                               FStar_Compiler_Util.print2
                                 "Checked %s implicits (1): %s\n" uu___8
@@ -1068,7 +1070,7 @@ let run_unembedded_tactic_on_ps :
                                let uu___10 =
                                  FStar_Class_Show.show
                                    (FStar_Class_Show.show_list
-                                      FStar_TypeChecker_Common.show_implicit)
+                                      FStar_TypeChecker_Common.showable_implicit)
                                    ps3.FStar_Tactics_Types.all_implicits in
                                FStar_Compiler_Util.print2
                                  "Checked %s implicits (2): %s\n" uu___9

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Monad.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Monad.ml
@@ -844,7 +844,8 @@ let (new_uvar :
               | (u, ctx_uvar, g_u) ->
                   let uu___1 =
                     let uu___2 =
-                      FStar_TypeChecker_Common.as_implicits
+                      FStar_Class_Listlike.to_list
+                        (FStar_Compiler_CList.listlike_clist ())
                         g_u.FStar_TypeChecker_Common.implicits in
                     add_implicits uu___2 in
                   bind uu___1
@@ -998,6 +999,9 @@ let (compress_implicits : unit tac) =
     (fun ps ->
        let imps = ps.FStar_Tactics_Types.all_implicits in
        let g =
+         let uu___ =
+           FStar_Class_Listlike.from_list
+             (FStar_Compiler_CList.listlike_clist ()) imps in
          {
            FStar_TypeChecker_Common.guard_f =
              (FStar_TypeChecker_Env.trivial_guard.FStar_TypeChecker_Common.guard_f);
@@ -1007,8 +1011,7 @@ let (compress_implicits : unit tac) =
              (FStar_TypeChecker_Env.trivial_guard.FStar_TypeChecker_Common.deferred);
            FStar_TypeChecker_Common.univ_ineqs =
              (FStar_TypeChecker_Env.trivial_guard.FStar_TypeChecker_Common.univ_ineqs);
-           FStar_TypeChecker_Common.implicits =
-             (FStar_TypeChecker_Common.Flat imps)
+           FStar_TypeChecker_Common.implicits = uu___
          } in
        let imps1 =
          FStar_TypeChecker_Rel.resolve_implicits_tac

--- a/ocaml/fstar-lib/generated/FStar_Tactics_V1_Basic.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_V1_Basic.ml
@@ -487,7 +487,8 @@ let (proc_guard' :
                      reason uu___1)
                 (fun uu___ ->
                    let imps =
-                     FStar_TypeChecker_Common.as_implicits
+                     FStar_Class_Listlike.to_list
+                       (FStar_Compiler_CList.listlike_clist ())
                        g.FStar_TypeChecker_Common.implicits in
                    (match sc_opt with
                     | FStar_Pervasives_Native.Some
@@ -1057,7 +1058,9 @@ let (__do_unify_wflags :
                                                                     =
                                                                     let uu___10
                                                                     =
-                                                                    FStar_TypeChecker_Common.as_implicits
+                                                                    FStar_Class_Listlike.to_list
+                                                                    (FStar_Compiler_CList.listlike_clist
+                                                                    ())
                                                                     g.FStar_TypeChecker_Common.implicits in
                                                                     FStar_Tactics_Monad.add_implicits
                                                                     uu___10 in

--- a/ocaml/fstar-lib/generated/FStar_Tactics_V2_Basic.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_V2_Basic.ml
@@ -775,7 +775,8 @@ let (proc_guard' :
                    (fun uu___1 ->
                       let uu___1 = Obj.magic uu___1 in
                       let imps =
-                        FStar_TypeChecker_Common.as_implicits
+                        FStar_Class_Listlike.to_list
+                          (FStar_Compiler_CList.listlike_clist ())
                           g.FStar_TypeChecker_Common.implicits in
                       (match sc_opt with
                        | FStar_Pervasives_Native.Some
@@ -1270,7 +1271,9 @@ let (__do_unify_wflags :
                                                                     =
                                                                     let uu___9
                                                                     =
-                                                                    FStar_TypeChecker_Common.as_implicits
+                                                                    FStar_Class_Listlike.to_list
+                                                                    (FStar_Compiler_CList.listlike_clist
+                                                                    ())
                                                                     g.FStar_TypeChecker_Common.implicits in
                                                                     FStar_Tactics_Monad.add_implicits
                                                                     uu___9 in
@@ -11901,7 +11904,9 @@ let (refl_instantiate_implicits :
                                      uu___5 in
                                  let bvs_and_ts =
                                    let uu___5 =
-                                     FStar_TypeChecker_Common.as_implicits
+                                     FStar_Class_Listlike.to_list
+                                       (FStar_Compiler_CList.listlike_clist
+                                          ())
                                        guard1.FStar_TypeChecker_Common.implicits in
                                    match uu___5 with
                                    | [] -> []
@@ -12370,7 +12375,9 @@ let (refl_try_unify :
                                                     g2 uu___5 in
                                                 let b =
                                                   let uu___5 =
-                                                    FStar_TypeChecker_Common.as_implicits
+                                                    FStar_Class_Listlike.to_list
+                                                      (FStar_Compiler_CList.listlike_clist
+                                                         ())
                                                       guard2.FStar_TypeChecker_Common.implicits in
                                                   FStar_Compiler_List.existsb
                                                     (fun uu___6 ->
@@ -13363,7 +13370,8 @@ let (proofstate_of_goal_ty :
         | (g, g_u) ->
             let ps =
               let uu___1 =
-                FStar_TypeChecker_Common.as_implicits
+                FStar_Class_Listlike.to_list
+                  (FStar_Compiler_CList.listlike_clist ())
                   g_u.FStar_TypeChecker_Common.implicits in
               proofstate_of_goals rng env3 [g] uu___1 in
             let uu___1 = FStar_Tactics_Types.goal_witness g in (ps, uu___1)
@@ -13447,16 +13455,8 @@ let run_unembedded_tactic_on_ps_and_solve_remaining :
                         match uu___2 with
                         | FStar_Pervasives_Native.Some vc ->
                             let guard =
-                              {
-                                FStar_TypeChecker_Common.guard_f =
-                                  (FStar_TypeChecker_Common.NonTrivial vc);
-                                FStar_TypeChecker_Common.deferred_to_tac = [];
-                                FStar_TypeChecker_Common.deferred = [];
-                                FStar_TypeChecker_Common.univ_ineqs =
-                                  ([], []);
-                                FStar_TypeChecker_Common.implicits =
-                                  (FStar_TypeChecker_Common.Flat [])
-                              } in
+                              FStar_TypeChecker_Env.guard_of_guard_formula
+                                (FStar_TypeChecker_Common.NonTrivial vc) in
                             let uu___3 = FStar_Tactics_Types.goal_env g in
                             FStar_TypeChecker_Rel.force_trivial_guard uu___3
                               guard
@@ -13584,15 +13584,8 @@ let run_tactic_on_ps_and_solve_remaining :
                        match uu___2 with
                        | FStar_Pervasives_Native.Some vc ->
                            let guard =
-                             {
-                               FStar_TypeChecker_Common.guard_f =
-                                 (FStar_TypeChecker_Common.NonTrivial vc);
-                               FStar_TypeChecker_Common.deferred_to_tac = [];
-                               FStar_TypeChecker_Common.deferred = [];
-                               FStar_TypeChecker_Common.univ_ineqs = ([], []);
-                               FStar_TypeChecker_Common.implicits =
-                                 (FStar_TypeChecker_Common.Flat [])
-                             } in
+                             FStar_TypeChecker_Env.guard_of_guard_formula
+                               (FStar_TypeChecker_Common.NonTrivial vc) in
                            let uu___3 = FStar_Tactics_Types.goal_env g in
                            FStar_TypeChecker_Rel.force_trivial_guard uu___3
                              guard

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Common.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Common.ml
@@ -578,7 +578,7 @@ let (__proj__Mkimplicit__item__imp_range :
   fun projectee ->
     match projectee with
     | { imp_reason; imp_uvar; imp_tm; imp_range;_} -> imp_range
-let (show_implicit : implicit FStar_Class_Show.showable) =
+let (showable_implicit : implicit FStar_Class_Show.showable) =
   {
     FStar_Class_Show.show =
       (fun i ->
@@ -586,36 +586,13 @@ let (show_implicit : implicit FStar_Class_Show.showable) =
            (i.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_head)
   }
 type implicits = implicit Prims.list
-type implicits_t =
-  | Flat of implicits 
-  | Conj of implicits_t * implicits_t 
-let (uu___is_Flat : implicits_t -> Prims.bool) =
-  fun projectee -> match projectee with | Flat _0 -> true | uu___ -> false
-let (__proj__Flat__item___0 : implicits_t -> implicits) =
-  fun projectee -> match projectee with | Flat _0 -> _0
-let (uu___is_Conj : implicits_t -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Conj (_0, _1) -> true | uu___ -> false
-let (__proj__Conj__item___0 : implicits_t -> implicits_t) =
-  fun projectee -> match projectee with | Conj (_0, _1) -> _0
-let (__proj__Conj__item___1 : implicits_t -> implicits_t) =
-  fun projectee -> match projectee with | Conj (_0, _1) -> _1
-let (as_implicits : implicits_t -> implicits) =
-  fun imps ->
-    let rec aux imps1 out =
-      match imps1 with
-      | Flat i ->
-          (match out with
-           | [] -> i
-           | uu___ -> FStar_Compiler_List.op_At i out)
-      | Conj (imps11, imps2) -> let uu___ = aux imps2 out in aux imps11 uu___ in
-    aux imps []
 let (implicits_to_string : implicits -> Prims.string) =
   fun imps ->
     let imp_to_string i =
       FStar_Class_Show.show FStar_Syntax_Print.showable_uvar
         (i.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_head in
     (FStar_Common.string_of_list ()) imp_to_string imps
+type implicits_t = implicit FStar_Compiler_CList.t
 type guard_t =
   {
   guard_f: guard_formula ;
@@ -657,7 +634,10 @@ let (trivial_guard : guard_t) =
     deferred_to_tac = [];
     deferred = [];
     univ_ineqs = ([], []);
-    implicits = (Flat [])
+    implicits =
+      (Obj.magic
+         (FStar_Class_Listlike.empty ()
+            (Obj.magic (FStar_Compiler_CList.listlike_clist ()))))
   }
 let (conj_guard_f : guard_formula -> guard_formula -> guard_formula) =
   fun g1 ->
@@ -675,6 +655,9 @@ let (binop_guard :
     fun g1 ->
       fun g2 ->
         let uu___ = f g1.guard_f g2.guard_f in
+        let uu___1 =
+          FStar_Class_Monoid.op_Plus_Plus
+            (FStar_Compiler_CList.monoid_clist ()) g1.implicits g2.implicits in
         {
           guard_f = uu___;
           deferred_to_tac =
@@ -687,7 +670,7 @@ let (binop_guard :
               (FStar_Compiler_List.op_At
                  (FStar_Pervasives_Native.snd g1.univ_ineqs)
                  (FStar_Pervasives_Native.snd g2.univ_ineqs)));
-          implicits = (Conj ((g1.implicits), (g2.implicits)))
+          implicits = uu___1
         }
 let (conj_guard : guard_t -> guard_t -> guard_t) =
   fun g1 -> fun g2 -> binop_guard conj_guard_f g1 g2

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_DeferredImplicits.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_DeferredImplicits.ml
@@ -695,7 +695,8 @@ let (solve_deferred_to_tactic_goals :
              g.FStar_TypeChecker_Common.deferred_to_tac in
          let uu___1 =
            let uu___2 =
-             FStar_TypeChecker_Common.as_implicits
+             FStar_Class_Listlike.to_list
+               (FStar_Compiler_CList.listlike_clist ())
                g.FStar_TypeChecker_Common.implicits in
            FStar_Compiler_List.fold_right
              (fun imp ->
@@ -751,14 +752,16 @@ let (solve_deferred_to_tactic_goals :
                    match uu___3 with
                    | (imps1, sigel) -> solve_goals_with_tac env g imps1 sigel)
                 buckets;
-              {
-                FStar_TypeChecker_Common.guard_f =
-                  (g.FStar_TypeChecker_Common.guard_f);
-                FStar_TypeChecker_Common.deferred_to_tac = [];
-                FStar_TypeChecker_Common.deferred =
-                  (g.FStar_TypeChecker_Common.deferred);
-                FStar_TypeChecker_Common.univ_ineqs =
-                  (g.FStar_TypeChecker_Common.univ_ineqs);
-                FStar_TypeChecker_Common.implicits =
-                  (FStar_TypeChecker_Common.Flat imps)
-              }))
+              (let uu___3 =
+                 FStar_Class_Listlike.from_list
+                   (FStar_Compiler_CList.listlike_clist ()) imps in
+               {
+                 FStar_TypeChecker_Common.guard_f =
+                   (g.FStar_TypeChecker_Common.guard_f);
+                 FStar_TypeChecker_Common.deferred_to_tac = [];
+                 FStar_TypeChecker_Common.deferred =
+                   (g.FStar_TypeChecker_Common.deferred);
+                 FStar_TypeChecker_Common.univ_ineqs =
+                   (g.FStar_TypeChecker_Common.univ_ineqs);
+                 FStar_TypeChecker_Common.implicits = uu___3
+               })))

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Env.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Env.ml
@@ -6864,7 +6864,10 @@ let (guard_of_guard_formula :
       FStar_TypeChecker_Common.deferred_to_tac = [];
       FStar_TypeChecker_Common.deferred = [];
       FStar_TypeChecker_Common.univ_ineqs = ([], []);
-      FStar_TypeChecker_Common.implicits = (FStar_TypeChecker_Common.Flat [])
+      FStar_TypeChecker_Common.implicits =
+        (Obj.magic
+           (FStar_Class_Listlike.empty ()
+              (Obj.magic (FStar_Compiler_CList.listlike_clist ()))))
     }
 let (guard_form : guard_t -> FStar_TypeChecker_Common.guard_formula) =
   fun g -> g.FStar_TypeChecker_Common.guard_f
@@ -6876,19 +6879,18 @@ let (is_trivial : guard_t -> Prims.bool) =
         FStar_TypeChecker_Common.deferred = [];
         FStar_TypeChecker_Common.univ_ineqs = ([], []);
         FStar_TypeChecker_Common.implicits = i;_} ->
-        let uu___1 = FStar_TypeChecker_Common.as_implicits i in
-        FStar_Compiler_Util.for_all
+        FStar_Compiler_CList.for_all
           (fun imp ->
-             (let uu___2 =
+             (let uu___1 =
                 FStar_Syntax_Util.ctx_uvar_should_check
                   imp.FStar_TypeChecker_Common.imp_uvar in
-              FStar_Syntax_Syntax.uu___is_Allow_unresolved uu___2) ||
-               (let uu___2 =
+              FStar_Syntax_Syntax.uu___is_Allow_unresolved uu___1) ||
+               (let uu___1 =
                   FStar_Syntax_Unionfind.find
                     (imp.FStar_TypeChecker_Common.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_head in
-                match uu___2 with
-                | FStar_Pervasives_Native.Some uu___3 -> true
-                | FStar_Pervasives_Native.None -> false)) uu___1
+                match uu___1 with
+                | FStar_Pervasives_Native.Some uu___2 -> true
+                | FStar_Pervasives_Native.None -> false)) i
     | uu___ -> false
 let (is_trivial_guard_formula : guard_t -> Prims.bool) =
   fun g ->
@@ -7204,6 +7206,14 @@ let (new_tac_implicit_var :
                         "Just created uvar for implicit {%s}\n" uu___3
                     else ());
                    (let g =
+                      let uu___2 =
+                        Obj.magic
+                          (FStar_Class_Listlike.cons ()
+                             (Obj.magic
+                                (FStar_Compiler_CList.listlike_clist ())) imp
+                             (FStar_Class_Listlike.empty ()
+                                (Obj.magic
+                                   (FStar_Compiler_CList.listlike_clist ())))) in
                       {
                         FStar_TypeChecker_Common.guard_f =
                           (trivial_guard.FStar_TypeChecker_Common.guard_f);
@@ -7213,8 +7223,7 @@ let (new_tac_implicit_var :
                           (trivial_guard.FStar_TypeChecker_Common.deferred);
                         FStar_TypeChecker_Common.univ_ineqs =
                           (trivial_guard.FStar_TypeChecker_Common.univ_ineqs);
-                        FStar_TypeChecker_Common.implicits =
-                          (FStar_TypeChecker_Common.Flat [imp])
+                        FStar_TypeChecker_Common.implicits = uu___2
                       } in
                     (t, (ctx_uvar, r), g)))
 let (new_implicit_var_aux :

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Rel.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Rel.ml
@@ -367,23 +367,27 @@ let (new_uvar :
                       FStar_Compiler_Util.print1
                         "Just created uvar (Rel) {%s}\n" uu___3
                     else ());
-                   (ctx_uvar, t,
-                     {
-                       attempting = (wl.attempting);
-                       wl_deferred = (wl.wl_deferred);
-                       wl_deferred_to_tac = (wl.wl_deferred_to_tac);
-                       ctr = (wl.ctr);
-                       defer_ok = (wl.defer_ok);
-                       smt_ok = (wl.smt_ok);
-                       umax_heuristic_ok = (wl.umax_heuristic_ok);
-                       tcenv = (wl.tcenv);
-                       wl_implicits =
-                         (FStar_TypeChecker_Common.Conj
-                            ((FStar_TypeChecker_Common.Flat [imp]),
-                              (wl.wl_implicits)));
-                       repr_subcomp_allowed = (wl.repr_subcomp_allowed);
-                       typeclass_variables = (wl.typeclass_variables)
-                     }))
+                   (let uu___2 =
+                      let uu___3 =
+                        Obj.magic
+                          (FStar_Class_Listlike.cons ()
+                             (Obj.magic
+                                (FStar_Compiler_CList.listlike_clist ())) imp
+                             (Obj.magic wl.wl_implicits)) in
+                      {
+                        attempting = (wl.attempting);
+                        wl_deferred = (wl.wl_deferred);
+                        wl_deferred_to_tac = (wl.wl_deferred_to_tac);
+                        ctr = (wl.ctr);
+                        defer_ok = (wl.defer_ok);
+                        smt_ok = (wl.smt_ok);
+                        umax_heuristic_ok = (wl.umax_heuristic_ok);
+                        tcenv = (wl.tcenv);
+                        wl_implicits = uu___3;
+                        repr_subcomp_allowed = (wl.repr_subcomp_allowed);
+                        typeclass_variables = (wl.typeclass_variables)
+                      } in
+                    (ctx_uvar, t, uu___2)))
 let (copy_uvar :
   FStar_Syntax_Syntax.ctx_uvar ->
     FStar_Syntax_Syntax.binders ->
@@ -543,6 +547,9 @@ let (extend_wl :
           let uu___1 =
             let uu___2 = as_wl_deferred wl defer_to_tac in
             FStar_Compiler_List.op_At wl.wl_deferred_to_tac uu___2 in
+          let uu___2 =
+            FStar_Class_Monoid.op_Plus_Plus
+              (FStar_Compiler_CList.monoid_clist ()) wl.wl_implicits imps in
           {
             attempting = (wl.attempting);
             wl_deferred = uu___;
@@ -552,8 +559,7 @@ let (extend_wl :
             smt_ok = (wl.smt_ok);
             umax_heuristic_ok = (wl.umax_heuristic_ok);
             tcenv = (wl.tcenv);
-            wl_implicits =
-              (FStar_TypeChecker_Common.Conj ((wl.wl_implicits), imps));
+            wl_implicits = uu___2;
             repr_subcomp_allowed = (wl.repr_subcomp_allowed);
             typeclass_variables = (wl.typeclass_variables)
           }
@@ -1163,7 +1169,10 @@ let (empty_worklist : FStar_TypeChecker_Env.env -> worklist) =
       smt_ok = true;
       umax_heuristic_ok = true;
       tcenv = env;
-      wl_implicits = (FStar_TypeChecker_Common.Flat []);
+      wl_implicits =
+        (Obj.magic
+           (FStar_Class_Listlike.empty ()
+              (Obj.magic (FStar_Compiler_CList.listlike_clist ()))));
       repr_subcomp_allowed = false;
       typeclass_variables = uu___
     }
@@ -4862,11 +4871,13 @@ let (apply_substitutive_indexed_subcomp :
                                                             r1 in
                                                         (match uu___6 with
                                                          | (uv_t::[], g) ->
-                                                             ((FStar_Compiler_List.op_At
-                                                                 ss
-                                                                 [FStar_Syntax_Syntax.NT
-                                                                    ((b.FStar_Syntax_Syntax.binder_bv),
-                                                                    uv_t)]),
+                                                             let uu___7 =
+                                                               let uu___8 =
+                                                                 FStar_Class_Monoid.op_Plus_Plus
+                                                                   (FStar_Compiler_CList.monoid_clist
+                                                                    ())
+                                                                   g.FStar_TypeChecker_Common.implicits
+                                                                   wl3.wl_implicits in
                                                                {
                                                                  attempting =
                                                                    (wl3.attempting);
@@ -4888,17 +4899,20 @@ let (apply_substitutive_indexed_subcomp :
                                                                  tcenv =
                                                                    (wl3.tcenv);
                                                                  wl_implicits
-                                                                   =
-                                                                   (FStar_TypeChecker_Common.Conj
-                                                                    ((g.FStar_TypeChecker_Common.implicits),
-                                                                    (wl3.wl_implicits)));
+                                                                   = uu___8;
                                                                  repr_subcomp_allowed
                                                                    =
                                                                    (wl3.repr_subcomp_allowed);
                                                                  typeclass_variables
                                                                    =
                                                                    (wl3.typeclass_variables)
-                                                               })))
+                                                               } in
+                                                             ((FStar_Compiler_List.op_At
+                                                                 ss
+                                                                 [FStar_Syntax_Syntax.NT
+                                                                    ((b.FStar_Syntax_Syntax.binder_bv),
+                                                                    uv_t)]),
+                                                               uu___7)))
                                                (subst3, wl2) bs5 in
                                            (match uu___4 with
                                             | (subst4, wl3) ->
@@ -5022,6 +5036,11 @@ let (apply_ad_hoc_indexed_subcomp :
                         (match uu___1 with
                          | (rest_bs_uvars, g_uvars) ->
                              let wl1 =
+                               let uu___2 =
+                                 FStar_Class_Monoid.op_Plus_Plus
+                                   (FStar_Compiler_CList.monoid_clist ())
+                                   g_uvars.FStar_TypeChecker_Common.implicits
+                                   wl.wl_implicits in
                                {
                                  attempting = (wl.attempting);
                                  wl_deferred = (wl.wl_deferred);
@@ -5031,10 +5050,7 @@ let (apply_ad_hoc_indexed_subcomp :
                                  smt_ok = (wl.smt_ok);
                                  umax_heuristic_ok = (wl.umax_heuristic_ok);
                                  tcenv = (wl.tcenv);
-                                 wl_implicits =
-                                   (FStar_TypeChecker_Common.Conj
-                                      ((g_uvars.FStar_TypeChecker_Common.implicits),
-                                        (wl.wl_implicits)));
+                                 wl_implicits = uu___2;
                                  repr_subcomp_allowed =
                                    (wl.repr_subcomp_allowed);
                                  typeclass_variables =
@@ -5260,9 +5276,9 @@ let rec (solve : worklist -> solution) =
      if uu___2
      then
        let uu___3 =
-         let uu___4 =
-           FStar_TypeChecker_Common.as_implicits probs.wl_implicits in
-         FStar_TypeChecker_Common.implicits_to_string uu___4 in
+         FStar_Class_Show.show
+           (FStar_Compiler_CList.showable_clist
+              FStar_TypeChecker_Common.showable_implicit) probs.wl_implicits in
        FStar_Compiler_Util.print1 "solve: wl_implicits = %s\n" uu___3
      else ());
     (let uu___2 = next_prob probs in
@@ -5779,8 +5795,12 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                     (wl4.umax_heuristic_ok);
                                                   tcenv = (wl4.tcenv);
                                                   wl_implicits =
-                                                    (FStar_TypeChecker_Common.Flat
-                                                       []);
+                                                    (Obj.magic
+                                                       (FStar_Class_Listlike.empty
+                                                          ()
+                                                          (Obj.magic
+                                                             (FStar_Compiler_CList.listlike_clist
+                                                                ()))));
                                                   repr_subcomp_allowed =
                                                     (wl4.repr_subcomp_allowed);
                                                   typeclass_variables =
@@ -6271,8 +6291,12 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                             (wl'.umax_heuristic_ok);
                                                           tcenv = (wl'.tcenv);
                                                           wl_implicits =
-                                                            (FStar_TypeChecker_Common.Flat
-                                                               []);
+                                                            (Obj.magic
+                                                               (FStar_Class_Listlike.empty
+                                                                  ()
+                                                                  (Obj.magic
+                                                                    (FStar_Compiler_CList.listlike_clist
+                                                                    ()))));
                                                           repr_subcomp_allowed
                                                             =
                                                             (wl'.repr_subcomp_allowed);
@@ -6920,7 +6944,10 @@ and (try_solve_without_smt_or_else :
             smt_ok = false;
             umax_heuristic_ok = false;
             tcenv = (wl.tcenv);
-            wl_implicits = (FStar_TypeChecker_Common.Flat []);
+            wl_implicits =
+              (Obj.magic
+                 (FStar_Class_Listlike.empty ()
+                    (Obj.magic (FStar_Compiler_CList.listlike_clist ()))));
             repr_subcomp_allowed = (wl.repr_subcomp_allowed);
             typeclass_variables = (wl.typeclass_variables)
           } in
@@ -6951,7 +6978,10 @@ and (try_solve_then_or_else :
               smt_ok = (wl.smt_ok);
               umax_heuristic_ok = (wl.umax_heuristic_ok);
               tcenv = (wl.tcenv);
-              wl_implicits = (FStar_TypeChecker_Common.Flat []);
+              wl_implicits =
+                (Obj.magic
+                   (FStar_Class_Listlike.empty ()
+                      (Obj.magic (FStar_Compiler_CList.listlike_clist ()))));
               repr_subcomp_allowed = (wl.repr_subcomp_allowed);
               typeclass_variables = (wl.typeclass_variables)
             } in
@@ -6983,7 +7013,10 @@ and (try_solve_probs_without_smt :
               smt_ok = false;
               umax_heuristic_ok = false;
               tcenv = (wl.tcenv);
-              wl_implicits = (FStar_TypeChecker_Common.Flat []);
+              wl_implicits =
+                (Obj.magic
+                   (FStar_Class_Listlike.empty ()
+                      (Obj.magic (FStar_Compiler_CList.listlike_clist ()))));
               repr_subcomp_allowed = (wl.repr_subcomp_allowed);
               typeclass_variables = (wl.typeclass_variables)
             } in
@@ -7720,8 +7753,12 @@ and (solve_t_flex_rigid_eq :
                                                             (wl5.umax_heuristic_ok);
                                                           tcenv = (wl5.tcenv);
                                                           wl_implicits =
-                                                            (FStar_TypeChecker_Common.Flat
-                                                               []);
+                                                            (Obj.magic
+                                                               (FStar_Class_Listlike.empty
+                                                                  ()
+                                                                  (Obj.magic
+                                                                    (FStar_Compiler_CList.listlike_clist
+                                                                    ()))));
                                                           repr_subcomp_allowed
                                                             =
                                                             (wl5.repr_subcomp_allowed);
@@ -8991,8 +9028,12 @@ and (solve_t' : tprob -> worklist -> solution) =
                                              (wl4.umax_heuristic_ok);
                                            tcenv = (wl4.tcenv);
                                            wl_implicits =
-                                             (FStar_TypeChecker_Common.Flat
-                                                []);
+                                             (Obj.magic
+                                                (FStar_Class_Listlike.empty
+                                                   ()
+                                                   (Obj.magic
+                                                      (FStar_Compiler_CList.listlike_clist
+                                                         ()))));
                                            repr_subcomp_allowed =
                                              (wl4.repr_subcomp_allowed);
                                            typeclass_variables =
@@ -9000,7 +9041,11 @@ and (solve_t' : tprob -> worklist -> solution) =
                                          }
                                          g_pat_term.FStar_TypeChecker_Common.deferred
                                          g_pat_term.FStar_TypeChecker_Common.deferred_to_tac
-                                         (FStar_TypeChecker_Common.Flat []) in
+                                         (Obj.magic
+                                            (FStar_Class_Listlike.empty ()
+                                               (Obj.magic
+                                                  (FStar_Compiler_CList.listlike_clist
+                                                     ())))) in
                                      let tx =
                                        FStar_Syntax_Unionfind.new_transaction
                                          () in
@@ -9036,18 +9081,25 @@ and (solve_t' : tprob -> worklist -> solution) =
                                                (FStar_Syntax_Unionfind.commit
                                                   tx;
                                                 (let uu___13 =
+                                                   let uu___14 =
+                                                     let uu___15 =
+                                                       let uu___16 =
+                                                         FStar_Class_Monoid.op_Plus_Plus
+                                                           (FStar_Compiler_CList.monoid_clist
+                                                              ()) imps imps' in
+                                                       FStar_Class_Monoid.op_Plus_Plus
+                                                         (FStar_Compiler_CList.monoid_clist
+                                                            ()) uu___16
+                                                         g_pat_as_exp.FStar_TypeChecker_Common.implicits in
+                                                     FStar_Class_Monoid.op_Plus_Plus
+                                                       (FStar_Compiler_CList.monoid_clist
+                                                          ()) uu___15
+                                                       g_pat_term.FStar_TypeChecker_Common.implicits in
                                                    extend_wl wl4 []
                                                      (FStar_Compiler_List.op_At
                                                         defer_to_tac
                                                         defer_to_tac')
-                                                     (FStar_TypeChecker_Common.Conj
-                                                        (imps,
-                                                          (FStar_TypeChecker_Common.Conj
-                                                             (imps',
-                                                               (FStar_TypeChecker_Common.Conj
-                                                                  ((g_pat_as_exp.FStar_TypeChecker_Common.implicits),
-                                                                    (
-                                                                    g_pat_term.FStar_TypeChecker_Common.implicits))))))) in
+                                                     uu___14 in
                                                  FStar_Pervasives_Native.Some
                                                    uu___13))
                                            | Failed uu___11 ->
@@ -10114,8 +10166,12 @@ and (solve_t' : tprob -> worklist -> solution) =
                                                     (wl2.umax_heuristic_ok);
                                                   tcenv = (wl2.tcenv);
                                                   wl_implicits =
-                                                    (FStar_TypeChecker_Common.Flat
-                                                       []);
+                                                    (Obj.magic
+                                                       (FStar_Class_Listlike.empty
+                                                          ()
+                                                          (Obj.magic
+                                                             (FStar_Compiler_CList.listlike_clist
+                                                                ()))));
                                                   repr_subcomp_allowed =
                                                     (wl2.repr_subcomp_allowed);
                                                   typeclass_variables =
@@ -13055,6 +13111,11 @@ and (solve_c :
                               | FStar_TypeChecker_Common.NonTrivial f ->
                                   FStar_Syntax_Util.mk_conj guard1 f in
                             let wl4 =
+                              let uu___7 =
+                                FStar_Class_Monoid.op_Plus_Plus
+                                  (FStar_Compiler_CList.monoid_clist ())
+                                  g_lift.FStar_TypeChecker_Common.implicits
+                                  wl3.wl_implicits in
                               {
                                 attempting = (wl3.attempting);
                                 wl_deferred = (wl3.wl_deferred);
@@ -13064,10 +13125,7 @@ and (solve_c :
                                 smt_ok = (wl3.smt_ok);
                                 umax_heuristic_ok = (wl3.umax_heuristic_ok);
                                 tcenv = (wl3.tcenv);
-                                wl_implicits =
-                                  (FStar_TypeChecker_Common.Conj
-                                     ((g_lift.FStar_TypeChecker_Common.implicits),
-                                       (wl3.wl_implicits)));
+                                wl_implicits = uu___7;
                                 repr_subcomp_allowed =
                                   (wl3.repr_subcomp_allowed);
                                 typeclass_variables =
@@ -13996,13 +14054,16 @@ let (print_pending_implicits :
   fun g ->
     let uu___ =
       let uu___1 =
-        FStar_TypeChecker_Common.as_implicits
+        FStar_Class_Listlike.to_list (FStar_Compiler_CList.listlike_clist ())
           g.FStar_TypeChecker_Common.implicits in
       FStar_Compiler_List.map
         (fun i ->
            FStar_Class_Show.show FStar_Syntax_Print.showable_ctxu
              i.FStar_TypeChecker_Common.imp_uvar) uu___1 in
-    FStar_Compiler_String.concat ", " uu___
+    FStar_Class_Show.show
+      (FStar_Class_Show.show_list
+         (FStar_Class_Show.printableshow
+            FStar_Class_Printable.printable_string)) uu___
 let (ineqs_to_string :
   (FStar_Syntax_Syntax.universe Prims.list * (FStar_Syntax_Syntax.universe *
     FStar_Syntax_Syntax.universe) Prims.list) -> Prims.string)
@@ -14070,7 +14131,7 @@ let (guard_to_string :
           let uu___2 = carry g.FStar_TypeChecker_Common.deferred_to_tac in
           let uu___3 = ineqs_to_string g.FStar_TypeChecker_Common.univ_ineqs in
           FStar_Compiler_Util.format5
-            "\n\t{guard_f=%s;\n\t deferred={\n%s};\n\t deferred_to_tac={\n%s};\n\t univ_ineqs={%s};\n\t implicits={%s}}\n"
+            "\n\t{guard_f=%s;\n\t deferred={\n%s};\n\t deferred_to_tac={\n%s};\n\t univ_ineqs={%s};\n\t implicits=%s}\n"
             form uu___1 uu___2 uu___3 imps
 let (new_t_problem :
   worklist ->
@@ -14709,7 +14770,8 @@ let (try_solve_deferred_constraints :
                  FStar_Profiling.profile
                    (fun uu___2 ->
                       let imps_l =
-                        FStar_TypeChecker_Common.as_implicits
+                        FStar_Class_Listlike.to_list
+                          (FStar_Compiler_CList.listlike_clist ())
                           g.FStar_TypeChecker_Common.implicits in
                       let typeclass_variables =
                         let uu___3 =
@@ -14804,6 +14866,10 @@ let (try_solve_deferred_constraints :
                                "Impossible: Unexpected deferred constraints remain"
                          | FStar_Pervasives_Native.Some
                              (deferred, defer_to_tac, imps) ->
+                             let uu___5 =
+                               FStar_Class_Monoid.op_Plus_Plus
+                                 (FStar_Compiler_CList.monoid_clist ())
+                                 g.FStar_TypeChecker_Common.implicits imps in
                              {
                                FStar_TypeChecker_Common.guard_f =
                                  (g.FStar_TypeChecker_Common.guard_f);
@@ -14814,10 +14880,7 @@ let (try_solve_deferred_constraints :
                                FStar_TypeChecker_Common.deferred = deferred;
                                FStar_TypeChecker_Common.univ_ineqs =
                                  (g.FStar_TypeChecker_Common.univ_ineqs);
-                               FStar_TypeChecker_Common.implicits =
-                                 (FStar_TypeChecker_Common.Conj
-                                    ((g.FStar_TypeChecker_Common.implicits),
-                                      imps))
+                               FStar_TypeChecker_Common.implicits = uu___5
                              }
                          | uu___5 ->
                              FStar_Compiler_Effect.failwith
@@ -14848,10 +14911,13 @@ let (try_solve_deferred_constraints :
                            let uu___8 =
                              let uu___9 =
                                let uu___10 =
-                                 FStar_TypeChecker_Common.as_implicits
+                                 FStar_Class_Listlike.to_list
+                                   (FStar_Compiler_CList.listlike_clist ())
                                    g2.FStar_TypeChecker_Common.implicits in
                                FStar_Compiler_List.length uu___10 in
-                             FStar_Compiler_Util.string_of_int uu___9 in
+                             FStar_Class_Show.show
+                               (FStar_Class_Show.printableshow
+                                  FStar_Class_Printable.printable_nat) uu___9 in
                            FStar_Compiler_Util.print2
                              "ResolveImplicitsHook: Solved deferred to tactic goals, remaining guard is\n%s (and %s implicits)\n"
                              uu___7 uu___8
@@ -15934,14 +16000,16 @@ let (resolve_implicits' :
                                             FStar_Compiler_Util.must uu___6 in
                                           let uu___6 =
                                             let uu___7 =
-                                              FStar_TypeChecker_Common.as_implicits
-                                                imps1 in
+                                              FStar_Class_Listlike.to_list
+                                                (FStar_Compiler_CList.listlike_clist
+                                                   ()) imps1 in
                                             let uu___8 =
                                               FStar_Compiler_List.map
                                                 FStar_Pervasives_Native.fst
                                                 rest in
-                                            FStar_Compiler_List.op_At uu___7
-                                              uu___8 in
+                                            FStar_Class_Monoid.op_Plus_Plus
+                                              (FStar_Class_Monoid.monoid_list
+                                                 ()) uu___7 uu___8 in
                                           until_fixpoint ([], false, true)
                                             uu___6)))
                  | hd::tl ->
@@ -16204,7 +16272,9 @@ let (resolve_implicits' :
                                                          "resolve_implicits: unifying with an unresolved uvar failed?"
                                                    | FStar_Pervasives_Native.Some
                                                        g ->
-                                                       FStar_TypeChecker_Common.as_implicits
+                                                       FStar_Class_Listlike.to_list
+                                                         (FStar_Compiler_CList.listlike_clist
+                                                            ())
                                                          g.FStar_TypeChecker_Common.implicits in
                                                  until_fixpoint
                                                    (out, true,
@@ -16426,7 +16496,9 @@ let (resolve_implicits' :
                                                let res1 =
                                                  FStar_Compiler_Util.map_opt
                                                    res
-                                                   FStar_TypeChecker_Common.as_implicits in
+                                                   (FStar_Class_Listlike.to_list
+                                                      (FStar_Compiler_CList.listlike_clist
+                                                         ())) in
                                                (if
                                                   res1 <>
                                                     (FStar_Pervasives_Native.Some
@@ -16459,8 +16531,9 @@ let (resolve_implicits' :
                                                   let uu___8 =
                                                     let uu___9 =
                                                       let uu___10 =
-                                                        FStar_TypeChecker_Common.as_implicits
-                                                          imps in
+                                                        FStar_Class_Listlike.to_list
+                                                          (FStar_Compiler_CList.listlike_clist
+                                                             ()) imps in
                                                       FStar_Compiler_List.map
                                                         (fun i ->
                                                            (i,
@@ -16488,7 +16561,8 @@ let (resolve_implicits :
        else ());
       (let tagged_implicits1 =
          let uu___1 =
-           FStar_TypeChecker_Common.as_implicits
+           FStar_Class_Listlike.to_list
+             (FStar_Compiler_CList.listlike_clist ())
              g.FStar_TypeChecker_Common.implicits in
          resolve_implicits' env false false uu___1 in
        (let uu___2 = FStar_Compiler_Effect.op_Bang dbg_ResolveImplicitsHook in
@@ -16501,7 +16575,8 @@ let (resolve_implicits :
           let uu___3 =
             FStar_Compiler_List.map FStar_Pervasives_Native.fst
               tagged_implicits1 in
-          FStar_TypeChecker_Common.Flat uu___3 in
+          FStar_Class_Listlike.from_list
+            (FStar_Compiler_CList.listlike_clist ()) uu___3 in
         {
           FStar_TypeChecker_Common.guard_f =
             (g.FStar_TypeChecker_Common.guard_f);
@@ -16521,14 +16596,16 @@ let (resolve_generalization_implicits :
     fun g ->
       let tagged_implicits1 =
         let uu___ =
-          FStar_TypeChecker_Common.as_implicits
+          FStar_Class_Listlike.to_list
+            (FStar_Compiler_CList.listlike_clist ())
             g.FStar_TypeChecker_Common.implicits in
         resolve_implicits' env false true uu___ in
       let uu___ =
         let uu___1 =
           FStar_Compiler_List.map FStar_Pervasives_Native.fst
             tagged_implicits1 in
-        FStar_TypeChecker_Common.Flat uu___1 in
+        FStar_Class_Listlike.from_list
+          (FStar_Compiler_CList.listlike_clist ()) uu___1 in
       {
         FStar_TypeChecker_Common.guard_f =
           (g.FStar_TypeChecker_Common.guard_f);
@@ -16547,7 +16624,7 @@ let (resolve_implicits_tac :
   fun env ->
     fun g ->
       let uu___ =
-        FStar_TypeChecker_Common.as_implicits
+        FStar_Class_Listlike.to_list (FStar_Compiler_CList.listlike_clist ())
           g.FStar_TypeChecker_Common.implicits in
       resolve_implicits' env true false uu___
 let (force_trivial_guard :
@@ -16565,7 +16642,8 @@ let (force_trivial_guard :
       (let g1 = solve_deferred_constraints env g in
        let g2 = resolve_implicits env g1 in
        let uu___1 =
-         FStar_TypeChecker_Common.as_implicits
+         FStar_Class_Listlike.to_list
+           (FStar_Compiler_CList.listlike_clist ())
            g2.FStar_TypeChecker_Common.implicits in
        match uu___1 with
        | [] -> let uu___2 = discharge_guard env g2 in ()

--- a/src/class/FStar.Class.Listlike.fst
+++ b/src/class/FStar.Class.Listlike.fst
@@ -1,0 +1,21 @@
+module FStar.Class.Listlike
+
+open FStar.Compiler.Effect
+
+let is_empty (#e #s : Type) {| listlike e s |} (l : s) : bool =
+  match view l with
+  | VNil -> true
+  | VCons _ _ -> false
+
+let singleton (#e #s : Type) {| listlike e s |} (x : e) : s =
+  cons x empty
+
+let rec to_list (#e #s : Type) {| listlike e s |} (l : s) : list e =
+  match view l with
+  | VNil -> []
+  | VCons x xs -> x :: to_list xs
+
+let rec from_list (#e #s : Type) {| listlike e s |} (l : list e) : s =
+  match l with
+  | [] -> empty
+  | x :: xs -> cons x (from_list xs)

--- a/src/class/FStar.Class.Listlike.fsti
+++ b/src/class/FStar.Class.Listlike.fsti
@@ -1,0 +1,22 @@
+module FStar.Class.Listlike
+
+open FStar.Compiler.Effect
+
+type view_t e s =
+  | VNil  : view_t e s
+  | VCons : e -> s -> view_t e s
+
+[@@Tactics.Typeclasses.fundeps [0]]
+class listlike (e:Type) (s:Type) = {
+  empty         : s;
+  cons          : e -> s -> s;
+  view          : s -> view_t e s;
+}
+
+val is_empty (#e #s : Type) {| listlike e s |} (l : s) : bool
+
+val singleton (#e #s : Type) {| listlike e s |} (x : e) : s
+
+val to_list (#e #s : Type) {| listlike e s |} (l : s) : list e
+
+val from_list (#e #s : Type) {| listlike e s |} (l : list e) : s

--- a/src/data/FStar.Compiler.CList.fst
+++ b/src/data/FStar.Compiler.CList.fst
@@ -1,0 +1,103 @@
+(*
+   Copyright 2008-2017 Microsoft Research
+
+   Authors: Aseem Rastogi, Nikhil Swamy, Jonathan Protzenko
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*)
+
+module FStar.Compiler.CList
+
+open FStar.Tactics.Typeclasses
+open FStar.Class.Ord
+open FStar.Class.Listlike
+
+type clist (a:Type0) : Type0 =
+  | CNil : clist a
+  | CCons : a -> clist a -> clist a
+  | CCat  : clist a -> clist a -> clist a
+
+let ccat (#a:Type0) (xs ys : clist a) : clist a =
+  match xs, ys with
+  | CNil, _ -> ys
+  | _, CNil -> xs
+  | _ -> CCat xs ys
+
+let rec view (#a:Type0) (l:clist a) : Tot (view_t a (clist a)) =
+  match l with
+  | CNil -> VNil
+  | CCons x xs -> VCons x xs
+  | CCat (CCat xs ys) zs -> view (CCat xs (CCat ys zs))
+  | CCat xs ys ->
+    match view xs with
+    | VNil -> view ys
+    | VCons x xs' -> VCons x (CCat xs' ys)
+
+instance listlike_clist (a:Type0) : Tot (listlike a (t a)) = {
+  empty = CNil;
+  cons = CCons;
+  view = view;
+}
+
+instance monoid_clist (a:Type0) : Tot (monoid (t a)) = {
+  mzero = CNil;
+  mplus = ccat;
+}
+
+instance showable_clist (a:Type0) (_ : showable a) : Tot (showable (t a)) = {
+  show = (fun l -> show (to_list l));
+}
+
+instance eq_clist (a:Type0) (d : deq a) : Tot (deq (t a)) = {
+  (=?) = (fun l1 l2 -> to_list l1 =? to_list l2);
+}
+
+instance ord_clist (a:Type0) (d : ord a) : Tot (ord (t a)) = {
+  super = solve;
+  cmp = (fun l1 l2 -> cmp (to_list l1) (to_list l2));
+}
+
+let rec map (#a #b : Type0) (f : a -> b) (l : clist a) : clist b =
+  match l with
+  | CNil -> CNil
+  | CCons x xs -> CCons (f x) (map f xs)
+  | CCat xs ys -> ccat (map f xs) (map f ys)
+
+let rec existsb (#a : Type0) (p : a -> bool) (l : clist a) : bool =
+  match l with
+  | CNil -> false
+  | CCons x xs -> p x || existsb p xs
+  | CCat xs ys -> existsb p xs || existsb p ys
+
+let rec for_all (#a : Type0) (p : a -> bool) (l : clist a) : bool =
+  match l with
+  | CNil -> true
+  | CCons x xs -> p x && for_all p xs
+  | CCat xs ys -> for_all p xs && for_all p ys
+
+let rec partition (#a : Type0) (p : a -> bool) (l : clist a) : clist a * clist a =
+  match l with
+  | CNil -> (CNil, CNil)
+  | CCons x xs ->
+    let (ys, zs) = partition p xs in
+    if p x then (CCons x ys, zs) else (ys, CCons x zs)
+  | CCat xs ys ->
+    let (ys, zs) = partition p xs in
+    let (us, vs) = partition p ys in
+    (ccat ys us, ccat zs vs)
+
+let rec collect (#a #b : Type0) (f : a -> clist b) (l : clist a) : clist b =
+  match l with
+  | CNil -> CNil
+  | CCons x xs -> ccat (f x) (collect f xs)
+  | CCat xs ys -> ccat (collect f xs) (collect f ys)

--- a/src/data/FStar.Compiler.CList.fsti
+++ b/src/data/FStar.Compiler.CList.fsti
@@ -1,0 +1,47 @@
+(*
+   Copyright 2008-2017 Microsoft Research
+
+   Authors: Aseem Rastogi, Nikhil Swamy, Jonathan Protzenko
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*)
+
+(* Catenable lists, based on Jaskelioff and Rivas' "Functional Pearl: A Smart View on Datatypes" *)
+module FStar.Compiler.CList
+
+open FStar.Class.Deq
+open FStar.Class.Ord
+open FStar.Class.Show
+open FStar.Class.Monoid
+open FStar.Class.Listlike
+
+new
+val clist (a:Type0) : Type0
+
+type t = clist
+
+instance val listlike_clist (a:Type0) : Tot (listlike a (t a))
+instance val monoid_clist (a:Type0) : Tot (monoid (t a))
+instance val showable_clist (a:Type0) (_ : showable a) : Tot (showable (t a))
+instance val eq_clist (a:Type0) (_ : deq a) : Tot (deq (t a))
+instance val ord_clist (a:Type0) (_ : ord a) : Tot (ord (t a))
+
+val map (#a #b : Type0) (f : a -> b) (l : clist a) : clist b
+
+val existsb (#a : Type0) (p : a -> bool) (l : clist a) : bool
+
+val for_all (#a : Type0) (p : a -> bool) (l : clist a) : bool
+
+val partition (#a : Type0) (p : a -> bool) (l : clist a) : clist a * clist a
+
+val collect : ('a -> clist 'b) -> clist 'a -> clist 'b

--- a/src/tactics/FStar.Tactics.Hooks.fst
+++ b/src/tactics/FStar.Tactics.Hooks.fst
@@ -717,11 +717,7 @@ let synthesize (env:Env.env) (typ:typ) (tau:term) : term =
             begin
             if !dbg_Tac then
               BU.print1 "Synthesis left a goal: %s\n" (show vc);
-            let guard = { guard_f = NonTrivial vc
-                        ; deferred_to_tac = []
-                        ; deferred = []
-                        ; univ_ineqs = [], []
-                        ; implicits = Listlike.empty } in
+            let guard = guard_of_guard_formula (NonTrivial vc) in
             TcRel.force_trivial_guard (goal_env g) guard
             end
         | None ->
@@ -753,11 +749,7 @@ let solve_implicits (env:Env.env) (tau:term) (imps:Env.implicits) : unit =
               BU.print1 "Synthesis left a goal: %s\n" (show vc);
             if not env.admit
             then (
-              let guard = { guard_f = NonTrivial vc
-                          ; deferred_to_tac = []
-                          ; deferred = []
-                          ; univ_ineqs = [], []
-                          ; implicits = Listlike.empty } in
+              let guard = guard_of_guard_formula (NonTrivial vc) in
               Profiling.profile (fun () ->
                 TcRel.force_trivial_guard (goal_env g) guard)
               None
@@ -935,12 +927,8 @@ let splice
             begin
             if !dbg_Tac then
               BU.print1 "Splice left a goal: %s\n" (show vc);
-            let guard = { guard_f = NonTrivial vc
-                        ; deferred_to_tac = []
-                        ; deferred = []
-                        ; univ_ineqs = [], []
-                        ; implicits = Listlike.empty } in
-              TcRel.force_trivial_guard (goal_env g) guard
+            let guard = guard_of_guard_formula (NonTrivial vc) in
+            TcRel.force_trivial_guard (goal_env g) guard
             end
         | None ->
             Err.raise_error rng Err.Fatal_OpenGoalsInSynthesis "splice left open goals") gs);
@@ -1027,11 +1015,7 @@ let postprocess (env:Env.env) (tau:term) (typ:term) (tm:term) : term =
             begin
             if !dbg_Tac then
               BU.print1 "Postprocessing left a goal: %s\n" (show vc);
-            let guard = { guard_f = NonTrivial vc
-                        ; deferred_to_tac = []
-                        ; deferred = []
-                        ; univ_ineqs = [], []
-                        ; implicits = Listlike.empty } in
+            let guard = guard_of_guard_formula (NonTrivial vc) in
             TcRel.force_trivial_guard (goal_env g) guard
             end
         | None ->

--- a/src/tactics/FStar.Tactics.Hooks.fst
+++ b/src/tactics/FStar.Tactics.Hooks.fst
@@ -29,6 +29,7 @@ open FStar.TypeChecker.Common
 open FStar.Tactics.Types
 open FStar.Tactics.Interpreter
 open FStar.Class.Show
+module Listlike = FStar.Class.Listlike
 
 module BU      = FStar.Compiler.Util
 module Range   = FStar.Compiler.Range
@@ -720,7 +721,7 @@ let synthesize (env:Env.env) (typ:typ) (tau:term) : term =
                         ; deferred_to_tac = []
                         ; deferred = []
                         ; univ_ineqs = [], []
-                        ; implicits = Flat [] } in
+                        ; implicits = Listlike.empty } in
             TcRel.force_trivial_guard (goal_env g) guard
             end
         | None ->
@@ -756,7 +757,7 @@ let solve_implicits (env:Env.env) (tau:term) (imps:Env.implicits) : unit =
                           ; deferred_to_tac = []
                           ; deferred = []
                           ; univ_ineqs = [], []
-                          ; implicits = Flat [] } in
+                          ; implicits = Listlike.empty } in
               Profiling.profile (fun () ->
                 TcRel.force_trivial_guard (goal_env g) guard)
               None
@@ -938,7 +939,7 @@ let splice
                         ; deferred_to_tac = []
                         ; deferred = []
                         ; univ_ineqs = [], []
-                        ; implicits = Flat [] } in
+                        ; implicits = Listlike.empty } in
               TcRel.force_trivial_guard (goal_env g) guard
             end
         | None ->
@@ -1030,7 +1031,7 @@ let postprocess (env:Env.env) (tau:term) (typ:term) (tm:term) : term =
                         ; deferred_to_tac = []
                         ; deferred = []
                         ; univ_ineqs = [], []
-                        ; implicits = Flat [] } in
+                        ; implicits = Listlike.empty } in
             TcRel.force_trivial_guard (goal_env g) guard
             end
         | None ->

--- a/src/tactics/FStar.Tactics.Interpreter.fst
+++ b/src/tactics/FStar.Tactics.Interpreter.fst
@@ -39,6 +39,7 @@ open FStar.Tactics.Common
 open FStar.Class.Show
 open FStar.Class.PP
 open FStar.Class.Monad
+module Listlike = FStar.Class.Listlike
 
 module BU      = FStar.Compiler.Util
 module Cfg     = FStar.TypeChecker.Cfg
@@ -341,7 +342,7 @@ let run_unembedded_tactic_on_ps
                                                                       (fun imp -> show imp.imp_uvar)
                                                                       ps.all_implicits);
 
-          let g = {Env.trivial_guard with TcComm.implicits=Flat ps.all_implicits} in
+          let g = {Env.trivial_guard with TcComm.implicits=Listlike.from_list ps.all_implicits} in
           let g = TcRel.solve_deferred_constraints env g in
           if !dbg_Tac then
               BU.print2 "Checked %s implicits (1): %s\n"

--- a/src/tactics/FStar.Tactics.Monad.fst
+++ b/src/tactics/FStar.Tactics.Monad.fst
@@ -32,6 +32,9 @@ open FStar.Errors.Msg
 
 open FStar.Class.Show
 open FStar.Class.Setlike
+open FStar.Class.Listlike
+module Setlike = FStar.Class.Setlike
+module Listlike = FStar.Class.Listlike
 
 module O       = FStar.Options
 module BU      = FStar.Compiler.Util
@@ -60,7 +63,7 @@ let is_goal_safe_as_well_typed (g:goal) =
       List.for_all 
           (fun uv -> 
             match UF.find uv.ctx_uvar_head with
-            | Some t -> is_empty (FStar.Syntax.Free.uvars t)
+            | Some t -> Setlike.is_empty (FStar.Syntax.Free.uvars t)
             | _ -> false)
           (U.ctx_uvar_typedness_deps uv)
   in
@@ -333,7 +336,7 @@ let new_uvar (reason:string) (env:env) (typ:typ)
     let u, ctx_uvar, g_u =
         Env.new_tac_implicit_var reason rng env typ should_check uvar_typedness_deps None false
     in
-    bind (add_implicits (as_implicits g_u.implicits)) (fun _ ->
+    bind (add_implicits (Listlike.to_list g_u.implicits)) (fun _ ->
     ret (u, fst ctx_uvar))
 
 let mk_irrelevant_goal (reason:string) (env:env) (phi:typ) (sc_opt:option should_check_uvar) (rng:Range.range) opts label : tac goal =
@@ -397,7 +400,7 @@ let if_verbose f = if_verbose_tac (fun _ -> f(); ret ())
 let compress_implicits : tac unit =
     bind get (fun ps ->
     let imps = ps.all_implicits in
-    let g = { Env.trivial_guard with implicits = Flat imps } in
+    let g = { Env.trivial_guard with implicits = Listlike.from_list imps } in
     let imps = Rel.resolve_implicits_tac ps.main_context g in
     let ps' = { ps with all_implicits = List.map fst imps } in
     set ps')

--- a/src/tactics/FStar.Tactics.V1.Basic.fst
+++ b/src/tactics/FStar.Tactics.V1.Basic.fst
@@ -34,6 +34,7 @@ open FStar.Syntax.Syntax
 open FStar.VConfig
 open FStar.Class.Show
 open FStar.Class.Tagged
+module Listlike = FStar.Class.Listlike
 
 friend FStar.Pervasives (* to use Delta below *)
 
@@ -253,7 +254,7 @@ let with_policy pol (t : tac 'a) : tac 'a =
 let proc_guard' (simplify:bool) (reason:string) (e : env) (g : guard_t) (sc_opt:option should_check_uvar) (rng:Range.range) : tac unit =
     mlog (fun () ->
         BU.print2 "Processing guard (%s:%s)\n" reason (Rel.guard_to_string e g)) (fun () ->
-    let imps = as_implicits g.implicits in 
+    let imps = Listlike.to_list g.implicits in 
     let _ =
       match sc_opt with
       | Some (Allow_untyped r) ->
@@ -414,7 +415,7 @@ let __do_unify_wflags
             ret None
           | Some g ->
             tc_unifier_solved_implicits env must_tot allow_guards all_uvars;!
-            add_implicits (as_implicits g.implicits);!
+            add_implicits (Listlike.to_list g.implicits);!
             ret (Some g)
 
         with | Errors.Error (_, msg, r, _) -> begin

--- a/src/tactics/FStar.Tactics.V2.Basic.fst
+++ b/src/tactics/FStar.Tactics.V2.Basic.fst
@@ -2943,11 +2943,7 @@ let run_unembedded_tactic_on_ps_and_solve_remaining
   remaining_goals |> List.iter (fun g ->
       match getprop (goal_env g) (goal_type g) with
       | Some vc ->
-          let guard = { guard_f = NonTrivial vc
-                      ; deferred_to_tac = []
-                      ; deferred = []
-                      ; univ_ineqs = [], []
-                      ; implicits = Listlike.empty } in
+          let guard = guard_of_guard_formula (NonTrivial vc) in
           Rel.force_trivial_guard (goal_env g) guard
       | None ->
           Err.raise_error g_range Err.Fatal_OpenGoalsInSynthesis "tactic left a computationally-relevant goal unsolved");
@@ -2980,11 +2976,7 @@ let run_tactic_on_ps_and_solve_remaining
   remaining_goals |> List.iter (fun g ->
       match getprop (goal_env g) (goal_type g) with
       | Some vc ->
-          let guard = { guard_f = NonTrivial vc
-                      ; deferred_to_tac = []
-                      ; deferred = []
-                      ; univ_ineqs = [], []
-                      ; implicits = Listlike.empty } in
+          let guard = guard_of_guard_formula (NonTrivial vc) in
           Rel.force_trivial_guard (goal_env g) guard
       | None ->
           Err.raise_error g_range Err.Fatal_OpenGoalsInSynthesis "tactic left a computationally-relevant goal unsolved");

--- a/src/typechecker/FStar.TypeChecker.Common.fst
+++ b/src/typechecker/FStar.TypeChecker.Common.fst
@@ -207,17 +207,9 @@ let check_uvar_ctx_invariant (reason:string) (r:range) (should_check:bool) (g:ga
         end
      | _ -> fail()
 
-instance show_implicit : showable implicit = {
+instance showable_implicit : showable implicit = {
   show = (fun i -> show i.imp_uvar.ctx_uvar_head);
 }
-
-let as_implicits imps =
-  let rec aux imps out =
-    match imps with
-    | Flat i -> (match out with | [] -> i | _ -> i@out)
-    | Conj imps1 imps2 -> aux imps1 (aux imps2 out)
-  in
-  aux imps []
 
 let implicits_to_string imps =
     let imp_to_string i = show i.imp_uvar.ctx_uvar_head in
@@ -228,7 +220,7 @@ let trivial_guard = {
   deferred_to_tac=[];
   deferred=[];
   univ_ineqs=([], []);
-  implicits=Flat []
+  implicits=Class.Listlike.empty;
 }
 
 let conj_guard_f g1 g2 = match g1, g2 with
@@ -242,7 +234,7 @@ let binop_guard f g1 g2 = {
   deferred=g1.deferred@g2.deferred;
   univ_ineqs=(fst g1.univ_ineqs@fst g2.univ_ineqs,
               snd g1.univ_ineqs@snd g2.univ_ineqs);
-  implicits=Conj g1.implicits g2.implicits
+  implicits=g1.implicits ++ g2.implicits;
 }
 let conj_guard g1 g2 = binop_guard conj_guard_f g1 g2
 

--- a/src/typechecker/FStar.TypeChecker.Common.fsti
+++ b/src/typechecker/FStar.TypeChecker.Common.fsti
@@ -27,6 +27,8 @@ open FStar.Ident
 open FStar.Class.Show
 open FStar.Class.Monoid
 
+module CList = FStar.Compiler.CList
+
 (* Bring instances in scope *)
 open FStar.Syntax.Print {}
 
@@ -152,14 +154,12 @@ type implicit = {
     imp_range  : Range.range;             // Position where it was introduced
 }
 
-instance val show_implicit : showable implicit
+instance val showable_implicit : showable implicit
 
+(* Bad naming here *)
 type implicits = list implicit
-type implicits_t =
-| Flat of implicits
-| Conj : implicits_t -> implicits_t -> implicits_t
-val as_implicits : implicits_t -> implicits
 val implicits_to_string : implicits -> string
+type implicits_t = CList.t implicit
 
 type guard_t = {
   guard_f:    guard_formula;

--- a/src/typechecker/FStar.TypeChecker.DeferredImplicits.fst
+++ b/src/typechecker/FStar.TypeChecker.DeferredImplicits.fst
@@ -274,7 +274,7 @@ let solve_deferred_to_tactic_goals env g =
                    more, imp::imps
                  | Some se ->
                    (imp, se)::more, imps)
-            (as_implicits g.implicits)
+            (Class.Listlike.to_list g.implicits)
             ([], [])
     in
     (** Each implicit is associated with a sigelt.
@@ -299,4 +299,4 @@ let solve_deferred_to_tactic_goals env g =
     let buckets = bucketize (eqs@more) in
     // Dispatch each bucket of implicits to their respective tactic
     List.iter (fun (imps, sigel) -> solve_goals_with_tac env g imps sigel) buckets;
-    { g with deferred_to_tac=[]; implicits = Flat imps}
+    { g with deferred_to_tac=[]; implicits = Class.Listlike.from_list imps}

--- a/src/typechecker/FStar.TypeChecker.Env.fst
+++ b/src/typechecker/FStar.TypeChecker.Env.fst
@@ -32,6 +32,7 @@ open FStar.Class.Setlike
 
 open FStar.Class.Show
 open FStar.Class.PP
+module Listlike = FStar.Class.Listlike
 
 module S = FStar.Syntax.Syntax
 module SS = FStar.Syntax.Subst
@@ -1888,14 +1889,14 @@ let guard_of_guard_formula g = {
   deferred=[];
   deferred_to_tac=[];
   univ_ineqs=([], []);
-  implicits=Flat []
+  implicits=Class.Listlike.empty;
 }
 
 let guard_form g = g.guard_f
 
 let is_trivial g = match g with
     | {guard_f=Trivial; deferred=[]; univ_ineqs=([], []); implicits=i} ->
-      as_implicits i |> BU.for_all (fun imp ->
+      i |> CList.for_all (fun imp ->
            (Allow_unresolved? (U.ctx_uvar_should_check imp.imp_uvar))
            || (match Unionfind.find imp.imp_uvar.ctx_uvar_head with
                | Some _ -> true
@@ -2025,7 +2026,7 @@ let new_tac_implicit_var
             } in
   if !dbg_ImplicitTrace then
     BU.print1 "Just created uvar for implicit {%s}\n" (show ctx_uvar.ctx_uvar_head);
-  let g = {trivial_guard with implicits=Flat [imp]} in
+  let g = {trivial_guard with implicits = Listlike.cons imp Listlike.empty} in
   t, (ctx_uvar, r), g
 
 let new_implicit_var_aux reason r env k should_check meta unrefine =


### PR DESCRIPTION
As a follow up to https://github.com/FStarLang/FStar/pull/3521, this makes the data strucuture reusable, and also introduces a class for other list-like things. Maybe in the future all list operations will go via the class, including desugaring `[]` to `Listlike.empty`.