### PR TITLE
Some error nits

### DIFF
--- a/src/basic/FStarC.Range.Ops.fst
+++ b/src/basic/FStarC.Range.Ops.fst
@@ -50,13 +50,13 @@ let rng_included r1 r2 =
     r2.end_pos >=? r1.end_pos
 
 let string_of_pos pos =
-    format2 "%s,%s" (string_of_int pos.line) (string_of_int pos.col)
+    format2 "%s.%s" (string_of_int pos.line) (string_of_int pos.col)
 let file_of_range r       =
     let f = r.def_range.file_name in
     string_of_file_name f
 let set_file_of_range r (f:string) = {r with def_range = {r.def_range with file_name = f}}
 let string_of_rng r =
-    format3 "%s(%s-%s)" (string_of_file_name r.file_name) (string_of_pos r.start_pos) (string_of_pos r.end_pos)
+    format3 "%s:%s-%s" (string_of_file_name r.file_name) (string_of_pos r.start_pos) (string_of_pos r.end_pos)
 let string_of_def_range r = string_of_rng r.def_range
 let string_of_use_range r = string_of_rng r.use_range
 let string_of_range r     = string_of_def_range r

--- a/src/ml/bare/FStarC_Parser_Util.ml
+++ b/src/ml/bare/FStarC_Parser_Util.ml
@@ -12,7 +12,7 @@ type bytes = byte array
 let parseState = ()
 
 let pos_of_lexpos (p:position) =
-  mk_pos (Z.of_int p.pos_lnum) (Z.of_int (p.pos_cnum - p.pos_bol))
+  mk_pos (Z.of_int p.pos_lnum) (Z.of_int (1 + p.pos_cnum - p.pos_bol))
 
 let mksyn_range (p1:position) p2 =
   mk_range p1.pos_fname (pos_of_lexpos p1) (pos_of_lexpos p2)

--- a/src/ml/bare/FStarC_Util.ml
+++ b/src/ml/bare/FStarC_Util.ml
@@ -535,32 +535,32 @@ let colorize s colors =
 
 let colorize_bold s =
   match stdout_isatty () with
-  | Some true -> format3 "%s%s%s" "\x1b[39;1m" s "\x1b[0m"
+  | Some true -> format3 "%s%s%s" "\x1b[39m" s "\x1b[0m"
   | _ -> s
 
 let colorize_red s =
   match stdout_isatty () with
-  | Some true -> format3 "%s%s%s" "\x1b[31;1m" s "\x1b[0m"
+  | Some true -> format3 "%s%s%s" "\x1b[31m" s "\x1b[0m"
   | _ -> s
 
 let colorize_yellow s =
   match stdout_isatty () with
-  | Some true -> format3 "%s%s%s" "\x1b[33;1m" s "\x1b[0m"
+  | Some true -> format3 "%s%s%s" "\x1b[33m" s "\x1b[0m"
   | _ -> s
 
 let colorize_cyan s =
   match stdout_isatty () with
-  | Some true -> format3 "%s%s%s" "\x1b[36;1m" s "\x1b[0m"
+  | Some true -> format3 "%s%s%s" "\x1b[36m" s "\x1b[0m"
   | _ -> s
 
 let colorize_green s =
   match stdout_isatty () with
-  | Some true -> format3 "%s%s%s" "\x1b[32;1m" s "\x1b[0m"
+  | Some true -> format3 "%s%s%s" "\x1b[32m" s "\x1b[0m"
   | _ -> s
 
 let colorize_magenta  s =
   match stdout_isatty () with
-  | Some true -> format3 "%s%s%s" "\x1b[35;1m" s "\x1b[0m"
+  | Some true -> format3 "%s%s%s" "\x1b[35m" s "\x1b[0m"
   | _ -> s
 
 let pr  = Printf.printf


### PR DESCRIPTION
This makes F* print errors like
```
* Error 189 at X.fst:3.13-3.16:
  - Expected expression of type Prims.int
    got expression 'a'
    of type FStar.Char.char
```

Where X.fst:
```
module X

let x = 1 + 'a'
```
Clicking on the error location in VS code highlights over the `'a'`. It requires offsetting the column in source positions by 1, to make them 1-based instead of 0-based, as I think other tools do.

Marking as a draft since it requires patches to interactive modes to deal with the offset (or as an alternative we could just change the show instance of range to add a +1 there). This also removes the bold style in errors and warnings.