### PR TITLE
Adapt CI to the new official Windows opam 2.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
 
     needs: build-linux
 
-    runs-on: [self-hosted, Windows, X64]
+    runs-on: [self-hosted, Windows, X64, opam-2-3]
 
     steps:
     - name: Check out repo        
@@ -67,6 +67,6 @@ jobs:
     - name: Package and release FStar
       shell: C:\cygwin64\bin\bash.exe --login '{0}'
       run: |
-        FSTAR_COMMIT=$GITHUB_SHA CI_THREADS=24 $GITHUB_WORKSPACE/.scripts/release.sh && echo "There is a CR at the end of this line"
+        eval $(opam env) && CC=x86_64-w64-mingw32-gcc.exe FSTAR_COMMIT=$GITHUB_SHA CI_THREADS=24 $GITHUB_WORKSPACE/.scripts/release.sh && echo "There is a CR at the end of this line"
       env:
         GH_TOKEN: ${{ secrets.DZOMO_GITHUB_TOKEN }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -7,7 +7,7 @@ jobs:
 
   build-windows:
 
-    runs-on: [self-hosted, Windows, X64]
+    runs-on: [self-hosted, Windows, X64, opam-2-3]
 
     steps:
     - name: Check out repo        
@@ -16,11 +16,11 @@ jobs:
     - name: Build a package
       shell: C:\cygwin64\bin\bash.exe --login '{0}'
       run: |
-          make -C $GITHUB_WORKSPACE -j package && echo "There is a CR at the end of this line"
+        eval $(opam env) && CC=x86_64-w64-mingw32-gcc.exe make -C $GITHUB_WORKSPACE -j package && echo "There is a CR at the end of this line"
     - name: Test the package
       shell: C:\cygwin64\bin\bash.exe --login '{0}'
       run: |
-        env CI_THREADS=24 $GITHUB_WORKSPACE/.scripts/test_package.sh && echo "There is a CR at the end of this line"
+        eval $(opam env) && CC=x86_64-w64-mingw32-gcc.exe CI_THREADS=24 $GITHUB_WORKSPACE/.scripts/test_package.sh && echo "There is a CR at the end of this line"
     - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
The environment on the CI machine was set up with `windows-init.ps1` from project-everest/everest#118
The environment is no longer set up with the OCaml paths on the CI machine, so we need to set it up on the F* CI side.

Windows CI is now green, cf. https://github.com/FStarLang/FStar/actions/runs/12419622143