### PR TITLE
Options: print the option's help when arguments are wrong

### DIFF
--- a/ocaml/fstar-lib/generated/FStarC_Errors.ml
+++ b/ocaml/fstar-lib/generated/FStarC_Errors.ml
@@ -804,8 +804,8 @@ let (uu___0 :
         (FStarC_Compiler_Util.smap_add error_flags we
            FStar_Pervasives_Native.None;
          FStarC_Getopt.Error
-           (Prims.strcat "Invalid --warn_error setting: "
-              (Prims.strcat msg "\n"))) in
+           ((Prims.strcat "Invalid --warn_error setting: "
+               (Prims.strcat msg "\n")), "warn_error")) in
   let get_error_flags uu___ =
     let we = FStarC_Options.warn_error () in
     let uu___1 = FStarC_Compiler_Util.smap_try_find error_flags we in

--- a/ocaml/fstar-lib/generated/FStarC_Interactive_Ide.ml
+++ b/ocaml/fstar-lib/generated/FStarC_Interactive_Ide.ml
@@ -3003,7 +3003,7 @@ let (js_repl_init_opts : unit -> unit) =
     match uu___1 with
     | (res, fnames) ->
         (match res with
-         | FStarC_Getopt.Error msg ->
+         | FStarC_Getopt.Error (msg, uu___2) ->
              failwith (Prims.strcat "repl_init: " msg)
          | FStarC_Getopt.Help -> failwith "repl_init: --help unexpected"
          | FStarC_Getopt.Success ->

--- a/ocaml/fstar-lib/generated/FStarC_Main.ml
+++ b/ocaml/fstar-lib/generated/FStarC_Main.ml
@@ -147,6 +147,14 @@ let (set_error_trap : unit -> unit) =
       FStarC_Compiler_Effect.exit Prims.int_one in
     let uu___1 = FStarC_Compiler_Util.sigint_handler_f h' in
     FStarC_Compiler_Util.set_sigint_handler uu___1
+let (print_help_for : Prims.string -> unit) =
+  fun o ->
+    let uu___ = FStarC_Options.help_for_option o in
+    match uu___ with
+    | FStar_Pervasives_Native.None -> ()
+    | FStar_Pervasives_Native.Some doc ->
+        let uu___1 = FStarC_Errors_Msg.renderdoc doc in
+        FStarC_Compiler_Util.print_error uu___1
 let (go_normal : unit -> unit) =
   fun uu___ ->
     let uu___1 = process_args () in
@@ -161,8 +169,9 @@ let (go_normal : unit -> unit) =
           | FStarC_Getopt.Help ->
               (FStarC_Options.display_usage ();
                FStarC_Compiler_Effect.exit Prims.int_zero)
-          | FStarC_Getopt.Error msg ->
-              (FStarC_Compiler_Util.print_error msg;
+          | FStarC_Getopt.Error (msg, opt) ->
+              (FStarC_Compiler_Util.print_error (Prims.strcat "error: " msg);
+               print_help_for opt;
                FStarC_Compiler_Effect.exit Prims.int_one)
           | FStarC_Getopt.Success when FStarC_Options.print_cache_version ()
               ->

--- a/ocaml/fstar-lib/generated/FStarC_Options.ml
+++ b/ocaml/fstar-lib/generated/FStarC_Options.ml
@@ -865,6 +865,19 @@ let (display_version : unit -> unit) =
         "F* %s\nplatform=%s\ncompiler=%s\ndate=%s\ncommit=%s\n" uu___2 uu___3
         uu___4 uu___5 uu___6 in
     FStarC_Compiler_Util.print_string uu___1
+let (bold_doc : FStarC_Pprint.document -> FStarC_Pprint.document) =
+  fun d ->
+    let uu___ =
+      let uu___1 = FStarC_Compiler_Util.stdout_isatty () in
+      uu___1 = (FStar_Pervasives_Native.Some true) in
+    if uu___
+    then
+      let uu___1 = FStarC_Pprint.fancystring "\027[39;1m" Prims.int_zero in
+      let uu___2 =
+        let uu___3 = FStarC_Pprint.fancystring "\027[0m" Prims.int_zero in
+        FStarC_Pprint.op_Hat_Hat d uu___3 in
+      FStarC_Pprint.op_Hat_Hat uu___1 uu___2
+    else d
 let (display_debug_keys : unit -> unit) =
   fun uu___ ->
     let keys = FStarC_Compiler_Debug.list_all_toggles () in
@@ -874,24 +887,69 @@ let (display_debug_keys : unit -> unit) =
       (fun s ->
          let uu___2 = FStarC_Compiler_String.op_Hat s "\n" in
          FStarC_Compiler_Util.print_string uu___2) uu___1
+let (usage_for :
+  (FStarC_Getopt.opt * FStarC_Pprint.document) -> FStarC_Pprint.document) =
+  fun o ->
+    let uu___ = o in
+    match uu___ with
+    | ((short, flag, p), explain) ->
+        let arg =
+          match p with
+          | FStarC_Getopt.ZeroArgs uu___1 -> FStarC_Pprint.empty
+          | FStarC_Getopt.OneArg (uu___1, argname) ->
+              let uu___2 = FStarC_Pprint.blank Prims.int_one in
+              let uu___3 = FStarC_Pprint.doc_of_string argname in
+              FStarC_Pprint.op_Hat_Hat uu___2 uu___3 in
+        let short_opt =
+          if short <> FStarC_Getopt.noshort
+          then
+            let uu___1 =
+              let uu___2 =
+                let uu___3 =
+                  let uu___4 =
+                    FStarC_Compiler_String.make Prims.int_one short in
+                  FStarC_Compiler_String.op_Hat "-" uu___4 in
+                FStarC_Pprint.doc_of_string uu___3 in
+              FStarC_Pprint.op_Hat_Hat uu___2 arg in
+            [uu___1]
+          else [] in
+        let long_opt =
+          if flag <> ""
+          then
+            let uu___1 =
+              let uu___2 =
+                let uu___3 = FStarC_Compiler_String.op_Hat "--" flag in
+                FStarC_Pprint.doc_of_string uu___3 in
+              FStarC_Pprint.op_Hat_Hat uu___2 arg in
+            [uu___1]
+          else [] in
+        let uu___1 =
+          let uu___2 =
+            let uu___3 =
+              let uu___4 =
+                let uu___5 = FStarC_Pprint.blank Prims.int_one in
+                FStarC_Pprint.op_Hat_Hat FStarC_Pprint.comma uu___5 in
+              FStarC_Pprint.separate uu___4
+                (FStarC_Compiler_List.op_At short_opt long_opt) in
+            bold_doc uu___3 in
+          FStarC_Pprint.group uu___2 in
+        let uu___2 =
+          let uu___3 =
+            let uu___4 =
+              let uu___5 =
+                let uu___6 = FStarC_Pprint.blank (Prims.of_int (4)) in
+                let uu___7 = FStarC_Pprint.align explain in
+                FStarC_Pprint.op_Hat_Hat uu___6 uu___7 in
+              FStarC_Pprint.group uu___5 in
+            FStarC_Pprint.op_Hat_Hat uu___4 FStarC_Pprint.hardline in
+          FStarC_Pprint.op_Hat_Hat FStarC_Pprint.hardline uu___3 in
+        FStarC_Pprint.op_Hat_Hat uu___1 uu___2
 let (display_usage_aux :
   (FStarC_Getopt.opt * FStarC_Pprint.document) Prims.list -> unit) =
   fun specs ->
     let text s =
       let uu___ = FStarC_Pprint.break_ Prims.int_one in
       let uu___1 = FStarC_Pprint.words s in FStarC_Pprint.flow uu___ uu___1 in
-    let bold_doc d =
-      let uu___ =
-        let uu___1 = FStarC_Compiler_Util.stdout_isatty () in
-        uu___1 = (FStar_Pervasives_Native.Some true) in
-      if uu___
-      then
-        let uu___1 = FStarC_Pprint.fancystring "\027[39;1m" Prims.int_zero in
-        let uu___2 =
-          let uu___3 = FStarC_Pprint.fancystring "\027[0m" Prims.int_zero in
-          FStarC_Pprint.op_Hat_Hat d uu___3 in
-        FStarC_Pprint.op_Hat_Hat uu___1 uu___2
-      else d in
     let d =
       let uu___ =
         FStarC_Pprint.doc_of_string
@@ -906,68 +964,10 @@ let (display_usage_aux :
           FStarC_Pprint.doc_of_string uu___3 in
         let uu___3 =
           FStarC_Compiler_List.fold_right
-            (fun uu___4 ->
+            (fun o ->
                fun rest ->
-                 match uu___4 with
-                 | ((short, flag, p), explain) ->
-                     let arg =
-                       match p with
-                       | FStarC_Getopt.ZeroArgs uu___5 -> FStarC_Pprint.empty
-                       | FStarC_Getopt.OneArg (uu___5, argname) ->
-                           let uu___6 = FStarC_Pprint.blank Prims.int_one in
-                           let uu___7 = FStarC_Pprint.doc_of_string argname in
-                           FStarC_Pprint.op_Hat_Hat uu___6 uu___7 in
-                     let short_opt =
-                       if short <> FStarC_Getopt.noshort
-                       then
-                         let uu___5 =
-                           let uu___6 =
-                             let uu___7 =
-                               let uu___8 =
-                                 FStarC_Compiler_String.make Prims.int_one
-                                   short in
-                               FStarC_Compiler_String.op_Hat "-" uu___8 in
-                             FStarC_Pprint.doc_of_string uu___7 in
-                           FStarC_Pprint.op_Hat_Hat uu___6 arg in
-                         [uu___5]
-                       else [] in
-                     let long_opt =
-                       if flag <> ""
-                       then
-                         let uu___5 =
-                           let uu___6 =
-                             let uu___7 =
-                               FStarC_Compiler_String.op_Hat "--" flag in
-                             FStarC_Pprint.doc_of_string uu___7 in
-                           FStarC_Pprint.op_Hat_Hat uu___6 arg in
-                         [uu___5]
-                       else [] in
-                     let uu___5 =
-                       let uu___6 =
-                         let uu___7 =
-                           let uu___8 =
-                             let uu___9 = FStarC_Pprint.blank Prims.int_one in
-                             FStarC_Pprint.op_Hat_Hat FStarC_Pprint.comma
-                               uu___9 in
-                           FStarC_Pprint.separate uu___8
-                             (FStarC_Compiler_List.op_At short_opt long_opt) in
-                         bold_doc uu___7 in
-                       FStarC_Pprint.group uu___6 in
-                     let uu___6 =
-                       let uu___7 =
-                         let uu___8 =
-                           let uu___9 =
-                             let uu___10 =
-                               FStarC_Pprint.blank (Prims.of_int (4)) in
-                             let uu___11 = FStarC_Pprint.align explain in
-                             FStarC_Pprint.op_Hat_Hat uu___10 uu___11 in
-                           FStarC_Pprint.group uu___9 in
-                         let uu___9 =
-                           FStarC_Pprint.op_Hat_Hat FStarC_Pprint.hardline
-                             rest in
-                         FStarC_Pprint.op_Hat_Hat uu___8 uu___9 in
-                       FStarC_Pprint.op_Hat_Hat FStarC_Pprint.hardline uu___7 in
-                     FStarC_Pprint.op_Hat_Hat uu___5 uu___6) specs
+                 let uu___4 = usage_for o in
+                 FStarC_Pprint.op_Hat_Hat uu___4 rest) specs
             FStarC_Pprint.empty in
         FStarC_Pprint.op_Hat_Slash_Hat uu___2 uu___3 in
       FStarC_Pprint.op_Hat_Slash_Hat uu___ uu___1 in
@@ -4084,6 +4084,18 @@ let (settable_specs :
     (fun uu___ ->
        match uu___ with | ((uu___2, x, uu___3), uu___4) -> settable x)
     all_specs
+let (help_for_option :
+  Prims.string -> FStarC_Pprint.document FStar_Pervasives_Native.option) =
+  fun s ->
+    let uu___ =
+      FStarC_Compiler_List.filter
+        (fun uu___2 ->
+           match uu___2 with | ((uu___3, x, uu___4), uu___5) -> x = s)
+        all_specs in
+    match uu___ with
+    | [] -> FStar_Pervasives_Native.None
+    | o::uu___2 ->
+        let uu___3 = usage_for o in FStar_Pervasives_Native.Some uu___3
 let (uu___2 :
   (((unit -> FStarC_Getopt.parse_cmdline_res) -> unit) *
     (unit -> FStarC_Getopt.parse_cmdline_res)))
@@ -4930,15 +4942,17 @@ let (set_options : Prims.string -> FStarC_Getopt.parse_cmdline_res) =
                   FStarC_Getopt.parse_string settable_specs1
                     (fun s1 ->
                        FStarC_Compiler_Effect.raise (File_argument s1);
-                       FStarC_Getopt.Error "set_options with file argument")
-                    s in
+                       FStarC_Getopt.Error
+                         ("set_options with file argument", "")) s in
                 if res = FStarC_Getopt.Success
                 then set_error_flags ()
                 else res)) ()
     with
     | File_argument s1 ->
         let uu___3 =
-          FStarC_Compiler_Util.format1 "File %s is not a valid option" s1 in
+          let uu___4 =
+            FStarC_Compiler_Util.format1 "File %s is not a valid option" s1 in
+          (uu___4, "") in
         FStarC_Getopt.Error uu___3
 let with_options : 'a . Prims.string -> (unit -> 'a) -> 'a =
   fun s ->

--- a/ocaml/fstar-lib/generated/FStarC_Syntax_Util.ml
+++ b/ocaml/fstar-lib/generated/FStarC_Syntax_Util.ml
@@ -3679,11 +3679,16 @@ let (process_pragma :
                (Obj.magic FStarC_Errors_Msg.is_error_message_string)
                (Obj.magic
                   "Failed to process pragma: use 'fstar --help' to see which options are available")
-         | FStarC_Getopt.Error s1 ->
+         | FStarC_Getopt.Error (s1, opt) ->
+             let uu___2 =
+               let uu___3 =
+                 FStarC_Errors_Msg.text
+                   (Prims.strcat "Failed to process pragma: " s1) in
+               [uu___3] in
              FStarC_Errors.raise_error FStarC_Class_HasRange.hasRange_range r
                FStarC_Errors_Codes.Fatal_FailToProcessPragma ()
-               (Obj.magic FStarC_Errors_Msg.is_error_message_string)
-               (Obj.magic (Prims.strcat "Failed to process pragma: " s1)) in
+               (Obj.magic FStarC_Errors_Msg.is_error_message_list_doc)
+               (Obj.magic uu___2) in
        match p with
        | FStarC_Syntax_Syntax.ShowOptions -> ()
        | FStarC_Syntax_Syntax.SetOptions o -> set_options o

--- a/ocaml/fstar-lib/generated/FStarC_Tactics_V1_Basic.ml
+++ b/ocaml/fstar-lib/generated/FStarC_Tactics_V1_Basic.ml
@@ -6238,7 +6238,7 @@ let (set_options : Prims.string -> unit FStarC_Tactics_Monad.tac) =
                           (g.FStarC_Tactics_Types.label)
                       } in
                     Obj.magic (FStarC_Tactics_Monad.replace_cur g')
-                | FStarC_Getopt.Error err ->
+                | FStarC_Getopt.Error (err, uu___4) ->
                     Obj.magic (fail2 "Setting options `%s` failed: %s" s err)
                 | FStarC_Getopt.Help ->
                     Obj.magic

--- a/ocaml/fstar-lib/generated/FStarC_Tactics_V2_Basic.ml
+++ b/ocaml/fstar-lib/generated/FStarC_Tactics_V2_Basic.ml
@@ -7346,7 +7346,7 @@ let (set_options : Prims.string -> unit FStarC_Tactics_Monad.tac) =
                           (g.FStarC_Tactics_Types.label)
                       } in
                     Obj.magic (FStarC_Tactics_Monad.replace_cur g')
-                | FStarC_Getopt.Error err ->
+                | FStarC_Getopt.Error (err, uu___4) ->
                     Obj.magic (fail2 "Setting options `%s` failed: %s" s err)
                 | FStarC_Getopt.Help ->
                     Obj.magic

--- a/ocaml/fstar-tests/generated/FStarC_Tests_Test.ml
+++ b/ocaml/fstar-tests/generated/FStarC_Tests_Test.ml
@@ -14,7 +14,7 @@ let main : 'uuuuu 'uuuuu1 . 'uuuuu -> 'uuuuu1 =
                         (FStarC_Compiler_Util.print_string
                            "F* unit tests. This binary can take the same options as F*, but not all of them are meaningful.";
                          FStarC_Compiler_Effect.exit Prims.int_zero)
-                    | FStarC_Getopt.Error msg ->
+                    | FStarC_Getopt.Error (msg, uu___3) ->
                         (FStarC_Compiler_Util.print_error msg;
                          FStarC_Compiler_Effect.exit Prims.int_one)
                     | FStarC_Getopt.Empty ->

--- a/src/basic/FStarC.Errors.fst
+++ b/src/basic/FStarC.Errors.fst
@@ -436,7 +436,7 @@ let t_set_parse_warn_error,
             Getopt.Success
         with Invalid_warn_error_setting msg ->
             (BU.smap_add error_flags we None;
-             Getopt.Error ("Invalid --warn_error setting: " ^ msg ^ "\n"))
+             Getopt.Error ("Invalid --warn_error setting: " ^ msg ^ "\n", "warn_error"))
     in
     (* get_error_flags is called when logging an issue to figure out
        which error level to report a particular issue at (Warning, Error etc.)

--- a/src/basic/FStarC.Getopt.fsti
+++ b/src/basic/FStarC.Getopt.fsti
@@ -29,7 +29,7 @@ type opt = opt' unit
 type parse_cmdline_res =
   | Empty
   | Help
-  | Error of string
+  | Error of (string & string) // second arg is the long name of the failed option
   | Success
 
 val parse_cmdline: list opt -> (string -> parse_cmdline_res) -> parse_cmdline_res

--- a/src/basic/FStarC.Options.fsti
+++ b/src/basic/FStarC.Options.fsti
@@ -102,6 +102,7 @@ val add_verify_module           : string  -> unit
 val set_option_warning_callback : (string -> unit) -> unit
 val desc_of_opt_type            : opt_type -> option string
 val all_specs_with_types        : list (char & string & opt_type & Pprint.document)
+val help_for_option             : string -> option Pprint.document
 val settable                    : string -> bool
 
 val abort_counter : ref int

--- a/src/fstar/FStarC.Interactive.Ide.fst
+++ b/src/fstar/FStarC.Interactive.Ide.fst
@@ -1191,7 +1191,7 @@ let js_repl_eval_str st query_str =
 let js_repl_init_opts () =
   let res, fnames = Options.parse_cmd_line () in
   match res with
-  | Getopt.Error msg -> failwith ("repl_init: " ^ msg)
+  | Getopt.Error (msg, _) -> failwith ("repl_init: " ^ msg)
   | Getopt.Help -> failwith "repl_init: --help unexpected"
   | Getopt.Success ->
     match fnames with

--- a/src/fstar/FStarC.Main.fst
+++ b/src/fstar/FStarC.Main.fst
@@ -129,6 +129,11 @@ let set_error_trap () =
   in
   set_sigint_handler (sigint_handler_f h')
 
+let print_help_for (o : string) : unit =
+  match Options.help_for_option o with
+  | None -> ()
+  | Some doc -> Util.print_error (Errors.Msg.renderdoc doc)
+
 (* Normal mode with some flags, files, etc *)
 let go_normal () =
   let res, filenames = process_args () in
@@ -136,7 +141,10 @@ let go_normal () =
   match res with
     | Empty     -> Options.display_usage(); exit 1
     | Help      -> Options.display_usage(); exit 0
-    | Error msg -> Util.print_error msg; exit 1
+    | Error (msg, opt) ->
+      Util.print_error ("error: " ^ msg);
+      print_help_for opt;
+      exit 1
 
     | Success when Options.print_cache_version () ->
       Util.print1 "F* cache version number: %s\n"

--- a/src/syntax/FStarC.Syntax.Util.fst
+++ b/src/syntax/FStarC.Syntax.Util.fst
@@ -1587,9 +1587,10 @@ let process_pragma p r =
       | Getopt.Help  ->
         Errors.raise_error r Errors.Fatal_FailToProcessPragma
           "Failed to process pragma: use 'fstar --help' to see which options are available"
-      | Getopt.Error s ->
-        Errors.raise_error r Errors.Fatal_FailToProcessPragma
-          ("Failed to process pragma: " ^ s)
+      | Getopt.Error (s, opt) ->
+        Errors.raise_error r Errors.Fatal_FailToProcessPragma [
+          Errors.Msg.text <| "Failed to process pragma: " ^ s;
+        ]
     in
     match p with
     | ShowOptions ->

--- a/src/tactics/FStarC.Tactics.V1.Basic.fst
+++ b/src/tactics/FStarC.Tactics.V1.Basic.fst
@@ -1595,7 +1595,7 @@ let set_options (s : string) : tac unit = wrap_err "set_options" <| (
     | FStarC.Getopt.Success ->
         let g' = { g with opts = opts' } in
         replace_cur g'
-    | FStarC.Getopt.Error err ->
+    | FStarC.Getopt.Error (err, _) ->
         fail2 "Setting options `%s` failed: %s" s err
     | FStarC.Getopt.Help ->
         fail1 "Setting options `%s` failed (got `Help`?)" s

--- a/src/tactics/FStarC.Tactics.V2.Basic.fst
+++ b/src/tactics/FStarC.Tactics.V2.Basic.fst
@@ -1703,7 +1703,7 @@ let set_options (s : string) : tac unit = wrap_err "set_options" <| (
     | FStarC.Getopt.Success ->
         let g' = { g with opts = opts' } in
         replace_cur g'
-    | FStarC.Getopt.Error err ->
+    | FStarC.Getopt.Error (err, _) ->
         fail2 "Setting options `%s` failed: %s" s err
     | FStarC.Getopt.Help ->
         fail1 "Setting options `%s` failed (got `Help`?)" s

--- a/src/tests/FStarC.Tests.Test.fst
+++ b/src/tests/FStarC.Tests.Test.fst
@@ -34,7 +34,7 @@ let main argv =
           BU.print_string "F* unit tests. This binary can take the same options \
                            as F*, but not all of them are meaningful.";
           exit 0
-        | G.Error msg ->
+        | G.Error (msg, _) ->
           BU.print_error msg; exit 1
         | G.Empty
         | G.Success ->


### PR DESCRIPTION
```
$ ./bin/fstar.exe --admit_smt_queries
error: last option 'admit_smt_queries' takes an argument but has none
--admit_smt_queries <true|false>
    Admit SMT queries, unsafe! (default 'false')
```