### PR TITLE
SMT: only set produce-unsat-cores when recording hints

### DIFF
--- a/src/smtencoding/FStarC.SMTEncoding.Z3.fst
+++ b/src/smtencoding/FStarC.SMTEncoding.Z3.fst
@@ -552,7 +552,6 @@ let z3_options (ver:string) =
     "(set-option :global-decls false)";
     "(set-option :smt.mbqi false)";
     "(set-option :auto_config false)";
-    "(set-option :produce-unsat-cores true)";
     "(set-option :model true)";
     "(set-option :smt.case_split 3)";
     "(set-option :smt.relevancy 2)";
@@ -614,6 +613,13 @@ let mk_input (fresh : bool) (theory : list decl) : string & option string & opti
       ) :: theory
     in
     let options = z3_options ver in
+    let options =
+      (* With --ext fast_hints, we only enable unsat-core generation
+      if we are actually recording hints. *)
+      if Options.Ext.enabled "fast_hints" && not (Options.record_hints ())
+      then options
+      else options ^ "(set-option :produce-unsat-cores true)\n"
+    in
     let options = options ^ (Options.z3_smtopt() |> String.concat "\n") ^ "\n\n" in
     if Options.print_z3_statistics() then context_profile theory;
     let r, hash =


### PR DESCRIPTION
This PR makes F* *not* set the `produce-unsat-cores` flag of Z3 unless we are recording hints. It is currently unconditionally enabled, which is not ideal as it makes Z3 slower. Example:
```
$ /bin/time z3 queries-FStar.Math.Lemmas.smt2 unsat_core=false > /dev/null
Command exited with non-zero status 1
0.57user 0.01system 0:00.58elapsed 100%CPU (0avgtext+0avgdata 39672maxresident)k
0inputs+0outputs (0major+7255minor)pagefaults 0swaps
$ /bin/time z3 queries-FStar.Math.Lemmas.smt2 unsat_core=true > /dev/null
Command exited with non-zero status 1
2.34user 0.00system 0:02.35elapsed 100%CPU (0avgtext+0avgdata 51964maxresident)k
0inputs+0outputs (0major+9023minor)pagefaults 0swaps
```
So almost 5x improvement on this example (and it's stable across random seeds), though the usual gain is more modest.

However, it does also affect Z3's heuristics, so this will introduce a bunch of noise and breakage in flaky proofs, so I don't think it can be merged right now. See related Z3 issue: https://github.com/Z3Prover/z3/issues/7538