### PR TITLE
nix: enable more systems (e.g. MacOS)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   outputs = { self, flake-utils, nixpkgs }:
-    flake-utils.lib.eachSystem [ "x86_64-linux" ] (system:
+    flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs { inherit system; };
         ocamlPackages = pkgs.ocaml-ng.ocamlPackages_4_14;


### PR DESCRIPTION
The Nix build was hardcoding an over-restrictive list of systems for which F* could be built. This PR allows to build F* via Nix on more system, notably on apple silicon.