### PR TITLE
mk: removing extraneous .ml files after extracting

### DIFF
--- a/mk/fstar-12.mk
+++ b/mk/fstar-12.mk
@@ -79,13 +79,13 @@ DEPSTEM := $(CACHE_DIR)/.depend$(TAG)
 # triggering an actual dependency run.
 .PHONY: .force
 $(DEPSTEM).touch: .force
+	mkdir -p $(dir $@)
 	find $(SRC) -name '*.fst*' > $@.chk
 	diff -q $@ $@.chk || cp $@.chk $@
 
 $(DEPSTEM): $(DEPSTEM).touch
 	$(call msg, "DEPEND", $(SRC))
 	$(FSTAR) --dep full $(ROOTS) $(EXTRACT) $(DEPFLAGS) --output_deps_to $@
-	mkdir -p $(CACHE_DIR)
 
 depend: $(DEPSTEM)
 include $(DEPSTEM)

--- a/mk/fstar-12.mk
+++ b/mk/fstar-12.mk
@@ -79,4 +79,10 @@ depend: $(CACHE_DIR)/.depend$(TAG)
 include $(CACHE_DIR)/.depend$(TAG)
 
 all-ml: $(ALL_ML_FILES)
+	@# Remove extraneous .ml files, which can linger after
+	@# module renamings. The realpath is necessary to prevent
+	@# discrepancies between absolute and relative paths, double
+	@# slashes, etc.
+	rm -vf $(filter-out $(realpath $(ALL_ML_FILES)), $(realpath $(wildcard $(OUTPUT_DIR)/*.ml)))
+
 all-checked: $(ALL_CHECKED_FILES)

--- a/mk/fstar-12.mk
+++ b/mk/fstar-12.mk
@@ -81,7 +81,7 @@ DEPSTEM := $(CACHE_DIR)/.depend$(TAG)
 $(DEPSTEM).touch: .force
 	mkdir -p $(dir $@)
 	find $(SRC) -name '*.fst*' > $@.chk
-	diff -q $@ $@.chk || cp $@.chk $@
+	diff -q $@ $@.chk 2>/dev/null || cp $@.chk $@
 
 $(DEPSTEM): $(DEPSTEM).touch
 	$(call msg, "DEPEND", $(SRC))

--- a/mk/lib.mk
+++ b/mk/lib.mk
@@ -142,4 +142,11 @@ all-checked: $(ALL_CHECKED_FILES)
 # These targets imply verification of every file too, regardless
 # of extraction.
 all-ml: all-checked $(ALL_ML_FILES)
+	@# Remove extraneous .ml files, which can linger after
+	@# module renamings. The realpath is necessary to prevent
+	@# discrepancies between absolute and relative paths, double
+	@# slashes, etc.
+	rm -vf $(filter-out $(realpath $(ALL_ML_FILES)), $(realpath $(wildcard $(OUTPUT_DIR)/*.ml)))
+
 all-fs: all-checked $(ALL_FS_FILES)
+	rm -vf $(filter-out $(realpath $(ALL_FS_FILES)), $(realpath $(wildcard $(OUTPUT_DIR)/*.fs)))

--- a/mk/lib.mk
+++ b/mk/lib.mk
@@ -141,7 +141,7 @@ DEPSTEM := $(CACHE_DIR)/.depend$(TAG)
 $(DEPSTEM).touch: .force
 	mkdir -p $(dir $@)
 	find $(SRC) -name '*.fst*' > $@.chk
-	diff -q $@ $@.chk || cp $@.chk $@
+	diff -q $@ $@.chk 2>/dev/null || cp $@.chk $@
 
 $(DEPSTEM): $(DEPSTEM).touch
 	$(call msg, "DEPEND", $(SRC))

--- a/mk/lib.mk
+++ b/mk/lib.mk
@@ -139,13 +139,13 @@ DEPSTEM := $(CACHE_DIR)/.depend$(TAG)
 # triggering an actual dependency run.
 .PHONY: .force
 $(DEPSTEM).touch: .force
+	mkdir -p $(dir $@)
 	find $(SRC) -name '*.fst*' > $@.chk
 	diff -q $@ $@.chk || cp $@.chk $@
 
 $(DEPSTEM): $(DEPSTEM).touch
 	$(call msg, "DEPEND", $(SRC))
 	$(FSTAR) --dep full $(ROOTS) $(EXTRACT) $(DEPFLAGS) --output_deps_to $@
-	mkdir -p $(CACHE_DIR)
 
 depend: $(DEPSTEM)
 include $(DEPSTEM)

--- a/mk/lib.mk
+++ b/mk/lib.mk
@@ -130,13 +130,25 @@ EXTRACT := --extract '* $(EXTRACT_NS)'
 # file in the cwd named like a file in ulib/, F* may prefer the former.
 ROOTS := $(shell find $(SRC) -name '*.fst' -o -name '*.fsti')
 
-$(CACHE_DIR)/.depend$(TAG):
+DEPSTEM := $(CACHE_DIR)/.depend$(TAG)
+# We always run this to compute a full list of fst/fsti files in the
+# $(SRC) (ignoring the roots, it's a bit conservative). The list is
+# saved in $(DEPSTEM).touch.chk, and compared to the one we generated
+# before in $(DEPSTEM).touch. If there's a change (or the 'previous')
+# does not exist, the timestamp of $(DEPSTEM0.touch will be updated
+# triggering an actual dependency run.
+.PHONY: .force
+$(DEPSTEM).touch: .force
+	find $(SRC) -name '*.fst*' > $@.chk
+	diff -q $@ $@.chk || cp $@.chk $@
+
+$(DEPSTEM): $(DEPSTEM).touch
 	$(call msg, "DEPEND", $(SRC))
 	$(FSTAR) --dep full $(ROOTS) $(EXTRACT) $(DEPFLAGS) --output_deps_to $@
 	mkdir -p $(CACHE_DIR)
 
-depend: $(CACHE_DIR)/.depend$(TAG)
-include $(CACHE_DIR)/.depend$(TAG)
+depend: $(DEPSTEM)
+include $(DEPSTEM)
 
 all-checked: $(ALL_CHECKED_FILES)
 # These targets imply verification of every file too, regardless

--- a/mk/plugins.mk
+++ b/mk/plugins.mk
@@ -125,7 +125,7 @@ DEPSTEM := $(CACHE_DIR)/.depend$(TAG)
 $(DEPSTEM).touch: .force
 	mkdir -p $(dir $@)
 	find $(SRC) -name '*.fst*' > $@.chk
-	diff -q $@ $@.chk || cp $@.chk $@
+	diff -q $@ $@.chk 2>/dev/null || cp $@.chk $@
 
 $(DEPSTEM): $(DEPSTEM).touch
 	$(call msg, "DEPEND", $(SRC))

--- a/mk/plugins.mk
+++ b/mk/plugins.mk
@@ -123,3 +123,8 @@ depend: $(CACHE_DIR)/.depend$(TAG)
 include $(CACHE_DIR)/.depend$(TAG)
 
 all-ml: $(ALL_ML_FILES)
+	@# Remove extraneous .ml files, which can linger after
+	@# module renamings. The realpath is necessary to prevent
+	@# discrepancies between absolute and relative paths, double
+	@# slashes, etc.
+	rm -vf $(filter-out $(realpath $(ALL_ML_FILES)), $(realpath $(wildcard $(OUTPUT_DIR)/*.ml)))

--- a/mk/plugins.mk
+++ b/mk/plugins.mk
@@ -114,13 +114,25 @@ ROOTS += ../ulib/FStar.Tactics.V2.Logic.fsti
 ROOTS += ../ulib/FStar.Tactics.V2.SyntaxHelpers.fst
 ROOTS += ../ulib/FStar.Tactics.Visit.fst
 
-$(CACHE_DIR)/.depend$(TAG):
-	$(call msg, "DEPEND")
-	$(FSTAR) --dep full $(ROOTS) $(EXTRACT) --output_deps_to $@
+DEPSTEM := $(CACHE_DIR)/.depend$(TAG)
+# We always run this to compute a full list of fst/fsti files in the
+# $(SRC) (ignoring the roots, it's a bit conservative). The list is
+# saved in $(DEPSTEM).touch.chk, and compared to the one we generated
+# before in $(DEPSTEM).touch. If there's a change (or the 'previous')
+# does not exist, the timestamp of $(DEPSTEM0.touch will be updated
+# triggering an actual dependency run.
+.PHONY: .force
+$(DEPSTEM).touch: .force
+	find $(SRC) -name '*.fst*' > $@.chk
+	diff -q $@ $@.chk || cp $@.chk $@
+
+$(DEPSTEM): $(DEPSTEM).touch
+	$(call msg, "DEPEND", $(SRC))
+	$(FSTAR) --dep full $(ROOTS) $(EXTRACT) $(DEPFLAGS) --output_deps_to $@
 	mkdir -p $(CACHE_DIR)
 
-depend: $(CACHE_DIR)/.depend$(TAG)
-include $(CACHE_DIR)/.depend$(TAG)
+depend: $(DEPSTEM)
+include $(DEPSTEM)
 
 all-ml: $(ALL_ML_FILES)
 	@# Remove extraneous .ml files, which can linger after

--- a/mk/plugins.mk
+++ b/mk/plugins.mk
@@ -123,13 +123,13 @@ DEPSTEM := $(CACHE_DIR)/.depend$(TAG)
 # triggering an actual dependency run.
 .PHONY: .force
 $(DEPSTEM).touch: .force
+	mkdir -p $(dir $@)
 	find $(SRC) -name '*.fst*' > $@.chk
 	diff -q $@ $@.chk || cp $@.chk $@
 
 $(DEPSTEM): $(DEPSTEM).touch
 	$(call msg, "DEPEND", $(SRC))
 	$(FSTAR) --dep full $(ROOTS) $(EXTRACT) $(DEPFLAGS) --output_deps_to $@
-	mkdir -p $(CACHE_DIR)
 
 depend: $(DEPSTEM)
 include $(DEPSTEM)


### PR DESCRIPTION
Helps when renaming modules.