### PR TITLE
Moving FStar.Pprint into the (normal, application) library

### DIFF
--- a/mk/test.mk
+++ b/mk/test.mk
@@ -75,5 +75,8 @@ $(OUTPUT_DIR)/%.ml:
 
 verify-all: $(ALL_CHECKED_FILES)
 
-clean:
+common_clean:
 	rm -rf $(OUTPUT_DIR) $(CACHE_DIR) .depend
+
+# Client makefiles can extend the clean, inheriting the common step
+clean: common_clean

--- a/ocaml/fstar-lib/FStarC_Pprint.ml
+++ b/ocaml/fstar-lib/FStarC_Pprint.ml
@@ -82,7 +82,6 @@ let pretty_out_channel rfrac width doc ch =
     PPrint.ToChannel.pretty rfrac (Z.to_int width) ch doc;
     flush ch
 
-(* A simple renderer, with some default values. This is
-   exposed to userspace in FStar.Stubs.Pprint. *)
+(* A simple renderer, with some default values. *)
 let render (doc:document) : string =
     pretty_string 1.0 (Z.of_int 80) doc

--- a/ocaml/fstar-lib/FStar_Pprint.ml
+++ b/ocaml/fstar-lib/FStar_Pprint.ml
@@ -90,7 +90,6 @@ let pretty_out_channel rfrac width doc ch =
     PPrint.ToChannel.pretty rfrac (Z.to_int width) ch doc;
     flush ch
 
-(* A simple renderer, with some default values. This is
-   exposed to userspace in FStar.Stubs.Pprint. *)
+(* A simple renderer, with some default values. *)
 let render (doc:document) : string =
     pretty_string 1.0 (Z.of_int 80) doc

--- a/ocaml/fstar-lib/FStar_Pprint.ml
+++ b/ocaml/fstar-lib/FStar_Pprint.ml
@@ -1,0 +1,96 @@
+(*
+   Copyright 2016 Microsoft Research
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*)
+
+(* NOTE!!! This is a copy of FStarC_Pprint that is exposed to applications
+via the library, without needing to link against compiler modules. The compiler
+itself could also use this but there are some issues with effect polymorphism
+(e.g. flow_map would need two versions, and having the ML one in the ulib module
+would introduce a lot of dependencies) and also would need to have a single definition
+of `float` (the compiler defines its own, though this is probably unneeded and can
+be removed). *)
+
+(*  prettyprint.fsti's OCaml implementation is just a thin wrapper around
+    Francois Pottier's pprint package. *)
+include PPrint
+
+(* FIXME(adl) also print the char in a comment if it's representable *)
+let doc_of_char c = PPrint.OCaml.char (Char.chr c)
+let doc_of_string = PPrint.string
+let doc_of_bool b = PPrint.string (string_of_bool b)
+let blank_buffer_doc = [ ("", PPrint.empty) ]
+
+let substring s ofs len =
+    PPrint.substring s (Z.to_int ofs) (Z.to_int len)
+
+let fancystring s apparent_length =
+    PPrint.fancystring s (Z.to_int apparent_length)
+
+let fancysubstring s ofs len apparent_length =
+    PPrint.fancysubstring  s (Z.to_int ofs) (Z.to_int len) (Z.to_int apparent_length)
+
+let blank n = PPrint.blank (Z.to_int n)
+
+let break_ n = PPrint.break (Z.to_int n)
+
+let op_Hat_Hat = PPrint.(^^)
+let op_Hat_Slash_Hat = PPrint.(^/^)
+
+let nest j doc = PPrint.nest (Z.to_int j) doc
+
+let long_left_arrow = PPrint.string "<--"
+let larrow = PPrint.string "<-"
+let rarrow = PPrint.string "->"
+
+let repeat n doc = PPrint.repeat (Z.to_int n) doc
+
+let hang n doc = PPrint.hang (Z.to_int n) doc
+
+let prefix n b left right =
+    PPrint.prefix (Z.to_int n) (Z.to_int b) left right
+
+let jump n b right =
+    PPrint.jump (Z.to_int n) (Z.to_int b) right
+
+let infix n b middle left right =
+    PPrint.infix (Z.to_int n) (Z.to_int b) middle left right
+
+let surround n b opening contents closing =
+    PPrint.surround (Z.to_int n) (Z.to_int b) opening contents closing
+
+let soft_surround n b opening contents closing =
+    PPrint.soft_surround (Z.to_int n) (Z.to_int b) opening contents closing
+
+let surround_separate n b void_ opening sep closing docs =
+    PPrint.surround_separate (Z.to_int n) (Z.to_int b) void_ opening sep closing docs
+
+let surround_separate_map n b void_ opening sep closing f xs =
+    PPrint.surround_separate_map (Z.to_int n) (Z.to_int b) void_ opening sep closing f xs
+
+(* Wrap up ToBuffer.pretty. *)
+let pretty_string rfrac width doc =
+    let buf = Buffer.create 0 in
+    PPrint.ToBuffer.pretty rfrac (Z.to_int width) buf doc;
+    Buffer.contents buf
+
+(* Wrap up ToChannel.pretty *)
+let pretty_out_channel rfrac width doc ch =
+    PPrint.ToChannel.pretty rfrac (Z.to_int width) ch doc;
+    flush ch
+
+(* A simple renderer, with some default values. This is
+   exposed to userspace in FStar.Stubs.Pprint. *)
+let render (doc:document) : string =
+    pretty_string 1.0 (Z.of_int 80) doc

--- a/ocaml/fstar-lib/generated/FStarC_Parser_Const.ml
+++ b/ocaml/fstar-lib/generated/FStarC_Parser_Const.ml
@@ -673,7 +673,7 @@ let (bind_seal_lid : FStarC_Ident.lident) =
 let (tref_lid : FStarC_Ident.lident) =
   p2l ["FStar"; "Stubs"; "Tactics"; "Types"; "tref"]
 let (document_lid : FStarC_Ident.lident) =
-  p2l ["FStar"; "Stubs"; "Pprint"; "document"]
+  p2l ["FStar"; "Pprint"; "document"]
 let (issue_lid : FStarC_Ident.lident) = p2l ["FStar"; "Issue"; "issue"]
 let (extract_as_lid : FStarC_Ident.lident) =
   p2l ["FStar"; "ExtractAs"; "extract_as"]

--- a/ocaml/fstar-lib/generated/FStarC_Reflection_V2_Embeddings.ml
+++ b/ocaml/fstar-lib/generated/FStarC_Reflection_V2_Embeddings.ml
@@ -2705,7 +2705,7 @@ let (unfold_lazy_doc :
   FStarC_Syntax_Syntax.lazyinfo -> FStarC_Syntax_Syntax.term) =
   fun i ->
     let d = FStarC_Dyn.undyn i.FStarC_Syntax_Syntax.blob in
-    let lid = FStarC_Ident.lid_of_str "FStar.Stubs.Pprint.arbitrary_string" in
+    let lid = FStarC_Ident.lid_of_str "FStar.Pprint.arbitrary_string" in
     let s = FStarC_Pprint.render d in
     let uu___ = FStarC_Syntax_Syntax.fvar lid FStar_Pervasives_Native.None in
     let uu___1 =

--- a/ocaml/fstar-lib/generated/FStarC_TypeChecker_Primops_Docs.ml
+++ b/ocaml/fstar-lib/generated/FStarC_TypeChecker_Primops_Docs.ml
@@ -1,6 +1,6 @@
 open Prims
 let (ops : FStarC_TypeChecker_Primops_Base.primitive_step Prims.list) =
-  let nm l = FStarC_Parser_Const.p2l ["FStar"; "Stubs"; "Pprint"; l] in
+  let nm l = FStarC_Parser_Const.p2l ["FStar"; "Pprint"; l] in
   let uu___ =
     let uu___1 = nm "arbitrary_string" in
     FStarC_TypeChecker_Primops_Base.mk1 Prims.int_zero uu___1

--- a/ocaml/fstar-lib/generated/FStar_InteractiveHelpers_Effectful.ml
+++ b/ocaml/fstar-lib/generated/FStar_InteractiveHelpers_Effectful.ml
@@ -1689,9 +1689,7 @@ let (compute_eterm_info :
                                      (Obj.repr
                                         (FStar_InteractiveHelpers_Base.mfail_doc
                                            (FStar_List_Tot_Base.op_At
-                                              [FStarC_Pprint.arbitrary_string
-                                                 "compute_eterm_info: failure"]
-                                              msg)))
+                                              [Obj.magic ()] msg)))
                                | e1 ->
                                    Obj.magic
                                      (Obj.repr

--- a/ocaml/fstar-lib/generated/FStar_InteractiveHelpers_Effectful.ml
+++ b/ocaml/fstar-lib/generated/FStar_InteractiveHelpers_Effectful.ml
@@ -1689,7 +1689,9 @@ let (compute_eterm_info :
                                      (Obj.repr
                                         (FStar_InteractiveHelpers_Base.mfail_doc
                                            (FStar_List_Tot_Base.op_At
-                                              [Obj.magic ()] msg)))
+                                              [FStar_Pprint.arbitrary_string
+                                                 "compute_eterm_info: failure"]
+                                              msg)))
                                | e1 ->
                                    Obj.magic
                                      (Obj.repr

--- a/ocaml/fstar-lib/generated/FStar_InteractiveHelpers_ExploreTerm.ml
+++ b/ocaml/fstar-lib/generated/FStar_InteractiveHelpers_ExploreTerm.ml
@@ -1843,8 +1843,7 @@ let rec (inst_comp :
                                          (Obj.repr
                                             (FStar_InteractiveHelpers_Base.mfail_doc
                                                (FStar_List_Tot_Base.op_At
-                                                  [FStarC_Pprint.arbitrary_string
-                                                     "inst_comp: error"] msg)))
+                                                  [Obj.magic ()] msg)))
                                    | err ->
                                        Obj.magic
                                          (Obj.repr

--- a/ocaml/fstar-lib/generated/FStar_InteractiveHelpers_ExploreTerm.ml
+++ b/ocaml/fstar-lib/generated/FStar_InteractiveHelpers_ExploreTerm.ml
@@ -1843,7 +1843,8 @@ let rec (inst_comp :
                                          (Obj.repr
                                             (FStar_InteractiveHelpers_Base.mfail_doc
                                                (FStar_List_Tot_Base.op_At
-                                                  [Obj.magic ()] msg)))
+                                                  [FStar_Pprint.arbitrary_string
+                                                     "inst_comp: error"] msg)))
                                    | err ->
                                        Obj.magic
                                          (Obj.repr

--- a/ocaml/fstar-lib/generated/FStar_Reflection_V2_Formula.ml
+++ b/ocaml/fstar-lib/generated/FStar_Reflection_V2_Formula.ml
@@ -999,8 +999,7 @@ let (term_as_formula' :
                   (Obj.repr
                      (FStar_Tactics_Effect.raise
                         (FStarC_Tactics_Common.TacticFailure
-                           ([FStarC_Pprint.arbitrary_string
-                               "Unexpected: term_as_formula"],
+                           ((Obj.magic [Obj.repr ()]),
                              FStar_Pervasives_Native.None))))) uu___1)
 let _ =
   FStarC_Tactics_Native.register_tactic

--- a/ocaml/fstar-lib/generated/FStar_Reflection_V2_Formula.ml
+++ b/ocaml/fstar-lib/generated/FStar_Reflection_V2_Formula.ml
@@ -999,7 +999,8 @@ let (term_as_formula' :
                   (Obj.repr
                      (FStar_Tactics_Effect.raise
                         (FStarC_Tactics_Common.TacticFailure
-                           ((Obj.magic [Obj.repr ()]),
+                           ([FStar_Pprint.arbitrary_string
+                               "Unexpected: term_as_formula"],
                              FStar_Pervasives_Native.None))))) uu___1)
 let _ =
   FStarC_Tactics_Native.register_tactic

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Typeclasses.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Typeclasses.ml
@@ -2301,7 +2301,7 @@ let (tcresolve : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                                     (fun
                                                                     uu___19
                                                                     ->
-                                                                    FStarC_Pprint.bquotes
+                                                                    FStar_Pprint.bquotes
                                                                     uu___18)) in
                                                                     FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
@@ -2329,11 +2329,11 @@ let (tcresolve : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                                     (fun
                                                                     uu___18
                                                                     ->
-                                                                    FStarC_Pprint.prefix
+                                                                    FStar_Pprint.prefix
                                                                     (Prims.of_int (2))
                                                                     Prims.int_one
-                                                                    (FStarC_Pprint.arbitrary_string
-                                                                    "Could not solve typeclass constraint")
+                                                                    (Obj.magic
+                                                                    ())
                                                                     uu___17)) in
                                                                     FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
@@ -2396,9 +2396,9 @@ let (tcresolve : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                                     ((op_At
                                                                     ())
                                                                     [
-                                                                    FStarC_Pprint.arbitrary_string
-                                                                    "Typeclass resolution failed."]
-                                                                    msg) r))
+                                                                    Obj.magic
+                                                                    ()] msg)
+                                                                    r))
                                                                     | 
                                                                     e ->
                                                                     Obj.magic

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Typeclasses.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Typeclasses.ml
@@ -2332,8 +2332,8 @@ let (tcresolve : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                                     FStar_Pprint.prefix
                                                                     (Prims.of_int (2))
                                                                     Prims.int_one
-                                                                    (Obj.magic
-                                                                    ())
+                                                                    (FStar_Pprint.arbitrary_string
+                                                                    "Could not solve typeclass constraint")
                                                                     uu___17)) in
                                                                     FStar_Tactics_Effect.tac_bind
                                                                     (FStar_Sealed.seal
@@ -2396,9 +2396,9 @@ let (tcresolve : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
                                                                     ((op_At
                                                                     ())
                                                                     [
-                                                                    Obj.magic
-                                                                    ()] msg)
-                                                                    r))
+                                                                    FStar_Pprint.arbitrary_string
+                                                                    "Typeclass resolution failed."]
+                                                                    msg) r))
                                                                     | 
                                                                     e ->
                                                                     Obj.magic

--- a/ocaml/fstar-lib/generated/FStar_Tactics_V1_Logic.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_V1_Logic.ml
@@ -38,8 +38,7 @@ let (cur_goal :
          | uu___3 ->
              FStar_Tactics_Effect.raise
                (FStarC_Tactics_Common.TacticFailure
-                  ([FStarC_Pprint.arbitrary_string "no more goals"],
-                    FStar_Pervasives_Native.None)))
+                  ((Obj.magic [Obj.repr ()]), FStar_Pervasives_Native.None)))
 let (cur_formula :
   unit ->
     (FStar_Reflection_V1_Formula.formula, unit) FStar_Tactics_Effect.tac_repr)

--- a/ocaml/fstar-lib/generated/FStar_Tactics_V1_Logic.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_V1_Logic.ml
@@ -38,7 +38,8 @@ let (cur_goal :
          | uu___3 ->
              FStar_Tactics_Effect.raise
                (FStarC_Tactics_Common.TacticFailure
-                  ((Obj.magic [Obj.repr ()]), FStar_Pervasives_Native.None)))
+                  ([FStar_Pprint.arbitrary_string "no more goals"],
+                    FStar_Pervasives_Native.None)))
 let (cur_formula :
   unit ->
     (FStar_Reflection_V1_Formula.formula, unit) FStar_Tactics_Effect.tac_repr)

--- a/ocaml/fstar-lib/generated/FStar_Tactics_V2_Logic.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_V2_Logic.ml
@@ -38,8 +38,7 @@ let (cur_goal :
          | uu___3 ->
              FStar_Tactics_Effect.raise
                (FStarC_Tactics_Common.TacticFailure
-                  ([FStarC_Pprint.arbitrary_string "no more goals"],
-                    FStar_Pervasives_Native.None)))
+                  ((Obj.magic [Obj.repr ()]), FStar_Pervasives_Native.None)))
 let (cur_formula :
   unit ->
     (FStar_Reflection_V2_Formula.formula, unit) FStar_Tactics_Effect.tac_repr)

--- a/ocaml/fstar-lib/generated/FStar_Tactics_V2_Logic.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_V2_Logic.ml
@@ -38,7 +38,8 @@ let (cur_goal :
          | uu___3 ->
              FStar_Tactics_Effect.raise
                (FStarC_Tactics_Common.TacticFailure
-                  ((Obj.magic [Obj.repr ()]), FStar_Pervasives_Native.None)))
+                  ([FStar_Pprint.arbitrary_string "no more goals"],
+                    FStar_Pervasives_Native.None)))
 let (cur_formula :
   unit ->
     (FStar_Reflection_V2_Formula.formula, unit) FStar_Tactics_Effect.tac_repr)

--- a/src/parser/FStarC.Parser.Const.fst
+++ b/src/parser/FStarC.Parser.Const.fst
@@ -578,7 +578,7 @@ let map_seal_lid    = p2l ["FStar"; "Sealed"; "map_seal"]
 let bind_seal_lid   = p2l ["FStar"; "Sealed"; "bind_seal"]
 let tref_lid        = p2l ["FStar"; "Stubs"; "Tactics"; "Types"; "tref"]
 
-let document_lid = p2l ["FStar"; "Stubs"; "Pprint"; "document"]
+let document_lid = p2l ["FStar"; "Pprint"; "document"]
 let issue_lid = p2l ["FStar"; "Issue"; "issue"]
 
 let extract_as_lid = p2l ["FStar"; "ExtractAs"; "extract_as"]

--- a/src/reflection/FStarC.Reflection.V2.Embeddings.fst
+++ b/src/reflection/FStarC.Reflection.V2.Embeddings.fst
@@ -837,7 +837,7 @@ let unfold_lazy_universe (i : lazyinfo) : term =
 let unfold_lazy_doc (i : lazyinfo) : term =
   let open FStarC.Pprint in
   let d : Pprint.document = undyn i.blob in
-  let lid = Ident.lid_of_str "FStar.Stubs.Pprint.arbitrary_string" in
+  let lid = Ident.lid_of_str "FStar.Pprint.arbitrary_string" in
   let s = Pprint.render d in
   S.mk_Tm_app (S.fvar lid None) [S.as_arg (embed i.rng s)]
               i.rng

--- a/src/typechecker/FStarC.TypeChecker.Primops.Docs.fst
+++ b/src/typechecker/FStarC.TypeChecker.Primops.Docs.fst
@@ -17,7 +17,7 @@ for it. I'm actually not sure how to do that since the document
 type is abstract even internally. *)
 
 let ops =
-  let nm l = PC.p2l ["FStar"; "Stubs"; "Pprint"; l] in
+  let nm l = PC.p2l ["FStar"; "Pprint"; l] in
     let open FStarC.Pprint in
     [
       (* mk1 0 (nm "doc_of_char") doc_of_char; *)

--- a/tests/dune_hello/Makefile
+++ b/tests/dune_hello/Makefile
@@ -13,3 +13,6 @@ bin/hello.exe: Hello.ml
 .PHONY: run
 run: bin/hello.exe
 	./bin/hello.exe | grep "Hi!"
+
+clean:
+	dune clean

--- a/tests/simple_hello/Makefile
+++ b/tests/simple_hello/Makefile
@@ -14,3 +14,6 @@ Hello.test: Hello.exe
 
 %.exe: %.ml
 	$(FSTAR) --ocamlc $< -o $@
+
+clean:
+	rm -f *.ml *.exe

--- a/tests/tactics/TestPprint.fst
+++ b/tests/tactics/TestPprint.fst
@@ -2,12 +2,12 @@ module TestPprint
 
 open FStar.Tactics.V2
 
-let _ = assert_norm (Stubs.Pprint.render (Stubs.Pprint.arbitrary_string "hello") == "hello")
+let _ = assert_norm (Pprint.render (Pprint.arbitrary_string "hello") == "hello")
 
 let _ = assert True by (
   let t = (`(1+2+3)) in
   let d = term_to_doc t in
-  let s = Stubs.Pprint.render d in
+  let s = Pprint.render d in
   if s <> "1 + 2 + 3" then
    fail s
 )

--- a/ulib/FStar.Issue.fsti
+++ b/ulib/FStar.Issue.fsti
@@ -1,7 +1,7 @@
 module FStar.Issue
 open FStar.Range
 
-module Pprint = FStar.Stubs.Pprint
+module Pprint = FStar.Pprint
 
 new
 val issue : Type0

--- a/ulib/FStar.Pprint.fsti
+++ b/ulib/FStar.Pprint.fsti
@@ -13,7 +13,7 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 *)
-module FStar.Stubs.Pprint
+module FStar.Pprint
 
 (* Unfortunate *)
 open FStar.Char

--- a/ulib/FStar.Stubs.Errors.Msg.fsti
+++ b/ulib/FStar.Stubs.Errors.Msg.fsti
@@ -2,7 +2,7 @@ module FStar.Stubs.Errors.Msg
 
 (* Implemented in src/, allows constructing structured pretty-printed error messages. *)
 
-open FStar.Stubs.Pprint
+open FStar.Pprint
 
 (* An error message is a list of documents. This allows us to print errors like
 these:

--- a/ulib/FStar.Stubs.Tactics.V2.Builtins.fsti
+++ b/ulib/FStar.Stubs.Tactics.V2.Builtins.fsti
@@ -427,11 +427,11 @@ val comp_to_string : comp -> Tac string
 
 (** Like term_to_string, but returns an unrendered pretty-printing
 document *)
-val term_to_doc : term -> Tac Stubs.Pprint.document
+val term_to_doc : term -> Tac Pprint.document
 
 (** Like comp_to_string, but returns an unrendered pretty-printing
 document *)
-val comp_to_doc : comp -> Tac Stubs.Pprint.document
+val comp_to_doc : comp -> Tac Pprint.document
 
 (** Print a source range as a string *)
 val range_to_string : range -> Tac string

--- a/ulib/FStar.Tactics.Typeclasses.fst
+++ b/ulib/FStar.Tactics.Typeclasses.fst
@@ -266,7 +266,7 @@ let rec tcresolve' (st:st_t) : Tac unit =
 
 [@@plugin]
 let tcresolve () : Tac unit =
-    let open FStar.Stubs.Pprint in
+    let open FStar.Pprint in
     debug (fun () -> dump ""; "tcresolve entry point");
     norm [];
     let w = cur_witness () in
@@ -293,7 +293,7 @@ let tcresolve () : Tac unit =
       debug (fun () -> "Solved to:\n\t" ^ term_to_string w)
     with
     | NoInst ->
-      let open FStar.Stubs.Pprint in
+      let open FStar.Pprint in
       fail_doc [
         prefix 2 1 (text "Could not solve typeclass constraint")
           (bquotes (term_to_doc (cur_goal ())));


### PR DESCRIPTION
This exposes the pretty-printing module for all F* applications by placing it into `FStar.Pprint.fsti`, instead of `FStar.Stubs.Pprint.fsti`. The `FStar.Stubs` namespace is for interacting with compiler internals, which made sense since FStarC_Pprint.ml is the implementation of this module, but prevents normal applications from using pretty printing without bringing in the rest of the compiler.

This removes this problem by just making this a normal ulib module. The compile still uses a different version internally, due to needing it in the ML effect, but this does not concern F* application writers.

It also fixes a nasty issue I hadn't noticed where extracting a literal doc was essentially returning `Obj.magic ()`. This is since extraction does not know about `FStar.Pprint.doc` which is what FStar.Stubs.Pprint (with --codegen OCaml) was translated to, since the FStar.Pprint module doesn't exist. The right thing here, now that FStar and FStarC are distinguished, is drop the Stubs namespace and have an FStarC namespace of interfaces in ulib, avoiding the name wrangling.