### PR TITLE
--ocamlenv: fix for Windows, cannot use exec

### DIFF
--- a/ocaml/fstar-lib/FStarC_Compiler_Util.ml
+++ b/ocaml/fstar-lib/FStarC_Compiler_Util.ml
@@ -1171,7 +1171,16 @@ let array_length (l:'a FStar_ImmutableArray_Base.t) = FStar_ImmutableArray_Base.
 let array_index (l:'a FStar_ImmutableArray_Base.t) (i:Z.t) = FStar_ImmutableArray_Base.index l i
 
 let putenv k v = Unix.putenv k v
-let execvp c args = Unix.execvp c (Array.of_list args)
+let create_process (prog:string) (args:string list) : Z.t =
+  let pid = Unix.create_process prog (Array.of_list args) Unix.stdin Unix.stdout Unix.stderr in
+  Z.of_int pid
+
+let waitpid (pid:Z.t) : (Z.t, Z.t) FStar_Pervasives.either =
+  let pid, s = Unix.waitpid [] (Z.to_int pid) in
+  match s with
+  | WEXITED rc -> FStar_Pervasives.Inl (Z.of_int rc)
+  | WSIGNALED rc -> FStar_Pervasives.Inr (Z.of_int rc)
+  | WSTOPPED _ -> failwith "waitpid: unexpected WSTOPPED, should not happen with empty flags"
 
 let exn_is_enoent (e:exn) : bool =
   match e with

--- a/ocaml/fstar-lib/generated/FStarC_OCaml.ml
+++ b/ocaml/fstar-lib/generated/FStarC_OCaml.ml
@@ -28,8 +28,12 @@ let exec_in_ocamlenv : 'a . Prims.string -> Prims.string Prims.list -> 'a =
     fun args ->
       let new_ocamlpath1 = new_ocamlpath () in
       FStarC_Compiler_Util.putenv "OCAMLPATH" new_ocamlpath1;
-      FStarC_Compiler_Util.execvp cmd (cmd :: args);
-      failwith "execvp failed"
+      (let pid = FStarC_Compiler_Util.create_process cmd (cmd :: args) in
+       let rc = FStarC_Compiler_Util.waitpid pid in
+       match rc with
+       | FStar_Pervasives.Inl rc1 -> FStarC_Compiler_Effect.exit rc1
+       | FStar_Pervasives.Inr uu___1 ->
+           FStarC_Compiler_Effect.exit Prims.int_one)
 let (app_lib : Prims.string) = "fstar.lib"
 let (plugin_lib : Prims.string) = "fstar.lib"
 let (wstr : Prims.string) = "-8"

--- a/src/basic/FStarC.Compiler.Util.fsti
+++ b/src/basic/FStarC.Compiler.Util.fsti
@@ -398,7 +398,10 @@ val print_array (f: 'a -> string) (s:FStar.ImmutableArray.Base.t 'a) : string
 val array_length (s:FStar.ImmutableArray.Base.t 'a) : FStarC.BigInt.t
 val array_index (s:FStar.ImmutableArray.Base.t 'a) (i:FStarC.BigInt.t) : 'a
 
+(* From OCaml's Unix module (simplified).
+NOTE: execv and friends are evil on Windows, do not use them. *)
 val putenv : string -> string -> unit
-val execvp : string -> list string -> unit // will return only on error
+val create_process : prog:string -> args:(list string) -> (*pid:*)int
+val waitpid : pid:int -> (either int int) // Inl: exited, Inr: killed by signal
 
 val exn_is_enoent (e:exn) : bool

--- a/src/fstar/FStarC.OCaml.fst
+++ b/src/fstar/FStarC.OCaml.fst
@@ -40,10 +40,13 @@ let new_ocamlpath () : string =
 
 let exec_in_ocamlenv #a (cmd : string) (args : list string) : a =
   let new_ocamlpath = new_ocamlpath () in
-  (* Update OCAMLPATH and run (exec) the command *)
+  (* Update OCAMLPATH and run the command *)
   Util.putenv "OCAMLPATH" new_ocamlpath;
-  Util.execvp cmd (cmd :: args);
-  failwith "execvp failed"
+  let pid = Util.create_process cmd (cmd :: args) in
+  let rc = Util.waitpid pid in
+  match rc with
+  | Inl rc -> exit rc
+  | Inr _ -> exit 1
 
 let app_lib = "fstar.lib"
 let plugin_lib = "fstar.lib"


### PR DESCRIPTION
OCaml's Unix module exposes an execv family of functions, which "seem" to work
correctly on Windows, but have a critical discrepancy: the new process
is not really replacing the current one, but instead being executed on
the side, and the parent process will *not even wait* for the spawned
process. This usually wreaks havoc.
    
This PR replaces our use of execv by Unix.create_process + Unix.waitpid,
both of which seem to work correctly on Windows too.
    
See https://lacamb.re/blog/windows_ocaml_execvp.html
    
Thanks @tahina-pro for figuring this out.