### PR TITLE
Replace Div test with terminating Collatz conjecture

### DIFF
--- a/tests/extraction/Div.fst
+++ b/tests/extraction/Div.fst
@@ -1,7 +1,18 @@
 module Div
+open FStar.Mul
+
+let collatz_body (f: (int -> Dv int)) (i: int) : Dv int =
+  if i = 1
+  then i
+  else if i % 2 = 0
+  then f (i / 2)
+  else f (3 * i + 1)
+
+let rec collatz (i: int) : Dv int = collatz_body collatz i
 
 let rec f () : Dv int = f ()
 
 let _ =
-  let _ = f () in
+  let x = collatz 6171 in
+  let y = if x = 1 then x else f () in
   1

--- a/tests/extraction/Makefile
+++ b/tests/extraction/Makefile
@@ -9,14 +9,6 @@ RUN += InlineLet.fst
 
 include $(FSTAR_ROOT)/mk/test.mk
 
-# Overriding the default rule for this one. We need to wrap this in a timeout.
-$(OUTPUT_DIR)/Div.out: $(OUTPUT_DIR)/Div.exe
-	$(call msg,TIMEOUT,$<)
-	$(Q)timeout 1 $(OUTPUT_DIR)/Div.exe ; \
-	  RC=$$? ;\
-	  if ! [ $$RC -eq 124 ]; then echo "ERROR: Div.exe terminated!?!?!"; false; fi
-	$(Q)touch $@
-
 # all: inline_let all_cmi Eta_expand.test Div.test ExtractAs.test
 
 # %.exe: %.fst


### PR DESCRIPTION
Catching signals is inconsistent on Windows. In particular, the extracted `div.exe` failed to catch the TERM signal sent by `timeout` on Cygwin with the official opam 2.3 and OCaml 5.2.1.
So, this PR drops `timeout` in favor of a more "traditional", terminating, `Div` program.
