### PR TITLE
Fixes for release

### DIFF
--- a/.docker/release.Dockerfile
+++ b/.docker/release.Dockerfile
@@ -15,11 +15,12 @@ RUN opam depext conf-gmp conf-m4
 
 ADD --chown=opam:opam ./fstar.opam fstar.opam
 
-# Install opam dependencies only, but not z3
-RUN grep -v z3 < fstar.opam > fstar-no-z3.opam && \
-    rm fstar.opam && \
-    opam install --deps-only ./fstar-no-z3.opam && \
-    rm fstar-no-z3.opam
+# Install opam dependencies only
+RUN opam install --deps-only ./fstar.opam
+
+# Install the relevant Z3 versions.
+COPY ./bin/get_fstar_z3.sh /usr/local/bin
+RUN sudo get_fstar_z3.sh /usr/local/bin
 
 # Install GitHub CLI
 # From https://github.com/cli/cli/blob/trunk/docs/install_linux.md#debian-ubuntu-linux-raspberry-pi-os-apt

--- a/.docker/standalone.Dockerfile
+++ b/.docker/standalone.Dockerfile
@@ -19,7 +19,7 @@ ARG CI_BRANCH=master
 ARG CI_NO_KARAMEL=
 ARG RESOURCEMONITOR=
 ARG FSTAR_CI_NO_GITDIFF=
-RUN eval $(opam env) && Z3_LICENSE="$(opam config expand '%{prefix}%')/.opam-switch/sources/z3.4.8.5/LICENSE.txt" CI_NO_KARAMEL=$CI_NO_KARAMEL .docker/build/build-standalone.sh $CI_THREADS $CI_BRANCH
+RUN eval $(opam env) && CI_NO_KARAMEL=$CI_NO_KARAMEL .docker/build/build-standalone.sh $CI_THREADS $CI_BRANCH
 
 WORKDIR $HOME
 ENV FSTAR_HOME $HOME/FStar

--- a/.scripts/test_package.sh
+++ b/.scripts/test_package.sh
@@ -53,9 +53,8 @@ else
 fi
 pushd fstar
 
-diag "-- Versions --"
+diag "-- Version --"
 bin/fstar.exe --version
-bin/z3 --version
 
 diag "*** Test the binary package"
 # We need two FSTAR_HOMEs in this script: one for the host (from where

--- a/ocaml/fstar-lib/generated/FStarC_Find.ml
+++ b/ocaml/fstar-lib/generated/FStarC_Find.ml
@@ -180,3 +180,135 @@ let (locate_ocaml : unit -> Prims.string) =
       let uu___2 = FStarC_Compiler_Util.get_exec_dir () in
       Prims.strcat uu___2 "/../lib" in
     FStarC_Compiler_Util.normalize_file_path uu___1
+let (z3url : Prims.string) = "https://github.com/Z3Prover/z3/releases"
+let (packaged_z3_versions : Prims.string Prims.list) = ["4.8.5"; "4.13.3"]
+let (z3_install_suggestion :
+  Prims.string -> FStarC_Pprint.document Prims.list) =
+  fun v ->
+    let uu___ =
+      let uu___1 =
+        let uu___2 =
+          let uu___3 =
+            FStarC_Compiler_Util.format1
+              "Please download version %s of Z3 from" v in
+          FStarC_Errors_Msg.text uu___3 in
+        let uu___3 = FStarC_Pprint.url z3url in
+        FStarC_Pprint.prefix (Prims.of_int (4)) Prims.int_one uu___2 uu___3 in
+      let uu___2 =
+        let uu___3 =
+          let uu___4 =
+            FStarC_Errors_Msg.text "and install it into your $PATH as" in
+          let uu___5 =
+            let uu___6 =
+              let uu___7 =
+                let uu___8 = FStarC_Platform.exe (Prims.strcat "z3-" v) in
+                FStarC_Pprint.doc_of_string uu___8 in
+              FStarC_Pprint.squotes uu___7 in
+            FStarC_Pprint.op_Hat_Hat uu___6 FStarC_Pprint.dot in
+          FStarC_Pprint.op_Hat_Slash_Hat uu___4 uu___5 in
+        FStarC_Pprint.group uu___3 in
+      FStarC_Pprint.op_Hat_Slash_Hat uu___1 uu___2 in
+    let uu___1 =
+      let uu___2 =
+        if FStarC_Compiler_List.mem v packaged_z3_versions
+        then
+          let uu___3 =
+            FStarC_Compiler_Util.format1
+              "Version %s of Z3 should be included in binary packages of F*. If you are using a binary package and are seeing\n              this error, please file a bug report."
+              v in
+          FStarC_Errors_Msg.text uu___3
+        else FStarC_Pprint.empty in
+      [uu___2] in
+    uu___ :: uu___1
+let (z3_inpath : Prims.string -> Prims.bool) =
+  fun path ->
+    try
+      (fun uu___ ->
+         match () with
+         | () ->
+             let s =
+               FStarC_Compiler_Util.run_process "z3_pathtest" path
+                 ["-version"] FStar_Pervasives_Native.None in
+             s <> "") ()
+    with | uu___ -> false
+let (do_locate_z3 :
+  Prims.string -> Prims.string FStar_Pervasives_Native.option) =
+  fun v ->
+    let guard b =
+      if b
+      then FStar_Pervasives_Native.Some ()
+      else FStar_Pervasives_Native.None in
+    let op_Less_Bar_Greater o1 o2 uu___ =
+      let uu___1 = o1 () in
+      match uu___1 with
+      | FStar_Pervasives_Native.Some v1 -> FStar_Pervasives_Native.Some v1
+      | FStar_Pervasives_Native.None -> o2 () in
+    let path =
+      let in_lib uu___ =
+        (fun uu___ ->
+           let uu___1 = lib_root () in
+           Obj.magic
+             (FStarC_Class_Monad.op_let_Bang FStarC_Class_Monad.monad_option
+                () () (Obj.magic uu___1)
+                (fun uu___2 ->
+                   (fun root ->
+                      let root = Obj.magic root in
+                      let path1 =
+                        FStarC_Platform.exe
+                          (Prims.strcat root
+                             (Prims.strcat "/z3-" (Prims.strcat v "/bin/z3"))) in
+                      let path2 =
+                        FStarC_Compiler_Util.normalize_file_path path1 in
+                      let uu___2 =
+                        guard (FStarC_Compiler_Util.file_exists path2) in
+                      Obj.magic
+                        (FStarC_Class_Monad.op_let_Bang
+                           FStarC_Class_Monad.monad_option () () uu___2
+                           (fun uu___3 ->
+                              (fun uu___3 ->
+                                 let uu___3 = Obj.magic uu___3 in
+                                 Obj.magic
+                                   (FStar_Pervasives_Native.Some path2))
+                                uu___3))) uu___2))) uu___ in
+      let from_path uu___1 uu___ =
+        (fun cmd ->
+           fun uu___ ->
+             let cmd1 = FStarC_Platform.exe cmd in
+             let uu___1 = let uu___2 = z3_inpath cmd1 in guard uu___2 in
+             Obj.magic
+               (FStarC_Class_Monad.op_let_Bang
+                  FStarC_Class_Monad.monad_option () () uu___1
+                  (fun uu___2 ->
+                     (fun uu___2 ->
+                        let uu___2 = Obj.magic uu___2 in
+                        Obj.magic (FStar_Pervasives_Native.Some cmd1)) uu___2)))
+          uu___1 uu___ in
+      op_Less_Bar_Greater
+        (op_Less_Bar_Greater
+           (op_Less_Bar_Greater
+              (op_Less_Bar_Greater FStarC_Options.smt in_lib)
+              (from_path (Prims.strcat "z3-" v))) (from_path "z3"))
+        (fun uu___ -> FStar_Pervasives_Native.None) () in
+    (let uu___1 = FStarC_Compiler_Debug.any () in
+     if uu___1
+     then
+       let uu___2 =
+         FStarC_Class_Show.show FStarC_Class_Show.showable_string v in
+       let uu___3 =
+         FStarC_Class_Show.show
+           (FStarC_Class_Show.show_option FStarC_Class_Show.showable_string)
+           path in
+       FStarC_Compiler_Util.print2 "do_locate_z3(%s) = %s\n" uu___2 uu___3
+     else ());
+    path
+let (locate_z3 : Prims.string -> Prims.string FStar_Pervasives_Native.option)
+  =
+  fun v ->
+    let cache = FStarC_Compiler_Util.smap_create (Prims.of_int (5)) in
+    let find_or k f =
+      let uu___ = FStarC_Compiler_Util.smap_try_find cache k in
+      match uu___ with
+      | FStar_Pervasives_Native.Some v1 -> v1
+      | FStar_Pervasives_Native.None ->
+          let v1 = f k in (FStarC_Compiler_Util.smap_add cache k v1; v1) in
+    find_or v do_locate_z3

--- a/ocaml/fstar-lib/generated/FStarC_Main.ml
+++ b/ocaml/fstar-lib/generated/FStarC_Main.ml
@@ -331,7 +331,7 @@ let (go_normal : unit -> unit) =
           | FStarC_Getopt.Success when
               let uu___3 = FStarC_Options.locate_file () in
               FStar_Pervasives_Native.uu___is_Some uu___3 ->
-              (check_no_filenames "--locate_fle";
+              (check_no_filenames "--locate_file";
                (let f =
                   let uu___4 = FStarC_Options.locate_file () in
                   FStar_Pervasives_Native.__proj__Some__item__v uu___4 in
@@ -345,6 +345,36 @@ let (go_normal : unit -> unit) =
                     ((let uu___6 =
                         FStarC_Compiler_Util.normalize_file_path fn in
                       FStarC_Compiler_Util.print1 "%s\n" uu___6);
+                     FStarC_Compiler_Effect.exit Prims.int_zero)))
+          | FStarC_Getopt.Success when
+              let uu___3 = FStarC_Options.locate_z3 () in
+              FStar_Pervasives_Native.uu___is_Some uu___3 ->
+              (check_no_filenames "--locate_z3";
+               (let v =
+                  let uu___4 = FStarC_Options.locate_z3 () in
+                  FStar_Pervasives_Native.__proj__Some__item__v uu___4 in
+                let uu___4 = FStarC_Find.locate_z3 v in
+                match uu___4 with
+                | FStar_Pervasives_Native.None ->
+                    ((let uu___6 =
+                        let uu___7 =
+                          let uu___8 =
+                            let uu___9 =
+                              FStarC_Compiler_Util.format1
+                                "Z3 version '%s' was not found." v in
+                            FStarC_Errors_Msg.text uu___9 in
+                          [uu___8] in
+                        let uu___8 = FStarC_Find.z3_install_suggestion v in
+                        FStarC_Compiler_List.op_At uu___7 uu___8 in
+                      FStarC_Errors.log_issue0
+                        FStarC_Errors_Codes.Error_Z3InvocationError ()
+                        (Obj.magic
+                           FStarC_Errors_Msg.is_error_message_list_doc)
+                        (Obj.magic uu___6));
+                     report_errors [];
+                     FStarC_Compiler_Effect.exit Prims.int_one)
+                | FStar_Pervasives_Native.Some fn ->
+                    (FStarC_Compiler_Util.print1 "%s\n" fn;
                      FStarC_Compiler_Effect.exit Prims.int_zero)))
           | FStarC_Getopt.Success ->
               (FStarC_Compiler_Effect.op_Colon_Equals fstar_files

--- a/ocaml/fstar-lib/generated/FStarC_Options.ml
+++ b/ocaml/fstar-lib/generated/FStarC_Options.ml
@@ -365,6 +365,7 @@ let (defaults : (Prims.string * option_val) Prims.list) =
   ("locate_lib", (Bool false));
   ("locate_ocaml", (Bool false));
   ("locate_file", Unset);
+  ("locate_z3", Unset);
   ("read_krml_file", Unset);
   ("record_hints", (Bool false));
   ("record_options", (Bool false));
@@ -744,6 +745,8 @@ let (get_locate_ocaml : unit -> Prims.bool) =
   fun uu___ -> lookup_opt "locate_ocaml" as_bool
 let (get_locate_file : unit -> Prims.string FStar_Pervasives_Native.option) =
   fun uu___ -> lookup_opt "locate_file" (as_option as_string)
+let (get_locate_z3 : unit -> Prims.string FStar_Pervasives_Native.option) =
+  fun uu___ -> lookup_opt "locate_z3" (as_option as_string)
 let (get_record_hints : unit -> Prims.bool) =
   fun uu___ -> lookup_opt "record_hints" as_bool
 let (get_record_options : unit -> Prims.bool) =
@@ -3530,20 +3533,11 @@ let rec (specs_with_types :
                                                                     let uu___282
                                                                     =
                                                                     text
-                                                                    "With no arguments: print shell code to set up an environment with the OCaml libraries in scope (similar to 'opam env'). With arguments: run a command in that environment. NOTE: this must be the FIRST argument passed to F* and other options are NOT processed." in
+                                                                    "Locate the executable for a given Z3 version, then exit. The output is either an absolute path, or a name that was found in the PATH. Note: this is the Z3 executable that F* will attempt to call for the given version, but the version check is not performed at this point." in
                                                                     (FStarC_Getopt.noshort,
-                                                                    "ocamlenv",
-                                                                    (WithSideEffect
-                                                                    ((fun
-                                                                    uu___283
-                                                                    ->
-                                                                    FStarC_Compiler_Util.print_error
-                                                                    "--ocamlenv must be the first argument, see fstar.exe --help for details\n";
-                                                                    FStarC_Compiler_Effect.exit
-                                                                    Prims.int_one),
-                                                                    (Const
-                                                                    (Bool
-                                                                    true)))),
+                                                                    "locate_z3",
+                                                                    (SimpleStr
+                                                                    "version"),
                                                                     uu___282) in
                                                                     let uu___282
                                                                     =
@@ -3552,15 +3546,15 @@ let rec (specs_with_types :
                                                                     let uu___284
                                                                     =
                                                                     text
-                                                                    "A helper. This runs 'ocamlc' in the environment set up by --ocamlenv, for building an F* application bytecode executable." in
+                                                                    "With no arguments: print shell code to set up an environment with the OCaml libraries in scope (similar to 'opam env'). With arguments: run a command in that environment. NOTE: this must be the FIRST argument passed to F* and other options are NOT processed." in
                                                                     (FStarC_Getopt.noshort,
-                                                                    "ocamlc",
+                                                                    "ocamlenv",
                                                                     (WithSideEffect
                                                                     ((fun
                                                                     uu___285
                                                                     ->
                                                                     FStarC_Compiler_Util.print_error
-                                                                    "--ocamlc must be the first argument, see fstar.exe --help for details\n";
+                                                                    "--ocamlenv must be the first argument, see fstar.exe --help for details\n";
                                                                     FStarC_Compiler_Effect.exit
                                                                     Prims.int_one),
                                                                     (Const
@@ -3574,15 +3568,15 @@ let rec (specs_with_types :
                                                                     let uu___286
                                                                     =
                                                                     text
-                                                                    "A helper. This runs 'ocamlopt' in the environment set up by --ocamlenv, for building an F* application native executable." in
+                                                                    "A helper. This runs 'ocamlc' in the environment set up by --ocamlenv, for building an F* application bytecode executable." in
                                                                     (FStarC_Getopt.noshort,
-                                                                    "ocamlopt",
+                                                                    "ocamlc",
                                                                     (WithSideEffect
                                                                     ((fun
                                                                     uu___287
                                                                     ->
                                                                     FStarC_Compiler_Util.print_error
-                                                                    "--ocamlopt must be the first argument, see fstar.exe --help for details\n";
+                                                                    "--ocamlc must be the first argument, see fstar.exe --help for details\n";
                                                                     FStarC_Compiler_Effect.exit
                                                                     Prims.int_one),
                                                                     (Const
@@ -3596,12 +3590,34 @@ let rec (specs_with_types :
                                                                     let uu___288
                                                                     =
                                                                     text
+                                                                    "A helper. This runs 'ocamlopt' in the environment set up by --ocamlenv, for building an F* application native executable." in
+                                                                    (FStarC_Getopt.noshort,
+                                                                    "ocamlopt",
+                                                                    (WithSideEffect
+                                                                    ((fun
+                                                                    uu___289
+                                                                    ->
+                                                                    FStarC_Compiler_Util.print_error
+                                                                    "--ocamlopt must be the first argument, see fstar.exe --help for details\n";
+                                                                    FStarC_Compiler_Effect.exit
+                                                                    Prims.int_one),
+                                                                    (Const
+                                                                    (Bool
+                                                                    true)))),
+                                                                    uu___288) in
+                                                                    let uu___288
+                                                                    =
+                                                                    let uu___289
+                                                                    =
+                                                                    let uu___290
+                                                                    =
+                                                                    text
                                                                     "A helper. This runs 'ocamlopt' in the environment set up by --ocamlenv, for building an F* plugin." in
                                                                     (FStarC_Getopt.noshort,
                                                                     "ocamlopt_plugin",
                                                                     (WithSideEffect
                                                                     ((fun
-                                                                    uu___289
+                                                                    uu___291
                                                                     ->
                                                                     FStarC_Compiler_Util.print_error
                                                                     "--ocamlopt_plugin must be the first argument, see fstar.exe --help for details\n";
@@ -3610,8 +3626,11 @@ let rec (specs_with_types :
                                                                     (Const
                                                                     (Bool
                                                                     true)))),
-                                                                    uu___288) in
-                                                                    [uu___287] in
+                                                                    uu___290) in
+                                                                    [uu___289] in
+                                                                    uu___287
+                                                                    ::
+                                                                    uu___288 in
                                                                     uu___285
                                                                     ::
                                                                     uu___286 in
@@ -4523,6 +4542,8 @@ let (locate_lib : unit -> Prims.bool) = fun uu___ -> get_locate_lib ()
 let (locate_ocaml : unit -> Prims.bool) = fun uu___ -> get_locate_ocaml ()
 let (locate_file : unit -> Prims.string FStar_Pervasives_Native.option) =
   fun uu___ -> get_locate_file ()
+let (locate_z3 : unit -> Prims.string FStar_Pervasives_Native.option) =
+  fun uu___ -> get_locate_z3 ()
 let (read_krml_file : unit -> Prims.string FStar_Pervasives_Native.option) =
   fun uu___ -> get_read_krml_file ()
 let (record_hints : unit -> Prims.bool) = fun uu___ -> get_record_hints ()

--- a/src/basic/FStarC.Find.fst
+++ b/src/basic/FStarC.Find.fst
@@ -16,10 +16,12 @@
 module FStarC.Find
 
 open FStar
+open FStarC
 open FStarC.Compiler
 open FStarC.Compiler.Effect
 open FStarC.Compiler.List
 module BU = FStarC.Compiler.Util
+open FStarC.Class.Show
 
 let fstar_bin_directory : string =
   BU.get_exec_dir ()
@@ -144,3 +146,93 @@ let locate_lib () =
 let locate_ocaml () =
   // This is correct right now, but probably should change.
   Util.get_exec_dir () ^ "/../lib" |> Util.normalize_file_path
+
+let z3url = "https://github.com/Z3Prover/z3/releases"
+
+let packaged_z3_versions = ["4.8.5"; "4.13.3"]
+
+let z3_install_suggestion (v : string) : list Pprint.document =
+  let open FStarC.Errors.Msg in
+  let open FStarC.Pprint in
+  [
+    prefix 4 1 (text <| BU.format1 "Please download version %s of Z3 from" v)
+              (url z3url) ^/^
+      group (text "and install it into your $PATH as" ^/^ squotes
+        (doc_of_string (Platform.exe ("z3-" ^ v))) ^^ dot);
+    if List.mem v packaged_z3_versions then
+      text <| BU.format1 "Version %s of Z3 should be included in binary packages \
+              of F*. If you are using a binary package and are seeing
+              this error, please file a bug report." v
+    else
+      empty
+  ]
+
+(* Check if [path] is potentially a valid z3, by trying to run
+it with -version and checking for non-empty output. Alternatively
+we could call [which] on it (if it's not an absolute path), but
+we shouldn't rely on the existence of a binary which. *)
+let z3_inpath (path:string) : bool =
+  try
+    let s = BU.run_process "z3_pathtest" path ["-version"] None in
+    s <> ""
+  with
+  | _ -> false
+
+(* Find the Z3 executable that we should invoke for a given version.
+
+- If the user provided the --smt option, use that binary unconditionally.
+- We then look in $LIB/z3-VER/z3, where LIB is the F* library root, for example
+  /usr/local/lib/fstar/z3-4.8.5/bin/z3, for an installed package. We ship Z3 4.8.5
+  and 4.13.3 in the binary package in these paths, so F* automatically find them
+  without relying on PATH or adding more stuff to the user's /usr/local/bin.
+  Each $PREFIX/lib/fstar/z3-VER directory roughly contains an extracted Z3
+  binary package, but with many files removed (currently we just keep LICENSE
+  and the executable).
+
+- Else we check the PATH:
+  - If z3-VER (or z3-VER.exe) exists in the PATH use it.
+  - Otherwise, default to "z3" in the PATH.
+
+We cache the chosen executable for every Z3 version we've ran.
+*)
+let do_locate_z3 (v:string) : option string =
+  let open FStarC.Class.Monad in
+  let guard (b:bool) : option unit = if b then Some () else None in
+  let (<|>) o1 o2 () =
+    match o1 () with
+    | Some v -> Some v
+    | None -> o2 ()
+  in
+  let path =
+    let in_lib () : option string =
+      let! root = lib_root () in
+      let path = Platform.exe (root ^ "/z3-" ^ v ^ "/bin/z3") in
+      let path = BU.normalize_file_path path in
+      guard (BU.file_exists path);!
+      Some path
+    in
+    let from_path (cmd : string) () =
+      let cmd = Platform.exe cmd in
+      guard (z3_inpath cmd);!
+      Some cmd
+    in
+    (Options.smt <|>
+    in_lib <|>
+    from_path ("z3-" ^ v) <|>
+    from_path "z3" <|> (fun _ -> None)) ()
+  in
+  if Debug.any () then
+    BU.print2 "do_locate_z3(%s) = %s\n" (Class.Show.show v) (Class.Show.show path);
+  path
+
+let locate_z3 (v : string) : option string =
+  let cache : BU.smap (option string) = BU.smap_create 5 in
+  let find_or (k:string) (f : string -> option string) : option string =
+    match BU.smap_try_find cache k with
+    | Some v -> v
+    | None ->
+      let v = f k in
+      BU.smap_add cache k v;
+      v
+  in
+  find_or v do_locate_z3

--- a/src/basic/FStarC.Find.fsti
+++ b/src/basic/FStarC.Find.fsti
@@ -47,3 +47,9 @@ val locate_lib () : option string
 
 (* Return absolute path of OCaml-installed components of F*. *)
 val locate_ocaml () : string
+
+(* A message for the user suggesting how to install the proper Z3 version. *)
+val z3_install_suggestion (v : string) : list Pprint.document
+
+(* Locate executable for Z3 version [v]. *)
+val locate_z3 (v : string) : option string

--- a/src/basic/FStarC.Options.fst
+++ b/src/basic/FStarC.Options.fst
@@ -274,6 +274,7 @@ let defaults =
       ("locate_lib"                   , Bool false);
       ("locate_ocaml"                 , Bool false);
       ("locate_file"                  , Unset);
+      ("locate_z3"                    , Unset);
       ("read_krml_file"               , Unset);
       ("record_hints"                 , Bool false);
       ("record_options"               , Bool false);
@@ -536,6 +537,7 @@ let get_locate                  ()      = lookup_opt "locate"                   
 let get_locate_lib              ()      = lookup_opt "locate_lib"               as_bool
 let get_locate_ocaml            ()      = lookup_opt "locate_ocaml"             as_bool
 let get_locate_file             ()      = lookup_opt "locate_file"              (as_option as_string)
+let get_locate_z3               ()      = lookup_opt "locate_z3"                (as_option as_string)
 let get_record_hints            ()      = lookup_opt "record_hints"             as_bool
 let get_record_options          ()      = lookup_opt "record_options"           as_bool
 let get_retry                   ()      = lookup_opt "retry"                    as_bool
@@ -1640,6 +1642,13 @@ let rec specs_with_types warn_unsafe : list (char & string & opt_type & Pprint.d
     SimpleStr "basename",
     text "Find a file in F*'s include path and print its absolute path, then exit");
   ( noshort,
+    "locate_z3",
+    SimpleStr "version",
+    text "Locate the executable for a given Z3 version, then exit. \
+          The output is either an absolute path, or a name that was found in the PATH. \
+          Note: this is the Z3 executable that F* will attempt to call for the given version, \
+          but the version check is not performed at this point.");
+  ( noshort,
     "ocamlenv",
     WithSideEffect ((fun _ -> print_error "--ocamlenv must be the first argument, see fstar.exe --help for details\n"; exit 1),
                      (Const (Bool true))),
@@ -2061,6 +2070,7 @@ let locate                       () = get_locate                      ()
 let locate_lib                   () = get_locate_lib                  ()
 let locate_ocaml                 () = get_locate_ocaml                ()
 let locate_file                  () = get_locate_file                 ()
+let locate_z3                    () = get_locate_z3                   ()
 let read_krml_file               () = get_read_krml_file              ()
 let record_hints                 () = get_record_hints                ()
 let record_options               () = get_record_options              ()

--- a/src/basic/FStarC.Options.fsti
+++ b/src/basic/FStarC.Options.fsti
@@ -180,6 +180,7 @@ val locate                      : unit    -> bool
 val locate_lib                  : unit    -> bool
 val locate_ocaml                : unit    -> bool
 val locate_file                 : unit    -> option string
+val locate_z3                   : unit    -> option string
 val output_deps_to              : unit    -> option string
 val output_dir                  : unit    -> option string
 val custom_prims                : unit    -> option string

--- a/src/fstar/FStarC.Main.fst
+++ b/src/fstar/FStarC.Main.fst
@@ -241,7 +241,7 @@ let go_normal () =
       exit 0
 
     | Success when Some? (Options.locate_file ()) -> (
-      check_no_filenames "--locate_fle";
+      check_no_filenames "--locate_file";
       let f = Some?.v (Options.locate_file ()) in
       match Find.find_file f with
       | None ->
@@ -249,6 +249,22 @@ let go_normal () =
         exit 1
       | Some fn ->
         Util.print1 "%s\n" (Util.normalize_file_path fn);
+        exit 0
+    )
+
+    | Success when Some? (Options.locate_z3 ()) -> (
+      check_no_filenames "--locate_z3";
+      let v = Some?.v (Options.locate_z3 ()) in
+      match Find.locate_z3 v with
+      | None ->
+        // Use an actual error to reuse the pretty printing.
+        Errors.log_issue0 Errors.Error_Z3InvocationError ([
+          Errors.Msg.text <| Util.format1 "Z3 version '%s' was not found." v;
+          ] @ Find.z3_install_suggestion v);
+        report_errors []; // but make sure to report.
+        exit 1
+      | Some fn ->
+        Util.print1 "%s\n" fn;
         exit 0
     )
 

--- a/src/ocaml-output/Makefile
+++ b/src/ocaml-output/Makefile
@@ -96,17 +96,6 @@ endif
 
 PACKAGE_NAME ?= fstar
 
-ifeq ($(OS),Windows_NT)
-  Z3_NAME=z3.exe
-else
-  Z3_NAME=z3
-endif
-Z3_DIR=$(dir $(shell which $(Z3_NAME)))
-# Z3_LICENSE MUST be explicitly overridden if z3 is installed from an opam package.
-# See for instance $(FSTAR_HOME)/.docker/package.Dockerfile
-ifndef Z3_LICENSE
-  Z3_LICENSE?=$(shell if test -f $(Z3_DIR)/LICENSE.txt ; then echo $(Z3_DIR)/LICENSE.txt ; elif test -f $(Z3_DIR)/../LICENSE.txt ; then echo $(Z3_DIR)/../LICENSE.txt ; fi)
-endif
 
 # Create a zip / tar.gz package of FStar that contains a Z3 binary and
 # proper license files.
@@ -118,7 +107,6 @@ package_prefix=$(call maybe_cygwin_path,$(CURDIR)/fstar)
 package_dir = cd ../../$(1) && find . -type f -exec $(INSTALL_EXEC) -m 644 -D {} $(package_prefix)/$(2)/{} \;
 
 package:
-	if test -z "$(Z3_LICENSE)" ; then echo Please set Z3_LICENSE to the location of the license file for Z3 ; false ; fi
 	@# Clean previous packages.
 	! [ -d "$(package_prefix)" ]
 	rm -f $(PACKAGE_NAME).zip $(PACKAGE_NAME).tar.gz
@@ -130,15 +118,26 @@ package:
 	cp ../../version.txt $(package_prefix)/
 	@# Documentation and licenses
 	cp ../../README.md ../../INSTALL.md ../../LICENSE ../../LICENSE-fsharp.txt $(package_prefix)
-	cp $(Z3_LICENSE) $(package_prefix)/LICENSE-z3.txt
-	@# Z3
+	@# packaged Z3 versions
+	rm -rf z3tmp && mkdir -p z3tmp
+	$(FSTAR_HOME)/bin/get_fstar_z3.sh --full ./z3tmp
 ifeq ($(OS),Windows_NT)
 	cp $(shell which libgmp-10.dll) $(package_prefix)/bin
-	cp $(Z3_DIR)/*.exe $(Z3_DIR)/*.dll $(Z3_DIR)/*.lib $(package_prefix)/bin
-	chmod a+x $(package_prefix)/bin/z3.exe $(package_prefix)/bin/*.dll
+	# cp $(Z3_DIR)/*.exe $(Z3_DIR)/*.dll $(Z3_DIR)/*.lib $(package_prefix)/bin
+	# trying to slim down and avoid dlls,etc
+	mkdir -p $(package_prefix)/lib/fstar/z3-4.8.5/bin/
+	cp z3tmp/z3-4.8.5/bin/z3.exe   $(package_prefix)/lib/fstar/z3-4.8.5/bin/z3.exe
+	cp z3tmp/z3-4.8.5/LICENSE.txt  $(package_prefix)/lib/fstar/z3-4.8.5/LICENSE.txt
+	mkdir -p $(package_prefix)/lib/fstar/z3-4.13.3/bin/
+	cp z3tmp/z3-4.13.3/bin/z3.exe  $(package_prefix)/lib/fstar/z3-4.13.3/bin/z3.exe
+	cp z3tmp/z3-4.13.3/LICENSE.txt $(package_prefix)/lib/fstar/z3-4.13.3/LICENSE.txt
+	chmod a+x $(package_prefix)/lib/fstar/z3-*/z3.exe
 	zip -r -9 $(PACKAGE_NAME).zip fstar
 else
-	cp $(Z3_DIR)/z3 $(package_prefix)/bin
+	$(INSTALL_EXEC) -D -T z3tmp/z3-4.8.5/bin/z3       $(package_prefix)/lib/fstar/z3-4.8.5/bin/z3
+	$(INSTALL_EXEC) -D -T z3tmp/z3-4.8.5/LICENSE.txt  $(package_prefix)/lib/fstar/z3-4.8.5/LICENSE.txt
+	$(INSTALL_EXEC) -D -T z3tmp/z3-4.13.3/bin/z3      $(package_prefix)/lib/fstar/z3-4.13.3/bin/z3
+	$(INSTALL_EXEC) -D -T z3tmp/z3-4.13.3/LICENSE.txt $(package_prefix)/lib/fstar/z3-4.13.3/LICENSE.txt
 	tar czf $(PACKAGE_NAME).tar.gz fstar
 endif
 


### PR DESCRIPTION
Ship both Z3 versions in the package, allow F* to find them in its own `lib/` directory and prefer them to externally-found z3's.