### PR TITLE
docker dev container: explicit platform, install pkg-config

### DIFF
--- a/.devcontainer/minimal.Dockerfile
+++ b/.devcontainer/minimal.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:23.10
+FROM --platform=linux/amd64  ubuntu:23.10
 
 SHELL ["/bin/bash", "-c"]
 
@@ -17,6 +17,7 @@ RUN apt-get update \
       python-is-python3 \
       libgmp-dev \
       opam \
+      pkg-config \
     && apt-get clean -y
 # FIXME: libgmp-dev should be installed automatically by opam,
 # but it is not working, so just adding it above.


### PR DESCRIPTION
Hi,
The docker dev container wasn't working for me on an M1 Mac. I fixed it by specifying AMD64 emulation. I believe this change should not affect other x86 users.


* Set platform to amd64 so it works on M1 Macs. Otherwise the Z3 binary had the wrong architecture.
* Install pkg-config with apt. Otherwise the opam was failing for me.