### PR TITLE
Print a suggestion for a common Windows footgun

### DIFF
--- a/ocaml/fstar-lib/generated/FStarC_Parser_Dep.ml
+++ b/ocaml/fstar-lib/generated/FStarC_Parser_Dep.ml
@@ -143,10 +143,31 @@ let (module_name_of_file : Prims.string -> Prims.string) =
     | FStar_Pervasives_Native.Some longname -> longname
     | FStar_Pervasives_Native.None ->
         let uu___1 =
-          FStarC_Compiler_Util.format1 "Not a valid FStar file: '%s'" f in
+          let uu___2 =
+            let uu___3 =
+              let uu___4 =
+                FStarC_Compiler_Util.format1 "Not a valid FStar file: '%s'" f in
+              FStarC_Errors_Msg.text uu___4 in
+            [uu___3] in
+          let uu___3 =
+            if
+              (FStarC_Platform.system = FStarC_Platform.Windows) &&
+                (f = "..")
+            then
+              let uu___4 =
+                FStarC_Errors_Msg.text
+                  "Note: In Windows-compiled versions of F*, a literal\n          asterisk as argument will be expanded to a list of files,\n          **even if quoted**. It is possible you provided such an\n          argument which got expanded to the list of all files in this\n          directory, causing spurious arguments that F* attempts to interpret as files." in
+              let uu___5 =
+                let uu___6 =
+                  FStarC_Errors_Msg.text
+                    "Hint: did you perhaps pass --already_cached '*' or similar? You can add\n          a comma (',*') to prevent the expansion and retain the behavior." in
+                [uu___6] in
+              uu___4 :: uu___5
+            else [] in
+          FStarC_Compiler_List.op_At uu___2 uu___3 in
         FStarC_Errors.raise_error0
           FStarC_Errors_Codes.Fatal_NotValidFStarFile ()
-          (Obj.magic FStarC_Errors_Msg.is_error_message_string)
+          (Obj.magic FStarC_Errors_Msg.is_error_message_list_doc)
           (Obj.magic uu___1)
 let (lowercase_module_name : Prims.string -> Prims.string) =
   fun f ->

--- a/src/parser/FStarC.Parser.Dep.fst
+++ b/src/parser/FStarC.Parser.Dep.fst
@@ -127,7 +127,18 @@ let module_name_of_file f =
     | Some longname ->
       longname
     | None ->
-      raise_error0 Errors.Fatal_NotValidFStarFile (Util.format1 "Not a valid FStar file: '%s'" f)
+      raise_error0 Errors.Fatal_NotValidFStarFile (
+        [ text <| Util.format1 "Not a valid FStar file: '%s'" f; ] @
+        (if Platform.system = Platform.Windows && f = ".." then [
+          text <| "Note: In Windows-compiled versions of F*, a literal
+          asterisk as argument will be expanded to a list of files,
+          **even if quoted**. It is possible you provided such an
+          argument which got expanded to the list of all files in this
+          directory, causing spurious arguments that F* attempts to interpret as files.";
+          text <| "Hint: did you perhaps pass --already_cached '*' or similar? You can add
+          a comma (',*') to prevent the expansion and retain the behavior.";
+        ] else [])
+      )
 
 (* In public interface *)
 let lowercase_module_name f = String.lowercase (module_name_of_file f)


### PR DESCRIPTION
After a wild ride trying to figure out what was failing [here ](https://github.com/project-everest/everest/actions/runs/12363378047/job/34504571802)(snippet below)
```
   CHECK           Steel.Semantics.Hoare.MST.fst
* Error 151:
  - Not a valid FStar file: '..'
```
@tahina-pro reminded me about the crazy expansion of wildcards in Windows. The shell does not expand them, the programs do it instead. So when we pass `--already_cached '*'` to F*, that asterisk is expanded to a list of arguments __even if it's quoted__. AFAIK this is done by some code injected into the program by the MinGW compiler, which we're using for Windows, and I'm not sure how to avoid it. This is why some `--already_cached` had `',*'` instead, a trick I forgot about in some new Makefiles.

This PR documents the trick, by detecting this particular error on Windows builds and warning the user. (The asterisk is expanded to `.` `..`, and then some files; the first `.` is taken to be an argument of `--already_cached` and we fail on the second.) Now we get this:
![image](https://github.com/user-attachments/assets/886fb73b-f521-49a7-807a-6bb8eca94e7e)


(We also discovered that non-MinGW Cygwin builds (the ones you get if you install cygwin, clone the repo and build) are completely broken. I will follow up on that.)