### PR TITLE
fix(check-world): only update F* for Comparse, DY* and MLS*

### DIFF
--- a/.github/workflows/check-world.yml
+++ b/.github/workflows/check-world.yml
@@ -724,7 +724,7 @@ jobs:
 
       - name: Update fstar flake and check
         run: |
-          nix flake update --override-input fstar-flake "github:${{github.repository}}?rev=${{github.sha}}"
+          nix flake update --update-input fstar-flake --override-input fstar-flake "github:${{github.repository}}?rev=${{github.sha}}"
           nix flake check
 
   dy-star:
@@ -740,7 +740,7 @@ jobs:
 
       - name: Update fstar flake and check
         run: |
-          nix flake update --override-input fstar-flake "github:${{github.repository}}?rev=${{github.sha}}"
+          nix flake update --update-input fstar-flake --override-input fstar-flake "github:${{github.repository}}?rev=${{github.sha}}"
           nix flake check
 
   mls-star:
@@ -756,5 +756,5 @@ jobs:
 
       - name: Update fstar flake and check
         run: |
-          nix flake update --override-input fstar-flake "github:${{github.repository}}?rev=${{github.sha}}"
+          nix flake update --update-input fstar-flake --override-input fstar-flake "github:${{github.repository}}?rev=${{github.sha}}"
           nix flake check


### PR DESCRIPTION
This would prevent having the check-world red when e.g. MLS* fails because of a breaking change in DY*.