### PR TITLE
Introduce --locate_file to ask F* for the location of modules or checked files

### DIFF
--- a/ocaml/fstar-lib/generated/FStarC_Main.ml
+++ b/ocaml/fstar-lib/generated/FStarC_Main.ml
@@ -160,6 +160,13 @@ let (go_normal : unit -> unit) =
     let uu___1 = process_args () in
     match uu___1 with
     | (res, filenames) ->
+        let check_no_filenames opt =
+          if Prims.uu___is_Cons filenames
+          then
+            (FStarC_Compiler_Util.print1_error
+               "error: No filenames should be passed with option %s\n" opt;
+             FStarC_Compiler_Effect.exit Prims.int_one)
+          else () in
         ((let uu___3 = FStarC_Options.trace_error () in
           if uu___3 then set_error_trap () else ());
          (match res with
@@ -301,23 +308,44 @@ let (go_normal : unit -> unit) =
                 FStarC_Compiler_Util.print1
                   "Registered tactic plugins:\n%s\n" uu___5))
           | FStarC_Getopt.Success when FStarC_Options.locate () ->
-              ((let uu___4 = FStarC_Find.locate () in
-                FStarC_Compiler_Util.print1 "%s\n" uu___4);
+              (check_no_filenames "--locate";
+               (let uu___5 = FStarC_Find.locate () in
+                FStarC_Compiler_Util.print1 "%s\n" uu___5);
                FStarC_Compiler_Effect.exit Prims.int_zero)
           | FStarC_Getopt.Success when FStarC_Options.locate_lib () ->
-              let uu___3 = FStarC_Find.locate_lib () in
-              (match uu___3 with
-               | FStar_Pervasives_Native.None ->
-                   (FStarC_Compiler_Util.print_error
-                      "No library found (is --no_default_includes set?)\n";
-                    FStarC_Compiler_Effect.exit Prims.int_one)
-               | FStar_Pervasives_Native.Some s ->
-                   (FStarC_Compiler_Util.print1 "%s\n" s;
-                    FStarC_Compiler_Effect.exit Prims.int_zero))
+              (check_no_filenames "--locate_lib";
+               (let uu___4 = FStarC_Find.locate_lib () in
+                match uu___4 with
+                | FStar_Pervasives_Native.None ->
+                    (FStarC_Compiler_Util.print_error
+                       "No library found (is --no_default_includes set?)\n";
+                     FStarC_Compiler_Effect.exit Prims.int_one)
+                | FStar_Pervasives_Native.Some s ->
+                    (FStarC_Compiler_Util.print1 "%s\n" s;
+                     FStarC_Compiler_Effect.exit Prims.int_zero)))
           | FStarC_Getopt.Success when FStarC_Options.locate_ocaml () ->
-              ((let uu___4 = FStarC_Find.locate_ocaml () in
-                FStarC_Compiler_Util.print1 "%s\n" uu___4);
+              (check_no_filenames "--locate_ocaml";
+               (let uu___5 = FStarC_Find.locate_ocaml () in
+                FStarC_Compiler_Util.print1 "%s\n" uu___5);
                FStarC_Compiler_Effect.exit Prims.int_zero)
+          | FStarC_Getopt.Success when
+              let uu___3 = FStarC_Options.locate_file () in
+              FStar_Pervasives_Native.uu___is_Some uu___3 ->
+              (check_no_filenames "--locate_fle";
+               (let f =
+                  let uu___4 = FStarC_Options.locate_file () in
+                  FStar_Pervasives_Native.__proj__Some__item__v uu___4 in
+                let uu___4 = FStarC_Find.find_file f in
+                match uu___4 with
+                | FStar_Pervasives_Native.None ->
+                    (FStarC_Compiler_Util.print1_error
+                       "File %s was not found in include path.\n" f;
+                     FStarC_Compiler_Effect.exit Prims.int_one)
+                | FStar_Pervasives_Native.Some fn ->
+                    ((let uu___6 =
+                        FStarC_Compiler_Util.normalize_file_path fn in
+                      FStarC_Compiler_Util.print1 "%s\n" uu___6);
+                     FStarC_Compiler_Effect.exit Prims.int_zero)))
           | FStarC_Getopt.Success ->
               (FStarC_Compiler_Effect.op_Colon_Equals fstar_files
                  (FStar_Pervasives_Native.Some filenames);

--- a/ocaml/fstar-lib/generated/FStarC_Options.ml
+++ b/ocaml/fstar-lib/generated/FStarC_Options.ml
@@ -364,6 +364,7 @@ let (defaults : (Prims.string * option_val) Prims.list) =
   ("locate", (Bool false));
   ("locate_lib", (Bool false));
   ("locate_ocaml", (Bool false));
+  ("locate_file", Unset);
   ("read_krml_file", Unset);
   ("record_hints", (Bool false));
   ("record_options", (Bool false));
@@ -741,6 +742,8 @@ let (get_locate_lib : unit -> Prims.bool) =
   fun uu___ -> lookup_opt "locate_lib" as_bool
 let (get_locate_ocaml : unit -> Prims.bool) =
   fun uu___ -> lookup_opt "locate_ocaml" as_bool
+let (get_locate_file : unit -> Prims.string FStar_Pervasives_Native.option) =
+  fun uu___ -> lookup_opt "locate_file" (as_option as_string)
 let (get_record_hints : unit -> Prims.bool) =
   fun uu___ -> lookup_opt "record_hints" as_bool
 let (get_record_options : unit -> Prims.bool) =
@@ -3514,20 +3517,11 @@ let rec (specs_with_types :
                                                                     let uu___280
                                                                     =
                                                                     text
-                                                                    "With no arguments: print shell code to set up an environment with the OCaml libraries in scope (similar to 'opam env'). With arguments: run a command in that environment. NOTE: this must be the FIRST argument passed to F* and other options are NOT processed." in
+                                                                    "Find a file in F*'s include path and print its absolute path, then exit" in
                                                                     (FStarC_Getopt.noshort,
-                                                                    "ocamlenv",
-                                                                    (WithSideEffect
-                                                                    ((fun
-                                                                    uu___281
-                                                                    ->
-                                                                    FStarC_Compiler_Util.print_error
-                                                                    "--ocamlenv must be the first argument, see fstar.exe --help for details\n";
-                                                                    FStarC_Compiler_Effect.exit
-                                                                    Prims.int_one),
-                                                                    (Const
-                                                                    (Bool
-                                                                    true)))),
+                                                                    "locate_file",
+                                                                    (SimpleStr
+                                                                    "basename"),
                                                                     uu___280) in
                                                                     let uu___280
                                                                     =
@@ -3536,15 +3530,15 @@ let rec (specs_with_types :
                                                                     let uu___282
                                                                     =
                                                                     text
-                                                                    "A helper. This runs 'ocamlc' in the environment set up by --ocamlenv, for building an F* application bytecode executable." in
+                                                                    "With no arguments: print shell code to set up an environment with the OCaml libraries in scope (similar to 'opam env'). With arguments: run a command in that environment. NOTE: this must be the FIRST argument passed to F* and other options are NOT processed." in
                                                                     (FStarC_Getopt.noshort,
-                                                                    "ocamlc",
+                                                                    "ocamlenv",
                                                                     (WithSideEffect
                                                                     ((fun
                                                                     uu___283
                                                                     ->
                                                                     FStarC_Compiler_Util.print_error
-                                                                    "--ocamlc must be the first argument, see fstar.exe --help for details\n";
+                                                                    "--ocamlenv must be the first argument, see fstar.exe --help for details\n";
                                                                     FStarC_Compiler_Effect.exit
                                                                     Prims.int_one),
                                                                     (Const
@@ -3558,15 +3552,15 @@ let rec (specs_with_types :
                                                                     let uu___284
                                                                     =
                                                                     text
-                                                                    "A helper. This runs 'ocamlopt' in the environment set up by --ocamlenv, for building an F* application native executable." in
+                                                                    "A helper. This runs 'ocamlc' in the environment set up by --ocamlenv, for building an F* application bytecode executable." in
                                                                     (FStarC_Getopt.noshort,
-                                                                    "ocamlopt",
+                                                                    "ocamlc",
                                                                     (WithSideEffect
                                                                     ((fun
                                                                     uu___285
                                                                     ->
                                                                     FStarC_Compiler_Util.print_error
-                                                                    "--ocamlopt must be the first argument, see fstar.exe --help for details\n";
+                                                                    "--ocamlc must be the first argument, see fstar.exe --help for details\n";
                                                                     FStarC_Compiler_Effect.exit
                                                                     Prims.int_one),
                                                                     (Const
@@ -3580,12 +3574,34 @@ let rec (specs_with_types :
                                                                     let uu___286
                                                                     =
                                                                     text
+                                                                    "A helper. This runs 'ocamlopt' in the environment set up by --ocamlenv, for building an F* application native executable." in
+                                                                    (FStarC_Getopt.noshort,
+                                                                    "ocamlopt",
+                                                                    (WithSideEffect
+                                                                    ((fun
+                                                                    uu___287
+                                                                    ->
+                                                                    FStarC_Compiler_Util.print_error
+                                                                    "--ocamlopt must be the first argument, see fstar.exe --help for details\n";
+                                                                    FStarC_Compiler_Effect.exit
+                                                                    Prims.int_one),
+                                                                    (Const
+                                                                    (Bool
+                                                                    true)))),
+                                                                    uu___286) in
+                                                                    let uu___286
+                                                                    =
+                                                                    let uu___287
+                                                                    =
+                                                                    let uu___288
+                                                                    =
+                                                                    text
                                                                     "A helper. This runs 'ocamlopt' in the environment set up by --ocamlenv, for building an F* plugin." in
                                                                     (FStarC_Getopt.noshort,
                                                                     "ocamlopt_plugin",
                                                                     (WithSideEffect
                                                                     ((fun
-                                                                    uu___287
+                                                                    uu___289
                                                                     ->
                                                                     FStarC_Compiler_Util.print_error
                                                                     "--ocamlopt_plugin must be the first argument, see fstar.exe --help for details\n";
@@ -3594,8 +3610,11 @@ let rec (specs_with_types :
                                                                     (Const
                                                                     (Bool
                                                                     true)))),
-                                                                    uu___286) in
-                                                                    [uu___285] in
+                                                                    uu___288) in
+                                                                    [uu___287] in
+                                                                    uu___285
+                                                                    ::
+                                                                    uu___286 in
                                                                     uu___283
                                                                     ::
                                                                     uu___284 in
@@ -4502,6 +4521,8 @@ let (list_plugins : unit -> Prims.bool) = fun uu___ -> get_list_plugins ()
 let (locate : unit -> Prims.bool) = fun uu___ -> get_locate ()
 let (locate_lib : unit -> Prims.bool) = fun uu___ -> get_locate_lib ()
 let (locate_ocaml : unit -> Prims.bool) = fun uu___ -> get_locate_ocaml ()
+let (locate_file : unit -> Prims.string FStar_Pervasives_Native.option) =
+  fun uu___ -> get_locate_file ()
 let (read_krml_file : unit -> Prims.string FStar_Pervasives_Native.option) =
   fun uu___ -> get_read_krml_file ()
 let (record_hints : unit -> Prims.bool) = fun uu___ -> get_record_hints ()

--- a/src/basic/FStarC.Options.fst
+++ b/src/basic/FStarC.Options.fst
@@ -273,6 +273,7 @@ let defaults =
       ("locate"                       , Bool false);
       ("locate_lib"                   , Bool false);
       ("locate_ocaml"                 , Bool false);
+      ("locate_file"                  , Unset);
       ("read_krml_file"               , Unset);
       ("record_hints"                 , Bool false);
       ("record_options"               , Bool false);
@@ -534,6 +535,7 @@ let get_list_plugins            ()      = lookup_opt "list_plugins"             
 let get_locate                  ()      = lookup_opt "locate"                   as_bool
 let get_locate_lib              ()      = lookup_opt "locate_lib"               as_bool
 let get_locate_ocaml            ()      = lookup_opt "locate_ocaml"             as_bool
+let get_locate_file             ()      = lookup_opt "locate_file"              (as_option as_string)
 let get_record_hints            ()      = lookup_opt "record_hints"             as_bool
 let get_record_options          ()      = lookup_opt "record_options"           as_bool
 let get_retry                   ()      = lookup_opt "retry"                    as_bool
@@ -1634,6 +1636,10 @@ let rec specs_with_types warn_unsafe : list (char & string & opt_type & Pprint.d
     Const (Bool true),
     text "Print the root of the built OCaml F* library and exit");
   ( noshort,
+    "locate_file",
+    SimpleStr "basename",
+    text "Find a file in F*'s include path and print its absolute path, then exit");
+  ( noshort,
     "ocamlenv",
     WithSideEffect ((fun _ -> print_error "--ocamlenv must be the first argument, see fstar.exe --help for details\n"; exit 1),
                      (Const (Bool true))),
@@ -2054,6 +2060,7 @@ let list_plugins                 () = get_list_plugins                ()
 let locate                       () = get_locate                      ()
 let locate_lib                   () = get_locate_lib                  ()
 let locate_ocaml                 () = get_locate_ocaml                ()
+let locate_file                  () = get_locate_file                 ()
 let read_krml_file               () = get_read_krml_file              ()
 let record_hints                 () = get_record_hints                ()
 let record_options               () = get_record_options              ()

--- a/src/basic/FStarC.Options.fsti
+++ b/src/basic/FStarC.Options.fsti
@@ -179,6 +179,7 @@ val list_plugins                : unit    -> bool
 val locate                      : unit    -> bool
 val locate_lib                  : unit    -> bool
 val locate_ocaml                : unit    -> bool
+val locate_file                 : unit    -> option string
 val output_deps_to              : unit    -> option string
 val output_dir                  : unit    -> option string
 val custom_prims                : unit    -> option string

--- a/src/fstar/FStarC.Main.fst
+++ b/src/fstar/FStarC.Main.fst
@@ -212,10 +212,11 @@ let go_normal () =
       Util.print1 "Registered tactic plugins:\n%s\n" (String.concat "\n" (List.map (fun p -> "  " ^ show p.TypeChecker.Primops.Base.name) ts));
       ()
 
-    (* --locate, --locate_lib, --locate_ocaml *)
+    (* --locate, --locate_lib, --locate_ocaml, --locate_file *)
     | Success when Options.locate () ->
       Util.print1 "%s\n" (Find.locate ());
       exit 0
+
     | Success when Options.locate_lib () -> (
       match Find.locate_lib () with
       | None ->
@@ -225,9 +226,21 @@ let go_normal () =
         Util.print1 "%s\n" s;
         exit 0
     )
+
     | Success when Options.locate_ocaml () ->
       Util.print1 "%s\n" (Find.locate_ocaml ());
       exit 0
+
+    | Success when Some? (Options.locate_file ()) -> (
+      let f = Some?.v (Options.locate_file ()) in
+      match Find.find_file f with
+      | None ->
+        Util.print1_error "File %s was not found in include path.\n" f;
+        exit 1
+      | Some fn ->
+        Util.print1 "%s\n" (Util.normalize_file_path fn);
+        exit 0
+    )
 
     (* either batch or interactive mode *)
     | Success ->

--- a/src/fstar/FStarC.Main.fst
+++ b/src/fstar/FStarC.Main.fst
@@ -137,6 +137,12 @@ let print_help_for (o : string) : unit =
 (* Normal mode with some flags, files, etc *)
 let go_normal () =
   let res, filenames = process_args () in
+  let check_no_filenames opt =
+    if Cons? filenames then (
+      Util.print1_error "error: No filenames should be passed with option %s\n" opt;
+      exit 1
+    )
+  in
   if Options.trace_error () then set_error_trap ();
   match res with
     | Empty     -> Options.display_usage(); exit 1
@@ -214,10 +220,12 @@ let go_normal () =
 
     (* --locate, --locate_lib, --locate_ocaml, --locate_file *)
     | Success when Options.locate () ->
+      check_no_filenames "--locate";
       Util.print1 "%s\n" (Find.locate ());
       exit 0
 
     | Success when Options.locate_lib () -> (
+      check_no_filenames "--locate_lib";
       match Find.locate_lib () with
       | None ->
         Util.print_error "No library found (is --no_default_includes set?)\n";
@@ -228,10 +236,12 @@ let go_normal () =
     )
 
     | Success when Options.locate_ocaml () ->
+      check_no_filenames "--locate_ocaml";
       Util.print1 "%s\n" (Find.locate_ocaml ());
       exit 0
 
     | Success when Some? (Options.locate_file ()) -> (
+      check_no_filenames "--locate_fle";
       let f = Some?.v (Options.locate_file ()) in
       match Find.find_file f with
       | None ->


### PR DESCRIPTION
Given that we have fstar.include, and potentially many --include
options, it's not trivial to figure out where a given module can be
found or how F* resolved it. This option allows to query F* for the
location.

```
$ fstar.exe --locate_file Prims.fst
/home/guido/.gswitch/test/lib/fstar/Prims.fst
$ fstar.exe --locate_file Prims.fst.checked
/home/guido/.gswitch/test/lib/fstar/.cache/Prims.fst.checked
```
