### PR TITLE
workflow: nix: disable soon-to-eol magic Nix cache

### DIFF
--- a/.github/workflows/check-nix-friends.yml
+++ b/.github/workflows/check-nix-friends.yml
@@ -14,7 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
 
       - uses: actions/checkout@master
         with:
@@ -29,7 +28,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
 
       - uses: actions/checkout@master
         with:
@@ -44,7 +42,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
 
       - uses: actions/checkout@master
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,13 +22,17 @@ jobs:
     needs: build
     uses: ./.github/workflows/tests.yml
 
-  nix-build:
-    name: nix
-    uses: ./.github/workflows/nix.yml
+  # Disabled as it takes too long without the magic nix cache.
+  # nix-build:
+  #   name: nix
+  #   uses: ./.github/workflows/nix.yml
 
   # Branch protection points here
   ciok:
     runs-on: ubuntu-latest
-    needs: [build, tests, nix-build]
+    needs:
+      - build
+      - tests
+      # - nix-build
     steps:
       - run: exit 0

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -14,6 +14,5 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: DeterminateSystems/nix-installer-action@main
-    - uses: DeterminateSystems/magic-nix-cache-action@main
     - name: Build
       run: nix build -L


### PR DESCRIPTION
Github will soon begin forbidding these kind of actions. See https://determinate.systems/posts/magic-nix-cache-free-tier-eol/ for more details.

In our workflows, we don't rely too heavily on this cache, and the Nix builds are not in the critical path during a check-world, so just disabling it is not too bad.