### PR TITLE
Use the directory of any file on the command line in the include path rather than "."

### DIFF
--- a/src/basic/FStarC.Find.fst
+++ b/src/basic/FStarC.Find.fst
@@ -90,15 +90,13 @@ let include_path () =
   let include_paths =
     Options.include_ () |> expand_include_ds
   in
-  cache_dir @ lib_paths () @ include_paths @ expand_include_d "."
+  let cmd_line_file_dirs =
+    Options.file_list() |> List.map (fun f -> BU.normalize_file_path <| BU.dirname f)
+  in
+  cache_dir @ lib_paths () @ include_paths @ cmd_line_file_dirs
 
 let do_find (paths : list string) (filename : string) : option string =
-  if BU.is_path_absolute filename then
-    if BU.file_exists filename then
-      Some filename
-    else
-      None
-  else
+  let filename = BU.basename filename in
   try
       (* In reverse, because the last directory has the highest precedence. *)
       (* FIXME: We should fail if we find two files with the same name *)


### PR DESCRIPTION
If you invoke `fstar.exe path/to/A.fst` then with this PR, the include path contains `path/to` enabling F* to resolve files in the same directory as `A.fst`.

Previously, we instead included `.` in the include path.