### PR TITLE
Use nanosecond timing from monotonic clock mtime for profiling

### DIFF
--- a/.devcontainer/minimal.Dockerfile
+++ b/.devcontainer/minimal.Dockerfile
@@ -46,7 +46,7 @@ ARG OCAML_VERSION=4.14.0
 RUN opam init --compiler=$OCAML_VERSION --disable-sandboxing
 RUN opam option depext-run-installs=true
 ENV OPAMYES=1
-RUN opam install --yes batteries zarith stdint yojson dune menhir menhirLib pprint sedlex ppxlib process ppx_deriving ppx_deriving_yojson memtrace
+RUN opam install --yes batteries zarith stdint yojson dune menhir menhirLib mtime pprint sedlex ppxlib process ppx_deriving ppx_deriving_yojson memtrace
 
 # Get compiled Z3
 RUN wget -nv https://github.com/Z3Prover/z3/releases/download/Z3-4.8.5/z3-4.8.5-x64-ubuntu-16.04.zip \

--- a/.docker/base/Dockerfile
+++ b/.docker/base/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR /home/build
 # Prepare and build OPAM and OCaml
 RUN opam init -y --disable-sandboxing
 RUN opam update
-RUN opam install -y ocamlbuild ocamlfind batteries stdint zarith yojson fileutils pprint menhir sedlex ppx_deriving ppx_deriving_yojson process pprint visitors fix wasm ppxlib=0.22.0
+RUN opam install -y ocamlbuild ocamlfind batteries stdint zarith yojson fileutils pprint menhir mtime sedlex ppx_deriving ppx_deriving_yojson process pprint visitors fix wasm ppxlib=0.22.0
 
 # Prepare and build Z3
 ENV z3=z3-4.8.5-x64-debian-8.11

--- a/fstar.opam
+++ b/fstar.opam
@@ -14,6 +14,7 @@ depends: [
   "memtrace"
   "menhirLib"
   "menhir" {build & >= "2.1"}
+  "mtime"
   "pprint"
   "sedlex"
   "ppxlib" {>= "0.27.0"}

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -1,5 +1,5 @@
 { batteries, buildDunePackage, includeBinaryAnnotations ? false
-, installShellFiles, lib, makeWrapper, menhir, menhirLib, memtrace, ocaml
+, installShellFiles, lib, makeWrapper, menhir, menhirLib, memtrace, mtime, ocaml
 , pprint, ppxlib, ppx_deriving, ppx_deriving_yojson, process, removeReferencesTo
 , sedlex, stdint, version, yojson, zarith }:
 
@@ -32,6 +32,7 @@ buildDunePackage {
     yojson
     zarith
     memtrace
+    mtime
   ];
 
   enableParallelBuilding = true;

--- a/ocaml/fstar-lib/FStarC_Parser_ParseIt.ml
+++ b/ocaml/fstar-lib/FStarC_Parser_ParseIt.ml
@@ -39,13 +39,13 @@ let find_file filename =
     | None ->
       raise_error_text FStarC_Compiler_Range.dummyRange Fatal_ModuleOrFileNotFound (U.format1 "Unable to find file: %s\n" filename)
 
-let vfs_entries : (U.time * string) U.smap = U.smap_create (Z.of_int 1)
+let vfs_entries : (U.time_of_day * string) U.smap = U.smap_create (Z.of_int 1)
 
 let read_vfs_entry fname =
   U.smap_try_find vfs_entries (U.normalize_file_path fname)
 
 let add_vfs_entry fname contents =
-  U.smap_add vfs_entries (U.normalize_file_path fname) (U.now (), contents)
+  U.smap_add vfs_entries (U.normalize_file_path fname) (U.get_time_of_day (), contents)
 
 let get_file_last_modification_time filename =
   match read_vfs_entry filename with

--- a/ocaml/fstar-lib/FStarC_Parser_ParseIt.mli
+++ b/ocaml/fstar-lib/FStarC_Parser_ParseIt.mli
@@ -15,9 +15,9 @@ type input_frag = {
     frag_col:Prims.int
 }
 
-val read_vfs_entry : string -> (U.time * string) option
+val read_vfs_entry : string -> (U.time_of_day * string) option
 val add_vfs_entry: string -> string -> unit
-val get_file_last_modification_time: string -> U.time
+val get_file_last_modification_time: string -> U.time_of_day
 
 type parse_frag =
     | Filename of filename

--- a/ocaml/fstar-lib/dune
+++ b/ocaml/fstar-lib/dune
@@ -13,6 +13,7 @@
     pprint
     process
     sedlex
+    mtime.clock.os
  )
  (modes native byte)
  ; ^ Note: we need to compile fstar-lib in bytecode since some

--- a/ocaml/fstar-lib/generated/FStarC_Interactive_Ide_Types.ml
+++ b/ocaml/fstar-lib/generated/FStarC_Interactive_Ide_Types.ml
@@ -104,12 +104,12 @@ type optmod_t = FStarC_Syntax_Syntax.modul FStar_Pervasives_Native.option
 type timed_fname =
   {
   tf_fname: Prims.string ;
-  tf_modtime: FStarC_Compiler_Util.time }
+  tf_modtime: FStarC_Compiler_Util.time_of_day }
 let (__proj__Mktimed_fname__item__tf_fname : timed_fname -> Prims.string) =
   fun projectee ->
     match projectee with | { tf_fname; tf_modtime;_} -> tf_fname
 let (__proj__Mktimed_fname__item__tf_modtime :
-  timed_fname -> FStarC_Compiler_Util.time) =
+  timed_fname -> FStarC_Compiler_Util.time_of_day) =
   fun projectee ->
     match projectee with | { tf_fname; tf_modtime;_} -> tf_modtime
 type repl_task =
@@ -394,7 +394,8 @@ let (__proj__Mkgrepl_state__item__grepl_stdin :
   grepl_state -> FStarC_Compiler_Util.stream_reader) =
   fun projectee ->
     match projectee with | { grepl_repls; grepl_stdin;_} -> grepl_stdin
-let (t0 : FStarC_Compiler_Util.time) = FStarC_Compiler_Util.now ()
+let (t0 : FStarC_Compiler_Util.time_of_day) =
+  FStarC_Compiler_Util.get_time_of_day ()
 let (dummy_tf_of_fname : Prims.string -> timed_fname) =
   fun fname -> { tf_fname = fname; tf_modtime = t0 }
 let (string_of_timed_fname : timed_fname -> Prims.string) =
@@ -404,7 +405,7 @@ let (string_of_timed_fname : timed_fname -> Prims.string) =
         if modtime = t0
         then FStarC_Compiler_Util.format1 "{ %s }" fname
         else
-          (let uu___2 = FStarC_Compiler_Util.string_of_time modtime in
+          (let uu___2 = FStarC_Compiler_Util.string_of_time_of_day modtime in
            FStarC_Compiler_Util.format2 "{ %s; %s }" fname uu___2)
 let (string_of_repl_task : repl_task -> Prims.string) =
   fun uu___ ->

--- a/ocaml/fstar-lib/generated/FStarC_Interactive_Legacy.ml
+++ b/ocaml/fstar-lib/generated/FStarC_Interactive_Legacy.ml
@@ -464,8 +464,8 @@ let (deps_of_our_file :
              (deps1, maybe_intf, dep_graph))
 type m_timestamps =
   (Prims.string FStar_Pervasives_Native.option * Prims.string *
-    FStarC_Compiler_Util.time FStar_Pervasives_Native.option *
-    FStarC_Compiler_Util.time) Prims.list
+    FStarC_Compiler_Util.time_of_day FStar_Pervasives_Native.option *
+    FStarC_Compiler_Util.time_of_day) Prims.list
 let rec (tc_deps :
   modul_t ->
     stack_t ->

--- a/ocaml/fstar-lib/generated/FStarC_Interactive_PushHelper.ml
+++ b/ocaml/fstar-lib/generated/FStarC_Interactive_PushHelper.ml
@@ -153,7 +153,7 @@ let (repl_ld_tasks_of_deps :
   fun deps ->
     fun final_tasks ->
       let wrap fname =
-        let uu___ = FStarC_Compiler_Util.now () in
+        let uu___ = FStarC_Compiler_Util.get_time_of_day () in
         {
           FStarC_Interactive_Ide_Types.tf_fname = fname;
           FStarC_Interactive_Ide_Types.tf_modtime = uu___
@@ -224,7 +224,7 @@ let (deps_and_repl_ld_tasks_of_our_file :
                      else ());
                     (let uu___4 =
                        let uu___5 =
-                         let uu___6 = FStarC_Compiler_Util.now () in
+                         let uu___6 = FStarC_Compiler_Util.get_time_of_day () in
                          {
                            FStarC_Interactive_Ide_Types.tf_fname = intf;
                            FStarC_Interactive_Ide_Types.tf_modtime = uu___6

--- a/ocaml/fstar-lib/generated/FStarC_Main.ml
+++ b/ocaml/fstar-lib/generated/FStarC_Main.ml
@@ -519,7 +519,7 @@ let main : 'uuuuu . unit -> 'uuuuu =
          match () with
          | () ->
              (setup_hooks ();
-              (let uu___3 = FStarC_Compiler_Util.record_time go in
+              (let uu___3 = FStarC_Compiler_Util.record_time_ms go in
                match uu___3 with
                | (uu___4, time) ->
                    ((let uu___6 = FStarC_Options.query_stats () in

--- a/ocaml/fstar-lib/generated/FStarC_Profiling.ml
+++ b/ocaml/fstar-lib/generated/FStarC_Profiling.ml
@@ -86,7 +86,7 @@ let profile :
                    match () with
                    | () ->
                        (FStarC_Compiler_Effect.op_Colon_Equals c.running true;
-                        (let uu___5 = FStarC_Compiler_Util.record_time f in
+                        (let uu___5 = FStarC_Compiler_Util.record_time_ns f in
                          match uu___5 with
                          | (res, elapsed) ->
                              ((let uu___7 =
@@ -128,7 +128,9 @@ let (report_human : Prims.string -> counter -> unit) =
              " (Warning, some operations raised exceptions and we not accounted for)"
            else "") in
       let uu___ =
-        let uu___1 = FStarC_Compiler_Effect.op_Bang c.total_time in
+        let uu___1 =
+          let uu___2 = FStarC_Compiler_Effect.op_Bang c.total_time in
+          uu___2 / (Prims.parse_int "1000000") in
         FStarC_Compiler_Util.string_of_int uu___1 in
       FStarC_Compiler_Util.print4 "%s, profiled %s:\t %s ms%s\n" tag 
         c.cid uu___ warn

--- a/ocaml/fstar-lib/generated/FStarC_SMTEncoding_Encode.ml
+++ b/ocaml/fstar-lib/generated/FStarC_SMTEncoding_Encode.ml
@@ -7863,7 +7863,7 @@ let (encode_query :
                              "Encoding query formula {: %s\n" uu___6
                          else ());
                         (let uu___5 =
-                           FStarC_Compiler_Util.record_time
+                           FStarC_Compiler_Util.record_time_ms
                              (fun uu___6 ->
                                 FStarC_SMTEncoding_EncodeTerm.encode_formula
                                   q1 env1) in

--- a/ocaml/fstar-lib/generated/FStarC_SMTEncoding_Z3.ml
+++ b/ocaml/fstar-lib/generated/FStarC_SMTEncoding_Z3.ml
@@ -1292,7 +1292,7 @@ let (z3_job :
                          (fun uu___3 ->
                             match () with
                             | () ->
-                                FStarC_Compiler_Util.record_time
+                                FStarC_Compiler_Util.record_time_ms
                                   (fun uu___4 ->
                                      doZ3Exe log_file r fresh input
                                        label_messages queryid)) ()

--- a/ocaml/fstar-lib/generated/FStarC_Tactics_V1_Basic.ml
+++ b/ocaml/fstar-lib/generated/FStarC_Tactics_V1_Basic.ml
@@ -1478,7 +1478,7 @@ let (fresh : unit -> FStarC_BigInt.t FStarC_Tactics_Monad.tac) =
 let (curms : unit -> FStarC_BigInt.t FStarC_Tactics_Monad.tac) =
   fun uu___ ->
     let uu___1 =
-      let uu___2 = FStarC_Compiler_Util.now_ms () in
+      let uu___2 = FStarC_Compiler_Util.get_time_of_day_ms () in
       FStarC_BigInt.of_int_fs uu___2 in
     ret uu___1
 let (__tc :

--- a/ocaml/fstar-lib/generated/FStarC_Tactics_V2_Basic.ml
+++ b/ocaml/fstar-lib/generated/FStarC_Tactics_V2_Basic.ml
@@ -1859,7 +1859,7 @@ let meas :
       FStarC_Tactics_Monad.mk_tac
         (fun ps ->
            let uu___ =
-             FStarC_Compiler_Util.record_time
+             FStarC_Compiler_Util.record_time_ms
                (fun uu___1 -> FStarC_Tactics_Monad.run f ps) in
            match uu___ with
            | (r, ms) ->
@@ -1968,7 +1968,7 @@ let (curms : unit -> FStarC_BigInt.t FStarC_Tactics_Monad.tac) =
   fun uu___ ->
     (fun uu___ ->
        let uu___1 =
-         let uu___2 = FStarC_Compiler_Util.now_ms () in
+         let uu___2 = FStarC_Compiler_Util.get_time_of_day_ms () in
          FStarC_BigInt.of_int_fs uu___2 in
        Obj.magic
          (FStarC_Class_Monad.return FStarC_Tactics_Monad.monad_tac ()

--- a/ocaml/fstar-lib/generated/FStarC_TypeChecker_Cfg.ml
+++ b/ocaml/fstar-lib/generated/FStarC_TypeChecker_Cfg.ml
@@ -2340,13 +2340,13 @@ let (primop_time_reset : unit -> unit) =
   fun uu___ -> FStarC_Compiler_Util.smap_clear primop_time_map
 let (primop_time_count : Prims.string -> Prims.int -> unit) =
   fun nm ->
-    fun ms ->
+    fun ns ->
       let uu___ = FStarC_Compiler_Util.smap_try_find primop_time_map nm in
       match uu___ with
       | FStar_Pervasives_Native.None ->
-          FStarC_Compiler_Util.smap_add primop_time_map nm ms
-      | FStar_Pervasives_Native.Some ms0 ->
-          FStarC_Compiler_Util.smap_add primop_time_map nm (ms0 + ms)
+          FStarC_Compiler_Util.smap_add primop_time_map nm ns
+      | FStar_Pervasives_Native.Some ns0 ->
+          FStarC_Compiler_Util.smap_add primop_time_map nm (ns0 + ns)
 let (fixto : Prims.int -> Prims.string -> Prims.string) =
   fun n ->
     fun s ->
@@ -2361,7 +2361,7 @@ let (primop_time_report : unit -> Prims.string) =
   fun uu___ ->
     let pairs =
       FStarC_Compiler_Util.smap_fold primop_time_map
-        (fun nm -> fun ms -> fun rest -> (nm, ms) :: rest) [] in
+        (fun nm -> fun ns -> fun rest -> (nm, ns) :: rest) [] in
     let pairs1 =
       FStarC_Compiler_Util.sort_with
         (fun uu___1 ->
@@ -2372,10 +2372,12 @@ let (primop_time_report : unit -> Prims.string) =
       (fun uu___1 ->
          fun rest ->
            match uu___1 with
-           | (nm, ms) ->
+           | (nm, ns) ->
                let uu___2 =
                  let uu___3 =
-                   let uu___4 = FStarC_Compiler_Util.string_of_int ms in
+                   let uu___4 =
+                     FStarC_Compiler_Util.string_of_int
+                       (ns / (Prims.parse_int "1000000")) in
                    fixto (Prims.of_int (10)) uu___4 in
                  FStarC_Compiler_Util.format2 "%sms --- %s\n" uu___3 nm in
                FStarC_Compiler_String.op_Hat uu___2 rest) pairs1 ""

--- a/ocaml/fstar-lib/generated/FStarC_TypeChecker_Rel.ml
+++ b/ocaml/fstar-lib/generated/FStarC_TypeChecker_Rel.ml
@@ -14428,7 +14428,8 @@ let (solve_and_commit :
              wl.attempting in
          FStarC_Compiler_Util.print1 "solving problems %s {\n" uu___2
        else ());
-      (let uu___1 = FStarC_Compiler_Util.record_time (fun uu___2 -> solve wl) in
+      (let uu___1 =
+         FStarC_Compiler_Util.record_time_ms (fun uu___2 -> solve wl) in
        match uu___1 with
        | (sol, ms) ->
            ((let uu___3 = FStarC_Compiler_Effect.op_Bang dbg_RelBench in
@@ -14440,7 +14441,7 @@ let (solve_and_commit :
             (match sol with
              | Success (deferred, defer_to_tac, implicits) ->
                  let uu___3 =
-                   FStarC_Compiler_Util.record_time
+                   FStarC_Compiler_Util.record_time_ms
                      (fun uu___4 -> FStarC_Syntax_Unionfind.commit tx) in
                  (match uu___3 with
                   | ((), ms1) ->
@@ -14727,7 +14728,7 @@ let (sub_or_eq_comp :
                     let prob1 = FStarC_TypeChecker_Common.CProb prob in
                     (def_check_prob "sub_comp" prob1;
                      (let uu___5 =
-                        FStarC_Compiler_Util.record_time
+                        FStarC_Compiler_Util.record_time_ms
                           (fun uu___6 ->
                              let uu___7 =
                                solve_and_commit (singleton wl1 prob1 true)

--- a/ocaml/fstar-lib/generated/FStarC_TypeChecker_TcTerm.ml
+++ b/ocaml/fstar-lib/generated/FStarC_TypeChecker_TcTerm.ml
@@ -1894,7 +1894,7 @@ let rec (tc_term :
            uu___4 uu___5 uu___6 uu___7
        else ());
       (let uu___2 =
-         FStarC_Compiler_Util.record_time
+         FStarC_Compiler_Util.record_time_ms
            (fun uu___3 ->
               tc_maybe_toplevel_term
                 {

--- a/ocaml/fstar-lib/generated/FStarC_Universal.ml
+++ b/ocaml/fstar-lib/generated/FStarC_Universal.ml
@@ -1150,7 +1150,7 @@ let (tc_one_file :
                  if uu___2
                  then (FStar_Pervasives_Native.None, Prims.int_zero)
                  else
-                   FStarC_Compiler_Util.record_time
+                   FStarC_Compiler_Util.record_time_ms
                      (fun uu___4 ->
                         with_env env1
                           (fun env2 ->
@@ -1164,7 +1164,7 @@ let (tc_one_file :
              if uu___1
              then (env1, Prims.int_zero)
              else
-               FStarC_Compiler_Util.record_time
+               FStarC_Compiler_Util.record_time_ms
                  (fun uu___3 ->
                     let uu___4 =
                       with_env env1
@@ -1173,7 +1173,12 @@ let (tc_one_file :
                              tcmod) in
                     match uu___4 with | (env2, uu___5) -> env2) in
            let tc_source_file uu___1 =
-             let uu___2 = parse env pre_fn fn in
+             let uu___2 =
+               let uu___3 =
+                 let uu___4 = FStarC_Parser_Dep.module_name_of_file fn in
+                 FStar_Pervasives_Native.Some uu___4 in
+               FStarC_Profiling.profile (fun uu___4 -> parse env pre_fn fn)
+                 uu___3 "FStarC.Universal.tc_source_file.parse" in
              match uu___2 with
              | (fmod, env1) ->
                  let mii =
@@ -1223,7 +1228,7 @@ let (tc_one_file :
                            fmod.FStarC_Syntax_Syntax.name in
                        FStar_Pervasives_Native.Some uu___6 in
                      FStarC_Profiling.profile (fun uu___6 -> check env1)
-                       uu___5 "FStarC.Universal.tc_source_file" in
+                       uu___5 "FStarC.Universal.tc_source_file.check" in
                    match uu___4 with
                    | ((tcmod, smt_decls), env2) ->
                        let tc_time = Prims.int_zero in

--- a/ocaml/fstar-tests/generated/FStarC_Tests_Data.ml
+++ b/ocaml/fstar-tests/generated/FStarC_Tests_Data.ml
@@ -48,7 +48,7 @@ let (run_all : unit -> unit) =
   fun uu___ ->
     FStarC_Compiler_Util.print_string "data tests\n";
     (let uu___2 =
-       FStarC_Compiler_Util.record_time
+       FStarC_Compiler_Util.record_time_ms
          (fun uu___3 ->
             let uu___4 =
               Obj.magic
@@ -65,7 +65,7 @@ let (run_all : unit -> unit) =
              FStarC_Class_Show.show FStarC_Class_Show.showable_int ms in
            FStarC_Compiler_Util.print1 "FlatSet insert: %s\n" uu___4);
           (let uu___4 =
-             FStarC_Compiler_Util.record_time
+             FStarC_Compiler_Util.record_time_ms
                (fun uu___5 ->
                   all_mem nn
                     (FStarC_Compiler_FlatSet.setlike_flat_set
@@ -76,7 +76,7 @@ let (run_all : unit -> unit) =
                    FStarC_Class_Show.show FStarC_Class_Show.showable_int ms1 in
                  FStarC_Compiler_Util.print1 "FlatSet all_mem: %s\n" uu___6);
                 (let uu___6 =
-                   FStarC_Compiler_Util.record_time
+                   FStarC_Compiler_Util.record_time_ms
                      (fun uu___7 ->
                         all_remove nn
                           (FStarC_Compiler_FlatSet.setlike_flat_set
@@ -102,7 +102,7 @@ let (run_all : unit -> unit) =
                        then failwith "FlatSet all_remove failed"
                        else ());
                       (let uu___10 =
-                         FStarC_Compiler_Util.record_time
+                         FStarC_Compiler_Util.record_time_ms
                            (fun uu___11 ->
                               let uu___12 =
                                 Obj.magic
@@ -121,7 +121,7 @@ let (run_all : unit -> unit) =
                              FStarC_Compiler_Util.print1 "RBSet insert: %s\n"
                                uu___12);
                             (let uu___12 =
-                               FStarC_Compiler_Util.record_time
+                               FStarC_Compiler_Util.record_time_ms
                                  (fun uu___13 ->
                                     all_mem nn
                                       (FStarC_Compiler_RBSet.setlike_rbset
@@ -134,7 +134,7 @@ let (run_all : unit -> unit) =
                                    FStarC_Compiler_Util.print1
                                      "RBSet all_mem: %s\n" uu___14);
                                   (let uu___14 =
-                                     FStarC_Compiler_Util.record_time
+                                     FStarC_Compiler_Util.record_time_ms
                                        (fun uu___15 ->
                                           all_remove nn
                                             (FStarC_Compiler_RBSet.setlike_rbset

--- a/src/basic/FStarC.Compiler.Util.fsti
+++ b/src/basic/FStarC.Compiler.Util.fsti
@@ -25,14 +25,19 @@ exception Impos
 val max_int: int
 val return_all: 'a -> ML 'a
 
-type time
-val now : unit -> time
-val now_ms : unit -> int
-val time_diff: time -> time -> float&int
-val record_time: (unit -> 'a) -> ('a & int)
-val is_before: time -> time -> bool
-val get_file_last_modification_time: string -> time
-val string_of_time: time -> string
+type time_ns
+val now_ns : unit -> time_ns
+val time_diff_ms: time_ns -> time_ns -> int
+val time_diff_ns: time_ns -> time_ns -> int
+val record_time_ns: (unit -> 'a) -> ('a & int)
+val record_time_ms: (unit -> 'a) -> ('a & int)
+
+type time_of_day
+val get_time_of_day : unit -> time_of_day
+val get_time_of_day_ms : unit -> int
+val is_before: time_of_day -> time_of_day -> bool
+val get_file_last_modification_time: string -> time_of_day
+val string_of_time_of_day: time_of_day -> string
 
 (* generic utils *)
 (* smap: map from string keys *)

--- a/src/basic/FStarC.Profiling.fst
+++ b/src/basic/FStarC.Profiling.fst
@@ -74,7 +74,7 @@ let profile  (f: unit -> 'a) (module_name:option string) (cid:string) : 'a =
        else begin
          try
            c.running := true; //mark the counter as running
-           let res, elapsed = BU.record_time f in
+           let res, elapsed = BU.record_time_ns f in
            c.total_time := !c.total_time + elapsed; //accumulate the time
            c.running := false; //finally mark the counter as not running
            res
@@ -105,7 +105,7 @@ let report_human tag c =
     BU.print4 "%s, profiled %s:\t %s ms%s\n"
                   tag
                   c.cid
-                  (BU.string_of_int (!c.total_time))
+                  (BU.string_of_int (!c.total_time / 1000000))
                   warn
 
 let report tag c =

--- a/src/fstar/FStarC.Interactive.Ide.Types.fst
+++ b/src/fstar/FStarC.Interactive.Ide.Types.fst
@@ -89,7 +89,7 @@ type optmod_t = option Syntax.Syntax.modul
 
 type timed_fname =
   { tf_fname: string;
-    tf_modtime: time }
+    tf_modtime: time_of_day }
 
 (** Every snapshot pushed in the repl stack is annotated with one of these.  The
 ``LD``-prefixed (“Load Dependency”) onces are useful when loading or updating
@@ -166,7 +166,7 @@ type grepl_state = { grepl_repls: U.psmap repl_state; grepl_stdin: stream_reader
 (* REPL tasks and states *)
 (*************************)
 
-let t0 = Util.now ()
+let t0 = Util.get_time_of_day ()
 
 (** Create a timed_fname with a dummy modtime **)
 let dummy_tf_of_fname fname =
@@ -175,7 +175,7 @@ let dummy_tf_of_fname fname =
 
 let string_of_timed_fname { tf_fname = fname; tf_modtime = modtime } =
   if modtime = t0 then Util.format1 "{ %s }" fname
-  else Util.format2 "{ %s; %s }" fname (string_of_time modtime)
+  else Util.format2 "{ %s; %s }" fname (string_of_time_of_day modtime)
 
 let string_of_repl_task = function
   | LDInterleaved (intf, impl) ->

--- a/src/fstar/FStarC.Interactive.Legacy.fst
+++ b/src/fstar/FStarC.Interactive.Legacy.fst
@@ -240,7 +240,7 @@ let deps_of_our_file filename =
   deps, maybe_intf, dep_graph
 
 (* .fsti name (optional) * .fst name * .fsti recorded timestamp (optional) * .fst recorded timestamp  *)
-type m_timestamps = list (option string & string & option time & time)
+type m_timestamps = list (option string & string & option time_of_day & time_of_day)
 
 (*
  * type check remaining dependencies and record the timestamps.
@@ -286,7 +286,7 @@ let rec tc_deps (m:modul_t) (stack:stack_t)
  *)
 let update_deps (filename:string) (m:modul_t) (stk:stack_t) (env:env_t) (ts:m_timestamps)
   : (stack_t & env_t & m_timestamps) =
-  let is_stale (intf:option string) (impl:string) (intf_t:option time) (impl_t:time) :bool =
+  let is_stale (intf:option string) (impl:string) (intf_t:option time_of_day) (impl_t:time_of_day) :bool =
     let impl_mt = get_file_last_modification_time impl in
     (is_before impl_t impl_mt ||
      (match intf, intf_t with

--- a/src/fstar/FStarC.Interactive.PushHelper.fst
+++ b/src/fstar/FStarC.Interactive.PushHelper.fst
@@ -47,7 +47,7 @@ let set_check_kind env check_kind =
 
 (** Build a list of dependency loading tasks from a list of dependencies **)
 let repl_ld_tasks_of_deps (deps: list string) (final_tasks: list repl_task) =
-  let wrap fname = { tf_fname = fname; tf_modtime = U.now () } in
+  let wrap fname = { tf_fname = fname; tf_modtime = U.get_time_of_day () } in
   let rec aux (deps:list string) (final_tasks:list repl_task)
     : list repl_task =
     match deps with
@@ -86,7 +86,7 @@ let deps_and_repl_ld_tasks_of_our_file filename
       if not (Parser.Dep.is_implementation impl) then
          raise_error0 Errors.Fatal_MissingImplementation
            (U.format1 "Expecting an implementation, got %s" impl);
-      [LDInterfaceOfCurrentFile ({ tf_fname = intf; tf_modtime = U.now () }) ]
+      [LDInterfaceOfCurrentFile ({ tf_fname = intf; tf_modtime = U.get_time_of_day () }) ]
     | [impl] ->
       []
     | _ ->

--- a/src/fstar/FStarC.Main.fst
+++ b/src/fstar/FStarC.Main.fst
@@ -362,7 +362,7 @@ let handle_error e =
 let main () =
   try
     setup_hooks ();
-    let _, time = Util.record_time go in
+    let _, time = Util.record_time_ms go in
     if FStarC.Options.query_stats()
     then Util.print2_error "TOTAL TIME %s ms: %s\n"
               (FStarC.Compiler.Util.string_of_int time)

--- a/src/parser/FStarC.Parser.ParseIt.fsti
+++ b/src/parser/FStarC.Parser.ParseIt.fsti
@@ -30,11 +30,11 @@ type input_frag = {
     frag_col:int
 }
 
-val read_vfs_entry : string -> option (time & string)
+val read_vfs_entry : string -> option (time_of_day & string)
 // This lets the ide tell us about edits not (yet) reflected on disk.
 val add_vfs_entry: fname:string -> contents:string -> unit
 // This reads mtimes from the VFS as well
-val get_file_last_modification_time: fname:string -> time
+val get_file_last_modification_time: fname:string -> time_of_day
 
 type parse_frag =
     | Filename of filename

--- a/src/smtencoding/FStarC.SMTEncoding.Encode.fst
+++ b/src/smtencoding/FStarC.SMTEncoding.Encode.fst
@@ -2016,7 +2016,7 @@ let encode_query use_env_msg (tcenv:Env.env) (q:S.term)
     let env_decls, env = encode_env_bindings env bindings in
     if Debug.medium () || !dbg_SMTEncoding || !dbg_SMTQuery
     then BU.print1 "Encoding query formula {: %s\n" (show q);
-    let (phi, qdecls), ms = BU.record_time (fun () -> encode_formula q env) in
+    let (phi, qdecls), ms = BU.record_time_ms (fun () -> encode_formula q env) in
     let labels, phi = ErrorReporting.label_goals use_env_msg (Env.get_range tcenv) phi in
     let label_prefix, label_suffix = encode_labels labels in
     let caption =

--- a/src/smtencoding/FStarC.SMTEncoding.Z3.fst
+++ b/src/smtencoding/FStarC.SMTEncoding.Z3.fst
@@ -752,7 +752,7 @@ let z3_job
     Profiling.profile
       (fun () ->
         try
-          BU.record_time (fun () -> doZ3Exe log_file r fresh input label_messages queryid)
+          BU.record_time_ms (fun () -> doZ3Exe log_file r fresh input label_messages queryid)
         with e ->
           refresh None; //refresh the solver but don't handle the exception; it'll be caught upstream
           raise e

--- a/src/tactics/FStarC.Tactics.V1.Basic.fst
+++ b/src/tactics/FStarC.Tactics.V1.Basic.fst
@@ -596,7 +596,7 @@ let fresh () : tac Z.t =
     ret (Z.of_int_fs n)))
 
 let curms () : tac Z.t =
-    ret (BU.now_ms () |> Z.of_int_fs)
+    ret (BU.get_time_of_day_ms () |> Z.of_int_fs)
 
 (* Annoying duplication here *)
 let __tc (e : env) (t : term) : tac (term & typ & guard_t) =

--- a/src/tactics/FStarC.Tactics.V2.Basic.fst
+++ b/src/tactics/FStarC.Tactics.V2.Basic.fst
@@ -578,7 +578,7 @@ let is_false t =
 
 let meas (s:string) (f : tac 'a) : tac 'a =
   mk_tac (fun ps ->
-    let (r, ms) = BU.record_time (fun () -> Tactics.Monad.run f ps) in
+    let (r, ms) = BU.record_time_ms (fun () -> Tactics.Monad.run f ps) in
     BU.print2 "++ Tactic %s ran in \t\t%sms\n" s (show ms);
     r)
 
@@ -606,7 +606,7 @@ let fresh () : tac Z.t =
   return (Z.of_int_fs n)
 
 let curms () : tac Z.t =
-    return (BU.now_ms () |> Z.of_int_fs)
+    return (BU.get_time_of_day_ms () |> Z.of_int_fs)
 
 (* Annoying duplication here *)
 let __tc (e : env) (t : term) : tac (term & typ & guard_t) =

--- a/src/tests/FStarC.Tests.Data.fst
+++ b/src/tests/FStarC.Tests.Data.fst
@@ -44,21 +44,21 @@ let nn = 10000
 
 let run_all () =
   BU.print_string "data tests\n";
-  let (f, ms) = BU.record_time (fun () -> insert nn (empty () <: FlatSet.t int)) in
+  let (f, ms) = BU.record_time_ms (fun () -> insert nn (empty () <: FlatSet.t int)) in
   BU.print1 "FlatSet insert: %s\n" (show ms);
-  let (f_ok, ms) = BU.record_time (fun () -> all_mem nn f) in
+  let (f_ok, ms) = BU.record_time_ms (fun () -> all_mem nn f) in
   BU.print1 "FlatSet all_mem: %s\n" (show ms);
-  let (f, ms) = BU.record_time (fun () -> all_remove nn f) in
+  let (f, ms) = BU.record_time_ms (fun () -> all_remove nn f) in
   BU.print1 "FlatSet all_remove: %s\n" (show ms);
 
   if not f_ok then failwith "FlatSet all_mem failed";
   if not (is_empty f) then failwith "FlatSet all_remove failed";
 
-  let (rb, ms) = BU.record_time (fun () -> insert nn (empty () <: RBSet.t int)) in
+  let (rb, ms) = BU.record_time_ms (fun () -> insert nn (empty () <: RBSet.t int)) in
   BU.print1 "RBSet insert: %s\n" (show ms);
-  let (rb_ok, ms) = BU.record_time (fun () -> all_mem nn rb) in
+  let (rb_ok, ms) = BU.record_time_ms (fun () -> all_mem nn rb) in
   BU.print1 "RBSet all_mem: %s\n" (show ms);
-  let (rb, ms) = BU.record_time (fun () -> all_remove nn rb) in
+  let (rb, ms) = BU.record_time_ms (fun () -> all_remove nn rb) in
   BU.print1 "RBSet all_remove: %s\n" (show ms);
 
   if not rb_ok then failwith "RBSet all_mem failed";

--- a/src/typechecker/FStarC.TypeChecker.Cfg.fst
+++ b/src/typechecker/FStarC.TypeChecker.Cfg.fst
@@ -302,10 +302,10 @@ let primop_time_map : BU.smap int = BU.smap_create 50
 let primop_time_reset () =
     BU.smap_clear primop_time_map
 
-let primop_time_count (nm : string) (ms : int) : unit =
+let primop_time_count (nm : string) (ns : int) : unit =
     match BU.smap_try_find primop_time_map nm with
-    | None     -> BU.smap_add primop_time_map nm ms
-    | Some ms0 -> BU.smap_add primop_time_map nm (ms0 + ms)
+    | None     -> BU.smap_add primop_time_map nm ns
+    | Some ns0 -> BU.smap_add primop_time_map nm (ns0 + ns)
 
 let fixto n s =
     if String.length s < n
@@ -313,9 +313,9 @@ let fixto n s =
     else s
 
 let primop_time_report () : string =
-    let pairs = BU.smap_fold primop_time_map (fun nm ms rest -> (nm, ms)::rest) [] in
+    let pairs = BU.smap_fold primop_time_map (fun nm ns rest -> (nm, ns)::rest) [] in
     let pairs = BU.sort_with (fun (_, t1) (_, t2) -> t1 - t2) pairs in
-    List.fold_right (fun (nm, ms) rest -> (BU.format2 "%sms --- %s\n" (fixto 10 (BU.string_of_int ms)) nm) ^ rest) pairs ""
+    List.fold_right (fun (nm, ns) rest -> (BU.format2 "%sms --- %s\n" (fixto 10 (BU.string_of_int (ns / 1000000))) nm) ^ rest) pairs ""
 
 let extendable_primops_dirty : ref bool = BU.mk_ref true
 

--- a/src/typechecker/FStarC.TypeChecker.Rel.fst
+++ b/src/typechecker/FStarC.TypeChecker.Rel.fst
@@ -4836,13 +4836,13 @@ let solve_and_commit wl err
   if !dbg_RelBench then
     BU.print1 "solving problems %s {\n"
       (FStarC.Common.string_of_list (fun p -> string_of_int (p_pid p)) wl.attempting);
-  let (sol, ms) = BU.record_time (fun () -> solve wl) in
+  let (sol, ms) = BU.record_time_ms (fun () -> solve wl) in
   if !dbg_RelBench then
     BU.print1 "} solved in %s ms\n" (string_of_int ms);
 
   match sol with
     | Success (deferred, defer_to_tac, implicits) ->
-      let ((), ms) = BU.record_time (fun () -> UF.commit tx) in
+      let ((), ms) = BU.record_time_ms (fun () -> UF.commit tx) in
       if !dbg_RelBench then
         BU.print1 "committed in %s ms\n" (string_of_int ms);
       Some (deferred, defer_to_tac, implicits)
@@ -4925,7 +4925,7 @@ let sub_or_eq_comp env (use_eq:bool) c1 c2 =
     let wl = { wl with repr_subcomp_allowed = true } in
     let prob = CProb prob in
     def_check_prob "sub_comp" prob;
-    let (r, ms) = BU.record_time
+    let (r, ms) = BU.record_time_ms
                   (fun () -> with_guard env prob <| solve_and_commit (singleton wl prob true)  (fun _ -> None))
     in
     if !dbg_Rel || !dbg_RelTop || !dbg_RelBench then

--- a/src/typechecker/FStarC.TypeChecker.TcTerm.fst
+++ b/src/typechecker/FStarC.TypeChecker.TcTerm.fst
@@ -738,7 +738,7 @@ let rec tc_term env e =
           (tag_of (SS.compress e))
           (print_expected_ty_str env);
 
-    let r, ms = BU.record_time (fun () ->
+    let r, ms = BU.record_time_ms (fun () ->
                     tc_maybe_toplevel_term ({env with top_level=false}) e) in
     if Debug.medium () then begin
         BU.print4 "(%s) } tc_term of %s (%s) took %sms\n" (Range.string_of_range <| Env.get_range env)


### PR DESCRIPTION
This PR uses the mtime package for measuring time, providing more accurate profiling. Previously, we were accumulating only millisecond timings in the profiling counters, which led to incorrect accounting.

Thanks to @LukeXuan for reporting the issue.


**Note: This PR adds mtime to the list of opam dependences**