### PR TITLE
Disable Div test on Windows

### DIFF
--- a/tests/extraction/Makefile
+++ b/tests/extraction/Makefile
@@ -3,7 +3,14 @@ FSTAR_ROOT ?= ../..
 SUBDIRS += cmi
 
 RUN += Eta_expand.fst
+
+# The Div test is based on testing a non-terminating program and
+# sending it a signal to interrupt it, which is not well-supported on
+# Windows.
+ifneq ($(OS),Windows_NT)
 RUN += Div.fst
+endif
+
 RUN += ExtractAs.fst
 RUN += InlineLet.fst
 


### PR DESCRIPTION
Catching signals is inconsistent on Windows. In particular, the extracted div.exe failed to catch the TERM signal sent by timeout on Cygwin with the official opam 2.3 and OCaml 5.2.1.

This PR disables this test on Windows (thanks @mtzguido for your suggestion.) This PR supersedes #3628
 
With that, I have `./everest make` and `./everest test` successfully work on Windows+Cygwin with official opam 2.3: https://github.com/project-everest/everest/actions/runs/12239757622