### PR TITLE
Allow use_hints even when context_pruning is set

### DIFF
--- a/src/smtencoding/FStarC.SMTEncoding.Solver.fst
+++ b/src/smtencoding/FStarC.SMTEncoding.Solver.fst
@@ -65,7 +65,7 @@ let replaying_hints: ref (option hints) = BU.mk_ref None
 (****************************************************************************)
 (* Hint databases (public)                                                  *)
 (****************************************************************************)
-let use_hints () = Options.use_hints () && Options.Ext.get "context_pruning" = ""
+let use_hints () = Options.use_hints ()
 let initialize_hints_db src_filename format_filename : unit =
     if Options.record_hints() then recorded_hints := Some [];
     let norm_src_filename = BU.normalize_file_path src_filename in


### PR DESCRIPTION
Probably shouldn't have disabled use_hints when context_pruning is set, in the first place.

Now the behavior is that if you have both `--use_hints --ext context_pruning`, we will try to first prove the query in a fresh Z3 context with the recorded unsat core in the hints file.

If that fails, we fall back to trying the query in the background incremental solver, but this time we will prune the context before trying the query.

check-world works: https://github.com/FStarLang/FStar/actions/runs/13054935803