### PR TITLE
Remove squash axioms.

### DIFF
--- a/ulib/FStar.IndefiniteDescription.fst
+++ b/ulib/FStar.IndefiniteDescription.fst
@@ -1,5 +1,5 @@
 (*
-   Copyright 2008-2018 Microsoft Research
+   Copyright 2008-2024 Microsoft Research
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -19,49 +19,36 @@ module FStar.IndefiniteDescription
 /// Indefinite description is an axiom that allows picking a witness
 /// for existentially quantified predicate. See the interface for more
 /// context.
-///
-open FStar.Classical
-open FStar.Squash
 
-(** The main axiom:
+(** A proof for squash p can be eliminated to get p in the Ghost effect *)
+irreducible let elim_squash (#p:Type u#a) (s:squash p) : GTot p = admit ()
 
-    Given a classical proof of [exists x. p x], we can exhibit an erased
+(** Given a classical proof of [exists x. p x], we can exhibit an erased
     (computationally irrelevant) a witness [x:erased a] validating
-    [p x].
-*)
+    [p x].  *)
 irreducible
-let indefinite_description_tot (a:Type) (p:(a -> prop) { exists x. p x })
-  : Tot (w:Ghost.erased a{ p w })
-  = admit() //this is an axiom
-
-(** A version in ghost is easily derivable *)
 let indefinite_description_ghost (a: Type) (p: (a -> prop) { exists x. p x })
   : GTot (x: a { p x })
-  = let w = indefinite_description_tot a p in
-    let x = Ghost.reveal w in
+  = let h : squash (exists x. p x) = () in
+    let h : (exists x. p x) = elim_squash h in
+    let (| x, h |) : x:a & p x = elim_squash h in
     x
+
+(** A version in ghost is easily derivable *)
+let indefinite_description_tot (a:Type) (p:(a -> prop) { exists x. p x })
+  : Tot (w:Ghost.erased a{ p w })
+  = Ghost.hide (indefinite_description_ghost a p)
 
 (** Indefinite description entails the a strong form of the excluded
     middle, i.e., one can case-analyze the truth of a proposition
     (only in [Ghost]) *)
 let strong_excluded_middle (p: Type0) : GTot (b: bool{b = true <==> p}) =
-  let aux (p: Type0) : Lemma (exists b. b = true <==> p) =
-    give_proof (bind_squash (get_proof (l_or p (~p)))
-          (fun (b: l_or p (~p)) ->
-              bind_squash b
-                (fun (b': Prims.sum p (~p)) ->
-                    match b' with
-                    | Prims.Left hp ->
-                      give_witness hp;
-                      exists_intro (fun b -> b = true <==> p) true;
-                      get_proof (exists b. b = true <==> p)
-                    | Prims.Right hnp ->
-                      give_witness hnp;
-                      exists_intro (fun b -> b = true <==> p) false;
-                      get_proof (exists b. b = true <==> p))))
-  in
-  aux p;
-  indefinite_description_ghost bool (fun b -> b = true <==> p)
+  let h : squash (p \/ ~p) = () in
+  let h : (p \/ ~p) = elim_squash h in
+  let h : sum p (~p) = elim_squash h in
+  match h with
+  | Left h -> true
+  | Right h -> false
 
 (** We also can combine this with a the classical tautology converting
     with a [forall] and an [exists] to extract a witness of validity of [p] from
@@ -78,12 +65,3 @@ let stronger_markovs_principle (p: (nat -> GTot bool))
 let stronger_markovs_principle_prop (p: (nat -> GTot prop))
     : Ghost nat (requires (~(forall (n: nat). ~(p n)))) (ensures (fun n -> p n)) =
     indefinite_description_ghost _ p
-
-
-(** A proof for squash p can be eliminated to get p in the Ghost effect *)
-
-let elim_squash (#p:Type u#a) (s:squash p) : GTot p =
-  let uu : squash (x:p & squash trivial) =
-    bind_squash s (fun x -> return_squash (| x, return_squash T |)) in
-  give_proof (return_squash uu);
-  indefinite_description_ghost p (fun _ -> squash trivial)

--- a/ulib/FStar.IndefiniteDescription.fsti
+++ b/ulib/FStar.IndefiniteDescription.fsti
@@ -26,19 +26,18 @@ module FStar.IndefiniteDescription
 /// https://github.com/coq/coq/wiki/CoqAndAxioms#indefinite-description--hilberts-epsilon-operator
 /// https://en.wikipedia.org/wiki/Theory_of_descriptions#Indefinite_descriptions
 
-(** The main axiom:
+(** The main axiom: a proof for squash p can be eliminated to get p in the Ghost effect *)
+val elim_squash (#p:Type u#a) (s:squash p) : GTot p
 
-    Given a classical proof of [exists x. p x], we can exhibit an erased
-    (computationally irrelevant) a witness [x:erased a] validating
-    [p x].
-*)
-val indefinite_description_tot (a:Type) (p:(a -> prop) { exists x. p x })
-  : Tot (w:Ghost.erased a{ p w })
-
-
-(** A version in ghost is easily derivable *)
+(** Given a classical proof of [exists x. p x], we can exhibit
+    a witness [x:erased a] validating [p x] in GTot. *)
 val indefinite_description_ghost (a: Type) (p: (a -> prop) { exists x. p x })
   : GTot (x: a { p x })
+
+(** Given a classical proof of [exists x. p x], we can exhibit an erased
+    (computationally irrelevant) a witness [x:erased a] validating [p x].  *)
+val indefinite_description_tot (a:Type) (p:(a -> prop) { exists x. p x })
+  : Tot (w:Ghost.erased a{ p w })
     
 (** Indefinite description entails the a strong form of the excluded
     middle, i.e., one can case-analyze the truth of a proposition
@@ -58,8 +57,3 @@ val stronger_markovs_principle (p: (nat -> GTot bool))
     boolean predicate *)
 val stronger_markovs_principle_prop (p: (nat -> GTot prop))
     : Ghost nat (requires (~(forall (n: nat). ~(p n)))) (ensures (fun n -> p n))
-
-
-(** A proof for squash p can be eliminated to get p in the Ghost effect *)
-
-val elim_squash (#p:Type u#a) (s:squash p) : GTot p

--- a/ulib/FStar.Squash.fst
+++ b/ulib/FStar.Squash.fst
@@ -1,5 +1,5 @@
 (*
-   Copyright 2008-2018 Microsoft Research
+   Copyright 2008-2024 Microsoft Research
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
    limitations under the License.
 *)
 module FStar.Squash
+open FStar.IndefiniteDescription
 
 (* This file shows that there is another natural model for some of the
    squash things; for this one it doesn't seem to harm importing this
@@ -21,9 +22,11 @@ module FStar.Squash
 
 let return_squash (#a:Type) x = ()
 
-let bind_squash (#a:Type) (#b:Type) f g = admit()
+let bind_squash (#a:Type) (#b:Type) f g =
+    g (elim_squash f)
 
-let push_squash (#a:Type) (#b:(a->Type)) f = admit()
+let push_squash (#a:Type) (#b:(a->Type)) f =
+    return_squash fun x -> elim_squash (f x)
 
 let get_proof (p:Type) = ()
 

--- a/ulib/FStar.StrongExcludedMiddle.fst
+++ b/ulib/FStar.StrongExcludedMiddle.fst
@@ -15,5 +15,5 @@
 *)
 module FStar.StrongExcludedMiddle
 
-(* WARNING: this breaks parametricity; use with care *)
-assume val strong_excluded_middle : p:Type0 -> GTot (b:bool{b = true <==> p})
+let strong_excluded_middle : p:Type0 -> GTot (b:bool{b = true <==> p}) =
+  IndefiniteDescription.strong_excluded_middle


### PR DESCRIPTION
 - Use `elim_squash` as the base axiom in FStar.IndefiniteDescription (it is a theorem right now)
 - This makes FStar.IndefiniteDescription a standalone file only depending on Prims and Ghost, removing the dependency on FStar.Squash.
 - bind_squash and push_squash are now implemented using indefinite description, removing two axioms.

This PR takes a lot of inspiration from Guido's PR #2183.