### PR TITLE
Preparing to use this F* as stage0

### DIFF
--- a/examples/Makefile.common
+++ b/examples/Makefile.common
@@ -96,11 +96,11 @@ include .depend
 
 %.fst.output: %.fst
 	$(call msg, "OUTPUT", $(basename $(notdir $@)))
-	$(Q)$(VERBOSE_FSTAR) -f --print_expected_failures $< >$@ 2>&1
+	$(Q)$(VERBOSE_FSTAR) --message_format human -f --print_expected_failures $< >$@ 2>&1
 
 %.fsti.output: %.fsti
 	$(call msg, "OUTPUT", $(basename $(notdir $@)))
-	$(Q)$(VERBOSE_FSTAR) -f --print_expected_failures $< >$@ 2>&1
+	$(Q)$(VERBOSE_FSTAR) --message_format human -f --print_expected_failures $< >$@ 2>&1
 
 %.fst.json_output: %.fst
 	$(call msg, "JSONOUT", $(basename $(notdir $@)))

--- a/ocaml/fstar-lib/FStar_All.ml
+++ b/ocaml/fstar-lib/FStar_All.ml
@@ -1,7 +1,7 @@
-exception Failure = Failure
-let failwith x = raise (Failure x)
+exception Failure = Failure (* NB: reusing OCaml's native Failure. *)
 let exit i = exit (Z.to_int i)
 (* Not used: handled specially by extraction. If used,
    you will get all sorts of weird failures (e.g. an incomplete match
    on f2!). *)
 (* let try_with f1 f2 = try f1 () with | e -> f2 e *)
+(* let failwith x = raise (Failure x) *)

--- a/ocaml/fstar-lib/FStar_Compiler_Effect.ml
+++ b/ocaml/fstar-lib/FStar_Compiler_Effect.ml
@@ -6,9 +6,9 @@ let op_Colon_Equals x y = x := y
 let alloc x = ref x
 let raise = raise
 let exit i = exit (Z.to_int i)
-exception Failure = Failure
-let failwith x = raise (Failure x)
+exception Failure = Failure (* NB: reusing OCaml's native Failure. *)
 (* Not used: handled specially by extraction. If used,
    you will get all sorts of weird failures (e.g. an incomplete match
    on f2!). *)
 (* let try_with f1 f2 = try f1 () with | e -> f2 e *)
+(* let failwith x = raise (Failure x) *)

--- a/ocaml/fstar-lib/FStar_Parser_ParseIt.ml
+++ b/ocaml/fstar-lib/FStar_Parser_ParseIt.ml
@@ -33,7 +33,7 @@ let setLexbufPos filename lexbuf line col =
 module Path = BatPathGen.OfString
 
 let find_file filename =
-  match FStar_Options.find_file filename with
+  match FStar_Find.find_file filename with
     | Some s ->
       s
     | None ->

--- a/ocaml/fstar-lib/generated/FStar_Basefiles.ml
+++ b/ocaml/fstar-lib/generated/FStar_Basefiles.ml
@@ -1,0 +1,35 @@
+open Prims
+let (must_find : Prims.string -> Prims.string) =
+  fun fn ->
+    let uu___ = FStar_Find.find_file fn in
+    match uu___ with
+    | FStar_Pervasives_Native.Some f -> f
+    | FStar_Pervasives_Native.None ->
+        let uu___1 =
+          let uu___2 =
+            let uu___3 =
+              FStar_Compiler_Util.format1
+                "Unable to find required file \"%s\" in the module search path."
+                fn in
+            FStar_Errors_Msg.text uu___3 in
+          [uu___2] in
+        FStar_Errors.raise_error0 FStar_Errors_Codes.Fatal_ModuleNotFound ()
+          (Obj.magic FStar_Errors_Msg.is_error_message_list_doc)
+          (Obj.magic uu___1)
+let (prims : unit -> Prims.string) =
+  fun uu___ ->
+    let uu___1 = FStar_Options.custom_prims () in
+    match uu___1 with
+    | FStar_Pervasives_Native.Some fn -> fn
+    | FStar_Pervasives_Native.None -> must_find "Prims.fst"
+let (prims_basename : unit -> Prims.string) =
+  fun uu___ -> let uu___1 = prims () in FStar_Compiler_Util.basename uu___1
+let (pervasives : unit -> Prims.string) =
+  fun uu___ -> must_find "FStar.Pervasives.fsti"
+let (pervasives_basename : unit -> Prims.string) =
+  fun uu___ ->
+    let uu___1 = pervasives () in FStar_Compiler_Util.basename uu___1
+let (pervasives_native_basename : unit -> Prims.string) =
+  fun uu___ ->
+    let uu___1 = must_find "FStar.Pervasives.Native.fst" in
+    FStar_Compiler_Util.basename uu___1

--- a/ocaml/fstar-lib/generated/FStar_CheckedFiles.ml
+++ b/ocaml/fstar-lib/generated/FStar_CheckedFiles.ml
@@ -116,7 +116,7 @@ let (hash_dependences :
   fun deps ->
     fun fn ->
       let fn1 =
-        let uu___ = FStar_Options.find_file fn in
+        let uu___ = FStar_Find.find_file fn in
         match uu___ with
         | FStar_Pervasives_Native.Some fn2 -> fn2
         | uu___1 -> fn in

--- a/ocaml/fstar-lib/generated/FStar_CheckedFiles.ml
+++ b/ocaml/fstar-lib/generated/FStar_CheckedFiles.ml
@@ -179,7 +179,7 @@ let (hash_dependences :
                    FStar_Compiler_Util.format1
                      "Impossible: unknown entry in the mcache for interface %s\n"
                      iface in
-                 FStar_Compiler_Effect.failwith uu___2) in
+                 failwith uu___2) in
       let rec hash_deps out uu___ =
         match uu___ with
         | [] -> maybe_add_iface_hash out
@@ -207,7 +207,7 @@ let (hash_dependences :
                     FStar_Compiler_Util.format2
                       "Impossible: unknown entry in the cache for dependence %s of module %s"
                       fn2 module_name in
-                  FStar_Compiler_Effect.failwith uu___3 in
+                  failwith uu___3 in
             (match digest with
              | FStar_Pervasives.Inl msg -> FStar_Pervasives.Inl msg
              | FStar_Pervasives.Inr dig ->
@@ -305,7 +305,7 @@ let (load_checked_file_with_tc_result :
            match uu___1 with
            | FStar_Pervasives_Native.Some x -> x
            | FStar_Pervasives_Native.None ->
-               FStar_Compiler_Effect.failwith
+               failwith
                  "Impossible! if first phase of loading was unknown, it should have succeeded" in
          let elt = load_checked_file fn checked_fn in
          match elt with

--- a/ocaml/fstar-lib/generated/FStar_Common.ml
+++ b/ocaml/fstar-lib/generated/FStar_Common.ml
@@ -51,7 +51,7 @@ let rollback :
       fun depth ->
         let rec aux n =
           if n <= Prims.int_zero
-          then FStar_Compiler_Effect.failwith "Too many pops"
+          then failwith "Too many pops"
           else
             if n = Prims.int_one
             then pop ()
@@ -67,7 +67,7 @@ let rollback :
 let raise_failed_assertion : 'uuuuu . Prims.string -> 'uuuuu =
   fun msg ->
     let uu___ = FStar_Compiler_Util.format1 "Assertion failed: %s" msg in
-    FStar_Compiler_Effect.failwith uu___
+    failwith uu___
 let (runtime_assert : Prims.bool -> Prims.string -> unit) =
   fun b ->
     fun msg -> if Prims.op_Negation b then raise_failed_assertion msg else ()

--- a/ocaml/fstar-lib/generated/FStar_Compiler_Option.ml
+++ b/ocaml/fstar-lib/generated/FStar_Compiler_Option.ml
@@ -34,5 +34,4 @@ let get : 'a . 'a FStar_Pervasives_Native.option -> 'a =
   fun uu___ ->
     match uu___ with
     | FStar_Pervasives_Native.Some x -> x
-    | FStar_Pervasives_Native.None ->
-        FStar_Compiler_Effect.failwith "empty option"
+    | FStar_Pervasives_Native.None -> failwith "empty option"

--- a/ocaml/fstar-lib/generated/FStar_Compiler_Plugins.ml
+++ b/ocaml/fstar-lib/generated/FStar_Compiler_Plugins.ml
@@ -175,7 +175,7 @@ let (autoload_plugin : Prims.string -> Prims.bool) =
           FStar_Compiler_Util.print1
             "Trying to find a plugin for extension %s\n" ext
         else ());
-       (let uu___3 = FStar_Options.find_file (Prims.strcat ext ".cmxs") in
+       (let uu___3 = FStar_Find.find_file (Prims.strcat ext ".cmxs") in
         match uu___3 with
         | FStar_Pervasives_Native.Some fn ->
             let uu___4 =

--- a/ocaml/fstar-lib/generated/FStar_Compiler_Range_Ops.ml
+++ b/ocaml/fstar-lib/generated/FStar_Compiler_Range_Ops.ml
@@ -65,28 +65,28 @@ let (string_of_pos : FStar_Compiler_Range_Type.pos -> Prims.string) =
     FStar_Compiler_Util.format2 "%s,%s" uu___ uu___1
 let (string_of_file_name : Prims.string -> Prims.string) =
   fun f ->
-    let uu___ = FStar_Options.ide () in
+    let uu___ =
+      let uu___1 = FStar_Options_Ext.get "fstar:no_absolute_paths" in
+      uu___1 = "1" in
     if uu___
-    then
-      let uu___1 =
-        let uu___2 = FStar_Options_Ext.get "fstar:no_absolute_paths" in
-        uu___2 = "1" in
-      (if uu___1
-       then FStar_Compiler_Util.basename f
-       else
-         (try
-            (fun uu___3 ->
-               match () with
-               | () ->
-                   let uu___4 =
-                     let uu___5 = FStar_Compiler_Util.basename f in
-                     FStar_Options.find_file uu___5 in
-                   (match uu___4 with
-                    | FStar_Pervasives_Native.None -> f
-                    | FStar_Pervasives_Native.Some absolute_path ->
-                        absolute_path)) ()
-          with | uu___3 -> f))
-    else f
+    then FStar_Compiler_Util.basename f
+    else
+      (let uu___2 = FStar_Options.ide () in
+       if uu___2
+       then
+         try
+           (fun uu___3 ->
+              match () with
+              | () ->
+                  let uu___4 =
+                    let uu___5 = FStar_Compiler_Util.basename f in
+                    FStar_Find.find_file uu___5 in
+                  (match uu___4 with
+                   | FStar_Pervasives_Native.None -> f
+                   | FStar_Pervasives_Native.Some absolute_path ->
+                       absolute_path)) ()
+         with | uu___3 -> f
+       else f)
 let (file_of_range : FStar_Compiler_Range_Type.range -> Prims.string) =
   fun r ->
     let f =

--- a/ocaml/fstar-lib/generated/FStar_Errors.ml
+++ b/ocaml/fstar-lib/generated/FStar_Errors.ml
@@ -40,7 +40,7 @@ let lookup_error :
       match uu___ with
       | FStar_Pervasives_Native.Some i -> i
       | FStar_Pervasives_Native.None ->
-          FStar_Compiler_Effect.failwith "Impossible: unrecognized error"
+          failwith "Impossible: unrecognized error"
 let lookup_error_range :
   'uuuuu 'uuuuu1 .
     ('uuuuu * 'uuuuu1 * Prims.int) Prims.list ->
@@ -588,10 +588,7 @@ let (mk_default_handler : Prims.bool -> error_handler) =
       (let uu___3 =
          (FStar_Options.defensive_abort ()) &&
            (e.issue_number = (FStar_Pervasives_Native.Some defensive_errno)) in
-       if uu___3
-       then
-         FStar_Compiler_Effect.failwith "Aborting due to --defensive abort"
-       else ()) in
+       if uu___3 then failwith "Aborting due to --defensive abort" else ()) in
     let count_errors uu___ = FStar_Compiler_Effect.op_Bang err_count in
     let report uu___ =
       let unique_issues =
@@ -661,9 +658,7 @@ let (wrapped_eh_add_one : error_handler -> issue -> unit) =
             let uu___3 =
               FStar_Compiler_Effect.op_Bang FStar_Options.abort_counter in
             uu___3 = Prims.int_zero in
-          if uu___2
-          then FStar_Compiler_Effect.failwith "Aborting due to --abort_on"
-          else ()))
+          if uu___2 then failwith "Aborting due to --abort_on" else ()))
       else ()
 let (add_one : issue -> unit) =
   fun issue1 ->
@@ -731,7 +726,7 @@ let (error_context : error_context_t) =
     let uu___ = FStar_Compiler_Effect.op_Bang ctxs in
     match uu___ with
     | h::t -> (FStar_Compiler_Effect.op_Colon_Equals ctxs t; h)
-    | uu___1 -> FStar_Compiler_Effect.failwith "cannot pop error prefix..." in
+    | uu___1 -> failwith "cannot pop error prefix..." in
   let clear1 uu___ = FStar_Compiler_Effect.op_Colon_Equals ctxs [] in
   let get uu___ = FStar_Compiler_Effect.op_Bang ctxs in
   let set c = FStar_Compiler_Effect.op_Colon_Equals ctxs c in
@@ -790,8 +785,7 @@ let (uu___0 :
       let uu___1 = FStar_Compiler_Effect.op_Bang parser_callback in
       match uu___1 with
       | FStar_Pervasives_Native.None ->
-          FStar_Compiler_Effect.failwith
-            "Callback for parsing warn_error strings is not set"
+          failwith "Callback for parsing warn_error strings is not set"
       | FStar_Pervasives_Native.Some f -> f s in
     let we = FStar_Options.warn_error () in
     try
@@ -902,7 +896,7 @@ let (log_issue_ctx :
                       Prims.strcat
                         "don't use log_issue to report fatal error, should use raise_error: "
                         uu___6 in
-                    FStar_Compiler_Effect.failwith uu___5))
+                    failwith uu___5))
 let info :
   'posut .
     'posut FStar_Class_HasRange.hasRange ->

--- a/ocaml/fstar-lib/generated/FStar_Extraction_Krml.ml
+++ b/ocaml/fstar-lib/generated/FStar_Extraction_Krml.ml
@@ -1560,7 +1560,7 @@ let (find_name : env -> Prims.string -> name) =
       match uu___ with
       | FStar_Pervasives_Native.Some name1 -> name1
       | FStar_Pervasives_Native.None ->
-          FStar_Compiler_Effect.failwith "internal error: name not found"
+          failwith "internal error: name not found"
 let (find : env -> Prims.string -> Prims.int) =
   fun env1 ->
     fun x ->
@@ -1575,7 +1575,7 @@ let (find : env -> Prims.string -> Prims.int) =
           let uu___1 =
             FStar_Compiler_Util.format1 "Internal error: name not found %s\n"
               x in
-          FStar_Compiler_Effect.failwith uu___1
+          failwith uu___1
 let (find_t : env -> Prims.string -> Prims.int) =
   fun env1 ->
     fun x ->
@@ -1590,7 +1590,7 @@ let (find_t : env -> Prims.string -> Prims.int) =
           let uu___1 =
             FStar_Compiler_Util.format1 "Internal error: name not found %s\n"
               x in
-          FStar_Compiler_Effect.failwith uu___1
+          failwith uu___1
 let (add_binders :
   env -> FStar_Extraction_ML_Syntax.mlbinder Prims.list -> env) =
   fun env1 ->
@@ -1611,8 +1611,7 @@ let (list_elements :
     let lopt = FStar_Extraction_ML_Util.list_elements e in
     match lopt with
     | FStar_Pervasives_Native.None ->
-        FStar_Compiler_Effect.failwith
-          "Argument of FStar.Buffer.createL is not a list literal!"
+        failwith "Argument of FStar.Buffer.createL is not a list literal!"
     | FStar_Pervasives_Native.Some l -> l
 let (translate_flags :
   FStar_Extraction_ML_Syntax.meta Prims.list -> flag Prims.list) =
@@ -3002,7 +3001,7 @@ and (translate_expr' : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
            | FStar_Extraction_ML_Syntax.MLE_Const
                (FStar_Extraction_ML_Syntax.MLC_String s) -> EString s
            | uu___4 ->
-               FStar_Compiler_Effect.failwith
+               failwith
                  "Cannot extract string_of_literal applied to a non-literal")
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
@@ -3019,7 +3018,7 @@ and (translate_expr' : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
            | FStar_Extraction_ML_Syntax.MLE_Const
                (FStar_Extraction_ML_Syntax.MLC_String s) -> EString s
            | uu___4 ->
-               FStar_Compiler_Effect.failwith
+               failwith
                  "Cannot extract string_of_literal applied to a non-literal")
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
@@ -3036,7 +3035,7 @@ and (translate_expr' : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
            | FStar_Extraction_ML_Syntax.MLE_Const
                (FStar_Extraction_ML_Syntax.MLC_String s) -> EString s
            | uu___4 ->
-               FStar_Compiler_Effect.failwith
+               failwith
                  "Cannot extract string_of_literal applied to a non-literal")
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
@@ -3068,22 +3067,17 @@ and (translate_expr' : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
               FStar_Extraction_ML_Syntax.MLE_Const
               (FStar_Extraction_ML_Syntax.MLC_String safter)) ->
                (if FStar_Compiler_Util.contains sbefore "*/"
-                then
-                  FStar_Compiler_Effect.failwith
-                    "Before Comment contains end-of-comment marker"
+                then failwith "Before Comment contains end-of-comment marker"
                 else ();
                 if FStar_Compiler_Util.contains safter "*/"
-                then
-                  FStar_Compiler_Effect.failwith
-                    "After Comment contains end-of-comment marker"
+                then failwith "After Comment contains end-of-comment marker"
                 else ();
                 (let uu___11 =
                    let uu___12 = translate_expr env1 e1 in
                    (sbefore, uu___12, safter) in
                  EComment uu___11))
            | uu___9 ->
-               FStar_Compiler_Effect.failwith
-                 "Cannot extract comment applied to a non-literal")
+               failwith "Cannot extract comment applied to a non-literal")
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -3101,13 +3095,12 @@ and (translate_expr' : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                (FStar_Extraction_ML_Syntax.MLC_String s) ->
                (if FStar_Compiler_Util.contains s "*/"
                 then
-                  FStar_Compiler_Effect.failwith
+                  failwith
                     "Standalone Comment contains end-of-comment marker"
                 else ();
                 EStandaloneComment s)
            | uu___4 ->
-               FStar_Compiler_Effect.failwith
-                 "Cannot extract comment applied to a non-literal")
+               failwith "Cannot extract comment applied to a non-literal")
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =
@@ -3124,7 +3117,7 @@ and (translate_expr' : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                (FStar_Extraction_ML_Syntax.MLC_String s) ->
                ECast ((EString s), (TBuf (TInt UInt8)))
            | uu___4 ->
-               FStar_Compiler_Effect.failwith
+               failwith
                  "Cannot extract buffer_of_literal applied to a non-literal")
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
@@ -3303,14 +3296,14 @@ and (translate_expr' : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
             let uu___2 = FStar_Extraction_ML_Code.string_of_mlexpr ([], "") e in
             FStar_Compiler_Util.format1
               "todo: translate_expr [MLE_Let] (expr is: %s)" uu___2 in
-          FStar_Compiler_Effect.failwith uu___1
+          failwith uu___1
       | FStar_Extraction_ML_Syntax.MLE_App (head, uu___) ->
           let uu___1 =
             let uu___2 =
               FStar_Extraction_ML_Code.string_of_mlexpr ([], "") head in
             FStar_Compiler_Util.format1
               "todo: translate_expr [MLE_App] (head is: %s)" uu___2 in
-          FStar_Compiler_Effect.failwith uu___1
+          failwith uu___1
       | FStar_Extraction_ML_Syntax.MLE_Seq seqs ->
           let uu___ = FStar_Compiler_List.map (translate_expr env1) seqs in
           ESequence uu___
@@ -3343,11 +3336,11 @@ and (translate_expr' : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
             (uu___1, uu___2, uu___3) in
           EIfThenElse uu___
       | FStar_Extraction_ML_Syntax.MLE_Raise uu___ ->
-          FStar_Compiler_Effect.failwith "todo: translate_expr [MLE_Raise]"
+          failwith "todo: translate_expr [MLE_Raise]"
       | FStar_Extraction_ML_Syntax.MLE_Try uu___ ->
-          FStar_Compiler_Effect.failwith "todo: translate_expr [MLE_Try]"
+          failwith "todo: translate_expr [MLE_Try]"
       | FStar_Extraction_ML_Syntax.MLE_Coerce uu___ ->
-          FStar_Compiler_Effect.failwith "todo: translate_expr [MLE_Coerce]"
+          failwith "todo: translate_expr [MLE_Coerce]"
 and (assert_lid : env -> FStar_Extraction_ML_Syntax.mlty -> typ) =
   fun env1 ->
     fun t ->
@@ -3365,7 +3358,7 @@ and (assert_lid : env -> FStar_Extraction_ML_Syntax.mlty -> typ) =
             let uu___2 = FStar_Extraction_ML_Code.string_of_mlty ([], "") t in
             FStar_Compiler_Util.format1
               "invalid argument: expected MLTY_Named, got %s" uu___2 in
-          FStar_Compiler_Effect.failwith uu___1
+          failwith uu___1
 and (translate_branches :
   env ->
     (FStar_Extraction_ML_Syntax.mlpattern * FStar_Extraction_ML_Syntax.mlexpr
@@ -3391,7 +3384,7 @@ and (translate_branch :
             (match uu___1 with
              | (env2, pat1) ->
                  let uu___2 = translate_expr env2 expr1 in (pat1, uu___2))
-          else FStar_Compiler_Effect.failwith "todo: translate_branch"
+          else failwith "todo: translate_branch"
 and (translate_width :
   (FStar_Const.signedness * FStar_Const.width) FStar_Pervasives_Native.option
     -> width)
@@ -3477,9 +3470,9 @@ and (translate_pat :
           (match uu___ with
            | (env2, ps1) -> (env2, (PTuple (FStar_Compiler_List.rev ps1))))
       | FStar_Extraction_ML_Syntax.MLP_Const uu___ ->
-          FStar_Compiler_Effect.failwith "todo: translate_pat [MLP_Const]"
+          failwith "todo: translate_pat [MLP_Const]"
       | FStar_Extraction_ML_Syntax.MLP_Branch uu___ ->
-          FStar_Compiler_Effect.failwith "todo: translate_pat [MLP_Branch]"
+          failwith "todo: translate_pat [MLP_Branch]"
 and (translate_constant : FStar_Extraction_ML_Syntax.mlconstant -> expr) =
   fun c ->
     match c with
@@ -3496,7 +3489,7 @@ and (translate_constant : FStar_Extraction_ML_Syntax.mlconstant -> expr) =
               FStar_Compiler_Util.format1
                 "Refusing to translate a string literal that contains a null character: %s"
                 s in
-            FStar_Compiler_Effect.failwith uu___2
+            failwith uu___2
           else ());
          EString s)
     | FStar_Extraction_ML_Syntax.MLC_Char c1 ->
@@ -3513,9 +3506,9 @@ and (translate_constant : FStar_Extraction_ML_Syntax.mlconstant -> expr) =
           (uu___1, s) in
         EConstant uu___
     | FStar_Extraction_ML_Syntax.MLC_Float uu___ ->
-        FStar_Compiler_Effect.failwith "todo: translate_expr [MLC_Float]"
+        failwith "todo: translate_expr [MLC_Float]"
     | FStar_Extraction_ML_Syntax.MLC_Bytes uu___ ->
-        FStar_Compiler_Effect.failwith "todo: translate_expr [MLC_Bytes]"
+        failwith "todo: translate_expr [MLC_Bytes]"
     | FStar_Extraction_ML_Syntax.MLC_Int (s, FStar_Pervasives_Native.None) ->
         EConstant (CInt, s)
 and (mk_op_app :
@@ -3937,7 +3930,7 @@ let (translate_decl :
       | FStar_Extraction_ML_Syntax.MLM_Ty tys ->
           FStar_Compiler_List.choose (translate_type_decl env1) tys
       | FStar_Extraction_ML_Syntax.MLM_Top uu___ ->
-          FStar_Compiler_Effect.failwith "todo: translate_decl [MLM_Top]"
+          failwith "todo: translate_decl [MLM_Top]"
       | FStar_Extraction_ML_Syntax.MLM_Exn (m, uu___) ->
           (FStar_Compiler_Util.print1_warning
              "Not extracting exception %s to KaRaMeL (exceptions unsupported)\n"
@@ -3964,8 +3957,7 @@ let (translate_module :
                 FStar_Compiler_List.collect
                   (translate_decl (empty uenv module_name1)) decls
             | uu___2 ->
-                FStar_Compiler_Effect.failwith
-                  "Unexpected standalone interface or nested modules" in
+                failwith "Unexpected standalone interface or nested modules" in
           ((FStar_Compiler_String.concat "_" module_name1), program1)
 let (translate :
   FStar_Extraction_ML_UEnv.uenv ->

--- a/ocaml/fstar-lib/generated/FStar_Extraction_ML_Code.ml
+++ b/ocaml/fstar-lib/generated/FStar_Extraction_ML_Code.ml
@@ -443,9 +443,7 @@ let (string_of_mlconstant :
               (escape_or FStar_Compiler_Util.string_of_char) chars in
           Prims.strcat uu___1 "\"" in
         Prims.strcat "\"" uu___
-    | uu___ ->
-        FStar_Compiler_Effect.failwith
-          "TODO: extract integer constants properly into OCaml"
+    | uu___ -> failwith "TODO: extract integer constants properly into OCaml"
 let (string_of_etag : FStar_Extraction_ML_Syntax.e_tag -> Prims.string) =
   fun uu___ ->
     match uu___ with

--- a/ocaml/fstar-lib/generated/FStar_Extraction_ML_Modul.ml
+++ b/ocaml/fstar-lib/generated/FStar_Extraction_ML_Modul.ml
@@ -175,8 +175,7 @@ let as_pair : 'uuuuu . 'uuuuu Prims.list -> ('uuuuu * 'uuuuu) =
   fun uu___ ->
     match uu___ with
     | a::b::[] -> (a, b)
-    | uu___1 ->
-        FStar_Compiler_Effect.failwith "Expected a list with 2 elements"
+    | uu___1 -> failwith "Expected a list with 2 elements"
 let (flag_of_qual :
   FStar_Syntax_Syntax.qualifier ->
     FStar_Extraction_ML_Syntax.meta FStar_Pervasives_Native.option)
@@ -356,7 +355,7 @@ let (binders_as_mlty_binders :
                    match uu___3 with
                    | FStar_Pervasives.Inl ty ->
                        ty.FStar_Extraction_ML_UEnv.ty_b_name
-                   | uu___4 -> FStar_Compiler_Effect.failwith "Impossible" in
+                   | uu___4 -> failwith "Impossible" in
                  let ty_param_attrs =
                    FStar_Compiler_List.map
                      (fun attr ->
@@ -1098,8 +1097,7 @@ let (extract_bundle_iface :
                         iface_union uu___6
                           (iface_of_bindings (FStar_Compiler_List.flatten td)) in
                       (env2, uu___5)))
-      | uu___ ->
-          FStar_Compiler_Effect.failwith "Unexpected signature element"
+      | uu___ -> failwith "Unexpected signature element"
 let (extract_type_declaration :
   FStar_Extraction_ML_UEnv.uenv ->
     Prims.bool ->
@@ -1247,7 +1245,7 @@ let (extract_reifiable_effect :
                let uu___5 =
                  FStar_Class_Show.show FStar_Syntax_Print.showable_term tm in
                FStar_Compiler_Util.format2 "(%s) Not an fv: %s" uu___4 uu___5 in
-             FStar_Compiler_Effect.failwith uu___3) in
+             failwith uu___3) in
       let extract_action g1 a =
         (let uu___1 = FStar_Compiler_Effect.op_Bang dbg_ExtractionReify in
          if uu___1
@@ -1296,8 +1294,8 @@ let (extract_reifiable_effect :
                     | FStar_Pervasives_Native.Some tysc ->
                         ((mllb.FStar_Extraction_ML_Syntax.mllb_def), tysc)
                     | FStar_Pervasives_Native.None ->
-                        FStar_Compiler_Effect.failwith "No type scheme")
-               | uu___4 -> FStar_Compiler_Effect.failwith "Impossible" in
+                        failwith "No type scheme")
+               | uu___4 -> failwith "Impossible" in
              (match uu___3 with
               | (exp, tysc) ->
                   let uu___4 =
@@ -1536,9 +1534,7 @@ let (extract_let_rec_types :
                    lb.FStar_Syntax_Syntax.lbtyp in
                Prims.op_Negation uu___1) lbs in
         if uu___
-        then
-          FStar_Compiler_Effect.failwith
-            "Impossible: mixed mutual types and terms"
+        then failwith "Impossible: mixed mutual types and terms"
         else
           (let uu___2 =
              FStar_Compiler_List.fold_left
@@ -1861,11 +1857,9 @@ let rec (extract_sigelt_iface :
                 se2.FStar_Syntax_Syntax.sigrng;
               (g, empty_iface))
          | FStar_Syntax_Syntax.Sig_splice uu___2 ->
-             FStar_Compiler_Effect.failwith
-               "impossible: trying to extract splice"
+             failwith "impossible: trying to extract splice"
          | FStar_Syntax_Syntax.Sig_fail uu___2 ->
-             FStar_Compiler_Effect.failwith
-               "impossible: trying to extract Sig_fail"
+             failwith "impossible: trying to extract Sig_fail"
          | FStar_Syntax_Syntax.Sig_new_effect ed ->
              let uu___2 =
                (let uu___3 =
@@ -2178,8 +2172,7 @@ let (extract_bundle :
                             (FStar_Extraction_ML_Syntax.MLM_Ty td) mlattrs in
                         [uu___6] in
                       (env2, uu___5)))
-      | uu___ ->
-          FStar_Compiler_Effect.failwith "Unexpected signature element"
+      | uu___ -> failwith "Unexpected signature element"
 let (lb_is_irrelevant :
   env_t -> FStar_Syntax_Syntax.letbinding -> Prims.bool) =
   fun g ->
@@ -2275,11 +2268,9 @@ let rec (extract_sig :
                    let uu___5 = extract_reifiable_effect g ed in
                    (match uu___5 with | (env, _iface, impl) -> (env, impl))
                | FStar_Syntax_Syntax.Sig_splice uu___5 ->
-                   FStar_Compiler_Effect.failwith
-                     "impossible: trying to extract splice"
+                   failwith "impossible: trying to extract splice"
                | FStar_Syntax_Syntax.Sig_fail uu___5 ->
-                   FStar_Compiler_Effect.failwith
-                     "impossible: trying to extract Sig_fail"
+                   failwith "impossible: trying to extract Sig_fail"
                | FStar_Syntax_Syntax.Sig_new_effect uu___5 -> (g, [])
                | FStar_Syntax_Syntax.Sig_let
                    { FStar_Syntax_Syntax.lbs1 = (uu___5, lbs);
@@ -2446,8 +2437,7 @@ let rec (extract_sig :
                                                FStar_Compiler_Util.format1
                                                  "Unexpected ML decl returned by the extension: %s"
                                                  uu___11 in
-                                             FStar_Compiler_Effect.failwith
-                                               uu___10)) (g, []) decls
+                                             failwith uu___10)) (g, []) decls
                          | FStar_Pervasives.Inr err ->
                              let uu___8 =
                                FStar_Compiler_Util.format2
@@ -2571,9 +2561,7 @@ and (extract_sig_let :
       if
         Prims.op_Negation
           (FStar_Syntax_Syntax.uu___is_Sig_let se.FStar_Syntax_Syntax.sigel)
-      then
-        FStar_Compiler_Effect.failwith
-          "Impossible: should only be called with Sig_let"
+      then failwith "Impossible: should only be called with Sig_let"
       else
         (let uu___1 = se.FStar_Syntax_Syntax.sigel in
          match uu___1 with
@@ -3040,7 +3028,7 @@ and (extract_sig_let :
                          FStar_Compiler_Util.format1
                            "Impossible: Translated a let to a non-let: %s"
                            uu___8 in
-                       FStar_Compiler_Effect.failwith uu___7)))
+                       failwith uu___7)))
 let (extract' :
   FStar_Extraction_ML_UEnv.uenv ->
     FStar_Syntax_Syntax.modul ->
@@ -3133,8 +3121,7 @@ let (extract :
          let uu___1 = FStar_Options.codegen () in
          match uu___1 with
          | FStar_Pervasives_Native.None ->
-             FStar_Compiler_Effect.failwith
-               "Impossible: We're in extract, codegen must be set!"
+             failwith "Impossible: We're in extract, codegen must be set!"
          | FStar_Pervasives_Native.Some t -> t in
        (let uu___2 =
           let uu___3 =
@@ -3148,7 +3135,7 @@ let (extract :
             FStar_Compiler_Util.format1
               "Extract called on a module %s that should not be extracted"
               uu___4 in
-          FStar_Compiler_Effect.failwith uu___3
+          failwith uu___3
         else ());
        (let uu___2 = FStar_Options.interactive () in
         if uu___2

--- a/ocaml/fstar-lib/generated/FStar_Extraction_ML_RegEmb.ml
+++ b/ocaml/fstar-lib/generated/FStar_Extraction_ML_RegEmb.ml
@@ -1866,9 +1866,7 @@ let (mk_unembed :
                           br :: uu___5 in
                         FStar_Compiler_Effect.op_Colon_Equals e_branches
                           uu___4)
-               | uu___1 ->
-                   FStar_Compiler_Effect.failwith "impossible, filter above")
-            ctors;
+               | uu___1 -> failwith "impossible, filter above") ctors;
           (let nomatch =
              (FStar_Extraction_ML_Syntax.MLP_Wild,
                FStar_Pervasives_Native.None, ml_none) in
@@ -2025,9 +2023,7 @@ let (mk_embed :
                           br :: uu___5 in
                         FStar_Compiler_Effect.op_Colon_Equals e_branches
                           uu___4)
-               | uu___1 ->
-                   FStar_Compiler_Effect.failwith "impossible, filter above")
-            ctors;
+               | uu___1 -> failwith "impossible, filter above") ctors;
           (let branches =
              let uu___1 = FStar_Compiler_Effect.op_Bang e_branches in
              FStar_Compiler_List.rev uu___1 in

--- a/ocaml/fstar-lib/generated/FStar_Extraction_ML_RemoveUnusedParameters.ml
+++ b/ocaml/fstar-lib/generated/FStar_Extraction_ML_RemoveUnusedParameters.ml
@@ -104,7 +104,7 @@ let rec (elim_mlty :
                   (FStar_Compiler_List.length entry1) <>
                     (FStar_Compiler_List.length args1)
                 then
-                  FStar_Compiler_Effect.failwith
+                  failwith
                     "Impossible: arity mismatch between definition and use"
                 else ();
                 (let args2 =

--- a/ocaml/fstar-lib/generated/FStar_Extraction_ML_Syntax.ml
+++ b/ocaml/fstar-lib/generated/FStar_Extraction_ML_Syntax.ml
@@ -793,12 +793,8 @@ let (pop_unit : mltyscheme -> (e_tag * mltyscheme)) =
          | MLTY_Fun (l, eff, t) ->
              if l = ml_unit_ty
              then (eff, (vs, t))
-             else
-               FStar_Compiler_Effect.failwith
-                 "unexpected: pop_unit: domain was not unit"
-         | uu___1 ->
-             FStar_Compiler_Effect.failwith
-               "unexpected: pop_unit: not a function type")
+             else failwith "unexpected: pop_unit: domain was not unit"
+         | uu___1 -> failwith "unexpected: pop_unit: not a function type")
 let (ctor' :
   Prims.string -> FStar_Pprint.document Prims.list -> FStar_Pprint.document)
   =

--- a/ocaml/fstar-lib/generated/FStar_Extraction_ML_Term.ml
+++ b/ocaml/fstar-lib/generated/FStar_Extraction_ML_Term.ml
@@ -250,25 +250,25 @@ let rec (is_arity_aux :
             let uu___2 =
               FStar_Class_Tagged.tag_of FStar_Syntax_Syntax.tagged_term t1 in
             FStar_Compiler_Util.format1 "Impossible: is_arity (%s)" uu___2 in
-          FStar_Compiler_Effect.failwith uu___1
+          failwith uu___1
       | FStar_Syntax_Syntax.Tm_delayed uu___1 ->
           let uu___2 =
             let uu___3 =
               FStar_Class_Tagged.tag_of FStar_Syntax_Syntax.tagged_term t1 in
             FStar_Compiler_Util.format1 "Impossible: is_arity (%s)" uu___3 in
-          FStar_Compiler_Effect.failwith uu___2
+          failwith uu___2
       | FStar_Syntax_Syntax.Tm_ascribed uu___1 ->
           let uu___2 =
             let uu___3 =
               FStar_Class_Tagged.tag_of FStar_Syntax_Syntax.tagged_term t1 in
             FStar_Compiler_Util.format1 "Impossible: is_arity (%s)" uu___3 in
-          FStar_Compiler_Effect.failwith uu___2
+          failwith uu___2
       | FStar_Syntax_Syntax.Tm_meta uu___1 ->
           let uu___2 =
             let uu___3 =
               FStar_Class_Tagged.tag_of FStar_Syntax_Syntax.tagged_term t1 in
             FStar_Compiler_Util.format1 "Impossible: is_arity (%s)" uu___3 in
-          FStar_Compiler_Effect.failwith uu___2
+          failwith uu___2
       | FStar_Syntax_Syntax.Tm_lazy i ->
           let uu___1 = FStar_Syntax_Util.unfold_lazy i in
           is_arity_aux tcenv uu___1
@@ -342,13 +342,13 @@ let rec (is_type_aux :
             let uu___2 =
               FStar_Class_Tagged.tag_of FStar_Syntax_Syntax.tagged_term t1 in
             FStar_Compiler_Util.format1 "Impossible: %s" uu___2 in
-          FStar_Compiler_Effect.failwith uu___1
+          failwith uu___1
       | FStar_Syntax_Syntax.Tm_unknown ->
           let uu___ =
             let uu___1 =
               FStar_Class_Tagged.tag_of FStar_Syntax_Syntax.tagged_term t1 in
             FStar_Compiler_Util.format1 "Impossible: %s" uu___1 in
-          FStar_Compiler_Effect.failwith uu___
+          failwith uu___
       | FStar_Syntax_Syntax.Tm_lazy i ->
           let uu___ = FStar_Syntax_Util.unfold_lazy i in
           is_type_aux env uu___
@@ -381,7 +381,7 @@ let rec (is_type_aux :
                      t1 in
                  FStar_Compiler_Util.format1
                    "Extraction: variable not found: %s" uu___3 in
-               FStar_Compiler_Effect.failwith uu___2)
+               failwith uu___2)
       | FStar_Syntax_Syntax.Tm_ascribed
           { FStar_Syntax_Syntax.tm = t2; FStar_Syntax_Syntax.asc = uu___;
             FStar_Syntax_Syntax.eff_opt = uu___1;_}
@@ -793,7 +793,7 @@ let (instantiate_maybe_partial :
                                 (vs_ts, tapp)) in
                          (f, eff, t1))
                   else
-                    FStar_Compiler_Effect.failwith
+                    failwith
                       "Impossible: instantiate_maybe_partial called with too many arguments"
 let (eta_expand :
   FStar_Extraction_ML_UEnv.uenv ->
@@ -1284,21 +1284,21 @@ let rec (translate_term_to_mlty :
                 FStar_Class_Show.show FStar_Syntax_Print.showable_term t1 in
               FStar_Compiler_Util.format1 "Impossible: Unexpected term %s"
                 uu___2 in
-            FStar_Compiler_Effect.failwith uu___1
+            failwith uu___1
         | FStar_Syntax_Syntax.Tm_delayed uu___ ->
             let uu___1 =
               let uu___2 =
                 FStar_Class_Show.show FStar_Syntax_Print.showable_term t1 in
               FStar_Compiler_Util.format1 "Impossible: Unexpected term %s"
                 uu___2 in
-            FStar_Compiler_Effect.failwith uu___1
+            failwith uu___1
         | FStar_Syntax_Syntax.Tm_unknown ->
             let uu___ =
               let uu___1 =
                 FStar_Class_Show.show FStar_Syntax_Print.showable_term t1 in
               FStar_Compiler_Util.format1 "Impossible: Unexpected term %s"
                 uu___1 in
-            FStar_Compiler_Effect.failwith uu___
+            failwith uu___
         | FStar_Syntax_Syntax.Tm_lazy i ->
             let uu___ = FStar_Syntax_Util.unfold_lazy i in
             translate_term_to_mlty env uu___
@@ -1727,7 +1727,7 @@ let rec (extract_one_pat :
                         FStar_Extraction_ML_UEnv.exp_b_eff = uu___6;_}
                       -> (n, ttys)
                   | FStar_Pervasives_Native.Some uu___3 ->
-                      FStar_Compiler_Effect.failwith "Expected a constructor"
+                      failwith "Expected a constructor"
                   | FStar_Pervasives_Native.None ->
                       let uu___3 =
                         let uu___4 =
@@ -1900,9 +1900,7 @@ let (extract_pat :
               extract_one_pat false g1 p1 expected_t1 term_as_mlexpr in
             match uu___ with
             | (g2, FStar_Pervasives_Native.Some (x, v), b) -> (g2, (x, v), b)
-            | uu___1 ->
-                FStar_Compiler_Effect.failwith
-                  "Impossible: Unable to translate pattern" in
+            | uu___1 -> failwith "Impossible: Unable to translate pattern" in
           let mk_when_clause whens =
             match whens with
             | [] -> FStar_Pervasives_Native.None
@@ -1957,7 +1955,7 @@ let (maybe_eta_data_and_project_record :
                   FStar_Compiler_Util.format2
                     "Impossible: Head type is not an arrow: (%s : %s)" uu___2
                     uu___3 in
-                FStar_Compiler_Effect.failwith uu___1 in
+                failwith uu___1 in
           let as_record qual1 e =
             match ((e.FStar_Extraction_ML_Syntax.expr), qual1) with
             | (FStar_Extraction_ML_Syntax.MLE_CTor (uu___, args),
@@ -2023,8 +2021,7 @@ let (maybe_eta_data_and_project_record :
                                FStar_Extraction_ML_Syntax.with_ty
                                  e.FStar_Extraction_ML_Syntax.mlty uu___3
                            | uu___3 ->
-                               FStar_Compiler_Effect.failwith
-                                 "Impossible: Not a constructor"))) in
+                               failwith "Impossible: Not a constructor"))) in
           match ((mlAppExpr.FStar_Extraction_ML_Syntax.expr), qual) with
           | (uu___, FStar_Pervasives_Native.None) -> mlAppExpr
           | (FStar_Extraction_ML_Syntax.MLE_App
@@ -2440,8 +2437,7 @@ let rec (extract_lb_sig :
                                                 add_unit, has_c_inline,
                                                 body2))
                                        else
-                                         FStar_Compiler_Effect.failwith
-                                           "Not enough type binders")
+                                         failwith "Not enough type binders")
                               | FStar_Syntax_Syntax.Tm_uinst uu___7 ->
                                   let env =
                                     FStar_Compiler_List.fold_left
@@ -2814,7 +2810,7 @@ and (term_as_mlexpr' :
                  (head.FStar_Syntax_Syntax.hash_code)
              }
          | uu___2 ->
-             FStar_Compiler_Effect.failwith
+             failwith
                "Impossible! cannot apply args to match branches if head is not a match" in
        let t = FStar_Syntax_Subst.compress top1 in
        match t.FStar_Syntax_Syntax.n with
@@ -2824,28 +2820,28 @@ and (term_as_mlexpr' :
                FStar_Class_Tagged.tag_of FStar_Syntax_Syntax.tagged_term t in
              FStar_Compiler_Util.format1 "Impossible: Unexpected term: %s"
                uu___2 in
-           FStar_Compiler_Effect.failwith uu___1
+           failwith uu___1
        | FStar_Syntax_Syntax.Tm_delayed uu___1 ->
            let uu___2 =
              let uu___3 =
                FStar_Class_Tagged.tag_of FStar_Syntax_Syntax.tagged_term t in
              FStar_Compiler_Util.format1 "Impossible: Unexpected term: %s"
                uu___3 in
-           FStar_Compiler_Effect.failwith uu___2
+           failwith uu___2
        | FStar_Syntax_Syntax.Tm_uvar uu___1 ->
            let uu___2 =
              let uu___3 =
                FStar_Class_Tagged.tag_of FStar_Syntax_Syntax.tagged_term t in
              FStar_Compiler_Util.format1 "Impossible: Unexpected term: %s"
                uu___3 in
-           FStar_Compiler_Effect.failwith uu___2
+           failwith uu___2
        | FStar_Syntax_Syntax.Tm_bvar uu___1 ->
            let uu___2 =
              let uu___3 =
                FStar_Class_Tagged.tag_of FStar_Syntax_Syntax.tagged_term t in
              FStar_Compiler_Util.format1 "Impossible: Unexpected term: %s"
                uu___3 in
-           FStar_Compiler_Effect.failwith uu___2
+           failwith uu___2
        | FStar_Syntax_Syntax.Tm_lazy i ->
            let uu___1 = FStar_Syntax_Util.unfold_lazy i in
            term_as_mlexpr g uu___1
@@ -2975,7 +2971,7 @@ and (term_as_mlexpr' :
                           FStar_Compiler_Util.format1
                             "This should not happen (should have been handled at Tm_abs level for effect %s)"
                             uu___6 in
-                        FStar_Compiler_Effect.failwith uu___5))
+                        failwith uu___5))
             | uu___2 -> term_as_mlexpr g t2)
        | FStar_Syntax_Syntax.Tm_meta
            { FStar_Syntax_Syntax.tm2 = t1;
@@ -3567,7 +3563,7 @@ and (term_as_mlexpr' :
                                 (exp_b.FStar_Extraction_ML_UEnv.exp_b_tscheme),
                                 (exp_b.FStar_Extraction_ML_UEnv.exp_b_eff)),
                                q))
-                        | uu___7 -> FStar_Compiler_Effect.failwith "FIXME Ty" in
+                        | uu___7 -> failwith "FIXME Ty" in
                       (match uu___5 with
                        | ((head_ml, (vars, t1), head_eff), qual) ->
                            let has_typ_apps =
@@ -3646,7 +3642,7 @@ and (term_as_mlexpr' :
                                                      [FStar_Extraction_ML_Syntax.ml_unit])) in
                                             (uu___12, eff, t2))
                                    | uu___9 ->
-                                       FStar_Compiler_Effect.failwith
+                                       failwith
                                          "Impossible: Unexpected head term" in
                                  (match uu___8 with
                                   | (head2, head_eff1, t2) ->
@@ -3693,7 +3689,7 @@ and (term_as_mlexpr' :
                                 (exp_b.FStar_Extraction_ML_UEnv.exp_b_tscheme),
                                 (exp_b.FStar_Extraction_ML_UEnv.exp_b_eff)),
                                q))
-                        | uu___7 -> FStar_Compiler_Effect.failwith "FIXME Ty" in
+                        | uu___7 -> failwith "FIXME Ty" in
                       (match uu___5 with
                        | ((head_ml, (vars, t1), head_eff), qual) ->
                            let has_typ_apps =
@@ -3772,7 +3768,7 @@ and (term_as_mlexpr' :
                                                      [FStar_Extraction_ML_Syntax.ml_unit])) in
                                             (uu___12, eff, t2))
                                    | uu___9 ->
-                                       FStar_Compiler_Effect.failwith
+                                       failwith
                                          "Impossible: Unexpected head term" in
                                  (match uu___8 with
                                   | (head2, head_eff1, t2) ->
@@ -3832,8 +3828,7 @@ and (term_as_mlexpr' :
            let f1 =
              match f with
              | FStar_Pervasives_Native.None ->
-                 FStar_Compiler_Effect.failwith
-                   "Ascription node with an empty effect label"
+                 failwith "Ascription node with an empty effect label"
              | FStar_Pervasives_Native.Some l -> effect_as_etag g l in
            let uu___3 = check_term_as_mlexpr g e0 f1 t1 in
            (match uu___3 with | (e, t2) -> (e, f1, t2))
@@ -4295,7 +4290,7 @@ and (term_as_mlexpr' :
                                                f_then f_else in
                                            (uu___8, uu___9, t_branch))))
                         | uu___5 ->
-                            FStar_Compiler_Effect.failwith
+                            failwith
                               "ITE pats matched but then and else expressions not found?")
                      else
                        (let uu___6 =
@@ -4543,9 +4538,7 @@ let (ind_discriminator_body :
                                   (g1,
                                     ((v, FStar_Extraction_ML_Syntax.MLTY_Top)
                                     :: vs)))) binders1 (env, [])
-              | uu___4 ->
-                  FStar_Compiler_Effect.failwith
-                    "Discriminator must be a function" in
+              | uu___4 -> failwith "Discriminator must be a function" in
             (match uu___2 with
              | (g, wildcards) ->
                  let uu___3 = FStar_Extraction_ML_UEnv.new_mlident g in

--- a/ocaml/fstar-lib/generated/FStar_Extraction_ML_UEnv.ml
+++ b/ocaml/fstar-lib/generated/FStar_Extraction_ML_UEnv.ml
@@ -366,7 +366,7 @@ let (lookup_fv :
               FStar_Compiler_Util.format3
                 "Internal error: (%s) free variable %s not found during extraction (erased=%s)\n"
                 uu___2 uu___3 uu___4 in
-            FStar_Compiler_Effect.failwith uu___1
+            failwith uu___1
 let (lookup_bv : uenv -> FStar_Syntax_Syntax.bv -> ty_or_exp_b) =
   fun g ->
     fun bv ->
@@ -388,7 +388,7 @@ let (lookup_bv : uenv -> FStar_Syntax_Syntax.bv -> ty_or_exp_b) =
               FStar_Class_Show.show FStar_Syntax_Print.showable_bv bv in
             FStar_Compiler_Util.format2 "(%s) bound Variable %s not found\n"
               uu___1 uu___2 in
-          FStar_Compiler_Effect.failwith uu___
+          failwith uu___
       | FStar_Pervasives_Native.Some y -> y
 let (lookup_term :
   uenv ->
@@ -406,16 +406,14 @@ let (lookup_term :
             let uu___1 = lookup_fv t.FStar_Syntax_Syntax.pos g x in
             FStar_Pervasives.Inr uu___1 in
           (uu___, (x.FStar_Syntax_Syntax.fv_qual))
-      | uu___ ->
-          FStar_Compiler_Effect.failwith
-            "Impossible: lookup_term for a non-name"
+      | uu___ -> failwith "Impossible: lookup_term for a non-name"
 let (lookup_ty : uenv -> FStar_Syntax_Syntax.bv -> ty_binding) =
   fun g ->
     fun x ->
       let uu___ = lookup_bv g x in
       match uu___ with
       | FStar_Pervasives.Inl ty -> ty
-      | uu___1 -> FStar_Compiler_Effect.failwith "Expected a type name"
+      | uu___1 -> failwith "Expected a type name"
 let (lookup_tydef :
   uenv ->
     FStar_Extraction_ML_Syntax.mlpath ->
@@ -459,7 +457,7 @@ let (mlpath_of_lident :
            (let uu___2 =
               let uu___3 = FStar_Ident.string_of_lid x in
               Prims.strcat "Identifier not found: " uu___3 in
-            FStar_Compiler_Effect.failwith uu___2))
+            failwith uu___2))
       | FStar_Pervasives_Native.Some mlp -> mlp
 let (is_type_name : uenv -> FStar_Syntax_Syntax.fv -> Prims.bool) =
   fun g ->
@@ -509,7 +507,7 @@ let (lookup_record_field_name :
                let uu___2 =
                  let uu___3 = FStar_Ident.string_of_lid key in
                  Prims.strcat "Field name not found: " uu___3 in
-               FStar_Compiler_Effect.failwith uu___2
+               failwith uu___2
            | FStar_Pervasives_Native.Some mlp ->
                let uu___2 = mlp in
                (match uu___2 with
@@ -919,7 +917,7 @@ let (extend_fv :
                let uu___3 =
                  FStar_Extraction_ML_Syntax.mltyscheme_to_string t_x in
                FStar_Compiler_Util.format1 "freevars found (%s)" uu___3 in
-             FStar_Compiler_Effect.failwith uu___2)
+             failwith uu___2)
 let (extend_erased_fv : uenv -> FStar_Syntax_Syntax.fv -> uenv) =
   fun g ->
     fun f ->

--- a/ocaml/fstar-lib/generated/FStar_Extraction_ML_Util.ml
+++ b/ocaml/fstar-lib/generated/FStar_Extraction_ML_Util.ml
@@ -22,8 +22,7 @@ let (mlconst_of_const' :
   FStar_Const.sconst -> FStar_Extraction_ML_Syntax.mlconstant) =
   fun sctt ->
     match sctt with
-    | FStar_Const.Const_effect ->
-        FStar_Compiler_Effect.failwith "Unsupported constant"
+    | FStar_Const.Const_effect -> failwith "Unsupported constant"
     | FStar_Const.Const_range uu___ -> FStar_Extraction_ML_Syntax.MLC_Unit
     | FStar_Const.Const_unit -> FStar_Extraction_ML_Syntax.MLC_Unit
     | FStar_Const.Const_char c -> FStar_Extraction_ML_Syntax.MLC_Char c
@@ -33,20 +32,15 @@ let (mlconst_of_const' :
     | FStar_Const.Const_string (s, uu___) ->
         FStar_Extraction_ML_Syntax.MLC_String s
     | FStar_Const.Const_range_of ->
-        FStar_Compiler_Effect.failwith
-          "Unhandled constant: range_of/set_range_of"
+        failwith "Unhandled constant: range_of/set_range_of"
     | FStar_Const.Const_set_range_of ->
-        FStar_Compiler_Effect.failwith
-          "Unhandled constant: range_of/set_range_of"
+        failwith "Unhandled constant: range_of/set_range_of"
     | FStar_Const.Const_real uu___ ->
-        FStar_Compiler_Effect.failwith
-          "Unhandled constant: real/reify/reflect"
+        failwith "Unhandled constant: real/reify/reflect"
     | FStar_Const.Const_reify uu___ ->
-        FStar_Compiler_Effect.failwith
-          "Unhandled constant: real/reify/reflect"
+        failwith "Unhandled constant: real/reify/reflect"
     | FStar_Const.Const_reflect uu___ ->
-        FStar_Compiler_Effect.failwith
-          "Unhandled constant: real/reify/reflect"
+        failwith "Unhandled constant: real/reify/reflect"
 let (mlconst_of_const :
   FStar_Compiler_Range_Type.range ->
     FStar_Const.sconst -> FStar_Extraction_ML_Syntax.mlconstant)
@@ -62,7 +56,7 @@ let (mlconst_of_const :
               FStar_Class_Show.show FStar_Syntax_Print.showable_const c in
             FStar_Compiler_Util.format2
               "(%s) Failed to translate constant %s " uu___2 uu___3 in
-          FStar_Compiler_Effect.failwith uu___1
+          failwith uu___1
 let (mlexpr_of_range :
   FStar_Compiler_Range_Type.range -> FStar_Extraction_ML_Syntax.mlexpr') =
   fun r ->
@@ -194,7 +188,7 @@ let (subst :
       let uu___ = try_subst ts args in
       match uu___ with
       | FStar_Pervasives_Native.None ->
-          FStar_Compiler_Effect.failwith
+          failwith
             "Substitution must be fully applied (see GitHub issue #490)"
       | FStar_Pervasives_Native.Some t -> t
 let (udelta_unfold :
@@ -225,7 +219,7 @@ let (udelta_unfold :
                       FStar_Compiler_Util.format3
                         "Substitution must be fully applied; got an application of %s with %s args whereas %s were expected (see GitHub issue #490)"
                         uu___4 uu___5 uu___6 in
-                    FStar_Compiler_Effect.failwith uu___3
+                    failwith uu___3
                 | FStar_Pervasives_Native.Some r ->
                     FStar_Pervasives_Native.Some r)
            | uu___2 -> FStar_Pervasives_Native.None)
@@ -287,7 +281,7 @@ let (join :
               FStar_Compiler_Util.format3
                 "Impossible (%s): Inconsistent effects %s and %s" uu___2
                 uu___3 uu___4 in
-            FStar_Compiler_Effect.failwith uu___1
+            failwith uu___1
 let (join_l :
   FStar_Compiler_Range_Type.range ->
     FStar_Extraction_ML_Syntax.e_tag Prims.list ->
@@ -528,7 +522,7 @@ let (record_field_path :
          | (ns, uu___3) ->
              FStar_Compiler_List.map (fun id -> FStar_Ident.string_of_id id)
                ns)
-    | uu___1 -> FStar_Compiler_Effect.failwith "impos"
+    | uu___1 -> failwith "impos"
 let record_fields :
   'a .
     FStar_Ident.lident Prims.list ->

--- a/ocaml/fstar-lib/generated/FStar_Find.ml
+++ b/ocaml/fstar-lib/generated/FStar_Find.ml
@@ -1,0 +1,38 @@
+open Prims
+let (find_file : Prims.string -> Prims.string FStar_Pervasives_Native.option)
+  =
+  let file_map = FStar_Compiler_Util.smap_create (Prims.of_int (100)) in
+  fun filename ->
+    let uu___ = FStar_Compiler_Util.smap_try_find file_map filename in
+    match uu___ with
+    | FStar_Pervasives_Native.Some f -> f
+    | FStar_Pervasives_Native.None ->
+        let result =
+          try
+            (fun uu___1 ->
+               match () with
+               | () ->
+                   let uu___2 = FStar_Compiler_Util.is_path_absolute filename in
+                   if uu___2
+                   then
+                     (if FStar_Compiler_Util.file_exists filename
+                      then FStar_Pervasives_Native.Some filename
+                      else FStar_Pervasives_Native.None)
+                   else
+                     (let uu___4 =
+                        let uu___5 = FStar_Options.include_path () in
+                        FStar_List_Tot_Base.rev uu___5 in
+                      FStar_Compiler_Util.find_map uu___4
+                        (fun p ->
+                           let path =
+                             if p = "."
+                             then filename
+                             else FStar_Compiler_Util.join_paths p filename in
+                           if FStar_Compiler_Util.file_exists path
+                           then FStar_Pervasives_Native.Some path
+                           else FStar_Pervasives_Native.None))) ()
+          with | uu___1 -> FStar_Pervasives_Native.None in
+        (if FStar_Pervasives_Native.uu___is_Some result
+         then FStar_Compiler_Util.smap_add file_map filename result
+         else ();
+         result)

--- a/ocaml/fstar-lib/generated/FStar_Interactive_CompletionTable.ml
+++ b/ocaml/fstar-lib/generated/FStar_Interactive_CompletionTable.ml
@@ -101,10 +101,8 @@ let merge_increasing_lists_rev :
     fun lists ->
       let cmp v1 v2 =
         match (v1, v2) with
-        | ((uu___, []), uu___1) ->
-            FStar_Compiler_Effect.failwith "impossible"
-        | (uu___, (uu___1, [])) ->
-            FStar_Compiler_Effect.failwith "impossible"
+        | ((uu___, []), uu___1) -> failwith "impossible"
+        | (uu___, (uu___1, [])) -> failwith "impossible"
         | ((pr1, h1::uu___), (pr2, h2::uu___1)) ->
             let cmp_h =
               let uu___2 = key_fn h1 in
@@ -115,7 +113,7 @@ let merge_increasing_lists_rev :
         match uu___ with
         | FStar_Pervasives_Native.None -> acc
         | FStar_Pervasives_Native.Some ((pr, []), uu___1) ->
-            FStar_Compiler_Effect.failwith "impossible"
+            failwith "impossible"
         | FStar_Pervasives_Native.Some ((pr, v::[]), lists2) ->
             let uu___1 = push_nodup key_fn v acc in aux lists2 uu___1
         | FStar_Pervasives_Native.Some ((pr, v::tl), lists2) ->
@@ -168,9 +166,7 @@ let rec btree_from_list :
          match uu___1 with
          | (lbt, nodes_left) ->
              (match nodes_left with
-              | [] ->
-                  FStar_Compiler_Effect.failwith
-                    "Invalid size passed to btree_from_list"
+              | [] -> failwith "Invalid size passed to btree_from_list"
               | (k, v)::nodes_left1 ->
                   let uu___2 = btree_from_list nodes_left1 rbt_size in
                   (match uu___2 with
@@ -396,7 +392,7 @@ let rec trie_find_exact :
   fun tr ->
     fun query1 ->
       match query1 with
-      | [] -> FStar_Compiler_Effect.failwith "Empty query in trie_find_exact"
+      | [] -> failwith "Empty query in trie_find_exact"
       | name::[] -> names_find_exact tr.bindings name
       | ns::query2 ->
           let uu___ = names_find_exact tr.namespaces ns in

--- a/ocaml/fstar-lib/generated/FStar_Interactive_Ide.ml
+++ b/ocaml/fstar-lib/generated/FStar_Interactive_Ide.ml
@@ -1467,8 +1467,7 @@ let (load_partial_checked_file :
         let uu___ = FStar_CheckedFiles.load_module_from_cache env filename in
         match uu___ with
         | FStar_Pervasives_Native.None ->
-            FStar_Compiler_Effect.failwith
-              (Prims.strcat "cannot find checked file for " filename)
+            failwith (Prims.strcat "cannot find checked file for " filename)
         | FStar_Pervasives_Native.Some tc_result ->
             let uu___1 =
               FStar_Universal.with_dsenv_of_tcenv env
@@ -1506,7 +1505,7 @@ let (load_partial_checked_file :
                        | (found_decl, m) ->
                            if Prims.op_Negation found_decl
                            then
-                             FStar_Compiler_Effect.failwith
+                             failwith
                                (Prims.strcat
                                   "did not find declaration with lident "
                                   until_lid)
@@ -2977,16 +2976,15 @@ let (js_repl_init_opts : unit -> unit) =
     | (res, fnames) ->
         (match res with
          | FStar_Getopt.Error msg ->
-             FStar_Compiler_Effect.failwith (Prims.strcat "repl_init: " msg)
-         | FStar_Getopt.Help ->
-             FStar_Compiler_Effect.failwith "repl_init: --help unexpected"
+             failwith (Prims.strcat "repl_init: " msg)
+         | FStar_Getopt.Help -> failwith "repl_init: --help unexpected"
          | FStar_Getopt.Success ->
              (match fnames with
               | [] ->
-                  FStar_Compiler_Effect.failwith
+                  failwith
                     "repl_init: No file name given in --ide invocation"
               | h::uu___2::uu___3 ->
-                  FStar_Compiler_Effect.failwith
+                  failwith
                     "repl_init: Too many file names given in --ide invocation"
               | uu___2 -> ()))
 let rec (go : FStar_Interactive_Ide_Types.repl_state -> Prims.int) =

--- a/ocaml/fstar-lib/generated/FStar_Interactive_Incremental.ml
+++ b/ocaml/fstar-lib/generated/FStar_Interactive_Incremental.ml
@@ -517,8 +517,7 @@ let (run_full_buffer :
                        log_syntax_issues (FStar_Pervasives_Native.Some err)
                      else ();
                      ([], []))
-                | uu___ ->
-                    FStar_Compiler_Effect.failwith "Unexpected parse result" in
+                | uu___ -> failwith "Unexpected parse result" in
               qs
 let (format_code :
   FStar_Interactive_Ide_Types.repl_state ->
@@ -582,4 +581,4 @@ let (format_code :
       | FStar_Parser_ParseIt.ParseError err ->
           let uu___ = let uu___1 = syntax_issue err in [uu___1] in
           FStar_Pervasives.Inr uu___
-      | uu___ -> FStar_Compiler_Effect.failwith "Unexpected parse result"
+      | uu___ -> failwith "Unexpected parse result"

--- a/ocaml/fstar-lib/generated/FStar_Interactive_Legacy.ml
+++ b/ocaml/fstar-lib/generated/FStar_Interactive_Legacy.ml
@@ -28,7 +28,7 @@ let (tc_one_file :
              | (uu___2, env1) ->
                  ((FStar_Pervasives_Native.None, intf_or_impl), env1,
                    remaining1))
-        | [] -> FStar_Compiler_Effect.failwith "Impossible" in
+        | [] -> failwith "Impossible" in
       match uu___ with
       | ((intf, impl), env1, remaining1) -> ((intf, impl), env1, remaining1)
 type env_t = FStar_TypeChecker_Env.env
@@ -526,7 +526,7 @@ let (update_deps :
                  | (FStar_Pervasives_Native.None,
                     FStar_Pervasives_Native.None) -> false
                  | (uu___, uu___1) ->
-                     FStar_Compiler_Effect.failwith
+                     failwith
                        "Impossible, if the interface is None, the timestamp entry should also be None") in
             let rec iterate depnames st env' ts1 good_stack good_ts =
               let match_dep depnames1 intf impl =

--- a/ocaml/fstar-lib/generated/FStar_Interactive_PushHelper.ml
+++ b/ocaml/fstar-lib/generated/FStar_Interactive_PushHelper.ml
@@ -873,7 +873,8 @@ let (add_module_completions :
         let mods = FStar_Parser_Dep.build_inclusion_candidates_list () in
         let loaded_mods_set =
           let uu___ = FStar_Compiler_Util.psmap_empty () in
-          let uu___1 = let uu___2 = FStar_Options.prims () in uu___2 :: deps in
+          let uu___1 =
+            let uu___2 = FStar_Basefiles.prims () in uu___2 :: deps in
           FStar_Compiler_List.fold_left
             (fun acc ->
                fun dep ->

--- a/ocaml/fstar-lib/generated/FStar_Interactive_PushHelper.ml
+++ b/ocaml/fstar-lib/generated/FStar_Interactive_PushHelper.ml
@@ -338,7 +338,7 @@ let (pop_repl :
     fun st ->
       let uu___ = FStar_Compiler_Effect.op_Bang repl_stack in
       match uu___ with
-      | [] -> FStar_Compiler_Effect.failwith "Too many pops"
+      | [] -> failwith "Too many pops"
       | (depth, (uu___1, st'))::stack_tl ->
           let env =
             rollback_env

--- a/ocaml/fstar-lib/generated/FStar_Main.ml
+++ b/ocaml/fstar-lib/generated/FStar_Main.ml
@@ -71,7 +71,7 @@ let (load_native_tactics : unit -> unit) =
       let uu___1 = ml_module_name m in Prims.strcat uu___1 ".ml" in
     let cmxs_file m =
       let cmxs = let uu___1 = ml_module_name m in Prims.strcat uu___1 ".cmxs" in
-      let uu___1 = FStar_Options.find_file cmxs in
+      let uu___1 = FStar_Find.find_file cmxs in
       match uu___1 with
       | FStar_Pervasives_Native.Some f -> f
       | FStar_Pervasives_Native.None ->
@@ -85,7 +85,7 @@ let (load_native_tactics : unit -> unit) =
               (Obj.magic uu___2)
           else
             (let uu___3 =
-               let uu___4 = ml_file m in FStar_Options.find_file uu___4 in
+               let uu___4 = ml_file m in FStar_Find.find_file uu___4 in
              match uu___3 with
              | FStar_Pervasives_Native.None ->
                  let uu___4 =
@@ -101,7 +101,7 @@ let (load_native_tactics : unit -> unit) =
                  let dir = FStar_Compiler_Util.dirname ml in
                  ((let uu___5 = let uu___6 = ml_module_name m in [uu___6] in
                    FStar_Compiler_Plugins.compile_modules dir uu___5);
-                  (let uu___5 = FStar_Options.find_file cmxs in
+                  (let uu___5 = FStar_Find.find_file cmxs in
                    match uu___5 with
                    | FStar_Pervasives_Native.None ->
                        let uu___6 =

--- a/ocaml/fstar-lib/generated/FStar_Main.ml
+++ b/ocaml/fstar-lib/generated/FStar_Main.ml
@@ -225,7 +225,7 @@ let go : 'uuuuu . 'uuuuu -> unit =
                           else FStar_Prettyprint.FromTempToFile in
                         FStar_Prettyprint.generate printing_mode filenames
                       else
-                        FStar_Compiler_Effect.failwith
+                        failwith
                           "You seem to be using the F#-generated version ofthe compiler ; \\o\n                         reindenting is not known to work yet with this version")
                    else
                      (let uu___11 =
@@ -494,8 +494,7 @@ let (lazy_chooser :
   fun k ->
     fun i ->
       match k with
-      | FStar_Syntax_Syntax.BadLazy ->
-          FStar_Compiler_Effect.failwith "lazy chooser: got a BadLazy"
+      | FStar_Syntax_Syntax.BadLazy -> failwith "lazy chooser: got a BadLazy"
       | FStar_Syntax_Syntax.Lazy_bv ->
           FStar_Reflection_V2_Embeddings.unfold_lazy_bv i
       | FStar_Syntax_Syntax.Lazy_namedv ->

--- a/ocaml/fstar-lib/generated/FStar_Options.ml
+++ b/ocaml/fstar-lib/generated/FStar_Options.ml
@@ -141,23 +141,21 @@ let (as_bool : option_val -> Prims.bool) =
   fun uu___ ->
     match uu___ with
     | Bool b -> b
-    | uu___1 -> FStar_Compiler_Effect.failwith "Impos: expected Bool"
+    | uu___1 -> failwith "Impos: expected Bool"
 let (as_int : option_val -> Prims.int) =
   fun uu___ ->
-    match uu___ with
-    | Int b -> b
-    | uu___1 -> FStar_Compiler_Effect.failwith "Impos: expected Int"
+    match uu___ with | Int b -> b | uu___1 -> failwith "Impos: expected Int"
 let (as_string : option_val -> Prims.string) =
   fun uu___ ->
     match uu___ with
     | String b -> b
     | Path b -> FStar_Common.try_convert_file_name_to_mixed b
-    | uu___1 -> FStar_Compiler_Effect.failwith "Impos: expected String"
+    | uu___1 -> failwith "Impos: expected String"
 let (as_list' : option_val -> option_val Prims.list) =
   fun uu___ ->
     match uu___ with
     | List ts -> ts
-    | uu___1 -> FStar_Compiler_Effect.failwith "Impos: expected List"
+    | uu___1 -> failwith "Impos: expected List"
 let as_list :
   'uuuuu . (option_val -> 'uuuuu) -> option_val -> 'uuuuu Prims.list =
   fun as_t ->
@@ -182,8 +180,7 @@ let (as_comma_string_list : option_val -> Prims.string Prims.list) =
                let uu___2 = as_string l in
                FStar_Compiler_Util.split uu___2 ",") ls in
         FStar_Compiler_List.flatten uu___1
-    | uu___1 ->
-        FStar_Compiler_Effect.failwith "Impos: expected String (comma list)"
+    | uu___1 -> failwith "Impos: expected String (comma list)"
 let copy_optionstate :
   'uuuuu . 'uuuuu FStar_Compiler_Util.smap -> 'uuuuu FStar_Compiler_Util.smap
   = fun m -> FStar_Compiler_Util.smap_copy m
@@ -237,12 +234,12 @@ let (pop : unit -> unit) =
   fun uu___ ->
     let uu___1 = FStar_Compiler_Effect.op_Bang history in
     match uu___1 with
-    | [] -> FStar_Compiler_Effect.failwith "TOO MANY POPS!"
+    | [] -> failwith "TOO MANY POPS!"
     | uu___2::levs ->
         (FStar_Compiler_Effect.op_Colon_Equals history levs;
          (let uu___4 =
             let uu___5 = internal_pop () in Prims.op_Negation uu___5 in
-          if uu___4 then FStar_Compiler_Effect.failwith "aaa!!!" else ()))
+          if uu___4 then failwith "aaa!!!" else ()))
 let (set : optionstate -> unit) =
   fun o -> FStar_Compiler_Effect.op_Colon_Equals fstar_options o
 let (depth : unit -> Prims.int) =
@@ -433,7 +430,7 @@ let (get_option : Prims.string -> option_val) =
         let uu___1 =
           let uu___2 = FStar_Compiler_String.op_Hat s " not found" in
           FStar_Compiler_String.op_Hat "Impossible: option " uu___2 in
-        FStar_Compiler_Effect.failwith uu___1
+        failwith uu___1
     | FStar_Pervasives_Native.Some s1 -> s1
 let rec (option_val_to_string : option_val -> Prims.string) =
   fun v ->
@@ -1101,7 +1098,7 @@ let rec (parse_opt_val :
             let uu___1 =
               FStar_Compiler_Util.format1 "Invalid argument to --%s"
                 opt_name1 in
-            FStar_Compiler_Effect.failwith uu___1
+            failwith uu___1
 let rec (desc_of_opt_type :
   opt_type -> Prims.string FStar_Pervasives_Native.option) =
   fun typ ->
@@ -1161,8 +1158,8 @@ let (interp_quake_arg : Prims.string -> (Prims.int * Prims.int * Prims.bool))
         if k = "k"
         then
           let uu___ = ios f1 in let uu___1 = ios f2 in (uu___, uu___1, true)
-        else FStar_Compiler_Effect.failwith "unexpected value for --quake"
-    | uu___ -> FStar_Compiler_Effect.failwith "unexpected value for --quake"
+        else failwith "unexpected value for --quake"
+    | uu___ -> failwith "unexpected value for --quake"
 let (uu___1 : (((Prims.string -> unit) -> unit) * (Prims.string -> unit))) =
   let cb = FStar_Compiler_Util.mk_ref FStar_Pervasives_Native.None in
   let set1 f =
@@ -1203,8 +1200,8 @@ let rec (specs_with_types :
                | Int x ->
                    (FStar_Compiler_Effect.op_Colon_Equals abort_counter x;
                     Int x)
-               | x -> FStar_Compiler_Effect.failwith "?"),
-             (IntStr "non-negative integer"))), uu___2) in
+               | x -> failwith "?"), (IntStr "non-negative integer"))),
+        uu___2) in
     let uu___2 =
       let uu___3 =
         let uu___4 = text "Admit SMT queries, unsafe! (default 'false')" in
@@ -1348,9 +1345,7 @@ let rec (specs_with_types :
                                                    (FStar_Compiler_Debug.set_debug_all
                                                       ();
                                                     o)
-                                               | uu___35 ->
-                                                   FStar_Compiler_Effect.failwith
-                                                     "?"),
+                                               | uu___35 -> failwith "?"),
                                              (Const (Bool true)))), uu___34) in
                                     let uu___34 =
                                       let uu___35 =
@@ -1806,7 +1801,7 @@ let rec (specs_with_types :
                                                                     | 
                                                                     uu___91
                                                                     ->
-                                                                    FStar_Compiler_Effect.failwith
+                                                                    failwith
                                                                     "unexpected value for --fuel" in
                                                                     (match uu___90
                                                                     with
@@ -1828,7 +1823,7 @@ let rec (specs_with_types :
                                                                     | 
                                                                     uu___90
                                                                     ->
-                                                                    FStar_Compiler_Effect.failwith
+                                                                    failwith
                                                                     "impos"),
                                                                     (SimpleStr
                                                                     "non-negative integer or pair of non-negative integers"))),
@@ -1875,7 +1870,7 @@ let rec (specs_with_types :
                                                                     | 
                                                                     uu___93
                                                                     ->
-                                                                    FStar_Compiler_Effect.failwith
+                                                                    failwith
                                                                     "unexpected value for --ifuel" in
                                                                     (match uu___92
                                                                     with
@@ -1897,7 +1892,7 @@ let rec (specs_with_types :
                                                                     | 
                                                                     uu___92
                                                                     ->
-                                                                    FStar_Compiler_Effect.failwith
+                                                                    failwith
                                                                     "impos"),
                                                                     (SimpleStr
                                                                     "non-negative integer or pair of non-negative integers"))),
@@ -2435,7 +2430,7 @@ let rec (specs_with_types :
                                                                     | 
                                                                     uu___156
                                                                     ->
-                                                                    FStar_Compiler_Effect.failwith
+                                                                    failwith
                                                                     "impos"),
                                                                     (SimpleStr
                                                                     "positive integer or pair of positive integers"))),
@@ -2559,7 +2554,7 @@ let rec (specs_with_types :
                                                                     | 
                                                                     uu___170
                                                                     ->
-                                                                    FStar_Compiler_Effect.failwith
+                                                                    failwith
                                                                     "impos"),
                                                                     (IntStr
                                                                     "positive integer"))),
@@ -4010,7 +4005,7 @@ let (uu___2 :
     let uu___3 = FStar_Compiler_Effect.op_Bang callback in
     match uu___3 with
     | FStar_Pervasives_Native.None ->
-        FStar_Compiler_Effect.failwith "Error flags callback not yet set"
+        failwith "Error flags callback not yet set"
     | FStar_Pervasives_Native.Some f -> f () in
   (set1, call)
 let (set_error_flags_callback_aux :
@@ -4138,7 +4133,7 @@ let (read_fstar_include :
     with
     | uu___ ->
         ((let uu___4 = FStar_Compiler_String.op_Hat "Could not read " fn in
-          FStar_Compiler_Effect.failwith uu___4);
+          failwith uu___4);
          FStar_Pervasives_Native.None)
 let rec (expand_include_d : Prims.string -> Prims.string Prims.list) =
   fun dirname ->
@@ -4385,7 +4380,7 @@ let (message_format : unit -> message_format_t) =
           FStar_Compiler_String.op_Hat
             "print_issue: option `message_format` was expected to be `human` or `json`, not `"
             uu___5 in
-        FStar_Compiler_Effect.failwith uu___4
+        failwith uu___4
 let (force : unit -> Prims.bool) = fun uu___ -> get_force ()
 let (full_context_dependency : unit -> Prims.bool) = fun uu___ -> true
 let (hide_uvar_nums : unit -> Prims.bool) =
@@ -4425,7 +4420,7 @@ let (ide_file_name_st :
         FStar_Compiler_Effect.op_Colon_Equals v
           (FStar_Pervasives_Native.Some f)
     | FStar_Pervasives_Native.Some uu___3 ->
-        FStar_Compiler_Effect.failwith "ide_file_name_st already set" in
+        failwith "ide_file_name_st already set" in
   let get uu___ = FStar_Compiler_Effect.op_Bang v in (set1, get)
 let (set_ide_filename : Prims.string -> unit) =
   FStar_Pervasives_Native.fst ide_file_name_st
@@ -4750,7 +4745,7 @@ let (extract_settings :
           (let uu___5 =
              FStar_Compiler_Util.format1
                "Could not parse '%s' passed to the --extract option" msg in
-           FStar_Compiler_Effect.failwith uu___5) in
+           failwith uu___5) in
         if set1
         then result
         else
@@ -4787,7 +4782,7 @@ let (extract_settings :
                       FStar_Compiler_Util.format2
                         "Could not parse '%s'; multiple setting for %s target"
                         msg tgt in
-                    FStar_Compiler_Effect.failwith uu___7) in
+                    failwith uu___7) in
                  let pes =
                    FStar_Compiler_List.fold_right
                      (fun setting ->
@@ -4861,7 +4856,7 @@ let (should_extract : Prims.string -> codegen_t -> Prims.bool) =
                match uu___5 with
                | ([], [], []) -> ()
                | uu___6 ->
-                   FStar_Compiler_Effect.failwith
+                   failwith
                      "Incompatible options: --extract cannot be used with --no_extract, --extract_namespace or --extract_module");
               (let tsetting =
                  let uu___5 =

--- a/ocaml/fstar-lib/generated/FStar_Options.ml
+++ b/ocaml/fstar-lib/generated/FStar_Options.ml
@@ -4213,89 +4213,8 @@ let (include_path : unit -> Prims.string Prims.list) =
         FStar_Compiler_List.op_At include_paths uu___6 in
       FStar_Compiler_List.op_At uu___4 uu___5 in
     FStar_Compiler_List.op_At cache_dir uu___3
-let (find_file : Prims.string -> Prims.string FStar_Pervasives_Native.option)
-  =
-  let file_map = FStar_Compiler_Util.smap_create (Prims.of_int (100)) in
-  fun filename ->
-    let uu___ = FStar_Compiler_Util.smap_try_find file_map filename in
-    match uu___ with
-    | FStar_Pervasives_Native.Some f -> f
-    | FStar_Pervasives_Native.None ->
-        let result =
-          try
-            (fun uu___3 ->
-               match () with
-               | () ->
-                   let uu___4 = FStar_Compiler_Util.is_path_absolute filename in
-                   if uu___4
-                   then
-                     (if FStar_Compiler_Util.file_exists filename
-                      then FStar_Pervasives_Native.Some filename
-                      else FStar_Pervasives_Native.None)
-                   else
-                     (let uu___6 =
-                        let uu___7 = include_path () in
-                        FStar_Compiler_List.rev uu___7 in
-                      FStar_Compiler_Util.find_map uu___6
-                        (fun p ->
-                           let path =
-                             if p = "."
-                             then filename
-                             else FStar_Compiler_Util.join_paths p filename in
-                           if FStar_Compiler_Util.file_exists path
-                           then FStar_Pervasives_Native.Some path
-                           else FStar_Pervasives_Native.None))) ()
-          with | uu___3 -> FStar_Pervasives_Native.None in
-        (if FStar_Compiler_Option.isSome result
-         then FStar_Compiler_Util.smap_add file_map filename result
-         else ();
-         result)
-let (prims : unit -> Prims.string) =
-  fun uu___ ->
-    let uu___3 = get_prims () in
-    match uu___3 with
-    | FStar_Pervasives_Native.None ->
-        let filename = "Prims.fst" in
-        let uu___4 = find_file filename in
-        (match uu___4 with
-         | FStar_Pervasives_Native.Some result -> result
-         | FStar_Pervasives_Native.None ->
-             let uu___5 =
-               FStar_Compiler_Util.format1
-                 "unable to find required file \"%s\" in the module search path.\n"
-                 filename in
-             FStar_Compiler_Effect.failwith uu___5)
-    | FStar_Pervasives_Native.Some x -> x
-let (prims_basename : unit -> Prims.string) =
-  fun uu___ -> let uu___3 = prims () in FStar_Compiler_Util.basename uu___3
-let (pervasives : unit -> Prims.string) =
-  fun uu___ ->
-    let filename = "FStar.Pervasives.fsti" in
-    let uu___3 = find_file filename in
-    match uu___3 with
-    | FStar_Pervasives_Native.Some result -> result
-    | FStar_Pervasives_Native.None ->
-        let uu___4 =
-          FStar_Compiler_Util.format1
-            "unable to find required file \"%s\" in the module search path.\n"
-            filename in
-        FStar_Compiler_Effect.failwith uu___4
-let (pervasives_basename : unit -> Prims.string) =
-  fun uu___ ->
-    let uu___3 = pervasives () in FStar_Compiler_Util.basename uu___3
-let (pervasives_native_basename : unit -> Prims.string) =
-  fun uu___ ->
-    let filename = "FStar.Pervasives.Native.fst" in
-    let uu___3 = find_file filename in
-    match uu___3 with
-    | FStar_Pervasives_Native.Some result ->
-        FStar_Compiler_Util.basename result
-    | FStar_Pervasives_Native.None ->
-        let uu___4 =
-          FStar_Compiler_Util.format1
-            "unable to find required file \"%s\" in the module search path.\n"
-            filename in
-        FStar_Compiler_Effect.failwith uu___4
+let (custom_prims : unit -> Prims.string FStar_Pervasives_Native.option) =
+  fun uu___ -> get_prims ()
 let (prepend_output_dir : Prims.string -> Prims.string) =
   fun fname ->
     let uu___ = get_odir () in
@@ -5158,3 +5077,5 @@ let (set_vconfig : FStar_VConfig.vconfig -> unit) =
        option_as (fun uu___31 -> String uu___31)
          vcfg.FStar_VConfig.reuse_hint_for in
      set_option "reuse_hint_for" uu___30)
+let (showable_codegen_t : codegen_t FStar_Class_Show.showable) =
+  { FStar_Class_Show.show = print_codegen }

--- a/ocaml/fstar-lib/generated/FStar_Parser_AST.ml
+++ b/ocaml/fstar-lib/generated/FStar_Parser_AST.ml
@@ -2335,7 +2335,7 @@ and (try_or_match_to_string :
               match x.tm with
               | Match uu___ -> "match"
               | TryWith uu___ -> "try"
-              | uu___ -> FStar_Compiler_Effect.failwith "impossible" in
+              | uu___ -> failwith "impossible" in
             let uu___ =
               match op_opt with
               | FStar_Pervasives_Native.Some op ->
@@ -2414,11 +2414,9 @@ and (aqual_to_string :
     | FStar_Pervasives_Native.Some (Implicit) -> "#"
     | FStar_Pervasives_Native.None -> ""
     | FStar_Pervasives_Native.Some (Meta uu___1) ->
-        FStar_Compiler_Effect.failwith
-          "aqual_to_strings: meta arg qualifier?"
+        failwith "aqual_to_strings: meta arg qualifier?"
     | FStar_Pervasives_Native.Some (TypeClassArg) ->
-        FStar_Compiler_Effect.failwith
-          "aqual_to_strings: meta arg qualifier?"
+        failwith "aqual_to_strings: meta arg qualifier?"
 and (attr_list_to_string : term Prims.list -> Prims.string) =
   fun uu___ ->
     match uu___ with

--- a/ocaml/fstar-lib/generated/FStar_Parser_Const.ml
+++ b/ocaml/fstar-lib/generated/FStar_Parser_Const.ml
@@ -138,9 +138,10 @@ let (bool_of_string_lid : FStar_Ident.lident) =
 let (string_compare : FStar_Ident.lident) =
   p2l ["FStar"; "String"; "compare"]
 let (order_lid : FStar_Ident.lident) = p2l ["FStar"; "Order"; "order"]
-let (vconfig_lid : FStar_Ident.lident) = p2l ["FStar"; "VConfig"; "vconfig"]
+let (vconfig_lid : FStar_Ident.lident) =
+  p2l ["FStar"; "Stubs"; "VConfig"; "vconfig"]
 let (mkvconfig_lid : FStar_Ident.lident) =
-  p2l ["FStar"; "VConfig"; "Mkvconfig"]
+  p2l ["FStar"; "Stubs"; "VConfig"; "Mkvconfig"]
 let (op_Eq : FStar_Ident.lident) = pconst "op_Equality"
 let (op_notEq : FStar_Ident.lident) = pconst "op_disEquality"
 let (op_LT : FStar_Ident.lident) = pconst "op_LessThan"
@@ -576,7 +577,7 @@ let (ctx_uvar_and_subst_lid : FStar_Ident.lident) =
 let (universe_uvar_lid : FStar_Ident.lident) =
   p2l ["FStar"; "Stubs"; "Reflection"; "Types"; "universe_uvar"]
 let (check_with_lid : FStar_Ident.lident) =
-  FStar_Ident.lid_of_path ["FStar"; "VConfig"; "check_with"]
+  FStar_Ident.lid_of_path ["FStar"; "Stubs"; "VConfig"; "check_with"]
     FStar_Compiler_Range_Type.dummyRange
 let (decls_lid : FStar_Ident.lident) =
   p2l ["FStar"; "Stubs"; "Reflection"; "Types"; "decls"]

--- a/ocaml/fstar-lib/generated/FStar_Parser_Dep.ml
+++ b/ocaml/fstar-lib/generated/FStar_Parser_Dep.ml
@@ -2004,7 +2004,7 @@ let (topological_dependences_of' :
                     FStar_Compiler_Util.must uu___1 in
                   (match dep_node1.color with
                    | Gray ->
-                       FStar_Compiler_Effect.failwith
+                       failwith
                          "Impossible: cycle detected after cycle detection has passed"
                    | Black -> (all_friends, all_files)
                    | White ->
@@ -2272,7 +2272,7 @@ let (collect :
                  let uu___2 =
                    FStar_Compiler_Util.format1
                      "Impossible: Failed to find dependencies of %s" filename in
-                 FStar_Compiler_Effect.failwith uu___2 in
+                 failwith uu___2 in
            let direct_deps =
              FStar_Compiler_List.collect
                (fun x ->
@@ -2494,7 +2494,7 @@ let (print_full : FStar_Compiler_Util.out_channel -> deps -> unit) =
                            FStar_Compiler_Util.format2
                              "Impossible: module %s: %s not found"
                              lc_module_name file_name1 in
-                         FStar_Compiler_Effect.failwith uu___2
+                         failwith uu___2
                      | FStar_Pervasives_Native.Some
                          { edges = immediate_deps; color = uu___2;_} ->
                          let immediate_deps1 =

--- a/ocaml/fstar-lib/generated/FStar_Parser_Dep.ml
+++ b/ocaml/fstar-lib/generated/FStar_Parser_Dep.ml
@@ -523,7 +523,7 @@ let (cache_file_name : Prims.string -> Prims.string) =
     let mname = module_name_of_file fn in
     let uu___ =
       let uu___1 = FStar_Compiler_Util.basename cache_fn in
-      FStar_Options.find_file uu___1 in
+      FStar_Find.find_file uu___1 in
     match uu___ with
     | FStar_Pervasives_Native.Some path ->
         let expected_cache_file = FStar_Options.prepend_cache_dir cache_fn in
@@ -945,11 +945,11 @@ let (uu___is_Exit : Prims.exn -> Prims.bool) =
 let (core_modules : unit -> Prims.string Prims.list) =
   fun uu___ ->
     let uu___1 =
-      let uu___2 = FStar_Options.prims_basename () in
+      let uu___2 = FStar_Basefiles.prims_basename () in
       let uu___3 =
-        let uu___4 = FStar_Options.pervasives_basename () in
+        let uu___4 = FStar_Basefiles.pervasives_basename () in
         let uu___5 =
-          let uu___6 = FStar_Options.pervasives_native_basename () in
+          let uu___6 = FStar_Basefiles.pervasives_native_basename () in
           [uu___6] in
         uu___4 :: uu___5 in
       uu___2 :: uu___3 in
@@ -2161,7 +2161,7 @@ let (collect :
       let all_cmd_line_files2 =
         FStar_Compiler_List.map
           (fun fn ->
-             let uu___ = FStar_Options.find_file fn in
+             let uu___ = FStar_Find.find_file fn in
              match uu___ with
              | FStar_Pervasives_Native.None ->
                  let uu___1 =

--- a/ocaml/fstar-lib/generated/FStar_Parser_Driver.ml
+++ b/ocaml/fstar-lib/generated/FStar_Parser_Driver.ml
@@ -48,7 +48,7 @@ let (parse_fragment :
             (Obj.magic FStar_Errors_Msg.is_error_message_list_doc)
             (Obj.magic msg)
       | FStar_Parser_ParseIt.Term uu___1 ->
-          FStar_Compiler_Effect.failwith
+          failwith
             "Impossible: parsing a Toplevel always results in an ASTFragment"
 let (maybe_dump_module : FStar_Parser_AST.modul -> unit) =
   fun m ->
@@ -106,5 +106,5 @@ let (parse_file :
           (Obj.magic FStar_Errors_Msg.is_error_message_list_doc)
           (Obj.magic msg)
     | FStar_Parser_ParseIt.Term uu___1 ->
-        FStar_Compiler_Effect.failwith
+        failwith
           "Impossible: parsing a Filename always results in an ASTFragment"

--- a/ocaml/fstar-lib/generated/FStar_Parser_ToDocument.ml
+++ b/ocaml/fstar-lib/generated/FStar_Parser_ToDocument.ml
@@ -457,7 +457,7 @@ let rec (extract_from_ref_set :
         let uu___1 =
           let uu___2 = FStar_Parser_AST.term_to_string e in
           FStar_Compiler_Util.format1 "Not a ref set %s" uu___2 in
-        FStar_Compiler_Effect.failwith uu___1
+        failwith uu___1
 let (is_general_application : FStar_Parser_AST.term -> Prims.bool) =
   fun e ->
     let uu___ = (is_array e) || (is_ref_set e) in Prims.op_Negation uu___
@@ -591,9 +591,7 @@ let (assign_levels :
       let uu___ = FStar_Compiler_List.tryFind (matches_level s) level_table in
       match uu___ with
       | FStar_Pervasives_Native.Some (assoc_levels, uu___1) -> assoc_levels
-      | uu___1 ->
-          FStar_Compiler_Effect.failwith
-            (Prims.strcat "Unrecognized operator " s)
+      | uu___1 -> failwith (Prims.strcat "Unrecognized operator " s)
 let max_level : 'uuuuu . ('uuuuu * token Prims.list) Prims.list -> Prims.int
   =
   fun l ->
@@ -616,7 +614,7 @@ let max_level : 'uuuuu . ('uuuuu * token Prims.list) Prims.list -> Prims.int
               FStar_Compiler_String.concat "," uu___3 in
             FStar_Compiler_Util.format1 "Undefined associativity level %s"
               uu___2 in
-          FStar_Compiler_Effect.failwith uu___1 in
+          failwith uu___1 in
     FStar_Compiler_List.fold_left find_level_and_max Prims.int_zero l
 let (levels : Prims.string -> (Prims.int * Prims.int * Prims.int)) =
   fun op ->
@@ -1383,7 +1381,7 @@ and (p_rawDecl : FStar_Parser_AST.decl -> FStar_Pprint.document) =
         FStar_Pprint.op_Hat_Hat uu___ uu___1
     | FStar_Parser_AST.Pragma p -> p_pragma p
     | FStar_Parser_AST.Tycon (true, uu___, uu___1) ->
-        FStar_Compiler_Effect.failwith
+        failwith
           "Effect abbreviation is expected to be defined by an abbreviation"
     | FStar_Parser_AST.Splice (is_typed, ids, t) ->
         let uu___ = str "%splice" in
@@ -1880,7 +1878,7 @@ and (p_effectDecl :
             FStar_Compiler_Util.format1
               "Not a declaration of an effect member... or at least I hope so : %s"
               uu___2 in
-          FStar_Compiler_Effect.failwith uu___1
+          failwith uu___1
 and (p_subEffect : FStar_Parser_AST.lift -> FStar_Pprint.document) =
   fun lift ->
     let lift_op_doc =
@@ -2148,8 +2146,7 @@ and (p_atomicPattern : FStar_Parser_AST.pattern -> FStar_Pprint.document) =
           let uu___3 = p_lident lid in FStar_Pprint.op_Hat_Hat uu___2 uu___3 in
         FStar_Pprint.op_Hat_Hat uu___ uu___1
     | FStar_Parser_AST.PatName uid -> p_quident uid
-    | FStar_Parser_AST.PatOr uu___ ->
-        FStar_Compiler_Effect.failwith "Inner or pattern !"
+    | FStar_Parser_AST.PatOr uu___ -> failwith "Inner or pattern !"
     | FStar_Parser_AST.PatApp
         ({ FStar_Parser_AST.pat = FStar_Parser_AST.PatName uu___;
            FStar_Parser_AST.prange = uu___1;_},
@@ -2161,7 +2158,7 @@ and (p_atomicPattern : FStar_Parser_AST.pattern -> FStar_Pprint.document) =
         let uu___1 =
           let uu___2 = FStar_Parser_AST.pat_to_string p in
           FStar_Compiler_Util.format1 "Invalid pattern %s" uu___2 in
-        FStar_Compiler_Effect.failwith uu___1
+        failwith uu___1
 and (is_typ_tuple : FStar_Parser_AST.term -> Prims.bool) =
   fun e ->
     match e.FStar_Parser_AST.tm with
@@ -2270,7 +2267,7 @@ and (p_binder' :
                           FStar_Pprint.group uu___2) in
                  (b', (FStar_Pervasives_Native.Some (t', catf1))))
         | FStar_Parser_AST.TAnnotated uu___ ->
-            FStar_Compiler_Effect.failwith "Is this still used ?"
+            failwith "Is this still used ?"
         | FStar_Parser_AST.NoName t ->
             (match t.FStar_Parser_AST.tm with
              | FStar_Parser_AST.Refine
@@ -3712,7 +3709,7 @@ and (collapse_pats :
       | (bs, typ, istcarg, uu___1) ->
           let body =
             match bs with
-            | [] -> FStar_Compiler_Effect.failwith "Impossible"
+            | [] -> failwith "Impossible"
             | hd::tl ->
                 let uu___2 =
                   FStar_Compiler_List.fold_left
@@ -3792,8 +3789,7 @@ and (p_quantifier : FStar_Parser_AST.term -> FStar_Pprint.document) =
     | FStar_Parser_AST.QExists uu___ -> str "exists"
     | FStar_Parser_AST.QuantOp (i, uu___, uu___1, uu___2) -> p_ident i
     | uu___ ->
-        FStar_Compiler_Effect.failwith
-          "Imposible : p_quantifier called on a non-quantifier term"
+        failwith "Imposible : p_quantifier called on a non-quantifier term"
 and (p_trigger :
   FStar_Parser_AST.term Prims.list Prims.list -> FStar_Pprint.document) =
   fun uu___ ->
@@ -3973,8 +3969,7 @@ and (p_patternBranch :
                       FStar_Pprint.op_Hat_Hat FStar_Pprint.bar uu___2 in
                     FStar_Pprint.group uu___1
                 | [] ->
-                    FStar_Compiler_Effect.failwith
-                      "Impossible: disjunctive pattern can't be empty")
+                    failwith "Impossible: disjunctive pattern can't be empty")
            | uu___1 -> one_pattern_branch pat)
 and (p_tmIff : FStar_Parser_AST.term -> FStar_Pprint.document) =
   fun e ->
@@ -4178,10 +4173,10 @@ and (collapse_binders :
                | FStar_Pervasives_Native.None ->
                    (match bs with
                     | b::[] -> wrap is_tc b
-                    | uu___2 -> FStar_Compiler_Effect.failwith "Impossible")
+                    | uu___2 -> failwith "Impossible")
                | FStar_Pervasives_Native.Some (typ, f) ->
                    (match bs with
-                    | [] -> FStar_Compiler_Effect.failwith "Impossible"
+                    | [] -> failwith "Impossible"
                     | hd::tl ->
                         let uu___2 =
                           let uu___3 =
@@ -4465,22 +4460,21 @@ and (p_refinedBinder :
               FStar_Parser_AST.Type_level in
           p_refinement b.FStar_Parser_AST.aqual
             b.FStar_Parser_AST.battributes uu___ uu___1 phi
-      | FStar_Parser_AST.TAnnotated uu___ ->
-          FStar_Compiler_Effect.failwith "Is this still used ?"
+      | FStar_Parser_AST.TAnnotated uu___ -> failwith "Is this still used ?"
       | FStar_Parser_AST.TVariable uu___ ->
           let uu___1 =
             let uu___2 = FStar_Parser_AST.binder_to_string b in
             FStar_Compiler_Util.format1
               "Impossible: a refined binder ought to be annotated (%s)"
               uu___2 in
-          FStar_Compiler_Effect.failwith uu___1
+          failwith uu___1
       | FStar_Parser_AST.NoName uu___ ->
           let uu___1 =
             let uu___2 = FStar_Parser_AST.binder_to_string b in
             FStar_Compiler_Util.format1
               "Impossible: a refined binder ought to be annotated (%s)"
               uu___2 in
-          FStar_Compiler_Effect.failwith uu___1
+          failwith uu___1
 and (p_simpleDef :
   Prims.bool ->
     (FStar_Ident.lid * FStar_Parser_AST.term) -> FStar_Pprint.document)
@@ -4795,10 +4789,9 @@ and (p_projectionLHS : FStar_Parser_AST.term -> FStar_Pprint.document) =
               Prims.strcat " with " uu___4 in
             Prims.strcat uu___2 uu___3 in
           Prims.strcat "Operation " uu___1 in
-        FStar_Compiler_Effect.failwith uu___
+        failwith uu___
     | FStar_Parser_AST.Uvar id ->
-        FStar_Compiler_Effect.failwith
-          "Unexpected universe variable out of universe context"
+        failwith "Unexpected universe variable out of universe context"
     | FStar_Parser_AST.Wild ->
         let uu___ = p_term false false e in soft_parens_with_nesting uu___
     | FStar_Parser_AST.Const uu___ ->
@@ -4969,7 +4962,7 @@ and (p_universeFrom : FStar_Parser_AST.term -> FStar_Pprint.document) =
                     let uu___4 = FStar_Parser_AST.term_to_string u in
                     FStar_Compiler_Util.format1
                       "Invalid term in universe context %s" uu___4 in
-                  FStar_Compiler_Effect.failwith uu___3))
+                  failwith uu___3))
     | uu___ -> p_atomicUniverse u
 and (p_atomicUniverse : FStar_Parser_AST.term -> FStar_Pprint.document) =
   fun u ->
@@ -4991,7 +4984,7 @@ and (p_atomicUniverse : FStar_Parser_AST.term -> FStar_Pprint.document) =
           let uu___2 = FStar_Parser_AST.term_to_string u in
           FStar_Compiler_Util.format1 "Invalid term in universe context %s"
             uu___2 in
-        FStar_Compiler_Effect.failwith uu___1
+        failwith uu___1
 let (term_to_document : FStar_Parser_AST.term -> FStar_Pprint.document) =
   fun e -> p_term false false e
 let (signature_to_document : FStar_Parser_AST.decl -> FStar_Pprint.document)

--- a/ocaml/fstar-lib/generated/FStar_Reflection_V1_Builtins.ml
+++ b/ocaml/fstar-lib/generated/FStar_Reflection_V1_Builtins.ml
@@ -6,8 +6,7 @@ let (get_env : unit -> FStar_TypeChecker_Env.env) =
         FStar_TypeChecker_Normalize.reflection_env_hook in
     match uu___1 with
     | FStar_Pervasives_Native.None ->
-        FStar_Compiler_Effect.failwith
-          "impossible: env_hook unset in reflection"
+        failwith "impossible: env_hook unset in reflection"
     | FStar_Pervasives_Native.Some e -> e
 let (inspect_bqual :
   FStar_Syntax_Syntax.bqual -> FStar_Reflection_V1_Data.aqualv) =
@@ -92,13 +91,13 @@ let (pack_fv : Prims.string Prims.list -> FStar_Syntax_Syntax.fv) =
 let rec last : 'a . 'a Prims.list -> 'a =
   fun l ->
     match l with
-    | [] -> FStar_Compiler_Effect.failwith "last: empty list"
+    | [] -> failwith "last: empty list"
     | x::[] -> x
     | uu___::xs -> last xs
 let rec init : 'a . 'a Prims.list -> 'a Prims.list =
   fun l ->
     match l with
-    | [] -> FStar_Compiler_Effect.failwith "init: empty list"
+    | [] -> failwith "init: empty list"
     | x::[] -> []
     | x::xs -> let uu___ = init xs in x :: uu___
 let (inspect_const :
@@ -123,7 +122,7 @@ let (inspect_const :
           let uu___2 =
             FStar_Class_Show.show FStar_Syntax_Print.showable_const c in
           FStar_Compiler_Util.format1 "unknown constant: %s" uu___2 in
-        FStar_Compiler_Effect.failwith uu___1
+        failwith uu___1
 let (inspect_universe :
   FStar_Syntax_Syntax.universe -> FStar_Reflection_V1_Data.universe_view) =
   fun u ->
@@ -172,8 +171,7 @@ let rec (inspect_ln :
          | FStar_Syntax_Syntax.Tm_fvar fv ->
              FStar_Reflection_V1_Data.Tv_UInst (fv, us)
          | uu___ ->
-             FStar_Compiler_Effect.failwith
-               "Reflection::inspect_ln: uinst for a non-fvar node")
+             failwith "Reflection::inspect_ln: uinst for a non-fvar node")
     | FStar_Syntax_Syntax.Tm_ascribed
         { FStar_Syntax_Syntax.tm = t2;
           FStar_Syntax_Syntax.asc = (FStar_Pervasives.Inl ty, tacopt, eq);
@@ -186,8 +184,7 @@ let rec (inspect_ln :
         -> FStar_Reflection_V1_Data.Tv_AscribedC (t2, cty, tacopt, eq)
     | FStar_Syntax_Syntax.Tm_app
         { FStar_Syntax_Syntax.hd = uu___; FStar_Syntax_Syntax.args = [];_} ->
-        FStar_Compiler_Effect.failwith
-          "inspect_ln: empty arguments on Tm_app"
+        failwith "inspect_ln: empty arguments on Tm_app"
     | FStar_Syntax_Syntax.Tm_app
         { FStar_Syntax_Syntax.hd = hd; FStar_Syntax_Syntax.args = args;_} ->
         let uu___ = last args in
@@ -202,9 +199,7 @@ let rec (inspect_ln :
     | FStar_Syntax_Syntax.Tm_abs
         { FStar_Syntax_Syntax.bs = []; FStar_Syntax_Syntax.body = uu___;
           FStar_Syntax_Syntax.rc_opt = uu___1;_}
-        ->
-        FStar_Compiler_Effect.failwith
-          "inspect_ln: empty arguments on Tm_abs"
+        -> failwith "inspect_ln: empty arguments on Tm_abs"
     | FStar_Syntax_Syntax.Tm_abs
         { FStar_Syntax_Syntax.bs = b::bs; FStar_Syntax_Syntax.body = t2;
           FStar_Syntax_Syntax.rc_opt = k;_}
@@ -224,15 +219,13 @@ let rec (inspect_ln :
     | FStar_Syntax_Syntax.Tm_type u -> FStar_Reflection_V1_Data.Tv_Type u
     | FStar_Syntax_Syntax.Tm_arrow
         { FStar_Syntax_Syntax.bs1 = []; FStar_Syntax_Syntax.comp = uu___;_}
-        ->
-        FStar_Compiler_Effect.failwith "inspect_ln: empty binders on arrow"
+        -> failwith "inspect_ln: empty binders on arrow"
     | FStar_Syntax_Syntax.Tm_arrow uu___ ->
         let uu___1 = FStar_Syntax_Util.arrow_one_ln t1 in
         (match uu___1 with
          | FStar_Pervasives_Native.Some (b, c) ->
              FStar_Reflection_V1_Data.Tv_Arrow (b, c)
-         | FStar_Pervasives_Native.None ->
-             FStar_Compiler_Effect.failwith "impossible")
+         | FStar_Pervasives_Native.None -> failwith "impossible")
     | FStar_Syntax_Syntax.Tm_refine
         { FStar_Syntax_Syntax.b = bv; FStar_Syntax_Syntax.phi = t2;_} ->
         FStar_Reflection_V1_Data.Tv_Refine
@@ -356,7 +349,7 @@ let (inspect_comp :
               (Obj.magic FStar_Errors_Msg.is_error_message_string)
               (Obj.magic uu___3));
            [])
-      | uu___1 -> FStar_Compiler_Effect.failwith "Impossible!" in
+      | uu___1 -> failwith "Impossible!" in
     match c.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Total t -> FStar_Reflection_V1_Data.C_Total t
     | FStar_Syntax_Syntax.GTotal t -> FStar_Reflection_V1_Data.C_GTotal t
@@ -376,8 +369,7 @@ let (inspect_comp :
            | (pre, uu___1)::(post, uu___2)::(pats, uu___3)::uu___4 ->
                FStar_Reflection_V1_Data.C_Lemma (pre, post, pats)
            | uu___1 ->
-               FStar_Compiler_Effect.failwith
-                 "inspect_comp: Lemma does not have enough arguments?")
+               failwith "inspect_comp: Lemma does not have enough arguments?")
         else
           (let inspect_arg uu___2 =
              match uu___2 with
@@ -934,7 +926,7 @@ let (inspect_sigelt :
                                 (FStar_Compiler_List.length param_ctor_bs) <>
                                   nparam
                               then
-                                FStar_Compiler_Effect.failwith
+                                failwith
                                   "impossible: inspect_sigelt: could not obtain sufficient ctor param binders"
                               else ();
                               (let uu___18 =
@@ -943,7 +935,7 @@ let (inspect_sigelt :
                                  Prims.op_Negation uu___19 in
                                if uu___18
                                then
-                                 FStar_Compiler_Effect.failwith
+                                 failwith
                                    "impossible: inspect_sigelt: removed parameters and got an effectful comp"
                                else ());
                               (let cty2 = FStar_Syntax_Util.comp_result c in
@@ -964,7 +956,7 @@ let (inspect_sigelt :
                                let uu___18 = FStar_Ident.path_of_lid lid1 in
                                (uu___18, cty4))))
                     | uu___6 ->
-                        FStar_Compiler_Effect.failwith
+                        failwith
                           "impossible: inspect_sigelt: did not find ctor" in
                   let uu___5 =
                     let uu___6 = FStar_Compiler_List.map inspect_ident us1 in
@@ -1000,7 +992,7 @@ let (pack_sigelt :
             let uu___3 = FStar_Ident.string_of_lid lid in
             Prims.strcat uu___3 "\" (did you forget a module path?)" in
           Prims.strcat "pack_sigelt: invalid long identifier \"" uu___2 in
-        FStar_Compiler_Effect.failwith uu___1
+        failwith uu___1
       else () in
     match sv with
     | FStar_Reflection_V1_Data.Sg_Let (r, lbs) ->
@@ -1018,7 +1010,7 @@ let (pack_sigelt :
                 match nm with
                 | FStar_Pervasives.Inr fv -> FStar_Syntax_Syntax.lid_of_fv fv
                 | uu___1 ->
-                    FStar_Compiler_Effect.failwith
+                    failwith
                       "impossible: pack_sigelt: bv in toplevel let binding" in
               (check_lid lid;
                (let s = FStar_Syntax_Subst.univ_var_closing us in
@@ -1125,8 +1117,7 @@ let (pack_sigelt :
                  FStar_Syntax_Syntax.us2 = us_names1;
                  FStar_Syntax_Syntax.t2 = typ
                })))
-    | FStar_Reflection_V1_Data.Unk ->
-        FStar_Compiler_Effect.failwith "packing Unk, sorry"
+    | FStar_Reflection_V1_Data.Unk -> failwith "packing Unk, sorry"
 let (inspect_lb :
   FStar_Syntax_Syntax.letbinding -> FStar_Reflection_V1_Data.lb_view) =
   fun lb ->
@@ -1150,9 +1141,7 @@ let (inspect_lb :
                     FStar_Reflection_V1_Data.lb_typ = typ1;
                     FStar_Reflection_V1_Data.lb_def = def1
                   }
-              | uu___2 ->
-                  FStar_Compiler_Effect.failwith
-                    "Impossible: bv in top-level let binding"))
+              | uu___2 -> failwith "Impossible: bv in top-level let binding"))
 let (pack_lb :
   FStar_Reflection_V1_Data.lb_view -> FStar_Syntax_Syntax.letbinding) =
   fun lbv ->

--- a/ocaml/fstar-lib/generated/FStar_Reflection_V1_Derived.ml
+++ b/ocaml/fstar-lib/generated/FStar_Reflection_V1_Derived.ml
@@ -354,7 +354,7 @@ let (add_check_with :
              ((FStar_Reflection_V2_Builtins.pack_ln
                  (FStar_Reflection_V2_Data.Tv_FVar
                     (FStar_Reflection_V2_Builtins.pack_fv
-                       ["FStar"; "VConfig"; "check_with"]))),
+                       ["FStar"; "Stubs"; "VConfig"; "check_with"]))),
                (vcfg_t, FStar_Reflection_V2_Data.Q_Explicit))) in
       FStar_Reflection_V1_Builtins.set_sigelt_attrs (t :: attrs) se
 let (un_uinst : FStar_Reflection_Types.term -> FStar_Reflection_Types.term) =

--- a/ocaml/fstar-lib/generated/FStar_Reflection_V1_NBEEmbeddings.ml
+++ b/ocaml/fstar-lib/generated/FStar_Reflection_V1_NBEEmbeddings.ml
@@ -672,9 +672,7 @@ let unlazy_as_t :
           FStar_Class_Deq.op_Equals_Question
             FStar_Syntax_Syntax.deq_lazy_kind k k'
           -> FStar_Dyn.undyn v
-      | uu___ ->
-          FStar_Compiler_Effect.failwith
-            "Not a Lazy of the expected kind (NBE)"
+      | uu___ -> failwith "Not a Lazy of the expected kind (NBE)"
 let (e_ident :
   FStar_Reflection_V1_Data.ident FStar_TypeChecker_NBETerm.embedding) =
   FStar_TypeChecker_NBETerm.e_tuple2 FStar_TypeChecker_NBETerm.e_string
@@ -2320,8 +2318,8 @@ let (e_qualifiers :
     FStar_TypeChecker_NBETerm.embedding)
   = FStar_TypeChecker_NBETerm.e_list e_qualifier
 let (e_vconfig : FStar_Order.order FStar_TypeChecker_NBETerm.embedding) =
-  let emb cb o = FStar_Compiler_Effect.failwith "emb vconfig NBE" in
-  let unemb cb t = FStar_Compiler_Effect.failwith "unemb vconfig NBE" in
+  let emb cb o = failwith "emb vconfig NBE" in
+  let unemb cb t = failwith "unemb vconfig NBE" in
   let uu___ =
     FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.vconfig_lid
       FStar_Pervasives_Native.None in

--- a/ocaml/fstar-lib/generated/FStar_Reflection_V2_Builtins.ml
+++ b/ocaml/fstar-lib/generated/FStar_Reflection_V2_Builtins.ml
@@ -6,8 +6,7 @@ let (get_env : unit -> FStar_TypeChecker_Env.env) =
         FStar_TypeChecker_Normalize.reflection_env_hook in
     match uu___1 with
     | FStar_Pervasives_Native.None ->
-        FStar_Compiler_Effect.failwith
-          "impossible: env_hook unset in reflection"
+        failwith "impossible: env_hook unset in reflection"
     | FStar_Pervasives_Native.Some e -> e
 let (inspect_bqual :
   FStar_Syntax_Syntax.bqual -> FStar_Reflection_V2_Data.aqualv) =
@@ -94,13 +93,13 @@ let (pack_fv : Prims.string Prims.list -> FStar_Syntax_Syntax.fv) =
 let rec last : 'a . 'a Prims.list -> 'a =
   fun l ->
     match l with
-    | [] -> FStar_Compiler_Effect.failwith "last: empty list"
+    | [] -> failwith "last: empty list"
     | x::[] -> x
     | uu___::xs -> last xs
 let rec init : 'a . 'a Prims.list -> 'a Prims.list =
   fun l ->
     match l with
-    | [] -> FStar_Compiler_Effect.failwith "init: empty list"
+    | [] -> failwith "init: empty list"
     | x::[] -> []
     | x::xs -> let uu___ = init xs in x :: uu___
 let (inspect_const :
@@ -126,7 +125,7 @@ let (inspect_const :
           let uu___2 =
             FStar_Class_Show.show FStar_Syntax_Print.showable_const c in
           FStar_Compiler_Util.format1 "unknown constant: %s" uu___2 in
-        FStar_Compiler_Effect.failwith uu___1
+        failwith uu___1
 let (inspect_universe :
   FStar_Syntax_Syntax.universe -> FStar_Reflection_V2_Data.universe_view) =
   fun u ->
@@ -191,8 +190,7 @@ let rec (inspect_ln :
          | FStar_Syntax_Syntax.Tm_fvar fv ->
              FStar_Reflection_V2_Data.Tv_UInst (fv, us)
          | uu___ ->
-             FStar_Compiler_Effect.failwith
-               "Reflection::inspect_ln: uinst for a non-fvar node")
+             failwith "Reflection::inspect_ln: uinst for a non-fvar node")
     | FStar_Syntax_Syntax.Tm_ascribed
         { FStar_Syntax_Syntax.tm = t2;
           FStar_Syntax_Syntax.asc = (FStar_Pervasives.Inl ty, tacopt, eq);
@@ -205,8 +203,7 @@ let rec (inspect_ln :
         -> FStar_Reflection_V2_Data.Tv_AscribedC (t2, cty, tacopt, eq)
     | FStar_Syntax_Syntax.Tm_app
         { FStar_Syntax_Syntax.hd = uu___; FStar_Syntax_Syntax.args = [];_} ->
-        FStar_Compiler_Effect.failwith
-          "inspect_ln: empty arguments on Tm_app"
+        failwith "inspect_ln: empty arguments on Tm_app"
     | FStar_Syntax_Syntax.Tm_app
         { FStar_Syntax_Syntax.hd = hd; FStar_Syntax_Syntax.args = args;_} ->
         let uu___ = last args in
@@ -221,9 +218,7 @@ let rec (inspect_ln :
     | FStar_Syntax_Syntax.Tm_abs
         { FStar_Syntax_Syntax.bs = []; FStar_Syntax_Syntax.body = uu___;
           FStar_Syntax_Syntax.rc_opt = uu___1;_}
-        ->
-        FStar_Compiler_Effect.failwith
-          "inspect_ln: empty arguments on Tm_abs"
+        -> failwith "inspect_ln: empty arguments on Tm_abs"
     | FStar_Syntax_Syntax.Tm_abs
         { FStar_Syntax_Syntax.bs = b::bs; FStar_Syntax_Syntax.body = t2;
           FStar_Syntax_Syntax.rc_opt = k;_}
@@ -243,15 +238,13 @@ let rec (inspect_ln :
     | FStar_Syntax_Syntax.Tm_type u -> FStar_Reflection_V2_Data.Tv_Type u
     | FStar_Syntax_Syntax.Tm_arrow
         { FStar_Syntax_Syntax.bs1 = []; FStar_Syntax_Syntax.comp = uu___;_}
-        ->
-        FStar_Compiler_Effect.failwith "inspect_ln: empty binders on arrow"
+        -> failwith "inspect_ln: empty binders on arrow"
     | FStar_Syntax_Syntax.Tm_arrow uu___ ->
         let uu___1 = FStar_Syntax_Util.arrow_one_ln t1 in
         (match uu___1 with
          | FStar_Pervasives_Native.Some (b, c) ->
              FStar_Reflection_V2_Data.Tv_Arrow (b, c)
-         | FStar_Pervasives_Native.None ->
-             FStar_Compiler_Effect.failwith "impossible")
+         | FStar_Pervasives_Native.None -> failwith "impossible")
     | FStar_Syntax_Syntax.Tm_refine
         { FStar_Syntax_Syntax.b = bv; FStar_Syntax_Syntax.phi = t2;_} ->
         let uu___ =
@@ -341,7 +334,7 @@ let (inspect_comp :
               (Obj.magic FStar_Errors_Msg.is_error_message_string)
               (Obj.magic uu___3));
            [])
-      | uu___1 -> FStar_Compiler_Effect.failwith "Impossible!" in
+      | uu___1 -> failwith "Impossible!" in
     match c.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Total t -> FStar_Reflection_V2_Data.C_Total t
     | FStar_Syntax_Syntax.GTotal t -> FStar_Reflection_V2_Data.C_GTotal t
@@ -361,8 +354,7 @@ let (inspect_comp :
            | (pre, uu___1)::(post, uu___2)::(pats, uu___3)::uu___4 ->
                FStar_Reflection_V2_Data.C_Lemma (pre, post, pats)
            | uu___1 ->
-               FStar_Compiler_Effect.failwith
-                 "inspect_comp: Lemma does not have enough arguments?")
+               failwith "inspect_comp: Lemma does not have enough arguments?")
         else
           (let inspect_arg uu___2 =
              match uu___2 with
@@ -868,8 +860,7 @@ let (inspect_sigelt :
                 FStar_Syntax_Syntax.sigopts = uu___12;_}
               -> let uu___13 = FStar_Ident.path_of_lid lid1 in (uu___13, cty)
           | uu___4 ->
-              FStar_Compiler_Effect.failwith
-                "impossible: inspect_sigelt: did not find ctor" in
+              failwith "impossible: inspect_sigelt: did not find ctor" in
         let uu___3 =
           let uu___4 = FStar_Compiler_List.map inspect_ctor c_lids in
           (nm, us, param_bs, ty, uu___4) in
@@ -897,7 +888,7 @@ let (pack_sigelt :
             let uu___3 = FStar_Ident.string_of_lid lid in
             Prims.strcat uu___3 "\" (did you forget a module path?)" in
           Prims.strcat "pack_sigelt: invalid long identifier \"" uu___2 in
-        FStar_Compiler_Effect.failwith uu___1
+        failwith uu___1
       else () in
     match sv with
     | FStar_Reflection_V2_Data.Sg_Let (r, lbs) ->
@@ -915,7 +906,7 @@ let (pack_sigelt :
                 match nm with
                 | FStar_Pervasives.Inr fv -> FStar_Syntax_Syntax.lid_of_fv fv
                 | uu___7 ->
-                    FStar_Compiler_Effect.failwith
+                    failwith
                       "impossible: pack_sigelt: bv in toplevel let binding" in
               (check_lid lid; (lid, lb)) in
         let packed = FStar_Compiler_List.map pack_letbinding lbs in
@@ -1004,8 +995,7 @@ let (pack_sigelt :
                 FStar_Syntax_Syntax.t2 = ty
               }))
     | FStar_Reflection_V2_Data.Unk ->
-        FStar_Compiler_Effect.failwith
-          "packing Unk, this should never happen"
+        failwith "packing Unk, this should never happen"
 let (inspect_lb :
   FStar_Syntax_Syntax.letbinding -> FStar_Reflection_V2_Data.lb_view) =
   fun lb ->
@@ -1024,9 +1014,7 @@ let (inspect_lb :
                FStar_Reflection_V2_Data.lb_typ = typ;
                FStar_Reflection_V2_Data.lb_def = def
              }
-         | uu___4 ->
-             FStar_Compiler_Effect.failwith
-               "Impossible: bv in top-level let binding")
+         | uu___4 -> failwith "Impossible: bv in top-level let binding")
 let (pack_lb :
   FStar_Reflection_V2_Data.lb_view -> FStar_Syntax_Syntax.letbinding) =
   fun lbv ->

--- a/ocaml/fstar-lib/generated/FStar_Reflection_V2_Derived.ml
+++ b/ocaml/fstar-lib/generated/FStar_Reflection_V2_Derived.ml
@@ -358,7 +358,7 @@ let (add_check_with :
              ((FStar_Reflection_V2_Builtins.pack_ln
                  (FStar_Reflection_V2_Data.Tv_FVar
                     (FStar_Reflection_V2_Builtins.pack_fv
-                       ["FStar"; "VConfig"; "check_with"]))),
+                       ["FStar"; "Stubs"; "VConfig"; "check_with"]))),
                (vcfg_t, FStar_Reflection_V2_Data.Q_Explicit))) in
       FStar_Reflection_V2_Builtins.set_sigelt_attrs (t :: attrs) se
 let (un_uinst : FStar_Reflection_Types.term -> FStar_Reflection_Types.term) =

--- a/ocaml/fstar-lib/generated/FStar_Reflection_V2_NBEEmbeddings.ml
+++ b/ocaml/fstar-lib/generated/FStar_Reflection_V2_NBEEmbeddings.ml
@@ -700,9 +700,7 @@ let unlazy_as_t :
           FStar_Class_Deq.op_Equals_Question
             FStar_Syntax_Syntax.deq_lazy_kind k k'
           -> FStar_Dyn.undyn v
-      | uu___ ->
-          FStar_Compiler_Effect.failwith
-            "Not a Lazy of the expected kind (NBE)"
+      | uu___ -> failwith "Not a Lazy of the expected kind (NBE)"
 let (e_ident : FStar_Ident.ident FStar_TypeChecker_NBETerm.embedding) =
   let embed_ident cb se =
     mk_lazy cb se FStar_Reflection_V2_Constants.fstar_refl_ident
@@ -2632,8 +2630,8 @@ let (e_qualifiers :
     FStar_TypeChecker_NBETerm.embedding)
   = FStar_TypeChecker_NBETerm.e_list e_qualifier
 let (e_vconfig : FStar_Order.order FStar_TypeChecker_NBETerm.embedding) =
-  let emb cb o = FStar_Compiler_Effect.failwith "emb vconfig NBE" in
-  let unemb cb t = FStar_Compiler_Effect.failwith "unemb vconfig NBE" in
+  let emb cb o = failwith "emb vconfig NBE" in
+  let unemb cb t = failwith "unemb vconfig NBE" in
   let uu___ =
     FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.vconfig_lid
       FStar_Pervasives_Native.None in

--- a/ocaml/fstar-lib/generated/FStar_SMTEncoding_Encode.ml
+++ b/ocaml/fstar-lib/generated/FStar_SMTEncoding_Encode.ml
@@ -2770,9 +2770,7 @@ let (encode_top_level_let :
                                          let uu___12 =
                                            match e_t with
                                            | e1::t_norm1::[] -> (e1, t_norm1)
-                                           | uu___13 ->
-                                               FStar_Compiler_Effect.failwith
-                                                 "Impossible" in
+                                           | uu___13 -> failwith "Impossible" in
                                          (match uu___12 with
                                           | (e1, t_norm1) ->
                                               ({
@@ -3144,9 +3142,7 @@ let (encode_top_level_let :
                                                                  decls1
                                                                  uu___17 in
                                                              (uu___16, env2)))))))
-                               | uu___5 ->
-                                   FStar_Compiler_Effect.failwith
-                                     "Impossible" in
+                               | uu___5 -> failwith "Impossible" in
                              let encode_rec_lbdefs bindings1 typs2 toks1 env2
                                =
                                let fuel =
@@ -3222,8 +3218,7 @@ let (encode_top_level_let :
                                                  | e1::t_norm1::[] ->
                                                      (e1, t_norm1)
                                                  | uu___16 ->
-                                                     FStar_Compiler_Effect.failwith
-                                                       "Impossible" in
+                                                     failwith "Impossible" in
                                                (match uu___15 with
                                                 | (e1, t_norm1) ->
                                                     ({
@@ -4138,9 +4133,7 @@ let (encode_sig_inductive :
                                                        <>
                                                        (FStar_Compiler_List.length
                                                           vars)
-                                                   then
-                                                     FStar_Compiler_Effect.failwith
-                                                       "Impossible"
+                                                   then failwith "Impossible"
                                                    else ();
                                                    (let eqs =
                                                       FStar_Compiler_List.map2
@@ -6485,10 +6478,9 @@ and (encode_sigelt' :
          | uu___2 -> false in
        match se.FStar_Syntax_Syntax.sigel with
        | FStar_Syntax_Syntax.Sig_splice uu___1 ->
-           FStar_Compiler_Effect.failwith
-             "impossible -- splice should have been removed by Tc.fs"
+           failwith "impossible -- splice should have been removed by Tc.fs"
        | FStar_Syntax_Syntax.Sig_fail uu___1 ->
-           FStar_Compiler_Effect.failwith
+           failwith
              "impossible -- Sig_fail should have been removed by Tc.fs"
        | FStar_Syntax_Syntax.Sig_pragma uu___1 -> ([], env)
        | FStar_Syntax_Syntax.Sig_effect_abbrev uu___1 -> ([], env)
@@ -7322,7 +7314,7 @@ let (get_env :
     fun tcenv ->
       let uu___ = FStar_Compiler_Effect.op_Bang last_env in
       match uu___ with
-      | [] -> FStar_Compiler_Effect.failwith "No env; call init first!"
+      | [] -> failwith "No env; call init first!"
       | e::uu___1 ->
           let uu___2 = FStar_Ident.string_of_lid cmn in
           {
@@ -7349,7 +7341,7 @@ let (set_env : FStar_SMTEncoding_Env.env_t -> unit) =
   fun env ->
     let uu___ = FStar_Compiler_Effect.op_Bang last_env in
     match uu___ with
-    | [] -> FStar_Compiler_Effect.failwith "Empty env stack"
+    | [] -> failwith "Empty env stack"
     | uu___1::tl ->
         FStar_Compiler_Effect.op_Colon_Equals last_env (env :: tl)
 let (get_current_env :
@@ -7361,7 +7353,7 @@ let (push_env : unit -> unit) =
   fun uu___ ->
     let uu___1 = FStar_Compiler_Effect.op_Bang last_env in
     match uu___1 with
-    | [] -> FStar_Compiler_Effect.failwith "Empty env stack"
+    | [] -> failwith "Empty env stack"
     | hd::tl ->
         let top = copy_env hd in
         FStar_Compiler_Effect.op_Colon_Equals last_env (top :: hd :: tl)
@@ -7369,7 +7361,7 @@ let (pop_env : unit -> unit) =
   fun uu___ ->
     let uu___1 = FStar_Compiler_Effect.op_Bang last_env in
     match uu___1 with
-    | [] -> FStar_Compiler_Effect.failwith "Popping an empty stack"
+    | [] -> failwith "Popping an empty stack"
     | uu___2::tl -> FStar_Compiler_Effect.op_Colon_Equals last_env tl
 let (snapshot_env : unit -> (Prims.int * unit)) =
   fun uu___ -> FStar_Common.snapshot push_env last_env ()

--- a/ocaml/fstar-lib/generated/FStar_SMTEncoding_EncodeTerm.ml
+++ b/ocaml/fstar-lib/generated/FStar_SMTEncoding_EncodeTerm.ml
@@ -316,9 +316,7 @@ let (isTotFun_axioms :
                   let rest =
                     is_tot_fun_axioms ctx1 ctx_guard1 app vars2 guards2 in
                   FStar_SMTEncoding_Util.mkAnd (is_tot_fun_head, rest)
-              | uu___ ->
-                  FStar_Compiler_Effect.failwith
-                    "impossible: isTotFun_axioms" in
+              | uu___ -> failwith "impossible: isTotFun_axioms" in
             is_tot_fun_axioms [] FStar_SMTEncoding_Util.mkTrue head vars
               guards
 let (maybe_curry_app :
@@ -515,7 +513,7 @@ let (as_function_typ :
                    FStar_Class_Show.show FStar_Syntax_Print.showable_term t0 in
                  FStar_Compiler_Util.format2
                    "(%s) Expected a function typ; got %s" uu___3 uu___4 in
-               FStar_Compiler_Effect.failwith uu___2) in
+               failwith uu___2) in
       aux true t0
 let rec (curried_arrow_formals_comp :
   FStar_Syntax_Syntax.term ->
@@ -600,7 +598,7 @@ let (getInteger : FStar_Syntax_Syntax.term' -> Prims.int) =
     | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_int
         (n, FStar_Pervasives_Native.None)) ->
         FStar_Compiler_Util.int_of_string n
-    | uu___ -> FStar_Compiler_Effect.failwith "Expected an Integer term"
+    | uu___ -> failwith "Expected an Integer term"
 let is_BitVector_primitive :
   'uuuuu .
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
@@ -734,7 +732,7 @@ let rec (encode_const :
                  let uu___2 =
                    FStar_Class_Show.show FStar_Syntax_Print.showable_const c1 in
                  FStar_Compiler_Util.format1 "Unhandled constant: %s" uu___2 in
-               FStar_Compiler_Effect.failwith uu___1)
+               failwith uu___1)
 and (encode_binders :
   FStar_SMTEncoding_Term.term FStar_Pervasives_Native.option ->
     FStar_Syntax_Syntax.binders ->
@@ -820,7 +818,7 @@ and (encode_arith_term :
             let head_fv =
               match head.FStar_Syntax_Syntax.n with
               | FStar_Syntax_Syntax.Tm_fvar fv -> fv
-              | uu___1 -> FStar_Compiler_Effect.failwith "Impossible" in
+              | uu___1 -> failwith "Impossible" in
             let unary unbox arg_tms1 =
               let uu___1 = FStar_Compiler_List.hd arg_tms1 in unbox uu___1 in
             let binary unbox arg_tms1 =
@@ -1033,7 +1031,7 @@ and (encode_BitVector_term :
                         sz_arg in
                     FStar_Compiler_Util.format1
                       "Not a constant bitvector extend size: %s" uu___8 in
-                  FStar_Compiler_Effect.failwith uu___7
+                  failwith uu___7
               | uu___4 ->
                   let uu___5 = FStar_Compiler_List.tail args_e in
                   (uu___5, FStar_Pervasives_Native.None) in
@@ -1045,8 +1043,7 @@ and (encode_BitVector_term :
                       let head_fv =
                         match head.FStar_Syntax_Syntax.n with
                         | FStar_Syntax_Syntax.Tm_fvar fv -> fv
-                        | uu___5 ->
-                            FStar_Compiler_Effect.failwith "Impossible" in
+                        | uu___5 -> failwith "Impossible" in
                       let unary arg_tms2 =
                         let uu___5 = FStar_Compiler_List.hd arg_tms2 in
                         FStar_SMTEncoding_Term.unboxBitVec sz uu___5 in
@@ -1130,7 +1127,7 @@ and (encode_BitVector_term :
                             match ext_sz with
                             | FStar_Pervasives_Native.Some x -> x
                             | FStar_Pervasives_Native.None ->
-                                FStar_Compiler_Effect.failwith "impossible" in
+                                failwith "impossible" in
                           FStar_SMTEncoding_Util.mkBvUext uu___6 in
                         let uu___6 =
                           let uu___7 =
@@ -1138,7 +1135,7 @@ and (encode_BitVector_term :
                               match ext_sz with
                               | FStar_Pervasives_Native.Some x -> x
                               | FStar_Pervasives_Native.None ->
-                                  FStar_Compiler_Effect.failwith "impossible" in
+                                  failwith "impossible" in
                             sz + uu___8 in
                           FStar_SMTEncoding_Term.boxBitVec uu___7 in
                         mk_bv uu___5 unary uu___6 arg_tms2 in
@@ -1319,7 +1316,7 @@ and (encode_term :
                 FStar_Class_Show.show FStar_Syntax_Print.showable_term t1 in
               FStar_Compiler_Util.format3 "(%s) Impossible: %s\n%s\n" uu___4
                 uu___5 uu___6 in
-            FStar_Compiler_Effect.failwith uu___3
+            failwith uu___3
         | FStar_Syntax_Syntax.Tm_unknown ->
             let uu___2 =
               let uu___3 =
@@ -1331,7 +1328,7 @@ and (encode_term :
                 FStar_Class_Show.show FStar_Syntax_Print.showable_term t1 in
               FStar_Compiler_Util.format3 "(%s) Impossible: %s\n%s\n" uu___3
                 uu___4 uu___5 in
-            FStar_Compiler_Effect.failwith uu___2
+            failwith uu___2
         | FStar_Syntax_Syntax.Tm_lazy i ->
             let e = FStar_Syntax_Util.unfold_lazy i in
             ((let uu___3 = FStar_Compiler_Effect.op_Bang dbg_SMTEncoding in
@@ -1351,7 +1348,7 @@ and (encode_term :
                 FStar_Class_Show.show FStar_Syntax_Print.showable_bv x in
               FStar_Compiler_Util.format1
                 "Impossible: locally nameless; got %s" uu___3 in
-            FStar_Compiler_Effect.failwith uu___2
+            failwith uu___2
         | FStar_Syntax_Syntax.Tm_ascribed
             { FStar_Syntax_Syntax.tm = t2;
               FStar_Syntax_Syntax.asc = (k, uu___2, uu___3);
@@ -1902,7 +1899,7 @@ and (encode_term :
                         match t2.FStar_SMTEncoding_Term.tm with
                         | FStar_SMTEncoding_Term.FreeV fv -> fv
                         | uu___6 ->
-                            FStar_Compiler_Effect.failwith
+                            failwith
                               "Impossible: getfreeV: gen_term_var should always returns a FreeV" in
                       let uu___6 =
                         FStar_Compiler_List.fold_left
@@ -2028,7 +2025,7 @@ and (encode_term :
                          let uu___10 = FStar_Compiler_List.hd b in
                          uu___10.FStar_Syntax_Syntax.binder_bv in
                        (uu___9, f1))
-              | uu___5 -> FStar_Compiler_Effect.failwith "impossible" in
+              | uu___5 -> failwith "impossible" in
             (match uu___3 with
              | (x, f) ->
                  let uu___4 = encode_term x.FStar_Syntax_Syntax.sort env in
@@ -3038,9 +3035,7 @@ and (encode_term :
                    FStar_Syntax_Syntax.lbattrs = uu___8;
                    FStar_Syntax_Syntax.lbpos = uu___9;_}::uu___10);
               FStar_Syntax_Syntax.body1 = uu___11;_}
-            ->
-            FStar_Compiler_Effect.failwith
-              "Impossible: already handled by encoding of Sig_let"
+            -> failwith "Impossible: already handled by encoding of Sig_let"
         | FStar_Syntax_Syntax.Tm_let
             {
               FStar_Syntax_Syntax.lbs =
@@ -3058,8 +3053,7 @@ and (encode_term :
             { FStar_Syntax_Syntax.lbs = (false, uu___2::uu___3);
               FStar_Syntax_Syntax.body1 = uu___4;_}
             ->
-            FStar_Compiler_Effect.failwith
-              "Impossible: non-recursive let with multiple bindings"
+            failwith "Impossible: non-recursive let with multiple bindings"
         | FStar_Syntax_Syntax.Tm_let
             { FStar_Syntax_Syntax.lbs = (uu___2, lbs);
               FStar_Syntax_Syntax.body1 = uu___3;_}
@@ -3285,7 +3279,7 @@ and (encode_pat :
                        | (tm, decls) ->
                            ((match decls with
                              | uu___5::uu___6 ->
-                                 FStar_Compiler_Effect.failwith
+                                 failwith
                                    "Unexpected encoding of constant pattern"
                              | uu___5 -> ());
                             FStar_SMTEncoding_Util.mkEq (scrutinee, tm)))
@@ -3516,7 +3510,7 @@ and (encode_formula :
       let bin_op f uu___ =
         match uu___ with
         | t1::t2::[] -> f (t1, t2)
-        | uu___1 -> FStar_Compiler_Effect.failwith "Impossible" in
+        | uu___1 -> failwith "Impossible" in
       let enc_prop_c f r l =
         let uu___ =
           FStar_Compiler_Util.fold_map
@@ -3559,7 +3553,7 @@ and (encode_formula :
             FStar_Compiler_Util.format1
               "eq_op: got %s non-implicit arguments instead of 2?"
               (Prims.string_of_int (FStar_Compiler_List.length rf)) in
-          FStar_Compiler_Effect.failwith uu___
+          failwith uu___
         else
           (let uu___1 = enc (bin_op FStar_SMTEncoding_Util.mkEq) in
            uu___1 r rf) in
@@ -3580,7 +3574,7 @@ and (encode_formula :
                              FStar_SMTEncoding_Term.mkImp (l2, l1) r in
                            (uu___6,
                              (FStar_Compiler_List.op_At decls1 decls2)))))
-        | uu___1 -> FStar_Compiler_Effect.failwith "impossible" in
+        | uu___1 -> failwith "impossible" in
       let mk_ite r uu___ =
         match uu___ with
         | (guard, uu___1)::(_then, uu___2)::(_else, uu___3)::[] ->
@@ -3597,7 +3591,7 @@ and (encode_formula :
                            (res,
                              (FStar_Compiler_List.op_At decls1
                                 (FStar_Compiler_List.op_At decls2 decls3))))))
-        | uu___1 -> FStar_Compiler_Effect.failwith "impossible" in
+        | uu___1 -> failwith "impossible" in
       let unboxInt_l f l =
         let uu___ = FStar_Compiler_List.map FStar_SMTEncoding_Term.unboxInt l in
         f uu___ in

--- a/ocaml/fstar-lib/generated/FStar_SMTEncoding_Env.ml
+++ b/ocaml/fstar-lib/generated/FStar_SMTEncoding_Env.ml
@@ -53,7 +53,7 @@ let (primitive_projector_by_pos :
             FStar_Compiler_Util.format2
               "Projector %s on data constructor %s not found"
               (Prims.string_of_int i) uu___2 in
-          FStar_Compiler_Effect.failwith uu___1 in
+          failwith uu___1 in
         let uu___ = FStar_TypeChecker_Env.lookup_datacon env lid in
         match uu___ with
         | (uu___1, t) ->
@@ -339,7 +339,7 @@ let (check_valid_fvb : fvar_binding -> unit) =
          let uu___2 = FStar_Ident.string_of_lid fvb.fvar_lid in
          FStar_Compiler_Util.format1 "Unexpected thunked SMT symbol: %s"
            uu___2 in
-       FStar_Compiler_Effect.failwith uu___1)
+       failwith uu___1)
     else
       if fvb.fvb_thunked && (fvb.smt_arity <> Prims.int_zero)
       then
@@ -347,7 +347,7 @@ let (check_valid_fvb : fvar_binding -> unit) =
            let uu___3 = FStar_Ident.string_of_lid fvb.fvar_lid in
            FStar_Compiler_Util.format1
              "Unexpected arity of thunked SMT symbol: %s" uu___3 in
-         FStar_Compiler_Effect.failwith uu___2)
+         failwith uu___2)
       else ();
     (match fvb.smt_token with
      | FStar_Pervasives_Native.Some
@@ -358,7 +358,7 @@ let (check_valid_fvb : fvar_binding -> unit) =
          let uu___4 =
            let uu___5 = fvb_to_string fvb in
            FStar_Compiler_Util.format1 "bad fvb\n%s" uu___5 in
-         FStar_Compiler_Effect.failwith uu___4
+         failwith uu___4
      | uu___1 -> ())
 let binder_of_eithervar :
   'uuuuu 'uuuuu1 .
@@ -674,7 +674,7 @@ let (lookup_term_var :
             FStar_Compiler_Util.format2
               "Bound term variable not found  %s in environment: %s" uu___2
               uu___3 in
-          FStar_Compiler_Effect.failwith uu___1
+          failwith uu___1
 let (mk_fvb :
   FStar_Ident.lident ->
     Prims.string ->
@@ -777,7 +777,7 @@ let fail_fvar_lookup : 'uuuuu . env_t -> FStar_Ident.lident -> 'uuuuu =
             FStar_Compiler_Util.format1
               "Name %s not found in the smtencoding and typechecker env"
               uu___1 in
-          FStar_Compiler_Effect.failwith uu___
+          failwith uu___
       | uu___ ->
           let quals = FStar_TypeChecker_Env.quals_of_qninfo q in
           let uu___1 =
@@ -803,7 +803,7 @@ let fail_fvar_lookup : 'uuuuu . env_t -> FStar_Ident.lident -> 'uuuuu =
                  FStar_Class_Show.show FStar_Ident.showable_lident a in
                FStar_Compiler_Util.format1
                  "Name %s not found in the smtencoding env" uu___4 in
-             FStar_Compiler_Effect.failwith uu___3)
+             failwith uu___3)
 let (lookup_lid : env_t -> FStar_Ident.lident -> fvar_binding) =
   fun env ->
     fun a ->
@@ -911,9 +911,7 @@ let (force_thunk : fvar_binding -> FStar_SMTEncoding_Term.term) =
     if
       (Prims.op_Negation fvb.fvb_thunked) ||
         (fvb.smt_arity <> Prims.int_zero)
-    then
-      FStar_Compiler_Effect.failwith
-        "Forcing a non-thunk in the SMT encoding"
+    then failwith "Forcing a non-thunk in the SMT encoding"
     else ();
     FStar_SMTEncoding_Util.mkFreeV
       (FStar_SMTEncoding_Term.FV

--- a/ocaml/fstar-lib/generated/FStar_SMTEncoding_ErrorReporting.ml
+++ b/ocaml/fstar-lib/generated/FStar_SMTEncoding_ErrorReporting.ml
@@ -142,8 +142,7 @@ let (label_goals :
               | FStar_SMTEncoding_Term.Integer uu___1 -> (labels1, q1)
               | FStar_SMTEncoding_Term.String uu___1 -> (labels1, q1)
               | FStar_SMTEncoding_Term.Real uu___1 -> (labels1, q1)
-              | FStar_SMTEncoding_Term.LblPos uu___1 ->
-                  FStar_Compiler_Effect.failwith "Impossible"
+              | FStar_SMTEncoding_Term.LblPos uu___1 -> failwith "Impossible"
               | FStar_SMTEncoding_Term.Labeled (arg, d::[], label_range) when
                   let uu___1 = FStar_Errors_Msg.renderdoc d in
                   uu___1 = "Could not prove post-condition" ->
@@ -647,90 +646,70 @@ let (label_goals :
                   (match uu___3 with | (lab, q2) -> ((lab :: labels1), q2))
               | FStar_SMTEncoding_Term.App
                   (FStar_SMTEncoding_Term.RealDiv, uu___1) ->
-                  FStar_Compiler_Effect.failwith
-                    "Impossible: non-propositional term"
+                  failwith "Impossible: non-propositional term"
               | FStar_SMTEncoding_Term.App
                   (FStar_SMTEncoding_Term.Add, uu___1) ->
-                  FStar_Compiler_Effect.failwith
-                    "Impossible: non-propositional term"
+                  failwith "Impossible: non-propositional term"
               | FStar_SMTEncoding_Term.App
                   (FStar_SMTEncoding_Term.Sub, uu___1) ->
-                  FStar_Compiler_Effect.failwith
-                    "Impossible: non-propositional term"
+                  failwith "Impossible: non-propositional term"
               | FStar_SMTEncoding_Term.App
                   (FStar_SMTEncoding_Term.Div, uu___1) ->
-                  FStar_Compiler_Effect.failwith
-                    "Impossible: non-propositional term"
+                  failwith "Impossible: non-propositional term"
               | FStar_SMTEncoding_Term.App
                   (FStar_SMTEncoding_Term.Mul, uu___1) ->
-                  FStar_Compiler_Effect.failwith
-                    "Impossible: non-propositional term"
+                  failwith "Impossible: non-propositional term"
               | FStar_SMTEncoding_Term.App
                   (FStar_SMTEncoding_Term.Minus, uu___1) ->
-                  FStar_Compiler_Effect.failwith
-                    "Impossible: non-propositional term"
+                  failwith "Impossible: non-propositional term"
               | FStar_SMTEncoding_Term.App
                   (FStar_SMTEncoding_Term.Mod, uu___1) ->
-                  FStar_Compiler_Effect.failwith
-                    "Impossible: non-propositional term"
+                  failwith "Impossible: non-propositional term"
               | FStar_SMTEncoding_Term.App
                   (FStar_SMTEncoding_Term.BvAnd, uu___1) ->
-                  FStar_Compiler_Effect.failwith
-                    "Impossible: non-propositional term"
+                  failwith "Impossible: non-propositional term"
               | FStar_SMTEncoding_Term.App
                   (FStar_SMTEncoding_Term.BvXor, uu___1) ->
-                  FStar_Compiler_Effect.failwith
-                    "Impossible: non-propositional term"
+                  failwith "Impossible: non-propositional term"
               | FStar_SMTEncoding_Term.App
                   (FStar_SMTEncoding_Term.BvOr, uu___1) ->
-                  FStar_Compiler_Effect.failwith
-                    "Impossible: non-propositional term"
+                  failwith "Impossible: non-propositional term"
               | FStar_SMTEncoding_Term.App
                   (FStar_SMTEncoding_Term.BvAdd, uu___1) ->
-                  FStar_Compiler_Effect.failwith
-                    "Impossible: non-propositional term"
+                  failwith "Impossible: non-propositional term"
               | FStar_SMTEncoding_Term.App
                   (FStar_SMTEncoding_Term.BvSub, uu___1) ->
-                  FStar_Compiler_Effect.failwith
-                    "Impossible: non-propositional term"
+                  failwith "Impossible: non-propositional term"
               | FStar_SMTEncoding_Term.App
                   (FStar_SMTEncoding_Term.BvShl, uu___1) ->
-                  FStar_Compiler_Effect.failwith
-                    "Impossible: non-propositional term"
+                  failwith "Impossible: non-propositional term"
               | FStar_SMTEncoding_Term.App
                   (FStar_SMTEncoding_Term.BvShr, uu___1) ->
-                  FStar_Compiler_Effect.failwith
-                    "Impossible: non-propositional term"
+                  failwith "Impossible: non-propositional term"
               | FStar_SMTEncoding_Term.App
                   (FStar_SMTEncoding_Term.BvUdiv, uu___1) ->
-                  FStar_Compiler_Effect.failwith
-                    "Impossible: non-propositional term"
+                  failwith "Impossible: non-propositional term"
               | FStar_SMTEncoding_Term.App
                   (FStar_SMTEncoding_Term.BvMod, uu___1) ->
-                  FStar_Compiler_Effect.failwith
-                    "Impossible: non-propositional term"
+                  failwith "Impossible: non-propositional term"
               | FStar_SMTEncoding_Term.App
                   (FStar_SMTEncoding_Term.BvMul, uu___1) ->
-                  FStar_Compiler_Effect.failwith
-                    "Impossible: non-propositional term"
+                  failwith "Impossible: non-propositional term"
               | FStar_SMTEncoding_Term.App
                   (FStar_SMTEncoding_Term.BvUext uu___1, uu___2) ->
-                  FStar_Compiler_Effect.failwith
-                    "Impossible: non-propositional term"
+                  failwith "Impossible: non-propositional term"
               | FStar_SMTEncoding_Term.App
                   (FStar_SMTEncoding_Term.BvToNat, uu___1) ->
-                  FStar_Compiler_Effect.failwith
-                    "Impossible: non-propositional term"
+                  failwith "Impossible: non-propositional term"
               | FStar_SMTEncoding_Term.App
                   (FStar_SMTEncoding_Term.NatToBv uu___1, uu___2) ->
-                  FStar_Compiler_Effect.failwith
-                    "Impossible: non-propositional term"
+                  failwith "Impossible: non-propositional term"
               | FStar_SMTEncoding_Term.App
                   (FStar_SMTEncoding_Term.ITE, uu___1) ->
-                  FStar_Compiler_Effect.failwith "Impossible: arity mismatch"
+                  failwith "Impossible: arity mismatch"
               | FStar_SMTEncoding_Term.App
                   (FStar_SMTEncoding_Term.Imp, uu___1) ->
-                  FStar_Compiler_Effect.failwith "Impossible: arity mismatch"
+                  failwith "Impossible: arity mismatch"
               | FStar_SMTEncoding_Term.Quant
                   (FStar_SMTEncoding_Term.Forall, pats, iopt, sorts, body) ->
                   let uu___1 =

--- a/ocaml/fstar-lib/generated/FStar_SMTEncoding_Solver.ml
+++ b/ocaml/fstar-lib/generated/FStar_SMTEncoding_Solver.ml
@@ -1271,7 +1271,7 @@ let (make_solver_configs :
                     match (env.FStar_SMTEncoding_Env.tcenv).FStar_TypeChecker_Env.qtbl_name_and_index
                     with
                     | (FStar_Pervasives_Native.None, uu___2) ->
-                        FStar_Compiler_Effect.failwith "No query name set!"
+                        failwith "No query name set!"
                     | (FStar_Pervasives_Native.Some (q, _typ, n), uu___2) ->
                         let uu___3 = FStar_Ident.string_of_lid q in
                         (uu___3, n) in
@@ -2188,8 +2188,7 @@ let (encode_and_ask :
                                  match uu___8 with
                                  | (configs, next_hint) ->
                                      ask_solver env configs next_hint))
-                           | uu___6 ->
-                               FStar_Compiler_Effect.failwith "Impossible"))))) in
+                           | uu___6 -> failwith "Impossible"))))) in
             let uu___ =
               FStar_SMTEncoding_Solver_Cache.try_find_query_cache tcenv q in
             if uu___
@@ -2264,8 +2263,7 @@ let (do_solve :
             | FStar_Pervasives_Native.Some (uu___, ans) when ans.ok -> ()
             | FStar_Pervasives_Native.Some ([], ans) when
                 Prims.op_Negation ans.ok ->
-                FStar_Compiler_Effect.failwith
-                  "impossible: bad answer from encode_and_ask"
+                failwith "impossible: bad answer from encode_and_ask"
             | FStar_Pervasives_Native.None -> ()
 let (split_and_solve :
   Prims.bool ->
@@ -2297,8 +2295,7 @@ let (split_and_solve :
              let uu___1 = FStar_TypeChecker_Env.split_smt_query tcenv q in
              match uu___1 with
              | FStar_Pervasives_Native.None ->
-                 FStar_Compiler_Effect.failwith
-                   "Impossible: split_query callback is not set"
+                 failwith "Impossible: split_query callback is not set"
              | FStar_Pervasives_Native.Some goals1 -> goals1 in
            FStar_Compiler_List.iter
              (fun uu___2 ->

--- a/ocaml/fstar-lib/generated/FStar_SMTEncoding_SolverState.ml
+++ b/ocaml/fstar-lib/generated/FStar_SMTEncoding_SolverState.ml
@@ -172,9 +172,7 @@ let (debug : Prims.string -> solver_state -> solver_state -> unit) =
 let (peek : solver_state -> (decls_at_level * decls_at_level Prims.list)) =
   fun s ->
     match s.levels with
-    | [] ->
-        FStar_Compiler_Effect.failwith
-          "Solver state cannot have an empty stack"
+    | [] -> failwith "Solver state cannot have an empty stack"
     | hd::tl -> (hd, tl)
 let (replace_head : decls_at_level -> solver_state -> solver_state) =
   fun hd ->
@@ -227,9 +225,7 @@ let (pop : solver_state -> solver_state) =
     match uu___ with
     | (hd, tl) ->
         (if Prims.uu___is_Nil tl
-         then
-           FStar_Compiler_Effect.failwith
-             "Solver state cannot have an empty stack"
+         then failwith "Solver state cannot have an empty stack"
          else ();
          (let s1 =
             if Prims.op_Negation hd.given_some_decls
@@ -597,7 +593,7 @@ let (name_of_assumption : FStar_SMTEncoding_Term.decl -> Prims.string) =
     match d with
     | FStar_SMTEncoding_Term.Assume a ->
         a.FStar_SMTEncoding_Term.assumption_name
-    | uu___ -> FStar_Compiler_Effect.failwith "Expected an assumption"
+    | uu___ -> failwith "Expected an assumption"
 let (prune_level :
   FStar_SMTEncoding_Term.decl Prims.list ->
     decls_at_level -> solver_state -> decls_at_level)

--- a/ocaml/fstar-lib/generated/FStar_SMTEncoding_Term.ml
+++ b/ocaml/fstar-lib/generated/FStar_SMTEncoding_Term.ml
@@ -578,12 +578,12 @@ let (freevar_sort : term -> sort) =
   fun uu___ ->
     match uu___ with
     | { tm = FreeV x; freevars = uu___1; rng = uu___2;_} -> fv_sort x
-    | uu___1 -> FStar_Compiler_Effect.failwith "impossible"
+    | uu___1 -> failwith "impossible"
 let (fv_of_term : term -> fv) =
   fun uu___ ->
     match uu___ with
     | { tm = FreeV fv1; freevars = uu___1; rng = uu___2;_} -> fv1
-    | uu___1 -> FStar_Compiler_Effect.failwith "impossible"
+    | uu___1 -> failwith "impossible"
 let rec (freevars : term -> fv Prims.list) =
   fun t ->
     match t.tm with
@@ -1089,7 +1089,7 @@ let (mkCases : term Prims.list -> FStar_Compiler_Range_Type.range -> term) =
   fun t ->
     fun r ->
       match t with
-      | [] -> FStar_Compiler_Effect.failwith "Impos"
+      | [] -> failwith "Impos"
       | hd::tl ->
           FStar_Compiler_List.fold_left
             (fun out -> fun t1 -> mkAnd (out, t1) r) hd tl
@@ -2399,7 +2399,7 @@ let (mk_Valid : term -> term) =
           let uu___2 = getBoxedInteger t0 in
           match uu___2 with
           | FStar_Pervasives_Native.Some sz1 -> sz1
-          | uu___3 -> FStar_Compiler_Effect.failwith "impossible" in
+          | uu___3 -> failwith "impossible" in
         let uu___2 =
           let uu___3 = unboxBitVec sz t1 in
           let uu___4 = unboxBitVec sz t2 in (uu___3, uu___4) in
@@ -2415,7 +2415,7 @@ let (mk_Valid : term -> term) =
           let uu___4 = getBoxedInteger t0 in
           match uu___4 with
           | FStar_Pervasives_Native.Some sz1 -> sz1
-          | uu___5 -> FStar_Compiler_Effect.failwith "impossible" in
+          | uu___5 -> failwith "impossible" in
         let uu___4 =
           let uu___5 = unboxBitVec sz t1 in
           let uu___6 = unboxBitVec sz t2 in (uu___5, uu___6) in

--- a/ocaml/fstar-lib/generated/FStar_SMTEncoding_Z3.ml
+++ b/ocaml/fstar-lib/generated/FStar_SMTEncoding_Z3.ml
@@ -204,8 +204,7 @@ let (query_logging : query_log) =
   let get_module_name uu___ =
     let uu___1 = FStar_Compiler_Effect.op_Bang current_module_name in
     match uu___1 with
-    | FStar_Pervasives_Native.None ->
-        FStar_Compiler_Effect.failwith "Module name not set"
+    | FStar_Pervasives_Native.None -> failwith "Module name not set"
     | FStar_Pervasives_Native.Some n -> n in
   let next_file_name uu___ =
     let n = get_module_name () in
@@ -263,8 +262,7 @@ let (query_logging : query_log) =
   let log_file_name uu___ =
     let uu___1 = FStar_Compiler_Effect.op_Bang current_file_name in
     match uu___1 with
-    | FStar_Pervasives_Native.None ->
-        FStar_Compiler_Effect.failwith "no log file"
+    | FStar_Pervasives_Native.None -> failwith "no log file"
     | FStar_Pervasives_Native.Some n -> n in
   { get_module_name; set_module_name; write_to_log; append_to_log; close_log
   }
@@ -669,7 +667,7 @@ let (smt_output_sections :
               let uu___1 = until (end_tag tag) suffix in
               (match uu___1 with
                | FStar_Pervasives_Native.None ->
-                   FStar_Compiler_Effect.failwith
+                   failwith
                      (Prims.strcat "Parse error: "
                         (Prims.strcat (end_tag tag) " not found"))
                | FStar_Pervasives_Native.Some (section, suffix1) ->
@@ -685,7 +683,7 @@ let (smt_output_sections :
                     FStar_Compiler_Util.format1
                       "Unexpexted output from Z3: no result section found:\n%s"
                       (FStar_Compiler_String.concat "\n" lines1) in
-                  FStar_Compiler_Effect.failwith uu___1
+                  failwith uu___1
               | FStar_Pervasives_Native.Some result1 -> result1 in
             let uu___1 = find_section "reason-unknown" lines1 in
             (match uu___1 with
@@ -977,7 +975,7 @@ let (doZ3Exe :
                            "Unexpected output from Z3: got output result: %s\n"
                            (FStar_Compiler_String.concat "\n"
                               smt_output1.smt_result) in
-                       FStar_Compiler_Effect.failwith uu___2) in
+                       failwith uu___2) in
                 (status, statistics) in
               let log_result fwrite uu___ =
                 match uu___ with
@@ -1359,7 +1357,7 @@ let (ask :
                   | FStar_Pervasives_Native.Some core1 ->
                       (if Prims.op_Negation fresh
                        then
-                         FStar_Compiler_Effect.failwith
+                         failwith
                            "Unexpected: unsat core must only be used with fresh solvers"
                        else ();
                        reading_solver_state

--- a/ocaml/fstar-lib/generated/FStar_Syntax_DsEnv.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_DsEnv.ml
@@ -457,8 +457,7 @@ let (set_current_module : env -> FStar_Ident.lident -> env) =
 let (current_module : env -> FStar_Ident.lident) =
   fun env1 ->
     match env1.curmodule with
-    | FStar_Pervasives_Native.None ->
-        FStar_Compiler_Effect.failwith "Unset current module"
+    | FStar_Pervasives_Native.None -> failwith "Unset current module"
     | FStar_Pervasives_Native.Some m -> m
 let (iface_decls :
   env ->
@@ -3628,8 +3627,7 @@ let (pop : unit -> env) =
              (pop_record_cache ();
               FStar_Compiler_Effect.op_Colon_Equals stack tl;
               env1)
-         | uu___3 ->
-             FStar_Compiler_Effect.failwith "Impossible: Too many pops")
+         | uu___3 -> failwith "Impossible: Too many pops")
 let (snapshot : env -> (Prims.int * env)) =
   fun env1 -> FStar_Common.snapshot push stack env1
 let (rollback : Prims.int FStar_Pervasives_Native.option -> env) =

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Embeddings.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Embeddings.ml
@@ -44,7 +44,7 @@ let (term_as_fv : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.fv) =
             FStar_Class_Show.show FStar_Syntax_Print.showable_term t in
           FStar_Compiler_Util.format1 "Embeddings not defined for type %s"
             uu___3 in
-        FStar_Compiler_Effect.failwith uu___2
+        failwith uu___2
 let lazy_embed :
   'a .
     'a printer ->

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Embeddings_Base.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Embeddings_Base.ml
@@ -99,7 +99,7 @@ let (term_as_fv : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.fv) =
             FStar_Class_Show.show FStar_Syntax_Print.showable_term t in
           FStar_Compiler_Util.format1 "Embeddings not defined for type %s"
             uu___3 in
-        FStar_Compiler_Effect.failwith uu___2
+        failwith uu___2
 let mk_emb :
   'a .
     'a raw_embedder ->

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Formula.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Formula.ml
@@ -398,9 +398,7 @@ and (destruct_sq_exists :
                                      let b1 =
                                        match bs with
                                        | b2::[] -> b2
-                                       | uu___8 ->
-                                           FStar_Compiler_Effect.failwith
-                                             "impossible" in
+                                       | uu___8 -> failwith "impossible" in
                                      let uu___8 = patterns q1 in
                                      (match uu___8 with
                                       | (pats, q2) ->

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Free.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Free.ml
@@ -340,8 +340,7 @@ let rec (free_names_and_uvs' :
         op_Plus_Plus from_binders from_body in
       let t = FStar_Syntax_Subst.compress tm in
       match t.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Tm_delayed uu___ ->
-          FStar_Compiler_Effect.failwith "Impossible"
+      | FStar_Syntax_Syntax.Tm_delayed uu___ -> failwith "Impossible"
       | FStar_Syntax_Syntax.Tm_name x -> singleton_bv x
       | FStar_Syntax_Syntax.Tm_uvar (uv, (s, uu___)) ->
           let uu___1 = singleton_uv uv in

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Hash.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Hash.ml
@@ -235,8 +235,7 @@ and (hash_term' : FStar_Syntax_Syntax.term -> FStar_Hash.hash_code mm) =
           let uu___4 = hash_quoteinfo qi in mix uu___3 uu___4 in
         mix uu___1 uu___2
     | FStar_Syntax_Syntax.Tm_unknown -> of_int (Prims.of_int (73))
-    | FStar_Syntax_Syntax.Tm_delayed uu___1 ->
-        FStar_Compiler_Effect.failwith "Impossible"
+    | FStar_Syntax_Syntax.Tm_delayed uu___1 -> failwith "Impossible"
 and (hash_comp' : FStar_Syntax_Syntax.comp -> FStar_Hash.hash_code mm) =
   fun c ->
     match c.FStar_Syntax_Syntax.n with

--- a/ocaml/fstar-lib/generated/FStar_Syntax_InstFV.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_InstFV.ml
@@ -15,8 +15,7 @@ let rec (inst :
       let t1 = FStar_Syntax_Subst.compress t in
       let mk1 = mk t1 in
       match t1.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Tm_delayed uu___ ->
-          FStar_Compiler_Effect.failwith "Impossible"
+      | FStar_Syntax_Syntax.Tm_delayed uu___ -> failwith "Impossible"
       | FStar_Syntax_Syntax.Tm_name uu___ -> t1
       | FStar_Syntax_Syntax.Tm_uvar uu___ -> t1
       | FStar_Syntax_Syntax.Tm_uvar uu___ -> t1

--- a/ocaml/fstar-lib/generated/FStar_Syntax_MutRecTy.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_MutRecTy.ml
@@ -41,7 +41,7 @@ let (disentangle_abbrevs_from_bundle :
                        FStar_Syntax_Syntax.lids1 = uu___7;_}
                      -> [x]
                  | FStar_Syntax_Syntax.Sig_let uu___ ->
-                     FStar_Compiler_Effect.failwith
+                     failwith
                        "mutrecty: disentangle_abbrevs_from_bundle: type_abbrev_sigelts: impossible"
                  | uu___ -> []) sigelts in
           match type_abbrev_sigelts with
@@ -83,7 +83,7 @@ let (disentangle_abbrevs_from_bundle :
                          ->
                          (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                      | uu___1 ->
-                         FStar_Compiler_Effect.failwith
+                         failwith
                            "mutrecty: disentangle_abbrevs_from_bundle: type_abbrevs: impossible")
                   type_abbrev_sigelts in
               let unfolded_type_abbrevs =
@@ -224,7 +224,7 @@ let (disentangle_abbrevs_from_bundle :
                         | FStar_Pervasives.Inr fv ->
                             (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                         | uu___2 ->
-                            FStar_Compiler_Effect.failwith
+                            failwith
                               "mutrecty: disentangle_abbrevs_from_bundle: rename_abbrev: lid: impossible" in
                       ((let uu___3 =
                           let uu___4 =
@@ -297,7 +297,7 @@ let (disentangle_abbrevs_from_bundle :
                                             in_progress uu___6);
                                          (match () with | () -> tm'))))))))
                   | uu___1 ->
-                      FStar_Compiler_Effect.failwith
+                      failwith
                         "mutrecty: disentangle_abbrevs_from_bundle: rename_abbrev: impossible" in
                 let rec aux uu___1 =
                   let uu___2 = FStar_Compiler_Effect.op_Bang not_unfolded_yet in
@@ -431,7 +431,7 @@ let (disentangle_abbrevs_from_bundle :
                        }]
                   | FStar_Syntax_Syntax.Sig_let uu___1 -> []
                   | uu___1 ->
-                      FStar_Compiler_Effect.failwith
+                      failwith
                         "mutrecty: inductives_with_abbrevs_unfolded: unfold_in_sig: impossible" in
                 FStar_Compiler_List.collect unfold_in_sig sigelts in
               let new_members = filter_out_type_abbrevs members in

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Print.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Print.ml
@@ -726,8 +726,7 @@ let rec (sigelt_to_string_short : FStar_Syntax_Syntax.sigelt -> Prims.string)
           FStar_Compiler_String.concat " and " uu___2 in
         FStar_Compiler_Util.format1 "let rec %s" uu___1
     | FStar_Syntax_Syntax.Sig_let uu___ ->
-        FStar_Compiler_Effect.failwith
-          "Impossible: sigelt_to_string_short, ill-formed let"
+        failwith "Impossible: sigelt_to_string_short, ill-formed let"
     | FStar_Syntax_Syntax.Sig_declare_typ
         { FStar_Syntax_Syntax.lid2 = lid; FStar_Syntax_Syntax.us2 = uu___;
           FStar_Syntax_Syntax.t2 = uu___1;_}

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Print_Ugly.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Print_Ugly.ml
@@ -242,12 +242,11 @@ let rec (term_to_string : FStar_Syntax_Syntax.term -> Prims.string) =
            let uu___1 = FStar_Options.print_implicits () in
            if uu___1 then x1 else FStar_Syntax_Util.unmeta x1 in
          match x2.FStar_Syntax_Syntax.n with
-         | FStar_Syntax_Syntax.Tm_delayed uu___1 ->
-             FStar_Compiler_Effect.failwith "impossible"
+         | FStar_Syntax_Syntax.Tm_delayed uu___1 -> failwith "impossible"
          | FStar_Syntax_Syntax.Tm_app
              { FStar_Syntax_Syntax.hd = uu___1;
                FStar_Syntax_Syntax.args = [];_}
-             -> FStar_Compiler_Effect.failwith "Empty args!"
+             -> failwith "Empty args!"
          | FStar_Syntax_Syntax.Tm_lazy
              { FStar_Syntax_Syntax.blob = b;
                FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_embedding
@@ -1390,7 +1389,7 @@ let rec (sigelt_to_string : FStar_Syntax_Syntax.sigelt -> Prims.string) =
                        { FStar_Syntax_Syntax.bs1 = bs;
                          FStar_Syntax_Syntax.comp = c1;_}
                        -> (bs, c1)
-                   | uu___4 -> FStar_Compiler_Effect.failwith "impossible" in
+                   | uu___4 -> failwith "impossible" in
                  (match uu___2 with
                   | (tps1, c1) ->
                       let uu___3 = sli l in

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Resugar.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Resugar.ml
@@ -167,9 +167,7 @@ let rec (resugar_universe :
                     mk uu___3 r))
       | FStar_Syntax_Syntax.U_max l ->
           (match l with
-           | [] ->
-               FStar_Compiler_Effect.failwith
-                 "Impossible: U_max without arguments"
+           | [] -> failwith "Impossible: U_max without arguments"
            | uu___ ->
                let t =
                  let uu___1 =
@@ -468,7 +466,7 @@ let (resugar_machine_integer :
         let uu___ = parse_machine_integer_desc fv in
         match uu___ with
         | FStar_Pervasives_Native.None ->
-            FStar_Compiler_Effect.failwith
+            failwith
               "Impossible: should be guarded by can_resugar_machine_integer"
         | FStar_Pervasives_Native.Some (sw, uu___1) ->
             FStar_Parser_AST.mk_term
@@ -575,8 +573,7 @@ let rec (resugar_term' :
         uu___1.FStar_Syntax_Syntax.n in
       match uu___ with
       | FStar_Syntax_Syntax.Tm_delayed uu___1 ->
-          FStar_Compiler_Effect.failwith
-            "Tm_delayed is impossible after compress"
+          failwith "Tm_delayed is impossible after compress"
       | FStar_Syntax_Syntax.Tm_lazy i ->
           let uu___1 = FStar_Syntax_Util.unfold_lazy i in
           resugar_term' env uu___1
@@ -634,8 +631,7 @@ let rec (resugar_term' :
                    let r1 =
                      FStar_Ident.mk_ident (snd, (t.FStar_Syntax_Syntax.pos)) in
                    mk (FStar_Parser_AST.Projector (l, r1))
-               | uu___2 ->
-                   FStar_Compiler_Effect.failwith "wrong projector format")
+               | uu___2 -> failwith "wrong projector format")
             else
               (let uu___3 =
                  FStar_Ident.lid_equals a FStar_Parser_Const.smtpat_lid in
@@ -774,9 +770,7 @@ let rec (resugar_term' :
                 { FStar_Syntax_Syntax.bs1 = xs;
                   FStar_Syntax_Syntax.comp = body;_}
                 -> (xs, body)
-            | uu___4 ->
-                FStar_Compiler_Effect.failwith
-                  "impossible: Tm_arrow in resugar_term" in
+            | uu___4 -> failwith "impossible: Tm_arrow in resugar_term" in
           (match uu___2 with
            | (xs, body) ->
                let uu___3 = FStar_Syntax_Subst.open_comp xs body in
@@ -862,8 +856,7 @@ let rec (resugar_term' :
                  match uu___3 with
                  | hd::[] -> [hd]
                  | hd::tl -> last tl
-                 | uu___4 ->
-                     FStar_Compiler_Effect.failwith "last of an empty list" in
+                 | uu___4 -> failwith "last of an empty list" in
                let first_two_explicit args1 =
                  let rec drop_implicits args2 =
                    match args2 with
@@ -874,12 +867,8 @@ let rec (resugar_term' :
                    | uu___3 -> args2 in
                  let uu___3 = drop_implicits args1 in
                  match uu___3 with
-                 | [] ->
-                     FStar_Compiler_Effect.failwith
-                       "not_enough explicit_arguments"
-                 | uu___4::[] ->
-                     FStar_Compiler_Effect.failwith
-                       "not_enough explicit_arguments"
+                 | [] -> failwith "not_enough explicit_arguments"
+                 | uu___4::[] -> failwith "not_enough explicit_arguments"
                  | a1::a2::uu___4 -> [a1; a2] in
                let resugar_as_app e1 args1 =
                  let args2 =
@@ -953,9 +942,7 @@ let rec (resugar_term' :
                               FStar_Ident.mk_ident
                                 (snd, (t2.FStar_Syntax_Syntax.pos)) in
                             FStar_Pervasives_Native.Some (l, r1)
-                        | uu___4 ->
-                            FStar_Compiler_Effect.failwith
-                              "wrong projector format")
+                        | uu___4 -> failwith "wrong projector format")
                      else FStar_Pervasives_Native.None
                  | uu___4 -> FStar_Pervasives_Native.None in
                let uu___3 =
@@ -1014,9 +1001,7 @@ let rec (resugar_term' :
                     (let unsnoc l =
                        let rec unsnoc' acc uu___7 =
                          match uu___7 with
-                         | [] ->
-                             FStar_Compiler_Effect.failwith
-                               "unsnoc: empty list"
+                         | [] -> failwith "unsnoc: empty list"
                          | x::[] -> ((FStar_Compiler_List.rev acc), x)
                          | x::xs -> unsnoc' (x :: acc) xs in
                        unsnoc' [] l in
@@ -1326,7 +1311,7 @@ let rec (resugar_term' :
                                                | (a1, uu___13)::(a2, uu___14)::[]
                                                    -> (a1, a2)
                                                | uu___13 ->
-                                                   FStar_Compiler_Effect.failwith
+                                                   failwith
                                                      "wrong arguments to try_with" in
                                              (match uu___12 with
                                               | (body, handler) ->
@@ -1362,8 +1347,7 @@ let rec (resugar_term' :
                                                           Prims.strcat
                                                             "wrong argument format to try_with: "
                                                             uu___16 in
-                                                        FStar_Compiler_Effect.failwith
-                                                          uu___15 in
+                                                        failwith uu___15 in
                                                   let body1 =
                                                     let uu___13 = decomp body in
                                                     resugar_term' env uu___13 in
@@ -1399,7 +1383,7 @@ let rec (resugar_term' :
                                                             uu___14 in
                                                         mk uu___13
                                                     | uu___13 ->
-                                                        FStar_Compiler_Effect.failwith
+                                                        failwith
                                                           "unexpected body format to try_with" in
                                                   let e1 = resugar_body body1 in
                                                   let rec resugar_branches t2
@@ -1547,7 +1531,7 @@ let rec (resugar_term' :
                                                             mk uu___18 in
                                                           ([], uu___17)
                                                       | uu___17 ->
-                                                          FStar_Compiler_Effect.failwith
+                                                          failwith
                                                             "wrong pattern format for QForall/QExists" in
                                                     (match uu___16 with
                                                      | (pats, body4) ->
@@ -1656,7 +1640,7 @@ let rec (resugar_term' :
                                       | (b, uu___11)::[] ->
                                           resugar_forall_body b
                                       | uu___11 ->
-                                          FStar_Compiler_Effect.failwith
+                                          failwith
                                             "wrong args format to QForall")
                                    else resugar_as_app e args1
                                | FStar_Pervasives_Native.Some
@@ -1830,9 +1814,7 @@ let rec (resugar_term' :
                              FStar_Syntax_Syntax.args =
                                (t1, uu___6)::(d, uu___7)::[];_}
                            -> (t1, d)
-                       | uu___5 ->
-                           FStar_Compiler_Effect.failwith
-                             "wrong let binding format" in
+                       | uu___5 -> failwith "wrong let binding format" in
                      (match uu___3 with
                       | (typ, def) ->
                           let uu___4 =
@@ -2340,7 +2322,7 @@ and (resugar_match_returns :
                      | (asc2, FStar_Pervasives_Native.None, use_eq) ->
                          (asc2, use_eq)
                      | uu___3 ->
-                         FStar_Compiler_Effect.failwith
+                         failwith
                            "resugaring does not support match return annotation with a tactic" in
                    (match uu___1 with
                     | (asc2, use_eq) ->
@@ -2427,7 +2409,7 @@ and (resugar_comp' :
               match c1.FStar_Syntax_Syntax.effect_args with
               | (pre, uu___2)::(post, uu___3)::(pats, uu___4)::[] ->
                   (pre, post, pats)
-              | uu___2 -> FStar_Compiler_Effect.failwith "impossible" in
+              | uu___2 -> failwith "impossible" in
             (match uu___1 with
              | (pre, post, pats) ->
                  let pre1 =
@@ -2914,8 +2896,7 @@ let (resugar_typ :
                          FStar_Syntax_Syntax.mutuals1 = uu___8;
                          FStar_Syntax_Syntax.injective_type_params1 = uu___9;_}
                        -> FStar_Ident.lid_equals inductive_lid tylid
-                   | uu___4 -> FStar_Compiler_Effect.failwith "unexpected")
-                datacon_ses in
+                   | uu___4 -> failwith "unexpected") datacon_ses in
             (match uu___3 with
              | (current_datacons, other_datacons) ->
                  let bs1 = filter_imp_bs bs in
@@ -2979,7 +2960,7 @@ let (resugar_typ :
                                 (uu___10, bs2, FStar_Pervasives_Native.None,
                                   uu___11, fields) in
                               FStar_Parser_AST.TyconRecord uu___9
-                          | uu___6 -> FStar_Compiler_Effect.failwith "ggg1")
+                          | uu___6 -> failwith "ggg1")
                    else
                      (let resugar_datacon constructors se1 =
                         match se1.FStar_Syntax_Syntax.sigel with
@@ -3006,8 +2987,7 @@ let (resugar_typ :
                                   se1.FStar_Syntax_Syntax.sigattrs in
                               (uu___9, uu___10, uu___11) in
                             c :: constructors
-                        | uu___6 ->
-                            FStar_Compiler_Effect.failwith "unexpected" in
+                        | uu___6 -> failwith "unexpected" in
                       let constructors =
                         FStar_Compiler_List.fold_left resugar_datacon []
                           current_datacons in
@@ -3018,7 +2998,7 @@ let (resugar_typ :
                       FStar_Parser_AST.TyconVariant uu___6) in
                  (other_datacons, tyc))
         | uu___ ->
-            FStar_Compiler_Effect.failwith
+            failwith
               "Impossible : only Sig_inductive_typ can be resugared as types"
 let (mk_decl :
   FStar_Compiler_Range_Type.range ->
@@ -3290,7 +3270,7 @@ let (resugar_sigelt' :
                    | FStar_Syntax_Syntax.Sig_declare_typ uu___2 -> true
                    | FStar_Syntax_Syntax.Sig_datacon uu___2 -> false
                    | uu___2 ->
-                       FStar_Compiler_Effect.failwith
+                       failwith
                          "Found a sigelt which is neither a type declaration or a data constructor in a sigelt")
                 ses in
             (match uu___1 with
@@ -3336,11 +3316,9 @@ let (resugar_sigelt' :
                                   decl'_to_decl se1 uu___10 in
                                 FStar_Pervasives_Native.Some uu___9
                             | uu___3 ->
-                                FStar_Compiler_Effect.failwith
+                                failwith
                                   "wrong format for resguar to Exception")
-                       | uu___3 ->
-                           FStar_Compiler_Effect.failwith
-                             "Should not happen hopefully")))
+                       | uu___3 -> failwith "Should not happen hopefully")))
         | FStar_Syntax_Syntax.Sig_fail uu___ -> FStar_Pervasives_Native.None
         | FStar_Syntax_Syntax.Sig_let
             { FStar_Syntax_Syntax.lbs1 = lbs;
@@ -3419,9 +3397,7 @@ let (resugar_sigelt' :
                        FStar_Parser_AST.TopLevelLet uu___6 in
                      decl'_to_decl se uu___5 in
                    FStar_Pervasives_Native.Some uu___4
-               | uu___3 ->
-                   FStar_Compiler_Effect.failwith
-                     "Should not happen hopefully")
+               | uu___3 -> failwith "Should not happen hopefully")
         | FStar_Syntax_Syntax.Sig_assume
             { FStar_Syntax_Syntax.lid3 = lid;
               FStar_Syntax_Syntax.us3 = uu___;
@@ -3474,9 +3450,7 @@ let (resugar_sigelt' :
                   FStar_Parser_AST.ReifiableLift (wp, t)
               | (FStar_Pervasives_Native.None, FStar_Pervasives_Native.Some
                  t) -> FStar_Parser_AST.LiftForFree t
-              | uu___ ->
-                  FStar_Compiler_Effect.failwith
-                    "Should not happen hopefully" in
+              | uu___ -> failwith "Should not happen hopefully" in
             let uu___ =
               decl'_to_decl se
                 (FStar_Parser_AST.SubEffect

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Subst.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Subst.ml
@@ -749,8 +749,7 @@ let rec (push_subst_aux :
           FStar_Syntax_Syntax.mk t' uu___ in
         match t.FStar_Syntax_Syntax.n with
         | FStar_Syntax_Syntax.Tm_delayed uu___ ->
-            FStar_Compiler_Effect.failwith
-              "Impossible (delayed node in push_subst)"
+            failwith "Impossible (delayed node in push_subst)"
         | FStar_Syntax_Syntax.Tm_lazy i ->
             (match i.FStar_Syntax_Syntax.lkind with
              | FStar_Syntax_Syntax.Lazy_embedding uu___ ->
@@ -1683,7 +1682,7 @@ let (open_term_1 :
       let uu___ = open_term [b] t in
       match uu___ with
       | (b1::[], t1) -> (b1, t1)
-      | uu___1 -> FStar_Compiler_Effect.failwith "impossible: open_term_1"
+      | uu___1 -> failwith "impossible: open_term_1"
 let (open_term_bvs :
   FStar_Syntax_Syntax.bv Prims.list ->
     FStar_Syntax_Syntax.term ->
@@ -1711,4 +1710,4 @@ let (open_term_bv :
       let uu___ = open_term_bvs [bv] t in
       match uu___ with
       | (bv1::[], t1) -> (bv1, t1)
-      | uu___1 -> FStar_Compiler_Effect.failwith "impossible: open_term_bv"
+      | uu___1 -> failwith "impossible: open_term_bv"

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Syntax.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Syntax.ml
@@ -2414,8 +2414,7 @@ let (lookup_aq : bv -> antiquotations -> term) =
                       - Prims.int_one)
                      - bv1.index)
                     + (FStar_Pervasives_Native.fst aq))) ()
-      with
-      | uu___ -> FStar_Compiler_Effect.failwith "antiquotation out of bounds"
+      with | uu___ -> failwith "antiquotation out of bounds"
 type path = Prims.string Prims.list
 type subst_t = subst_elt Prims.list
 let deq_instance_from_cmp :
@@ -2530,8 +2529,7 @@ let (mk_Tm_uinst : term -> universes -> term) =
       match t.n with
       | Tm_fvar uu___ ->
           (match us with | [] -> t | us1 -> mk (Tm_uinst (t, us1)) t.pos)
-      | uu___ ->
-          FStar_Compiler_Effect.failwith "Unexpected universe instantiation"
+      | uu___ -> failwith "Unexpected universe instantiation"
 let (extend_app_n : term -> args -> FStar_Compiler_Range_Type.range -> term)
   =
   fun t ->
@@ -3209,9 +3207,7 @@ let (showable_lazy_kind : lazy_kind FStar_Class_Show.showable) =
          | Lazy_tref -> "Lazy_tref"
          | Lazy_embedding uu___1 -> "Lazy_embedding _"
          | Lazy_extension s -> Prims.strcat "Lazy_extension " s
-         | uu___1 ->
-             FStar_Compiler_Effect.failwith
-               "FIXME! lazy_kind_to_string must be complete")
+         | uu___1 -> failwith "FIXME! lazy_kind_to_string must be complete")
   }
 let (deq_lazy_kind : lazy_kind FStar_Class_Deq.deq) =
   {

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Util.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Util.ml
@@ -241,7 +241,7 @@ let (subst_of_list :
                     ((f.FStar_Syntax_Syntax.binder_bv),
                       (FStar_Pervasives_Native.fst a)))
                  :: out) formals actuals []
-      else FStar_Compiler_Effect.failwith "Ill-formed substitution"
+      else failwith "Ill-formed substitution"
 let (rename_binders :
   FStar_Syntax_Syntax.binders ->
     FStar_Syntax_Syntax.binders -> FStar_Syntax_Syntax.subst_t)
@@ -261,7 +261,7 @@ let (rename_binders :
                      y.FStar_Syntax_Syntax.binder_bv in
                  ((x.FStar_Syntax_Syntax.binder_bv), uu___1) in
                FStar_Syntax_Syntax.NT uu___) replace_xs with_ys
-      else FStar_Compiler_Effect.failwith "Ill-formed substitution"
+      else failwith "Ill-formed substitution"
 let rec (unmeta : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
   fun e ->
     let e1 = FStar_Syntax_Subst.compress e in
@@ -325,7 +325,7 @@ let rec (univ_kernel :
                    FStar_Class_Printable.printable_int) i in
             Prims.strcat uu___3 ")" in
           Prims.strcat "Imposible: univ_kernel (U_bvar " uu___2 in
-        FStar_Compiler_Effect.failwith uu___1
+        failwith uu___1
 let (constant_univ_as_nat : FStar_Syntax_Syntax.universe -> Prims.int) =
   fun u -> let uu___ = univ_kernel u in FStar_Pervasives_Native.snd uu___
 let rec (compare_univs :
@@ -340,13 +340,13 @@ let rec (compare_univs :
           (uu___1, uu___2) in
         match uu___ with
         | (FStar_Syntax_Syntax.U_bvar uu___1, uu___2) ->
-            FStar_Compiler_Effect.failwith "Impossible: compare_kernel bvar"
+            failwith "Impossible: compare_kernel bvar"
         | (uu___1, FStar_Syntax_Syntax.U_bvar uu___2) ->
-            FStar_Compiler_Effect.failwith "Impossible: compare_kernel bvar"
+            failwith "Impossible: compare_kernel bvar"
         | (FStar_Syntax_Syntax.U_succ uu___1, uu___2) ->
-            FStar_Compiler_Effect.failwith "Impossible: compare_kernel succ"
+            failwith "Impossible: compare_kernel succ"
         | (uu___1, FStar_Syntax_Syntax.U_succ uu___2) ->
-            FStar_Compiler_Effect.failwith "Impossible: compare_kernel succ"
+            failwith "Impossible: compare_kernel succ"
         | (FStar_Syntax_Syntax.U_unknown, FStar_Syntax_Syntax.U_unknown) ->
             Prims.int_zero
         | (FStar_Syntax_Syntax.U_unknown, uu___1) -> (Prims.of_int (-1))
@@ -513,7 +513,7 @@ let (destruct_comp :
             FStar_Compiler_Util.format2
               "Impossible: Got a computation %s with %s effect args" uu___2
               uu___3 in
-          FStar_Compiler_Effect.failwith uu___1 in
+          failwith uu___1 in
     let uu___ = FStar_Compiler_List.hd c.FStar_Syntax_Syntax.comp_univs in
     (uu___, (c.FStar_Syntax_Syntax.result_typ), wp)
 let (is_named_tot :
@@ -942,9 +942,8 @@ let unlazy_as_t :
                    k' in
                FStar_Compiler_Util.format2
                  "Expected Tm_lazy of kind %s, got %s" uu___6 uu___7 in
-             FStar_Compiler_Effect.failwith uu___5)
-      | uu___1 ->
-          FStar_Compiler_Effect.failwith "Not a Tm_lazy of the expected kind"
+             failwith uu___5)
+      | uu___1 -> failwith "Not a Tm_lazy of the expected kind"
 let mk_lazy :
   'a .
     'a ->
@@ -1257,8 +1256,7 @@ let (ses_of_sigbundle :
     | FStar_Syntax_Syntax.Sig_bundle
         { FStar_Syntax_Syntax.ses = ses; FStar_Syntax_Syntax.lids = uu___;_}
         -> ses
-    | uu___ ->
-        FStar_Compiler_Effect.failwith "ses_of_sigbundle: not a Sig_bundle"
+    | uu___ -> failwith "ses_of_sigbundle: not a Sig_bundle"
 let (set_uvar : FStar_Syntax_Syntax.uvar -> FStar_Syntax_Syntax.term -> unit)
   =
   fun uv ->
@@ -1275,7 +1273,7 @@ let (set_uvar : FStar_Syntax_Syntax.uvar -> FStar_Syntax_Syntax.term -> unit)
             FStar_Compiler_Util.format3
               "Changing a fixed uvar! ?%s to %s but it is already set to %s\n"
               uu___2 uu___3 uu___4 in
-          FStar_Compiler_Effect.failwith uu___1
+          failwith uu___1
       | uu___1 -> FStar_Syntax_Unionfind.change uv t
 let (qualifier_equal :
   FStar_Syntax_Syntax.qualifier ->
@@ -1865,7 +1863,7 @@ let (open_univ_vars_binders_and_comp :
                       { FStar_Syntax_Syntax.bs1 = binders1;
                         FStar_Syntax_Syntax.comp = c1;_}
                       -> (uvs1, binders1, c1)
-                  | uu___3 -> FStar_Compiler_Effect.failwith "Impossible"))
+                  | uu___3 -> failwith "Impossible"))
 let (is_tuple_constructor : FStar_Syntax_Syntax.typ -> Prims.bool) =
   fun t ->
     match t.FStar_Syntax_Syntax.n with
@@ -2667,8 +2665,7 @@ let (un_squash :
                        let b1 =
                          match bs with
                          | b2::[] -> b2
-                         | uu___3 ->
-                             FStar_Compiler_Effect.failwith "impossible" in
+                         | uu___3 -> failwith "impossible" in
                        let uu___3 =
                          let uu___4 = FStar_Syntax_Free.names p1 in
                          FStar_Class_Setlike.mem ()
@@ -2808,7 +2805,7 @@ let (arrow_one_ln :
     match uu___ with
     | FStar_Syntax_Syntax.Tm_arrow
         { FStar_Syntax_Syntax.bs1 = []; FStar_Syntax_Syntax.comp = uu___1;_}
-        -> FStar_Compiler_Effect.failwith "fatal: empty binders on arrow?"
+        -> failwith "fatal: empty binders on arrow?"
     | FStar_Syntax_Syntax.Tm_arrow
         { FStar_Syntax_Syntax.bs1 = b::[]; FStar_Syntax_Syntax.comp = c;_} ->
         FStar_Pervasives_Native.Some (b, c)
@@ -2848,7 +2845,7 @@ let (arrow_one :
                     match bs with
                     | b2::[] -> b2
                     | uu___3 ->
-                        FStar_Compiler_Effect.failwith
+                        failwith
                           "impossible: open_comp returned different amount of binders" in
                   FStar_Pervasives_Native.Some (b1, c1)))
 let (abs_one_ln :
@@ -2864,7 +2861,7 @@ let (abs_one_ln :
     | FStar_Syntax_Syntax.Tm_abs
         { FStar_Syntax_Syntax.bs = []; FStar_Syntax_Syntax.body = uu___1;
           FStar_Syntax_Syntax.rc_opt = uu___2;_}
-        -> FStar_Compiler_Effect.failwith "fatal: empty binders on abs?"
+        -> failwith "fatal: empty binders on abs?"
     | FStar_Syntax_Syntax.Tm_abs
         { FStar_Syntax_Syntax.bs = b::[]; FStar_Syntax_Syntax.body = body;
           FStar_Syntax_Syntax.rc_opt = uu___1;_}
@@ -2991,7 +2988,7 @@ let rec apply_last :
   fun f ->
     fun l ->
       match l with
-      | [] -> FStar_Compiler_Effect.failwith "apply_last: got empty list"
+      | [] -> failwith "apply_last: got empty list"
       | a::[] -> let uu___ = f a in [uu___]
       | x::xs -> let uu___ = apply_last f xs in x :: uu___
 let (dm4f_lid :
@@ -3137,23 +3134,17 @@ let rec (term_eq_dbg :
           (uu___1, uu___2) in
         match uu___ with
         | (FStar_Syntax_Syntax.Tm_uinst uu___1, uu___2) ->
-            FStar_Compiler_Effect.failwith
-              "term_eq: impossible, should have been removed"
+            failwith "term_eq: impossible, should have been removed"
         | (uu___1, FStar_Syntax_Syntax.Tm_uinst uu___2) ->
-            FStar_Compiler_Effect.failwith
-              "term_eq: impossible, should have been removed"
+            failwith "term_eq: impossible, should have been removed"
         | (FStar_Syntax_Syntax.Tm_delayed uu___1, uu___2) ->
-            FStar_Compiler_Effect.failwith
-              "term_eq: impossible, should have been removed"
+            failwith "term_eq: impossible, should have been removed"
         | (uu___1, FStar_Syntax_Syntax.Tm_delayed uu___2) ->
-            FStar_Compiler_Effect.failwith
-              "term_eq: impossible, should have been removed"
+            failwith "term_eq: impossible, should have been removed"
         | (FStar_Syntax_Syntax.Tm_ascribed uu___1, uu___2) ->
-            FStar_Compiler_Effect.failwith
-              "term_eq: impossible, should have been removed"
+            failwith "term_eq: impossible, should have been removed"
         | (uu___1, FStar_Syntax_Syntax.Tm_ascribed uu___2) ->
-            FStar_Compiler_Effect.failwith
-              "term_eq: impossible, should have been removed"
+            failwith "term_eq: impossible, should have been removed"
         | (FStar_Syntax_Syntax.Tm_bvar x, FStar_Syntax_Syntax.Tm_bvar y) ->
             check1 "bvar"
               (x.FStar_Syntax_Syntax.index = y.FStar_Syntax_Syntax.index)
@@ -3664,8 +3655,7 @@ let rec (unbound_variables :
   fun tm ->
     let t = FStar_Syntax_Subst.compress tm in
     match t.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_delayed uu___ ->
-        FStar_Compiler_Effect.failwith "Impossible"
+    | FStar_Syntax_Syntax.Tm_delayed uu___ -> failwith "Impossible"
     | FStar_Syntax_Syntax.Tm_name x -> []
     | FStar_Syntax_Syntax.Tm_uvar uu___ -> []
     | FStar_Syntax_Syntax.Tm_type u -> []
@@ -4074,7 +4064,7 @@ let (destruct_lemma_with_smt_patterns :
                     let uu___10 = lemma_pats pats in
                     (binders1, pre, post, uu___10) in
                   FStar_Pervasives_Native.Some uu___9
-              | uu___2 -> FStar_Compiler_Effect.failwith "impos"))
+              | uu___2 -> failwith "impos"))
     | uu___1 -> FStar_Pervasives_Native.None
 let (triggers_of_smt_lemma :
   FStar_Syntax_Syntax.term -> FStar_Ident.lident Prims.list Prims.list) =
@@ -4131,8 +4121,7 @@ let (smt_lemma_as_forall :
       let uu___ =
         let uu___1 = destruct_lemma_with_smt_patterns t in
         match uu___1 with
-        | FStar_Pervasives_Native.None ->
-            FStar_Compiler_Effect.failwith "impos"
+        | FStar_Pervasives_Native.None -> failwith "impos"
         | FStar_Pervasives_Native.Some res -> res in
       match uu___ with
       | (binders, pre, post, patterns) ->
@@ -4184,9 +4173,7 @@ let (eff_decl_of_new_effect :
   fun se ->
     match se.FStar_Syntax_Syntax.sigel with
     | FStar_Syntax_Syntax.Sig_new_effect ne -> ne
-    | uu___ ->
-        FStar_Compiler_Effect.failwith
-          "eff_decl_of_new_effect: not a Sig_new_effect"
+    | uu___ -> failwith "eff_decl_of_new_effect: not a Sig_new_effect"
 let (is_layered : FStar_Syntax_Syntax.eff_decl -> Prims.bool) =
   fun ed ->
     match ed.FStar_Syntax_Syntax.combinators with

--- a/ocaml/fstar-lib/generated/FStar_Syntax_VisitM.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_VisitM.ml
@@ -402,10 +402,8 @@ let on_sub_term : 'm . 'm lvm -> FStar_Syntax_Syntax.term -> 'm =
       let mk t = FStar_Syntax_Syntax.mk t tm.FStar_Syntax_Syntax.pos in
       let tm1 = compress tm in
       match tm1.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Tm_lazy uu___ ->
-          FStar_Compiler_Effect.failwith "impos"
-      | FStar_Syntax_Syntax.Tm_delayed uu___ ->
-          FStar_Compiler_Effect.failwith "impos"
+      | FStar_Syntax_Syntax.Tm_lazy uu___ -> failwith "impos"
+      | FStar_Syntax_Syntax.Tm_delayed uu___ -> failwith "impos"
       | FStar_Syntax_Syntax.Tm_fvar uu___ ->
           FStar_Class_Monad.return (_lvm_monad d) () (Obj.magic tm1)
       | FStar_Syntax_Syntax.Tm_constant uu___ ->
@@ -2104,7 +2102,7 @@ let rec on_sub_sigelt' : 'm . 'm lvm -> FStar_Syntax_Syntax.sigelt' -> 'm =
                                FStar_Syntax_Syntax.lids2 = lids;
                                FStar_Syntax_Syntax.tac = tac1
                              })))) uu___1)
-      | uu___ -> FStar_Compiler_Effect.failwith "on_sub_sigelt: missing case"
+      | uu___ -> failwith "on_sub_sigelt: missing case"
 and on_sub_sigelt : 'm . 'm lvm -> FStar_Syntax_Syntax.sigelt -> 'm =
   fun d ->
     fun se ->

--- a/ocaml/fstar-lib/generated/FStar_Tactics_CtrlRewrite.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_CtrlRewrite.ml
@@ -1050,7 +1050,7 @@ and (on_subterms :
                                                          | x2::[] ->
                                                              x2.FStar_Syntax_Syntax.binder_bv
                                                          | uu___3 ->
-                                                             FStar_Compiler_Effect.failwith
+                                                             failwith
                                                                "Impossible" in
                                                        FStar_Syntax_Syntax.Tm_refine
                                                          {
@@ -1262,9 +1262,7 @@ and (on_subterms :
                                                   FStar_Syntax_Syntax.body1 =
                                                     uu___7;_}
                                                 -> lb1
-                                            | uu___7 ->
-                                                FStar_Compiler_Effect.failwith
-                                                  "impossible" in
+                                            | uu___7 -> failwith "impossible" in
                                           let uu___6 =
                                             FStar_Syntax_Subst.open_term_bv
                                               bv e in
@@ -1578,7 +1576,7 @@ let (ctrl_rewrite :
                   let uu___1 =
                     match ps.FStar_Tactics_Types.goals with
                     | g::gs -> (g, gs)
-                    | [] -> FStar_Compiler_Effect.failwith "no goals" in
+                    | [] -> failwith "no goals" in
                   match uu___1 with
                   | (g, gs) ->
                       Obj.magic

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Embedding.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Embedding.ml
@@ -423,7 +423,7 @@ let (e_exn_nbe : Prims.exn FStar_TypeChecker_NBETerm.embedding) =
         let uu___1 =
           let uu___2 = FStar_Compiler_Util.message_of_exn e in
           FStar_Compiler_Util.format1 "cannot embed exn (NBE) : %s" uu___2 in
-        FStar_Compiler_Effect.failwith uu___1 in
+        failwith uu___1 in
   let unembed_exn cb t =
     let uu___ = FStar_TypeChecker_NBETerm.nbe_t_of_t t in
     match uu___ with

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Hooks.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Hooks.ml
@@ -572,8 +572,7 @@ let (preprocess :
               | Unchanged t' -> (false, (t', []))
               | Simplified (t', gs) -> (true, (t', gs))
               | uu___4 ->
-                  FStar_Compiler_Effect.failwith
-                    "preprocess: impossible, traverse returned a Dual" in
+                  failwith "preprocess: impossible, traverse returned a Dual" in
             match uu___2 with
             | (did_anything, (t', gs)) ->
                 ((let uu___4 = FStar_Compiler_Effect.op_Bang dbg_Tac in
@@ -1423,8 +1422,7 @@ let (spinoff_strictly_positive_goals :
              | Unchanged t' -> (t', [])
              | Simplified (t', gs) -> (t', gs)
              | uu___4 ->
-                 FStar_Compiler_Effect.failwith
-                   "preprocess: impossible, traverse returned a Dual" in
+                 failwith "preprocess: impossible, traverse returned a Dual" in
            match uu___2 with
            | (t', gs) ->
                let t'1 =
@@ -1708,8 +1706,7 @@ let (handle_smt_goal :
                        FStar_Syntax_Syntax.lid_as_fv lid
                          FStar_Pervasives_Native.None in
                      FStar_Syntax_Syntax.fv_to_tm uu___3
-                 | uu___2 ->
-                     FStar_Compiler_Effect.failwith "Resolve_tac not found" in
+                 | uu___2 -> failwith "Resolve_tac not found" in
                let gs =
                  FStar_Errors.with_ctx
                    "While handling an SMT goal with a tactic"

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Interpreter.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Interpreter.ml
@@ -398,9 +398,7 @@ let e_tactic_thunk :
       (fun uu___1 ->
          fun uu___2 ->
            fun uu___3 ->
-             fun uu___4 ->
-               FStar_Compiler_Effect.failwith
-                 "Impossible: embedding tactic (thunk)?")
+             fun uu___4 -> failwith "Impossible: embedding tactic (thunk)?")
       (fun t ->
          fun cb ->
            let uu___1 =
@@ -416,9 +414,7 @@ let e_tactic_nbe_thunk :
   fun er ->
     FStar_TypeChecker_NBETerm.mk_emb
       (fun cb ->
-         fun uu___ ->
-           FStar_Compiler_Effect.failwith
-             "Impossible: NBE embedding tactic (thunk)?")
+         fun uu___ -> failwith "Impossible: NBE embedding tactic (thunk)?")
       (fun cb ->
          fun t ->
            let uu___ =
@@ -445,9 +441,7 @@ let e_tactic_1 :
         (fun uu___1 ->
            fun uu___2 ->
              fun uu___3 ->
-               fun uu___4 ->
-                 FStar_Compiler_Effect.failwith
-                   "Impossible: embedding tactic (1)?")
+               fun uu___4 -> failwith "Impossible: embedding tactic (1)?")
         (fun t ->
            fun cb ->
              let uu___1 = unembed_tactic_1 ea er t cb in
@@ -463,9 +457,7 @@ let e_tactic_nbe_1 :
     fun er ->
       FStar_TypeChecker_NBETerm.mk_emb
         (fun cb ->
-           fun uu___ ->
-             FStar_Compiler_Effect.failwith
-               "Impossible: NBE embedding tactic (1)?")
+           fun uu___ -> failwith "Impossible: NBE embedding tactic (1)?")
         (fun cb ->
            fun t ->
              let uu___ = unembed_tactic_nbe_1 ea er cb t in
@@ -508,7 +500,7 @@ let e_tactic_1_alt :
   fun ea ->
     fun er ->
       let em uu___ uu___1 uu___2 uu___3 =
-        FStar_Compiler_Effect.failwith "Impossible: embedding tactic (1)?" in
+        failwith "Impossible: embedding tactic (1)?" in
       let un t0 n =
         let uu___ = unembed_tactic_1_alt ea er t0 n in
         match uu___ with
@@ -998,7 +990,7 @@ let run_unembedded_tactic_on_ps :
                                     FStar_Compiler_Util.format1
                                       "Irrelevant tactic witness does not unify with (): %s"
                                       uu___9 in
-                                  FStar_Compiler_Effect.failwith uu___8)))
+                                  failwith uu___8)))
                            else ())) remaining_smt_goals;
                      FStar_Errors.with_ctx
                        "While checking implicits left by a tactic"

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Printing.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Printing.ml
@@ -55,9 +55,7 @@ let (unshadow :
               let uu___ = FStar_Syntax_Subst.subst_binders subst [b] in
               match uu___ with
               | b2::[] -> b2
-              | uu___1 ->
-                  FStar_Compiler_Effect.failwith
-                    "impossible: unshadow subst_binders" in
+              | uu___1 -> failwith "impossible: unshadow subst_binders" in
             let uu___ =
               ((b1.FStar_Syntax_Syntax.binder_bv),
                 (b1.FStar_Syntax_Syntax.binder_qual)) in
@@ -162,8 +160,7 @@ let (goal_to_string :
                          FStar_Syntax_Syntax.binder_attrs =
                            (uu___1.FStar_Syntax_Syntax.binder_attrs)
                        }
-                   | uu___3 ->
-                       FStar_Compiler_Effect.failwith "Not a renaming") bs in
+                   | uu___3 -> failwith "Not a renaming") bs in
             let goal_binders =
               (g.FStar_Tactics_Types.goal_ctx_uvar).FStar_Syntax_Syntax.ctx_uvar_binders in
             let goal_ty = FStar_Tactics_Types.goal_type g in

--- a/ocaml/fstar-lib/generated/FStar_Tactics_V1_Basic.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_V1_Basic.ml
@@ -1183,7 +1183,7 @@ let (do_unify_aux :
                          Prims.op_Negation uu___5 in
                        if uu___4
                        then
-                         FStar_Compiler_Effect.failwith
+                         failwith
                            "internal error: do_unify: guard is not trivial"
                        else ());
                       ret true))
@@ -3829,9 +3829,7 @@ let (lemma_or_sq :
             | pre::post::uu___3 ->
                 ((FStar_Pervasives_Native.fst pre),
                   (FStar_Pervasives_Native.fst post))
-            | uu___3 ->
-                FStar_Compiler_Effect.failwith
-                  "apply_lemma: impossible: not a lemma" in
+            | uu___3 -> failwith "apply_lemma: impossible: not a lemma" in
           (match uu___2 with
            | (pre, post) ->
                let post1 =
@@ -5618,7 +5616,7 @@ let (_t_trefl :
                                                              if uu___6
                                                              then ret true
                                                              else
-                                                               FStar_Compiler_Effect.failwith
+                                                               failwith
                                                                  "internal error: _t_refl: guard is not trivial")))
                                                     uu___4)))) uu___2)))
                      uu___2 uu___1 in
@@ -7364,7 +7362,7 @@ let (t_destruct :
                                                       | FStar_Syntax_Syntax.Tm_fvar
                                                           fv -> ret (fv, us)
                                                       | uu___9 ->
-                                                          FStar_Compiler_Effect.failwith
+                                                          failwith
                                                             "impossible: uinst over something that's not an fvar")
                                                  | uu___8 ->
                                                      FStar_Tactics_Monad.fail
@@ -8329,13 +8327,13 @@ let (gather_explicit_guards_for_resolved_goals :
 let rec last : 'a . 'a Prims.list -> 'a =
   fun l ->
     match l with
-    | [] -> FStar_Compiler_Effect.failwith "last: empty list"
+    | [] -> failwith "last: empty list"
     | x::[] -> x
     | uu___::xs -> last xs
 let rec init : 'a . 'a Prims.list -> 'a Prims.list =
   fun l ->
     match l with
-    | [] -> FStar_Compiler_Effect.failwith "init: empty list"
+    | [] -> failwith "init: empty list"
     | x::[] -> []
     | x::xs -> let uu___ = init xs in x :: uu___
 let rec (inspect :
@@ -8376,7 +8374,7 @@ let rec (inspect :
                             (ret (FStar_Reflection_V1_Data.Tv_UInst (fv, us)))
                       | uu___3 ->
                           Obj.magic
-                            (FStar_Compiler_Effect.failwith
+                            (failwith
                                "Tac::inspect: Tm_uinst head not an fvar"))
                  | FStar_Syntax_Syntax.Tm_ascribed
                      { FStar_Syntax_Syntax.tm = t3;
@@ -8401,10 +8399,7 @@ let rec (inspect :
                  | FStar_Syntax_Syntax.Tm_app
                      { FStar_Syntax_Syntax.hd = uu___2;
                        FStar_Syntax_Syntax.args = [];_}
-                     ->
-                     Obj.magic
-                       (FStar_Compiler_Effect.failwith
-                          "empty arguments on Tm_app")
+                     -> Obj.magic (failwith "empty arguments on Tm_app")
                  | FStar_Syntax_Syntax.Tm_app
                      { FStar_Syntax_Syntax.hd = hd;
                        FStar_Syntax_Syntax.args = args;_}
@@ -8427,10 +8422,7 @@ let rec (inspect :
                      { FStar_Syntax_Syntax.bs = [];
                        FStar_Syntax_Syntax.body = uu___2;
                        FStar_Syntax_Syntax.rc_opt = uu___3;_}
-                     ->
-                     Obj.magic
-                       (FStar_Compiler_Effect.failwith
-                          "empty arguments on Tm_abs")
+                     -> Obj.magic (failwith "empty arguments on Tm_abs")
                  | FStar_Syntax_Syntax.Tm_abs
                      { FStar_Syntax_Syntax.bs = bs;
                        FStar_Syntax_Syntax.body = t3;
@@ -8440,9 +8432,7 @@ let rec (inspect :
                      (match uu___2 with
                       | (bs1, t4) ->
                           (match bs1 with
-                           | [] ->
-                               Obj.magic
-                                 (FStar_Compiler_Effect.failwith "impossible")
+                           | [] -> Obj.magic (failwith "impossible")
                            | b::bs2 ->
                                let uu___3 =
                                  let uu___4 =
@@ -8456,10 +8446,7 @@ let rec (inspect :
                  | FStar_Syntax_Syntax.Tm_arrow
                      { FStar_Syntax_Syntax.bs1 = [];
                        FStar_Syntax_Syntax.comp = uu___2;_}
-                     ->
-                     Obj.magic
-                       (FStar_Compiler_Effect.failwith
-                          "empty binders on arrow")
+                     -> Obj.magic (failwith "empty binders on arrow")
                  | FStar_Syntax_Syntax.Tm_arrow uu___2 ->
                      let uu___3 = FStar_Syntax_Util.arrow_one t2 in
                      (match uu___3 with
@@ -8467,8 +8454,7 @@ let rec (inspect :
                           Obj.magic
                             (ret (FStar_Reflection_V1_Data.Tv_Arrow (b, c)))
                       | FStar_Pervasives_Native.None ->
-                          Obj.magic
-                            (FStar_Compiler_Effect.failwith "impossible"))
+                          Obj.magic (failwith "impossible"))
                  | FStar_Syntax_Syntax.Tm_refine
                      { FStar_Syntax_Syntax.b = bv;
                        FStar_Syntax_Syntax.phi = t3;_}
@@ -8480,8 +8466,7 @@ let rec (inspect :
                           let b1 =
                             match b' with
                             | b'1::[] -> b'1
-                            | uu___3 ->
-                                FStar_Compiler_Effect.failwith "impossible" in
+                            | uu___3 -> failwith "impossible" in
                           Obj.magic
                             (ret
                                (FStar_Reflection_V1_Data.Tv_Refine
@@ -8525,7 +8510,7 @@ let rec (inspect :
                                    match bs with
                                    | b2::[] -> b2
                                    | uu___4 ->
-                                       FStar_Compiler_Effect.failwith
+                                       failwith
                                          "impossible: open_term returned different amount of binders" in
                                  Obj.magic
                                    (ret
@@ -8572,7 +8557,7 @@ let rec (inspect :
                                                      t22))))
                                   | uu___4 ->
                                       Obj.magic
-                                        (FStar_Compiler_Effect.failwith
+                                        (failwith
                                            "impossible: open_term returned different amount of binders"))))
                  | FStar_Syntax_Syntax.Tm_match
                      { FStar_Syntax_Syntax.scrutinee = t3;
@@ -9056,7 +9041,7 @@ let (t_commute_applied_match : unit -> unit FStar_Tactics_Monad.tac) =
                                                    FStar_Syntax_Util.exp_unit))
                                            else
                                              Obj.magic
-                                               (FStar_Compiler_Effect.failwith
+                                               (failwith
                                                   "internal error: _t_refl: guard is not trivial"))
                                       uu___6))
                         | uu___5 ->

--- a/ocaml/fstar-lib/generated/FStar_Tactics_V1_Primops.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_V1_Primops.ml
@@ -51,7 +51,7 @@ let (fix_module :
         FStar_TypeChecker_Primops_Base.interpretation_nbe =
           (ps.FStar_TypeChecker_Primops_Base.interpretation_nbe)
       }
-    else FStar_Compiler_Effect.failwith "huh?"
+    else failwith "huh?"
 let (ops : FStar_TypeChecker_Primops_Base.primitive_step Prims.list) =
   let uu___ =
     let uu___1 =
@@ -335,7 +335,7 @@ let (ops : FStar_TypeChecker_Primops_Base.primitive_step Prims.list) =
                                                       FStar_Tactics_V1_Basic.unquote
                                                       (fun uu___48 ->
                                                          fun uu___49 ->
-                                                           FStar_Compiler_Effect.failwith
+                                                           failwith
                                                              "NBE unquote") in
                                                   let uu___48 =
                                                     let uu___49 =

--- a/ocaml/fstar-lib/generated/FStar_Tactics_V2_Basic.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_V2_Basic.ml
@@ -1477,7 +1477,7 @@ let (do_unify_aux :
                                           Prims.op_Negation uu___4 in
                                         if uu___3
                                         then
-                                          FStar_Compiler_Effect.failwith
+                                          failwith
                                             "internal error: do_unify: guard is not trivial"
                                         else
                                           FStar_Class_Monad.return
@@ -4505,9 +4505,7 @@ let (lemma_or_sq :
             | pre::post::uu___3 ->
                 ((FStar_Pervasives_Native.fst pre),
                   (FStar_Pervasives_Native.fst post))
-            | uu___3 ->
-                FStar_Compiler_Effect.failwith
-                  "apply_lemma: impossible: not a lemma" in
+            | uu___3 -> failwith "apply_lemma: impossible: not a lemma" in
           (match uu___2 with
            | (pre, post) ->
                let post1 =
@@ -6761,7 +6759,7 @@ let (_t_trefl :
                                                                     true))
                                                           else
                                                             Obj.repr
-                                                              (FStar_Compiler_Effect.failwith
+                                                              (failwith
                                                                  "internal error: _t_refl: guard is not trivial"))))
                                                  uu___4))) uu___2))) uu___2
                      uu___1 in
@@ -8531,7 +8529,7 @@ let (t_destruct :
                                                                     (fv, us)))
                                                            | uu___9 ->
                                                                Obj.repr
-                                                                 (FStar_Compiler_Effect.failwith
+                                                                 (failwith
                                                                     "impossible: uinst over something that's not an fvar")))
                                                  | uu___8 ->
                                                      Obj.magic
@@ -9534,13 +9532,13 @@ let (gather_explicit_guards_for_resolved_goals :
 let rec last : 'a . 'a Prims.list -> 'a =
   fun l ->
     match l with
-    | [] -> FStar_Compiler_Effect.failwith "last: empty list"
+    | [] -> failwith "last: empty list"
     | x::[] -> x
     | uu___::xs -> last xs
 let rec init : 'a . 'a Prims.list -> 'a Prims.list =
   fun l ->
     match l with
-    | [] -> FStar_Compiler_Effect.failwith "init: empty list"
+    | [] -> failwith "init: empty list"
     | x::[] -> []
     | x::xs -> let uu___ = init xs in x :: uu___
 let (lget :
@@ -9801,7 +9799,7 @@ let (t_commute_applied_match : unit -> unit FStar_Tactics_Monad.tac) =
                                                    FStar_Syntax_Util.exp_unit))
                                            else
                                              Obj.magic
-                                               (FStar_Compiler_Effect.failwith
+                                               (failwith
                                                   "internal error: _t_refl: guard is not trivial"))
                                       uu___6))
                         | uu___5 ->
@@ -11678,7 +11676,7 @@ let (refl_check_match_complete :
                                                                     -> p)
                                                                brs1
                                                          | uu___7 ->
-                                                             FStar_Compiler_Effect.failwith
+                                                             failwith
                                                                "refl_check_match_complete: not a match?" in
                                                        let pats1 =
                                                          get_pats mm1 in

--- a/ocaml/fstar-lib/generated/FStar_Tactics_V2_Primops.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_V2_Primops.ml
@@ -547,7 +547,7 @@ let (ops : FStar_TypeChecker_Primops_Base.primitive_step Prims.list) =
                                                                     fun
                                                                     uu___79
                                                                     ->
-                                                                    FStar_Compiler_Effect.failwith
+                                                                    failwith
                                                                     "NBE unquote") in
                                                                     let uu___78
                                                                     =

--- a/ocaml/fstar-lib/generated/FStar_ToSyntax_ToSyntax.ml
+++ b/ocaml/fstar-lib/generated/FStar_ToSyntax_ToSyntax.ml
@@ -299,8 +299,7 @@ let rec (is_comp_type :
           let uu___2 = FStar_Syntax_DsEnv.try_lookup_effect_name env l in
           FStar_Compiler_Option.isSome uu___2
       | FStar_Parser_AST.App (head, uu___1, uu___2) -> is_comp_type env head
-      | FStar_Parser_AST.Paren t1 ->
-          FStar_Compiler_Effect.failwith "impossible"
+      | FStar_Parser_AST.Paren t1 -> failwith "impossible"
       | FStar_Parser_AST.Ascribed (t1, uu___1, uu___2, uu___3) ->
           is_comp_type env t1
       | FStar_Parser_AST.LetOpen (uu___1, t1) -> is_comp_type env t1
@@ -511,8 +510,7 @@ and (free_vars :
         let uu___ = let uu___1 = unparen t in uu___1.FStar_Parser_AST.tm in
         match uu___ with
         | FStar_Parser_AST.Labeled uu___1 ->
-            FStar_Compiler_Effect.failwith
-              "Impossible --- labeled source term"
+            failwith "Impossible --- labeled source term"
         | FStar_Parser_AST.Tvar a ->
             let uu___1 = FStar_Syntax_DsEnv.try_lookup_id env a in
             (match uu___1 with
@@ -552,8 +550,7 @@ and (free_vars :
             let uu___1 = free_vars tvars_only env rel in
             let uu___2 = free_vars tvars_only env e in
             FStar_Compiler_List.op_At uu___1 uu___2
-        | FStar_Parser_AST.Paren t1 ->
-            FStar_Compiler_Effect.failwith "impossible"
+        | FStar_Parser_AST.Paren t1 -> failwith "impossible"
         | FStar_Parser_AST.Ascribed (t1, t', tacopt, uu___1) ->
             let ts = t1 :: t' ::
               (match tacopt with
@@ -896,7 +893,7 @@ let rec (destruct_app_pattern :
              args)
             ->
             ((FStar_Pervasives.Inl id), args, FStar_Pervasives_Native.None)
-        | uu___ -> FStar_Compiler_Effect.failwith "Not an app pattern"
+        | uu___ -> failwith "Not an app pattern"
 let rec (gather_pattern_bound_vars_maybe_top :
   FStar_Ident.ident FStar_Compiler_FlatSet.t ->
     FStar_Parser_AST.pattern -> FStar_Ident.ident FStar_Compiler_FlatSet.t)
@@ -1000,7 +997,7 @@ let (binder_of_bnd :
   fun uu___ ->
     match uu___ with
     | LocalBinder (a, aq, attrs) -> (a, aq, attrs)
-    | uu___1 -> FStar_Compiler_Effect.failwith "Impossible"
+    | uu___1 -> failwith "Impossible"
 let (mk_lb :
   (FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax Prims.list *
     (FStar_Syntax_Syntax.bv, FStar_Syntax_Syntax.fv) FStar_Pervasives.either
@@ -1075,10 +1072,10 @@ let rec (generalize_annotated_univs :
     let unames = get () in
     match s.FStar_Syntax_Syntax.sigel with
     | FStar_Syntax_Syntax.Sig_inductive_typ uu___1 ->
-        FStar_Compiler_Effect.failwith
+        failwith
           "Impossible: collect_annotated_universes: bare data/type constructor"
     | FStar_Syntax_Syntax.Sig_datacon uu___1 ->
-        FStar_Compiler_Effect.failwith
+        failwith
           "Impossible: collect_annotated_universes: bare data/type constructor"
     | FStar_Syntax_Syntax.Sig_bundle
         { FStar_Syntax_Syntax.ses = sigs; FStar_Syntax_Syntax.lids = lids;_}
@@ -1176,7 +1173,7 @@ let rec (generalize_annotated_univs :
                            (se.FStar_Syntax_Syntax.sigopts)
                        }
                    | uu___4 ->
-                       FStar_Compiler_Effect.failwith
+                       failwith
                          "Impossible: collect_annotated_universes: Sig_bundle should not have a non data/type sigelt")
                 sigs in
             {
@@ -1519,8 +1516,7 @@ let rec (desugar_maybe_non_constant_universe :
                         match uu___6 with
                         | FStar_Pervasives.Inl n -> n
                         | FStar_Pervasives.Inr uu___7 ->
-                            FStar_Compiler_Effect.failwith "impossible")
-                     univargs in
+                            failwith "impossible") univargs in
                  let uu___6 =
                    FStar_Compiler_List.fold_left
                      (fun m -> fun n -> if m > n then m else n)
@@ -1865,8 +1861,7 @@ let rec (desugar_data_pat :
           let orig = p1 in
           match p1.FStar_Parser_AST.pat with
           | FStar_Parser_AST.PatOr uu___ ->
-              FStar_Compiler_Effect.failwith
-                "impossible: PatOr handled below"
+              failwith "impossible: PatOr handled below"
           | FStar_Parser_AST.PatOp op ->
               let id_op =
                 let uu___ =
@@ -1899,8 +1894,7 @@ let rec (desugar_data_pat :
                 | (loc1, aqs1, env', binder, p3, annots) ->
                     let uu___2 =
                       match binder with
-                      | LetBinder uu___3 ->
-                          FStar_Compiler_Effect.failwith "impossible"
+                      | LetBinder uu___3 -> failwith "impossible"
                       | LocalBinder (x, aq, attrs) ->
                           let uu___3 =
                             let uu___4 = close_fun env1 t in
@@ -2133,7 +2127,7 @@ let rec (desugar_data_pat :
                    let l1 =
                      match constr.FStar_Syntax_Syntax.n with
                      | FStar_Syntax_Syntax.Tm_fvar fv -> fv
-                     | uu___1 -> FStar_Compiler_Effect.failwith "impossible" in
+                     | uu___1 -> failwith "impossible" in
                    let x =
                      let uu___1 = tun_r p1.FStar_Parser_AST.prange in
                      FStar_Syntax_Syntax.new_bv
@@ -2218,8 +2212,7 @@ let rec (desugar_data_pat :
         let aux_maybe_or env1 p1 =
           let loc = [] in
           match p1.FStar_Parser_AST.pat with
-          | FStar_Parser_AST.PatOr [] ->
-              FStar_Compiler_Effect.failwith "impossible"
+          | FStar_Parser_AST.PatOr [] -> failwith "impossible"
           | FStar_Parser_AST.PatOr (p2::ps) ->
               let uu___ = aux' true loc [] env1 p2 in
               (match uu___ with
@@ -2468,7 +2461,7 @@ and (desugar_machine_integer :
                                (intro_term.FStar_Syntax_Syntax.hash_code)
                            }
                        | uu___3 ->
-                           FStar_Compiler_Effect.failwith
+                           failwith
                              (Prims.strcat "Unexpected non-fvar for "
                                 intro_nm))
                   | FStar_Pervasives_Native.None ->
@@ -2571,7 +2564,7 @@ and (desugar_term_maybe_top :
          | FStar_Parser_AST.Ensures (t, lopt) ->
              let uu___2 = desugar_formula env t in (uu___2, noaqs)
          | FStar_Parser_AST.Attributes ts ->
-             FStar_Compiler_Effect.failwith
+             failwith
                "Attributes should not be desugared by desugar_term_maybe_top"
          | FStar_Parser_AST.Const (FStar_Const.Const_int
              (i, FStar_Pervasives_Native.Some size)) ->
@@ -2837,7 +2830,7 @@ and (desugar_term_maybe_top :
                     FStar_Compiler_Util.format2
                       "Member %s of effect %s is not accessible (using an effect abbreviation instead of the original effect ?)"
                       uu___4 txt in
-                  FStar_Compiler_Effect.failwith uu___3)
+                  failwith uu___3)
          | FStar_Parser_AST.Var l ->
              let uu___2 = desugar_name mk setpos env true l in
              (uu___2, noaqs)
@@ -2985,8 +2978,7 @@ and (desugar_term_maybe_top :
                    (fun uu___3 ->
                       match uu___3 with
                       | FStar_Pervasives.Inr x -> x
-                      | FStar_Pervasives.Inl uu___4 ->
-                          FStar_Compiler_Effect.failwith "Impossible")
+                      | FStar_Pervasives.Inl uu___4 -> failwith "Impossible")
                    binders in
                FStar_Compiler_List.op_At uu___2 [t] in
              let uu___2 =
@@ -3129,8 +3121,7 @@ and (desugar_term_maybe_top :
              let uu___2 = desugar_binder env b in
              (match uu___2 with
               | (FStar_Pervasives_Native.None, uu___3, uu___4) ->
-                  FStar_Compiler_Effect.failwith
-                    "Missing binder in refinement"
+                  failwith "Missing binder in refinement"
               | b1 ->
                   let uu___3 = as_binder env FStar_Pervasives_Native.None b1 in
                   (match uu___3 with
@@ -3345,9 +3336,7 @@ and (desugar_term_maybe_top :
                                          "Disjunctive patterns are not supported in abstractions") in
                               let uu___6 =
                                 match b with
-                                | LetBinder uu___7 ->
-                                    FStar_Compiler_Effect.failwith
-                                      "Impossible"
+                                | LetBinder uu___7 -> failwith "Impossible"
                                 | LocalBinder (x, aq1, attrs) ->
                                     let sc_pat_opt1 =
                                       match (pat1, sc_pat_opt) with
@@ -3483,9 +3472,7 @@ and (desugar_term_maybe_top :
                                                    uu___10 in
                                                FStar_Pervasives_Native.Some
                                                  (sc1, p2)
-                                           | uu___7 ->
-                                               FStar_Compiler_Effect.failwith
-                                                 "Impossible") in
+                                           | uu___7 -> failwith "Impossible") in
                                     let uu___7 =
                                       mk_binder_with_attrs x aq1 attrs in
                                     (uu___7, sc_pat_opt1) in
@@ -3659,7 +3646,7 @@ and (desugar_term_maybe_top :
          | FStar_Parser_AST.LetOperator (lets, body) ->
              (match lets with
               | [] ->
-                  FStar_Compiler_Effect.failwith
+                  failwith
                     "Impossible: a LetOperator (e.g. let+, let*...) cannot contain zero let binding"
               | (letOp, letPat, letDef)::tl ->
                   let term_of_op op =
@@ -4536,8 +4523,7 @@ and (desugar_term_maybe_top :
                 (Obj.magic FStar_Errors_Msg.is_error_message_string)
                 (Obj.magic "This name is being ignored");
               desugar_term_aq env e)
-         | FStar_Parser_AST.Paren e ->
-             FStar_Compiler_Effect.failwith "impossible"
+         | FStar_Parser_AST.Paren e -> failwith "impossible"
          | FStar_Parser_AST.VQuote e ->
              let uu___2 =
                let uu___3 =
@@ -5083,7 +5069,7 @@ and (desugar_term_maybe_top :
                        let e1 = desugar_term env'' e in
                        let rec mk_exists bs1 p2 =
                          match bs1 with
-                         | [] -> FStar_Compiler_Effect.failwith "Impossible"
+                         | [] -> failwith "Impossible"
                          | b::[] ->
                              let x = b.FStar_Syntax_Syntax.binder_bv in
                              let head =
@@ -6103,7 +6089,7 @@ and (desugar_formula :
               (match (names, pats1) with
                | ([], []) -> body1
                | ([], uu___1::uu___2) ->
-                   FStar_Compiler_Effect.failwith
+                   failwith
                      "Impossible: Annotated pattern without binders in scope"
                | uu___1 ->
                    let names1 =
@@ -6174,7 +6160,7 @@ and (desugar_formula :
                      } in
                    FStar_Syntax_Syntax.Tm_app uu___3 in
                  mk uu___2)
-        | uu___ -> FStar_Compiler_Effect.failwith "impossible" in
+        | uu___ -> failwith "impossible" in
       let push_quant q binders pats body =
         match binders with
         | b::b'::_rest ->
@@ -6188,7 +6174,7 @@ and (desugar_formula :
             let uu___ = q ([b], ([], []), body1) in
             FStar_Parser_AST.mk_term uu___ f.FStar_Parser_AST.range
               FStar_Parser_AST.Formula
-        | uu___ -> FStar_Compiler_Effect.failwith "impossible" in
+        | uu___ -> failwith "impossible" in
       let uu___ = let uu___1 = unparen f in uu___1.FStar_Parser_AST.tm in
       match uu___ with
       | FStar_Parser_AST.Labeled (f1, l, p) ->
@@ -6207,14 +6193,11 @@ and (desugar_formula :
             FStar_Syntax_Syntax.Tm_meta uu___2 in
           mk uu___1
       | FStar_Parser_AST.QForall ([], uu___1, uu___2) ->
-          FStar_Compiler_Effect.failwith
-            "Impossible: Quantifier without binders"
+          failwith "Impossible: Quantifier without binders"
       | FStar_Parser_AST.QExists ([], uu___1, uu___2) ->
-          FStar_Compiler_Effect.failwith
-            "Impossible: Quantifier without binders"
+          failwith "Impossible: Quantifier without binders"
       | FStar_Parser_AST.QuantOp (uu___1, [], uu___2, uu___3) ->
-          FStar_Compiler_Effect.failwith
-            "Impossible: Quantifier without binders"
+          failwith "Impossible: Quantifier without binders"
       | FStar_Parser_AST.QForall (_1::_2::_3, pats, body) ->
           let binders = _1 :: _2 :: _3 in
           let uu___1 =
@@ -6267,8 +6250,7 @@ and (desugar_formula :
                   (Obj.magic uu___2)
             | FStar_Pervasives_Native.Some t -> t in
           desugar_quant q_head b pats false body
-      | FStar_Parser_AST.Paren f1 ->
-          FStar_Compiler_Effect.failwith "impossible"
+      | FStar_Parser_AST.Paren f1 -> failwith "impossible"
       | uu___1 -> desugar_term env f
 and (desugar_binder_aq :
   FStar_Syntax_DsEnv.env ->
@@ -7104,7 +7086,7 @@ let rec (desugar_tycon :
                              (FStar_Pervasives_Native.Some
                                 (FStar_Parser_AST.VpArbitrary constrTyp)),
                              attrs)])), uu___2)))
-              | uu___1 -> FStar_Compiler_Effect.failwith "impossible" in
+              | uu___1 -> failwith "impossible" in
             let desugar_abstract_tc quals1 _env mutuals d_attrs uu___ =
               match uu___ with
               | FStar_Parser_AST.TyconAbstract (id, binders, kopt) ->
@@ -7167,7 +7149,7 @@ let rec (desugar_tycon :
                                 _env' id in
                             (match uu___4 with
                              | (_env2, uu___5) -> (_env1, _env2, se, tconstr))))
-              | uu___1 -> FStar_Compiler_Effect.failwith "Unexpected tycon" in
+              | uu___1 -> failwith "Unexpected tycon" in
             let push_tparams env1 bs =
               let uu___ =
                 FStar_Compiler_List.fold_left
@@ -7283,8 +7265,7 @@ let rec (desugar_tycon :
                              FStar_Syntax_Syntax.sigopts =
                                (se.FStar_Syntax_Syntax.sigopts)
                            }
-                       | uu___4 ->
-                           FStar_Compiler_Effect.failwith "Impossible" in
+                       | uu___4 -> failwith "Impossible" in
                      let env1 = FStar_Syntax_DsEnv.push_sigelt env se1 in
                      (env1, [se1]))
             | (FStar_Parser_AST.TyconAbbrev (id, binders, kopt, t), _d_attrs)::[]
@@ -7664,7 +7645,7 @@ let rec (desugar_tycon :
                                                          | FStar_Pervasives_Native.Some
                                                              (FStar_Parser_AST.VpRecord
                                                              uu___14) ->
-                                                             FStar_Compiler_Effect.failwith
+                                                             failwith
                                                                "Impossible: [VpRecord _] should have disappeared after [desugar_tycon_variant_record]"
                                                          | FStar_Pervasives_Native.None
                                                              ->
@@ -7860,9 +7841,7 @@ let rec (desugar_tycon :
                                                      } in
                                                    ([], uu___14) in
                                                  uu___13 :: constrs1))))
-                                 | uu___4 ->
-                                     FStar_Compiler_Effect.failwith
-                                       "impossible")) tcs3 in
+                                 | uu___4 -> failwith "impossible")) tcs3 in
                      let sigelts =
                        FStar_Compiler_List.map
                          (fun uu___3 ->
@@ -7972,7 +7951,7 @@ let rec (desugar_tycon :
                             (env4,
                               (FStar_Compiler_List.op_At [bundle]
                                  (FStar_Compiler_List.op_At abbrevs ops)))))))
-            | [] -> FStar_Compiler_Effect.failwith "impossible"
+            | [] -> failwith "impossible"
 let (desugar_binders :
   FStar_Syntax_DsEnv.env ->
     FStar_Parser_AST.binder Prims.list ->
@@ -8245,7 +8224,7 @@ let rec (desugar_effect :
                                  (name, uu___4, uu___5, uu___6))::[])
                                 -> FStar_Ident.string_of_id name
                             | uu___2 ->
-                                FStar_Compiler_Effect.failwith
+                                failwith
                                   "Malformed effect member declaration." in
                           let uu___2 =
                             FStar_Compiler_List.partition
@@ -8591,7 +8570,7 @@ let rec (desugar_effect :
                                                                (eff_t1.FStar_Syntax_Syntax.hash_code)
                                                            }, n)))
                                             | uu___8 ->
-                                                FStar_Compiler_Effect.failwith
+                                                failwith
                                                   "desugaring indexed effect: effect type not an arrow" in
                                           match uu___6 with
                                           | (eff_t2, num_effect_params) ->
@@ -9816,14 +9795,13 @@ and (desugar_decl_core :
                               let env1 = FStar_Syntax_DsEnv.push_sigelt env s in
                               (env1, [s]))
                      | uu___3 ->
-                         FStar_Compiler_Effect.failwith
-                           "Desugaring a let did not produce a let")))
+                         failwith "Desugaring a let did not produce a let")))
             else
               (let uu___1 =
                  match lets with
                  | (pat, body)::[] -> (pat, body)
                  | uu___2 ->
-                     FStar_Compiler_Effect.failwith
+                     failwith
                        "expand_toplevel_pattern should only allow single definition lets" in
                match uu___1 with
                | (pat, body) ->
@@ -10131,7 +10109,7 @@ and (desugar_decl_core :
               eff_typ eff_decls
         | FStar_Parser_AST.LayeredEffect (FStar_Parser_AST.RedefineEffect
             uu___) ->
-            FStar_Compiler_Effect.failwith
+            failwith
               "Impossible: LayeredEffect (RedefineEffect _) (should not be parseable)"
         | FStar_Parser_AST.SubEffect l ->
             let src_ed =
@@ -10238,7 +10216,7 @@ and (desugar_decl_core :
                      [uu___3] in
                    (env, uu___2)
                | uu___2 ->
-                   FStar_Compiler_Effect.failwith
+                   failwith
                      "Impossible! unexpected lift_op for lift to a layered effect")
         | FStar_Parser_AST.Polymonadic_bind (m_eff, n_eff, p_eff, bind) ->
             let m = lookup_effect_lid env m_eff d.FStar_Parser_AST.drange in
@@ -10675,7 +10653,7 @@ let (add_modul_to_env_core :
                            FStar_Syntax_Syntax.body = uu___2;
                            FStar_Syntax_Syntax.rc_opt = uu___3;_}
                          -> bs1
-                     | uu___2 -> FStar_Compiler_Effect.failwith "Impossible") in
+                     | uu___2 -> failwith "Impossible") in
               let uu___ =
                 let uu___1 = erase_binders ed.FStar_Syntax_Syntax.binders in
                 FStar_Syntax_Subst.open_term' uu___1
@@ -10735,8 +10713,7 @@ let (add_modul_to_env_core :
                                  FStar_Syntax_Syntax.body = uu___4;
                                  FStar_Syntax_Syntax.rc_opt = uu___5;_}
                                -> bs1
-                           | uu___4 ->
-                               FStar_Compiler_Effect.failwith "Impossible") in
+                           | uu___4 -> failwith "Impossible") in
                     let erase_term1 t =
                       let uu___2 =
                         let uu___3 = FStar_Syntax_Subst.subst opening t in

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Cfg.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Cfg.ml
@@ -1108,8 +1108,7 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
             default_univs_to_zero = (fs.default_univs_to_zero);
             tactics = (fs.tactics)
           }
-      | FStar_TypeChecker_Env.Exclude uu___ ->
-          FStar_Compiler_Effect.failwith "Bad exclude"
+      | FStar_TypeChecker_Env.Exclude uu___ -> failwith "Bad exclude"
       | FStar_TypeChecker_Env.Weak ->
           {
             beta = (fs.beta);

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Common.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Common.ml
@@ -119,9 +119,7 @@ let (__proj__CProb__item___0 : prob -> FStar_Syntax_Syntax.comp problem) =
 type prob_t = prob
 let (as_tprob : prob -> FStar_Syntax_Syntax.typ problem) =
   fun uu___ ->
-    match uu___ with
-    | TProb p -> p
-    | uu___1 -> FStar_Compiler_Effect.failwith "Expected a TProb"
+    match uu___ with | TProb p -> p | uu___1 -> failwith "Expected a TProb"
 type probs = prob Prims.list
 type guard_formula =
   | Trivial 
@@ -528,7 +526,7 @@ let (check_uvar_ctx_invariant :
                   "Invariant violation: gamma and binders are out of sync\n\treason=%s, range=%s, should_check=%s\n\t\n                               gamma=%s\n\tbinders=%s\n"
                   reason uu___2 (if should_check then "true" else "false")
                   uu___3 uu___4 in
-              FStar_Compiler_Effect.failwith uu___1 in
+              failwith uu___1 in
             if Prims.op_Negation should_check
             then ()
             else

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Core.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Core.ml
@@ -65,7 +65,7 @@ let (push_binder : env -> FStar_Syntax_Syntax.binder -> env) =
         (b.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.index <=
           g.max_binder_index
       then
-        FStar_Compiler_Effect.failwith
+        failwith
           "Assertion failed: unexpected shadowing in the core environment"
       else
         (let uu___1 = FStar_TypeChecker_Env.push_binders g.tcenv [b] in
@@ -7569,8 +7569,7 @@ and (pattern_branch_condition :
               let uu___ =
                 FStar_TypeChecker_PatternUtils.raw_pat_as_exp g.tcenv pat in
               match uu___ with
-              | FStar_Pervasives_Native.None ->
-                  FStar_Compiler_Effect.failwith "Impossible"
+              | FStar_Pervasives_Native.None -> failwith "Impossible"
               | FStar_Pervasives_Native.Some (e, uu___1) -> e in
             let uu___ = check "constant pattern" g const_exp in
             (fun ctx0 ->
@@ -8113,7 +8112,7 @@ let (compute_term_type_handle_guards :
         match uu___ with
         | Success (r, FStar_Pervasives_Native.None) -> FStar_Pervasives.Inl r
         | Success (uu___1, FStar_Pervasives_Native.Some uu___2) ->
-            FStar_Compiler_Effect.failwith
+            failwith
               "Impossible: All guards should have been handled already"
         | Error err -> FStar_Pervasives.Inr err
 let (open_binders_in_term :

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_DMFF.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_DMFF.ml
@@ -1016,9 +1016,7 @@ let (gen_wps_for_free :
                     | FStar_Syntax_Syntax.Tm_arrow
                         { FStar_Syntax_Syntax.bs1 = [];
                           FStar_Syntax_Syntax.comp = uu___4;_}
-                        ->
-                        FStar_Compiler_Effect.failwith
-                          "impossible: arrow with empty binders"
+                        -> failwith "impossible: arrow with empty binders"
                     | uu___4 -> FStar_Syntax_Util.mk_untyped_eq2 x y in
                   let stronger =
                     let wp1 =
@@ -1073,7 +1071,7 @@ let (gen_wps_for_free :
                                          mk_stronger t2 uu___7 uu___8) args in
                             match uu___5 with
                             | [] ->
-                                FStar_Compiler_Effect.failwith
+                                failwith
                                   "Impossible: empty application when creating stronger relation in DM4F"
                             | rel0::rels -> (rel0, rels) in
                           (match uu___4 with
@@ -1168,9 +1166,7 @@ let (gen_wps_for_free :
                           FStar_Compiler_List.fold_right
                             (fun bv -> fun body1 -> mk_forall bv body1) bvs
                             body
-                      | uu___4 ->
-                          FStar_Compiler_Effect.failwith
-                            "Not a DM elaborated type" in
+                      | uu___4 -> failwith "Not a DM elaborated type" in
                     let body =
                       let uu___3 = FStar_Syntax_Util.unascribe wp_a1 in
                       let uu___4 = FStar_Syntax_Syntax.bv_to_name wp1 in
@@ -1251,7 +1247,7 @@ let (gen_wps_for_free :
                               FStar_Syntax_Util.close_forall_no_univs
                                 binders1 pattern_guarded_body
                           | uu___5 ->
-                              FStar_Compiler_Effect.failwith
+                              failwith
                                 "Impossible: Expected the equivalence to be a quantified formula" in
                         let body =
                           let uu___4 =
@@ -1385,7 +1381,7 @@ let (gen_wps_for_free :
                             } in
                           FStar_Syntax_Syntax.DM4F_eff uu___4
                       | uu___4 ->
-                          FStar_Compiler_Effect.failwith
+                          failwith
                             "Impossible! For a DM4F effect combinators must be in DM4f_eff" in
                     let uu___4 =
                       let uu___5 = FStar_Compiler_Effect.op_Bang sigelts in
@@ -1469,9 +1465,7 @@ let (is_monadic_arrow : FStar_Syntax_Syntax.term' -> nm) =
     | FStar_Syntax_Syntax.Tm_arrow
         { FStar_Syntax_Syntax.bs1 = uu___; FStar_Syntax_Syntax.comp = c;_} ->
         nm_of_comp c
-    | uu___ ->
-        FStar_Compiler_Effect.failwith
-          "unexpected_argument: [is_monadic_arrow]"
+    | uu___ -> failwith "unexpected_argument: [is_monadic_arrow]"
 let (is_monadic_comp :
   FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax -> Prims.bool) =
   fun c ->
@@ -2047,16 +2041,14 @@ and (star_type' :
       | FStar_Syntax_Syntax.Tm_lazy i ->
           let uu___ = FStar_Syntax_Util.unfold_lazy i in
           star_type' env1 uu___
-      | FStar_Syntax_Syntax.Tm_delayed uu___ ->
-          FStar_Compiler_Effect.failwith "impossible"
+      | FStar_Syntax_Syntax.Tm_delayed uu___ -> failwith "impossible"
 let (is_monadic :
   FStar_Syntax_Syntax.residual_comp FStar_Pervasives_Native.option ->
     Prims.bool)
   =
   fun uu___ ->
     match uu___ with
-    | FStar_Pervasives_Native.None ->
-        FStar_Compiler_Effect.failwith "un-annotated lambda?!"
+    | FStar_Pervasives_Native.None -> failwith "un-annotated lambda?!"
     | FStar_Pervasives_Native.Some rc ->
         FStar_Compiler_Util.for_some
           (fun uu___1 ->
@@ -2260,7 +2252,7 @@ let rec (check :
           let strip_m uu___ =
             match uu___ with
             | (M t, s_e, u_e) -> (t, s_e, u_e)
-            | uu___1 -> FStar_Compiler_Effect.failwith "impossible" in
+            | uu___1 -> failwith "impossible" in
           match context_nm with
           | N t ->
               let uu___ =
@@ -2326,31 +2318,31 @@ let rec (check :
               let uu___3 =
                 FStar_Class_Show.show FStar_Syntax_Print.showable_term e in
               FStar_Compiler_Util.format1 "[check]: Tm_let %s" uu___3 in
-            FStar_Compiler_Effect.failwith uu___2
+            failwith uu___2
         | FStar_Syntax_Syntax.Tm_type uu___1 ->
-            FStar_Compiler_Effect.failwith "impossible (DM stratification)"
+            failwith "impossible (DM stratification)"
         | FStar_Syntax_Syntax.Tm_arrow uu___1 ->
-            FStar_Compiler_Effect.failwith "impossible (DM stratification)"
+            failwith "impossible (DM stratification)"
         | FStar_Syntax_Syntax.Tm_refine uu___1 ->
             let uu___2 =
               let uu___3 =
                 FStar_Class_Show.show FStar_Syntax_Print.showable_term e in
               FStar_Compiler_Util.format1 "[check]: Tm_refine %s" uu___3 in
-            FStar_Compiler_Effect.failwith uu___2
+            failwith uu___2
         | FStar_Syntax_Syntax.Tm_uvar uu___1 ->
             let uu___2 =
               let uu___3 =
                 FStar_Class_Show.show FStar_Syntax_Print.showable_term e in
               FStar_Compiler_Util.format1 "[check]: Tm_uvar %s" uu___3 in
-            FStar_Compiler_Effect.failwith uu___2
+            failwith uu___2
         | FStar_Syntax_Syntax.Tm_delayed uu___1 ->
-            FStar_Compiler_Effect.failwith "impossible (compressed)"
+            failwith "impossible (compressed)"
         | FStar_Syntax_Syntax.Tm_unknown ->
             let uu___1 =
               let uu___2 =
                 FStar_Class_Show.show FStar_Syntax_Print.showable_term e in
               FStar_Compiler_Util.format1 "[check]: Tm_unknown %s" uu___2 in
-            FStar_Compiler_Effect.failwith uu___1
+            failwith uu___1
 and (infer :
   env ->
     FStar_Syntax_Syntax.term ->
@@ -2373,7 +2365,7 @@ and (infer :
         uu___1.FStar_Syntax_Syntax.n in
       match uu___ with
       | FStar_Syntax_Syntax.Tm_bvar bv ->
-          FStar_Compiler_Effect.failwith "I failed to open a binder... boo"
+          failwith "I failed to open a binder... boo"
       | FStar_Syntax_Syntax.Tm_name bv ->
           ((N (bv.FStar_Syntax_Syntax.sort)), e, e)
       | FStar_Syntax_Syntax.Tm_lazy i ->
@@ -3004,12 +2996,9 @@ and (infer :
                                                 uu___9 in
                                             mk uu___8 in
                                           N uu___7
-                                      | uu___7 ->
-                                          FStar_Compiler_Effect.failwith
-                                            "wat?")
+                                      | uu___7 -> failwith "wat?")
                                  | ([], uu___6::uu___7) ->
-                                     FStar_Compiler_Effect.failwith
-                                       "just checked that?!"
+                                     failwith "just checked that?!"
                                  | ({ FStar_Syntax_Syntax.binder_bv = bv;
                                       FStar_Syntax_Syntax.binder_qual =
                                         uu___6;
@@ -3130,31 +3119,31 @@ and (infer :
             let uu___3 =
               FStar_Class_Show.show FStar_Syntax_Print.showable_term e in
             FStar_Compiler_Util.format1 "[infer]: Tm_let %s" uu___3 in
-          FStar_Compiler_Effect.failwith uu___2
+          failwith uu___2
       | FStar_Syntax_Syntax.Tm_type uu___1 ->
-          FStar_Compiler_Effect.failwith "impossible (DM stratification)"
+          failwith "impossible (DM stratification)"
       | FStar_Syntax_Syntax.Tm_arrow uu___1 ->
-          FStar_Compiler_Effect.failwith "impossible (DM stratification)"
+          failwith "impossible (DM stratification)"
       | FStar_Syntax_Syntax.Tm_refine uu___1 ->
           let uu___2 =
             let uu___3 =
               FStar_Class_Show.show FStar_Syntax_Print.showable_term e in
             FStar_Compiler_Util.format1 "[infer]: Tm_refine %s" uu___3 in
-          FStar_Compiler_Effect.failwith uu___2
+          failwith uu___2
       | FStar_Syntax_Syntax.Tm_uvar uu___1 ->
           let uu___2 =
             let uu___3 =
               FStar_Class_Show.show FStar_Syntax_Print.showable_term e in
             FStar_Compiler_Util.format1 "[infer]: Tm_uvar %s" uu___3 in
-          FStar_Compiler_Effect.failwith uu___2
+          failwith uu___2
       | FStar_Syntax_Syntax.Tm_delayed uu___1 ->
-          FStar_Compiler_Effect.failwith "impossible (compressed)"
+          failwith "impossible (compressed)"
       | FStar_Syntax_Syntax.Tm_unknown ->
           let uu___1 =
             let uu___2 =
               FStar_Class_Show.show FStar_Syntax_Print.showable_term e in
             FStar_Compiler_Util.format1 "[infer]: Tm_unknown %s" uu___2 in
-          FStar_Compiler_Effect.failwith uu___1
+          failwith uu___1
 and (mk_match :
   env ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
@@ -3243,8 +3232,7 @@ and (mk_match :
                                             ((M t2), (pat, guard, s_body1),
                                               (pat, guard, u_body1)))
                                    | (M uu___6, false) ->
-                                       FStar_Compiler_Effect.failwith
-                                         "impossible")) nms branches1 in
+                                       failwith "impossible")) nms branches1 in
                      FStar_Compiler_List.unzip3 uu___4 in
                    (match uu___3 with
                     | (nms1, s_branches, u_branches) ->
@@ -3663,7 +3651,7 @@ and (check_n :
       let uu___ = check env1 e mn in
       match uu___ with
       | (N t, s_e, u_e) -> (t, s_e, u_e)
-      | uu___1 -> FStar_Compiler_Effect.failwith "[check_n]: impossible"
+      | uu___1 -> failwith "[check_n]: impossible"
 and (check_m :
   env_ ->
     FStar_Syntax_Syntax.term ->
@@ -3680,7 +3668,7 @@ and (check_m :
       let uu___ = check env1 e mn in
       match uu___ with
       | (M t, s_e, u_e) -> (t, s_e, u_e)
-      | uu___1 -> FStar_Compiler_Effect.failwith "[check_m]: impossible"
+      | uu___1 -> failwith "[check_m]: impossible"
 and (comp_of_nm : nm_ -> FStar_Syntax_Syntax.comp) =
   fun nm1 ->
     match nm1 with | N t -> FStar_Syntax_Syntax.mk_Total t | M t -> mk_M t
@@ -3743,9 +3731,7 @@ and (trans_F_ :
                                FStar_Compiler_Range_Type.dummyRange in
                            FStar_Syntax_Util.is_constructor wp_head uu___6 in
                          Prims.op_Negation uu___5) in
-                    if uu___4
-                    then FStar_Compiler_Effect.failwith "mismatch"
-                    else ());
+                    if uu___4 then failwith "mismatch" else ());
                    (let uu___4 =
                       let uu___5 =
                         let uu___6 =
@@ -3911,7 +3897,7 @@ and (trans_F_ :
              { FStar_Syntax_Syntax.tm = e; FStar_Syntax_Syntax.asc = uu___2;
                FStar_Syntax_Syntax.eff_opt = uu___3;_}
              -> trans_F_ env1 e wp
-         | uu___2 -> FStar_Compiler_Effect.failwith "impossible trans_F_")
+         | uu___2 -> failwith "impossible trans_F_")
 and (trans_G :
   env_ ->
     FStar_Syntax_Syntax.typ ->
@@ -4289,7 +4275,7 @@ let (cps_and_elaborate :
                                                  | (b11::b21::[], body1) ->
                                                      (b11, b21, body1)
                                                  | uu___17 ->
-                                                     FStar_Compiler_Effect.failwith
+                                                     failwith
                                                        "Impossible : open_term not preserving binders arity" in
                                                (match uu___15 with
                                                 | (b11, b21, body1) ->
@@ -4524,7 +4510,7 @@ let (cps_and_elaborate :
                                          let rec apply_last f l =
                                            match l with
                                            | [] ->
-                                               FStar_Compiler_Effect.failwith
+                                               failwith
                                                  "impossible: empty path.."
                                            | a2::[] ->
                                                let uu___14 = f a2 in
@@ -4964,7 +4950,7 @@ let (cps_and_elaborate :
                                                       | (b::bs, body) ->
                                                           (b, bs, body)
                                                       | uu___21 ->
-                                                          FStar_Compiler_Effect.failwith
+                                                          failwith
                                                             "Impossible : open_term nt preserving binders arity" in
                                                     (match uu___19 with
                                                      | (type_param1,
@@ -5209,7 +5195,7 @@ let (cps_and_elaborate :
                                                            FStar_Syntax_Syntax.DM4F_eff
                                                              uu___20
                                                        | uu___20 ->
-                                                           FStar_Compiler_Effect.failwith
+                                                           failwith
                                                              "Impossible! For a DM4F effect combinators must be in DM4f_eff" in
                                                      let ed1 =
                                                        let uu___20 =

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_DeferredImplicits.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_DeferredImplicits.ml
@@ -21,7 +21,7 @@ let (flex_uvar_head :
           uu___2.FStar_Syntax_Syntax.n in
         (match uu___1 with
          | FStar_Syntax_Syntax.Tm_uvar (u, uu___2) -> u
-         | uu___2 -> FStar_Compiler_Effect.failwith "Not a flex-uvar")
+         | uu___2 -> failwith "Not a flex-uvar")
 type goal_type =
   | FlexRigid of (FStar_Syntax_Syntax.ctx_uvar * FStar_Syntax_Syntax.term) 
   | FlexFlex of (FStar_Syntax_Syntax.ctx_uvar * FStar_Syntax_Syntax.ctx_uvar)
@@ -261,8 +261,7 @@ let solve_goals_with_tac :
                            FStar_Pervasives_Native.None in
                        FStar_Syntax_Syntax.fv_to_tm uu___3 in
                      term
-                 | uu___2 ->
-                     FStar_Compiler_Effect.failwith "Resolve_tac not found" in
+                 | uu___2 -> failwith "Resolve_tac not found" in
                let env1 =
                  {
                    FStar_TypeChecker_Env.solver =
@@ -683,13 +682,11 @@ let (solve_deferred_to_tactic_goals :
                                         else FStar_Pervasives_Native.None) in
                                    (match sigelt with
                                     | FStar_Pervasives_Native.None ->
-                                        FStar_Compiler_Effect.failwith
+                                        failwith
                                           "Impossible: No tactic associated with deferred problem"
                                     | FStar_Pervasives_Native.Some se ->
                                         (imp, se)))))
-                | uu___3 ->
-                    FStar_Compiler_Effect.failwith
-                      "Unexpected problem deferred to tactic") in
+                | uu___3 -> failwith "Unexpected problem deferred to tactic") in
          let eqs =
            let uu___1 =
              FStar_Class_Listlike.to_list
@@ -733,8 +730,7 @@ let (solve_deferred_to_tactic_goals :
                         let uu___4 = FStar_Syntax_Util.lid_of_sigelt s in
                         (match uu___4 with
                          | FStar_Pervasives_Native.None ->
-                             FStar_Compiler_Effect.failwith
-                               "Unexpected: tactic without a name"
+                             failwith "Unexpected: tactic without a name"
                          | FStar_Pervasives_Native.Some l ->
                              let lstr = FStar_Ident.string_of_lid l in
                              let uu___5 =

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Env.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Env.ml
@@ -1644,7 +1644,7 @@ let (rename_gamma :
                         FStar_Syntax_Syntax.sort = uu___3
                       } in
                     FStar_Syntax_Syntax.Binding_var uu___2
-                | uu___2 -> FStar_Compiler_Effect.failwith "Not a renaming")
+                | uu___2 -> failwith "Not a renaming")
            | b -> b) gamma
 let (rename_env : FStar_Syntax_Syntax.subst_t -> env -> env) =
   fun subst ->
@@ -2134,35 +2134,30 @@ let (initial_env :
                             (fun e ->
                                fun g ->
                                  fun tau ->
-                                   FStar_Compiler_Effect.failwith
-                                     "no synthesizer available");
+                                   failwith "no synthesizer available");
                           try_solve_implicits_hook =
                             (fun e ->
                                fun tau ->
                                  fun imps ->
-                                   FStar_Compiler_Effect.failwith
-                                     "no implicit hook available");
+                                   failwith "no implicit hook available");
                           splice =
                             (fun e ->
                                fun is_typed ->
                                  fun lids ->
                                    fun tau ->
                                      fun range ->
-                                       FStar_Compiler_Effect.failwith
-                                         "no splicer available");
+                                       failwith "no splicer available");
                           mpreprocess =
                             (fun e ->
                                fun tau ->
                                  fun tm ->
-                                   FStar_Compiler_Effect.failwith
-                                     "no preprocessor available");
+                                   failwith "no preprocessor available");
                           postprocess =
                             (fun e ->
                                fun tau ->
                                  fun typ ->
                                    fun tm ->
-                                     FStar_Compiler_Effect.failwith
-                                       "no postprocessor available");
+                                     failwith "no postprocessor available");
                           identifier_info = uu___7;
                           tc_hooks = default_tc_hooks;
                           dsenv = uu___8;
@@ -2191,7 +2186,7 @@ let (push_query_indices : unit -> unit) =
   fun uu___ ->
     let uu___1 = FStar_Compiler_Effect.op_Bang query_indices in
     match uu___1 with
-    | [] -> FStar_Compiler_Effect.failwith "Empty query indices!"
+    | [] -> failwith "Empty query indices!"
     | uu___2 ->
         let uu___3 =
           let uu___4 =
@@ -2204,7 +2199,7 @@ let (pop_query_indices : unit -> unit) =
   fun uu___ ->
     let uu___1 = FStar_Compiler_Effect.op_Bang query_indices in
     match uu___1 with
-    | [] -> FStar_Compiler_Effect.failwith "Empty query indices!"
+    | [] -> failwith "Empty query indices!"
     | hd::tl -> FStar_Compiler_Effect.op_Colon_Equals query_indices tl
 let (snapshot_query_indices : unit -> (Prims.int * unit)) =
   fun uu___ -> FStar_Common.snapshot push_query_indices query_indices ()
@@ -2220,7 +2215,7 @@ let (add_query_index : (FStar_Ident.lident * Prims.int) -> unit) =
          | hd::tl ->
              FStar_Compiler_Effect.op_Colon_Equals query_indices (((l, n) ::
                hd) :: tl)
-         | uu___2 -> FStar_Compiler_Effect.failwith "Empty query indices")
+         | uu___2 -> failwith "Empty query indices")
 let (peek_query_indices :
   unit -> (FStar_Ident.lident * Prims.int) Prims.list) =
   fun uu___ ->
@@ -2308,7 +2303,7 @@ let (pop_stack : unit -> env) =
     let uu___1 = FStar_Compiler_Effect.op_Bang stack in
     match uu___1 with
     | env1::tl -> (FStar_Compiler_Effect.op_Colon_Equals stack tl; env1)
-    | uu___2 -> FStar_Compiler_Effect.failwith "Impossible: Too many pops"
+    | uu___2 -> failwith "Impossible: Too many pops"
 let (snapshot_stack : env -> (Prims.int * env)) =
   fun env1 -> FStar_Common.snapshot push_stack stack env1
 let (rollback_stack : Prims.int FStar_Pervasives_Native.option -> env) =
@@ -2867,7 +2862,7 @@ let (inst_effect_fun_with :
                     FStar_Compiler_Util.format4
                       "Expected %s instantiations; got %s; failed universe instantiation in effect %s\n\t%s\n"
                       uu___4 uu___5 uu___6 uu___7 in
-                  FStar_Compiler_Effect.failwith uu___3)
+                  failwith uu___3)
                else ();
                (let uu___3 = inst_tscheme_with (us, t) insts in
                 FStar_Pervasives_Native.snd uu___3))
@@ -3185,8 +3180,7 @@ let (lookup_type_of_let :
             FStar_Compiler_Util.find_map lbs
               (fun lb ->
                  match lb.FStar_Syntax_Syntax.lbname with
-                 | FStar_Pervasives.Inl uu___2 ->
-                     FStar_Compiler_Effect.failwith "impossible"
+                 | FStar_Pervasives.Inl uu___2 -> failwith "impossible"
                  | FStar_Pervasives.Inr fv ->
                      let uu___2 = FStar_Syntax_Syntax.fv_eq_lid fv lid in
                      if uu___2
@@ -3251,7 +3245,7 @@ let (effect_signature :
                       Prims.strcat
                         "effect_signature: incorrect number of universes for the signature of "
                         uu___3 in
-                    FStar_Compiler_Effect.failwith uu___2
+                    failwith uu___2
                   else ());
              (let uu___2 =
                 let uu___3 = inst_ts us_opt sig_ts in
@@ -3763,7 +3757,7 @@ let (typ_of_datacon : env -> FStar_Ident.lident -> FStar_Ident.lident) =
             let uu___3 =
               FStar_Class_Show.show FStar_Ident.showable_lident lid in
             FStar_Compiler_Util.format1 "Not a datacon: %s" uu___3 in
-          FStar_Compiler_Effect.failwith uu___2
+          failwith uu___2
 let (num_datacon_non_injective_ty_params :
   env -> FStar_Ident.lident -> Prims.int FStar_Pervasives_Native.option) =
   fun env1 ->
@@ -3936,11 +3930,9 @@ let rec (delta_depth_of_qninfo_lid :
                         else FStar_Pervasives_Native.None) in
                  FStar_Compiler_Util.must uu___4
              | FStar_Syntax_Syntax.Sig_fail uu___2 ->
-                 FStar_Compiler_Effect.failwith
-                   "impossible: delta_depth_of_qninfo"
+                 failwith "impossible: delta_depth_of_qninfo"
              | FStar_Syntax_Syntax.Sig_splice uu___2 ->
-                 FStar_Compiler_Effect.failwith
-                   "impossible: delta_depth_of_qninfo"
+                 failwith "impossible: delta_depth_of_qninfo"
              | FStar_Syntax_Syntax.Sig_assume uu___2 ->
                  FStar_Syntax_Syntax.delta_constant
              | FStar_Syntax_Syntax.Sig_new_effect uu___2 ->
@@ -4010,9 +4002,9 @@ and (delta_depth_of_term :
       let t1 = FStar_Syntax_Util.unmeta t in
       match t1.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_meta uu___ ->
-          FStar_Compiler_Effect.failwith "Impossible (delta depth of term)"
+          failwith "Impossible (delta depth of term)"
       | FStar_Syntax_Syntax.Tm_delayed uu___ ->
-          FStar_Compiler_Effect.failwith "Impossible (delta depth of term)"
+          failwith "Impossible (delta depth of term)"
       | FStar_Syntax_Syntax.Tm_lazy i ->
           let uu___ = FStar_Syntax_Util.unfold_lazy i in
           delta_depth_of_term env1 uu___
@@ -4273,10 +4265,10 @@ let (lookup_effect_abbrev :
                       FStar_Compiler_Util.format3
                         "(%s) Unexpected instantiation of effect %s with %s universes"
                         uu___12 uu___13 uu___14 in
-                    FStar_Compiler_Effect.failwith uu___11) in
+                    failwith uu___11) in
                match (binders, univs) with
                | ([], uu___10) ->
-                   FStar_Compiler_Effect.failwith
+                   failwith
                      "Unexpected effect abbreviation with no arguments"
                | (uu___10, uu___11::uu___12::uu___13) ->
                    let uu___14 =
@@ -4288,7 +4280,7 @@ let (lookup_effect_abbrev :
                      FStar_Compiler_Util.format2
                        "Unexpected effect abbreviation %s; polymorphic in %s universes"
                        uu___15 uu___16 in
-                   FStar_Compiler_Effect.failwith uu___14
+                   failwith uu___14
                | uu___10 ->
                    let uu___11 =
                      let uu___12 =
@@ -4308,8 +4300,7 @@ let (lookup_effect_abbrev :
                              { FStar_Syntax_Syntax.bs1 = binders1;
                                FStar_Syntax_Syntax.comp = c1;_}
                              -> FStar_Pervasives_Native.Some (binders1, c1)
-                         | uu___14 ->
-                             FStar_Compiler_Effect.failwith "Impossible")))
+                         | uu___14 -> failwith "Impossible")))
         | uu___1 -> FStar_Pervasives_Native.None
 let (norm_eff_name : env -> FStar_Ident.lident -> FStar_Ident.lident) =
   fun env1 ->
@@ -4440,7 +4431,7 @@ let (lookup_projector :
             FStar_Compiler_Util.format2
               "Impossible: projecting field #%s from constructor %s is undefined"
               uu___2 uu___3 in
-          FStar_Compiler_Effect.failwith uu___1 in
+          failwith uu___1 in
         let uu___ = lookup_datacon env1 lid in
         match uu___ with
         | (uu___1, t) ->
@@ -4907,7 +4898,7 @@ let wp_sig_aux :
             let uu___2 = FStar_Ident.string_of_lid m in
             FStar_Compiler_Util.format1
               "Impossible: declaration for monad %s not found" uu___2 in
-          FStar_Compiler_Effect.failwith uu___1
+          failwith uu___1
       | FStar_Pervasives_Native.Some (md, _q) ->
           let uu___1 =
             let uu___2 =
@@ -4929,7 +4920,7 @@ let wp_sig_aux :
                     ->
                     ((b.FStar_Syntax_Syntax.binder_bv),
                       ((wp_b.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort))
-                | uu___3 -> FStar_Compiler_Effect.failwith "Impossible"))
+                | uu___3 -> failwith "Impossible"))
 let (wp_signature :
   env ->
     FStar_Ident.lident -> (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.term))
@@ -5303,8 +5294,7 @@ let (reify_comp :
         (let uu___1 = effect_repr_aux true env1 c u_c in
          match uu___1 with
          | FStar_Pervasives_Native.None ->
-             FStar_Compiler_Effect.failwith
-               "internal error: reifiable effect has no repr?"
+             failwith "internal error: reifiable effect has no repr?"
          | FStar_Pervasives_Native.Some tm -> tm)
 let rec (record_vals_and_defns : env -> FStar_Syntax_Syntax.sigelt -> env) =
   fun g ->
@@ -7048,8 +7038,7 @@ let (trivial : FStar_TypeChecker_Common.guard_formula -> unit) =
   fun t ->
     match t with
     | FStar_TypeChecker_Common.Trivial -> ()
-    | FStar_TypeChecker_Common.NonTrivial uu___ ->
-        FStar_Compiler_Effect.failwith "impossible"
+    | FStar_TypeChecker_Common.NonTrivial uu___ -> failwith "impossible"
 let (check_trivial :
   FStar_Syntax_Syntax.term -> FStar_TypeChecker_Common.guard_formula) =
   fun t -> FStar_TypeChecker_Common.check_trivial t

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Err.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Err.ml
@@ -52,20 +52,18 @@ let print_discrepancy : 'a 'b . ('a -> 'b) -> 'a -> 'a -> ('b * 'b) =
           | (h1::t1, h2::t2) ->
               ((Prims.op_Negation h1) || h2) && (blist_leq t1 t2)
           | ([], []) -> true
-          | uu___ ->
-              FStar_Compiler_Effect.failwith "print_discrepancy: bad lists" in
+          | uu___ -> failwith "print_discrepancy: bad lists" in
         let rec succ l =
           match l with
           | (false)::t -> true :: t
           | (true)::t -> let uu___ = succ t in false :: uu___
-          | [] -> FStar_Compiler_Effect.failwith "" in
+          | [] -> failwith "" in
         let full l = FStar_Compiler_List.for_all (fun b1 -> b1) l in
         let get_bool_option s =
           let uu___ = FStar_Options.get_option s in
           match uu___ with
           | FStar_Options.Bool b1 -> b1
-          | uu___1 ->
-              FStar_Compiler_Effect.failwith "print_discrepancy: impossible" in
+          | uu___1 -> failwith "print_discrepancy: impossible" in
         let set_bool_option s b1 =
           FStar_Options.set_option s (FStar_Options.Bool b1) in
         let get uu___ =
@@ -80,8 +78,7 @@ let print_discrepancy : 'a 'b . ('a -> 'b) -> 'a -> 'a -> ('b * 'b) =
                set_bool_option "print_universes" pu;
                set_bool_option "print_effect_args" pea;
                set_bool_option "print_full_names " pf)
-          | uu___ ->
-              FStar_Compiler_Effect.failwith "impossible: print_discrepancy" in
+          | uu___ -> failwith "impossible: print_discrepancy" in
         let bas = get () in
         let rec go cur =
           if full cur

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Generalize.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Generalize.ml
@@ -409,7 +409,7 @@ let (gen :
                              u.FStar_Syntax_Syntax.ctx_uvar_head in
                          match uu___4 with
                          | FStar_Pervasives_Native.Some uu___5 ->
-                             FStar_Compiler_Effect.failwith
+                             failwith
                                "Unexpected instantiation of mutually recursive uvar"
                          | uu___5 ->
                              let k =

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_NBE.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_NBE.ml
@@ -477,7 +477,7 @@ let (un_univ : FStar_TypeChecker_NBETerm.t -> FStar_Syntax_Syntax.universe) =
         let uu___1 =
           let uu___2 = FStar_TypeChecker_NBETerm.t_to_string tm in
           Prims.strcat "Not a universe: " uu___2 in
-        FStar_Compiler_Effect.failwith uu___1
+        failwith uu___1
 let (is_constr_fv : FStar_Syntax_Syntax.fv -> Prims.bool) =
   fun fvar ->
     fvar.FStar_Syntax_Syntax.fv_qual =
@@ -517,9 +517,7 @@ let (translate_univ :
                 if
                   ((cfg.core_cfg).FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.allow_unbound_universes
                 then FStar_Syntax_Syntax.U_zero
-                else
-                  FStar_Compiler_Effect.failwith
-                    "Universe index out of bounds"
+                else failwith "Universe index out of bounds"
           | FStar_Syntax_Syntax.U_succ u3 ->
               let uu___ = aux u3 in FStar_Syntax_Syntax.U_succ uu___
           | FStar_Syntax_Syntax.U_max us ->
@@ -540,8 +538,7 @@ let (find_let :
       FStar_Compiler_Util.find_map lbs
         (fun lb ->
            match lb.FStar_Syntax_Syntax.lbname with
-           | FStar_Pervasives.Inl uu___ ->
-               FStar_Compiler_Effect.failwith "find_let : impossible"
+           | FStar_Pervasives.Inl uu___ -> failwith "find_let : impossible"
            | FStar_Pervasives.Inr name ->
                let uu___ = FStar_Syntax_Syntax.fv_eq name fvar in
                if uu___
@@ -588,7 +585,7 @@ let rec (translate :
            uu___2.FStar_Syntax_Syntax.n in
          match uu___1 with
          | FStar_Syntax_Syntax.Tm_delayed uu___2 ->
-             FStar_Compiler_Effect.failwith "Tm_delayed: Impossible"
+             failwith "Tm_delayed: Impossible"
          | FStar_Syntax_Syntax.Tm_unknown ->
              mk_t1 FStar_TypeChecker_NBETerm.Unknown
          | FStar_Syntax_Syntax.Tm_constant c ->
@@ -614,8 +611,7 @@ let rec (translate :
                        "Resolved bvar to %s\n\tcontext is [%s]\n" uu___4
                        uu___5);
                 t)
-             else
-               FStar_Compiler_Effect.failwith "de Bruijn index out of bounds"
+             else failwith "de Bruijn index out of bounds"
          | FStar_Syntax_Syntax.Tm_uinst (t, us) ->
              (debug1
                 (fun uu___3 ->
@@ -745,8 +741,7 @@ let rec (translate :
                             (x, (x_j.FStar_Syntax_Syntax.index))
                       | uu___4 -> FStar_Syntax_Syntax.NT (x, t))
                  | uu___4 ->
-                     FStar_Compiler_Effect.failwith
-                       "Impossible: subst invariant of uvar nodes" in
+                     failwith "Impossible: subst invariant of uvar nodes" in
                let subst1 =
                  FStar_Compiler_List.map
                    (FStar_Compiler_List.map norm_subst_elt) subst in
@@ -772,9 +767,7 @@ let rec (translate :
              { FStar_Syntax_Syntax.bs = [];
                FStar_Syntax_Syntax.body = uu___2;
                FStar_Syntax_Syntax.rc_opt = uu___3;_}
-             ->
-             FStar_Compiler_Effect.failwith
-               "Impossible: abstraction with no binders"
+             -> failwith "Impossible: abstraction with no binders"
          | FStar_Syntax_Syntax.Tm_abs
              { FStar_Syntax_Syntax.bs = xs; FStar_Syntax_Syntax.body = body;
                FStar_Syntax_Syntax.rc_opt = resc;_}
@@ -1176,7 +1169,7 @@ let rec (translate :
                          FStar_TypeChecker_NBETerm.mkAccuMatch scrut2
                            make_returns make_branches make_rc
                      | FStar_Pervasives_Native.Some (uu___5, hd::tl) ->
-                         FStar_Compiler_Effect.failwith
+                         failwith
                            "Impossible: Matching on constants cannot bind more than one variable"))
                | uu___3 ->
                    FStar_TypeChecker_NBETerm.mkAccuMatch scrut2 make_returns
@@ -1733,7 +1726,7 @@ and (iapp :
                    let uu___3 = FStar_TypeChecker_NBETerm.t_to_string f in
                    Prims.strcat "NBE ill-typed application Const_range_of: "
                      uu___3 in
-                 FStar_Compiler_Effect.failwith uu___2)
+                 failwith uu___2)
         | FStar_TypeChecker_NBETerm.Constant
             (FStar_TypeChecker_NBETerm.SConst
             (FStar_Const.Const_set_range_of)) ->
@@ -1760,12 +1753,12 @@ and (iapp :
                    let uu___3 = FStar_TypeChecker_NBETerm.t_to_string f in
                    Prims.strcat
                      "NBE ill-typed application Const_set_range_of: " uu___3 in
-                 FStar_Compiler_Effect.failwith uu___2)
+                 failwith uu___2)
         | uu___1 ->
             let uu___2 =
               let uu___3 = FStar_TypeChecker_NBETerm.t_to_string f in
               Prims.strcat "NBE ill-typed application: " uu___3 in
-            FStar_Compiler_Effect.failwith uu___2
+            failwith uu___2
 and (translate_fv :
   config ->
     FStar_TypeChecker_NBETerm.t Prims.list ->
@@ -1789,7 +1782,7 @@ and (translate_fv :
                fvar qninfo in
            match uu___2 with
            | FStar_TypeChecker_Normalize_Unfolding.Should_unfold_fully ->
-               FStar_Compiler_Effect.failwith "Not yet handled"
+               failwith "Not yet handled"
            | FStar_TypeChecker_Normalize_Unfolding.Should_unfold_no ->
                (debug1
                   (fun uu___4 ->
@@ -1865,8 +1858,8 @@ and (translate_fv :
                                                      = uu___9;_},
                                                  uu___10) -> u
                                               | uu___9 ->
-                                                  FStar_Compiler_Effect.failwith
-                                                    "Impossible") univs in
+                                                  failwith "Impossible")
+                                           univs in
                                        let uu___8 =
                                          prim_step.FStar_TypeChecker_Primops_Base.interpretation_nbe
                                            callbacks univs1 rest in
@@ -1974,8 +1967,7 @@ and (translate_fv :
                                          (lb, ar, lst, [])))
                              else translate_letbinding cfg bs lb
                          | FStar_Pervasives_Native.None ->
-                             FStar_Compiler_Effect.failwith
-                               "Could not find let binding"))
+                             failwith "Could not find let binding"))
                    | uu___3 ->
                        (debug1
                           (fun uu___5 ->
@@ -2048,8 +2040,7 @@ and (translate_fv :
                                          (lb, ar, lst, [])))
                              else translate_letbinding cfg bs lb
                          | FStar_Pervasives_Native.None ->
-                             FStar_Compiler_Effect.failwith
-                               "Could not find let binding"))
+                             failwith "Could not find let binding"))
                    | uu___3 ->
                        (debug1
                           (fun uu___5 ->
@@ -2375,7 +2366,7 @@ and (translate_monadic :
                           let uu___3 = FStar_Ident.string_of_lid m in
                           FStar_Compiler_Util.format1
                             "Effect declaration not found: %s" uu___3 in
-                        FStar_Compiler_Effect.failwith uu___2
+                        failwith uu___2
                     | FStar_Pervasives_Native.Some (ed, q) ->
                         let cfg' = reifying_false cfg in
                         let body_lam =
@@ -2624,7 +2615,7 @@ and (translate_monadic :
                          FStar_Syntax_Syntax.tagged_term e1 in
                      FStar_Compiler_Util.format1
                        "Unexpected case in translate_monadic: %s" uu___3 in
-                   FStar_Compiler_Effect.failwith uu___2)
+                   failwith uu___2)
 and (translate_monadic_lift :
   (FStar_Syntax_Syntax.monad_name * FStar_Syntax_Syntax.monad_name *
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax) ->
@@ -2668,8 +2659,7 @@ and (translate_monadic_lift :
                            (ret1, [FStar_Syntax_Syntax.U_unknown]))
                         e1.FStar_Syntax_Syntax.pos
                   | uu___3 ->
-                      FStar_Compiler_Effect.failwith
-                        "NYI: Reification of indexed effect (NBE)" in
+                      failwith "NYI: Reification of indexed effect (NBE)" in
                 let cfg' = reifying_false cfg in
                 let t =
                   let uu___2 =
@@ -2708,7 +2698,7 @@ and (translate_monadic_lift :
                        FStar_Compiler_Util.format2
                          "Impossible : trying to reify a lift between unrelated effects (%s and %s)"
                          uu___5 uu___6 in
-                     FStar_Compiler_Effect.failwith uu___4
+                     failwith uu___4
                  | FStar_Pervasives_Native.Some
                      { FStar_TypeChecker_Env.msource = uu___4;
                        FStar_TypeChecker_Env.mtarget = uu___5;
@@ -2724,7 +2714,7 @@ and (translate_monadic_lift :
                        FStar_Compiler_Util.format2
                          "Impossible : trying to reify a non-reifiable lift (from %s to %s)"
                          uu___9 uu___10 in
-                     FStar_Compiler_Effect.failwith uu___8
+                     failwith uu___8
                  | FStar_Pervasives_Native.Some
                      { FStar_TypeChecker_Env.msource = uu___4;
                        FStar_TypeChecker_Env.mtarget = uu___5;
@@ -2787,8 +2777,7 @@ and (readback :
            FStar_Compiler_Util.print1 "Readback: %s\n" uu___2);
       (match x.FStar_TypeChecker_NBETerm.nbe_t with
        | FStar_TypeChecker_NBETerm.Univ u ->
-           FStar_Compiler_Effect.failwith
-             "Readback of universes should not occur"
+           failwith "Readback of universes should not occur"
        | FStar_TypeChecker_NBETerm.Unknown ->
            FStar_Syntax_Syntax.mk FStar_Syntax_Syntax.Tm_unknown
              x.FStar_TypeChecker_NBETerm.nbe_r

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_NBETerm.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_NBETerm.ml
@@ -497,9 +497,7 @@ let rec (eq_t :
               (if
                  (FStar_Compiler_List.length args1) <>
                    (FStar_Compiler_List.length args2)
-               then
-                 FStar_Compiler_Effect.failwith
-                   "eq_t, different number of args on Construct"
+               then failwith "eq_t, different number of args on Construct"
                else ();
                (let uu___2 =
                   let uu___3 = FStar_Syntax_Syntax.lid_of_fv v1 in
@@ -1835,9 +1833,7 @@ let (e_issue : FStar_Errors.issue embedding) =
   let em1 cb iss =
     let uu___ =
       let uu___1 =
-        FStar_Thunk.mk
-          (fun uu___2 ->
-             FStar_Compiler_Effect.failwith "Cannot unembed issue") in
+        FStar_Thunk.mk (fun uu___2 -> failwith "Cannot unembed issue") in
       ((FStar_Pervasives.Inl (li iss FStar_Compiler_Range_Type.dummyRange)),
         uu___1) in
     Lazy uu___ in
@@ -1870,9 +1866,7 @@ let (e_document : FStar_Pprint.document embedding) =
   let em1 cb doc =
     let uu___ =
       let uu___1 =
-        FStar_Thunk.mk
-          (fun uu___2 ->
-             FStar_Compiler_Effect.failwith "Cannot unembed document") in
+        FStar_Thunk.mk (fun uu___2 -> failwith "Cannot unembed document") in
       ((FStar_Pervasives.Inl (li doc FStar_Compiler_Range_Type.dummyRange)),
         uu___1) in
     Lazy uu___ in
@@ -1894,8 +1888,8 @@ let (e_document : FStar_Pprint.document embedding) =
     (FStar_Syntax_Embeddings_Base.emb_typ_of
        FStar_Syntax_Embeddings.e_document)
 let (e_vconfig : FStar_VConfig.vconfig embedding) =
-  let em1 cb r = FStar_Compiler_Effect.failwith "e_vconfig NBE" in
-  let un1 cb t1 = FStar_Compiler_Effect.failwith "e_vconfig NBE" in
+  let em1 cb r = failwith "e_vconfig NBE" in
+  let un1 cb t1 = failwith "e_vconfig NBE" in
   mk_emb' em1 un1
     (fun uu___ -> lid_as_typ FStar_Parser_Const.vconfig_lid [] [])
     (FStar_Syntax_Embeddings_Base.emb_typ_of
@@ -1998,8 +1992,7 @@ let e_arrow : 'a 'b . 'a embedding -> 'b embedding -> ('a -> 'b) embedding =
                         | FStar_Pervasives_Native.Some a1 ->
                             let uu___5 = f a1 in embed eb cb uu___5
                         | FStar_Pervasives_Native.None ->
-                            FStar_Compiler_Effect.failwith
-                              "cannot unembed function argument");
+                            failwith "cannot unembed function argument");
                    shape = uu___3;
                    arity = Prims.int_one
                  } in
@@ -2019,8 +2012,7 @@ let e_arrow : 'a 'b . 'a embedding -> 'b embedding -> ('a -> 'b) embedding =
                match uu___ with
                | FStar_Pervasives_Native.Some y -> y
                | FStar_Pervasives_Native.None ->
-                   FStar_Compiler_Effect.failwith
-                     "cannot unembed function result") in
+                   failwith "cannot unembed function result") in
         lazy_unembed etyp lam k in
       mk_emb em1 un1
         (fun uu___ ->
@@ -2033,10 +2025,8 @@ let (e_abstract_nbe_term : abstract_nbe_term embedding) =
     FStar_Pervasives_Native.None
 let e_unsupported : 'a . unit -> 'a embedding =
   fun uu___ ->
-    let em1 _cb a1 =
-      FStar_Compiler_Effect.failwith "Unsupported NBE embedding" in
-    let un1 _cb t1 =
-      FStar_Compiler_Effect.failwith "Unsupported NBE embedding" in
+    let em1 _cb a1 = failwith "Unsupported NBE embedding" in
+    let un1 _cb t1 = failwith "Unsupported NBE embedding" in
     mk_emb em1 un1
       (fun uu___1 -> lid_as_typ FStar_Parser_Const.term_lid [] [])
       (fun uu___1 -> FStar_Syntax_Syntax.ET_abstract)
@@ -2236,8 +2226,7 @@ let (e_norm_step : FStar_Pervasives.norm_step embedding) =
 let (bogus_cbs : nbe_cbs) =
   {
     iapp = (fun h -> fun _args -> h);
-    translate =
-      (fun uu___ -> FStar_Compiler_Effect.failwith "bogus_cbs translate")
+    translate = (fun uu___ -> failwith "bogus_cbs translate")
   }
 let (arg_as_int : arg -> FStar_BigInt.t FStar_Pervasives_Native.option) =
   fun a -> unembed e_int bogus_cbs (FStar_Pervasives_Native.fst a)
@@ -2349,7 +2338,7 @@ let (dummy_interp :
       let uu___ =
         let uu___1 = FStar_Ident.string_of_lid lid in
         Prims.strcat "No interpretation for " uu___1 in
-      FStar_Compiler_Effect.failwith uu___
+      failwith uu___
 let (and_op : args -> t FStar_Pervasives_Native.option) =
   fun args1 ->
     match args1 with
@@ -2362,8 +2351,7 @@ let (and_op : args -> t FStar_Pervasives_Native.option) =
          | FStar_Pervasives_Native.Some (true) ->
              FStar_Pervasives_Native.Some (FStar_Pervasives_Native.fst a2)
          | uu___1 -> FStar_Pervasives_Native.None)
-    | uu___ ->
-        FStar_Compiler_Effect.failwith "Unexpected number of arguments"
+    | uu___ -> failwith "Unexpected number of arguments"
 let (or_op : args -> t FStar_Pervasives_Native.option) =
   fun args1 ->
     match args1 with
@@ -2376,8 +2364,7 @@ let (or_op : args -> t FStar_Pervasives_Native.option) =
          | FStar_Pervasives_Native.Some (false) ->
              FStar_Pervasives_Native.Some (FStar_Pervasives_Native.fst a2)
          | uu___1 -> FStar_Pervasives_Native.None)
-    | uu___ ->
-        FStar_Compiler_Effect.failwith "Unexpected number of arguments"
+    | uu___ -> failwith "Unexpected number of arguments"
 let arrow_as_prim_step_1 :
   'a 'b .
     'a embedding ->

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Normalize.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Normalize.ml
@@ -244,9 +244,7 @@ let set_memo :
               let uu___2 = read_memo cfg r in
               FStar_Compiler_Option.isSome uu___2 in
             if uu___1
-            then
-              FStar_Compiler_Effect.failwith
-                "Unexpected set_memo: thunk already evaluated"
+            then failwith "Unexpected set_memo: thunk already evaluated"
             else ());
            FStar_Compiler_Effect.op_Colon_Equals r
              (FStar_Pervasives_Native.Some (cfg, t)))
@@ -320,7 +318,7 @@ let (lookup_bvar : env -> FStar_Syntax_Syntax.bv -> closure) =
                             FStar_Syntax_Print.showable_subst_elt)))) env1 in
             FStar_Compiler_Util.format2 "Failed to find %s\nEnv is %s\n"
               uu___2 uu___3 in
-          FStar_Compiler_Effect.failwith uu___1
+          failwith uu___1
 let (downgrade_ghost_effect_name :
   FStar_Ident.lident -> FStar_Ident.lident FStar_Pervasives_Native.option) =
   fun l ->
@@ -400,7 +398,7 @@ let (norm_universe :
                                FStar_Compiler_Util.format1
                                  "Impossible: universe variable u@%s bound to a term"
                                  uu___4 in
-                             FStar_Compiler_Effect.failwith uu___3)) ()
+                             failwith uu___3)) ()
                with
                | uu___ ->
                    if
@@ -410,7 +408,7 @@ let (norm_universe :
                      (let uu___2 =
                         let uu___3 = FStar_Compiler_Util.string_of_int x in
                         Prims.strcat "Universe variable not found: u@" uu___3 in
-                      FStar_Compiler_Effect.failwith uu___2))
+                      failwith uu___2))
           | FStar_Syntax_Syntax.U_unif uu___ when
               (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.default_univs_to_zero
               -> [FStar_Syntax_Syntax.U_zero]
@@ -428,7 +426,7 @@ let (norm_universe :
                 FStar_Compiler_Util.format2
                   "(%s) CheckNoUvars: unexpected universes variable remains: %s"
                   uu___2 uu___3 in
-              FStar_Compiler_Effect.failwith uu___1
+              failwith uu___1
           | FStar_Syntax_Syntax.U_zero -> [u2]
           | FStar_Syntax_Syntax.U_unif uu___ -> [u2]
           | FStar_Syntax_Syntax.U_name uu___ -> [u2]
@@ -1043,7 +1041,7 @@ let (rejig_norm_request :
                let uu___1 = FStar_Syntax_Util.mk_app hd [t1; t2] in
                FStar_Syntax_Util.mk_app uu___1 rest
            | uu___1 ->
-               FStar_Compiler_Effect.failwith
+               failwith
                  "Impossible! invalid rejig_norm_request for normalize_term")
       | FStar_Syntax_Syntax.Tm_fvar fv when
           FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.normalize ->
@@ -1053,7 +1051,7 @@ let (rejig_norm_request :
                let uu___1 = FStar_Syntax_Util.mk_app hd [t] in
                FStar_Syntax_Util.mk_app uu___1 rest
            | uu___1 ->
-               FStar_Compiler_Effect.failwith
+               failwith
                  "Impossible! invalid rejig_norm_request for normalize")
       | FStar_Syntax_Syntax.Tm_fvar fv when
           FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.norm ->
@@ -1063,15 +1061,14 @@ let (rejig_norm_request :
                let uu___1 = FStar_Syntax_Util.mk_app hd [t1; t2; t3] in
                FStar_Syntax_Util.mk_app uu___1 rest
            | uu___1 ->
-               FStar_Compiler_Effect.failwith
-                 "Impossible! invalid rejig_norm_request for norm")
+               failwith "Impossible! invalid rejig_norm_request for norm")
       | uu___1 ->
           let uu___2 =
             let uu___3 =
               FStar_Class_Show.show FStar_Syntax_Print.showable_term hd in
             Prims.strcat "Impossible! invalid rejig_norm_request for: %s"
               uu___3 in
-          FStar_Compiler_Effect.failwith uu___2
+          failwith uu___2
 let (is_nbe_request : FStar_TypeChecker_Env.step Prims.list -> Prims.bool) =
   fun s ->
     FStar_Compiler_Util.for_some
@@ -1236,8 +1233,7 @@ let rec (maybe_weakly_reduced :
                ct.FStar_Syntax_Syntax.effect_args) in
     let t = FStar_Syntax_Subst.compress tm in
     match t.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_delayed uu___ ->
-        FStar_Compiler_Effect.failwith "Impossible"
+    | FStar_Syntax_Syntax.Tm_delayed uu___ -> failwith "Impossible"
     | FStar_Syntax_Syntax.Tm_name uu___ -> false
     | FStar_Syntax_Syntax.Tm_uvar uu___ -> false
     | FStar_Syntax_Syntax.Tm_type uu___ -> false
@@ -1477,10 +1473,7 @@ let (__get_n_binders :
   FStar_Compiler_Util.mk_ref
     (fun e ->
        fun s ->
-         fun n ->
-           fun t ->
-             FStar_Compiler_Effect.failwith
-               "Impossible: __get_n_binders unset")
+         fun n -> fun t -> failwith "Impossible: __get_n_binders unset")
 let (is_partial_primop_app :
   FStar_TypeChecker_Cfg.cfg -> FStar_Syntax_Syntax.term -> Prims.bool) =
   fun cfg ->
@@ -2605,10 +2598,9 @@ let rec (norm :
                let uu___2 = lookup_bvar env1 x in
                (match uu___2 with
                 | Univ uu___3 ->
-                    FStar_Compiler_Effect.failwith
+                    failwith
                       "Impossible: term variable is bound to a universe"
-                | Dummy ->
-                    FStar_Compiler_Effect.failwith "Term variable not found"
+                | Dummy -> failwith "Term variable not found"
                 | Clos (env2, t0, r, fix) ->
                     if
                       ((Prims.op_Negation fix) ||
@@ -2751,7 +2743,7 @@ let rec (norm :
                           rebuild cfg env1 stack2 body_norm))) in
                (match stack2 with
                 | (UnivArgs uu___2)::uu___3 ->
-                    FStar_Compiler_Effect.failwith
+                    failwith
                       "Ill-typed term: universes cannot be applied to term abstraction"
                 | (Arg (Univ u, uu___2, uu___3))::stack_rest ->
                     let uu___4 =
@@ -2762,7 +2754,7 @@ let rec (norm :
                     norm cfg uu___4 stack_rest t1
                 | (Arg (c, uu___2, uu___3))::stack_rest ->
                     (match bs with
-                     | [] -> FStar_Compiler_Effect.failwith "Impossible"
+                     | [] -> failwith "Impossible"
                      | b::[] ->
                          (FStar_TypeChecker_Cfg.log cfg
                             (fun uu___5 ->
@@ -3829,8 +3821,7 @@ let rec (norm :
                                    }) t1.FStar_Syntax_Syntax.pos in
                             rebuild cfg env1 stack2 t2)))
            | FStar_Syntax_Syntax.Tm_delayed uu___2 ->
-               FStar_Compiler_Effect.failwith
-                 "impossible: Tm_delayed on norm"
+               failwith "impossible: Tm_delayed on norm"
            | FStar_Syntax_Syntax.Tm_uvar uu___2 ->
                (if
                   (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.check_no_uvars
@@ -3846,7 +3837,7 @@ let rec (norm :
                      FStar_Compiler_Util.format2
                        "(%s) CheckNoUvars: Unexpected unification variable remains: %s"
                        uu___5 uu___6 in
-                   FStar_Compiler_Effect.failwith uu___4)
+                   failwith uu___4)
                 else ();
                 (let t2 =
                    FStar_Errors.with_ctx "inlining"
@@ -3968,7 +3959,7 @@ and (do_unfold_fv :
                           FStar_Compiler_Util.format1
                             "Impossible: missing universe instantiation on %s"
                             uu___4 in
-                        FStar_Compiler_Effect.failwith uu___3
+                        failwith uu___3
                   else norm cfg empty_env stack1 t1))
 and (reduce_impure_comp :
   FStar_TypeChecker_Cfg.cfg ->
@@ -4033,7 +4024,7 @@ and (do_reify_monadic :
                        FStar_Compiler_Util.format1
                          "INTERNAL ERROR: do_reify_monadic: bad stack: %s"
                          uu___3 in
-                     FStar_Compiler_Effect.failwith uu___2);
+                     failwith uu___2);
                 (let top0 = top in
                  let top1 = FStar_Syntax_Util.unascribe top in
                  FStar_TypeChecker_Cfg.log cfg
@@ -4073,7 +4064,7 @@ and (do_reify_monadic :
                             | (uu___6, bind_repr) ->
                                 (match lb.FStar_Syntax_Syntax.lbname with
                                  | FStar_Pervasives.Inr uu___7 ->
-                                     FStar_Compiler_Effect.failwith
+                                     failwith
                                        "Cannot reify a top-level let binding"
                                  | FStar_Pervasives.Inl x ->
                                      let is_return e =
@@ -4260,7 +4251,7 @@ and (do_reify_monadic :
                                                    FStar_Syntax_Syntax.mk
                                                      uu___13 rng
                                                | uu___11 ->
-                                                   FStar_Compiler_Effect.failwith
+                                                   failwith
                                                      "NIY : Reification of indexed effects" in
                                              let bind_inst_args f_arg =
                                                let uu___10 =
@@ -4820,8 +4811,7 @@ and (reify_lift :
                               FStar_Syntax_Syntax.mk uu___8
                                 e.FStar_Syntax_Syntax.pos
                           | uu___7 ->
-                              FStar_Compiler_Effect.failwith
-                                "NIY : Reification of indexed effects" in
+                              failwith "NIY : Reification of indexed effects" in
                         let uu___6 =
                           let bv =
                             FStar_Syntax_Syntax.new_bv
@@ -4891,7 +4881,7 @@ and (reify_lift :
                       FStar_Compiler_Util.format2
                         "Impossible : trying to reify a lift between unrelated effects (%s and %s)"
                         uu___5 uu___6 in
-                    FStar_Compiler_Effect.failwith uu___4
+                    failwith uu___4
                 | FStar_Pervasives_Native.Some
                     { FStar_TypeChecker_Env.msource = uu___4;
                       FStar_TypeChecker_Env.mtarget = uu___5;
@@ -4907,7 +4897,7 @@ and (reify_lift :
                       FStar_Compiler_Util.format2
                         "Impossible : trying to reify a non-reifiable lift (from %s to %s)"
                         uu___9 uu___10 in
-                    FStar_Compiler_Effect.failwith uu___8
+                    failwith uu___8
                 | FStar_Pervasives_Native.Some
                     { FStar_TypeChecker_Env.msource = uu___4;
                       FStar_TypeChecker_Env.mtarget = uu___5;
@@ -5840,7 +5830,7 @@ and (maybe_simplify_aux :
                                                                     | 
                                                                     uu___37
                                                                     ->
-                                                                    FStar_Compiler_Effect.failwith
+                                                                    failwith
                                                                     "Impossible! We have already checked that this is a Tm_app" in
                                                                     let uu___36
                                                                     =
@@ -6427,7 +6417,7 @@ and (maybe_simplify_aux :
                                                                     | 
                                                                     uu___33
                                                                     ->
-                                                                    FStar_Compiler_Effect.failwith
+                                                                    failwith
                                                                     "Impossible! We have already checked that this is a Tm_app" in
                                                                     let uu___32
                                                                     =
@@ -6572,7 +6562,7 @@ and (rebuild :
                         FStar_Compiler_Util.print3
                           "!!! Rebuild (%s) %s, free vars=%s\n" uu___6 uu___7
                           uu___8);
-                       FStar_Compiler_Effect.failwith "DIE!")
+                       failwith "DIE!")
                 else ()));
           (let f_opt = is_fext_on_domain t in
            if
@@ -6670,9 +6660,8 @@ and (do_rebuild :
                 } in
               rebuild cfg env1 stack2 uu___
           | (Arg (Univ uu___, uu___1, uu___2))::uu___3 ->
-              FStar_Compiler_Effect.failwith "Impossible"
-          | (Arg (Dummy, uu___, uu___1))::uu___2 ->
-              FStar_Compiler_Effect.failwith "Impossible"
+              failwith "Impossible"
+          | (Arg (Dummy, uu___, uu___1))::uu___2 -> failwith "Impossible"
           | (UnivArgs (us, r))::stack2 ->
               let t1 = FStar_Syntax_Syntax.mk_Tm_uinst t us in
               rebuild cfg env1 stack2 t1
@@ -8451,8 +8440,7 @@ let (elim_uvars_aux_tc :
             match (binders, tc) with
             | ([], FStar_Pervasives.Inl t1) -> t1
             | ([], FStar_Pervasives.Inr c) ->
-                FStar_Compiler_Effect.failwith
-                  "Impossible: empty bindes with a comp"
+                failwith "Impossible: empty bindes with a comp"
             | (uu___, FStar_Pervasives.Inr c) ->
                 FStar_Syntax_Syntax.mk
                   (FStar_Syntax_Syntax.Tm_arrow
@@ -8499,7 +8487,7 @@ let (elim_uvars_aux_tc :
                               (FStar_Syntax_Util.comp_result c)))
                      | (uu___4, FStar_Pervasives.Inl uu___5) ->
                          ([], (FStar_Pervasives.Inl t3))
-                     | uu___4 -> FStar_Compiler_Effect.failwith "Impossible") in
+                     | uu___4 -> failwith "Impossible") in
               (match uu___1 with
                | (binders1, tc1) -> (univ_names1, binders1, tc1))
 let (elim_uvars_aux_t :
@@ -8889,8 +8877,7 @@ let rec (elim_uvars :
                                    FStar_Syntax_Syntax.eff_opt =
                                      FStar_Pervasives_Native.None;_}
                                  -> (defn, typ)
-                             | uu___5 ->
-                                 FStar_Compiler_Effect.failwith "Impossible" in
+                             | uu___5 -> failwith "Impossible" in
                            let destruct_action_typ_templ t =
                              let uu___4 =
                                let uu___5 = FStar_Syntax_Subst.compress t in

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Normalize_Unfolding.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Normalize_Unfolding.ml
@@ -749,7 +749,7 @@ let (should_unfold :
                              FStar_Class_Printable.printable_bool)) res in
                    FStar_Compiler_Util.format1
                      "Unexpected unfolding result: %s" uu___3 in
-                 FStar_Compiler_Effect.failwith uu___2 in
+                 failwith uu___2 in
            (let uu___2 =
               ((((FStar_Pervasives_Native.uu___is_Some
                     (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.dont_unfold_attr)

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Positivity.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Positivity.ml
@@ -119,8 +119,7 @@ let rec (term_as_fv_or_name :
          | FStar_Syntax_Syntax.Tm_fvar fv ->
              FStar_Pervasives_Native.Some (FStar_Pervasives.Inl (fv, us))
          | uu___2 ->
-             FStar_Compiler_Effect.failwith
-               "term_as_fv_or_name: impossible non fvar in uinst")
+             failwith "term_as_fv_or_name: impossible non fvar in uinst")
     | FStar_Syntax_Syntax.Tm_ascribed
         { FStar_Syntax_Syntax.tm = t1; FStar_Syntax_Syntax.asc = uu___1;
           FStar_Syntax_Syntax.eff_opt = uu___2;_}
@@ -154,7 +153,7 @@ let (open_sig_inductive_typ :
                let ty_params2 = FStar_Syntax_Subst.open_binders ty_params1 in
                let env2 = FStar_TypeChecker_Env.push_binders env1 ty_params2 in
                (env2, (lid, ty_us1, ty_params2)))
-      | uu___ -> FStar_Compiler_Effect.failwith "Impossible!"
+      | uu___ -> failwith "Impossible!"
 let (name_as_fv_in_t :
   FStar_Syntax_Syntax.term ->
     FStar_Syntax_Syntax.bv -> (FStar_Syntax_Syntax.term * FStar_Ident.lident))
@@ -652,12 +651,9 @@ let (may_be_an_arity :
             -> aux t3
         | FStar_Syntax_Syntax.Tm_uvar uu___1 -> true
         | FStar_Syntax_Syntax.Tm_let uu___1 -> true
-        | FStar_Syntax_Syntax.Tm_delayed uu___1 ->
-            FStar_Compiler_Effect.failwith "Impossible"
-        | FStar_Syntax_Syntax.Tm_bvar uu___1 ->
-            FStar_Compiler_Effect.failwith "Impossible"
-        | FStar_Syntax_Syntax.Tm_unknown ->
-            FStar_Compiler_Effect.failwith "Impossible" in
+        | FStar_Syntax_Syntax.Tm_delayed uu___1 -> failwith "Impossible"
+        | FStar_Syntax_Syntax.Tm_bvar uu___1 -> failwith "Impossible"
+        | FStar_Syntax_Syntax.Tm_unknown -> failwith "Impossible" in
       aux t1
 let (check_no_index_occurrences_in_arities :
   FStar_TypeChecker_Env.env ->
@@ -1398,8 +1394,7 @@ and (ty_strictly_positive_in_arguments_to_fvar :
                                   env ilid in
                               match uu___6 with
                               | FStar_Pervasives_Native.None ->
-                                  FStar_Compiler_Effect.failwith
-                                    "Unexpected type"
+                                  failwith "Unexpected type"
                               | FStar_Pervasives_Native.Some n -> n in
                             let uu___6 =
                               FStar_Compiler_List.splitAt num_uniform_params

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Primops.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Primops.ml
@@ -43,8 +43,7 @@ let (and_op :
                | FStar_Pervasives_Native.Some (true) ->
                    FStar_Pervasives_Native.Some a2
                | uu___1 -> FStar_Pervasives_Native.None)
-          | uu___ ->
-              FStar_Compiler_Effect.failwith "Unexpected number of arguments"
+          | uu___ -> failwith "Unexpected number of arguments"
 let (or_op :
   FStar_TypeChecker_Primops_Base.psc ->
     FStar_Syntax_Embeddings_Base.norm_cb ->
@@ -73,8 +72,7 @@ let (or_op :
                | FStar_Pervasives_Native.Some (false) ->
                    FStar_Pervasives_Native.Some a2
                | uu___1 -> FStar_Pervasives_Native.None)
-          | uu___ ->
-              FStar_Compiler_Effect.failwith "Unexpected number of arguments"
+          | uu___ -> failwith "Unexpected number of arguments"
 let (division_modulus_op :
   (FStar_BigInt.t -> FStar_BigInt.t -> FStar_BigInt.t) ->
     FStar_BigInt.t ->

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Primops_Array.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Primops_Array.ml
@@ -127,7 +127,7 @@ let (bogus_cbs : FStar_TypeChecker_NBETerm.nbe_cbs) =
   {
     FStar_TypeChecker_NBETerm.iapp = (fun h -> fun _args -> h);
     FStar_TypeChecker_NBETerm.translate =
-      (fun uu___ -> FStar_Compiler_Effect.failwith "bogus_cbs translate")
+      (fun uu___ -> failwith "bogus_cbs translate")
   }
 let (ops : FStar_TypeChecker_Primops_Base.primitive_step Prims.list) =
   let of_list_op =

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Primops_Base.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Primops_Base.ml
@@ -179,10 +179,7 @@ let mk_interp1 :
                                            (FStar_Class_Monad.return
                                               FStar_Class_Monad.monad_option
                                               () (Obj.magic uu___4))) uu___4)))
-                       | uu___2 ->
-                           Obj.magic
-                             (Obj.repr
-                                (FStar_Compiler_Effect.failwith "arity")))
+                       | uu___2 -> Obj.magic (Obj.repr (failwith "arity")))
           uu___2 uu___1 uu___
 let mk_nbe_interp1 :
   'a 'r .
@@ -283,9 +280,7 @@ let mk_interp2 :
                                                   () (Obj.magic uu___6)))
                                             uu___6)))
                            | uu___3 ->
-                               Obj.magic
-                                 (Obj.repr
-                                    (FStar_Compiler_Effect.failwith "arity")))
+                               Obj.magic (Obj.repr (failwith "arity")))
             uu___3 uu___2 uu___1 uu___
 let mk_nbe_interp2 :
   'a 'b 'r .
@@ -415,11 +410,8 @@ let mk_interp3 :
                                                       () (Obj.magic uu___8)))
                                                 uu___8)))
                                | uu___4 ->
-                                   Obj.magic
-                                     (Obj.repr
-                                        (FStar_Compiler_Effect.failwith
-                                           "arity"))) uu___4 uu___3 uu___2
-              uu___1 uu___
+                                   Obj.magic (Obj.repr (failwith "arity")))
+              uu___4 uu___3 uu___2 uu___1 uu___
 let mk_nbe_interp3 :
   'a 'b 'c 'r .
     'a FStar_TypeChecker_NBETerm.embedding ->
@@ -580,10 +572,8 @@ let mk_interp4 :
                                                     uu___10)))
                                    | uu___5 ->
                                        Obj.magic
-                                         (Obj.repr
-                                            (FStar_Compiler_Effect.failwith
-                                               "arity"))) uu___5 uu___4
-                uu___3 uu___2 uu___1 uu___
+                                         (Obj.repr (failwith "arity")))
+                uu___5 uu___4 uu___3 uu___2 uu___1 uu___
 let mk_nbe_interp4 :
   'a 'b 'c 'd 'r .
     'a FStar_TypeChecker_NBETerm.embedding ->
@@ -786,10 +776,8 @@ let mk_interp5 :
                                                         uu___12)))
                                        | uu___6 ->
                                            Obj.magic
-                                             (Obj.repr
-                                                (FStar_Compiler_Effect.failwith
-                                                   "arity"))) uu___6 uu___5
-                  uu___4 uu___3 uu___2 uu___1 uu___
+                                             (Obj.repr (failwith "arity")))
+                  uu___6 uu___5 uu___4 uu___3 uu___2 uu___1 uu___
 let mk_nbe_interp5 :
   'a 'b 'c 'd 'e 'r .
     'a FStar_TypeChecker_NBETerm.embedding ->
@@ -1113,9 +1101,7 @@ let mk1' :
                                                       FStar_Class_Monad.monad_option
                                                       () (Obj.magic uu___6)))
                                                 uu___6))) uu___6)))
-                    | uu___4 ->
-                        Obj.magic
-                          (Obj.repr (FStar_Compiler_Effect.failwith "arity")) in
+                    | uu___4 -> Obj.magic (Obj.repr (failwith "arity")) in
                   let nbe_interp cbs us args =
                     match args with
                     | (a1, uu___4)::[] ->
@@ -1151,9 +1137,7 @@ let mk1' :
                                                       FStar_Class_Monad.monad_option
                                                       () (Obj.magic uu___6)))
                                                 uu___6))) uu___6)))
-                    | uu___4 ->
-                        Obj.magic
-                          (Obj.repr (FStar_Compiler_Effect.failwith "arity")) in
+                    | uu___4 -> Obj.magic (Obj.repr (failwith "arity")) in
                   as_primitive_step_nbecbs true
                     (name, Prims.int_one, u_arity, interp, nbe_interp)
 let mk1_psc' :
@@ -1210,9 +1194,7 @@ let mk1_psc' :
                                                       FStar_Class_Monad.monad_option
                                                       () (Obj.magic uu___6)))
                                                 uu___6))) uu___6)))
-                    | uu___4 ->
-                        Obj.magic
-                          (Obj.repr (FStar_Compiler_Effect.failwith "arity")) in
+                    | uu___4 -> Obj.magic (Obj.repr (failwith "arity")) in
                   let nbe_interp cbs us args =
                     match args with
                     | (a1, uu___4)::[] ->
@@ -1249,9 +1231,7 @@ let mk1_psc' :
                                                       FStar_Class_Monad.monad_option
                                                       () (Obj.magic uu___6)))
                                                 uu___6))) uu___6)))
-                    | uu___4 ->
-                        Obj.magic
-                          (Obj.repr (FStar_Compiler_Effect.failwith "arity")) in
+                    | uu___4 -> Obj.magic (Obj.repr (failwith "arity")) in
                   as_primitive_step_nbecbs true
                     (name, Prims.int_one, u_arity, interp, nbe_interp)
 let mk2' :
@@ -1323,10 +1303,7 @@ let mk2' :
                                                           ()
                                                           (Obj.magic uu___9)))
                                                     uu___9))) uu___9)))
-                        | uu___6 ->
-                            Obj.magic
-                              (Obj.repr
-                                 (FStar_Compiler_Effect.failwith "arity")) in
+                        | uu___6 -> Obj.magic (Obj.repr (failwith "arity")) in
                       let nbe_interp cbs us args =
                         match args with
                         | (a1, uu___6)::(b1, uu___7)::[] ->
@@ -1375,10 +1352,7 @@ let mk2' :
                                                           ()
                                                           (Obj.magic uu___9)))
                                                     uu___9))) uu___9)))
-                        | uu___6 ->
-                            Obj.magic
-                              (Obj.repr
-                                 (FStar_Compiler_Effect.failwith "arity")) in
+                        | uu___6 -> Obj.magic (Obj.repr (failwith "arity")) in
                       as_primitive_step_nbecbs true
                         (name, (Prims.of_int (2)), u_arity, interp,
                           nbe_interp)
@@ -1471,9 +1445,7 @@ let mk3' :
                                                                  uu___12)))
                                                         uu___12))) uu___12)))
                             | uu___8 ->
-                                Obj.magic
-                                  (Obj.repr
-                                     (FStar_Compiler_Effect.failwith "arity")) in
+                                Obj.magic (Obj.repr (failwith "arity")) in
                           let nbe_interp cbs us args =
                             match args with
                             | (a1, uu___8)::(b1, uu___9)::(c1, uu___10)::[]
@@ -1535,9 +1507,7 @@ let mk3' :
                                                                  uu___12)))
                                                         uu___12))) uu___12)))
                             | uu___8 ->
-                                Obj.magic
-                                  (Obj.repr
-                                     (FStar_Compiler_Effect.failwith "arity")) in
+                                Obj.magic (Obj.repr (failwith "arity")) in
                           as_primitive_step_nbecbs true
                             (name, (Prims.of_int (3)), u_arity, interp,
                               nbe_interp)
@@ -1653,10 +1623,7 @@ let mk4' :
                                                             uu___15)))
                                                  uu___15)))
                                 | uu___10 ->
-                                    Obj.magic
-                                      (Obj.repr
-                                         (FStar_Compiler_Effect.failwith
-                                            "arity")) in
+                                    Obj.magic (Obj.repr (failwith "arity")) in
                               let nbe_interp cbs us args =
                                 match args with
                                 | (a1, uu___10)::(b1, uu___11)::(c1, uu___12)::
@@ -1731,10 +1698,7 @@ let mk4' :
                                                             uu___15)))
                                                  uu___15)))
                                 | uu___10 ->
-                                    Obj.magic
-                                      (Obj.repr
-                                         (FStar_Compiler_Effect.failwith
-                                            "arity")) in
+                                    Obj.magic (Obj.repr (failwith "arity")) in
                               as_primitive_step_nbecbs true
                                 (name, (Prims.of_int (4)), u_arity, interp,
                                   nbe_interp)
@@ -1878,9 +1842,7 @@ let mk5' :
                                                      uu___18)))
                                     | uu___12 ->
                                         Obj.magic
-                                          (Obj.repr
-                                             (FStar_Compiler_Effect.failwith
-                                                "arity")) in
+                                          (Obj.repr (failwith "arity")) in
                                   let nbe_interp cbs us args =
                                     match args with
                                     | (a1, uu___12)::(b1, uu___13)::(c1,
@@ -1976,9 +1938,7 @@ let mk5' :
                                                      uu___18)))
                                     | uu___12 ->
                                         Obj.magic
-                                          (Obj.repr
-                                             (FStar_Compiler_Effect.failwith
-                                                "arity")) in
+                                          (Obj.repr (failwith "arity")) in
                                   as_primitive_step_nbecbs true
                                     (name, (Prims.of_int (5)), u_arity,
                                       interp, nbe_interp)
@@ -2151,9 +2111,7 @@ let mk6' :
                                                          uu___21)))
                                         | uu___14 ->
                                             Obj.magic
-                                              (Obj.repr
-                                                 (FStar_Compiler_Effect.failwith
-                                                    "arity")) in
+                                              (Obj.repr (failwith "arity")) in
                                       let nbe_interp cbs us args =
                                         match args with
                                         | (a1, uu___14)::(b1, uu___15)::
@@ -2275,9 +2233,7 @@ let mk6' :
                                                          uu___21)))
                                         | uu___14 ->
                                             Obj.magic
-                                              (Obj.repr
-                                                 (FStar_Compiler_Effect.failwith
-                                                    "arity")) in
+                                              (Obj.repr (failwith "arity")) in
                                       as_primitive_step_nbecbs true
                                         (name, (Prims.of_int (6)), u_arity,
                                           interp, nbe_interp)

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Primops_Sealed.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Primops_Sealed.ml
@@ -3,7 +3,7 @@ let (bogus_cbs : FStar_TypeChecker_NBETerm.nbe_cbs) =
   {
     FStar_TypeChecker_NBETerm.iapp = (fun h -> fun _args -> h);
     FStar_TypeChecker_NBETerm.translate =
-      (fun uu___ -> FStar_Compiler_Effect.failwith "bogus_cbs translate")
+      (fun uu___ -> failwith "bogus_cbs translate")
   }
 let (ops : FStar_TypeChecker_Primops_Base.primitive_step Prims.list) =
   FStar_Compiler_List.map

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Rel.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Rel.ml
@@ -1683,7 +1683,7 @@ let (explain :
              match p_rel d1 with
              | FStar_TypeChecker_Common.EQ -> "equal to"
              | FStar_TypeChecker_Common.SUB -> "a subtype of"
-             | uu___2 -> FStar_Compiler_Effect.failwith "impossible" in
+             | uu___2 -> failwith "impossible" in
            let uu___2 =
              match d1 with
              | FStar_TypeChecker_Common.TProb tp ->
@@ -1797,9 +1797,7 @@ let set_uvar :
            then
              let uu___3 =
                let uu___4 = occurs u t in FStar_Pervasives_Native.snd uu___4 in
-             (if uu___3
-              then FStar_Compiler_Effect.failwith "OCCURS BUG!"
-              else ())
+             (if uu___3 then failwith "OCCURS BUG!" else ())
            else ());
           FStar_Syntax_Util.set_uvar u.FStar_Syntax_Syntax.ctx_uvar_head t
 let (commit : FStar_TypeChecker_Env.env_t -> uvi Prims.list -> unit) =
@@ -2070,7 +2068,7 @@ let (base_and_refinement_maybe_delta :
                            FStar_Syntax_Syntax.tagged_term tt in
                        FStar_Compiler_Util.format2
                          "impossible: Got %s ... %s\n" uu___3 uu___4 in
-                     FStar_Compiler_Effect.failwith uu___2)
+                     failwith uu___2)
           | FStar_Syntax_Syntax.Tm_lazy i ->
               let uu___ = FStar_Syntax_Util.unfold_lazy i in aux norm uu___
           | FStar_Syntax_Syntax.Tm_uinst uu___ ->
@@ -2135,7 +2133,7 @@ let (base_and_refinement_maybe_delta :
                     t12 in
                 FStar_Compiler_Util.format2
                   "impossible (outer): Got %s ... %s\n" uu___2 uu___3 in
-              FStar_Compiler_Effect.failwith uu___1
+              failwith uu___1
           | FStar_Syntax_Syntax.Tm_ascribed uu___ ->
               let uu___1 =
                 let uu___2 =
@@ -2145,7 +2143,7 @@ let (base_and_refinement_maybe_delta :
                     t12 in
                 FStar_Compiler_Util.format2
                   "impossible (outer): Got %s ... %s\n" uu___2 uu___3 in
-              FStar_Compiler_Effect.failwith uu___1
+              failwith uu___1
           | FStar_Syntax_Syntax.Tm_delayed uu___ ->
               let uu___1 =
                 let uu___2 =
@@ -2155,7 +2153,7 @@ let (base_and_refinement_maybe_delta :
                     t12 in
                 FStar_Compiler_Util.format2
                   "impossible (outer): Got %s ... %s\n" uu___2 uu___3 in
-              FStar_Compiler_Effect.failwith uu___1
+              failwith uu___1
           | FStar_Syntax_Syntax.Tm_unknown ->
               let uu___ =
                 let uu___1 =
@@ -2165,7 +2163,7 @@ let (base_and_refinement_maybe_delta :
                     t12 in
                 FStar_Compiler_Util.format2
                   "impossible (outer): Got %s ... %s\n" uu___1 uu___2 in
-              FStar_Compiler_Effect.failwith uu___ in
+              failwith uu___ in
         let uu___ = whnf env t1 in aux false uu___
 let (base_and_refinement :
   FStar_TypeChecker_Env.env ->
@@ -2297,7 +2295,7 @@ let (flex_uvar_head :
           uu___2.FStar_Syntax_Syntax.n in
         (match uu___1 with
          | FStar_Syntax_Syntax.Tm_uvar (u, uu___2) -> u
-         | uu___2 -> FStar_Compiler_Effect.failwith "Not a flex-uvar")
+         | uu___2 -> failwith "Not a flex-uvar")
 let ensure_no_uvar_subst :
   'uuuuu .
     'uuuuu ->
@@ -2418,7 +2416,7 @@ let ensure_no_uvar_subst :
                    FStar_Compiler_Util.format3
                      "ensure_no_uvar_subst: expected a uvar at the head (%s-%s-%s)"
                      uu___4 uu___5 uu___6 in
-                 FStar_Compiler_Effect.failwith uu___3)
+                 failwith uu___3)
 let (no_free_uvars : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t ->
     (let uu___ = FStar_Syntax_Free.uvars t in
@@ -2481,7 +2479,7 @@ let (destruct_flex_t' : FStar_Syntax_Syntax.term -> flex_t) =
           uu___2.FStar_Syntax_Syntax.n in
         (match uu___1 with
          | FStar_Syntax_Syntax.Tm_uvar (uv, s) -> Flex (t, uv, args)
-         | uu___2 -> FStar_Compiler_Effect.failwith "Not a flex-uvar")
+         | uu___2 -> failwith "Not a flex-uvar")
 let (destruct_flex_t :
   FStar_Syntax_Syntax.term -> worklist -> (flex_t * worklist)) =
   fun t ->
@@ -2600,7 +2598,7 @@ let (solve_prob' :
                  FStar_Compiler_Util.format2
                    "Impossible: this instance %s has already been assigned a solution\n%s\n"
                    uu___3 uu___4 in
-               FStar_Compiler_Effect.failwith uu___2 in
+               failwith uu___2 in
              let args_as_binders args =
                FStar_Compiler_List.collect
                  (fun uu___1 ->
@@ -4077,7 +4075,7 @@ let rec (really_solve_universe_eq :
                 FStar_Compiler_Util.format2
                   "Impossible: found an de Bruijn universe variable or unknown universe: %s, %s"
                   uu___3 uu___4 in
-              FStar_Compiler_Effect.failwith uu___2
+              failwith uu___2
           | (FStar_Syntax_Syntax.U_unknown, uu___) ->
               let uu___1 =
                 let uu___2 =
@@ -4087,7 +4085,7 @@ let rec (really_solve_universe_eq :
                 FStar_Compiler_Util.format2
                   "Impossible: found an de Bruijn universe variable or unknown universe: %s, %s"
                   uu___2 uu___3 in
-              FStar_Compiler_Effect.failwith uu___1
+              failwith uu___1
           | (uu___, FStar_Syntax_Syntax.U_bvar uu___1) ->
               let uu___2 =
                 let uu___3 =
@@ -4097,7 +4095,7 @@ let rec (really_solve_universe_eq :
                 FStar_Compiler_Util.format2
                   "Impossible: found an de Bruijn universe variable or unknown universe: %s, %s"
                   uu___3 uu___4 in
-              FStar_Compiler_Effect.failwith uu___2
+              failwith uu___2
           | (uu___, FStar_Syntax_Syntax.U_unknown) ->
               let uu___1 =
                 let uu___2 =
@@ -4107,7 +4105,7 @@ let rec (really_solve_universe_eq :
                 FStar_Compiler_Util.format2
                   "Impossible: found an de Bruijn universe variable or unknown universe: %s, %s"
                   uu___2 uu___3 in
-              FStar_Compiler_Effect.failwith uu___1
+              failwith uu___1
           | (FStar_Syntax_Syntax.U_name x, FStar_Syntax_Syntax.U_name y) ->
               let uu___ =
                 let uu___1 = FStar_Ident.string_of_id x in
@@ -4546,7 +4544,7 @@ let (run_meta_arg_tac :
                 let uu___2 = FStar_Syntax_Util.ctx_uvar_typ ctx_u in
                 env1.FStar_TypeChecker_Env.synth_hook env1 uu___2 tau))
       | uu___ ->
-          FStar_Compiler_Effect.failwith
+          failwith
             "run_meta_arg_tac must have been called with a uvar that has a meta tac"
 let (simplify_vc :
   Prims.bool ->
@@ -4846,7 +4844,7 @@ let (apply_substitutive_indexed_subcomp :
                                              | (probs, wl2) ->
                                                  (bs3, subst2, probs, wl2))
                                           else
-                                            FStar_Compiler_Effect.failwith
+                                            failwith
                                               "Impossible (rel.apply_substitutive_indexed_subcomp unexpected k" in
                                       (match uu___3 with
                                        | (bs4, subst3, f_g_args_eq_sub_probs,
@@ -5586,11 +5584,9 @@ and (solve_maybe_uinsts :
                us2)) ->
                let b = FStar_Syntax_Syntax.fv_eq f g in aux wl us1 us2
            | (FStar_Syntax_Syntax.Tm_uinst uu___2, uu___3) ->
-               FStar_Compiler_Effect.failwith
-                 "Impossible: expect head symbols to match"
+               failwith "Impossible: expect head symbols to match"
            | (uu___2, FStar_Syntax_Syntax.Tm_uinst uu___3) ->
-               FStar_Compiler_Effect.failwith
-                 "Impossible: expect head symbols to match"
+               failwith "Impossible: expect head symbols to match"
            | uu___2 -> USolved wl)
 and (giveup_or_defer :
   FStar_TypeChecker_Common.prob ->
@@ -6600,7 +6596,7 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                FStar_Compiler_Util.format2
                                  "Impossible: (rank=%s) Not a flex-rigid: %s"
                                  uu___9 uu___10 in
-                             FStar_Compiler_Effect.failwith uu___8
+                             failwith uu___8
                          | uu___7 ->
                              let uu___8 =
                                let uu___9 =
@@ -6612,7 +6608,7 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                FStar_Compiler_Util.format2
                                  "Impossible: (rank=%s) Not a rigid-flex: %s"
                                  uu___9 uu___10 in
-                             FStar_Compiler_Effect.failwith uu___8)))))
+                             failwith uu___8)))))
 and (imitate_arrow :
   FStar_TypeChecker_Common.prob ->
     worklist ->
@@ -9855,11 +9851,9 @@ and (solve_t' : tprob -> worklist -> solution) =
            (match ((t1.FStar_Syntax_Syntax.n), (t2.FStar_Syntax_Syntax.n))
             with
             | (FStar_Syntax_Syntax.Tm_delayed uu___7, uu___8) ->
-                FStar_Compiler_Effect.failwith
-                  "Impossible: terms were not compressed"
+                failwith "Impossible: terms were not compressed"
             | (uu___7, FStar_Syntax_Syntax.Tm_delayed uu___8) ->
-                FStar_Compiler_Effect.failwith
-                  "Impossible: terms were not compressed"
+                failwith "Impossible: terms were not compressed"
             | (FStar_Syntax_Syntax.Tm_ascribed uu___7, uu___8) ->
                 let uu___9 =
                   let uu___10 = FStar_Syntax_Util.unascribe t1 in
@@ -9974,10 +9968,10 @@ and (solve_t' : tprob -> worklist -> solution) =
                   solve_prob orig FStar_Pervasives_Native.None [] wl in
                 solve uu___9
             | (FStar_Syntax_Syntax.Tm_bvar uu___7, uu___8) ->
-                FStar_Compiler_Effect.failwith
+                failwith
                   "Only locally nameless! We should never see a de Bruijn variable"
             | (uu___7, FStar_Syntax_Syntax.Tm_bvar uu___8) ->
-                FStar_Compiler_Effect.failwith
+                failwith
                   "Only locally nameless! We should never see a de Bruijn variable"
             | (FStar_Syntax_Syntax.Tm_type u1, FStar_Syntax_Syntax.Tm_type
                u2) -> solve_one_universe_eq orig u1 u2 wl
@@ -10737,7 +10731,7 @@ and (solve_t' : tprob -> worklist -> solution) =
                                         "head tag mismatch: RHS is an abstraction" in
                                     giveup wl uu___17 orig)))
                  | uu___9 ->
-                     FStar_Compiler_Effect.failwith
+                     failwith
                        "Impossible: at least one side is an abstraction")
             | (uu___7, FStar_Syntax_Syntax.Tm_abs uu___8) ->
                 let is_abs t =
@@ -10876,7 +10870,7 @@ and (solve_t' : tprob -> worklist -> solution) =
                                         "head tag mismatch: RHS is an abstraction" in
                                     giveup wl uu___17 orig)))
                  | uu___9 ->
-                     FStar_Compiler_Effect.failwith
+                     failwith
                        "Impossible: at least one side is an abstraction")
             | (FStar_Syntax_Syntax.Tm_refine uu___7, uu___8) ->
                 let t21 =
@@ -13424,7 +13418,7 @@ and (solve_c :
                                      | FStar_Syntax_Syntax.Layered_eff_sig
                                          (n, uu___9) -> n
                                      | uu___9 ->
-                                         FStar_Compiler_Effect.failwith
+                                         failwith
                                            "Impossible (expected indexed effect subcomp)" in
                                    (c12, g_lift, tsopt, k, num_eff_params,
                                      false))))
@@ -13627,7 +13621,7 @@ and (solve_c :
         if
           problem.FStar_TypeChecker_Common.relation <>
             FStar_TypeChecker_Common.SUB
-        then FStar_Compiler_Effect.failwith "impossible: solve_sub"
+        then failwith "impossible: solve_sub"
         else ();
         (let r = FStar_TypeChecker_Env.get_range env in
          let lift_c1 uu___1 =
@@ -13838,7 +13832,7 @@ and (solve_c :
                                          c2_decl in
                                      match uu___11 with
                                      | FStar_Pervasives_Native.None ->
-                                         FStar_Compiler_Effect.failwith
+                                         failwith
                                            "Rel doesn't yet handle undefined trivial combinator in an effect"
                                      | FStar_Pervasives_Native.Some t -> t in
                                    let uu___11 =
@@ -15111,7 +15105,7 @@ let (try_solve_deferred_constraints :
                               FStar_Class_Listlike.uu___is_VCons uu___7) &&
                                (defer_ok = NoDefer)
                              ->
-                             FStar_Compiler_Effect.failwith
+                             failwith
                                "Impossible: Unexpected deferred constraints remain"
                          | FStar_Pervasives_Native.Some
                              (deferred, defer_to_tac, imps) ->
@@ -15135,7 +15129,7 @@ let (try_solve_deferred_constraints :
                                FStar_TypeChecker_Common.implicits = uu___6
                              }
                          | uu___5 ->
-                             FStar_Compiler_Effect.failwith
+                             failwith
                                "Impossible: should have raised a failure already" in
                        solve_universe_inequalities env
                          g1.FStar_TypeChecker_Common.univ_ineqs;
@@ -15501,7 +15495,7 @@ let (discharge_guard :
       match uu___ with
       | FStar_Pervasives_Native.Some g1 -> g1
       | FStar_Pervasives_Native.None ->
-          FStar_Compiler_Effect.failwith
+          failwith
             "Impossible, with use_smt = true, discharge_guard' should never have returned None"
 let (discharge_guard_no_smt :
   FStar_TypeChecker_Env.env ->
@@ -16108,7 +16102,7 @@ let (check_implicit_solution_and_discharge_guard :
                      match uu___4 with
                      | FStar_Pervasives_Native.Some g1 -> g1
                      | FStar_Pervasives_Native.None ->
-                         FStar_Compiler_Effect.failwith
+                         failwith
                            "Impossible, with use_smt = true, discharge_guard' must return Some" in
                    FStar_Pervasives_Native.Some
                      (g'.FStar_TypeChecker_Common.implicits))))
@@ -16531,7 +16525,7 @@ let (resolve_implicits' :
                                                    match uu___10 with
                                                    | FStar_Pervasives_Native.None
                                                        ->
-                                                       FStar_Compiler_Effect.failwith
+                                                       failwith
                                                          "resolve_implicits: unifying with an unresolved uvar failed?"
                                                    | FStar_Pervasives_Native.Some
                                                        g ->
@@ -16767,7 +16761,7 @@ let (resolve_implicits' :
                                                     (FStar_Pervasives_Native.Some
                                                        [])
                                                 then
-                                                  FStar_Compiler_Effect.failwith
+                                                  failwith
                                                     "Impossible: check_implicit_solution_and_discharge_guard for tac must return Some []"
                                                 else ())
                                              else ());

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Tc.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Tc.ml
@@ -454,9 +454,7 @@ let (tc_inductive' :
                                      FStar_Syntax_Syntax.injective_type_params
                                        = uu___13;_}
                                    -> (lid, (ty.FStar_Syntax_Syntax.sigrng))
-                               | uu___7 ->
-                                   FStar_Compiler_Effect.failwith
-                                     "Impossible!" in
+                               | uu___7 -> failwith "Impossible!" in
                              match uu___6 with
                              | (lid, r) ->
                                  let uu___7 =
@@ -488,8 +486,7 @@ let (tc_inductive' :
                                    FStar_Syntax_Syntax.injective_type_params1
                                      = uu___11;_}
                                  -> (data_lid, ty_lid)
-                             | uu___7 ->
-                                 FStar_Compiler_Effect.failwith "Impossible" in
+                             | uu___7 -> failwith "Impossible" in
                            match uu___6 with
                            | (data_lid, ty_lid) ->
                                let uu___7 =
@@ -534,8 +531,7 @@ let (tc_inductive' :
                                FStar_Syntax_Syntax.injective_type_params =
                                  uu___10;_}
                              -> lid1
-                         | uu___4 ->
-                             FStar_Compiler_Effect.failwith "Impossible" in
+                         | uu___4 -> failwith "Impossible" in
                        FStar_Compiler_List.existsb
                          (fun s ->
                             let uu___4 =
@@ -623,13 +619,11 @@ let proc_check_with :
               FStar_Syntax_Embeddings.e_vconfig a1
               FStar_Syntax_Embeddings_Base.id_norm_cb in
           (match uu___1 with
-           | FStar_Pervasives_Native.None ->
-               FStar_Compiler_Effect.failwith "nah"
+           | FStar_Pervasives_Native.None -> failwith "nah"
            | FStar_Pervasives_Native.Some vcfg ->
                FStar_Options.with_saved_options
                  (fun uu___2 -> FStar_Options.set_vconfig vcfg; kont ())
-           | uu___2 ->
-               FStar_Compiler_Effect.failwith "ill-formed `check_with`")
+           | uu___2 -> failwith "ill-formed `check_with`")
 let (handle_postprocess_with_attr :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.attribute Prims.list ->
@@ -1214,7 +1208,7 @@ let (tc_sig_let :
                                                 -> true
                                             | uu___10 -> false)
                                        | uu___7 ->
-                                           FStar_Compiler_Effect.failwith
+                                           failwith
                                              "Impossible: first phase lb and second phase lb differ in structure!" in
                                      if lb_unannotated
                                      then
@@ -1538,9 +1532,7 @@ let (tc_sig_let :
                                        (se2.FStar_Syntax_Syntax.sigopts)
                                    } in
                                  set_hint_correlator env' se3
-                             | uu___5 ->
-                                 FStar_Compiler_Effect.failwith
-                                   "no way, not a let?" in
+                             | uu___5 -> failwith "no way, not a let?" in
                            (FStar_Errors.stop_if_err ();
                             (let r1 =
                                let should_generalize1 =
@@ -1749,7 +1741,7 @@ let (tc_sig_let :
                                           (se2.FStar_Syntax_Syntax.sigopts)
                                       }, lbs3)))
                                | uu___6 ->
-                                   FStar_Compiler_Effect.failwith
+                                   failwith
                                      "impossible (typechecking should preserve Tm_let)" in
                              match uu___5 with
                              | (se3, lbs1) ->
@@ -2047,11 +2039,9 @@ let (tc_decl' :
              if uu___2 then store_sigopts se1 else se1 in
            match se2.FStar_Syntax_Syntax.sigel with
            | FStar_Syntax_Syntax.Sig_inductive_typ uu___2 ->
-               FStar_Compiler_Effect.failwith
-                 "Impossible bare data-constructor"
+               failwith "Impossible bare data-constructor"
            | FStar_Syntax_Syntax.Sig_datacon uu___2 ->
-               FStar_Compiler_Effect.failwith
-                 "Impossible bare data-constructor"
+               failwith "Impossible bare data-constructor"
            | FStar_Syntax_Syntax.Sig_fail
                { FStar_Syntax_Syntax.errs = uu___2;
                  FStar_Syntax_Syntax.fail_in_lax = false;
@@ -2990,7 +2980,7 @@ let (tc_decl' :
                               FStar_Syntax_Syntax.cflags = uu___6;_}
                             -> (lid1, uvs1, tps1, c1)
                         | uu___6 ->
-                            FStar_Compiler_Effect.failwith
+                            failwith
                               "Did not expect Sig_effect_abbrev to not be one after phase 1")
                  else (lid, uvs, tps, c) in
                (match uu___2 with
@@ -3840,7 +3830,7 @@ let (tc_decl' :
                                 FStar_Syntax_Syntax.kind1 = uu___11;_}
                               -> (t2, ty)
                           | uu___8 ->
-                              FStar_Compiler_Effect.failwith
+                              failwith
                                 "Impossible! tc for Sig_polymonadic_bind must be a Sig_polymonadic_bind" in
                         match uu___6 with
                         | (t2, ty) ->
@@ -4084,7 +4074,7 @@ let (tc_decl' :
                                 FStar_Syntax_Syntax.kind2 = uu___10;_}
                               -> (t2, ty)
                           | uu___8 ->
-                              FStar_Compiler_Effect.failwith
+                              failwith
                                 "Impossible! tc for Sig_polymonadic_subcomp must be a Sig_polymonadic_subcomp" in
                         match uu___6 with
                         | (t2, ty) ->

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_TcEffect.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_TcEffect.ml
@@ -3916,7 +3916,7 @@ let (tc_layered_eff_decl :
                     match ed.FStar_Syntax_Syntax.signature with
                     | FStar_Syntax_Syntax.Layered_eff_sig (n, ts) -> (n, ts)
                     | uu___6 ->
-                        FStar_Compiler_Effect.failwith
+                        failwith
                           "Impossible (tc_layered_eff_decl with a wp effect sig" in
                   match uu___5 with
                   | (n, sig_ts) ->
@@ -4369,8 +4369,7 @@ let (tc_layered_eff_decl :
                                                        } in
                                                      ([], uu___17)
                                                  | uu___16 ->
-                                                     FStar_Compiler_Effect.failwith
-                                                       "Impossible!"))
+                                                     failwith "Impossible!"))
                                        | uu___13 -> ts in
                                      let r =
                                        (FStar_Pervasives_Native.snd
@@ -4576,7 +4575,7 @@ let (tc_layered_eff_decl :
                                                              } in
                                                            ([], uu___19)
                                                        | uu___18 ->
-                                                           FStar_Compiler_Effect.failwith
+                                                           failwith
                                                              "Impossible!"))
                                              | uu___15 -> ts in
                                            let r =
@@ -4760,7 +4759,7 @@ let (tc_layered_eff_decl :
                                                                     f_b, g_b,
                                                                     uu___25))
                                                          | uu___20 ->
-                                                             FStar_Compiler_Effect.failwith
+                                                             failwith
                                                                "Impossible! ite_t must have been an abstraction with at least 3 binders" in
                                                        (match uu___18 with
                                                         | (env,
@@ -4862,7 +4861,7 @@ let (tc_layered_eff_decl :
                                                                     | 
                                                                     uu___26
                                                                     ->
-                                                                    FStar_Compiler_Effect.failwith
+                                                                    failwith
                                                                     "Impossible! subcomp_ty must have been an arrow with at lease 1 binder")) in
                                                             (match uu___19
                                                              with
@@ -6410,7 +6409,7 @@ let (tc_layered_eff_decl :
                                                                   (us, a_b,
                                                                     rest_bs))
                                                          | uu___19 ->
-                                                             FStar_Compiler_Effect.failwith
+                                                             failwith
                                                                "Impossible!") in
                                                   match uu___16 with
                                                   | (us, a_b, rest_bs) ->
@@ -7455,7 +7454,7 @@ let (tc_non_layered_eff_decl :
                                                          (wp, uu___21)::[];_}
                                                      -> (t1, wp)
                                                  | uu___19 ->
-                                                     FStar_Compiler_Effect.failwith
+                                                     failwith
                                                        "Unexpected repr type" in
                                                let return_repr =
                                                  let return_repr_ts =
@@ -7959,7 +7958,7 @@ let (tc_non_layered_eff_decl :
                                                           act.FStar_Syntax_Syntax.action_params)
                                                          <> Prims.int_zero
                                                      then
-                                                       FStar_Compiler_Effect.failwith
+                                                       failwith
                                                          "tc_eff_decl: expected action_params to be empty"
                                                      else ();
                                                      (let uu___21 =
@@ -8652,7 +8651,7 @@ let (tc_non_layered_eff_decl :
                                                                     | 
                                                                     uu___31
                                                                     ->
-                                                                    FStar_Compiler_Effect.failwith
+                                                                    failwith
                                                                     "Impossible (expected_k is an arrow)" in
                                                                     let uu___30
                                                                     =
@@ -8770,7 +8769,7 @@ let (tc_non_layered_eff_decl :
                                                  FStar_Syntax_Syntax.DM4F_eff
                                                    combinators1
                                              | uu___15 ->
-                                                 FStar_Compiler_Effect.failwith
+                                                 failwith
                                                    "Impossible! tc_eff_decl on a layered effect is not expected" in
                                            let ed3 =
                                              let uu___15 =
@@ -9108,7 +9107,7 @@ let (tc_lift :
                            FStar_TypeChecker_Env.effect_decl_opt env eff_name in
                          match uu___7 with
                          | FStar_Pervasives_Native.None ->
-                             FStar_Compiler_Effect.failwith
+                             failwith
                                "internal error: reifiable effect has no decl?"
                          | FStar_Pervasives_Native.Some (ed, qualifiers) ->
                              let repr =
@@ -9142,8 +9141,7 @@ let (tc_lift :
                         with
                         | (FStar_Pervasives_Native.None,
                            FStar_Pervasives_Native.None) ->
-                            FStar_Compiler_Effect.failwith
-                              "Impossible (parser)"
+                            failwith "Impossible (parser)"
                         | (lift, FStar_Pervasives_Native.Some (uvs, lift_wp))
                             ->
                             let uu___7 =
@@ -9739,7 +9737,7 @@ let (tc_effect_abbrev :
                                              FStar_Syntax_Syntax.comp = c5;_})
                                             -> (tps5, c5)
                                         | uu___10 ->
-                                            FStar_Compiler_Effect.failwith
+                                            failwith
                                               "Impossible (t is an arrow)" in
                                       (match uu___8 with
                                        | (tps5, c5) ->

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_TcInductive.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_TcInductive.ml
@@ -126,8 +126,7 @@ let (check_sig_inductive_injectivity_on_params :
                                                    FStar_Compiler_Util.format3
                                                      "Impossible: Unresolved or unknown universe in inductive type %s (%s, %s)"
                                                      uu___16 uu___17 uu___18 in
-                                                 FStar_Compiler_Effect.failwith
-                                                   uu___15
+                                                 failwith uu___15
                                              | (uu___14,
                                                 FStar_Syntax_Syntax.U_unknown)
                                                  ->
@@ -147,8 +146,7 @@ let (check_sig_inductive_injectivity_on_params :
                                                    FStar_Compiler_Util.format3
                                                      "Impossible: Unresolved or unknown universe in inductive type %s (%s, %s)"
                                                      uu___16 uu___17 uu___18 in
-                                                 FStar_Compiler_Effect.failwith
-                                                   uu___15
+                                                 failwith uu___15
                                              | (FStar_Syntax_Syntax.U_unif
                                                 uu___14, uu___15) ->
                                                  let uu___16 =
@@ -167,8 +165,7 @@ let (check_sig_inductive_injectivity_on_params :
                                                    FStar_Compiler_Util.format3
                                                      "Impossible: Unresolved or unknown universe in inductive type %s (%s, %s)"
                                                      uu___17 uu___18 uu___19 in
-                                                 FStar_Compiler_Effect.failwith
-                                                   uu___16
+                                                 failwith uu___16
                                              | (uu___14,
                                                 FStar_Syntax_Syntax.U_unif
                                                 uu___15) ->
@@ -188,8 +185,7 @@ let (check_sig_inductive_injectivity_on_params :
                                                    FStar_Compiler_Util.format3
                                                      "Impossible: Unresolved or unknown universe in inductive type %s (%s, %s)"
                                                      uu___17 uu___18 uu___19 in
-                                                 FStar_Compiler_Effect.failwith
-                                                   uu___16
+                                                 failwith uu___16
                                              | uu___14 -> false in
                                            let u_leq_u_k u =
                                              let u1 =
@@ -531,7 +527,7 @@ let (tc_tycon :
                                                          =
                                                          (s.FStar_Syntax_Syntax.sigopts)
                                                      }, u, guard1))))))))))
-      | uu___ -> FStar_Compiler_Effect.failwith "impossible"
+      | uu___ -> failwith "impossible"
 let (mk_implicit : FStar_Syntax_Syntax.bqual -> FStar_Syntax_Syntax.bqual) =
   fun uu___ ->
     match uu___ with
@@ -627,9 +623,7 @@ let (tc_data :
                                             (uu___14, tps2, u_tc) in
                                           FStar_Pervasives_Native.Some
                                             uu___13
-                                      | uu___6 ->
-                                          FStar_Compiler_Effect.failwith
-                                            "Impossible")
+                                      | uu___6 -> failwith "Impossible")
                                    else FStar_Pervasives_Native.None) in
                         match tps_u_opt with
                         | FStar_Pervasives_Native.Some x -> x
@@ -1054,7 +1048,7 @@ let (tc_data :
                                                          =
                                                          (se.FStar_Syntax_Syntax.sigopts)
                                                      }, g)))))))))))))
-        | uu___ -> FStar_Compiler_Effect.failwith "impossible"
+        | uu___ -> failwith "impossible"
 let (generalize_and_inst_within :
   FStar_TypeChecker_Env.env_t ->
     (FStar_Syntax_Syntax.sigelt * FStar_Syntax_Syntax.universe) Prims.list ->
@@ -1085,8 +1079,7 @@ let (generalize_and_inst_within :
                           let uu___9 = FStar_Syntax_Syntax.mk_Total k in
                           FStar_Syntax_Util.arrow tps uu___9 in
                         FStar_Syntax_Syntax.null_binder uu___8
-                    | uu___2 -> FStar_Compiler_Effect.failwith "Impossible"))
-            tcs in
+                    | uu___2 -> failwith "Impossible")) tcs in
         let binders' =
           FStar_Compiler_List.map
             (fun se ->
@@ -1100,7 +1093,7 @@ let (generalize_and_inst_within :
                      FStar_Syntax_Syntax.mutuals1 = uu___4;
                      FStar_Syntax_Syntax.injective_type_params1 = uu___5;_}
                    -> FStar_Syntax_Syntax.null_binder t
-               | uu___ -> FStar_Compiler_Effect.failwith "Impossible") datas in
+               | uu___ -> failwith "Impossible") datas in
         let t =
           let uu___ = FStar_Syntax_Syntax.mk_Total FStar_Syntax_Syntax.t_unit in
           FStar_Syntax_Util.arrow
@@ -1256,9 +1249,8 @@ let (generalize_and_inst_within :
                                                         =
                                                         (se.FStar_Syntax_Syntax.sigopts)
                                                     })
-                                           | uu___13 ->
-                                               FStar_Compiler_Effect.failwith
-                                                 "Impossible")) tc_types tcs in
+                                           | uu___13 -> failwith "Impossible"))
+                                 tc_types tcs in
                              let datas1 =
                                match uvs1 with
                                | [] -> datas
@@ -1305,9 +1297,8 @@ let (generalize_and_inst_within :
                                               FStar_Syntax_Syntax.sigopts =
                                                 uu___21;_}
                                               -> (tc, uvs_universes)
-                                          | uu___9 ->
-                                              FStar_Compiler_Effect.failwith
-                                                "Impossible") tcs1 in
+                                          | uu___9 -> failwith "Impossible")
+                                       tcs1 in
                                    FStar_Compiler_List.map2
                                      (fun uu___8 ->
                                         fun d ->
@@ -1388,8 +1379,7 @@ let (generalize_and_inst_within :
                                                        (d.FStar_Syntax_Syntax.sigopts)
                                                    }
                                                | uu___12 ->
-                                                   FStar_Compiler_Effect.failwith
-                                                     "Impossible"))
+                                                   failwith "Impossible"))
                                      data_types datas in
                              (tcs1, datas1))))))
 let (datacon_typ : FStar_Syntax_Syntax.sigelt -> FStar_Syntax_Syntax.term) =
@@ -1402,7 +1392,7 @@ let (datacon_typ : FStar_Syntax_Syntax.sigelt -> FStar_Syntax_Syntax.term) =
           FStar_Syntax_Syntax.mutuals1 = uu___4;
           FStar_Syntax_Syntax.injective_type_params1 = uu___5;_}
         -> t
-    | uu___ -> FStar_Compiler_Effect.failwith "Impossible!"
+    | uu___ -> failwith "Impossible!"
 let (haseq_suffix : Prims.string) = "__uu___haseq"
 let (is_haseq_lid : FStar_Ident.lid -> Prims.bool) =
   fun lid ->
@@ -1456,7 +1446,7 @@ let (get_optimized_haseq_axiom :
                   FStar_Syntax_Syntax.ds = uu___4;
                   FStar_Syntax_Syntax.injective_type_params = uu___5;_}
                 -> (lid, bs, t)
-            | uu___1 -> FStar_Compiler_Effect.failwith "Impossible!" in
+            | uu___1 -> failwith "Impossible!" in
           match uu___ with
           | (lid, bs, t) ->
               let bs1 = FStar_Syntax_Subst.subst_binders usubst bs in
@@ -1731,7 +1721,7 @@ let (optimized_haseq_ty :
                     FStar_Syntax_Syntax.ds = uu___5;
                     FStar_Syntax_Syntax.injective_type_params = uu___6;_}
                   -> lid1
-              | uu___ -> FStar_Compiler_Effect.failwith "Impossible!" in
+              | uu___ -> failwith "Impossible!" in
             let uu___ = acc in
             match uu___ with
             | (uu___1, en, uu___2, uu___3) ->
@@ -1761,9 +1751,8 @@ let (optimized_haseq_ty :
                                        FStar_Syntax_Syntax.injective_type_params1
                                          = uu___11;_}
                                      -> t_lid = lid
-                                 | uu___6 ->
-                                     FStar_Compiler_Effect.failwith
-                                       "Impossible") all_datas_in_the_bundle in
+                                 | uu___6 -> failwith "Impossible")
+                              all_datas_in_the_bundle in
                           let cond =
                             FStar_Compiler_List.fold_left
                               (fun acc1 ->
@@ -1800,7 +1789,7 @@ let (optimized_haseq_scheme :
                   FStar_Syntax_Syntax.ds = uu___5;
                   FStar_Syntax_Syntax.injective_type_params = uu___6;_}
                 -> (us, t)
-            | uu___1 -> FStar_Compiler_Effect.failwith "Impossible!" in
+            | uu___1 -> failwith "Impossible!" in
           match uu___ with
           | (us, t) ->
               let uu___1 = FStar_Syntax_Subst.univ_var_opening us in
@@ -2028,7 +2017,7 @@ let (unoptimized_haseq_ty :
                       FStar_Syntax_Syntax.ds = d_lids;
                       FStar_Syntax_Syntax.injective_type_params = uu___4;_}
                     -> (lid, bs, t, d_lids)
-                | uu___1 -> FStar_Compiler_Effect.failwith "Impossible!" in
+                | uu___1 -> failwith "Impossible!" in
               match uu___ with
               | (lid, bs, t, d_lids) ->
                   let bs1 = FStar_Syntax_Subst.subst_binders usubst bs in
@@ -2093,8 +2082,7 @@ let (unoptimized_haseq_ty :
                                     FStar_Syntax_Syntax.injective_type_params1
                                       = uu___7;_}
                                   -> t_lid = lid
-                              | uu___2 ->
-                                  FStar_Compiler_Effect.failwith "Impossible")
+                              | uu___2 -> failwith "Impossible")
                            all_datas_in_the_bundle in
                        let data_cond =
                          FStar_Compiler_List.fold_left
@@ -2199,7 +2187,7 @@ let (unoptimized_haseq_scheme :
                        FStar_Syntax_Syntax.ds = uu___5;
                        FStar_Syntax_Syntax.injective_type_params = uu___6;_}
                      -> lid
-                 | uu___ -> FStar_Compiler_Effect.failwith "Impossible!") tcs in
+                 | uu___ -> failwith "Impossible!") tcs in
           let uu___ =
             let ty = FStar_Compiler_List.hd tcs in
             match ty.FStar_Syntax_Syntax.sigel with
@@ -2212,7 +2200,7 @@ let (unoptimized_haseq_scheme :
                   FStar_Syntax_Syntax.ds = uu___5;
                   FStar_Syntax_Syntax.injective_type_params = uu___6;_}
                 -> (lid, us)
-            | uu___1 -> FStar_Compiler_Effect.failwith "Impossible!" in
+            | uu___1 -> failwith "Impossible!" in
           match uu___ with
           | (lid, us) ->
               let uu___1 = FStar_Syntax_Subst.univ_var_opening us in
@@ -2316,9 +2304,7 @@ let (check_inductive_well_typedness :
                            FStar_Syntax_Syntax.injective_type_params =
                              uu___10;_}
                          -> uvs
-                     | uu___4 ->
-                         FStar_Compiler_Effect.failwith
-                           "Impossible, can't happen!") in
+                     | uu___4 -> failwith "Impossible, can't happen!") in
                 let env0 = env in
                 let uu___2 =
                   FStar_Compiler_List.fold_right
@@ -3676,9 +3662,7 @@ let (mk_data_operations :
                                              ((FStar_Compiler_List.length
                                                  constrs)
                                                 > Prims.int_one))
-                                     | uu___7 ->
-                                         FStar_Compiler_Effect.failwith
-                                           "Impossible"
+                                     | uu___7 -> failwith "Impossible"
                                    else FStar_Pervasives_Native.None) in
                             match tps_opt with
                             | FStar_Pervasives_Native.Some x -> x

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_TcTerm.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_TcTerm.ml
@@ -649,9 +649,7 @@ let (check_expected_effect :
                    then
                      FStar_Syntax_Syntax.mk_GTotal
                        (FStar_Syntax_Util.comp_result c1)
-                   else
-                     FStar_Compiler_Effect.failwith
-                       "Impossible: Expected pure_or_ghost comp") in
+                   else failwith "Impossible: Expected pure_or_ghost comp") in
               let uu___1 =
                 let ct = FStar_Syntax_Util.comp_result c in
                 match copt with
@@ -744,9 +742,7 @@ let (check_expected_effect :
                                            FStar_Syntax_Syntax.flags =
                                              uu___12;_}
                                          -> (comp_univs, result_ty)
-                                     | uu___10 ->
-                                         FStar_Compiler_Effect.failwith
-                                           "Impossible!" in
+                                     | uu___10 -> failwith "Impossible!" in
                                    (match uu___9 with
                                     | (comp_univs, result_ty) ->
                                         let expected_c =
@@ -816,7 +812,7 @@ let (check_expected_effect :
                           ((match gopt with
                             | FStar_Pervasives_Native.None -> ()
                             | FStar_Pervasives_Native.Some uu___5 ->
-                                FStar_Compiler_Effect.failwith
+                                failwith
                                   "Impossible! check_expected_effect, gopt should have been None");
                            (let c3 =
                               let uu___5 =
@@ -1198,9 +1194,7 @@ let (check_smt_pat :
                 ->
                 (check_pat_fvs t.FStar_Syntax_Syntax.pos env pats bs;
                  check_no_smt_theory_symbols env pats)
-            | uu___1 ->
-                FStar_Compiler_Effect.failwith
-                  "Impossible: check_smt_pat: not Comp"
+            | uu___1 -> failwith "Impossible: check_smt_pat: not Comp"
           else ()
 let (guard_letrecs :
   FStar_TypeChecker_Env.env ->
@@ -1707,7 +1701,7 @@ let (guard_letrecs :
                    | (formals, c) ->
                        (if arity > (FStar_Compiler_List.length formals)
                         then
-                          FStar_Compiler_Effect.failwith
+                          failwith
                             "impossible: bad formals arity, guard_one_letrec"
                         else ();
                         (let formals1 =
@@ -2051,11 +2045,9 @@ and (tc_maybe_toplevel_term :
             uu___4 uu___5
         else ());
        (match top.FStar_Syntax_Syntax.n with
-        | FStar_Syntax_Syntax.Tm_delayed uu___2 ->
-            FStar_Compiler_Effect.failwith "Impossible"
+        | FStar_Syntax_Syntax.Tm_delayed uu___2 -> failwith "Impossible"
         | FStar_Syntax_Syntax.Tm_bvar uu___2 ->
-            FStar_Compiler_Effect.failwith
-              "Impossible: tc_maybe_toplevel_term: not LN"
+            failwith "Impossible: tc_maybe_toplevel_term: not LN"
         | FStar_Syntax_Syntax.Tm_uinst uu___2 -> tc_value env1 e
         | FStar_Syntax_Syntax.Tm_uvar uu___2 -> tc_value env1 e
         | FStar_Syntax_Syntax.Tm_name uu___2 -> tc_value env1 e
@@ -2070,8 +2062,7 @@ and (tc_maybe_toplevel_term :
             let projl uu___2 =
               match uu___2 with
               | FStar_Pervasives.Inl x -> x
-              | FStar_Pervasives.Inr uu___3 ->
-                  FStar_Compiler_Effect.failwith "projl fail" in
+              | FStar_Pervasives.Inr uu___3 -> failwith "projl fail" in
             let non_trivial_antiquotations qi1 =
               let is_not_name t =
                 let uu___2 =
@@ -2536,8 +2527,7 @@ and (tc_maybe_toplevel_term :
                                        use_eq);
                                    FStar_Syntax_Syntax.eff_opt = labopt1
                                  }) t'1.FStar_Syntax_Syntax.pos
-                        | uu___6 ->
-                            FStar_Compiler_Effect.failwith "impossible" in
+                        | uu___6 -> failwith "impossible" in
                       let g1 =
                         wrap_guard_with_tactic_opt
                           (FStar_Pervasives_Native.Some tac1) g in
@@ -3422,7 +3412,7 @@ and (tc_maybe_toplevel_term :
                   match args with
                   | (b, uu___8)::rest ->
                       ((FStar_Pervasives_Native.Some b), rest)
-                  | uu___8 -> FStar_Compiler_Effect.failwith "Impossible"
+                  | uu___8 -> failwith "Impossible"
                 else (FStar_Pervasives_Native.None, args) in
               match uu___7 with
               | (base_term, fields) ->
@@ -4452,7 +4442,7 @@ and (tc_match :
             let uu___3 =
               FStar_Class_Tagged.tag_of FStar_Syntax_Syntax.tagged_term top in
             FStar_Compiler_Util.format1 "tc_match called on %s\n" uu___3 in
-          FStar_Compiler_Effect.failwith uu___2
+          failwith uu___2
 and (tc_synth :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
     FStar_TypeChecker_Env.env ->
@@ -5177,7 +5167,7 @@ and (tc_value :
               FStar_Class_Tagged.tag_of FStar_Syntax_Syntax.tagged_term top in
             FStar_Compiler_Util.format2 "Unexpected value: %s (%s)" uu___2
               uu___3 in
-          FStar_Compiler_Effect.failwith uu___1
+          failwith uu___1
 and (tc_constant :
   FStar_TypeChecker_Env.env ->
     FStar_Compiler_Range_Type.range ->
@@ -5616,9 +5606,8 @@ and (tc_universe :
         let u2 = FStar_Syntax_Subst.compress_univ u1 in
         match u2 with
         | FStar_Syntax_Syntax.U_bvar uu___ ->
-            FStar_Compiler_Effect.failwith "Impossible: locally nameless"
-        | FStar_Syntax_Syntax.U_unknown ->
-            FStar_Compiler_Effect.failwith "Unknown universe"
+            failwith "Impossible: locally nameless"
+        | FStar_Syntax_Syntax.U_unknown -> failwith "Unknown universe"
         | FStar_Syntax_Syntax.U_unif uu___ -> u2
         | FStar_Syntax_Syntax.U_zero -> u2
         | FStar_Syntax_Syntax.U_succ u3 ->
@@ -5638,7 +5627,7 @@ and (tc_universe :
                        u2 in
                    Prims.strcat uu___4 " not found" in
                  Prims.strcat "Universe variable " uu___3 in
-               FStar_Compiler_Effect.failwith uu___2) in
+               failwith uu___2) in
       if env.FStar_TypeChecker_Env.lax_universes
       then FStar_Syntax_Syntax.U_zero
       else
@@ -5668,7 +5657,7 @@ and (tc_abs_expected_function_typ :
               ((match env.FStar_TypeChecker_Env.letrecs with
                 | [] -> ()
                 | uu___1 ->
-                    FStar_Compiler_Effect.failwith
+                    failwith
                       "Impossible: Can't have a let rec annotation but no expected type");
                (let uu___1 = tc_binders env bs in
                 match uu___1 with
@@ -5686,7 +5675,7 @@ and (tc_abs_expected_function_typ :
                     ((match env.FStar_TypeChecker_Env.letrecs with
                       | [] -> ()
                       | uu___3 ->
-                          FStar_Compiler_Effect.failwith
+                          failwith
                             "Impossible: uvar abs with non-empty environment");
                      (let uu___3 = tc_binders env bs in
                       match uu___3 with
@@ -5712,7 +5701,7 @@ and (tc_abs_expected_function_typ :
                     ((match env.FStar_TypeChecker_Env.letrecs with
                       | [] -> ()
                       | uu___7 ->
-                          FStar_Compiler_Effect.failwith
+                          failwith
                             "Impossible: uvar abs with non-empty environment");
                      (let uu___7 = tc_binders env bs in
                       match uu___7 with
@@ -6994,7 +6983,7 @@ and (tc_abs :
                                      | FStar_Pervasives_Native.Some
                                          (t2, use_eq) -> (t2, use_eq)
                                      | FStar_Pervasives_Native.None ->
-                                         FStar_Compiler_Effect.failwith
+                                         failwith
                                            "Impossible! tc_abs: if tfun_computed is Some, expected topt to also be Some" in
                                    (match uu___9 with
                                     | (t_annot, use_eq) ->
@@ -9069,7 +9058,7 @@ and (tc_pat :
                  FStar_Compiler_Util.format1
                    "Impossible: Expected an undecorated pattern, got %s"
                    uu___3 in
-               FStar_Compiler_Effect.failwith uu___2
+               failwith uu___2
            | FStar_Syntax_Syntax.Pat_var x ->
                let x1 =
                  {
@@ -9245,7 +9234,7 @@ and (tc_pat :
                           FStar_Compiler_Util.format4
                             "(%s) Impossible: pattern bvar mismatch: %s; expected %s sub pats; got %s"
                             uu___4 uu___5 uu___6 uu___7 in
-                        FStar_Compiler_Effect.failwith uu___3)
+                        failwith uu___3)
                      else ();
                      (let uu___3 =
                         let uu___4 = type_of_simple_pat env1 simple_pat_e in
@@ -9448,10 +9437,10 @@ and (tc_pat :
                                                      sub_pats3 in
                                                  (hd1, b) :: uu___7
                                              | uu___6 ->
-                                                 FStar_Compiler_Effect.failwith
+                                                 failwith
                                                    "Impossible: simple pat variable mismatch")
                                         | uu___6 ->
-                                            FStar_Compiler_Effect.failwith
+                                            failwith
                                               "Impossible: expected a simple pattern") in
                                  let us =
                                    let uu___6 =
@@ -9469,7 +9458,7 @@ and (tc_pat :
                                         | FStar_Syntax_Syntax.Tm_uinst
                                             (uu___9, us1) -> us1
                                         | uu___9 ->
-                                            FStar_Compiler_Effect.failwith
+                                            failwith
                                               "Impossible: tc_pat: pattern head not fvar or uinst") in
                                  match pat.FStar_Syntax_Syntax.v with
                                  | FStar_Syntax_Syntax.Pat_cons
@@ -9487,7 +9476,7 @@ and (tc_pat :
                                          (pat.FStar_Syntax_Syntax.p)
                                      }
                                  | uu___6 ->
-                                     FStar_Compiler_Effect.failwith
+                                     failwith
                                        "Impossible: tc_pat: pat.v expected Pat_cons" in
                                let uu___6 =
                                  reconstruct_nested_pat simple_pat_elab in
@@ -9657,7 +9646,7 @@ and (tc_eqn :
                                                         = uu___13;_}
                                                     -> branch_exp4
                                                 | uu___12 ->
-                                                    FStar_Compiler_Effect.failwith
+                                                    failwith
                                                       "Impossible (expected the match branch with an ascription)") in
                                          (branch_exp3, c, g_branch) in
                                    (match uu___8 with
@@ -9759,8 +9748,7 @@ and (tc_eqn :
                                                        "tc_eqn: Impossible (%s) %s (%s)"
                                                        uu___14 uu___15
                                                        uu___16 in
-                                                   FStar_Compiler_Effect.failwith
-                                                     uu___13 in
+                                                   failwith uu___13 in
                                                  let rec head_constructor t =
                                                    match t.FStar_Syntax_Syntax.n
                                                    with
@@ -9787,8 +9775,7 @@ and (tc_eqn :
                                                          FStar_Compiler_Util.format2
                                                            "Impossible (%s): scrutinee of match is not defined %s"
                                                            uu___14 uu___15 in
-                                                       FStar_Compiler_Effect.failwith
-                                                         uu___13
+                                                       failwith uu___13
                                                    | FStar_Pervasives_Native.Some
                                                        t -> t in
                                                  let pat_exp2 =
@@ -9864,7 +9851,7 @@ and (tc_eqn :
                                                          uu___16 in
                                                      if uu___15
                                                      then
-                                                       FStar_Compiler_Effect.failwith
+                                                       failwith
                                                          "Impossible: nullary patterns must be data constructors"
                                                      else
                                                        (let uu___17 =
@@ -9890,7 +9877,7 @@ and (tc_eqn :
                                                          uu___16 in
                                                      if uu___15
                                                      then
-                                                       FStar_Compiler_Effect.failwith
+                                                       failwith
                                                          "Impossible: nullary patterns must be data constructors"
                                                      else
                                                        (let uu___17 =
@@ -9927,7 +9914,7 @@ and (tc_eqn :
                                                                args)) in
                                                      if uu___14
                                                      then
-                                                       FStar_Compiler_Effect.failwith
+                                                       failwith
                                                          "Impossible: application patterns must be fully-applied data constructors"
                                                      else
                                                        (let sub_term_guards =
@@ -10028,8 +10015,7 @@ and (tc_eqn :
                                                        FStar_Compiler_Util.format2
                                                          "Internal error: unexpected elaborated pattern: %s and pattern expression %s"
                                                          uu___14 uu___15 in
-                                                     FStar_Compiler_Effect.failwith
-                                                       uu___13 in
+                                                     failwith uu___13 in
                                                let build_and_check_branch_guard
                                                  scrutinee_tm1 pattern2 pat =
                                                  let uu___12 =
@@ -10856,9 +10842,7 @@ and (check_top_level_let :
                             (uu___5, uu___6,
                               (FStar_Class_Monoid.mzero
                                  FStar_TypeChecker_Common.monoid_guard_t))))))))
-      | uu___ ->
-          FStar_Compiler_Effect.failwith
-            "Impossible: check_top_level_let: not a let"
+      | uu___ -> failwith "Impossible: check_top_level_let: not a let"
 and (maybe_intro_smt_lemma :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
@@ -11217,9 +11201,7 @@ and (check_inner_let :
                                        FStar_TypeChecker_Common.comp_thunk =
                                          (cres.FStar_TypeChecker_Common.comp_thunk)
                                      }, uu___9))))))))
-      | uu___ ->
-          FStar_Compiler_Effect.failwith
-            "Impossible (inner let with more than one lb)"
+      | uu___ -> failwith "Impossible (inner let with more than one lb)"
 and (check_top_level_let_rec :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
@@ -11355,8 +11337,7 @@ and (check_top_level_let_rec :
                                             (FStar_Class_Monoid.mzero
                                                FStar_TypeChecker_Common.monoid_guard_t))))))))))
       | uu___ ->
-          FStar_Compiler_Effect.failwith
-            "Impossible: check_top_level_let_rec: not a let rec"
+          failwith "Impossible: check_top_level_let_rec: not a let rec"
 and (check_inner_let_rec :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
@@ -11607,9 +11588,7 @@ and (check_inner_let_rec :
                                                            FStar_TypeChecker_Common.monoid_guard_t
                                                            g_ex guard1 in
                                                        (e, cres6, uu___8))))))))))
-      | uu___ ->
-          FStar_Compiler_Effect.failwith
-            "Impossible: check_inner_let_rec: not a let rec"
+      | uu___ -> failwith "Impossible: check_inner_let_rec: not a let rec"
 and (build_let_rec_env :
   Prims.bool ->
     FStar_TypeChecker_Env.env ->
@@ -13150,21 +13129,21 @@ let rec (universe_of_aux :
               FStar_Class_Show.show FStar_Syntax_Print.showable_term e in
             Prims.strcat "TcTerm.universe_of:Impossible (bvar/unknown/lazy) "
               uu___3 in
-          FStar_Compiler_Effect.failwith uu___2
+          failwith uu___2
       | FStar_Syntax_Syntax.Tm_unknown ->
           let uu___1 =
             let uu___2 =
               FStar_Class_Show.show FStar_Syntax_Print.showable_term e in
             Prims.strcat "TcTerm.universe_of:Impossible (bvar/unknown/lazy) "
               uu___2 in
-          FStar_Compiler_Effect.failwith uu___1
+          failwith uu___1
       | FStar_Syntax_Syntax.Tm_delayed uu___1 ->
           let uu___2 =
             let uu___3 =
               FStar_Class_Show.show FStar_Syntax_Print.showable_term e in
             Prims.strcat "TcTerm.universe_of:Impossible (bvar/unknown/lazy) "
               uu___3 in
-          FStar_Compiler_Effect.failwith uu___2
+          failwith uu___2
       | FStar_Syntax_Syntax.Tm_let uu___1 ->
           let e1 = FStar_TypeChecker_Normalize.normalize [] env e in
           universe_of_aux env e1
@@ -13260,8 +13239,7 @@ let rec (universe_of_aux :
                              (Obj.magic uu___9)) us' us;
                 t))
       | FStar_Syntax_Syntax.Tm_uinst uu___1 ->
-          FStar_Compiler_Effect.failwith
-            "Impossible: Tm_uinst's head must be an fvar"
+          failwith "Impossible: Tm_uinst's head must be an fvar"
       | FStar_Syntax_Syntax.Tm_refine
           { FStar_Syntax_Syntax.b = x; FStar_Syntax_Syntax.phi = uu___1;_} ->
           universe_of_aux env x.FStar_Syntax_Syntax.sort
@@ -13301,13 +13279,13 @@ let rec (universe_of_aux :
             let hd2 = FStar_Syntax_Subst.compress hd1 in
             match hd2.FStar_Syntax_Syntax.n with
             | FStar_Syntax_Syntax.Tm_unknown ->
-                FStar_Compiler_Effect.failwith
+                failwith
                   "Impossible: universe_of_aux: Tm_app: unexpected head type"
             | FStar_Syntax_Syntax.Tm_bvar uu___1 ->
-                FStar_Compiler_Effect.failwith
+                failwith
                   "Impossible: universe_of_aux: Tm_app: unexpected head type"
             | FStar_Syntax_Syntax.Tm_delayed uu___1 ->
-                FStar_Compiler_Effect.failwith
+                failwith
                   "Impossible: universe_of_aux: Tm_app: unexpected head type"
             | FStar_Syntax_Syntax.Tm_fvar uu___1 ->
                 let uu___2 = universe_of_aux env1 hd2 in (uu___2, args1)
@@ -13582,13 +13560,13 @@ let rec (__typeof_tot_or_gtot_term_fastpath :
               let uu___2 =
                 FStar_Class_Show.show FStar_Syntax_Print.showable_term t1 in
               Prims.strcat "Impossible: " uu___2 in
-            FStar_Compiler_Effect.failwith uu___1
+            failwith uu___1
         | FStar_Syntax_Syntax.Tm_bvar uu___ ->
             let uu___1 =
               let uu___2 =
                 FStar_Class_Show.show FStar_Syntax_Print.showable_term t1 in
               Prims.strcat "Impossible: " uu___2 in
-            FStar_Compiler_Effect.failwith uu___1
+            failwith uu___1
         | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reify uu___) ->
             FStar_Pervasives_Native.None
         | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reflect uu___)
@@ -13861,7 +13839,7 @@ let rec (__typeof_tot_or_gtot_term_fastpath :
                     t1 in
                 Prims.strcat uu___2 ")" in
               Prims.strcat "Impossible! (" uu___1 in
-            FStar_Compiler_Effect.failwith uu___
+            failwith uu___
         | uu___ ->
             let uu___1 =
               let uu___2 =
@@ -13870,7 +13848,7 @@ let rec (__typeof_tot_or_gtot_term_fastpath :
                     t1 in
                 Prims.strcat uu___3 ")" in
               Prims.strcat "Impossible! (" uu___2 in
-            FStar_Compiler_Effect.failwith uu___1
+            failwith uu___1
 let (typeof_tot_or_gtot_term_fastpath :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
@@ -13896,10 +13874,8 @@ let rec (effectof_tot_or_gtot_term_fastpath :
         let uu___1 = FStar_Syntax_Subst.compress t in
         uu___1.FStar_Syntax_Syntax.n in
       match uu___ with
-      | FStar_Syntax_Syntax.Tm_delayed uu___1 ->
-          FStar_Compiler_Effect.failwith "Impossible!"
-      | FStar_Syntax_Syntax.Tm_bvar uu___1 ->
-          FStar_Compiler_Effect.failwith "Impossible!"
+      | FStar_Syntax_Syntax.Tm_delayed uu___1 -> failwith "Impossible!"
+      | FStar_Syntax_Syntax.Tm_bvar uu___1 -> failwith "Impossible!"
       | FStar_Syntax_Syntax.Tm_name uu___1 ->
           FStar_Pervasives_Native.Some FStar_Parser_Const.effect_PURE_lid
       | FStar_Syntax_Syntax.Tm_lazy uu___1 ->

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_TermEqAndSimplify.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_TermEqAndSimplify.ml
@@ -926,7 +926,7 @@ let (simplify :
                                                                  = uu___34;_}
                                                              -> hd
                                                          | uu___34 ->
-                                                             FStar_Compiler_Effect.failwith
+                                                             failwith
                                                                "Impossible! We have already checked that this is a Tm_app" in
                                                        let uu___33 =
                                                          let uu___34 =
@@ -1320,7 +1320,7 @@ let (simplify :
                                                                  = uu___30;_}
                                                              -> hd
                                                          | uu___30 ->
-                                                             FStar_Compiler_Effect.failwith
+                                                             failwith
                                                                "Impossible! We have already checked that this is a Tm_app" in
                                                        let uu___29 =
                                                          let uu___30 =

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Util.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Util.ml
@@ -344,9 +344,7 @@ let (extract_let_rec_annotation :
                                        move_decreases d
                                          (FStar_Compiler_List.op_At pfx sfx)
                                          (FStar_Syntax_Util.comp_flags c')
-                                   | uu___10 ->
-                                       FStar_Compiler_Effect.failwith
-                                         "Impossible")))) in
+                                   | uu___10 -> failwith "Impossible")))) in
                  let extract_annot_from_body lbtyp_opt =
                    let rec aux_lbdef e2 =
                      let e3 = FStar_Syntax_Subst.compress e2 in
@@ -588,9 +586,7 @@ let (extract_let_rec_annotation :
                                                 (FStar_Compiler_List.length
                                                    bs')
                                                   <> n_bs
-                                              then
-                                                FStar_Compiler_Effect.failwith
-                                                  "Impossible"
+                                              then failwith "Impossible"
                                               else
                                                 (let subst =
                                                    FStar_Syntax_Util.rename_binders
@@ -740,7 +736,7 @@ let rec (decorated_pattern_as_term :
     | FStar_Syntax_Syntax.Pat_dot_term eopt ->
         (match eopt with
          | FStar_Pervasives_Native.None ->
-             FStar_Compiler_Effect.failwith
+             failwith
                "TcUtil::decorated_pattern_as_term: dot pattern not resolved"
          | FStar_Pervasives_Native.Some e -> ([], e))
 let (comp_univ_opt :
@@ -1857,7 +1853,7 @@ let (substitutive_indexed_bind_substs :
                                                                     uv_t)]),
                                                                     uu___11))
                                                                else
-                                                                 FStar_Compiler_Effect.failwith
+                                                                 failwith
                                                                    "Impossible (standard bind with unexpected binder kind)")
                                                   (subst2, guard) uu___6
                                                   args2 in
@@ -2084,8 +2080,7 @@ let (ad_hoc_indexed_bind_substs :
                                               Prims.strcat
                                                 "Impossible, expected a uvar, got : "
                                                 uu___7 in
-                                            FStar_Compiler_Effect.failwith
-                                              uu___6) rest_bs_uvars
+                                            failwith uu___6) rest_bs_uvars
                                  else ());
                                 (let subst =
                                    FStar_Compiler_List.map2
@@ -2205,7 +2200,7 @@ let (ad_hoc_indexed_bind_substs :
                                                 (FStar_Syntax_Subst.subst
                                                    subst) uu___5)
                                      | uu___4 ->
-                                         FStar_Compiler_Effect.failwith
+                                         failwith
                                            "impossible: mk_indexed_bind" in
                                    let env_g =
                                      FStar_TypeChecker_Env.push_binders env
@@ -2824,7 +2819,7 @@ let (mk_bind :
                                        | FStar_Syntax_Syntax.Layered_eff_sig
                                            (n, uu___6) -> n
                                        | uu___6 ->
-                                           FStar_Compiler_Effect.failwith
+                                           failwith
                                              "Impossible (mk_bind expected an indexed effect)" in
                                      let uu___6 =
                                        FStar_Syntax_Util.get_bind_vc_combinator
@@ -4064,7 +4059,7 @@ let (substitutive_indexed_ite_substs :
                                              guard args1 args2 in
                                          (bs3, subst2, uu___5))
                                       else
-                                        FStar_Compiler_Effect.failwith
+                                        failwith
                                           "Impossible (substitutive_indexed_ite: unexpected k)" in
                                   (match uu___3 with
                                    | (bs4, subst3, guard1) ->
@@ -4396,9 +4391,7 @@ let (mk_layered_conjunction :
                                     with
                                     | FStar_Syntax_Syntax.Layered_eff_sig
                                         (n, uu___6) -> n
-                                    | uu___6 ->
-                                        FStar_Compiler_Effect.failwith
-                                          "Impossible!" in
+                                    | uu___6 -> failwith "Impossible!" in
                                   substitutive_indexed_ite_substs env kind bs
                                     a p ct1 ct2 num_effect_params r) in
                              match uu___4 with
@@ -6361,10 +6354,8 @@ let (pure_or_ghost_pre_and_post :
         (FStar_Pervasives_Native.None, (FStar_Syntax_Util.comp_result comp))
       else
         (match comp.FStar_Syntax_Syntax.n with
-         | FStar_Syntax_Syntax.GTotal uu___2 ->
-             FStar_Compiler_Effect.failwith "Impossible"
-         | FStar_Syntax_Syntax.Total uu___2 ->
-             FStar_Compiler_Effect.failwith "Impossible"
+         | FStar_Syntax_Syntax.GTotal uu___2 -> failwith "Impossible"
+         | FStar_Syntax_Syntax.Total uu___2 -> failwith "Impossible"
          | FStar_Syntax_Syntax.Comp ct ->
              let uu___2 =
                (FStar_Ident.lid_equals ct.FStar_Syntax_Syntax.effect_name
@@ -6472,7 +6463,7 @@ let (pure_or_ghost_pre_and_post :
                                     ct1.FStar_Syntax_Syntax.result_typ ens in
                                 norm uu___12 in
                               (uu___10, uu___11)))
-                | uu___4 -> FStar_Compiler_Effect.failwith "Impossible"))
+                | uu___4 -> failwith "Impossible"))
 let (norm_reify :
   FStar_TypeChecker_Env.env ->
     FStar_TypeChecker_Env.steps ->
@@ -6533,7 +6524,7 @@ let (remove_reify : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
              (match args with
               | x::[] -> FStar_Pervasives_Native.fst x
               | uu___4 ->
-                  FStar_Compiler_Effect.failwith
+                  failwith
                     "Impossible : Reify applied to multiple arguments after normalization.")
            else t)
 let (maybe_implicit_with_meta_or_attr :
@@ -7167,9 +7158,7 @@ let (short_circuit :
         match uu___ with
         | [] -> FStar_TypeChecker_Common.Trivial
         | (fst, uu___1)::[] -> f fst
-        | uu___1 ->
-            FStar_Compiler_Effect.failwith
-              "Unexpected args to binary operator" in
+        | uu___1 -> failwith "Unexpected args to binary operator" in
       let op_and_e e =
         let uu___ = FStar_Syntax_Util.b2t e in
         FStar_TypeChecker_Common.NonTrivial uu___ in
@@ -7190,7 +7179,7 @@ let (short_circuit :
         | _then::(guard, uu___1)::[] ->
             let uu___2 = FStar_Syntax_Util.mk_neg guard in
             FStar_TypeChecker_Common.NonTrivial uu___2
-        | uu___1 -> FStar_Compiler_Effect.failwith "Unexpected args to ITE" in
+        | uu___1 -> failwith "Unexpected args to ITE" in
       let table =
         let uu___ =
           let uu___1 = short_bin_op op_and_e in

--- a/ocaml/fstar-lib/generated/FStar_Universal.ml
+++ b/ocaml/fstar-lib/generated/FStar_Universal.ml
@@ -979,6 +979,14 @@ let (emit :
   fun dep_graph ->
     fun mllibs ->
       let opt = FStar_Options.codegen () in
+      let fail uu___ =
+        let uu___1 =
+          let uu___2 =
+            FStar_Class_Show.show
+              (FStar_Class_Show.show_option FStar_Options.showable_codegen_t)
+              opt in
+          Prims.strcat "Unrecognized extraction backend: " uu___2 in
+        FStar_Compiler_Effect.failwith uu___1 in
       if opt <> FStar_Pervasives_Native.None
       then
         let ext =
@@ -988,7 +996,7 @@ let (emit :
           | FStar_Pervasives_Native.Some (FStar_Options.Plugin) -> ".ml"
           | FStar_Pervasives_Native.Some (FStar_Options.Krml) -> ".krml"
           | FStar_Pervasives_Native.Some (FStar_Options.Extension) -> ".ast"
-          | uu___ -> FStar_Compiler_Effect.failwith "Unrecognized option" in
+          | uu___ -> fail () in
         match opt with
         | FStar_Pervasives_Native.Some (FStar_Options.FSharp) ->
             let outdir = FStar_Options.output_dir () in
@@ -1068,7 +1076,7 @@ let (emit :
                        FStar_Options.prepend_output_dir
                          (Prims.strcat "out" ext)) in
             FStar_Compiler_Util.save_value_to_file oname bin
-        | uu___ -> FStar_Compiler_Effect.failwith "Unrecognized option"
+        | uu___ -> fail ()
       else ()
 let (tc_one_file :
   uenv ->

--- a/ocaml/fstar-lib/generated/FStar_Universal.ml
+++ b/ocaml/fstar-lib/generated/FStar_Universal.ml
@@ -970,7 +970,7 @@ let (load_interface_decls :
           FStar_Compiler_Effect.raise
             (FStar_Errors.Error (err, msg, rng, []))
       | FStar_Parser_ParseIt.Term uu___ ->
-          FStar_Compiler_Effect.failwith
+          failwith
             "Impossible: parsing a Toplevel always results in an ASTFragment"
 let (emit :
   FStar_Parser_Dep.deps ->
@@ -986,7 +986,7 @@ let (emit :
               (FStar_Class_Show.show_option FStar_Options.showable_codegen_t)
               opt in
           Prims.strcat "Unrecognized extraction backend: " uu___2 in
-        FStar_Compiler_Effect.failwith uu___1 in
+        failwith uu___1 in
       if opt <> FStar_Pervasives_Native.None
       then
         let ext =
@@ -1052,7 +1052,7 @@ let (emit :
                                         FStar_Compiler_Util.save_value_to_file
                                           uu___5 (deps, bindings, decls)
                                     | FStar_Pervasives_Native.None ->
-                                        FStar_Compiler_Effect.failwith
+                                        failwith
                                           "Unexpected ml modul in Extension extraction mode"))
                             ms)) mllibs
         | FStar_Pervasives_Native.Some (FStar_Options.Krml) ->
@@ -1161,7 +1161,7 @@ let (tc_one_file :
                           (match tcenv.FStar_TypeChecker_Env.gamma with
                            | [] -> ()
                            | uu___6 ->
-                               FStar_Compiler_Effect.failwith
+                               failwith
                                  "Impossible: gamma contains leaked names");
                           (let uu___6 =
                              FStar_TypeChecker_Tc.check_module tcenv fmod
@@ -1435,9 +1435,7 @@ let (tc_one_file_from_remaining :
                   uu___2 in
               (match uu___1 with
                | (m, mllib, env1) -> (remaining1, (m, mllib, env1)))
-          | [] ->
-              FStar_Compiler_Effect.failwith
-                "Impossible: Empty remaining modules" in
+          | [] -> failwith "Impossible: Empty remaining modules" in
         match uu___ with
         | (remaining1, (nmods, mllib, env1)) ->
             (remaining1, nmods, mllib, env1)

--- a/ocaml/fstar-tests/generated/FStar_Tests_Data.ml
+++ b/ocaml/fstar-tests/generated/FStar_Tests_Data.ml
@@ -94,9 +94,7 @@ let (run_all : unit -> unit) =
                        FStar_Compiler_Util.print1 "FlatSet all_remove: %s\n"
                          uu___8);
                       if Prims.op_Negation f_ok
-                      then
-                        FStar_Compiler_Effect.failwith
-                          "FlatSet all_mem failed"
+                      then failwith "FlatSet all_mem failed"
                       else ();
                       (let uu___10 =
                          let uu___11 =
@@ -106,9 +104,7 @@ let (run_all : unit -> unit) =
                                    FStar_Class_Ord.ord_int)) (Obj.magic f1) in
                          Prims.op_Negation uu___11 in
                        if uu___10
-                       then
-                         FStar_Compiler_Effect.failwith
-                           "FlatSet all_remove failed"
+                       then failwith "FlatSet all_remove failed"
                        else ());
                       (let uu___10 =
                          FStar_Compiler_Util.record_time
@@ -161,9 +157,7 @@ let (run_all : unit -> unit) =
                                          FStar_Compiler_Util.print1
                                            "RBSet all_remove: %s\n" uu___16);
                                         if Prims.op_Negation rb_ok
-                                        then
-                                          FStar_Compiler_Effect.failwith
-                                            "RBSet all_mem failed"
+                                        then failwith "RBSet all_mem failed"
                                         else ();
                                         (let uu___18 =
                                            let uu___19 =
@@ -175,6 +169,5 @@ let (run_all : unit -> unit) =
                                            Prims.op_Negation uu___19 in
                                          if uu___18
                                          then
-                                           FStar_Compiler_Effect.failwith
-                                             "RBSet all_remove failed"
+                                           failwith "RBSet all_remove failed"
                                          else ())))))))))))))

--- a/ocaml/fstar-tests/generated/FStar_Tests_Pars.ml
+++ b/ocaml/fstar-tests/generated/FStar_Tests_Pars.ml
@@ -50,7 +50,7 @@ let (parse_mod :
             () (Obj.magic FStar_Errors_Msg.is_error_message_string)
             (Obj.magic msg)
       | FStar_Parser_ParseIt.Term uu___1 ->
-          FStar_Compiler_Effect.failwith
+          failwith
             "Impossible: parsing a Filename always results in an ASTFragment"
 let (add_mods :
   Prims.string Prims.list ->
@@ -317,7 +317,7 @@ let (init : unit -> FStar_TypeChecker_Env.env) =
     match uu___1 with
     | FStar_Pervasives_Native.Some f -> f
     | uu___2 ->
-        FStar_Compiler_Effect.failwith
+        failwith
           "Should have already been initialized by the top-level effect"
 let (frag_of_text : Prims.string -> FStar_Parser_ParseIt.input_frag) =
   fun s ->
@@ -347,7 +347,7 @@ let (pars : Prims.string -> FStar_Syntax_Syntax.term) =
                     (Obj.magic FStar_Errors_Msg.is_error_message_list_doc)
                     (Obj.magic msg)
               | FStar_Parser_ParseIt.ASTFragment uu___2 ->
-                  FStar_Compiler_Effect.failwith
+                  failwith
                     "Impossible: parsing a Fragment always results in a Term"))
         ()
     with
@@ -706,13 +706,13 @@ let (parse_incremental_decls : unit -> unit) =
                FStar_Compiler_Util.format4
                  "Incremental parsing failed: Expected syntax error at (%s, %s), got error at (%s, %s)"
                  uu___7 uu___8 uu___9 uu___10 in
-             FStar_Compiler_Effect.failwith uu___6) in
+             failwith uu___6) in
         ((match (parse_err0, parse_err1) with
           | (FStar_Pervasives_Native.None, uu___5) ->
-              FStar_Compiler_Effect.failwith
+              failwith
                 "Incremental parsing failed: Expected syntax error at (8, 6), got no error"
           | (uu___5, FStar_Pervasives_Native.None) ->
-              FStar_Compiler_Effect.failwith
+              failwith
                 "Incremental parsing failed: Expected syntax error at (9, 6), got no error"
           | (FStar_Pervasives_Native.Some (uu___5, uu___6, rng0),
              FStar_Pervasives_Native.Some (uu___7, uu___8, rng1)) ->
@@ -730,7 +730,7 @@ let (parse_incremental_decls : unit -> unit) =
               if uu___5
               then ()
               else
-                FStar_Compiler_Effect.failwith
+                failwith
                   "Incremental parsing failed; unexpected change in a decl"
           | uu___5 ->
               let uu___6 =
@@ -743,24 +743,22 @@ let (parse_incremental_decls : unit -> unit) =
                 FStar_Compiler_Util.format2
                   "Incremental parsing failed; expected 6 decls got %s and %s\n"
                   uu___7 uu___8 in
-              FStar_Compiler_Effect.failwith uu___6))
+              failwith uu___6))
     | (FStar_Parser_ParseIt.ParseError (code, message, range), uu___2) ->
         let msg =
           let uu___3 = FStar_Compiler_Range_Ops.string_of_range range in
           let uu___4 = FStar_Errors_Msg.rendermsg message in
           FStar_Compiler_Util.format2
             "Incremental parsing failed: Syntax error @ %s: %s" uu___3 uu___4 in
-        FStar_Compiler_Effect.failwith msg
+        failwith msg
     | (uu___2, FStar_Parser_ParseIt.ParseError (code, message, range)) ->
         let msg =
           let uu___3 = FStar_Compiler_Range_Ops.string_of_range range in
           let uu___4 = FStar_Errors_Msg.rendermsg message in
           FStar_Compiler_Util.format2
             "Incremental parsing failed: Syntax error @ %s: %s" uu___3 uu___4 in
-        FStar_Compiler_Effect.failwith msg
-    | uu___2 ->
-        FStar_Compiler_Effect.failwith
-          "Incremental parsing failed: Unexpected output"
+        failwith msg
+    | uu___2 -> failwith "Incremental parsing failed: Unexpected output"
 let (parse_incremental_decls_use_lang : unit -> unit) =
   fun uu___ ->
     let source0 =
@@ -783,8 +781,7 @@ let (parse_incremental_decls_use_lang : unit -> unit) =
          ((match parse_err0 with
            | FStar_Pervasives_Native.None -> ()
            | FStar_Pervasives_Native.Some uu___5 ->
-               FStar_Compiler_Effect.failwith
-                 "Incremental parsing failed: ...");
+               failwith "Incremental parsing failed: ...");
           (let ds =
              FStar_Compiler_List.map FStar_Pervasives_Native.fst decls0 in
            match ds with
@@ -848,7 +845,7 @@ let (parse_incremental_decls_use_lang : unit -> unit) =
                         FStar_Parser_AST.showable_decl) ds in
                  Prims.strcat
                    "Incremental parsing failed; unexpected decls: " uu___7 in
-               FStar_Compiler_Effect.failwith uu___6))
+               failwith uu___6))
      | FStar_Parser_ParseIt.ParseError (code, message, range) ->
          let msg =
            let uu___3 = FStar_Compiler_Range_Ops.string_of_range range in
@@ -856,7 +853,5 @@ let (parse_incremental_decls_use_lang : unit -> unit) =
            FStar_Compiler_Util.format2
              "Incremental parsing failed: Syntax error @ %s: %s" uu___3
              uu___4 in
-         FStar_Compiler_Effect.failwith msg
-     | uu___3 ->
-         FStar_Compiler_Effect.failwith
-           "Incremental parsing failed: Unexpected output")
+         failwith msg
+     | uu___3 -> failwith "Incremental parsing failed: Unexpected output")

--- a/ocaml/fstar-tests/generated/FStar_Tests_Pars.ml
+++ b/ocaml/fstar-tests/generated/FStar_Tests_Pars.ml
@@ -90,7 +90,7 @@ let (init_once : unit -> unit) =
         FStar_Universal.core_check in
     (env.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.init env;
     (let uu___2 =
-       let uu___3 = FStar_Options.prims () in
+       let uu___3 = FStar_Basefiles.prims () in
        let uu___4 = FStar_Syntax_DsEnv.empty_env FStar_Parser_Dep.empty_deps in
        parse_mod uu___3 uu___4 in
      match uu___2 with

--- a/ocaml/fstar-tests/generated/FStar_Tests_Util.ml
+++ b/ocaml/fstar-tests/generated/FStar_Tests_Util.ml
@@ -298,7 +298,7 @@ let rec (term_eq' :
             let uu___4 =
               FStar_Class_Tagged.tag_of FStar_Syntax_Syntax.tagged_term t21 in
             FStar_Compiler_Util.format2 "Impossible: %s and %s" uu___3 uu___4 in
-          FStar_Compiler_Effect.failwith uu___2
+          failwith uu___2
       | (uu___, FStar_Syntax_Syntax.Tm_delayed uu___1) ->
           let uu___2 =
             let uu___3 =
@@ -306,7 +306,7 @@ let rec (term_eq' :
             let uu___4 =
               FStar_Class_Tagged.tag_of FStar_Syntax_Syntax.tagged_term t21 in
             FStar_Compiler_Util.format2 "Impossible: %s and %s" uu___3 uu___4 in
-          FStar_Compiler_Effect.failwith uu___2
+          failwith uu___2
       | (FStar_Syntax_Syntax.Tm_unknown, FStar_Syntax_Syntax.Tm_unknown) ->
           true
       | uu___ -> false

--- a/src/Makefile.boot
+++ b/src/Makefile.boot
@@ -30,7 +30,8 @@ EXTRACT_NAMESPACES=FStar.Extraction FStar.Parser			\
 		   FStar.Class						\
 		   FStar.Reflection FStar.SMTEncoding FStar.Syntax	\
 		   FStar.Tactics FStar.Tests FStar.ToSyntax		\
-		   FStar.TypeChecker FStar.Profiling FStar.Compiler
+		   FStar.TypeChecker FStar.Profiling FStar.Compiler	\
+		   FStar.Find FStar.Basefiles
 
 # Except some files that want to extract are not within a particularly
 # specific namespace. So, we mention extracting those explicitly.

--- a/src/Makefile.boot
+++ b/src/Makefile.boot
@@ -77,6 +77,7 @@ EXTRACT = $(addprefix --extract_module , $(EXTRACT_MODULES))		\
 	$(call msg, "EXTRACT", $(notdir $@))
 	$(Q)$(BENCHMARK_PRE) $(FSTAR_C) $(notdir $(subst .checked.lax,,$<)) \
 		   --odir "$(call OUTPUT_DIRECTORY_FOR,"$@")" \
+		   $(if $(findstring /ulib/,$<),,--MLish) \
 		   --codegen Plugin \
 		   --extract_module $(basename $(notdir $(subst .checked.lax,,$<)))
 

--- a/src/basic/FStar.Basefiles.fst
+++ b/src/basic/FStar.Basefiles.fst
@@ -1,0 +1,26 @@
+module FStar.Basefiles
+
+open FStar
+open FStar.Compiler.Effect
+
+module O  = FStar.Options
+module BU = FStar.Compiler.Util
+module E  = FStar.Errors
+
+let must_find (fn:string) : string =
+  match Find.find_file fn with
+  | Some f -> f
+  | None ->
+    E.raise_error0 E.Fatal_ModuleNotFound [
+      E.text (BU.format1 "Unable to find required file \"%s\" in the module search path." fn);
+    ]
+
+let prims () =
+  match O.custom_prims() with
+  | Some fn -> fn (* user-specified prims *)
+  | None -> must_find "Prims.fst"
+
+let prims_basename () = BU.basename (prims ())
+let pervasives () = must_find "FStar.Pervasives.fsti"
+let pervasives_basename () = BU.basename (pervasives ())
+let pervasives_native_basename () = must_find "FStar.Pervasives.Native.fst" |> BU.basename

--- a/src/basic/FStar.Basefiles.fsti
+++ b/src/basic/FStar.Basefiles.fsti
@@ -1,0 +1,9 @@
+module FStar.Basefiles
+
+open FStar.Compiler.Effect
+
+val prims                       : unit    -> string
+val prims_basename              : unit    -> string
+val pervasives                  : unit    -> string
+val pervasives_basename         : unit    -> string
+val pervasives_native_basename  : unit    -> string

--- a/src/basic/FStar.Compiler.Plugins.fst
+++ b/src/basic/FStar.Compiler.Plugins.fst
@@ -119,7 +119,7 @@ let autoload_plugin (ext:string) : bool =
   if Options.Ext.get "noautoload" <> "" then false else (
   if Debug.any () then
     BU.print1 "Trying to find a plugin for extension %s\n" ext;
-  match Options.find_file (ext ^ ".cmxs") with
+  match Find.find_file (ext ^ ".cmxs") with
   | Some fn ->
     if List.mem fn !loaded then false
     else (

--- a/src/basic/FStar.Compiler.Range.Ops.fst
+++ b/src/basic/FStar.Compiler.Range.Ops.fst
@@ -51,18 +51,16 @@ let rng_included r1 r2 =
 let string_of_pos pos =
     format2 "%s,%s" (string_of_int pos.line) (string_of_int pos.col)
 let string_of_file_name f =
-    if Options.ide () then
-      if Options.Ext.get "fstar:no_absolute_paths" = "1" then
-        basename f
-      else begin
-          try
-              match Find.find_file (basename f) with
-              | None -> f //couldn't find file; just return the relative path
-              | Some absolute_path ->
-                  absolute_path
-          with _ -> f
-      end
-    else f
+  if Options.Ext.get "fstar:no_absolute_paths" = "1" then
+    basename f
+  else if Options.ide () then
+    try
+        match Find.find_file (basename f) with
+        | None -> f //couldn't find file; just return the relative path
+        | Some absolute_path ->
+            absolute_path
+    with _ -> f
+  else f
 let file_of_range r       =
     let f = r.def_range.file_name in
     string_of_file_name f

--- a/src/basic/FStar.Compiler.Range.Ops.fst
+++ b/src/basic/FStar.Compiler.Range.Ops.fst
@@ -56,7 +56,7 @@ let string_of_file_name f =
         basename f
       else begin
           try
-              match Options.find_file (basename f) with
+              match Find.find_file (basename f) with
               | None -> f //couldn't find file; just return the relative path
               | Some absolute_path ->
                   absolute_path

--- a/src/basic/FStar.Find.fst
+++ b/src/basic/FStar.Find.fst
@@ -1,0 +1,50 @@
+(*
+   Copyright 2008-2024 Microsoft Research
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*)
+module FStar.Find
+
+open FStar
+open FStar.Compiler.List
+module BU = FStar.Compiler.Util
+
+let find_file =
+  let file_map = BU.smap_create 100 in
+  fun filename ->
+     match BU.smap_try_find file_map filename with
+     | Some f -> f
+     | None ->
+       let result =
+          (try
+              if BU.is_path_absolute filename then
+                if BU.file_exists filename then
+                  Some filename
+                else
+                  None
+              else
+                (* In reverse, because the last directory has the highest precedence. *)
+                BU.find_map (List.rev (Options.include_path ())) (fun p ->
+                  let path =
+                    if p = "." then filename
+                    else BU.join_paths p filename in
+                  if BU.file_exists path then
+                    Some path
+                  else
+                    None)
+           with | _ -> //to deal with issues like passing bogus strings as paths like " input"
+                  None)
+       in
+       if Some? result
+       then BU.smap_add file_map filename result;
+       result

--- a/src/basic/FStar.Find.fsti
+++ b/src/basic/FStar.Find.fsti
@@ -1,0 +1,21 @@
+﻿(*
+   Copyright 2008-2024 Microsoft Research
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*)
+module FStar.Find
+
+open FStar.Compiler.Effect
+
+(* Try to find a file in the include path with a given basename. *)
+val find_file (basename : string) : option string

--- a/src/basic/FStar.Options.fst
+++ b/src/basic/FStar.Options.fst
@@ -2461,3 +2461,7 @@ let set_vconfig (vcfg:vconfig) : unit =
   set_option "trivial_pre_for_unannotated_effectful_fns" (Bool vcfg.trivial_pre_for_unannotated_effectful_fns);
   set_option "reuse_hint_for"                            (option_as String vcfg.reuse_hint_for);
   ()
+
+instance showable_codegen_t : showable codegen_t = {
+  show = print_codegen;
+}

--- a/src/basic/FStar.Options.fst
+++ b/src/basic/FStar.Options.fst
@@ -1890,63 +1890,7 @@ let include_path () =
   in
   cache_dir @ lib_paths () @ include_paths @ expand_include_d "."
 
-let find_file =
-  let file_map = Util.smap_create 100 in
-  fun filename ->
-     match Util.smap_try_find file_map filename with
-     | Some f -> f
-     | None ->
-       let result =
-          (try
-              if Util.is_path_absolute filename then
-                if Util.file_exists filename then
-                  Some filename
-                else
-                  None
-              else
-                (* In reverse, because the last directory has the highest precedence. *)
-                Util.find_map (List.rev (include_path ())) (fun p ->
-                  let path =
-                    if p = "." then filename
-                    else Util.join_paths p filename in
-                  if Util.file_exists path then
-                    Some path
-                  else
-                    None)
-           with | _ -> //to deal with issues like passing bogus strings as paths like " input"
-                  None)
-       in
-       if Option.isSome result
-       then Util.smap_add file_map filename result;
-       result
-
-let prims () =
-  match get_prims() with
-  | None ->
-    let filename = "Prims.fst" in
-    begin match find_file filename with
-      | Some result ->
-        result
-      | None ->
-        failwith (Util.format1 "unable to find required file \"%s\" in the module search path.\n" filename)
-    end
-  | Some x -> x
-
-let prims_basename () = basename (prims ())
-
-let pervasives () =
-  let filename = "FStar.Pervasives.fsti" in
-  match find_file filename with
-  | Some result -> result
-  | None        -> failwith (Util.format1 "unable to find required file \"%s\" in the module search path.\n" filename)
-
-let pervasives_basename () = basename (pervasives ())
-let pervasives_native_basename () =
-  let filename = "FStar.Pervasives.Native.fst" in
-  match find_file filename with
-  | Some result -> basename result
-  | None        -> failwith (Util.format1 "unable to find required file \"%s\" in the module search path.\n" filename)
-
+let custom_prims () = get_prims()
 
 let prepend_output_dir fname =
   match get_odir() with

--- a/src/basic/FStar.Options.fsti
+++ b/src/basic/FStar.Options.fsti
@@ -168,7 +168,6 @@ val ml_ish                      : unit    -> bool
 val ml_ish_effect               : unit    -> string
 val set_ml_ish                  : unit    -> unit
 val no_default_includes         : unit    -> bool
-val no_extract                  : string  -> bool
 val no_location_info            : unit    -> bool
 val no_plugins                  : unit    -> bool
 val no_smt                      : unit    -> bool

--- a/src/basic/FStar.Options.fsti
+++ b/src/basic/FStar.Options.fsti
@@ -133,7 +133,6 @@ val error_contexts              : unit    -> bool
 val expose_interfaces           : unit    -> bool
 val message_format              : unit    -> message_format_t
 val file_list                   : unit    -> list string
-val find_file                   : (string  -> option string)
 val force                       : unit    -> bool
 val fstar_bin_directory         : string
 val get_option                  : string  -> option_val
@@ -182,11 +181,7 @@ val output_deps_to              : unit    -> option string
 val output_dir                  : unit    -> option string
 val prepend_cache_dir           : string  -> string
 val prepend_output_dir          : string  -> string
-val prims                       : unit    -> string
-val prims_basename              : unit    -> string
-val pervasives                  : unit    -> string
-val pervasives_basename         : unit    -> string
-val pervasives_native_basename  : unit    -> string
+val custom_prims                : unit    -> option string
 val print_bound_var_types       : unit    -> bool
 val print_effect_args           : unit    -> bool
 val print_expected_failures     : unit    -> bool

--- a/src/basic/FStar.Options.fsti
+++ b/src/basic/FStar.Options.fsti
@@ -22,7 +22,11 @@ open FStar.VConfig
 open FStar.Compiler
 
 type codegen_t =
-    | OCaml | FSharp | Krml | Plugin | Extension
+  | OCaml
+  | FSharp
+  | Krml
+  | Plugin
+  | Extension
 
 //let __test_norm_all = Util.mk_ref false
 
@@ -279,3 +283,5 @@ val eager_embedding: ref bool
 
 val get_vconfig : unit -> vconfig
 val set_vconfig : vconfig -> unit
+
+instance val showable_codegen_t : Class.Show.showable codegen_t

--- a/src/basic/FStar.VConfig.fst
+++ b/src/basic/FStar.VConfig.fst
@@ -15,5 +15,4 @@
 *)
 module FStar.VConfig
 
-(* Empty, since the type is defined in the interface file (in ulib/),
-but we still need this file to trigger extraction. *)
+(* This file here to trigger extraction. *)

--- a/src/basic/FStar.VConfig.fsti
+++ b/src/basic/FStar.VConfig.fsti
@@ -1,0 +1,55 @@
+(*
+   Copyright 2008-2018 Microsoft Research
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*)
+module FStar.VConfig
+
+(** This type represents the set of verification-relevant options used
+    to check a particular definition. It can be read from tactics via
+    sigelt_opts and set via the check_with attribute.
+ *)
+type vconfig = {
+  initial_fuel                              : int;
+  max_fuel                                  : int;
+  initial_ifuel                             : int;
+  max_ifuel                                 : int;
+  detail_errors                             : bool;
+  detail_hint_replay                        : bool;
+  no_smt                                    : bool;
+  quake_lo                                  : int;
+  quake_hi                                  : int;
+  quake_keep                                : bool;
+  retry                                     : bool;
+  smtencoding_elim_box                      : bool;
+  smtencoding_nl_arith_repr                 : string;
+  smtencoding_l_arith_repr                  : string;
+  smtencoding_valid_intro                   : bool;
+  smtencoding_valid_elim                    : bool;
+  tcnorm                                    : bool;
+  no_plugins                                : bool;
+  no_tactics                                : bool;
+  z3cliopt                                  : list string;
+  z3smtopt                                  : list string;  
+  z3refresh                                 : bool;
+  z3rlimit                                  : int;
+  z3rlimit_factor                           : int;
+  z3seed                                    : int;
+  z3version                                 : string;
+  trivial_pre_for_unannotated_effectful_fns : bool;
+  reuse_hint_for                            : option string;
+}
+
+(** Marker to check a sigelt with a particular vconfig, not really used internally.. *)
+irreducible
+let check_with (vcfg : vconfig) : unit = ()

--- a/src/fstar/FStar.CheckedFiles.fst
+++ b/src/fstar/FStar.CheckedFiles.fst
@@ -116,7 +116,7 @@ let mcache : smap cache_t = BU.smap_create 50
  *)
 let hash_dependences (deps:Dep.deps) (fn:string) :either string (list (string & string)) =
   let fn =
-    match FStar.Options.find_file fn with
+    match FStar.Find.find_file fn with
     | Some fn -> fn
     | _ -> fn
   in

--- a/src/fstar/FStar.Interactive.PushHelper.fst
+++ b/src/fstar/FStar.Interactive.PushHelper.fst
@@ -366,7 +366,7 @@ let add_module_completions this_fname deps table =
   let loaded_mods_set =
     List.fold_left
       (fun acc dep -> psmap_add acc (Parser.Dep.lowercase_module_name dep) true)
-      (psmap_empty ()) (Options.prims () :: deps) in // Prims is an implicit dependency
+      (psmap_empty ()) (Basefiles.prims () :: deps) in // Prims is an implicit dependency
   let loaded modname =
     psmap_find_default loaded_mods_set modname false in
   let this_mod_key =

--- a/src/fstar/FStar.Main.fst
+++ b/src/fstar/FStar.Main.fst
@@ -78,20 +78,20 @@ let load_native_tactics () =
     let ml_file m = ml_module_name m ^ ".ml" in
     let cmxs_file m =
         let cmxs = ml_module_name m ^ ".cmxs" in
-        match FStar.Options.find_file cmxs with
+        match Find.find_file cmxs with
         | Some f -> f
         | None ->
           if List.contains m cmxs_to_load  //if this module comes from the cmxs list, fail hard
           then E.raise_error0 E.Fatal_FailToCompileNativeTactic (Util.format1 "Could not find %s to load" cmxs)
           else  //else try to find and compile the ml file
-            match FStar.Options.find_file (ml_file m) with
+            match Find.find_file (ml_file m) with
             | None ->
               E.raise_error0 E.Fatal_FailToCompileNativeTactic
                 (Util.format1 "Failed to compile native tactic; extracted module %s not found" (ml_file m))
             | Some ml ->
               let dir = Util.dirname ml in
-              FStar.Compiler.Plugins.compile_modules dir [ml_module_name m];
-              begin match FStar.Options.find_file cmxs with
+              Plugins.compile_modules dir [ml_module_name m];
+              begin match Find.find_file cmxs with
                 | None ->
                   E.raise_error0 E.Fatal_FailToCompileNativeTactic
                     (Util.format1 "Failed to compile native tactic; compiled object %s not found" cmxs)
@@ -101,9 +101,9 @@ let load_native_tactics () =
     let cmxs_files = (modules_to_load@cmxs_to_load) |> List.map cmxs_file in
     if Debug.any () then
       Util.print1 "Will try to load cmxs files: [%s]\n" (String.concat ", " cmxs_files);
-    FStar.Compiler.Plugins.load_plugins cmxs_files;
+    Plugins.load_plugins cmxs_files;
     iter_opt (Options.use_native_tactics ())
-      FStar.Compiler.Plugins.load_plugins_dir;
+      Plugins.load_plugins_dir;
     ()
 
 

--- a/src/fstar/FStar.Universal.fst
+++ b/src/fstar/FStar.Universal.fst
@@ -299,6 +299,7 @@ let load_interface_decls env interface_file_name : TcEnv.env_t =
 (* Extraction to OCaml, F# or Krml *)
 let emit dep_graph (mllibs:list (uenv & MLSyntax.mllib)) =
   let opt = Options.codegen () in
+  let fail #a () : a = failwith ("Unrecognized extraction backend: " ^ show opt) in
   if opt <> None then
     let ext = match opt with
       | Some Options.FSharp -> ".fs"
@@ -306,7 +307,7 @@ let emit dep_graph (mllibs:list (uenv & MLSyntax.mllib)) =
       | Some Options.Plugin -> ".ml"
       | Some Options.Krml -> ".krml"
       | Some Options.Extension -> ".ast"
-      | _ -> failwith "Unrecognized option"
+      | _ -> fail ()
     in
     match opt with
     | Some Options.FSharp | Some Options.OCaml | Some Options.Plugin ->
@@ -354,7 +355,7 @@ let emit dep_graph (mllibs:list (uenv & MLSyntax.mllib)) =
       in
       save_value_to_file oname bin
 
-   | _ -> failwith "Unrecognized option"
+    | _ -> fail ()
 
 let tc_one_file
         (env:uenv)

--- a/src/parser/FStar.Parser.Const.fst
+++ b/src/parser/FStar.Parser.Const.fst
@@ -169,8 +169,8 @@ let int_of_string_lid = p2l ["FStar"; "Parse"; "int_of_string"]
 let bool_of_string_lid = p2l ["FStar"; "Parse"; "bool_of_string"]
 let string_compare = p2l ["FStar"; "String"; "compare"]
 let order_lid       = p2l ["FStar"; "Order"; "order"]
-let vconfig_lid     = p2l ["FStar"; "VConfig"; "vconfig"]
-let mkvconfig_lid   = p2l ["FStar"; "VConfig"; "Mkvconfig"]
+let vconfig_lid     = p2l ["FStar"; "Stubs"; "VConfig"; "vconfig"]
+let mkvconfig_lid   = p2l ["FStar"; "Stubs"; "VConfig"; "Mkvconfig"]
 
 (* Primitive operators *)
 let op_Eq              = pconst "op_Equality"
@@ -515,7 +515,7 @@ let postprocess_extr_with = p2l ["FStar"; "Tactics"; "Effect"; "postprocess_for_
 let term_lid       = p2l ["FStar"; "Stubs"; "Reflection"; "Types"; "term"]
 let ctx_uvar_and_subst_lid = p2l ["FStar"; "Stubs"; "Reflection"; "Types"; "ctx_uvar_and_subst"]
 let universe_uvar_lid      = p2l ["FStar"; "Stubs"; "Reflection"; "Types"; "universe_uvar"]
-let check_with_lid = lid_of_path (["FStar"; "VConfig"; "check_with"]) FStar.Compiler.Range.dummyRange
+let check_with_lid = lid_of_path (["FStar"; "Stubs"; "VConfig"; "check_with"]) FStar.Compiler.Range.dummyRange
 
 let decls_lid      = p2l ["FStar"; "Stubs"; "Reflection"; "Types"; "decls"]
 

--- a/src/parser/FStar.Parser.Dep.fst
+++ b/src/parser/FStar.Parser.Dep.fst
@@ -297,7 +297,7 @@ let cache_file_name =
         else fn ^".checked"
       in
       let mname = fn |> module_name_of_file in
-      match Options.find_file (cache_fn |> Util.basename) with
+      match Find.find_file (cache_fn |> Util.basename) with
       | Some path ->
         let expected_cache_file = Options.prepend_cache_dir cache_fn in
         if Option.isSome (Options.dep()) //if we're in the dependence analysis
@@ -527,9 +527,9 @@ exception Exit
 (* In public interface *)
 
 let core_modules () =
-  [Options.prims_basename () ;
-   Options.pervasives_basename () ;
-   Options.pervasives_native_basename ()]
+  [Basefiles.prims_basename () ;
+   Basefiles.pervasives_basename () ;
+   Basefiles.pervasives_native_basename ()]
   |> List.map module_name_of_file
 
 let implicit_ns_deps =
@@ -1456,7 +1456,7 @@ let collect (all_cmd_line_files: list file_name)
   in
   let all_cmd_line_files =
       all_cmd_line_files |> List.map (fun fn ->
-        match FStar.Options.find_file fn with
+        match Find.find_file fn with
         | None ->
           raise_error0 Errors.Fatal_ModuleOrFileNotFound
             (Util.format1 "File %s could not be found" fn)

--- a/src/tests/FStar.Tests.Pars.fst
+++ b/src/tests/FStar.Tests.Pars.fst
@@ -80,7 +80,7 @@ let init_once () : unit =
                 FStar.Universal.core_check
   in
   env.solver.init env;
-  let dsenv, prims_mod = parse_mod (Options.prims()) (DsEnv.empty_env FStar.Parser.Dep.empty_deps) in
+  let dsenv, prims_mod = parse_mod (Basefiles.prims()) (DsEnv.empty_env FStar.Parser.Dep.empty_deps) in
   let env = {env with dsenv=dsenv} in
   let _prims_mod, env = Tc.check_module env prims_mod false in
   // needed to run tests with chars

--- a/tests/error-messages/Makefile
+++ b/tests/error-messages/Makefile
@@ -18,6 +18,7 @@ OTHERFLAGS+=--already_cached 'Prims FStar'
 # they output timing info.
 OTHERFLAGS := $(filter-out --query_stats, $(OTHERFLAGS))
 OTHERFLAGS := $(filter-out --hint_info, $(OTHERFLAGS))
+OTHERFLAGS += --ext fstar:no_absolute_paths
 
 check-all: $(addsuffix .human_check, $(FSTAR_FILES)) \
            $(addsuffix .json_check, $(FSTAR_FILES))

--- a/tests/micro-benchmarks/RecordOpen.fst
+++ b/tests/micro-benchmarks/RecordOpen.fst
@@ -1,6 +1,6 @@
 module RecordOpen
 
-open FStar.VConfig
+open FStar.Stubs.VConfig
 open FStar.Mul
 
 type ty = {x:int; y:bool}
@@ -50,9 +50,9 @@ let bump_rlimit (v:vconfig) : vconfig =
   { v with z3rlimit = 2 * z3rlimit }
 
 let bump_rlimit2 (v:vconfig) : vconfig =
-  let open v <: FStar.VConfig.vconfig in
+  let open v <: FStar.Stubs.VConfig.vconfig in
   { v with z3rlimit = 2 * z3rlimit }
 
 let bump_rlimit3 (v:vconfig) : vconfig =
-  let open v <: VConfig.vconfig in
+  let open v <: Stubs.VConfig.vconfig in
   { v with z3rlimit = 2 * z3rlimit }

--- a/ulib/FStar.Reflection.V1.Derived.fst
+++ b/ulib/FStar.Reflection.V1.Derived.fst
@@ -20,7 +20,7 @@ open FStar.Reflection.Const
 open FStar.Stubs.Reflection.V1.Builtins
 open FStar.Stubs.Reflection.V1.Data
 open FStar.Order
-open FStar.VConfig
+open FStar.Stubs.VConfig
 
 let bv_of_binder (b : binder) : bv = (inspect_binder b).binder_bv
 

--- a/ulib/FStar.Reflection.V2.Derived.fst
+++ b/ulib/FStar.Reflection.V2.Derived.fst
@@ -20,7 +20,7 @@ open FStar.Reflection.Const
 open FStar.Stubs.Reflection.V2.Builtins
 open FStar.Stubs.Reflection.V2.Data
 open FStar.Order
-open FStar.VConfig
+open FStar.Stubs.VConfig
 open FStar.Reflection.V2.Collect
 
 let type_of_binder (b : binder) : typ =

--- a/ulib/FStar.Stubs.Reflection.V1.Builtins.fsti
+++ b/ulib/FStar.Stubs.Reflection.V1.Builtins.fsti
@@ -18,7 +18,7 @@ module FStar.Stubs.Reflection.V1.Builtins
 open FStar.Order
 open FStar.Stubs.Reflection.Types
 open FStar.Stubs.Reflection.V1.Data
-open FStar.VConfig
+open FStar.Stubs.VConfig
 
 (*** Views ***)
 

--- a/ulib/FStar.Stubs.Reflection.V2.Builtins.fsti
+++ b/ulib/FStar.Stubs.Reflection.V2.Builtins.fsti
@@ -17,7 +17,7 @@ module FStar.Stubs.Reflection.V2.Builtins
 
 open FStar.Order
 open FStar.Stubs.Syntax.Syntax
-open FStar.VConfig
+open FStar.Stubs.VConfig
 open FStar.Stubs.Reflection.Types
 open FStar.Stubs.Reflection.V2.Data
 

--- a/ulib/FStar.Stubs.Tactics.V1.Builtins.fsti
+++ b/ulib/FStar.Stubs.Tactics.V1.Builtins.fsti
@@ -19,7 +19,7 @@ Every tactic primitive, i.e., those built into the compiler
 *)
 module FStar.Stubs.Tactics.V1.Builtins
 
-open FStar.VConfig
+open FStar.Stubs.VConfig
 open FStar.Stubs.Reflection.V1.Builtins
 open FStar.Stubs.Reflection.Types
 open FStar.Stubs.Reflection.V1.Data

--- a/ulib/FStar.Stubs.Tactics.V2.Builtins.fsti
+++ b/ulib/FStar.Stubs.Tactics.V2.Builtins.fsti
@@ -19,7 +19,7 @@ Every tactic primitive, i.e., those built into the compiler
 *)
 module FStar.Stubs.Tactics.V2.Builtins
 
-open FStar.VConfig
+open FStar.Stubs.VConfig
 open FStar.Stubs.Reflection.Types
 open FStar.Reflection.Const
 open FStar.Stubs.Reflection.V2.Data

--- a/ulib/FStar.Stubs.VConfig.fsti
+++ b/ulib/FStar.Stubs.VConfig.fsti
@@ -13,7 +13,7 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 *)
-module FStar.VConfig
+module FStar.Stubs.VConfig
 
 (** This type represents the set of verification-relevant options used
     to check a particular definition. It can be read from tactics via

--- a/ulib/FStar.Tactics.SMT.fst
+++ b/ulib/FStar.Tactics.SMT.fst
@@ -2,7 +2,7 @@ module FStar.Tactics.SMT
 
 open FStar.Tactics.Effect
 open FStar.Stubs.Tactics.V2.Builtins
-open FStar.VConfig
+open FStar.Stubs.VConfig
 
 (* Alias to just use the current vconfig *)
 let smt_sync () : Tac unit = t_smt_sync (get_vconfig ())

--- a/ulib/FStar.Tactics.V1.Derived.fst
+++ b/ulib/FStar.Tactics.V1.Derived.fst
@@ -23,7 +23,7 @@ open FStar.Stubs.Tactics.Result
 open FStar.Tactics.Util
 open FStar.Stubs.Tactics.V1.Builtins
 open FStar.Tactics.V1.SyntaxHelpers
-open FStar.VConfig
+open FStar.Stubs.VConfig
 include FStar.Tactics.Names
 
 module L = FStar.List.Tot.Base

--- a/ulib/FStar.Tactics.V2.Derived.fst
+++ b/ulib/FStar.Tactics.V2.Derived.fst
@@ -23,7 +23,7 @@ open FStar.Stubs.Tactics.Result
 open FStar.Stubs.Tactics.V2.Builtins
 open FStar.Tactics.Util
 open FStar.Tactics.V2.SyntaxHelpers
-open FStar.VConfig
+open FStar.Stubs.VConfig
 open FStar.Tactics.NamedView
 open FStar.Tactics.V2.SyntaxCoercions
 include FStar.Tactics.Names


### PR DESCRIPTION
Some refactoring and making sense of modules. Also, call extraction with --MLish so it translates `FStar_Compiler_Effect.failwith` into OCaml's `failwith`, which allows us to even remove the definition for it. Ideally this would be attribute-based, but this is already a lot better.