### PR TITLE
Fixed Z3 version check again

### DIFF
--- a/src/smtencoding/FStarC.SMTEncoding.Z3.fst
+++ b/src/smtencoding/FStarC.SMTEncoding.Z3.fst
@@ -176,6 +176,11 @@ let check_z3version (p:proc) : unit =
     );
     _already_warned_solver_mismatch := true
   );
+  (* Note: Z3 can either output a "clean" version like 4.13.4 or something like
+     "4.13.4 - build hashcode 6d3cfb63daa9afdd7d6d6b4d2f2fb84bd7324571" depending
+     on how it was built. Hence we split by "-" and take the first component to
+     ignore the hashcode. See https://github.com/FStarLang/FStar/pull/3700 for
+     more details. *)
   let ver_found : string = BU.trim_string (List.hd (BU.split (getinfo "version") "-")) in
   let ver_conf  : string = BU.trim_string (Options.z3_version ()) in
   if ver_conf <> ver_found && not (!_already_warned_version_mismatch) then (

--- a/src/smtencoding/FStarC.SMTEncoding.Z3.fst
+++ b/src/smtencoding/FStarC.SMTEncoding.Z3.fst
@@ -176,7 +176,7 @@ let check_z3version (p:proc) : unit =
     );
     _already_warned_solver_mismatch := true
   );
-  let ver_found : string = BU.trim_string (getinfo "version") in
+  let ver_found : string = BU.trim_string (List.hd (BU.split (getinfo "version") "-")) in
   let ver_conf  : string = BU.trim_string (Options.z3_version ()) in
   if ver_conf <> ver_found && not (!_already_warned_version_mismatch) then (
     let open FStarC.Errors in


### PR DESCRIPTION
A recent commit (#d6991a4) reverted a previous change to the Z3 version checking, which causes some Z3 builds to fail the check even though the version is correct.

The change in #d6991a4 removed splitting the output of `z3-<version> --version` on the `-` character. With the Z3 binaries pulled by the [Everest build system](https://github.com/project-everest/everest), this isn't a problem because they simply output the version number. However, if you build Z3 manually, the `--version` command often outputs additional information, like the build hash (e.g. `Z3 version 4.13.3 - 64 bit - build hashcode 4d30f26f72ce62f5dcb5a5258f632f84858714f`).

This commit reverts this change and re-inserts the string-splitting such that custom Z3 builds (of the correct version) are supported again.