### PR TITLE
Errors: Introducing '--message_format github', for github actions

### DIFF
--- a/mk/diff.sh
+++ b/mk/diff.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+if [ $# -ne 2 ]; then
+  echo "usage: $0 <actual_output> <expected_output>" >&2
+  exit 1
+fi
+
+ACTUAL="$1"
+EXPECTED="$2"
+
+DIFF="diff -u --strip-trailing-cr"
+
+if $DIFF "$ACTUAL" "$EXPECTED" ; then
+  # OK
+  exit 0
+else
+  # We're gonna fail. If we're running in CI, emit a Github
+  # error message.
+  if [ -v GITHUB_ENV ]; then
+    DIFFTEXT=$($DIFF "$ACTUAL" "$EXPECTED" | sed 's/$/%0A/' | tr -d '\n')
+    ACTUAL=$(realpath "$ACTUAL")
+    ACTUAL="${ACTUAL#$FSTAR_ROOT}"
+    EXPECTED=$(realpath "$EXPECTED")
+    EXPECTED="${EXPECTED#$FSTAR_ROOT}"
+    echo "::error::Diff failed for files $ACTUAL and $EXPECTED:%0A%0A$DIFFTEXT"
+  else
+    echo "error: Diff failed for files $ACTUAL and $EXPECTED" >&2
+  fi
+  exit 1
+fi

--- a/mk/test.mk
+++ b/mk/test.mk
@@ -119,7 +119,7 @@ $(OUTPUT_DIR)/%.out: $(OUTPUT_DIR)/%.exe
 ### Checking expected output for any kind of file (error output, ml, etc)
 $(OUTPUT_DIR)/%.diff: $(OUTPUT_DIR)/% %.expected
 	$(call msg, "DIFF", $<)
-	diff -u --strip-trailing-cr $^
+	$(FSTAR_ROOT)/mk/diff.sh $^
 	touch $@
 
 $(OUTPUT_DIR)/%.accept: $(OUTPUT_DIR)/%

--- a/src/basic/FStarC.Errors.fst
+++ b/src/basic/FStarC.Errors.fst
@@ -175,27 +175,26 @@ let optional_def (f : 'a -> PP.document) (def : PP.document) (o : option 'a) : P
 
 let format_issue' (print_hdr:bool) (issue:issue) : string =
   let open FStarC.Pprint in
-  let level_header = doc_of_string (string_of_issue_level issue.issue_level) in
-  let num_opt =
-    if issue.issue_level = EError || issue.issue_level = EWarning
-    then blank 1 ^^ optional_def (fun n -> doc_of_string (string_of_int n)) (doc_of_string "<unknown>") issue.issue_number
-    else empty
-  in
   let r = issue.issue_range in
-  let atrng : document =
-    match r with
-    | Some r when r <> Range.dummyRange ->
-      blank 1 ^^ doc_of_string "at" ^^ blank 1 ^^ doc_of_string (Range.string_of_use_range r)
-    | _ ->
-      empty
-  in
   let hdr : document =
-    if print_hdr
-    then
+    if print_hdr then (
+      let level_header = doc_of_string (string_of_issue_level issue.issue_level) in
+      let num_opt =
+        if issue.issue_level = EError || issue.issue_level = EWarning
+        then blank 1 ^^ optional_def (fun n -> doc_of_string (string_of_int n)) (doc_of_string "<unknown>") issue.issue_number
+        else empty
+      in
+      let atrng : document =
+        match r with
+        | Some r when r <> Range.dummyRange ->
+          blank 1 ^^ doc_of_string "at" ^^ blank 1 ^^ doc_of_string (Range.string_of_use_range r)
+        | _ ->
+          empty
+      in
       doc_of_string "*" ^^ blank 1 ^^ level_header ^^ num_opt ^^
         atrng ^^
         doc_of_string ":" ^^ hardline
-    else empty
+    ) else empty
   in
   let seealso : document =
     match r with

--- a/src/basic/FStarC.Options.fst
+++ b/src/basic/FStarC.Options.fst
@@ -991,7 +991,7 @@ let rec specs_with_types warn_unsafe : list (char & string & opt_type & Pprint.d
 
   ( noshort,
     "message_format",
-    EnumStr ["human"; "json"],
+    EnumStr ["human"; "json"; "github"],
     text "Format of the messages emitted by F* (default `human`)");
 
   ( noshort,
@@ -1997,6 +1997,7 @@ let message_format               () =
   match get_message_format () with
   | "human" -> Human
   | "json" -> Json
+  | "github" -> Github
   | illegal -> failwith ("print_issue: option `message_format` was expected to be `human` or `json`, not `" ^ illegal ^ "`. This should be impossible: `message_format` was supposed to be validated.")
 let force                        () = get_force                       ()
 let full_context_dependency      () = true

--- a/src/basic/FStarC.Options.fsti
+++ b/src/basic/FStarC.Options.fsti
@@ -33,7 +33,7 @@ type codegen_t =
 
 type split_queries_t = | No | OnFailure | Always
 
-type message_format_t = | Json | Human
+type message_format_t = | Json | Human | Github
 
 type option_val =
   | Bool of bool


### PR DESCRIPTION
Inspired by @W95Psp 's PR #3491, I thought this could be a nice addition. By setting this flag the warnings and errors look like this:
```
::warning file=/home/guido/r/fstar/github/ulib/FStar.UInt.fsti,line=435,endLine=435::(271) Pattern uses these theory symbols or terms that should not be in an SMT pattern:   Prims.op_Subtraction
```
And are automatically picked up by Github actions to be displayed differently in the run log and also tallied at the end of a run

In log:
![image](https://github.com/user-attachments/assets/ee495f0f-5212-412b-bfe0-81840ef8d1bc)

In workflow page:
![image](https://github.com/user-attachments/assets/e62e064b-bc99-4cf2-b035-82ffe2621eb1)

In fact, we can also auto-detect if we're running in a Github actions environment by looking for GITHUB_ENV, and default to this format if so. This may be more controversial so I'm separating the patches.

Another option is using `--message_format json` and piping all output through this filter.
```bash
#!/bin/bash

set -eu

# Call this with no arguments and feeding a build log to stdin,
# or with arguments that are filenames to buildogs.

grep '^{' "$@" | while IFS= read -r msg; do
  echo "$msg" # Always echo everything back
  level=$(jq -r .level <<< $msg)
  file=$(jq -r .range.def.file_name <<< $msg)
  # -m: do not fail if file does not exist
  file=$(realpath -m --relative-to=. "${file}")
  line=$(jq -r .range.def.start_pos.line <<< $msg)
  endLine=$(jq -r .range.def.end_pos.line <<< $msg)
  body=$(cat <<< "$msg" | jq -r '.msg | join ("; ")')
  body=$(tr '\n' ' ' <<< $body)
  if [ "${level}" == "Error" ]; then
    glevel=error
  elif [ "${level}" == "Warning" ]; then
    glevel=warning
  else
    # Info message, probably
    continue
  fi
  echo "::${glevel} file=$file,line=$line,endLine=$endLine::$body"
done
```
This also works fine.. but wouldn't be surprised if it's broken in some edge cases.
