### PR TITLE
Extraction: not extracting tactics unless backend is Plugin

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_Syntax_Util.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Util.ml
@@ -1945,19 +1945,6 @@ let (is_fstar_tactics_by_tactic : FStar_Syntax_Syntax.term -> Prims.bool) =
     | FStar_Syntax_Syntax.Tm_fvar fv ->
         FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.by_tactic_lid
     | uu___1 -> false
-let (is_builtin_tactic : FStar_Ident.lident -> Prims.bool) =
-  fun md ->
-    let path = FStar_Ident.path_of_lid md in
-    if (FStar_Compiler_List.length path) > (Prims.of_int (2))
-    then
-      let uu___ =
-        let uu___1 = FStar_Compiler_List.splitAt (Prims.of_int (2)) path in
-        FStar_Pervasives_Native.fst uu___1 in
-      match uu___ with
-      | "FStar"::"Tactics"::[] -> true
-      | "FStar"::"Reflection"::[] -> true
-      | uu___1 -> false
-    else false
 let (ktype : FStar_Syntax_Syntax.term) =
   FStar_Syntax_Syntax.mk
     (FStar_Syntax_Syntax.Tm_type FStar_Syntax_Syntax.U_unknown)

--- a/src/syntax/FStar.Syntax.Util.fst
+++ b/src/syntax/FStar.Syntax.Util.fst
@@ -951,15 +951,6 @@ let is_fstar_tactics_by_tactic t =
     | Tm_fvar fv -> fv_eq_lid fv PC.by_tactic_lid
     | _ -> false
 
-let is_builtin_tactic md =
-  let path = Ident.path_of_lid md in
-  if List.length(path) > 2 then
-    match fst (List.splitAt 2 path) with
-    | ["FStar"; "Tactics"]
-    | ["FStar"; "Reflection"] -> true
-    | _ -> false
-  else false
-
 (********************************************************************************)
 (*********************** Constructors of common terms  **************************)
 (********************************************************************************)


### PR DESCRIPTION
This is an old wart, even with `--codegen OCaml` we are still extracting all tactics in the file, and only skipping their registration into the compiler as plugins. This is silly, since this function will never be called. This also means we cannot compile the module with a small fstar-lib meant for applications, which we want to do.

This patch skips the extraction for anything in Tac, except when `--codegen Plugin` was given.

Running a build here: https://github.com/mtzguido/FStar/actions/runs/11245452858