### PR TITLE
Restricted open: fix shadowing

### DIFF
--- a/ocaml/fstar-lib/generated/FStarC_Class_Setlike.ml
+++ b/ocaml/fstar-lib/generated/FStarC_Class_Setlike.ml
@@ -15,6 +15,7 @@ type ('e, 's) setlike =
   for_all: ('e -> Prims.bool) -> 's -> Prims.bool ;
   for_any: ('e -> Prims.bool) -> 's -> Prims.bool ;
   elems: 's -> 'e Prims.list ;
+  filter: ('e -> Prims.bool) -> 's -> 's ;
   collect: ('e -> 's) -> 'e Prims.list -> 's ;
   from_list: 'e Prims.list -> 's ;
   addn: 'e Prims.list -> 's -> 's }
@@ -22,164 +23,172 @@ let __proj__Mksetlike__item__empty : 'e 's . ('e, 's) setlike -> unit -> 's =
   fun projectee ->
     match projectee with
     | { empty; singleton; is_empty; add; remove; mem; equal; subset; 
-        union; inter; diff; for_all; for_any; elems; collect; from_list;
-        addn;_} -> empty
+        union; inter; diff; for_all; for_any; elems; filter; collect;
+        from_list; addn;_} -> empty
 let __proj__Mksetlike__item__singleton : 'e 's . ('e, 's) setlike -> 'e -> 's
   =
   fun projectee ->
     match projectee with
     | { empty; singleton; is_empty; add; remove; mem; equal; subset; 
-        union; inter; diff; for_all; for_any; elems; collect; from_list;
-        addn;_} -> singleton
+        union; inter; diff; for_all; for_any; elems; filter; collect;
+        from_list; addn;_} -> singleton
 let __proj__Mksetlike__item__is_empty :
   'e 's . ('e, 's) setlike -> 's -> Prims.bool =
   fun projectee ->
     match projectee with
     | { empty; singleton; is_empty; add; remove; mem; equal; subset; 
-        union; inter; diff; for_all; for_any; elems; collect; from_list;
-        addn;_} -> is_empty
+        union; inter; diff; for_all; for_any; elems; filter; collect;
+        from_list; addn;_} -> is_empty
 let __proj__Mksetlike__item__add : 'e 's . ('e, 's) setlike -> 'e -> 's -> 's
   =
   fun projectee ->
     match projectee with
     | { empty; singleton; is_empty; add; remove; mem; equal; subset; 
-        union; inter; diff; for_all; for_any; elems; collect; from_list;
-        addn;_} -> add
+        union; inter; diff; for_all; for_any; elems; filter; collect;
+        from_list; addn;_} -> add
 let __proj__Mksetlike__item__remove :
   'e 's . ('e, 's) setlike -> 'e -> 's -> 's =
   fun projectee ->
     match projectee with
     | { empty; singleton; is_empty; add; remove; mem; equal; subset; 
-        union; inter; diff; for_all; for_any; elems; collect; from_list;
-        addn;_} -> remove
+        union; inter; diff; for_all; for_any; elems; filter; collect;
+        from_list; addn;_} -> remove
 let __proj__Mksetlike__item__mem :
   'e 's . ('e, 's) setlike -> 'e -> 's -> Prims.bool =
   fun projectee ->
     match projectee with
     | { empty; singleton; is_empty; add; remove; mem; equal; subset; 
-        union; inter; diff; for_all; for_any; elems; collect; from_list;
-        addn;_} -> mem
+        union; inter; diff; for_all; for_any; elems; filter; collect;
+        from_list; addn;_} -> mem
 let __proj__Mksetlike__item__equal :
   'e 's . ('e, 's) setlike -> 's -> 's -> Prims.bool =
   fun projectee ->
     match projectee with
     | { empty; singleton; is_empty; add; remove; mem; equal; subset; 
-        union; inter; diff; for_all; for_any; elems; collect; from_list;
-        addn;_} -> equal
+        union; inter; diff; for_all; for_any; elems; filter; collect;
+        from_list; addn;_} -> equal
 let __proj__Mksetlike__item__subset :
   'e 's . ('e, 's) setlike -> 's -> 's -> Prims.bool =
   fun projectee ->
     match projectee with
     | { empty; singleton; is_empty; add; remove; mem; equal; subset; 
-        union; inter; diff; for_all; for_any; elems; collect; from_list;
-        addn;_} -> subset
+        union; inter; diff; for_all; for_any; elems; filter; collect;
+        from_list; addn;_} -> subset
 let __proj__Mksetlike__item__union :
   'e 's . ('e, 's) setlike -> 's -> 's -> 's =
   fun projectee ->
     match projectee with
     | { empty; singleton; is_empty; add; remove; mem; equal; subset; 
-        union; inter; diff; for_all; for_any; elems; collect; from_list;
-        addn;_} -> union
+        union; inter; diff; for_all; for_any; elems; filter; collect;
+        from_list; addn;_} -> union
 let __proj__Mksetlike__item__inter :
   'e 's . ('e, 's) setlike -> 's -> 's -> 's =
   fun projectee ->
     match projectee with
     | { empty; singleton; is_empty; add; remove; mem; equal; subset; 
-        union; inter; diff; for_all; for_any; elems; collect; from_list;
-        addn;_} -> inter
+        union; inter; diff; for_all; for_any; elems; filter; collect;
+        from_list; addn;_} -> inter
 let __proj__Mksetlike__item__diff :
   'e 's . ('e, 's) setlike -> 's -> 's -> 's =
   fun projectee ->
     match projectee with
     | { empty; singleton; is_empty; add; remove; mem; equal; subset; 
-        union; inter; diff; for_all; for_any; elems; collect; from_list;
-        addn;_} -> diff
+        union; inter; diff; for_all; for_any; elems; filter; collect;
+        from_list; addn;_} -> diff
 let __proj__Mksetlike__item__for_all :
   'e 's . ('e, 's) setlike -> ('e -> Prims.bool) -> 's -> Prims.bool =
   fun projectee ->
     match projectee with
     | { empty; singleton; is_empty; add; remove; mem; equal; subset; 
-        union; inter; diff; for_all; for_any; elems; collect; from_list;
-        addn;_} -> for_all
+        union; inter; diff; for_all; for_any; elems; filter; collect;
+        from_list; addn;_} -> for_all
 let __proj__Mksetlike__item__for_any :
   'e 's . ('e, 's) setlike -> ('e -> Prims.bool) -> 's -> Prims.bool =
   fun projectee ->
     match projectee with
     | { empty; singleton; is_empty; add; remove; mem; equal; subset; 
-        union; inter; diff; for_all; for_any; elems; collect; from_list;
-        addn;_} -> for_any
+        union; inter; diff; for_all; for_any; elems; filter; collect;
+        from_list; addn;_} -> for_any
 let __proj__Mksetlike__item__elems :
   'e 's . ('e, 's) setlike -> 's -> 'e Prims.list =
   fun projectee ->
     match projectee with
     | { empty; singleton; is_empty; add; remove; mem; equal; subset; 
-        union; inter; diff; for_all; for_any; elems; collect; from_list;
-        addn;_} -> elems
+        union; inter; diff; for_all; for_any; elems; filter; collect;
+        from_list; addn;_} -> elems
+let __proj__Mksetlike__item__filter :
+  'e 's . ('e, 's) setlike -> ('e -> Prims.bool) -> 's -> 's =
+  fun projectee ->
+    match projectee with
+    | { empty; singleton; is_empty; add; remove; mem; equal; subset; 
+        union; inter; diff; for_all; for_any; elems; filter; collect;
+        from_list; addn;_} -> filter
 let __proj__Mksetlike__item__collect :
   'e 's . ('e, 's) setlike -> ('e -> 's) -> 'e Prims.list -> 's =
   fun projectee ->
     match projectee with
     | { empty; singleton; is_empty; add; remove; mem; equal; subset; 
-        union; inter; diff; for_all; for_any; elems; collect; from_list;
-        addn;_} -> collect
+        union; inter; diff; for_all; for_any; elems; filter; collect;
+        from_list; addn;_} -> collect
 let __proj__Mksetlike__item__from_list :
   'e 's . ('e, 's) setlike -> 'e Prims.list -> 's =
   fun projectee ->
     match projectee with
     | { empty; singleton; is_empty; add; remove; mem; equal; subset; 
-        union; inter; diff; for_all; for_any; elems; collect; from_list;
-        addn;_} -> from_list
+        union; inter; diff; for_all; for_any; elems; filter; collect;
+        from_list; addn;_} -> from_list
 let __proj__Mksetlike__item__addn :
   'e 's . ('e, 's) setlike -> 'e Prims.list -> 's -> 's =
   fun projectee ->
     match projectee with
     | { empty; singleton; is_empty; add; remove; mem; equal; subset; 
-        union; inter; diff; for_all; for_any; elems; collect; from_list;
-        addn;_} -> addn
+        union; inter; diff; for_all; for_any; elems; filter; collect;
+        from_list; addn;_} -> addn
 let empty : 'e . unit -> ('e, Obj.t) setlike -> unit -> Obj.t =
   fun s ->
     fun projectee ->
       match projectee with
       | { empty = empty1; singleton; is_empty; add; remove; mem; equal;
-          subset; union; inter; diff; for_all; for_any; elems; collect;
-          from_list; addn;_} -> empty1
+          subset; union; inter; diff; for_all; for_any; elems; filter;
+          collect; from_list; addn;_} -> empty1
 let singleton : 'e . unit -> ('e, Obj.t) setlike -> 'e -> Obj.t =
   fun s ->
     fun projectee ->
       match projectee with
       | { empty = empty1; singleton = singleton1; is_empty; add; remove; 
           mem; equal; subset; union; inter; diff; for_all; for_any; elems;
-          collect; from_list; addn;_} -> singleton1
+          filter; collect; from_list; addn;_} -> singleton1
 let is_empty : 'e . unit -> ('e, Obj.t) setlike -> Obj.t -> Prims.bool =
   fun s ->
     fun projectee ->
       match projectee with
       | { empty = empty1; singleton = singleton1; is_empty = is_empty1; 
           add; remove; mem; equal; subset; union; inter; diff; for_all;
-          for_any; elems; collect; from_list; addn;_} -> is_empty1
+          for_any; elems; filter; collect; from_list; addn;_} -> is_empty1
 let add : 'e . unit -> ('e, Obj.t) setlike -> 'e -> Obj.t -> Obj.t =
   fun s ->
     fun projectee ->
       match projectee with
       | { empty = empty1; singleton = singleton1; is_empty = is_empty1;
           add = add1; remove; mem; equal; subset; union; inter; diff;
-          for_all; for_any; elems; collect; from_list; addn;_} -> add1
+          for_all; for_any; elems; filter; collect; from_list; addn;_} ->
+          add1
 let remove : 'e . unit -> ('e, Obj.t) setlike -> 'e -> Obj.t -> Obj.t =
   fun s ->
     fun projectee ->
       match projectee with
       | { empty = empty1; singleton = singleton1; is_empty = is_empty1;
           add = add1; remove = remove1; mem; equal; subset; union; inter;
-          diff; for_all; for_any; elems; collect; from_list; addn;_} ->
-          remove1
+          diff; for_all; for_any; elems; filter; collect; from_list; 
+          addn;_} -> remove1
 let mem : 'e . unit -> ('e, Obj.t) setlike -> 'e -> Obj.t -> Prims.bool =
   fun s ->
     fun projectee ->
       match projectee with
       | { empty = empty1; singleton = singleton1; is_empty = is_empty1;
           add = add1; remove = remove1; mem = mem1; equal; subset; union;
-          inter; diff; for_all; for_any; elems; collect; from_list; addn;_}
-          -> mem1
+          inter; diff; for_all; for_any; elems; filter; collect; from_list;
+          addn;_} -> mem1
 let equal : 'e . unit -> ('e, Obj.t) setlike -> Obj.t -> Obj.t -> Prims.bool
   =
   fun s ->
@@ -187,8 +196,8 @@ let equal : 'e . unit -> ('e, Obj.t) setlike -> Obj.t -> Obj.t -> Prims.bool
       match projectee with
       | { empty = empty1; singleton = singleton1; is_empty = is_empty1;
           add = add1; remove = remove1; mem = mem1; equal = equal1; subset;
-          union; inter; diff; for_all; for_any; elems; collect; from_list;
-          addn;_} -> equal1
+          union; inter; diff; for_all; for_any; elems; filter; collect;
+          from_list; addn;_} -> equal1
 let subset : 'e . unit -> ('e, Obj.t) setlike -> Obj.t -> Obj.t -> Prims.bool
   =
   fun s ->
@@ -197,7 +206,7 @@ let subset : 'e . unit -> ('e, Obj.t) setlike -> Obj.t -> Obj.t -> Prims.bool
       | { empty = empty1; singleton = singleton1; is_empty = is_empty1;
           add = add1; remove = remove1; mem = mem1; equal = equal1;
           subset = subset1; union; inter; diff; for_all; for_any; elems;
-          collect; from_list; addn;_} -> subset1
+          filter; collect; from_list; addn;_} -> subset1
 let union : 'e . unit -> ('e, Obj.t) setlike -> Obj.t -> Obj.t -> Obj.t =
   fun s ->
     fun projectee ->
@@ -205,7 +214,7 @@ let union : 'e . unit -> ('e, Obj.t) setlike -> Obj.t -> Obj.t -> Obj.t =
       | { empty = empty1; singleton = singleton1; is_empty = is_empty1;
           add = add1; remove = remove1; mem = mem1; equal = equal1;
           subset = subset1; union = union1; inter; diff; for_all; for_any;
-          elems; collect; from_list; addn;_} -> union1
+          elems; filter; collect; from_list; addn;_} -> union1
 let inter : 'e . unit -> ('e, Obj.t) setlike -> Obj.t -> Obj.t -> Obj.t =
   fun s ->
     fun projectee ->
@@ -213,7 +222,7 @@ let inter : 'e . unit -> ('e, Obj.t) setlike -> Obj.t -> Obj.t -> Obj.t =
       | { empty = empty1; singleton = singleton1; is_empty = is_empty1;
           add = add1; remove = remove1; mem = mem1; equal = equal1;
           subset = subset1; union = union1; inter = inter1; diff; for_all;
-          for_any; elems; collect; from_list; addn;_} -> inter1
+          for_any; elems; filter; collect; from_list; addn;_} -> inter1
 let diff : 'e . unit -> ('e, Obj.t) setlike -> Obj.t -> Obj.t -> Obj.t =
   fun s ->
     fun projectee ->
@@ -221,7 +230,8 @@ let diff : 'e . unit -> ('e, Obj.t) setlike -> Obj.t -> Obj.t -> Obj.t =
       | { empty = empty1; singleton = singleton1; is_empty = is_empty1;
           add = add1; remove = remove1; mem = mem1; equal = equal1;
           subset = subset1; union = union1; inter = inter1; diff = diff1;
-          for_all; for_any; elems; collect; from_list; addn;_} -> diff1
+          for_all; for_any; elems; filter; collect; from_list; addn;_} ->
+          diff1
 let for_all :
   'e .
     unit -> ('e, Obj.t) setlike -> ('e -> Prims.bool) -> Obj.t -> Prims.bool
@@ -232,8 +242,8 @@ let for_all :
       | { empty = empty1; singleton = singleton1; is_empty = is_empty1;
           add = add1; remove = remove1; mem = mem1; equal = equal1;
           subset = subset1; union = union1; inter = inter1; diff = diff1;
-          for_all = for_all1; for_any; elems; collect; from_list; addn;_} ->
-          for_all1
+          for_all = for_all1; for_any; elems; filter; collect; from_list;
+          addn;_} -> for_all1
 let for_any :
   'e .
     unit -> ('e, Obj.t) setlike -> ('e -> Prims.bool) -> Obj.t -> Prims.bool
@@ -244,8 +254,8 @@ let for_any :
       | { empty = empty1; singleton = singleton1; is_empty = is_empty1;
           add = add1; remove = remove1; mem = mem1; equal = equal1;
           subset = subset1; union = union1; inter = inter1; diff = diff1;
-          for_all = for_all1; for_any = for_any1; elems; collect; from_list;
-          addn;_} -> for_any1
+          for_all = for_all1; for_any = for_any1; elems; filter; collect;
+          from_list; addn;_} -> for_any1
 let elems : 'e . unit -> ('e, Obj.t) setlike -> Obj.t -> 'e Prims.list =
   fun s ->
     fun projectee ->
@@ -253,8 +263,18 @@ let elems : 'e . unit -> ('e, Obj.t) setlike -> Obj.t -> 'e Prims.list =
       | { empty = empty1; singleton = singleton1; is_empty = is_empty1;
           add = add1; remove = remove1; mem = mem1; equal = equal1;
           subset = subset1; union = union1; inter = inter1; diff = diff1;
-          for_all = for_all1; for_any = for_any1; elems = elems1; collect;
-          from_list; addn;_} -> elems1
+          for_all = for_all1; for_any = for_any1; elems = elems1; filter;
+          collect; from_list; addn;_} -> elems1
+let filter :
+  'e . unit -> ('e, Obj.t) setlike -> ('e -> Prims.bool) -> Obj.t -> Obj.t =
+  fun s ->
+    fun projectee ->
+      match projectee with
+      | { empty = empty1; singleton = singleton1; is_empty = is_empty1;
+          add = add1; remove = remove1; mem = mem1; equal = equal1;
+          subset = subset1; union = union1; inter = inter1; diff = diff1;
+          for_all = for_all1; for_any = for_any1; elems = elems1;
+          filter = filter1; collect; from_list; addn;_} -> filter1
 let collect :
   'e . unit -> ('e, Obj.t) setlike -> ('e -> Obj.t) -> 'e Prims.list -> Obj.t
   =
@@ -265,7 +285,8 @@ let collect :
           add = add1; remove = remove1; mem = mem1; equal = equal1;
           subset = subset1; union = union1; inter = inter1; diff = diff1;
           for_all = for_all1; for_any = for_any1; elems = elems1;
-          collect = collect1; from_list; addn;_} -> collect1
+          filter = filter1; collect = collect1; from_list; addn;_} ->
+          collect1
 let from_list : 'e . unit -> ('e, Obj.t) setlike -> 'e Prims.list -> Obj.t =
   fun s ->
     fun projectee ->
@@ -274,7 +295,8 @@ let from_list : 'e . unit -> ('e, Obj.t) setlike -> 'e Prims.list -> Obj.t =
           add = add1; remove = remove1; mem = mem1; equal = equal1;
           subset = subset1; union = union1; inter = inter1; diff = diff1;
           for_all = for_all1; for_any = for_any1; elems = elems1;
-          collect = collect1; from_list = from_list1; addn;_} -> from_list1
+          filter = filter1; collect = collect1; from_list = from_list1;
+          addn;_} -> from_list1
 let addn :
   'e . unit -> ('e, Obj.t) setlike -> 'e Prims.list -> Obj.t -> Obj.t =
   fun s ->
@@ -284,8 +306,8 @@ let addn :
           add = add1; remove = remove1; mem = mem1; equal = equal1;
           subset = subset1; union = union1; inter = inter1; diff = diff1;
           for_all = for_all1; for_any = for_any1; elems = elems1;
-          collect = collect1; from_list = from_list1; addn = addn1;_} ->
-          addn1
+          filter = filter1; collect = collect1; from_list = from_list1;
+          addn = addn1;_} -> addn1
 let symdiff : 'e 's . ('e, 's) setlike -> 's -> 's -> 's =
   fun uu___2 ->
     fun uu___1 ->

--- a/ocaml/fstar-lib/generated/FStarC_Compiler_FlatSet.ml
+++ b/ocaml/fstar-lib/generated/FStarC_Compiler_FlatSet.ml
@@ -134,6 +134,7 @@ let setlike_flat_set :
       FStarC_Class_Setlike.for_all = for_all;
       FStarC_Class_Setlike.for_any = for_any;
       FStarC_Class_Setlike.elems = elems;
+      FStarC_Class_Setlike.filter = FStarC_Compiler_List.filter;
       FStarC_Class_Setlike.collect = (collect uu___);
       FStarC_Class_Setlike.from_list = (from_list uu___);
       FStarC_Class_Setlike.addn = (addn uu___)

--- a/ocaml/fstar-lib/generated/FStarC_Compiler_RBSet.ml
+++ b/ocaml/fstar-lib/generated/FStarC_Compiler_RBSet.ml
@@ -55,6 +55,23 @@ let add : 'a . 'a FStarC_Class_Ord.ord -> 'a -> 'a rbset -> 'a rbset =
                  then let uu___4 = add' b in balance c a1 y uu___4
                  else s1) in
         let uu___1 = add' s in blackroot uu___1
+let filter :
+  'a . 'a FStarC_Class_Ord.ord -> ('a -> Prims.bool) -> 'a rbset -> 'a rbset
+  =
+  fun uu___ ->
+    fun predicate ->
+      fun set ->
+        let rec aux acc uu___1 =
+          match uu___1 with
+          | L -> acc
+          | N (uu___2, l, v, r) ->
+              let uu___3 =
+                let uu___4 =
+                  let uu___5 = predicate v in
+                  if uu___5 then add uu___ v acc else acc in
+                aux uu___4 l in
+              aux uu___3 r in
+        aux (empty ()) set
 let rec extract_min :
   'a . 'a FStarC_Class_Ord.ord -> 'a rbset -> ('a rbset * 'a) =
   fun uu___ ->
@@ -212,6 +229,7 @@ let setlike_rbset :
       FStarC_Class_Setlike.for_all = for_all;
       FStarC_Class_Setlike.for_any = for_any;
       FStarC_Class_Setlike.elems = elems;
+      FStarC_Class_Setlike.filter = (filter uu___);
       FStarC_Class_Setlike.collect = (collect uu___);
       FStarC_Class_Setlike.from_list = (from_list uu___);
       FStarC_Class_Setlike.addn = (addn uu___)

--- a/ocaml/fstar-lib/generated/FStarC_Syntax_DsEnv.ml
+++ b/ocaml/fstar-lib/generated/FStarC_Syntax_DsEnv.ml
@@ -105,6 +105,14 @@ let (uu___is_Exported_id_term_type : exported_id_kind -> Prims.bool) =
 let (uu___is_Exported_id_field : exported_id_kind -> Prims.bool) =
   fun projectee ->
     match projectee with | Exported_id_field -> true | uu___ -> false
+let (uu___0 : exported_id_kind FStarC_Class_Show.showable) =
+  {
+    FStarC_Class_Show.show =
+      (fun uu___ ->
+         match uu___ with
+         | Exported_id_field -> "Exported_id_field"
+         | Exported_id_term_type -> "Exported_id_term_type")
+  }
 type exported_id_set =
   exported_id_kind -> string_set FStarC_Compiler_Effect.ref
 type env =
@@ -3267,8 +3275,22 @@ let (push_include' :
                               ->
                               let update_exports k =
                                 let ns_ex =
-                                  let uu___6 = ns_trans_exports k in
-                                  FStarC_Compiler_Effect.op_Bang uu___6 in
+                                  let uu___6 =
+                                    let uu___7 = ns_trans_exports k in
+                                    FStarC_Compiler_Effect.op_Bang uu___7 in
+                                  Obj.magic
+                                    (FStarC_Class_Setlike.filter ()
+                                       (Obj.magic
+                                          (FStarC_Compiler_RBSet.setlike_rbset
+                                             FStarC_Class_Ord.ord_string))
+                                       (fun id ->
+                                          let uu___7 =
+                                            let uu___8 =
+                                              FStarC_Ident.id_of_text id in
+                                            FStarC_Syntax_Syntax.is_ident_allowed_by_restriction
+                                              uu___8 restriction in
+                                          FStarC_Compiler_Util.is_some uu___7)
+                                       (Obj.magic uu___6)) in
                                 let ex = cur_exports k in
                                 (let uu___7 =
                                    let uu___8 =

--- a/ocaml/fstar-lib/generated/FStarC_Syntax_Syntax.ml
+++ b/ocaml/fstar-lib/generated/FStarC_Syntax_Syntax.ml
@@ -3217,6 +3217,22 @@ let (showable_lazy_kind : lazy_kind FStarC_Class_Show.showable) =
          | Lazy_extension s -> Prims.strcat "Lazy_extension " s
          | uu___1 -> failwith "FIXME! lazy_kind_to_string must be complete")
   }
+let (showable_restriction : restriction FStarC_Class_Show.showable) =
+  {
+    FStarC_Class_Show.show =
+      (fun uu___ ->
+         match uu___ with
+         | Unrestricted -> "Unrestricted"
+         | AllowList l ->
+             let uu___1 =
+               FStarC_Class_Show.show
+                 (FStarC_Class_Show.show_list
+                    (FStarC_Class_Show.show_tuple2
+                       FStarC_Ident.showable_ident
+                       (FStarC_Class_Show.show_option
+                          FStarC_Ident.showable_ident))) l in
+             Prims.strcat "AllowList " uu___1)
+  }
 let (deq_lazy_kind : lazy_kind FStarC_Class_Deq.deq) =
   {
     FStarC_Class_Deq.op_Equals_Question =

--- a/src/class/FStarC.Class.Setlike.fsti
+++ b/src/class/FStarC.Class.Setlike.fsti
@@ -19,6 +19,7 @@ class setlike (e:Type) (s:Type) = {
   for_all       : (e -> bool) -> s -> bool;
   for_any       : (e -> bool) -> s -> bool;
   elems         : s -> list e;
+  filter        : (e -> bool) -> s -> s;
 
   collect       : (e -> s) -> list e -> s;
   from_list     : list e -> s;

--- a/src/data/FStarC.Compiler.FlatSet.fst
+++ b/src/data/FStarC.Compiler.FlatSet.fst
@@ -102,6 +102,7 @@ instance setlike_flat_set (a:Type) (_ : ord a) : Tot (setlike a (flat_set a)) = 
     remove = remove;
     mem = mem;
     elems = elems;
+    filter = List.filter;
     for_all = for_all;
     for_any = for_any;
     subset = subset;

--- a/src/data/FStarC.Compiler.RBSet.fst
+++ b/src/data/FStarC.Compiler.RBSet.fst
@@ -60,6 +60,13 @@ let add {| ord 'a |} (x:'a) (s:rbset 'a) : rbset 'a =
   in
   blackroot (add' s)
 
+let filter {| ord 'a |} (predicate: 'a -> bool) (set: rbset 'a): rbset 'a =
+  let rec aux acc = function
+    | L -> acc
+    | N (_, l, v, r) ->
+      aux (aux (if predicate v then add v acc else acc) l) r
+  in aux (empty ()) set
+
 let rec extract_min #a {| ord a |} (t : rbset a{N? t}) : rbset a & a =
   match t with
   | N (_, L, x, r) -> r, x
@@ -162,6 +169,7 @@ instance setlike_rbset (a:Type) (_ : ord a) : Tot (setlike a (rbset a)) = {
     for_all = for_all;
     for_any = for_any;
     elems = elems;
+    filter;
 
     collect = collect;
     from_list = from_list;

--- a/src/syntax/FStarC.Syntax.DsEnv.fst
+++ b/src/syntax/FStarC.Syntax.DsEnv.fst
@@ -1224,7 +1224,7 @@ let push_include' env ns restriction =
         let () = match (get_exported_id_set env curmod, get_trans_exported_id_set env curmod) with
         | (Some cur_exports, Some cur_trans_exports) ->
           let update_exports (k: exported_id_kind) =
-            let ns_ex = ! (ns_trans_exports k) in
+            let ns_ex = ! (ns_trans_exports k) |> filter (fun id -> is_ident_allowed_by_restriction (id_of_text id) restriction |> is_some) in
             let ex = cur_exports k in
             let () = ex := diff (!ex) ns_ex in
             let trans_ex = cur_trans_exports k in

--- a/src/syntax/FStarC.Syntax.DsEnv.fst
+++ b/src/syntax/FStarC.Syntax.DsEnv.fst
@@ -57,6 +57,12 @@ type string_set = RBSet.t string
 type exported_id_kind = (* kinds of identifiers exported by a module *)
 | Exported_id_term_type (* term and type identifiers *)
 | Exported_id_field     (* field identifiers *)
+
+instance _: showable exported_id_kind = {
+  show = (function | Exported_id_field -> "Exported_id_field"
+                   | Exported_id_term_type -> "Exported_id_term_type")
+}
+
 type exported_id_set = exported_id_kind -> ref string_set
 
 type env = {

--- a/src/syntax/FStarC.Syntax.Syntax.fst
+++ b/src/syntax/FStarC.Syntax.Syntax.fst
@@ -591,6 +591,11 @@ instance showable_lazy_kind = {
   );
 }
 
+instance showable_restriction: showable restriction = {
+  show = (function | Unrestricted -> "Unrestricted"
+                   | AllowList l  -> "AllowList " ^ show l);
+}
+
 instance deq_lazy_kind : deq lazy_kind = {
   (=?) = (fun k k' ->
 (* NOTE: Lazy_embedding compares false to itself, by design. *)

--- a/src/syntax/FStarC.Syntax.Syntax.fsti
+++ b/src/syntax/FStarC.Syntax.Syntax.fsti
@@ -945,6 +945,8 @@ instance val showable_should_check_uvar : showable should_check_uvar
 
 instance val showable_lazy_kind : showable lazy_kind
 
+instance val showable_restriction: showable restriction
+
 instance val deq_lazy_kind   : deq lazy_kind
 instance val deq_bv          : deq bv
 instance val deq_ident       : deq ident

--- a/tests/bug-reports/Bug3559a.fst
+++ b/tests/bug-reports/Bug3559a.fst
@@ -1,0 +1,4 @@
+module Bug3559a
+
+let a = "A.a"
+let b = "A.b"

--- a/tests/bug-reports/Bug3559b.fst
+++ b/tests/bug-reports/Bug3559b.fst
@@ -1,0 +1,4 @@
+module Bug3559b
+let a = "B.a"
+let b = "B.b"
+include Bug3559a {a}

--- a/tests/bug-reports/Bug3559c.fst
+++ b/tests/bug-reports/Bug3559c.fst
@@ -1,0 +1,4 @@
+module Bug3559c
+include Bug3559b
+let _ = assert (a == "A.a")
+let _ = assert (b == "B.b")

--- a/tests/bug-reports/Makefile
+++ b/tests/bug-reports/Makefile
@@ -80,7 +80,7 @@ SHOULD_VERIFY_CLOSED=\
 	Bug2155.fst Bug3224a.fst Bug3224b.fst Bug3236.fst Bug3252.fst \
 	BugBoxInjectivity.fst BugTypeParamProjector.fst Bug2172.fst Bug3266.fst		\
 	Bug3264a.fst Bug3264b.fst Bug3286a.fst Bug3286b.fst Bug3320.fst Bug2583.fst \
-	Bug2419.fst Bug3353.fst Bug3426.fst Bug3530.fst
+	Bug2419.fst Bug3353.fst Bug3426.fst Bug3530.fst Bug3559c.fst
 
 
 SHOULD_VERIFY_INTERFACE_CLOSED=Bug771.fsti Bug771b.fsti


### PR DESCRIPTION
Consider the following three modules:
```fstar
module A
let a = "A.a"
let b = "A.b"
```
```fstar
module B
let a = "B.a"
let b = "B.b"
include A {a}
```
```fstar
module C
include B
let _ = b
```

Running `fstar.exe C.fst` was producing the error:
```
* Error 72 at /tmp/C.fst(5,8-5,9):
  - Identifier not found: [b]
```

This PR fixes that bug, I just forgot to filter names in `push_include'`.

I also had to add a `filter` method (and implem) for setlike, does that looks fine @mtzguido?