### PR TITLE
Make the default effect in --MLish configurable

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_Options.ml
+++ b/ocaml/fstar-lib/generated/FStar_Options.ml
@@ -332,6 +332,7 @@ let (defaults : (Prims.string * option_val) Prims.list) =
   ("max_fuel", (Int (Prims.of_int (8))));
   ("max_ifuel", (Int (Prims.of_int (2))));
   ("MLish", (Bool false));
+  ("MLish_effect", (String "FStar.Compiler.Effect"));
   ("no_default_includes", (Bool false));
   ("no_extract", (List []));
   ("no_location_info", (Bool false));
@@ -691,6 +692,8 @@ let (get_max_ifuel : unit -> Prims.int) =
   fun uu___ -> lookup_opt "max_ifuel" as_int
 let (get_MLish : unit -> Prims.bool) =
   fun uu___ -> lookup_opt "MLish" as_bool
+let (get_MLish_effect : unit -> Prims.string) =
+  fun uu___ -> lookup_opt "MLish_effect" as_string
 let (get_no_default_includes : unit -> Prims.bool) =
   fun uu___ -> lookup_opt "no_default_includes" as_bool
 let (get_no_extract : unit -> Prims.string Prims.list) =
@@ -2078,12 +2081,11 @@ let rec (specs_with_types :
                                                                     let uu___116
                                                                     =
                                                                     text
-                                                                    "Ignore the default module search paths" in
+                                                                    "Set the default effect *module* for --MLish (default: FStar.Compiler.Effect)" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "no_default_includes",
-                                                                    (Const
-                                                                    (Bool
-                                                                    true)),
+                                                                    "MLish_effect",
+                                                                    (SimpleStr
+                                                                    "module_name"),
                                                                     uu___116) in
                                                                     let uu___116
                                                                     =
@@ -2092,12 +2094,12 @@ let rec (specs_with_types :
                                                                     let uu___118
                                                                     =
                                                                     text
-                                                                    "Deprecated: use --extract instead; Do not extract code from this module" in
+                                                                    "Ignore the default module search paths" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "no_extract",
-                                                                    (Accumulated
-                                                                    (PathStr
-                                                                    "module name")),
+                                                                    "no_default_includes",
+                                                                    (Const
+                                                                    (Bool
+                                                                    true)),
                                                                     uu___118) in
                                                                     let uu___118
                                                                     =
@@ -2106,12 +2108,12 @@ let rec (specs_with_types :
                                                                     let uu___120
                                                                     =
                                                                     text
-                                                                    "Suppress location information in the generated OCaml output (only relevant with --codegen OCaml)" in
+                                                                    "Deprecated: use --extract instead; Do not extract code from this module" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "no_location_info",
-                                                                    (Const
-                                                                    (Bool
-                                                                    true)),
+                                                                    "no_extract",
+                                                                    (Accumulated
+                                                                    (PathStr
+                                                                    "module name")),
                                                                     uu___120) in
                                                                     let uu___120
                                                                     =
@@ -2120,9 +2122,9 @@ let rec (specs_with_types :
                                                                     let uu___122
                                                                     =
                                                                     text
-                                                                    "Do not send any queries to the SMT solver, and fail on them instead" in
+                                                                    "Suppress location information in the generated OCaml output (only relevant with --codegen OCaml)" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "no_smt",
+                                                                    "no_location_info",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2134,9 +2136,9 @@ let rec (specs_with_types :
                                                                     let uu___124
                                                                     =
                                                                     text
-                                                                    "Extract top-level pure terms after normalizing them. This can lead to very large code, but can result in more partial evaluation and compile-time specialization." in
+                                                                    "Do not send any queries to the SMT solver, and fail on them instead" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "normalize_pure_terms_for_extraction",
+                                                                    "no_smt",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2148,17 +2150,31 @@ let rec (specs_with_types :
                                                                     let uu___126
                                                                     =
                                                                     text
-                                                                    "Place KaRaMeL extraction output in file <filename>. The path can be relative or absolute and does not dependon the --odir option." in
+                                                                    "Extract top-level pure terms after normalizing them. This can lead to very large code, but can result in more partial evaluation and compile-time specialization." in
                                                                     (FStar_Getopt.noshort,
-                                                                    "krmloutput",
-                                                                    (PathStr
-                                                                    "filename"),
+                                                                    "normalize_pure_terms_for_extraction",
+                                                                    (Const
+                                                                    (Bool
+                                                                    true)),
                                                                     uu___126) in
                                                                     let uu___126
                                                                     =
                                                                     let uu___127
                                                                     =
                                                                     let uu___128
+                                                                    =
+                                                                    text
+                                                                    "Place KaRaMeL extraction output in file <filename>. The path can be relative or absolute and does not dependon the --odir option." in
+                                                                    (FStar_Getopt.noshort,
+                                                                    "krmloutput",
+                                                                    (PathStr
+                                                                    "filename"),
+                                                                    uu___128) in
+                                                                    let uu___128
+                                                                    =
+                                                                    let uu___129
+                                                                    =
+                                                                    let uu___130
                                                                     =
                                                                     text
                                                                     "Place output in directory  dir" in
@@ -2168,19 +2184,6 @@ let rec (specs_with_types :
                                                                     (pp_validate_dir,
                                                                     (PathStr
                                                                     "dir"))),
-                                                                    uu___128) in
-                                                                    let uu___128
-                                                                    =
-                                                                    let uu___129
-                                                                    =
-                                                                    let uu___130
-                                                                    =
-                                                                    text
-                                                                    "Output the result of --dep into this file instead of to standard output." in
-                                                                    (FStar_Getopt.noshort,
-                                                                    "output_deps_to",
-                                                                    (PathStr
-                                                                    "file"),
                                                                     uu___130) in
                                                                     let uu___130
                                                                     =
@@ -2189,9 +2192,9 @@ let rec (specs_with_types :
                                                                     let uu___132
                                                                     =
                                                                     text
-                                                                    "Use a custom Prims.fst file. Do not use if you do not know exactly what you're doing." in
+                                                                    "Output the result of --dep into this file instead of to standard output." in
                                                                     (FStar_Getopt.noshort,
-                                                                    "prims",
+                                                                    "output_deps_to",
                                                                     (PathStr
                                                                     "file"),
                                                                     uu___132) in
@@ -2202,12 +2205,11 @@ let rec (specs_with_types :
                                                                     let uu___134
                                                                     =
                                                                     text
-                                                                    "Print the types of bound variables" in
+                                                                    "Use a custom Prims.fst file. Do not use if you do not know exactly what you're doing." in
                                                                     (FStar_Getopt.noshort,
-                                                                    "print_bound_var_types",
-                                                                    (Const
-                                                                    (Bool
-                                                                    true)),
+                                                                    "prims",
+                                                                    (PathStr
+                                                                    "file"),
                                                                     uu___134) in
                                                                     let uu___134
                                                                     =
@@ -2216,9 +2218,9 @@ let rec (specs_with_types :
                                                                     let uu___136
                                                                     =
                                                                     text
-                                                                    "Print inferred predicate transformers for all computation types" in
+                                                                    "Print the types of bound variables" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "print_effect_args",
+                                                                    "print_bound_var_types",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2230,9 +2232,9 @@ let rec (specs_with_types :
                                                                     let uu___138
                                                                     =
                                                                     text
-                                                                    "Print the errors generated by declarations marked with expect_failure, useful for debugging error locations" in
+                                                                    "Print inferred predicate transformers for all computation types" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "print_expected_failures",
+                                                                    "print_effect_args",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2244,9 +2246,9 @@ let rec (specs_with_types :
                                                                     let uu___140
                                                                     =
                                                                     text
-                                                                    "Print full names of variables" in
+                                                                    "Print the errors generated by declarations marked with expect_failure, useful for debugging error locations" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "print_full_names",
+                                                                    "print_expected_failures",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2258,9 +2260,9 @@ let rec (specs_with_types :
                                                                     let uu___142
                                                                     =
                                                                     text
-                                                                    "Print implicit arguments" in
+                                                                    "Print full names of variables" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "print_implicits",
+                                                                    "print_full_names",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2272,9 +2274,9 @@ let rec (specs_with_types :
                                                                     let uu___144
                                                                     =
                                                                     text
-                                                                    "Print universes" in
+                                                                    "Print implicit arguments" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "print_universes",
+                                                                    "print_implicits",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2286,9 +2288,9 @@ let rec (specs_with_types :
                                                                     let uu___146
                                                                     =
                                                                     text
-                                                                    "Print Z3 statistics for each SMT query (details such as relevant modules, facts, etc. for each proof)" in
+                                                                    "Print universes" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "print_z3_statistics",
+                                                                    "print_universes",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2300,9 +2302,9 @@ let rec (specs_with_types :
                                                                     let uu___148
                                                                     =
                                                                     text
-                                                                    "Print full names (deprecated; use --print_full_names instead)" in
+                                                                    "Print Z3 statistics for each SMT query (details such as relevant modules, facts, etc. for each proof)" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "prn",
+                                                                    "print_z3_statistics",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2314,9 +2316,9 @@ let rec (specs_with_types :
                                                                     let uu___150
                                                                     =
                                                                     text
-                                                                    "Proof recovery mode: before failing an SMT query, retry 3 times, increasing rlimits. If the query goes through after retrying, verification will succeed, but a warning will be emitted. This feature is useful to restore a project after some change to its libraries or F* upgrade. Importantly, then, this option cannot be used in a pragma (#set-options, etc)." in
+                                                                    "Print full names (deprecated; use --print_full_names instead)" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "proof_recovery",
+                                                                    "prn",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2327,76 +2329,90 @@ let rec (specs_with_types :
                                                                     =
                                                                     let uu___152
                                                                     =
+                                                                    text
+                                                                    "Proof recovery mode: before failing an SMT query, retry 3 times, increasing rlimits. If the query goes through after retrying, verification will succeed, but a warning will be emitted. This feature is useful to restore a project after some change to its libraries or F* upgrade. Importantly, then, this option cannot be used in a pragma (#set-options, etc)." in
+                                                                    (FStar_Getopt.noshort,
+                                                                    "proof_recovery",
+                                                                    (Const
+                                                                    (Bool
+                                                                    true)),
+                                                                    uu___152) in
+                                                                    let uu___152
+                                                                    =
                                                                     let uu___153
                                                                     =
-                                                                    text
-                                                                    "Repeats SMT queries to check for robustness" in
                                                                     let uu___154
                                                                     =
                                                                     let uu___155
                                                                     =
+                                                                    text
+                                                                    "Repeats SMT queries to check for robustness" in
                                                                     let uu___156
                                                                     =
                                                                     let uu___157
                                                                     =
-                                                                    text
-                                                                    "--quake N/M repeats each query checks that it succeeds at least N out of M times, aborting early if possible" in
                                                                     let uu___158
                                                                     =
                                                                     let uu___159
                                                                     =
                                                                     text
-                                                                    "--quake N/M/k works as above, except it will unconditionally run M times" in
+                                                                    "--quake N/M repeats each query checks that it succeeds at least N out of M times, aborting early if possible" in
                                                                     let uu___160
                                                                     =
                                                                     let uu___161
                                                                     =
                                                                     text
-                                                                    "--quake N is an alias for --quake N/N" in
+                                                                    "--quake N/M/k works as above, except it will unconditionally run M times" in
                                                                     let uu___162
                                                                     =
                                                                     let uu___163
                                                                     =
                                                                     text
+                                                                    "--quake N is an alias for --quake N/N" in
+                                                                    let uu___164
+                                                                    =
+                                                                    let uu___165
+                                                                    =
+                                                                    text
                                                                     "--quake N/k is an alias for --quake N/N/k" in
-                                                                    [uu___163] in
+                                                                    [uu___165] in
+                                                                    uu___163
+                                                                    ::
+                                                                    uu___164 in
                                                                     uu___161
                                                                     ::
                                                                     uu___162 in
                                                                     uu___159
                                                                     ::
                                                                     uu___160 in
-                                                                    uu___157
-                                                                    ::
-                                                                    uu___158 in
                                                                     FStar_Errors_Msg.bulleted
-                                                                    uu___156 in
-                                                                    let uu___156
+                                                                    uu___158 in
+                                                                    let uu___158
                                                                     =
                                                                     text
                                                                     "Using --quake disables --retry. When quake testing, queries are not splitted for error reporting unless '--split_queries always' is given. Queries from the smt_sync tactic are not quake-tested." in
                                                                     FStar_Pprint.op_Hat_Hat
+                                                                    uu___157
+                                                                    uu___158 in
+                                                                    FStar_Pprint.op_Hat_Hat
                                                                     uu___155
                                                                     uu___156 in
-                                                                    FStar_Pprint.op_Hat_Hat
-                                                                    uu___153
-                                                                    uu___154 in
                                                                     (FStar_Getopt.noshort,
                                                                     "quake",
                                                                     (PostProcessed
                                                                     ((fun
-                                                                    uu___153
+                                                                    uu___155
                                                                     ->
-                                                                    match uu___153
+                                                                    match uu___155
                                                                     with
                                                                     | 
                                                                     String s
                                                                     ->
-                                                                    let uu___154
+                                                                    let uu___156
                                                                     =
                                                                     interp_quake_arg
                                                                     s in
-                                                                    (match uu___154
+                                                                    (match uu___156
                                                                     with
                                                                     | 
                                                                     (min,
@@ -2417,26 +2433,12 @@ let rec (specs_with_types :
                                                                     false);
                                                                     String s))
                                                                     | 
-                                                                    uu___154
+                                                                    uu___156
                                                                     ->
                                                                     FStar_Compiler_Effect.failwith
                                                                     "impos"),
                                                                     (SimpleStr
                                                                     "positive integer or pair of positive integers"))),
-                                                                    uu___152) in
-                                                                    let uu___152
-                                                                    =
-                                                                    let uu___153
-                                                                    =
-                                                                    let uu___154
-                                                                    =
-                                                                    text
-                                                                    "Keep a running cache of SMT queries to make verification faster. Only available in the interactive mode. NOTE: This feature is experimental and potentially unsound! Hence why\n          it is not allowed in batch mode (where it is also less useful). If you\n          find a query that is mistakenly accepted with the cache, please\n          report a bug to the F* issue tracker on GitHub." in
-                                                                    (FStar_Getopt.noshort,
-                                                                    "query_cache",
-                                                                    (Const
-                                                                    (Bool
-                                                                    true)),
                                                                     uu___154) in
                                                                     let uu___154
                                                                     =
@@ -2445,9 +2447,9 @@ let rec (specs_with_types :
                                                                     let uu___156
                                                                     =
                                                                     text
-                                                                    "Print SMT query statistics" in
+                                                                    "Keep a running cache of SMT queries to make verification faster. Only available in the interactive mode. NOTE: This feature is experimental and potentially unsound! Hence why\n          it is not allowed in batch mode (where it is also less useful). If you\n          find a query that is mistakenly accepted with the cache, please\n          report a bug to the F* issue tracker on GitHub." in
                                                                     (FStar_Getopt.noshort,
-                                                                    "query_stats",
+                                                                    "query_cache",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2459,11 +2461,12 @@ let rec (specs_with_types :
                                                                     let uu___158
                                                                     =
                                                                     text
-                                                                    "Read a checked file and dump it to standard output." in
+                                                                    "Print SMT query statistics" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "read_checked_file",
-                                                                    (PathStr
-                                                                    "path"),
+                                                                    "query_stats",
+                                                                    (Const
+                                                                    (Bool
+                                                                    true)),
                                                                     uu___158) in
                                                                     let uu___158
                                                                     =
@@ -2472,9 +2475,9 @@ let rec (specs_with_types :
                                                                     let uu___160
                                                                     =
                                                                     text
-                                                                    "Read a Karamel binary file and dump it to standard output." in
+                                                                    "Read a checked file and dump it to standard output." in
                                                                     (FStar_Getopt.noshort,
-                                                                    "read_krml_file",
+                                                                    "read_checked_file",
                                                                     (PathStr
                                                                     "path"),
                                                                     uu___160) in
@@ -2485,12 +2488,11 @@ let rec (specs_with_types :
                                                                     let uu___162
                                                                     =
                                                                     text
-                                                                    "Record a database of hints for efficient proof replay" in
+                                                                    "Read a Karamel binary file and dump it to standard output." in
                                                                     (FStar_Getopt.noshort,
-                                                                    "record_hints",
-                                                                    (Const
-                                                                    (Bool
-                                                                    true)),
+                                                                    "read_krml_file",
+                                                                    (PathStr
+                                                                    "path"),
                                                                     uu___162) in
                                                                     let uu___162
                                                                     =
@@ -2499,9 +2501,9 @@ let rec (specs_with_types :
                                                                     let uu___164
                                                                     =
                                                                     text
-                                                                    "Record the state of options used to check each sigelt, useful for the `check_with` attribute and metaprogramming. Note that this implies a performance hit and increases the size of checked files." in
+                                                                    "Record a database of hints for efficient proof replay" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "record_options",
+                                                                    "record_hints",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2513,14 +2515,28 @@ let rec (specs_with_types :
                                                                     let uu___166
                                                                     =
                                                                     text
+                                                                    "Record the state of options used to check each sigelt, useful for the `check_with` attribute and metaprogramming. Note that this implies a performance hit and increases the size of checked files." in
+                                                                    (FStar_Getopt.noshort,
+                                                                    "record_options",
+                                                                    (Const
+                                                                    (Bool
+                                                                    true)),
+                                                                    uu___166) in
+                                                                    let uu___166
+                                                                    =
+                                                                    let uu___167
+                                                                    =
+                                                                    let uu___168
+                                                                    =
+                                                                    text
                                                                     "Retry each SMT query N times and succeed on the first try. Using --retry disables --quake." in
                                                                     (FStar_Getopt.noshort,
                                                                     "retry",
                                                                     (PostProcessed
                                                                     ((fun
-                                                                    uu___167
+                                                                    uu___169
                                                                     ->
-                                                                    match uu___167
+                                                                    match uu___169
                                                                     with
                                                                     | 
                                                                     Int i ->
@@ -2541,25 +2557,12 @@ let rec (specs_with_types :
                                                                     true);
                                                                     Bool true)
                                                                     | 
-                                                                    uu___168
+                                                                    uu___170
                                                                     ->
                                                                     FStar_Compiler_Effect.failwith
                                                                     "impos"),
                                                                     (IntStr
                                                                     "positive integer"))),
-                                                                    uu___166) in
-                                                                    let uu___166
-                                                                    =
-                                                                    let uu___167
-                                                                    =
-                                                                    let uu___168
-                                                                    =
-                                                                    text
-                                                                    "Optimistically, attempt using the recorded hint for  toplevel_name (a top-level name in the current module) when trying to verify some other term 'g'" in
-                                                                    (FStar_Getopt.noshort,
-                                                                    "reuse_hint_for",
-                                                                    (SimpleStr
-                                                                    "toplevel_name"),
                                                                     uu___168) in
                                                                     let uu___168
                                                                     =
@@ -2568,12 +2571,11 @@ let rec (specs_with_types :
                                                                     let uu___170
                                                                     =
                                                                     text
-                                                                    "Report every use of an escape hatch, include assume, admit, etc." in
+                                                                    "Optimistically, attempt using the recorded hint for  toplevel_name (a top-level name in the current module) when trying to verify some other term 'g'" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "report_assumes",
-                                                                    (EnumStr
-                                                                    ["warn";
-                                                                    "error"]),
+                                                                    "reuse_hint_for",
+                                                                    (SimpleStr
+                                                                    "toplevel_name"),
                                                                     uu___170) in
                                                                     let uu___170
                                                                     =
@@ -2582,12 +2584,12 @@ let rec (specs_with_types :
                                                                     let uu___172
                                                                     =
                                                                     text
-                                                                    "Disable all non-critical output" in
+                                                                    "Report every use of an escape hatch, include assume, admit, etc." in
                                                                     (FStar_Getopt.noshort,
-                                                                    "silent",
-                                                                    (Const
-                                                                    (Bool
-                                                                    true)),
+                                                                    "report_assumes",
+                                                                    (EnumStr
+                                                                    ["warn";
+                                                                    "error"]),
                                                                     uu___172) in
                                                                     let uu___172
                                                                     =
@@ -2596,11 +2598,12 @@ let rec (specs_with_types :
                                                                     let uu___174
                                                                     =
                                                                     text
-                                                                    "Path to the Z3 SMT solver (we could eventually support other solvers)" in
+                                                                    "Disable all non-critical output" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "smt",
-                                                                    (PathStr
-                                                                    "path"),
+                                                                    "silent",
+                                                                    (Const
+                                                                    (Bool
+                                                                    true)),
                                                                     uu___174) in
                                                                     let uu___174
                                                                     =
@@ -2609,10 +2612,11 @@ let rec (specs_with_types :
                                                                     let uu___176
                                                                     =
                                                                     text
-                                                                    "Toggle a peephole optimization that eliminates redundant uses of boxing/unboxing in the SMT encoding (default 'false')" in
+                                                                    "Path to the Z3 SMT solver (we could eventually support other solvers)" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "smtencoding.elim_box",
-                                                                    BoolStr,
+                                                                    "smt",
+                                                                    (PathStr
+                                                                    "path"),
                                                                     uu___176) in
                                                                     let uu___176
                                                                     =
@@ -2620,57 +2624,11 @@ let rec (specs_with_types :
                                                                     =
                                                                     let uu___178
                                                                     =
-                                                                    let uu___179
-                                                                    =
                                                                     text
-                                                                    "Control the representation of non-linear arithmetic functions in the SMT encoding:" in
-                                                                    let uu___180
-                                                                    =
-                                                                    let uu___181
-                                                                    =
-                                                                    let uu___182
-                                                                    =
-                                                                    let uu___183
-                                                                    =
-                                                                    text
-                                                                    "if 'boxwrap' use 'Prims.op_Multiply, Prims.op_Division, Prims.op_Modulus'" in
-                                                                    let uu___184
-                                                                    =
-                                                                    let uu___185
-                                                                    =
-                                                                    text
-                                                                    "if 'native' use '*, div, mod'" in
-                                                                    let uu___186
-                                                                    =
-                                                                    let uu___187
-                                                                    =
-                                                                    text
-                                                                    "if 'wrapped' use '_mul, _div, _mod : Int*Int -> Int'" in
-                                                                    [uu___187] in
-                                                                    uu___185
-                                                                    ::
-                                                                    uu___186 in
-                                                                    uu___183
-                                                                    ::
-                                                                    uu___184 in
-                                                                    FStar_Errors_Msg.bulleted
-                                                                    uu___182 in
-                                                                    let uu___182
-                                                                    =
-                                                                    text
-                                                                    "(default 'boxwrap')" in
-                                                                    FStar_Pprint.op_Hat_Hat
-                                                                    uu___181
-                                                                    uu___182 in
-                                                                    FStar_Pprint.op_Hat_Hat
-                                                                    uu___179
-                                                                    uu___180 in
+                                                                    "Toggle a peephole optimization that eliminates redundant uses of boxing/unboxing in the SMT encoding (default 'false')" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "smtencoding.nl_arith_repr",
-                                                                    (EnumStr
-                                                                    ["native";
-                                                                    "wrapped";
-                                                                    "boxwrap"]),
+                                                                    "smtencoding.elim_box",
+                                                                    BoolStr,
                                                                     uu___178) in
                                                                     let uu___178
                                                                     =
@@ -2681,7 +2639,7 @@ let rec (specs_with_types :
                                                                     let uu___181
                                                                     =
                                                                     text
-                                                                    "Toggle the representation of linear arithmetic functions in the SMT encoding:" in
+                                                                    "Control the representation of non-linear arithmetic functions in the SMT encoding:" in
                                                                     let uu___182
                                                                     =
                                                                     let uu___183
@@ -2691,14 +2649,23 @@ let rec (specs_with_types :
                                                                     let uu___185
                                                                     =
                                                                     text
-                                                                    "if 'boxwrap', use 'Prims.op_Addition, Prims.op_Subtraction, Prims.op_Minus'" in
+                                                                    "if 'boxwrap' use 'Prims.op_Multiply, Prims.op_Division, Prims.op_Modulus'" in
                                                                     let uu___186
                                                                     =
                                                                     let uu___187
                                                                     =
                                                                     text
-                                                                    "if 'native', use '+, -, -'" in
-                                                                    [uu___187] in
+                                                                    "if 'native' use '*, div, mod'" in
+                                                                    let uu___188
+                                                                    =
+                                                                    let uu___189
+                                                                    =
+                                                                    text
+                                                                    "if 'wrapped' use '_mul, _div, _mod : Int*Int -> Int'" in
+                                                                    [uu___189] in
+                                                                    uu___187
+                                                                    ::
+                                                                    uu___188 in
                                                                     uu___185
                                                                     ::
                                                                     uu___186 in
@@ -2715,9 +2682,10 @@ let rec (specs_with_types :
                                                                     uu___181
                                                                     uu___182 in
                                                                     (FStar_Getopt.noshort,
-                                                                    "smtencoding.l_arith_repr",
+                                                                    "smtencoding.nl_arith_repr",
                                                                     (EnumStr
                                                                     ["native";
+                                                                    "wrapped";
                                                                     "boxwrap"]),
                                                                     uu___180) in
                                                                     let uu___180
@@ -2726,24 +2694,10 @@ let rec (specs_with_types :
                                                                     =
                                                                     let uu___182
                                                                     =
-                                                                    text
-                                                                    "Include an axiom in the SMT encoding to introduce proof-irrelevance from a constructive proof" in
-                                                                    (FStar_Getopt.noshort,
-                                                                    "smtencoding.valid_intro",
-                                                                    BoolStr,
-                                                                    uu___182) in
-                                                                    let uu___182
-                                                                    =
                                                                     let uu___183
                                                                     =
-                                                                    let uu___184
-                                                                    =
                                                                     text
-                                                                    "Include an axiom in the SMT encoding to eliminate proof-irrelevance into the existence of a proof witness" in
-                                                                    (FStar_Getopt.noshort,
-                                                                    "smtencoding.valid_elim",
-                                                                    BoolStr,
-                                                                    uu___184) in
+                                                                    "Toggle the representation of linear arithmetic functions in the SMT encoding:" in
                                                                     let uu___184
                                                                     =
                                                                     let uu___185
@@ -2753,45 +2707,58 @@ let rec (specs_with_types :
                                                                     let uu___187
                                                                     =
                                                                     text
-                                                                    "Split SMT verification conditions into several separate queries, one per goal. Helps with localizing errors." in
+                                                                    "if 'boxwrap', use 'Prims.op_Addition, Prims.op_Subtraction, Prims.op_Minus'" in
                                                                     let uu___188
                                                                     =
                                                                     let uu___189
                                                                     =
-                                                                    let uu___190
-                                                                    =
                                                                     text
-                                                                    "Use 'no' to disable (this may reduce the quality of error messages)." in
-                                                                    let uu___191
-                                                                    =
-                                                                    let uu___192
-                                                                    =
-                                                                    text
-                                                                    "Use 'on_failure' to split queries and retry when discharging fails (the default)" in
-                                                                    let uu___193
-                                                                    =
-                                                                    let uu___194
-                                                                    =
-                                                                    text
-                                                                    "Use 'yes' to always split." in
-                                                                    [uu___194] in
-                                                                    uu___192
-                                                                    ::
-                                                                    uu___193 in
-                                                                    uu___190
-                                                                    ::
-                                                                    uu___191 in
-                                                                    FStar_Errors_Msg.bulleted
-                                                                    uu___189 in
-                                                                    FStar_Pprint.op_Hat_Hat
+                                                                    "if 'native', use '+, -, -'" in
+                                                                    [uu___189] in
                                                                     uu___187
+                                                                    ::
                                                                     uu___188 in
+                                                                    FStar_Errors_Msg.bulleted
+                                                                    uu___186 in
+                                                                    let uu___186
+                                                                    =
+                                                                    text
+                                                                    "(default 'boxwrap')" in
+                                                                    FStar_Pprint.op_Hat_Hat
+                                                                    uu___185
+                                                                    uu___186 in
+                                                                    FStar_Pprint.op_Hat_Hat
+                                                                    uu___183
+                                                                    uu___184 in
                                                                     (FStar_Getopt.noshort,
-                                                                    "split_queries",
+                                                                    "smtencoding.l_arith_repr",
                                                                     (EnumStr
-                                                                    ["no";
-                                                                    "on_failure";
-                                                                    "always"]),
+                                                                    ["native";
+                                                                    "boxwrap"]),
+                                                                    uu___182) in
+                                                                    let uu___182
+                                                                    =
+                                                                    let uu___183
+                                                                    =
+                                                                    let uu___184
+                                                                    =
+                                                                    text
+                                                                    "Include an axiom in the SMT encoding to introduce proof-irrelevance from a constructive proof" in
+                                                                    (FStar_Getopt.noshort,
+                                                                    "smtencoding.valid_intro",
+                                                                    BoolStr,
+                                                                    uu___184) in
+                                                                    let uu___184
+                                                                    =
+                                                                    let uu___185
+                                                                    =
+                                                                    let uu___186
+                                                                    =
+                                                                    text
+                                                                    "Include an axiom in the SMT encoding to eliminate proof-irrelevance into the existence of a proof witness" in
+                                                                    (FStar_Getopt.noshort,
+                                                                    "smtencoding.valid_elim",
+                                                                    BoolStr,
                                                                     uu___186) in
                                                                     let uu___186
                                                                     =
@@ -2799,13 +2766,48 @@ let rec (specs_with_types :
                                                                     =
                                                                     let uu___188
                                                                     =
+                                                                    let uu___189
+                                                                    =
                                                                     text
-                                                                    "Do not use the lexical scope of tactics to improve binder names" in
+                                                                    "Split SMT verification conditions into several separate queries, one per goal. Helps with localizing errors." in
+                                                                    let uu___190
+                                                                    =
+                                                                    let uu___191
+                                                                    =
+                                                                    let uu___192
+                                                                    =
+                                                                    text
+                                                                    "Use 'no' to disable (this may reduce the quality of error messages)." in
+                                                                    let uu___193
+                                                                    =
+                                                                    let uu___194
+                                                                    =
+                                                                    text
+                                                                    "Use 'on_failure' to split queries and retry when discharging fails (the default)" in
+                                                                    let uu___195
+                                                                    =
+                                                                    let uu___196
+                                                                    =
+                                                                    text
+                                                                    "Use 'yes' to always split." in
+                                                                    [uu___196] in
+                                                                    uu___194
+                                                                    ::
+                                                                    uu___195 in
+                                                                    uu___192
+                                                                    ::
+                                                                    uu___193 in
+                                                                    FStar_Errors_Msg.bulleted
+                                                                    uu___191 in
+                                                                    FStar_Pprint.op_Hat_Hat
+                                                                    uu___189
+                                                                    uu___190 in
                                                                     (FStar_Getopt.noshort,
-                                                                    "tactic_raw_binders",
-                                                                    (Const
-                                                                    (Bool
-                                                                    true)),
+                                                                    "split_queries",
+                                                                    (EnumStr
+                                                                    ["no";
+                                                                    "on_failure";
+                                                                    "always"]),
                                                                     uu___188) in
                                                                     let uu___188
                                                                     =
@@ -2814,9 +2816,9 @@ let rec (specs_with_types :
                                                                     let uu___190
                                                                     =
                                                                     text
-                                                                    "Do not recover from metaprogramming errors, and abort if one occurs" in
+                                                                    "Do not use the lexical scope of tactics to improve binder names" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "tactics_failhard",
+                                                                    "tactic_raw_binders",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2828,9 +2830,9 @@ let rec (specs_with_types :
                                                                     let uu___192
                                                                     =
                                                                     text
-                                                                    "Print some rough information on tactics, such as the time they take to run" in
+                                                                    "Do not recover from metaprogramming errors, and abort if one occurs" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "tactics_info",
+                                                                    "tactics_failhard",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2842,9 +2844,9 @@ let rec (specs_with_types :
                                                                     let uu___194
                                                                     =
                                                                     text
-                                                                    "Print a depth-indexed trace of tactic execution (Warning: very verbose)" in
+                                                                    "Print some rough information on tactics, such as the time they take to run" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "tactic_trace",
+                                                                    "tactics_info",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2856,11 +2858,12 @@ let rec (specs_with_types :
                                                                     let uu___196
                                                                     =
                                                                     text
-                                                                    "Trace tactics up to a certain binding depth" in
+                                                                    "Print a depth-indexed trace of tactic execution (Warning: very verbose)" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "tactic_trace_d",
-                                                                    (IntStr
-                                                                    "positive_integer"),
+                                                                    "tactic_trace",
+                                                                    (Const
+                                                                    (Bool
+                                                                    true)),
                                                                     uu___196) in
                                                                     let uu___196
                                                                     =
@@ -2869,12 +2872,11 @@ let rec (specs_with_types :
                                                                     let uu___198
                                                                     =
                                                                     text
-                                                                    "Use NBE to evaluate metaprograms (experimental)" in
+                                                                    "Trace tactics up to a certain binding depth" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "__tactics_nbe",
-                                                                    (Const
-                                                                    (Bool
-                                                                    true)),
+                                                                    "tactic_trace_d",
+                                                                    (IntStr
+                                                                    "positive_integer"),
                                                                     uu___198) in
                                                                     let uu___198
                                                                     =
@@ -2883,10 +2885,12 @@ let rec (specs_with_types :
                                                                     let uu___200
                                                                     =
                                                                     text
-                                                                    "Attempt to normalize definitions marked as tcnorm (default 'true')" in
+                                                                    "Use NBE to evaluate metaprograms (experimental)" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "tcnorm",
-                                                                    BoolStr,
+                                                                    "__tactics_nbe",
+                                                                    (Const
+                                                                    (Bool
+                                                                    true)),
                                                                     uu___200) in
                                                                     let uu___200
                                                                     =
@@ -2895,12 +2899,10 @@ let rec (specs_with_types :
                                                                     let uu___202
                                                                     =
                                                                     text
-                                                                    "Print the time it takes to verify each top-level definition. This is just an alias for an invocation of the profiler, so it may not work well if combined with --profile. In particular, it implies --profile_group_by_decl." in
+                                                                    "Attempt to normalize definitions marked as tcnorm (default 'true')" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "timing",
-                                                                    (Const
-                                                                    (Bool
-                                                                    true)),
+                                                                    "tcnorm",
+                                                                    BoolStr,
                                                                     uu___202) in
                                                                     let uu___202
                                                                     =
@@ -2909,9 +2911,9 @@ let rec (specs_with_types :
                                                                     let uu___204
                                                                     =
                                                                     text
-                                                                    "Attach stack traces on errors" in
+                                                                    "Print the time it takes to verify each top-level definition. This is just an alias for an invocation of the profiler, so it may not work well if combined with --profile. In particular, it implies --profile_group_by_decl." in
                                                                     (FStar_Getopt.noshort,
-                                                                    "trace_error",
+                                                                    "timing",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2923,9 +2925,9 @@ let rec (specs_with_types :
                                                                     let uu___206
                                                                     =
                                                                     text
-                                                                    "Emit output formatted for debugging" in
+                                                                    "Attach stack traces on errors" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "ugly",
+                                                                    "trace_error",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2937,9 +2939,9 @@ let rec (specs_with_types :
                                                                     let uu___208
                                                                     =
                                                                     text
-                                                                    "Let the SMT solver unfold inductive types to arbitrary depths (may affect verifier performance)" in
+                                                                    "Emit output formatted for debugging" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "unthrottle_inductives",
+                                                                    "ugly",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2951,9 +2953,9 @@ let rec (specs_with_types :
                                                                     let uu___210
                                                                     =
                                                                     text
-                                                                    "Allow tactics to run external processes. WARNING: checking an untrusted F* file while using this option can have disastrous effects." in
+                                                                    "Let the SMT solver unfold inductive types to arbitrary depths (may affect verifier performance)" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "unsafe_tactic_exec",
+                                                                    "unthrottle_inductives",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2965,9 +2967,9 @@ let rec (specs_with_types :
                                                                     let uu___212
                                                                     =
                                                                     text
-                                                                    "Use equality constraints when comparing higher-order types (Temporary)" in
+                                                                    "Allow tactics to run external processes. WARNING: checking an untrusted F* file while using this option can have disastrous effects." in
                                                                     (FStar_Getopt.noshort,
-                                                                    "use_eq_at_higher_order",
+                                                                    "unsafe_tactic_exec",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2979,9 +2981,9 @@ let rec (specs_with_types :
                                                                     let uu___214
                                                                     =
                                                                     text
-                                                                    "Use a previously recorded hints database for proof replay" in
+                                                                    "Use equality constraints when comparing higher-order types (Temporary)" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "use_hints",
+                                                                    "use_eq_at_higher_order",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -2993,9 +2995,9 @@ let rec (specs_with_types :
                                                                     let uu___216
                                                                     =
                                                                     text
-                                                                    "Admit queries if their hash matches the hash recorded in the hints database" in
+                                                                    "Use a previously recorded hints database for proof replay" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "use_hint_hashes",
+                                                                    "use_hints",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -3007,11 +3009,12 @@ let rec (specs_with_types :
                                                                     let uu___218
                                                                     =
                                                                     text
-                                                                    "Use compiled tactics from  path" in
+                                                                    "Admit queries if their hash matches the hash recorded in the hints database" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "use_native_tactics",
-                                                                    (PathStr
-                                                                    "path"),
+                                                                    "use_hint_hashes",
+                                                                    (Const
+                                                                    (Bool
+                                                                    true)),
                                                                     uu___218) in
                                                                     let uu___218
                                                                     =
@@ -3020,12 +3023,11 @@ let rec (specs_with_types :
                                                                     let uu___220
                                                                     =
                                                                     text
-                                                                    "Do not run plugins natively and interpret them as usual instead" in
+                                                                    "Use compiled tactics from  path" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "no_plugins",
-                                                                    (Const
-                                                                    (Bool
-                                                                    true)),
+                                                                    "use_native_tactics",
+                                                                    (PathStr
+                                                                    "path"),
                                                                     uu___220) in
                                                                     let uu___220
                                                                     =
@@ -3034,9 +3036,9 @@ let rec (specs_with_types :
                                                                     let uu___222
                                                                     =
                                                                     text
-                                                                    "Do not run the tactic engine before discharging a VC" in
+                                                                    "Do not run plugins natively and interpret them as usual instead" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "no_tactics",
+                                                                    "no_plugins",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -3048,12 +3050,12 @@ let rec (specs_with_types :
                                                                     let uu___224
                                                                     =
                                                                     text
-                                                                    "Prunes the context to include only the facts from the given namespace or fact id. Facts can be include or excluded using the [+|-] qualifier. For example --using_facts_from '* -FStar.Reflection +FStar.Compiler.List -FStar.Compiler.List.Tot' will remove all facts from FStar.Compiler.List.Tot.*, retain all remaining facts from FStar.Compiler.List.*, remove all facts from FStar.Reflection.*, and retain all the rest. Note, the '+' is optional: --using_facts_from 'FStar.Compiler.List' is equivalent to --using_facts_from '+FStar.Compiler.List'. Multiple uses of this option accumulate, e.g., --using_facts_from A --using_facts_from B is interpreted as --using_facts_from A^B." in
+                                                                    "Do not run the tactic engine before discharging a VC" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "using_facts_from",
-                                                                    (ReverseAccumulated
-                                                                    (SimpleStr
-                                                                    "One or more space-separated occurrences of '[+|-]( * | namespace | fact id)'")),
+                                                                    "no_tactics",
+                                                                    (Const
+                                                                    (Bool
+                                                                    true)),
                                                                     uu___224) in
                                                                     let uu___224
                                                                     =
@@ -3062,12 +3064,12 @@ let rec (specs_with_types :
                                                                     let uu___226
                                                                     =
                                                                     text
-                                                                    "This does nothing and will be removed" in
+                                                                    "Prunes the context to include only the facts from the given namespace or fact id. Facts can be include or excluded using the [+|-] qualifier. For example --using_facts_from '* -FStar.Reflection +FStar.Compiler.List -FStar.Compiler.List.Tot' will remove all facts from FStar.Compiler.List.Tot.*, retain all remaining facts from FStar.Compiler.List.*, remove all facts from FStar.Reflection.*, and retain all the rest. Note, the '+' is optional: --using_facts_from 'FStar.Compiler.List' is equivalent to --using_facts_from '+FStar.Compiler.List'. Multiple uses of this option accumulate, e.g., --using_facts_from A --using_facts_from B is interpreted as --using_facts_from A^B." in
                                                                     (FStar_Getopt.noshort,
-                                                                    "__temp_fast_implicits",
-                                                                    (Const
-                                                                    (Bool
-                                                                    true)),
+                                                                    "using_facts_from",
+                                                                    (ReverseAccumulated
+                                                                    (SimpleStr
+                                                                    "One or more space-separated occurrences of '[+|-]( * | namespace | fact id)'")),
                                                                     uu___226) in
                                                                     let uu___226
                                                                     =
@@ -3076,20 +3078,12 @@ let rec (specs_with_types :
                                                                     let uu___228
                                                                     =
                                                                     text
-                                                                    "Display version number" in
-                                                                    (118,
-                                                                    "version",
-                                                                    (WithSideEffect
-                                                                    ((fun
-                                                                    uu___229
-                                                                    ->
-                                                                    display_version
-                                                                    ();
-                                                                    FStar_Compiler_Effect.exit
-                                                                    Prims.int_zero),
+                                                                    "This does nothing and will be removed" in
+                                                                    (FStar_Getopt.noshort,
+                                                                    "__temp_fast_implicits",
                                                                     (Const
                                                                     (Bool
-                                                                    true)))),
+                                                                    true)),
                                                                     uu___228) in
                                                                     let uu___228
                                                                     =
@@ -3098,12 +3092,20 @@ let rec (specs_with_types :
                                                                     let uu___230
                                                                     =
                                                                     text
-                                                                    "Warn when (a -> b) is desugared to (a -> Tot b)" in
-                                                                    (FStar_Getopt.noshort,
-                                                                    "warn_default_effects",
+                                                                    "Display version number" in
+                                                                    (118,
+                                                                    "version",
+                                                                    (WithSideEffect
+                                                                    ((fun
+                                                                    uu___231
+                                                                    ->
+                                                                    display_version
+                                                                    ();
+                                                                    FStar_Compiler_Effect.exit
+                                                                    Prims.int_zero),
                                                                     (Const
                                                                     (Bool
-                                                                    true)),
+                                                                    true)))),
                                                                     uu___230) in
                                                                     let uu___230
                                                                     =
@@ -3112,12 +3114,12 @@ let rec (specs_with_types :
                                                                     let uu___232
                                                                     =
                                                                     text
-                                                                    "Z3 command line options" in
+                                                                    "Warn when (a -> b) is desugared to (a -> Tot b)" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "z3cliopt",
-                                                                    (ReverseAccumulated
-                                                                    (SimpleStr
-                                                                    "option")),
+                                                                    "warn_default_effects",
+                                                                    (Const
+                                                                    (Bool
+                                                                    true)),
                                                                     uu___232) in
                                                                     let uu___232
                                                                     =
@@ -3126,9 +3128,9 @@ let rec (specs_with_types :
                                                                     let uu___234
                                                                     =
                                                                     text
-                                                                    "Z3 options in smt2 format" in
+                                                                    "Z3 command line options" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "z3smtopt",
+                                                                    "z3cliopt",
                                                                     (ReverseAccumulated
                                                                     (SimpleStr
                                                                     "option")),
@@ -3140,12 +3142,12 @@ let rec (specs_with_types :
                                                                     let uu___236
                                                                     =
                                                                     text
-                                                                    "Restart Z3 after each query; useful for ensuring proof robustness" in
+                                                                    "Z3 options in smt2 format" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "z3refresh",
-                                                                    (Const
-                                                                    (Bool
-                                                                    true)),
+                                                                    "z3smtopt",
+                                                                    (ReverseAccumulated
+                                                                    (SimpleStr
+                                                                    "option")),
                                                                     uu___236) in
                                                                     let uu___236
                                                                     =
@@ -3154,11 +3156,12 @@ let rec (specs_with_types :
                                                                     let uu___238
                                                                     =
                                                                     text
-                                                                    "Set the Z3 per-query resource limit (default 5 units, taking roughtly 5s)" in
+                                                                    "Restart Z3 after each query; useful for ensuring proof robustness" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "z3rlimit",
-                                                                    (IntStr
-                                                                    "positive_integer"),
+                                                                    "z3refresh",
+                                                                    (Const
+                                                                    (Bool
+                                                                    true)),
                                                                     uu___238) in
                                                                     let uu___238
                                                                     =
@@ -3167,9 +3170,9 @@ let rec (specs_with_types :
                                                                     let uu___240
                                                                     =
                                                                     text
-                                                                    "Set the Z3 per-query resource limit multiplier. This is useful when, say, regenerating hints and you want to be more lax. (default 1)" in
+                                                                    "Set the Z3 per-query resource limit (default 5 units, taking roughtly 5s)" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "z3rlimit_factor",
+                                                                    "z3rlimit",
                                                                     (IntStr
                                                                     "positive_integer"),
                                                                     uu___240) in
@@ -3180,9 +3183,9 @@ let rec (specs_with_types :
                                                                     let uu___242
                                                                     =
                                                                     text
-                                                                    "Set the Z3 random seed (default 0)" in
+                                                                    "Set the Z3 per-query resource limit multiplier. This is useful when, say, regenerating hints and you want to be more lax. (default 1)" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "z3seed",
+                                                                    "z3rlimit_factor",
                                                                     (IntStr
                                                                     "positive_integer"),
                                                                     uu___242) in
@@ -3193,11 +3196,11 @@ let rec (specs_with_types :
                                                                     let uu___244
                                                                     =
                                                                     text
-                                                                    "Set the version of Z3 that is to be used. Default: 4.8.5" in
+                                                                    "Set the Z3 random seed (default 0)" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "z3version",
-                                                                    (SimpleStr
-                                                                    "version"),
+                                                                    "z3seed",
+                                                                    (IntStr
+                                                                    "positive_integer"),
                                                                     uu___244) in
                                                                     let uu___244
                                                                     =
@@ -3206,12 +3209,25 @@ let rec (specs_with_types :
                                                                     let uu___246
                                                                     =
                                                                     text
+                                                                    "Set the version of Z3 that is to be used. Default: 4.8.5" in
+                                                                    (FStar_Getopt.noshort,
+                                                                    "z3version",
+                                                                    (SimpleStr
+                                                                    "version"),
+                                                                    uu___246) in
+                                                                    let uu___246
+                                                                    =
+                                                                    let uu___247
+                                                                    =
+                                                                    let uu___248
+                                                                    =
+                                                                    text
                                                                     "Don't check positivity of inductive types" in
                                                                     (FStar_Getopt.noshort,
                                                                     "__no_positivity",
                                                                     (WithSideEffect
                                                                     ((fun
-                                                                    uu___247
+                                                                    uu___249
                                                                     ->
                                                                     if
                                                                     warn_unsafe
@@ -3222,63 +3238,6 @@ let rec (specs_with_types :
                                                                     (Const
                                                                     (Bool
                                                                     true)))),
-                                                                    uu___246) in
-                                                                    let uu___246
-                                                                    =
-                                                                    let uu___247
-                                                                    =
-                                                                    let uu___248
-                                                                    =
-                                                                    let uu___249
-                                                                    =
-                                                                    text
-                                                                    "The [-warn_error] option follows the OCaml syntax, namely:" in
-                                                                    let uu___250
-                                                                    =
-                                                                    let uu___251
-                                                                    =
-                                                                    let uu___252
-                                                                    =
-                                                                    text
-                                                                    "[r] is a range of warnings (either a number [n], or a range [n..n])" in
-                                                                    let uu___253
-                                                                    =
-                                                                    let uu___254
-                                                                    =
-                                                                    text
-                                                                    "[-r] silences range [r]" in
-                                                                    let uu___255
-                                                                    =
-                                                                    let uu___256
-                                                                    =
-                                                                    text
-                                                                    "[+r] enables range [r] as warnings (NOTE: \"enabling\" an error will downgrade it to a warning)" in
-                                                                    let uu___257
-                                                                    =
-                                                                    let uu___258
-                                                                    =
-                                                                    text
-                                                                    "[@r] makes range [r] fatal." in
-                                                                    [uu___258] in
-                                                                    uu___256
-                                                                    ::
-                                                                    uu___257 in
-                                                                    uu___254
-                                                                    ::
-                                                                    uu___255 in
-                                                                    uu___252
-                                                                    ::
-                                                                    uu___253 in
-                                                                    FStar_Errors_Msg.bulleted
-                                                                    uu___251 in
-                                                                    FStar_Pprint.op_Hat_Hat
-                                                                    uu___249
-                                                                    uu___250 in
-                                                                    (FStar_Getopt.noshort,
-                                                                    "warn_error",
-                                                                    (ReverseAccumulated
-                                                                    (SimpleStr
-                                                                    "")),
                                                                     uu___248) in
                                                                     let uu___248
                                                                     =
@@ -3286,11 +3245,56 @@ let rec (specs_with_types :
                                                                     =
                                                                     let uu___250
                                                                     =
+                                                                    let uu___251
+                                                                    =
                                                                     text
-                                                                    "Use normalization by evaluation as the default normalization strategy (default 'false')" in
+                                                                    "The [-warn_error] option follows the OCaml syntax, namely:" in
+                                                                    let uu___252
+                                                                    =
+                                                                    let uu___253
+                                                                    =
+                                                                    let uu___254
+                                                                    =
+                                                                    text
+                                                                    "[r] is a range of warnings (either a number [n], or a range [n..n])" in
+                                                                    let uu___255
+                                                                    =
+                                                                    let uu___256
+                                                                    =
+                                                                    text
+                                                                    "[-r] silences range [r]" in
+                                                                    let uu___257
+                                                                    =
+                                                                    let uu___258
+                                                                    =
+                                                                    text
+                                                                    "[+r] enables range [r] as warnings (NOTE: \"enabling\" an error will downgrade it to a warning)" in
+                                                                    let uu___259
+                                                                    =
+                                                                    let uu___260
+                                                                    =
+                                                                    text
+                                                                    "[@r] makes range [r] fatal." in
+                                                                    [uu___260] in
+                                                                    uu___258
+                                                                    ::
+                                                                    uu___259 in
+                                                                    uu___256
+                                                                    ::
+                                                                    uu___257 in
+                                                                    uu___254
+                                                                    ::
+                                                                    uu___255 in
+                                                                    FStar_Errors_Msg.bulleted
+                                                                    uu___253 in
+                                                                    FStar_Pprint.op_Hat_Hat
+                                                                    uu___251
+                                                                    uu___252 in
                                                                     (FStar_Getopt.noshort,
-                                                                    "use_nbe",
-                                                                    BoolStr,
+                                                                    "warn_error",
+                                                                    (ReverseAccumulated
+                                                                    (SimpleStr
+                                                                    "")),
                                                                     uu___250) in
                                                                     let uu___250
                                                                     =
@@ -3299,9 +3303,9 @@ let rec (specs_with_types :
                                                                     let uu___252
                                                                     =
                                                                     text
-                                                                    "Use normalization by evaluation for normalizing terms before extraction (default 'false')" in
+                                                                    "Use normalization by evaluation as the default normalization strategy (default 'false')" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "use_nbe_for_extraction",
+                                                                    "use_nbe",
                                                                     BoolStr,
                                                                     uu___252) in
                                                                     let uu___252
@@ -3311,9 +3315,9 @@ let rec (specs_with_types :
                                                                     let uu___254
                                                                     =
                                                                     text
-                                                                    "Enforce trivial preconditions for unannotated effectful functions (default 'true')" in
+                                                                    "Use normalization by evaluation for normalizing terms before extraction (default 'false')" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "trivial_pre_for_unannotated_effectful_fns",
+                                                                    "use_nbe_for_extraction",
                                                                     BoolStr,
                                                                     uu___254) in
                                                                     let uu___254
@@ -3323,19 +3327,10 @@ let rec (specs_with_types :
                                                                     let uu___256
                                                                     =
                                                                     text
-                                                                    "Debug messages for embeddings/unembeddings of natively compiled terms" in
+                                                                    "Enforce trivial preconditions for unannotated effectful functions (default 'true')" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "__debug_embedding",
-                                                                    (WithSideEffect
-                                                                    ((fun
-                                                                    uu___257
-                                                                    ->
-                                                                    FStar_Compiler_Effect.op_Colon_Equals
-                                                                    debug_embedding
-                                                                    true),
-                                                                    (Const
-                                                                    (Bool
-                                                                    true)))),
+                                                                    "trivial_pre_for_unannotated_effectful_fns",
+                                                                    BoolStr,
                                                                     uu___256) in
                                                                     let uu___256
                                                                     =
@@ -3344,15 +3339,15 @@ let rec (specs_with_types :
                                                                     let uu___258
                                                                     =
                                                                     text
-                                                                    "Eagerly embed and unembed terms to primitive operations and plugins: not recommended except for benchmarking" in
+                                                                    "Debug messages for embeddings/unembeddings of natively compiled terms" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "eager_embedding",
+                                                                    "__debug_embedding",
                                                                     (WithSideEffect
                                                                     ((fun
                                                                     uu___259
                                                                     ->
                                                                     FStar_Compiler_Effect.op_Colon_Equals
-                                                                    eager_embedding
+                                                                    debug_embedding
                                                                     true),
                                                                     (Const
                                                                     (Bool
@@ -3365,12 +3360,19 @@ let rec (specs_with_types :
                                                                     let uu___260
                                                                     =
                                                                     text
-                                                                    "Emit profiles grouped by declaration rather than by module" in
+                                                                    "Eagerly embed and unembed terms to primitive operations and plugins: not recommended except for benchmarking" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "profile_group_by_decl",
+                                                                    "eager_embedding",
+                                                                    (WithSideEffect
+                                                                    ((fun
+                                                                    uu___261
+                                                                    ->
+                                                                    FStar_Compiler_Effect.op_Colon_Equals
+                                                                    eager_embedding
+                                                                    true),
                                                                     (Const
                                                                     (Bool
-                                                                    true)),
+                                                                    true)))),
                                                                     uu___260) in
                                                                     let uu___260
                                                                     =
@@ -3379,12 +3381,12 @@ let rec (specs_with_types :
                                                                     let uu___262
                                                                     =
                                                                     text
-                                                                    "Specific source locations in the compiler are instrumented with profiling counters. Pass `--profile_component FStar.TypeChecker` to enable all counters in the FStar.TypeChecker namespace. This option is a module or namespace selector, like many other options (e.g., `--extract`)" in
+                                                                    "Emit profiles grouped by declaration rather than by module" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "profile_component",
-                                                                    (Accumulated
-                                                                    (SimpleStr
-                                                                    "One or more space-separated occurrences of '[+|-]( * | namespace | module | identifier)'")),
+                                                                    "profile_group_by_decl",
+                                                                    (Const
+                                                                    (Bool
+                                                                    true)),
                                                                     uu___262) in
                                                                     let uu___262
                                                                     =
@@ -3393,12 +3395,12 @@ let rec (specs_with_types :
                                                                     let uu___264
                                                                     =
                                                                     text
-                                                                    "Profiling can be enabled when the compiler is processing a given set of source modules. Pass `--profile FStar.Pervasives` to enable profiling when the compiler is processing any module in FStar.Pervasives. This option is a module or namespace selector, like many other options (e.g., `--extract`)" in
+                                                                    "Specific source locations in the compiler are instrumented with profiling counters. Pass `--profile_component FStar.TypeChecker` to enable all counters in the FStar.TypeChecker namespace. This option is a module or namespace selector, like many other options (e.g., `--extract`)" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "profile",
+                                                                    "profile_component",
                                                                     (Accumulated
                                                                     (SimpleStr
-                                                                    "One or more space-separated occurrences of '[+|-]( * | namespace | module)'")),
+                                                                    "One or more space-separated occurrences of '[+|-]( * | namespace | module | identifier)'")),
                                                                     uu___264) in
                                                                     let uu___264
                                                                     =
@@ -3407,25 +3409,12 @@ let rec (specs_with_types :
                                                                     let uu___266
                                                                     =
                                                                     text
-                                                                    "Display this information" in
-                                                                    (104,
-                                                                    "help",
-                                                                    (WithSideEffect
-                                                                    ((fun
-                                                                    uu___267
-                                                                    ->
-                                                                    (
-                                                                    let uu___269
-                                                                    =
-                                                                    specs
-                                                                    warn_unsafe in
-                                                                    display_usage_aux
-                                                                    uu___269);
-                                                                    FStar_Compiler_Effect.exit
-                                                                    Prims.int_zero),
-                                                                    (Const
-                                                                    (Bool
-                                                                    true)))),
+                                                                    "Profiling can be enabled when the compiler is processing a given set of source modules. Pass `--profile FStar.Pervasives` to enable profiling when the compiler is processing any module in FStar.Pervasives. This option is a module or namespace selector, like many other options (e.g., `--extract`)" in
+                                                                    (FStar_Getopt.noshort,
+                                                                    "profile",
+                                                                    (Accumulated
+                                                                    (SimpleStr
+                                                                    "One or more space-separated occurrences of '[+|-]( * | namespace | module)'")),
                                                                     uu___266) in
                                                                     let uu___266
                                                                     =
@@ -3434,15 +3423,20 @@ let rec (specs_with_types :
                                                                     let uu___268
                                                                     =
                                                                     text
-                                                                    "List all debug keys and exit" in
-                                                                    (FStar_Getopt.noshort,
-                                                                    "list_debug_keys",
+                                                                    "Display this information" in
+                                                                    (104,
+                                                                    "help",
                                                                     (WithSideEffect
                                                                     ((fun
                                                                     uu___269
                                                                     ->
-                                                                    display_debug_keys
-                                                                    ();
+                                                                    (
+                                                                    let uu___271
+                                                                    =
+                                                                    specs
+                                                                    warn_unsafe in
+                                                                    display_usage_aux
+                                                                    uu___271);
                                                                     FStar_Compiler_Effect.exit
                                                                     Prims.int_zero),
                                                                     (Const
@@ -3456,12 +3450,20 @@ let rec (specs_with_types :
                                                                     let uu___270
                                                                     =
                                                                     text
-                                                                    "List all registered plugins and exit" in
+                                                                    "List all debug keys and exit" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "list_plugins",
+                                                                    "list_debug_keys",
+                                                                    (WithSideEffect
+                                                                    ((fun
+                                                                    uu___271
+                                                                    ->
+                                                                    display_debug_keys
+                                                                    ();
+                                                                    FStar_Compiler_Effect.exit
+                                                                    Prims.int_zero),
                                                                     (Const
                                                                     (Bool
-                                                                    true)),
+                                                                    true)))),
                                                                     uu___270) in
                                                                     let uu___270
                                                                     =
@@ -3470,9 +3472,9 @@ let rec (specs_with_types :
                                                                     let uu___272
                                                                     =
                                                                     text
-                                                                    "Print the root of the F* installation and exit" in
+                                                                    "List all registered plugins and exit" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "locate",
+                                                                    "list_plugins",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -3484,9 +3486,9 @@ let rec (specs_with_types :
                                                                     let uu___274
                                                                     =
                                                                     text
-                                                                    "Print the root of the F* library and exit" in
+                                                                    "Print the root of the F* installation and exit" in
                                                                     (FStar_Getopt.noshort,
-                                                                    "locate_lib",
+                                                                    "locate",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
@@ -3498,14 +3500,31 @@ let rec (specs_with_types :
                                                                     let uu___276
                                                                     =
                                                                     text
+                                                                    "Print the root of the F* library and exit" in
+                                                                    (FStar_Getopt.noshort,
+                                                                    "locate_lib",
+                                                                    (Const
+                                                                    (Bool
+                                                                    true)),
+                                                                    uu___276) in
+                                                                    let uu___276
+                                                                    =
+                                                                    let uu___277
+                                                                    =
+                                                                    let uu___278
+                                                                    =
+                                                                    text
                                                                     "Print the root of the built OCaml F* library and exit" in
                                                                     (FStar_Getopt.noshort,
                                                                     "locate_ocaml",
                                                                     (Const
                                                                     (Bool
                                                                     true)),
-                                                                    uu___276) in
-                                                                    [uu___275] in
+                                                                    uu___278) in
+                                                                    [uu___277] in
+                                                                    uu___275
+                                                                    ::
+                                                                    uu___276 in
                                                                     uu___273
                                                                     ::
                                                                     uu___274 in
@@ -4523,6 +4542,7 @@ let (log_types : unit -> Prims.bool) = fun uu___ -> get_log_types ()
 let (max_fuel : unit -> Prims.int) = fun uu___ -> get_max_fuel ()
 let (max_ifuel : unit -> Prims.int) = fun uu___ -> get_max_ifuel ()
 let (ml_ish : unit -> Prims.bool) = fun uu___ -> get_MLish ()
+let (ml_ish_effect : unit -> Prims.string) = fun uu___ -> get_MLish_effect ()
 let (set_ml_ish : unit -> unit) = fun uu___ -> set_option "MLish" (Bool true)
 let (no_default_includes : unit -> Prims.bool) =
   fun uu___ -> get_no_default_includes ()

--- a/ocaml/fstar-lib/generated/FStar_Parser_Const.ml
+++ b/ocaml/fstar-lib/generated/FStar_Parser_Const.ml
@@ -219,39 +219,36 @@ let (effect_Ghost_lid : FStar_Ident.lident) = pconst "Ghost"
 let (effect_DIV_lid : FStar_Ident.lident) = psconst "DIV"
 let (effect_Div_lid : FStar_Ident.lident) = psconst "Div"
 let (effect_Dv_lid : FStar_Ident.lident) = psconst "Dv"
-let (compiler_effect_lid : FStar_Ident.lident) =
-  p2l ["FStar"; "Compiler"; "Effect"]
-let (compiler_effect_ALL_lid : FStar_Ident.lident) =
-  p2l ["FStar"; "Compiler"; "Effect"; "ALL"]
-let (compiler_effect_ML_lid : FStar_Ident.lident) =
-  p2l ["FStar"; "Compiler"; "Effect"; "ML"]
-let (compiler_effect_failwith_lid : FStar_Ident.lident) =
-  p2l ["FStar"; "Compiler"; "Effect"; "failwith"]
-let (compiler_effect_try_with_lid : FStar_Ident.lident) =
-  p2l ["FStar"; "Compiler"; "Effect"; "try_with"]
-let (all_lid : FStar_Ident.lident) = p2l ["FStar"; "All"]
-let (all_ALL_lid : FStar_Ident.lident) = p2l ["FStar"; "All"; "All"]
-let (all_ML_lid : FStar_Ident.lident) = p2l ["FStar"; "All"; "ML"]
-let (all_failwith_lid : FStar_Ident.lident) =
-  p2l ["FStar"; "All"; "failwith"]
-let (all_try_with_lid : FStar_Ident.lident) =
-  p2l ["FStar"; "All"; "try_with"]
+let (ef_base : unit -> Prims.string Prims.list) =
+  fun uu___ ->
+    let uu___1 = FStar_Options.ml_ish () in
+    if uu___1
+    then
+      let uu___2 = FStar_Options.ml_ish_effect () in
+      FStar_String.split [46] uu___2
+    else ["FStar"; "All"]
 let (effect_ALL_lid : unit -> FStar_Ident.lident) =
   fun uu___ ->
-    let uu___1 = FStar_Options.ml_ish () in
-    if uu___1 then compiler_effect_ALL_lid else all_lid
+    let uu___1 =
+      let uu___2 = ef_base () in FStar_Compiler_List.op_At uu___2 ["ALL"] in
+    p2l uu___1
 let (effect_ML_lid : unit -> FStar_Ident.lident) =
   fun uu___ ->
-    let uu___1 = FStar_Options.ml_ish () in
-    if uu___1 then compiler_effect_ML_lid else all_ML_lid
+    let uu___1 =
+      let uu___2 = ef_base () in FStar_Compiler_List.op_At uu___2 ["ML"] in
+    p2l uu___1
 let (failwith_lid : unit -> FStar_Ident.lident) =
   fun uu___ ->
-    let uu___1 = FStar_Options.ml_ish () in
-    if uu___1 then compiler_effect_failwith_lid else all_failwith_lid
+    let uu___1 =
+      let uu___2 = ef_base () in
+      FStar_Compiler_List.op_At uu___2 ["failwith"] in
+    p2l uu___1
 let (try_with_lid : unit -> FStar_Ident.lident) =
   fun uu___ ->
-    let uu___1 = FStar_Options.ml_ish () in
-    if uu___1 then compiler_effect_try_with_lid else all_try_with_lid
+    let uu___1 =
+      let uu___2 = ef_base () in
+      FStar_Compiler_List.op_At uu___2 ["try_with"] in
+    p2l uu___1
 let (as_requires : FStar_Ident.lident) = pconst "as_requires"
 let (as_ensures : FStar_Ident.lident) = pconst "as_ensures"
 let (decreases_lid : FStar_Ident.lident) = pconst "decreases"

--- a/ocaml/fstar-lib/generated/FStar_Syntax_DsEnv.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_DsEnv.ml
@@ -612,13 +612,6 @@ let (set_dep_graph : env -> FStar_Parser_Dep.deps -> env) =
 let (sigmap :
   env -> (FStar_Syntax_Syntax.sigelt * Prims.bool) FStar_Compiler_Util.smap)
   = fun env1 -> env1.sigmap
-let (has_all_in_scope : env -> Prims.bool) =
-  fun env1 ->
-    FStar_Compiler_List.existsb
-      (fun uu___ ->
-         match uu___ with
-         | (m, uu___1) -> FStar_Ident.lid_equals m FStar_Parser_Const.all_lid)
-      env1.modules
 let (set_bv_range :
   FStar_Syntax_Syntax.bv ->
     FStar_Compiler_Range_Type.range -> FStar_Syntax_Syntax.bv)

--- a/ocaml/fstar-lib/generated/FStar_ToSyntax_ToSyntax.ml
+++ b/ocaml/fstar-lib/generated/FStar_ToSyntax_ToSyntax.ml
@@ -10479,18 +10479,6 @@ let (desugar_decls :
                         (env2, (FStar_Compiler_List.op_At sigelts se))))
           (env, []) decls in
       match uu___ with | (env1, sigelts) -> (env1, sigelts)
-let (open_prims_all :
-  (FStar_Parser_AST.decoration Prims.list -> FStar_Parser_AST.decl)
-    Prims.list)
-  =
-  [FStar_Parser_AST.mk_decl
-     (FStar_Parser_AST.Open
-        (FStar_Parser_Const.prims_lid, FStar_Syntax_Syntax.Unrestricted))
-     FStar_Compiler_Range_Type.dummyRange;
-  FStar_Parser_AST.mk_decl
-    (FStar_Parser_AST.Open
-       (FStar_Parser_Const.all_lid, FStar_Syntax_Syntax.Unrestricted))
-    FStar_Compiler_Range_Type.dummyRange]
 let (desugar_modul_common :
   FStar_Syntax_Syntax.modul FStar_Pervasives_Native.option ->
     FStar_Syntax_DsEnv.env ->

--- a/src/basic/FStar.Options.fst
+++ b/src/basic/FStar.Options.fst
@@ -238,6 +238,7 @@ let defaults =
       ("max_fuel"                     , Int 8);
       ("max_ifuel"                    , Int 2);
       ("MLish"                        , Bool false);
+      ("MLish_effect"                 , String "FStar.Compiler.Effect");
       ("no_default_includes"          , Bool false);
       ("no_extract"                   , List []);
       ("no_location_info"             , Bool false);
@@ -500,6 +501,7 @@ let get_log_types               ()      = lookup_opt "log_types"                
 let get_max_fuel                ()      = lookup_opt "max_fuel"                 as_int
 let get_max_ifuel               ()      = lookup_opt "max_ifuel"                as_int
 let get_MLish                   ()      = lookup_opt "MLish"                    as_bool
+let get_MLish_effect            ()      = lookup_opt "MLish_effect"             as_string
 let get_no_default_includes     ()      = lookup_opt "no_default_includes"      as_bool
 let get_no_extract              ()      = lookup_opt "no_extract"               (as_list as_string)
 let get_no_location_info        ()      = lookup_opt "no_location_info"         as_bool
@@ -1141,6 +1143,11 @@ let rec specs_with_types warn_unsafe : list (char & string & opt_type & Pprint.d
     "MLish",
     Const (Bool true),
     text "Trigger various specializations for compiling the F* compiler itself (not meant for user code)");
+
+  ( noshort,
+    "MLish_effect",
+    SimpleStr "module_name",
+    text "Set the default effect *module* for --MLish (default: FStar.Compiler.Effect)");
 
   ( noshort,
     "no_default_includes",
@@ -2103,6 +2110,7 @@ let log_types                    () = get_log_types                   ()
 let max_fuel                     () = get_max_fuel                    ()
 let max_ifuel                    () = get_max_ifuel                   ()
 let ml_ish                       () = get_MLish                       ()
+let ml_ish_effect                () = get_MLish_effect                ()
 let set_ml_ish                   () = set_option "MLish" (Bool true)
 let no_default_includes          () = get_no_default_includes         ()
 let no_extract                   s  = get_no_extract() |> List.existsb (module_name_eq s)

--- a/src/basic/FStar.Options.fsti
+++ b/src/basic/FStar.Options.fsti
@@ -165,6 +165,7 @@ val log_types                   : unit    -> bool
 val max_fuel                    : unit    -> int
 val max_ifuel                   : unit    -> int
 val ml_ish                      : unit    -> bool
+val ml_ish_effect               : unit    -> string
 val set_ml_ish                  : unit    -> unit
 val no_default_includes         : unit    -> bool
 val no_extract                  : string  -> bool

--- a/src/parser/FStar.Parser.Const.fst
+++ b/src/parser/FStar.Parser.Const.fst
@@ -270,38 +270,19 @@ let effect_DIV_lid   = psconst "DIV"
 let effect_Div_lid   = psconst "Div"
 let effect_Dv_lid    = psconst "Dv"
 
-(* The "All" monad and its associated symbols *)
-let compiler_effect_lid          = p2l ["FStar"; "Compiler"; "Effect"]
-let compiler_effect_ALL_lid      = p2l ["FStar"; "Compiler"; "Effect"; "ALL"]
-let compiler_effect_ML_lid       = p2l ["FStar"; "Compiler"; "Effect"; "ML"]
-let compiler_effect_failwith_lid = p2l ["FStar"; "Compiler"; "Effect"; "failwith"]
-let compiler_effect_try_with_lid = p2l ["FStar"; "Compiler"; "Effect"; "try_with"]
+(* The "All" monad and its associated symbols.
 
-let all_lid          = p2l ["FStar"; "All"]
-let all_ALL_lid      = p2l ["FStar"; "All"; "All"]
-let all_ML_lid       = p2l ["FStar"; "All"; "ML"]
-let all_failwith_lid = p2l ["FStar"; "All"; "failwith"]
-let all_try_with_lid = p2l ["FStar"; "All"; "try_with"]
+NOTE: With --MLish and --MLish_effect <module> this is somewhat configurable *)
 
-let effect_ALL_lid () =
-  if Options.ml_ish()
-  then compiler_effect_ALL_lid
-  else all_lid
+let ef_base () =
+  if Options.ml_ish ()
+  then String.split ['.'] <| Options.ml_ish_effect ()
+  else ["FStar"; "All"]
 
-let effect_ML_lid () =
-  if Options.ml_ish()
-  then compiler_effect_ML_lid
-  else all_ML_lid
-
-let failwith_lid () =
-  if Options.ml_ish()
-  then compiler_effect_failwith_lid
-  else all_failwith_lid
-
-let try_with_lid () =
-  if Options.ml_ish()
-  then compiler_effect_try_with_lid
-  else all_try_with_lid
+let effect_ALL_lid () = p2l <| ef_base () @ ["ALL"]
+let effect_ML_lid  () = p2l <| ef_base () @ ["ML"]
+let failwith_lid   () = p2l <| ef_base () @ ["failwith"]
+let try_with_lid   () = p2l <| ef_base () @ ["try_with"]
 
 let as_requires    = pconst "as_requires"
 let as_ensures     = pconst "as_ensures"

--- a/src/syntax/FStar.Syntax.DsEnv.fst
+++ b/src/syntax/FStar.Syntax.DsEnv.fst
@@ -177,9 +177,6 @@ let empty_env deps = {curmodule=None;
 let dep_graph env = env.dep_graph
 let set_dep_graph env ds = {env with dep_graph=ds}
 let sigmap env = env.sigmap
-let has_all_in_scope env =
-  List.existsb (fun (m, _) ->
-    lid_equals m Const.all_lid) env.modules
 
 let set_bv_range bv r =
     let id = set_id_range r bv.ppname in

--- a/src/tosyntax/FStar.ToSyntax.ToSyntax.fst
+++ b/src/tosyntax/FStar.ToSyntax.ToSyntax.fst
@@ -4289,10 +4289,6 @@ let desugar_decls env decls =
   in
   env, sigelts
 
-let open_prims_all =
-    [AST.mk_decl (AST.Open (C.prims_lid, Unrestricted)) Range.dummyRange;
-     AST.mk_decl (AST.Open (C.all_lid, Unrestricted)) Range.dummyRange]
-
 (* Top-level functionality: from AST to a module
    Keeps track of the name of variables and so on (in the context)
  *)


### PR DESCRIPTION
Let the user provide a module name that must contain All, ML, try_with
and failwith. This is still a very expert-only feature, but allows to
remove some magic constants from the source.

This will come in handy for the staging of the build.