### PR TITLE
Loading plugins from the output dir too.

### DIFF
--- a/ocaml/fstar-lib/generated/FStarC_Compiler_Range_Ops.ml
+++ b/ocaml/fstar-lib/generated/FStarC_Compiler_Range_Ops.ml
@@ -63,35 +63,11 @@ let (string_of_pos : FStarC_Compiler_Range_Type.pos -> Prims.string) =
     let uu___1 =
       FStarC_Compiler_Util.string_of_int pos.FStarC_Compiler_Range_Type.col in
     FStarC_Compiler_Util.format2 "%s,%s" uu___ uu___1
-let (string_of_file_name : Prims.string -> Prims.string) =
-  fun f ->
-    let uu___ =
-      let uu___1 = FStarC_Options_Ext.get "fstar:no_absolute_paths" in
-      uu___1 = "1" in
-    if uu___
-    then FStarC_Compiler_Util.basename f
-    else
-      (let uu___2 = FStarC_Options.ide () in
-       if uu___2
-       then
-         try
-           (fun uu___3 ->
-              match () with
-              | () ->
-                  let uu___4 =
-                    let uu___5 = FStarC_Compiler_Util.basename f in
-                    FStarC_Find.find_file uu___5 in
-                  (match uu___4 with
-                   | FStar_Pervasives_Native.None -> f
-                   | FStar_Pervasives_Native.Some absolute_path ->
-                       absolute_path)) ()
-         with | uu___3 -> f
-       else f)
 let (file_of_range : FStarC_Compiler_Range_Type.range -> Prims.string) =
   fun r ->
     let f =
       (r.FStarC_Compiler_Range_Type.def_range).FStarC_Compiler_Range_Type.file_name in
-    string_of_file_name f
+    FStarC_Compiler_Range_Type.string_of_file_name f
 let (set_file_of_range :
   FStarC_Compiler_Range_Type.range ->
     Prims.string -> FStarC_Compiler_Range_Type.range)
@@ -113,7 +89,9 @@ let (set_file_of_range :
       }
 let (string_of_rng : FStarC_Compiler_Range_Type.rng -> Prims.string) =
   fun r ->
-    let uu___ = string_of_file_name r.FStarC_Compiler_Range_Type.file_name in
+    let uu___ =
+      FStarC_Compiler_Range_Type.string_of_file_name
+        r.FStarC_Compiler_Range_Type.file_name in
     let uu___1 = string_of_pos r.FStarC_Compiler_Range_Type.start_pos in
     let uu___2 = string_of_pos r.FStarC_Compiler_Range_Type.end_pos in
     FStarC_Compiler_Util.format3 "%s(%s-%s)" uu___ uu___1 uu___2

--- a/ocaml/fstar-lib/generated/FStarC_Compiler_Range_Type.ml
+++ b/ocaml/fstar-lib/generated/FStarC_Compiler_Range_Type.ml
@@ -75,6 +75,30 @@ let (mk_rng : Prims.string -> pos -> pos -> rng) =
       fun end_pos -> { file_name = file_name1; start_pos; end_pos }
 let (mk_range : Prims.string -> pos -> pos -> range) =
   fun f -> fun b -> fun e -> let r = mk_rng f b e in range_of_rng r r
+let (string_of_file_name : Prims.string -> Prims.string) =
+  fun f ->
+    let uu___ =
+      let uu___1 = FStarC_Options_Ext.get "fstar:no_absolute_paths" in
+      uu___1 = "1" in
+    if uu___
+    then FStarC_Compiler_Util.basename f
+    else
+      (let uu___2 = FStarC_Options.ide () in
+       if uu___2
+       then
+         try
+           (fun uu___3 ->
+              match () with
+              | () ->
+                  let uu___4 =
+                    let uu___5 = FStarC_Compiler_Util.basename f in
+                    FStarC_Find.find_file uu___5 in
+                  (match uu___4 with
+                   | FStar_Pervasives_Native.None -> f
+                   | FStar_Pervasives_Native.Some absolute_path ->
+                       absolute_path)) ()
+         with | uu___3 -> f
+       else f)
 let (json_of_pos : pos -> FStarC_Json.json) =
   fun r ->
     FStarC_Json.JsonAssoc
@@ -85,13 +109,18 @@ let (json_of_rng : rng -> FStarC_Json.json) =
     let uu___ =
       let uu___1 =
         let uu___2 =
-          let uu___3 = json_of_pos r.start_pos in ("start_pos", uu___3) in
+          let uu___3 = string_of_file_name r.file_name in
+          FStarC_Json.JsonStr uu___3 in
+        ("file_name", uu___2) in
+      let uu___2 =
         let uu___3 =
-          let uu___4 =
-            let uu___5 = json_of_pos r.end_pos in ("end_pos", uu___5) in
-          [uu___4] in
-        uu___2 :: uu___3 in
-      ("file_name", (FStarC_Json.JsonStr (r.file_name))) :: uu___1 in
+          let uu___4 = json_of_pos r.start_pos in ("start_pos", uu___4) in
+        let uu___4 =
+          let uu___5 =
+            let uu___6 = json_of_pos r.end_pos in ("end_pos", uu___6) in
+          [uu___5] in
+        uu___3 :: uu___4 in
+      uu___1 :: uu___2 in
     FStarC_Json.JsonAssoc uu___
 let (json_of_range : range -> FStarC_Json.json) =
   fun r ->

--- a/ocaml/fstar-lib/generated/FStarC_Main.ml
+++ b/ocaml/fstar-lib/generated/FStarC_Main.ml
@@ -71,7 +71,7 @@ let (load_native_tactics : unit -> unit) =
       let uu___1 = ml_module_name m in Prims.strcat uu___1 ".ml" in
     let cmxs_file m =
       let cmxs = let uu___1 = ml_module_name m in Prims.strcat uu___1 ".cmxs" in
-      let uu___1 = FStarC_Find.find_file cmxs in
+      let uu___1 = FStarC_Find.find_file_odir cmxs in
       match uu___1 with
       | FStar_Pervasives_Native.Some f -> f
       | FStar_Pervasives_Native.None ->
@@ -85,7 +85,7 @@ let (load_native_tactics : unit -> unit) =
               (Obj.magic uu___2)
           else
             (let uu___3 =
-               let uu___4 = ml_file m in FStarC_Find.find_file uu___4 in
+               let uu___4 = ml_file m in FStarC_Find.find_file_odir uu___4 in
              match uu___3 with
              | FStar_Pervasives_Native.None ->
                  let uu___4 =
@@ -101,7 +101,7 @@ let (load_native_tactics : unit -> unit) =
                  let dir = FStarC_Compiler_Util.dirname ml in
                  ((let uu___5 = let uu___6 = ml_module_name m in [uu___6] in
                    FStarC_Compiler_Plugins.compile_modules dir uu___5);
-                  (let uu___5 = FStarC_Find.find_file cmxs in
+                  (let uu___5 = FStarC_Find.find_file_odir cmxs in
                    match uu___5 with
                    | FStar_Pervasives_Native.None ->
                        let uu___6 =

--- a/src/basic/FStarC.Compiler.Range.Ops.fst
+++ b/src/basic/FStarC.Compiler.Range.Ops.fst
@@ -51,17 +51,6 @@ let rng_included r1 r2 =
 
 let string_of_pos pos =
     format2 "%s,%s" (string_of_int pos.line) (string_of_int pos.col)
-let string_of_file_name f =
-  if Options.Ext.get "fstar:no_absolute_paths" = "1" then
-    basename f
-  else if Options.ide () then
-    try
-        match Find.find_file (basename f) with
-        | None -> f //couldn't find file; just return the relative path
-        | Some absolute_path ->
-            absolute_path
-    with _ -> f
-  else f
 let file_of_range r       =
     let f = r.def_range.file_name in
     string_of_file_name f

--- a/src/basic/FStarC.Compiler.Range.Type.fst
+++ b/src/basic/FStarC.Compiler.Range.Type.fst
@@ -15,10 +15,12 @@
 *)
 module FStarC.Compiler.Range.Type
 
+open FStarC
 open FStarC.Compiler.Effect 
 open FStarC.Class.Deq
 open FStarC.Class.Ord
 open FStarC.Compiler.Order
+module BU = FStarC.Compiler.Util
 
 [@@ PpxDerivingYoJson; PpxDerivingShow ]
 type file_name = string
@@ -90,6 +92,18 @@ let mk_rng file_name start_pos end_pos = {
 
 let mk_range f b e = let r = mk_rng f b e in range_of_rng r r
 
+let string_of_file_name f =
+  if Options.Ext.get "fstar:no_absolute_paths" = "1" then
+    BU.basename f
+  else if Options.ide () then
+    try
+        match Find.find_file (BU.basename f) with
+        | None -> f //couldn't find file; just return the relative path
+        | Some absolute_path ->
+            absolute_path
+    with _ -> f
+  else f
+
 open FStarC.Json
 let json_of_pos (r: pos): json
   = JsonAssoc [
@@ -98,7 +112,7 @@ let json_of_pos (r: pos): json
     ]
 let json_of_rng (r: rng): json
   = JsonAssoc [
-      "file_name", JsonStr r.file_name;
+      "file_name", JsonStr (string_of_file_name r.file_name);
       "start_pos", json_of_pos r.start_pos;
       "end_pos", json_of_pos r.end_pos;
     ]

--- a/src/basic/FStarC.Find.fsti
+++ b/src/basic/FStarC.Find.fsti
@@ -31,10 +31,12 @@ val include_path () : list string
 (* Try to find a file in the include path with a given basename. *)
 val find_file (basename : string) : option string
 
+(* As above, but also looks in the output directory (--odir). This is useful to find
+plugins that we might have created. *)
+val find_file_odir (basename : string) : option string
+
 val prepend_cache_dir           : string  -> string
 val prepend_output_dir          : string  -> string
-
-
 
 (* Return absolute path of directory where fstar.exe lives *)
 val locate () : string

--- a/src/fstar/FStarC.Main.fst
+++ b/src/fstar/FStarC.Main.fst
@@ -79,20 +79,20 @@ let load_native_tactics () =
     let ml_file m = ml_module_name m ^ ".ml" in
     let cmxs_file m =
         let cmxs = ml_module_name m ^ ".cmxs" in
-        match Find.find_file cmxs with
+        match Find.find_file_odir cmxs with
         | Some f -> f
         | None ->
           if List.contains m cmxs_to_load  //if this module comes from the cmxs list, fail hard
           then E.raise_error0 E.Fatal_FailToCompileNativeTactic (Util.format1 "Could not find %s to load" cmxs)
           else  //else try to find and compile the ml file
-            match Find.find_file (ml_file m) with
+            match Find.find_file_odir (ml_file m) with
             | None ->
               E.raise_error0 E.Fatal_FailToCompileNativeTactic
                 (Util.format1 "Failed to compile native tactic; extracted module %s not found" (ml_file m))
             | Some ml ->
               let dir = Util.dirname ml in
               Plugins.compile_modules dir [ml_module_name m];
-              begin match Find.find_file cmxs with
+              begin match Find.find_file_odir cmxs with
                 | None ->
                   E.raise_error0 E.Fatal_FailToCompileNativeTactic
                     (Util.format1 "Failed to compile native tactic; compiled object %s not found" cmxs)


### PR DESCRIPTION
F* is silly in that `--codegen Plugin` will put an ml file in its output directory (which is not usually in the include path), and when called with `--load` it will try to compile a plugin from that ml file, not finding it as it's not in the include.

This PR makes F* also look in the output directory for cmxs/ml files.