### PR TITLE
Delay snapshotting of desugaring environment

### DIFF
--- a/ocaml/fstar-lib/generated/FStarC_ToSyntax_ToSyntax.ml
+++ b/ocaml/fstar-lib/generated/FStarC_ToSyntax_ToSyntax.ml
@@ -9177,9 +9177,6 @@ and (desugar_decl_maybe_fail_attr :
           (fun at ->
              let uu___ = get_fail_attr1 false at in
              FStarC_Compiler_Option.isNone uu___) ats in
-      let env0 =
-        let uu___ = FStarC_Syntax_DsEnv.snapshot env in
-        FStar_Pervasives_Native.snd uu___ in
       let uu___ =
         let attrs =
           FStarC_Compiler_List.map (desugar_term env)
@@ -9188,6 +9185,9 @@ and (desugar_decl_maybe_fail_attr :
         let uu___1 = get_fail_attr false attrs1 in
         match uu___1 with
         | FStar_Pervasives_Native.Some (expected_errs, lax) ->
+            let env0 =
+              let uu___2 = FStarC_Syntax_DsEnv.snapshot env in
+              FStar_Pervasives_Native.snd uu___2 in
             let d1 =
               {
                 FStarC_Parser_AST.d = (d.FStarC_Parser_AST.d);

--- a/src/tosyntax/FStarC.ToSyntax.ToSyntax.fst
+++ b/src/tosyntax/FStarC.ToSyntax.ToSyntax.fst
@@ -3645,12 +3645,6 @@ and desugar_decl_maybe_fail_attr env (d: decl): (env_t & sigelts) =
       List.filter (fun at -> Option.isNone (get_fail_attr1 false at)) ats
   in
 
-  // The `fail` attribute behaves
-  // differentrly! We only keep that one on the first new decl.
-  let env0 = Env.snapshot env |> snd in (* we need the snapshot since pushing the let
-                                         * will shadow a previous val *)
-
-
   (* If this is an expect_failure, check to see if it fails.
    * If it does, check that the errors match as we normally do.
    * If it doesn't fail, leave it alone! The typechecker will check the failure. *)
@@ -3659,6 +3653,12 @@ and desugar_decl_maybe_fail_attr env (d: decl): (env_t & sigelts) =
     let attrs = U.deduplicate_terms attrs in
     match get_fail_attr false attrs with
     | Some (expected_errs, lax) ->
+      // The `fail` attribute behaves
+      // differentrly! We only keep that one on the first new decl.
+      let env0 =
+          Env.snapshot env |> snd  (* we need the snapshot since pushing the let
+                                    * will shadow a previous val *)
+      in
       let d = { d with attrs = [] } in
       let errs, r = Errors.catch_errors (fun () ->
                       Options.with_saved_options (fun () ->


### PR DESCRIPTION
Snapshotting a desugaring environment is linear in the number of definitions in scope

We currently snapshot the environment before processing any declaration, which leads to quadratic behavior for desugaring modules with a large number of definitions. Thanks @LukeXuan for noting this! 

The snapshotting is needed to properly handle definitions marked with an "expect_failure" attribute. This PR snapshots the environment only when processing such a decorated definition, rather than unconditionally snapshotting it. This avoids the quadratic behavior in the common case of definitions that are not decorated with expect_failure

A better long-term solution would be to move to the use of persistent maps in desugaring, making such snapshots constant time.

(Note, there is still some quadratic behavior left in the desugaring phase, as name resolutions involve a linear scan---working on fixing that in a separate PR)