### PR TITLE
check-friends: restoring main repos

### DIFF
--- a/.github/workflows/check-friends.yml
+++ b/.github/workflows/check-friends.yml
@@ -28,8 +28,7 @@ jobs:
         uses: actions/checkout@master
         with:
           path: karamel/
-          repository: mtzguido/karamel
-          ref: dev
+          repository: FStarLang/karamel
 
       - name: Build krml
         run: make -C karamel -skj$(nproc)
@@ -95,8 +94,7 @@ jobs:
         uses: actions/checkout@master
         with:
           path: steel/
-          repository: mtzguido/steel
-          ref: dev
+          repository: FStarLang/steel
 
       - name: Build
         run: make -C steel -skj$(nproc)
@@ -148,8 +146,7 @@ jobs:
         uses: actions/checkout@master
         with:
           path: pulse/
-          repository: mtzguido/pulse
-          ref: dev
+          repository: FStarLang/pulse
 
       - uses: actions/download-artifact@v4
         with:
@@ -226,8 +223,7 @@ jobs:
         uses: actions/checkout@master
         with:
           path: hacl-star/
-          repository: mtzguido/hacl-star
-          ref: dev
+          repository: hacl-star/hacl-star
 
       # Patch HACL* for new lib
       - run: sed -i 's/^\(OCAMLSHARED.*\)fstar\.lib/\1fstar.pluginlib/' hacl-star/Makefile.common
@@ -308,8 +304,7 @@ jobs:
         uses: actions/checkout@master
         with:
           path: everparse/
-          repository: mtzguido/everparse
-          ref: dev
+          repository: project-everest/everparse
 
       - name: Build
         run: |
@@ -382,8 +377,7 @@ jobs:
         uses: actions/checkout@master
         with:
           path: merkle-tree/
-          repository: mtzguido/merkle-tree
-          ref: dev
+          repository: hacl-star/merkle-tree
 
       - name: Build
         run: |
@@ -464,8 +458,7 @@ jobs:
         uses: actions/checkout@master
         with:
           path: mitls-fstar/
-          repository: mtzguido/mitls-fstar
-          ref: dev
+          repository: project-everest/mitls-fstar
 
       - name: Build
         run: make -C mitls-fstar/src/tls -skj$(nproc)
@@ -554,7 +547,7 @@ jobs:
         with:
           path: everparse/
           ref: taramana_cbor
-          repository: mtzguido/everparse
+          repository: project-everest/everparse
 
       - name: Build
         run: |

--- a/.github/workflows/check-nix-friends.yml
+++ b/.github/workflows/check-nix-friends.yml
@@ -1,6 +1,7 @@
 name: Check F* friends (Nix)
 
-# This workflow must be called ONLY after a run of nix.yml
+# This workflow should be called ONLY after a run of nix.yml so the F*
+# build for the current sha has is already present in the Nix cache.
 on:
   workflow_call:
 
@@ -17,8 +18,7 @@ jobs:
 
       - uses: actions/checkout@master
         with:
-          repository: mtzguido/comparse
-          ref: dev
+          repository: TWal/comparse
 
       - name: Update fstar flake and check
         run: |
@@ -33,8 +33,7 @@ jobs:
 
       - uses: actions/checkout@master
         with:
-          repository: mtzguido/dolev-yao-star-extrinsic
-          ref: dev
+          repository: REPROSEC/dolev-yao-star-extrinsic
 
       - name: Update fstar flake and check
         run: |
@@ -49,8 +48,7 @@ jobs:
 
       - uses: actions/checkout@master
         with:
-          repository: mtzguido/mls-star
-          ref: dev
+          repository: Inria-Prosecco/mls-star
 
       - name: Update fstar flake and check
         run: |


### PR DESCRIPTION
This was pointing to forks in preparation of the new build, now that it's merged check against master again. Some PRs are still open (FStarLang/karamel#516, https://github.com/hacl-star/hacl-star/pull/1017) so some failures are expected currently.