### PR TITLE
Fix some quadratic name lookup behavior

### DIFF
--- a/ocaml/fstar-lib/generated/FStarC_SMTEncoding_Encode.ml
+++ b/ocaml/fstar-lib/generated/FStarC_SMTEncoding_Encode.ml
@@ -201,22 +201,20 @@ let (prims : prims_t) =
                                        let uu___8 =
                                          let uu___9 =
                                            let uu___10 =
-                                             let uu___11 =
-                                               FStarC_SMTEncoding_Term.mk_IsTotFun
-                                                 app1 in
-                                             ([[app1]], vars2, uu___11) in
-                                           FStarC_SMTEncoding_Term.mkForall
-                                             rng uu___10 in
-                                         (uu___9,
-                                           FStar_Pervasives_Native.None,
-                                           axiom_name1) in
-                                       FStarC_SMTEncoding_Util.mkAssume
-                                         uu___8 in
-                                     [uu___7] in
-                                   FStarC_Compiler_List.op_At axioms uu___6 in
+                                             FStarC_SMTEncoding_Term.mk_IsTotFun
+                                               app1 in
+                                           ([[app1]], vars2, uu___10) in
+                                         FStarC_SMTEncoding_Term.mkForall rng
+                                           uu___9 in
+                                       (uu___8, FStar_Pervasives_Native.None,
+                                         axiom_name1) in
+                                     FStarC_SMTEncoding_Util.mkAssume uu___7 in
+                                   uu___6 :: axioms in
                                  (uu___5, app1, vars2))
                         ([tot_fun_axiom_for_x], xtok1, []) all_vars_but_one in
-                    match uu___3 with | (axioms, uu___4, uu___5) -> axioms in
+                    match uu___3 with
+                    | (axioms, uu___4, uu___5) ->
+                        FStarC_Compiler_List.rev axioms in
                   let rel_body =
                     let rel_body1 = rel_type_f rel (xapp, body) in
                     match precondition with
@@ -2363,22 +2361,25 @@ let (encode_top_level_vals :
   fun env ->
     fun bindings ->
       fun quals ->
-        FStarC_Compiler_List.fold_left
-          (fun uu___ ->
-             fun lb ->
-               match uu___ with
-               | (decls, env1) ->
-                   let uu___1 =
+        let uu___ =
+          FStarC_Compiler_List.fold_left
+            (fun uu___1 ->
+               fun lb ->
+                 match uu___1 with
+                 | (decls, env1) ->
                      let uu___2 =
-                       FStarC_Compiler_Util.right
-                         lb.FStarC_Syntax_Syntax.lbname in
-                     encode_top_level_val false env1
-                       lb.FStarC_Syntax_Syntax.lbunivs uu___2
-                       lb.FStarC_Syntax_Syntax.lbtyp quals in
-                   (match uu___1 with
-                    | (decls', env2) ->
-                        ((FStarC_Compiler_List.op_At decls decls'), env2)))
-          ([], env) bindings
+                       let uu___3 =
+                         FStarC_Compiler_Util.right
+                           lb.FStarC_Syntax_Syntax.lbname in
+                       encode_top_level_val false env1
+                         lb.FStarC_Syntax_Syntax.lbunivs uu___3
+                         lb.FStarC_Syntax_Syntax.lbtyp quals in
+                     (match uu___2 with
+                      | (decls', env2) ->
+                          ((FStarC_Compiler_List.rev_append decls' decls),
+                            env2))) ([], env) bindings in
+        match uu___ with
+        | (decls, env1) -> ((FStarC_Compiler_List.rev decls), env1)
 exception Let_rec_unencodeable 
 let (uu___is_Let_rec_unencodeable : Prims.exn -> Prims.bool) =
   fun projectee ->
@@ -7675,16 +7676,19 @@ let (encode_modul :
                   let uu___5 = get_env modul.FStarC_Syntax_Syntax.name tcenv1 in
                   FStarC_SMTEncoding_Env.reset_current_module_fvbs uu___5 in
                 let encode_signature env1 ses =
-                  FStarC_Compiler_List.fold_left
-                    (fun uu___5 ->
-                       fun se ->
-                         match uu___5 with
-                         | (g, env2) ->
-                             let uu___6 = encode_top_level_facts env2 se in
-                             (match uu___6 with
-                              | (g', env3) ->
-                                  ((FStarC_Compiler_List.op_At g g'), env3)))
-                    ([], env1) ses in
+                  let uu___5 =
+                    FStarC_Compiler_List.fold_left
+                      (fun uu___6 ->
+                         fun se ->
+                           match uu___6 with
+                           | (g, env2) ->
+                               let uu___7 = encode_top_level_facts env2 se in
+                               (match uu___7 with
+                                | (g', env3) ->
+                                    ((FStarC_Compiler_List.rev_append g' g),
+                                      env3))) ([], env1) ses in
+                  match uu___5 with
+                  | (g', env2) -> ((FStarC_Compiler_List.rev g'), env2) in
                 let uu___5 =
                   encode_signature
                     {

--- a/ocaml/fstar-lib/generated/FStarC_TypeChecker_Env.ml
+++ b/ocaml/fstar-lib/generated/FStarC_TypeChecker_Env.ml
@@ -2946,72 +2946,20 @@ let (lookup_qname : env -> FStarC_Ident.lident -> qninfo) =
             FStarC_Compiler_Util.smap_try_find (gamma_cache env1) uu___1 in
           match uu___ with
           | FStar_Pervasives_Native.None ->
-              let uu___1 =
-                FStarC_Compiler_Util.find_map env1.gamma
-                  (fun uu___2 ->
-                     match uu___2 with
-                     | FStarC_Syntax_Syntax.Binding_lid (l, (us_names, t))
-                         when FStarC_Ident.lid_equals lid l ->
-                         let us =
-                           FStarC_Compiler_List.map
-                             (fun uu___3 ->
-                                FStarC_Syntax_Syntax.U_name uu___3) us_names in
-                         let uu___3 =
-                           let uu___4 = FStarC_Ident.range_of_lid l in
-                           ((FStar_Pervasives.Inl (us, t)), uu___4) in
-                         FStar_Pervasives_Native.Some uu___3
-                     | uu___3 -> FStar_Pervasives_Native.None) in
-              FStarC_Compiler_Util.catch_opt uu___1
-                (fun uu___2 ->
-                   FStarC_Compiler_Util.find_map env1.gamma_sig
-                     (fun uu___3 ->
-                        match uu___3 with
-                        | (uu___4,
-                           {
-                             FStarC_Syntax_Syntax.sigel =
-                               FStarC_Syntax_Syntax.Sig_bundle
-                               { FStarC_Syntax_Syntax.ses = ses;
-                                 FStarC_Syntax_Syntax.lids = uu___5;_};
-                             FStarC_Syntax_Syntax.sigrng = uu___6;
-                             FStarC_Syntax_Syntax.sigquals = uu___7;
-                             FStarC_Syntax_Syntax.sigmeta = uu___8;
-                             FStarC_Syntax_Syntax.sigattrs = uu___9;
-                             FStarC_Syntax_Syntax.sigopens_and_abbrevs =
-                               uu___10;
-                             FStarC_Syntax_Syntax.sigopts = uu___11;_})
-                            ->
-                            FStarC_Compiler_Util.find_map ses
-                              (fun se ->
-                                 let uu___12 =
-                                   FStarC_Compiler_Util.for_some
-                                     (FStarC_Ident.lid_equals lid)
-                                     (FStarC_Syntax_Util.lids_of_sigelt se) in
-                                 if uu___12
-                                 then
-                                   cache
-                                     ((FStar_Pervasives.Inr
-                                         (se, FStar_Pervasives_Native.None)),
-                                       (FStarC_Syntax_Util.range_of_sigelt se))
-                                 else FStar_Pervasives_Native.None)
-                        | (lids, s) ->
-                            let maybe_cache t =
-                              match s.FStarC_Syntax_Syntax.sigel with
-                              | FStarC_Syntax_Syntax.Sig_declare_typ uu___4
-                                  -> FStar_Pervasives_Native.Some t
-                              | uu___4 -> cache t in
-                            let uu___4 =
-                              FStarC_Compiler_List.tryFind
-                                (FStarC_Ident.lid_equals lid) lids in
-                            (match uu___4 with
-                             | FStar_Pervasives_Native.None ->
-                                 FStar_Pervasives_Native.None
-                             | FStar_Pervasives_Native.Some l ->
-                                 let uu___5 =
-                                   let uu___6 = FStarC_Ident.range_of_lid l in
-                                   ((FStar_Pervasives.Inr
-                                       (s, FStar_Pervasives_Native.None)),
-                                     uu___6) in
-                                 maybe_cache uu___5)))
+              FStarC_Compiler_Util.find_map env1.gamma
+                (fun uu___1 ->
+                   match uu___1 with
+                   | FStarC_Syntax_Syntax.Binding_lid (l, (us_names, t)) when
+                       FStarC_Ident.lid_equals lid l ->
+                       let us =
+                         FStarC_Compiler_List.map
+                           (fun uu___2 -> FStarC_Syntax_Syntax.U_name uu___2)
+                           us_names in
+                       let uu___2 =
+                         let uu___3 = FStarC_Ident.range_of_lid l in
+                         ((FStar_Pervasives.Inl (us, t)), uu___3) in
+                       FStar_Pervasives_Native.Some uu___2
+                   | uu___2 -> FStar_Pervasives_Native.None)
           | se -> se
         else FStar_Pervasives_Native.None in
       if FStarC_Compiler_Util.is_some found
@@ -6503,17 +6451,6 @@ let (finish_module : env -> FStarC_Syntax_Syntax.modul -> env) =
     FStarC_Ident.lid_of_ids uu___ in
   fun env1 ->
     fun m ->
-      let sigs =
-        let uu___ =
-          FStarC_Ident.lid_equals m.FStarC_Syntax_Syntax.name
-            FStarC_Parser_Const.prims_lid in
-        if uu___
-        then
-          let uu___1 =
-            FStarC_Compiler_List.map FStar_Pervasives_Native.snd
-              env1.gamma_sig in
-          FStarC_Compiler_List.rev uu___1
-        else m.FStarC_Syntax_Syntax.declarations in
       {
         solver = (env1.solver);
         range = (env1.range);


### PR DESCRIPTION
@LukeXuan reported that in files with a large number of top-level definitions, typechecking becomes quadratic.

One reason for this is because (surprisingly) we were resolving top-level names in a list (env.gamma_sig) even though we also have a hash map for lookups. Removing this linear scan eliminates one source of the quadratic behavior. I just removed the lookup in gamma_sig. 

I also fixed a couple of quadratic list concatenations in SMTEncoding.Encode, though as @mtzguido pointed out, switching systematically to catenable lists will be better.