### PR TITLE
CI: switch Dockerfiles back to Ubuntu 22.04 LTS

### DIFF
--- a/.devcontainer/minimal.Dockerfile
+++ b/.devcontainer/minimal.Dockerfile
@@ -1,4 +1,5 @@
-FROM ubuntu:latest
+# FIXME: z3.4.8.5-1 can no longer be installed on Ubuntu 24.04 because python3-distutils disappeared, and the z3 opam package has not been fixed for version 4.8.5, and 23.10 and all prior non-LTS are now EOL. Reverting to the previous LTS
+FROM ubuntu:22.04
 
 SHELL ["/bin/bash", "-c"]
 

--- a/.devcontainer/minimal.Dockerfile
+++ b/.devcontainer/minimal.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:23.10
+FROM ubuntu:latest
 
 SHELL ["/bin/bash", "-c"]
 

--- a/.docker/base.Dockerfile
+++ b/.docker/base.Dockerfile
@@ -8,8 +8,8 @@
 # and it is copied into the home directory on the image. CI jobs
 # will NOT use this file.
 
-# We always try to build against the most current ubuntu image.
-FROM ubuntu:latest
+# FIXME: z3.4.8.5-1 can no longer be installed on Ubuntu 24.04 because python3-distutils disappeared, and the z3 opam package has not been fixed for version 4.8.5, and 23.10 and all prior non-LTS are now EOL. Reverting to the previous LTS
+FROM ubuntu:22.04
 
 RUN apt-get update
 

--- a/.docker/base.Dockerfile
+++ b/.docker/base.Dockerfile
@@ -9,8 +9,7 @@
 # will NOT use this file.
 
 # We always try to build against the most current ubuntu image.
-# FIXME: Broken with 24.04, fixing it to 23.10 so we can keep working
-FROM ubuntu:23.10
+FROM ubuntu:latest
 
 RUN apt-get update
 

--- a/.docker/nu_base.Dockerfile
+++ b/.docker/nu_base.Dockerfile
@@ -1,6 +1,6 @@
 # For check-world workflow, should be coallesced to the other base.
 # This could definitely use a big cleanup too.
-FROM ubuntu:23.10
+FROM ubuntu:latest
 
 RUN apt-get update
 

--- a/.docker/nu_base.Dockerfile
+++ b/.docker/nu_base.Dockerfile
@@ -1,6 +1,7 @@
 # For check-world workflow, should be coallesced to the other base.
 # This could definitely use a big cleanup too.
-FROM ubuntu:latest
+# FIXME: z3.4.8.5-1 can no longer be installed on Ubuntu 24.04 because python3-distutils disappeared, and the z3 opam package has not been fixed for version 4.8.5, and 23.10 and all prior non-LTS are now EOL. Reverting to the previous LTS
+FROM ubuntu:22.04
 
 RUN apt-get update
 


### PR DESCRIPTION
z3.4.8.5-1 can no longer be installed on Ubuntu 24.04 because python3-distutils disappeared, and the z3 opam package has not been fixed for version 4.8.5, and 23.10 and all prior non-LTS are now EOL.  So, this PR reverts the Dockerfiles
to the previous Ubuntu LTS, i.e. 22.04

Commit 8d8149fa5517f1e3a4b923954c1354dadb675389 should be reverted once a new opam package for z3 4.8.5 appears, or we upgrade to a new z3 (see #2974)
