### PR TITLE
FStarC.Range: do no try to find files when printing ranges

### DIFF
--- a/src/basic/FStarC.Errors.fst
+++ b/src/basic/FStarC.Errors.fst
@@ -139,7 +139,7 @@ let json_of_issue issue =
     JsonAssoc [
         "msg",    json_of_error_message issue.issue_msg;
         "level",  json_of_issue_level issue.issue_level;
-        "range",  dflt JsonNull (json_of_range <$> issue.issue_range);
+        "range",  dflt JsonNull (json_of_range <$> map_opt issue.issue_range Range.refind_range);
         "number", dflt JsonNull (JsonInt <$> issue.issue_number);
         "ctx",    JsonList (JsonStr <$> issue.issue_ctx);
     ]
@@ -180,7 +180,7 @@ let optional_def (f : 'a -> PP.document) (def : PP.document) (o : option 'a) : P
 
 let issue_to_doc' (print_hdr:bool) (issue:issue) : PP.document =
   let open FStarC.Pprint in
-  let r = issue.issue_range in
+  let r = BU.map_opt issue.issue_range Range.refind_range in
   let hdr : document =
     if print_hdr then (
       let level_header = doc_of_string (string_of_issue_level issue.issue_level) in

--- a/src/basic/FStarC.Filepath.fsti
+++ b/src/basic/FStarC.Filepath.fsti
@@ -20,7 +20,6 @@ open FStarC.Effect
 val get_file_extension: string -> string
 val is_path_absolute: string -> bool
 val join_paths: string -> string -> string
-val normalize_file_path: string -> string
 val basename: string -> string (* name of file without directory *)
 val dirname : string -> string
 val getcwd: unit -> string
@@ -29,3 +28,10 @@ val paths_to_same_file: string -> string -> bool
 
 val file_exists: string -> Tot bool
 val is_directory: string -> Tot bool
+
+(* Remove /../ and /./ components from a path. Result is absolute or relative
+according to input. *)
+val canonicalize : string -> string
+
+(* Like canonicalize, but always returns an absolute path. *)
+val normalize_file_path: string -> string

--- a/src/basic/FStarC.Filepath.fsti
+++ b/src/basic/FStarC.Filepath.fsti
@@ -1,0 +1,31 @@
+(*
+   Copyright 2008-2025 Nikhil Swamy and Microsoft Research
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*)
+module FStarC.Filepath
+
+open FStarC.Effect
+
+val get_file_extension: string -> string
+val is_path_absolute: string -> bool
+val join_paths: string -> string -> string
+val normalize_file_path: string -> string
+val basename: string -> string (* name of file without directory *)
+val dirname : string -> string
+val getcwd: unit -> string
+val readdir: string -> list string
+val paths_to_same_file: string -> string -> bool
+
+val file_exists: string -> Tot bool
+val is_directory: string -> Tot bool

--- a/src/basic/FStarC.Find.Z3.fst
+++ b/src/basic/FStarC.Find.Z3.fst
@@ -1,0 +1,114 @@
+(*
+   Copyright 2008-2024 Microsoft Research
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*)
+module FStarC.Find.Z3
+
+open FStarC
+open FStarC.Effect
+open FStarC.List
+module BU = FStarC.Util
+module Find = FStarC.Find
+
+open FStarC.Class.Show
+
+let z3url = "https://github.com/Z3Prover/z3/releases"
+
+let packaged_z3_versions = ["4.8.5"; "4.13.3"]
+
+let z3_install_suggestion (v : string) : list Pprint.document =
+  let open FStarC.Errors.Msg in
+  let open FStarC.Pprint in
+  [
+    prefix 4 1 (text <| BU.format1 "Please download version %s of Z3 from" v)
+              (url z3url) ^/^
+      group (text "and install it into your $PATH as" ^/^ squotes
+        (doc_of_string (Platform.exe ("z3-" ^ v))) ^^ dot);
+    if List.mem v packaged_z3_versions then
+      text <| BU.format1 "Version %s of Z3 should be included in binary packages \
+              of F*. If you are using a binary package and are seeing
+              this error, please file a bug report." v
+    else
+      empty
+  ]
+
+(* Check if [path] is potentially a valid z3, by trying to run
+it with -version and checking for non-empty output. Alternatively
+we could call [which] on it (if it's not an absolute path), but
+we shouldn't rely on the existence of a binary which. *)
+let z3_inpath (path:string) : bool =
+  try
+    let s = BU.run_process "z3_pathtest" path ["-version"] None in
+    s <> ""
+  with
+  | _ -> false
+
+(* Find the Z3 executable that we should invoke for a given version.
+
+- If the user provided the --smt option, use that binary unconditionally.
+- We then look in $LIB/z3-VER/z3, where LIB is the F* library root, for example
+  /usr/local/lib/fstar/z3-4.8.5/bin/z3, for an installed package. We ship Z3 4.8.5
+  and 4.13.3 in the binary package in these paths, so F* automatically find them
+  without relying on PATH or adding more stuff to the user's /usr/local/bin.
+  Each $PREFIX/lib/fstar/z3-VER directory roughly contains an extracted Z3
+  binary package, but with many files removed (currently we just keep LICENSE
+  and the executable).
+
+- Else we check the PATH:
+  - If z3-VER (or z3-VER.exe) exists in the PATH use it.
+  - Otherwise, default to "z3" in the PATH.
+
+We cache the chosen executable for every Z3 version we've ran.
+*)
+let do_locate_z3 (v:string) : option string =
+  let open FStarC.Class.Monad in
+  let guard (b:bool) : option unit = if b then Some () else None in
+  let (<|>) o1 o2 () =
+    match o1 () with
+    | Some v -> Some v
+    | None -> o2 ()
+  in
+  let path =
+    let in_lib () : option string =
+      let! root = Find.lib_root () in
+      let path = Platform.exe (root ^ "/z3-" ^ v ^ "/bin/z3") in
+      let path = Filepath.normalize_file_path path in
+      guard (Filepath.file_exists path);!
+      Some path
+    in
+    let from_path (cmd : string) () =
+      let cmd = Platform.exe cmd in
+      guard (z3_inpath cmd);!
+      Some cmd
+    in
+    (Options.smt <|>
+    in_lib <|>
+    from_path ("z3-" ^ v) <|>
+    from_path "z3" <|> (fun _ -> None)) ()
+  in
+  if Debug.any () then
+    BU.print2 "do_locate_z3(%s) = %s\n" (Class.Show.show v) (Class.Show.show path);
+  path
+
+let locate_z3 (v : string) : option string =
+  let cache : SMap.t (option string) = SMap.create 5 in
+  let find_or (k:string) (f : string -> option string) : option string =
+    match SMap.try_find cache k with
+    | Some v -> v
+    | None ->
+      let v = f k in
+      SMap.add cache k v;
+      v
+  in
+  find_or v do_locate_z3

--- a/src/basic/FStarC.Find.Z3.fsti
+++ b/src/basic/FStarC.Find.Z3.fsti
@@ -1,0 +1,27 @@
+(*
+   Copyright 2008-2024 Microsoft Research
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*)
+module FStarC.Find.Z3
+
+(* Utilities for finding z3 *)
+
+open FStarC
+open FStarC.Effect
+
+(* A message for the user suggesting how to install the proper Z3 version. *)
+val z3_install_suggestion (v : string) : list Pprint.document
+
+(* Locate executable for Z3 version [v]. *)
+val locate_z3 (v : string) : option string

--- a/src/basic/FStarC.Find.fst
+++ b/src/basic/FStarC.Find.fst
@@ -246,3 +246,19 @@ let locate_z3 (v : string) : option string =
       v
   in
   find_or v do_locate_z3
+
+(* When reading checked files, we could obtain ranges where the
+filepath does not make sense any more. For instance if we check
+`a/A.fst`, and then go into `a/` and check `B.fst`, the ranges
+in `A.fst.checked` will still refer to `a/A.fst`, which is not
+a valid path. To palliate this, we
+  1) just take the basename (ignore the path completely); and
+  2) try to find this file in our include path.
+
+This function is called by error reporting (both batch and IDE). *)
+let refind_file (f:string) : string =
+  try
+    match find_file (BU.basename f) with
+    | None -> f // Couldn't find file; just return the original path
+    | Some abs -> abs
+  with _ -> f

--- a/src/basic/FStarC.Find.fst
+++ b/src/basic/FStarC.Find.fst
@@ -47,7 +47,7 @@ let read_fstar_include (fn : string) : option (list string) =
 
 let rec expand_include_d (dirname : string) : list string =
   let dot_inc_path = dirname ^ "/fstar.include" in
-  if Util.file_exists dot_inc_path then (
+  if Filepath.file_exists dot_inc_path then (
     let subdirs = Some?.v <| read_fstar_include dot_inc_path in
     dirname :: List.collect (fun subd -> expand_include_d (dirname ^ "/" ^ subd)) subdirs
   ) else
@@ -92,8 +92,8 @@ let include_path () =
   cache_dir @ lib_paths () @ include_paths @ expand_include_d "."
 
 let do_find (paths : list string) (filename : string) : option string =
-  if BU.is_path_absolute filename then
-    if BU.file_exists filename then
+  if Filepath.is_path_absolute filename then
+    if Filepath.file_exists filename then
       Some filename
     else
       None
@@ -104,8 +104,8 @@ let do_find (paths : list string) (filename : string) : option string =
       BU.find_map (List.rev paths) (fun p ->
         let path =
           if p = "." then filename
-          else BU.join_paths p filename in
-        if BU.file_exists path then
+          else Filepath.join_paths p filename in
+        if Filepath.file_exists path then
           Some path
         else
           None)
@@ -140,22 +140,22 @@ let find_file_odir =
 let prepend_output_dir fname =
   match Options.output_dir () with
   | None -> fname
-  | Some x -> Util.join_paths x fname
+  | Some x -> Filepath.join_paths x fname
 
 let prepend_cache_dir fpath =
   match Options.cache_dir () with
   | None -> fpath
-  | Some x -> Util.join_paths x (Util.basename fpath)
+  | Some x -> Filepath.join_paths x (Filepath.basename fpath)
 
 let locate () =
-  Util.get_exec_dir () |> Util.normalize_file_path
+  Util.get_exec_dir () |> Filepath.normalize_file_path
 
 let locate_lib () =
-  BU.map_opt (lib_root ()) Util.normalize_file_path
+  BU.map_opt (lib_root ()) Filepath.normalize_file_path
 
 let locate_ocaml () =
   // This is correct right now, but probably should change.
-  Util.get_exec_dir () ^ "/../lib" |> Util.normalize_file_path
+  Util.get_exec_dir () ^ "/../lib" |> Filepath.normalize_file_path
 
 let z3url = "https://github.com/Z3Prover/z3/releases"
 
@@ -217,8 +217,8 @@ let do_locate_z3 (v:string) : option string =
     let in_lib () : option string =
       let! root = lib_root () in
       let path = Platform.exe (root ^ "/z3-" ^ v ^ "/bin/z3") in
-      let path = BU.normalize_file_path path in
-      guard (BU.file_exists path);!
+      let path = Filepath.normalize_file_path path in
+      guard (Filepath.file_exists path);!
       Some path
     in
     let from_path (cmd : string) () =
@@ -258,7 +258,7 @@ a valid path. To palliate this, we
 This function is called by error reporting (both batch and IDE). *)
 let refind_file (f:string) : string =
   try
-    match find_file (BU.basename f) with
+    match find_file (Filepath.basename f) with
     | None -> f // Couldn't find file; just return the original path
     | Some abs -> abs
   with _ -> f

--- a/src/basic/FStarC.Find.fst
+++ b/src/basic/FStarC.Find.fst
@@ -16,10 +16,10 @@
 module FStarC.Find
 
 open FStarC
-open FStarC
 open FStarC.Effect
 open FStarC.List
 module BU = FStarC.Util
+
 open FStarC.Class.Show
 
 let fstar_bin_directory : string =
@@ -56,9 +56,6 @@ let rec expand_include_d (dirname : string) : list string =
 let expand_include_ds (dirnames : list string) : list string =
   List.collect expand_include_d dirnames
 
-(* TODO: normalize these paths. This will probably affect makefiles since
-make does not normalize the paths itself. Also, move this whole logic away
-from this module. *)
 let lib_root () : option string =
   (* No default includes means we don't try to find a library on our own. *)
   if Options.no_default_includes() then
@@ -69,11 +66,11 @@ let lib_root () : option string =
     | Some s -> Some s
     | None ->
       (* Otherwise, just at the default location *)
-      Some (fstar_bin_directory ^ "/../lib/fstar")
+      Some (Filepath.canonicalize <| fstar_bin_directory ^ "/../lib/fstar")
 
 let fstarc_paths () =
   if Options.with_fstarc ()
-  then expand_include_d (fstar_bin_directory ^ "/../lib/fstar/fstarc")
+  then expand_include_d (Filepath.canonicalize <| fstar_bin_directory ^ "/../lib/fstar/fstarc")
   else []
 
 let lib_paths () =

--- a/src/basic/FStarC.Find.fst
+++ b/src/basic/FStarC.Find.fst
@@ -17,10 +17,57 @@ module FStarC.Find
 
 open FStarC
 open FStarC.Effect
-open FStarC.List
+open FStar.List.Tot
 module BU = FStarC.Util
 
 open FStarC.Class.Show
+
+let cached_fun #a (cache : SMap.t a) (f : string -> a) : string -> a =
+  fun s ->
+    match SMap.try_find cache s with
+    | Some v -> v
+    | None ->
+      let v = f s in
+      SMap.add cache s v;
+      v
+
+let find_file_cache : SMap.t (option string) = SMap.create 100
+
+let clear () =
+  SMap.clear find_file_cache;
+  ()
+
+(* Internal state, settable with the functions exposed in the interface. *)
+let _include : ref (list string) = mk_ref []
+let _cache_dir : ref (option string) = mk_ref None
+let _odir : ref (option string) = mk_ref None
+let _no_default_includes : ref bool = mk_ref false
+let _with_fstarc : ref bool = mk_ref false
+
+let get_include_path () : list string = !_include
+let set_include_path (path : list string) : unit =
+  clear ();
+  _include := path
+
+let get_cache_dir () : option string = !_cache_dir
+let set_cache_dir (path : string) : unit =
+  clear ();
+  _cache_dir := Some path
+
+let get_odir () : option string = !_odir
+let set_odir (path : string) : unit =
+  clear ();
+  _odir := Some path
+
+let get_no_default_includes () : bool = !_no_default_includes
+let set_no_default_includes (b : bool) : unit =
+  clear ();
+  _no_default_includes := b
+
+let get_with_fstarc () : bool = !_with_fstarc
+let set_with_fstarc (b : bool) : unit =
+  clear ();
+  _with_fstarc := b
 
 let fstar_bin_directory : string =
   BU.get_exec_dir ()
@@ -58,7 +105,7 @@ let expand_include_ds (dirnames : list string) : list string =
 
 let lib_root () : option string =
   (* No default includes means we don't try to find a library on our own. *)
-  if Options.no_default_includes() then
+  if !_no_default_includes then
     None
   else
     (* FSTAR_LIB can be set in the environment to override the library *)
@@ -69,7 +116,7 @@ let lib_root () : option string =
       Some (Filepath.canonicalize <| fstar_bin_directory ^ "/../lib/fstar")
 
 let fstarc_paths () =
-  if Options.with_fstarc ()
+  if !_with_fstarc
   then expand_include_d (Filepath.canonicalize <| fstar_bin_directory ^ "/../lib/fstar/fstarc")
   else []
 
@@ -77,15 +124,13 @@ let lib_paths () =
   (Common.option_to_list (lib_root ()) |> expand_include_ds)
   @ fstarc_paths ()
 
-let include_path () =
+let full_include_path () =
   let cache_dir =
-    match Options.cache_dir() with
+    match !_cache_dir with
     | None -> []
     | Some c -> [c]
   in
-  let include_paths =
-    Options.include_ () |> expand_include_ds
-  in
+  let include_paths = !_include |> expand_include_ds in
   cache_dir @ lib_paths () @ include_paths @ expand_include_d "."
 
 let do_find (paths : list string) (filename : string) : option string =
@@ -107,40 +152,31 @@ let do_find (paths : list string) (filename : string) : option string =
         else
           None)
   with
-    | _ -> None
-    // ^ to deal with issues like passing bogus strings as paths like " input"
+  | _ -> None
+  // ^ to deal with issues like passing bogus strings as paths like " input"
 
+(* Note: eta important below. *)
 let find_file =
-  let cache = SMap.create 100 in
-  fun filename ->
-     match SMap.try_find cache filename with
-     | Some f -> f
-     | None ->
-       let result = do_find (include_path ()) filename in
-       if Some? result
-       then SMap.add cache filename result;
-       result
+  cached_fun find_file_cache fun s ->
+    do_find (full_include_path ()) s
 
 let find_file_odir =
-  let cache = SMap.create 100 in
-  fun filename ->
-     match SMap.try_find cache filename with
-     | Some f -> f
-     | None ->
-       let odir = match Options.output_dir () with Some d -> [d] | None -> [] in
-       let result = do_find (include_path () @ odir) filename in
-       if Some? result
-       then SMap.add cache filename result;
-       result
-
+  (* NOTE: this function is not cached, since the plugin-building code
+  will sometimes see a cmxs does not exist and then try to build it and load it,
+  so we should not cache a None result. However this is such a cold path that
+  it doesn't matter at all, so just drop the cache altogether. *)
+  // cached_fun find_file_odir_cache
+  fun s ->
+    let odir = match !_odir with Some d -> [d] | None -> [] in
+    do_find (full_include_path () @ odir) s
 
 let prepend_output_dir fname =
-  match Options.output_dir () with
+  match !_odir with
   | None -> fname
   | Some x -> Filepath.join_paths x fname
 
 let prepend_cache_dir fpath =
-  match Options.cache_dir () with
+  match !_cache_dir with
   | None -> fpath
   | Some x -> Filepath.join_paths x (Filepath.basename fpath)
 
@@ -154,95 +190,6 @@ let locate_ocaml () =
   // This is correct right now, but probably should change.
   Util.get_exec_dir () ^ "/../lib" |> Filepath.normalize_file_path
 
-let z3url = "https://github.com/Z3Prover/z3/releases"
-
-let packaged_z3_versions = ["4.8.5"; "4.13.3"]
-
-let z3_install_suggestion (v : string) : list Pprint.document =
-  let open FStarC.Errors.Msg in
-  let open FStarC.Pprint in
-  [
-    prefix 4 1 (text <| BU.format1 "Please download version %s of Z3 from" v)
-              (url z3url) ^/^
-      group (text "and install it into your $PATH as" ^/^ squotes
-        (doc_of_string (Platform.exe ("z3-" ^ v))) ^^ dot);
-    if List.mem v packaged_z3_versions then
-      text <| BU.format1 "Version %s of Z3 should be included in binary packages \
-              of F*. If you are using a binary package and are seeing
-              this error, please file a bug report." v
-    else
-      empty
-  ]
-
-(* Check if [path] is potentially a valid z3, by trying to run
-it with -version and checking for non-empty output. Alternatively
-we could call [which] on it (if it's not an absolute path), but
-we shouldn't rely on the existence of a binary which. *)
-let z3_inpath (path:string) : bool =
-  try
-    let s = BU.run_process "z3_pathtest" path ["-version"] None in
-    s <> ""
-  with
-  | _ -> false
-
-(* Find the Z3 executable that we should invoke for a given version.
-
-- If the user provided the --smt option, use that binary unconditionally.
-- We then look in $LIB/z3-VER/z3, where LIB is the F* library root, for example
-  /usr/local/lib/fstar/z3-4.8.5/bin/z3, for an installed package. We ship Z3 4.8.5
-  and 4.13.3 in the binary package in these paths, so F* automatically find them
-  without relying on PATH or adding more stuff to the user's /usr/local/bin.
-  Each $PREFIX/lib/fstar/z3-VER directory roughly contains an extracted Z3
-  binary package, but with many files removed (currently we just keep LICENSE
-  and the executable).
-
-- Else we check the PATH:
-  - If z3-VER (or z3-VER.exe) exists in the PATH use it.
-  - Otherwise, default to "z3" in the PATH.
-
-We cache the chosen executable for every Z3 version we've ran.
-*)
-let do_locate_z3 (v:string) : option string =
-  let open FStarC.Class.Monad in
-  let guard (b:bool) : option unit = if b then Some () else None in
-  let (<|>) o1 o2 () =
-    match o1 () with
-    | Some v -> Some v
-    | None -> o2 ()
-  in
-  let path =
-    let in_lib () : option string =
-      let! root = lib_root () in
-      let path = Platform.exe (root ^ "/z3-" ^ v ^ "/bin/z3") in
-      let path = Filepath.normalize_file_path path in
-      guard (Filepath.file_exists path);!
-      Some path
-    in
-    let from_path (cmd : string) () =
-      let cmd = Platform.exe cmd in
-      guard (z3_inpath cmd);!
-      Some cmd
-    in
-    (Options.smt <|>
-    in_lib <|>
-    from_path ("z3-" ^ v) <|>
-    from_path "z3" <|> (fun _ -> None)) ()
-  in
-  if Debug.any () then
-    BU.print2 "do_locate_z3(%s) = %s\n" (Class.Show.show v) (Class.Show.show path);
-  path
-
-let locate_z3 (v : string) : option string =
-  let cache : SMap.t (option string) = SMap.create 5 in
-  let find_or (k:string) (f : string -> option string) : option string =
-    match SMap.try_find cache k with
-    | Some v -> v
-    | None ->
-      let v = f k in
-      SMap.add cache k v;
-      v
-  in
-  find_or v do_locate_z3
 
 (* When reading checked files, we could obtain ranges where the
 filepath does not make sense any more. For instance if we check

--- a/src/basic/FStarC.Find.fsti
+++ b/src/basic/FStarC.Find.fsti
@@ -1,4 +1,4 @@
-﻿(*
+(*
    Copyright 2008-2024 Microsoft Research
 
    Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,6 +19,25 @@ operations. *)
 
 open FStarC.Effect
 
+(* --include *)
+val get_include_path () : list string
+val set_include_path (path : list string) : unit
+
+(* --cache_dir *)
+val get_cache_dir () : option string
+val set_cache_dir (path : string) : unit
+
+(* --odir *)
+val get_odir () : option string
+val set_odir (path : string) : unit
+
+(* --no_default_includes *)
+val get_no_default_includes () : bool
+val set_no_default_includes (b : bool) : unit
+
+val get_with_fstarc () : bool
+val set_with_fstarc (b : bool) : unit
+
 (* A bit silly to have this, but this is the directory where the fstar.exe executable is in. *)
 val fstar_bin_directory : string
 
@@ -26,7 +45,7 @@ val fstar_bin_directory : string
 val lib_root () : option string
 
 (* The full include path. We search files in all of these directories. *)
-val include_path () : list string
+val full_include_path () : list string
 
 (* Try to find a file in the include path with a given basename. *)
 val find_file (basename : string) : option string
@@ -47,12 +66,6 @@ val locate_lib () : option string
 
 (* Return absolute path of OCaml-installed components of F*. *)
 val locate_ocaml () : string
-
-(* A message for the user suggesting how to install the proper Z3 version. *)
-val z3_install_suggestion (v : string) : list Pprint.document
-
-(* Locate executable for Z3 version [v]. *)
-val locate_z3 (v : string) : option string
 
 (* Try to find a file from a path we might have read in a checked file.
 Essentially find_file(basename f). *)

--- a/src/basic/FStarC.Find.fsti
+++ b/src/basic/FStarC.Find.fsti
@@ -53,3 +53,7 @@ val z3_install_suggestion (v : string) : list Pprint.document
 
 (* Locate executable for Z3 version [v]. *)
 val locate_z3 (v : string) : option string
+
+(* Try to find a file from a path we might have read in a checked file.
+Essentially find_file(basename f). *)
+val refind_file (f:string) : string

--- a/src/basic/FStarC.Options.fst
+++ b/src/basic/FStarC.Options.fst
@@ -1879,8 +1879,8 @@ let restore_cmd_line_options should_clear =
     r
 
 let module_name_of_file_name f =
-    let f = basename f in
-    let f = String.substring f 0 (String.length f - String.length (get_file_extension f) - 1) in
+    let f = Filepath.basename f in
+    let f = String.substring f 0 (String.length f - String.length (Filepath.get_file_extension f) - 1) in
     String.lowercase f
 
 let should_check m =
@@ -2038,7 +2038,7 @@ let hint_file_for_src src_filename =
         let file_name =
           match hint_dir () with
           | Some dir ->
-            Util.concat_dir_filename dir (Util.basename src_filename)
+            Util.concat_dir_filename dir (Filepath.basename src_filename)
           | _ -> src_filename
         in
         Util.format1 "%s.hints" file_name

--- a/src/basic/FStarC.Options.fst
+++ b/src/basic/FStarC.Options.fst
@@ -185,7 +185,6 @@ let defaults =
       ("disallow_unification_guards"  , Bool false);
       ("already_cached"               , Unset);
       ("cache_checked_modules"        , Bool false);
-      ("cache_dir"                    , Unset);
       ("cache_off"                    , Bool false);
       ("compat_pre_core"              , Unset);
       ("compat_pre_typed_indexed_effects"
@@ -221,7 +220,6 @@ let defaults =
       ("ide"                          , Bool false);
       ("ide_id_info_off"              , Bool false);
       ("lsp"                          , Bool false);
-      ("include"                      , List []);
       ("print"                        , Bool false);
       ("print_in_place"               , Bool false);
       ("force"                        , Bool false);
@@ -240,7 +238,6 @@ let defaults =
       ("max_ifuel"                    , Int 2);
       ("MLish"                        , Bool false);
       ("MLish_effect"                 , String "FStar.Effect");
-      ("no_default_includes"          , Bool false);
       ("no_extract"                   , List []);
       ("no_location_info"             , Bool false);
       ("no_smt"                       , Bool false);
@@ -249,7 +246,6 @@ let defaults =
       ("normalize_pure_terms_for_extraction"
                                       , Bool false);
       ("krmloutput"                   , Unset);
-      ("odir"                         , Unset);
       ("output_deps_to"               , Unset);
       ("prims"                        , Unset);
       ("pretype"                      , Bool true);
@@ -323,7 +319,6 @@ let defaults =
       ("use_nbe_for_extraction"       , Bool false);
       ("trivial_pre_for_unannotated_effectful_fns"
                                       , Bool true);
-      ("with_fstarc"                  , Bool false);
       ("profile_group_by_decl"        , Bool false);
       ("profile_component"            , Unset);
       ("profile"                      , Unset);
@@ -463,7 +458,6 @@ let get_disallow_unification_guards  ()      = lookup_opt "disallow_unification_
 
 let get_already_cached          ()      = lookup_opt "already_cached"           (as_option (as_list as_string))
 let get_cache_checked_modules   ()      = lookup_opt "cache_checked_modules"    as_bool
-let get_cache_dir               ()      = lookup_opt "cache_dir"                (as_option as_string)
 let get_cache_off               ()      = lookup_opt "cache_off"                as_bool
 let get_print_cache_version     ()      = lookup_opt "print_cache_version"      as_bool
 let get_cmi                     ()      = lookup_opt "cmi"                      as_bool
@@ -490,7 +484,6 @@ let get_in                      ()      = lookup_opt "in"                       
 let get_ide                     ()      = lookup_opt "ide"                      as_bool
 let get_ide_id_info_off         ()      = lookup_opt "ide_id_info_off"          as_bool
 let get_lsp                     ()      = lookup_opt "lsp"                      as_bool
-let get_include                 ()      = lookup_opt "include"                  (as_list as_string)
 let get_print                   ()      = lookup_opt "print"                    as_bool
 let get_print_in_place          ()      = lookup_opt "print_in_place"           as_bool
 let get_initial_fuel            ()      = lookup_opt "initial_fuel"             as_int
@@ -506,7 +499,6 @@ let get_max_fuel                ()      = lookup_opt "max_fuel"                 
 let get_max_ifuel               ()      = lookup_opt "max_ifuel"                as_int
 let get_MLish                   ()      = lookup_opt "MLish"                    as_bool
 let get_MLish_effect            ()      = lookup_opt "MLish_effect"             as_string
-let get_no_default_includes     ()      = lookup_opt "no_default_includes"      as_bool
 let get_no_extract              ()      = lookup_opt "no_extract"               (as_list as_string)
 let get_no_location_info        ()      = lookup_opt "no_location_info"         as_bool
 let get_no_plugins              ()      = lookup_opt "no_plugins"               as_bool
@@ -514,7 +506,6 @@ let get_no_smt                  ()      = lookup_opt "no_smt"                   
 let get_normalize_pure_terms_for_extraction
                                 ()      = lookup_opt "normalize_pure_terms_for_extraction" as_bool
 let get_krmloutput              ()      = lookup_opt "krmloutput"               (as_option as_string)
-let get_odir                    ()      = lookup_opt "odir"                     (as_option as_string)
 let get_output_deps_to          ()      = lookup_opt "output_deps_to"           (as_option as_string)
 let get_ugly                    ()      = lookup_opt "ugly"                     as_bool
 let get_prims                   ()      = lookup_opt "prims"                    (as_option as_string)
@@ -586,7 +577,6 @@ let get_use_nbe                 ()      = lookup_opt "use_nbe"                  
 let get_use_nbe_for_extraction  ()      = lookup_opt "use_nbe_for_extraction"                  as_bool
 let get_trivial_pre_for_unannotated_effectful_fns
                                 ()      = lookup_opt "trivial_pre_for_unannotated_effectful_fns"    as_bool
-let get_with_fstarc             ()      = lookup_opt "with_fstarc"                                  as_bool
 let get_profile                 ()      = lookup_opt "profile"                  (as_option (as_list as_string))
 let get_profile_group_by_decl   ()      = lookup_opt "profile_group_by_decl"    as_bool
 let get_profile_component       ()      = lookup_opt "profile_component"        (as_option (as_list as_string))
@@ -832,7 +822,10 @@ let rec specs_with_types warn_unsafe : list (char & string & opt_type & Pprint.d
 
   ( noshort,
     "cache_dir",
-    PostProcessed (pp_validate_dir, PathStr "dir"),
+    PostProcessed ((fun (Path s) ->
+      (* Stateful, does not go to optionstate. *)
+      Find.set_cache_dir s;
+      Unset), PathStr "dir"),
     text "Read and write .checked and .checked.lax in directory dir");
 
   ( noshort,
@@ -1039,7 +1032,9 @@ let rec specs_with_types warn_unsafe : list (char & string & opt_type & Pprint.d
 
   ( noshort,
     "include",
-    ReverseAccumulated (PathStr "path"),
+    PostProcessed ((fun (Path s) ->
+      Find.set_include_path (Find.get_include_path () @ [s]);
+      Unset), PathStr "dir"),
     text "A directory in which to search for files included on the command line");
 
   ( noshort,
@@ -1162,7 +1157,8 @@ let rec specs_with_types warn_unsafe : list (char & string & opt_type & Pprint.d
 
   ( noshort,
     "no_default_includes",
-    Const (Bool true),
+    WithSideEffect ((fun _ -> Find.set_no_default_includes true),
+                    Const (Bool true)),
     text "Ignore the default module search paths");
 
   ( noshort,
@@ -1193,7 +1189,10 @@ let rec specs_with_types warn_unsafe : list (char & string & opt_type & Pprint.d
 
   ( noshort,
     "odir",
-    PostProcessed (pp_validate_dir, PathStr "dir"),
+    PostProcessed ((fun (Path s) ->
+      (* Stateful, does not go to optionstate. *)
+      Find.set_odir s;
+      Unset), PathStr "dir"),
     text "Place output in directory  dir");
 
   ( noshort,
@@ -1584,7 +1583,8 @@ let rec specs_with_types warn_unsafe : list (char & string & opt_type & Pprint.d
 
   ( noshort,
    "with_fstarc",
-    Const (Bool true),
+    WithSideEffect ((fun _ -> Find.set_with_fstarc true),
+                    Const (Bool true)),
     text "Expose compiler internal modules (FStarC namespace). Only for advanced plugins \
           you should probably not use it.");
 
@@ -1906,10 +1906,6 @@ let should_print_message m =
 
 let custom_prims () = get_prims()
 
-let cache_dir () = get_cache_dir ()
-
-let include_ () = get_include ()
-
 //Used to parse the options of
 //   --using_facts_from
 //   --extract
@@ -2075,7 +2071,6 @@ let max_ifuel                    () = get_max_ifuel                   ()
 let ml_ish                       () = get_MLish                       ()
 let ml_ish_effect                () = get_MLish_effect                ()
 let set_ml_ish                   () = set_option "MLish" (Bool true)
-let no_default_includes          () = get_no_default_includes         ()
 let no_extract                   s  = get_no_extract() |> List.existsb (module_name_eq s)
 let normalize_pure_terms_for_extraction
                                  () = get_normalize_pure_terms_for_extraction ()
@@ -2083,7 +2078,6 @@ let no_location_info             () = get_no_location_info            ()
 let no_plugins                   () = get_no_plugins                  ()
 let no_smt                       () = get_no_smt                      ()
 let krmloutput                   () = get_krmloutput                  ()
-let output_dir                   () = get_odir                        ()
 let output_deps_to               () = get_output_deps_to              ()
 let ugly                         () = get_ugly                        ()
 let print_bound_var_types        () = get_print_bound_var_types       ()
@@ -2165,7 +2159,6 @@ let use_nbe                      () = get_use_nbe                     ()
 let use_nbe_for_extraction       () = get_use_nbe_for_extraction      ()
 let trivial_pre_for_unannotated_effectful_fns
                                  () = get_trivial_pre_for_unannotated_effectful_fns ()
-let with_fstarc                  () = get_with_fstarc ()
 
 let debug_keys                   () = lookup_opt "debug" as_comma_string_list
 let debug_all                    () = lookup_opt "debug_all" as_bool

--- a/src/basic/FStarC.Options.fsti
+++ b/src/basic/FStarC.Options.fsti
@@ -173,7 +173,6 @@ val max_ifuel                   : unit    -> int
 val ml_ish                      : unit    -> bool
 val ml_ish_effect               : unit    -> string
 val set_ml_ish                  : unit    -> unit
-val no_default_includes         : unit    -> bool
 val no_location_info            : unit    -> bool
 val no_plugins                  : unit    -> bool
 val no_smt                      : unit    -> bool
@@ -187,10 +186,7 @@ val locate_ocaml                : unit    -> bool
 val locate_file                 : unit    -> option string
 val locate_z3                   : unit    -> option string
 val output_deps_to              : unit    -> option string
-val output_dir                  : unit    -> option string
 val custom_prims                : unit    -> option string
-val cache_dir                   : unit    -> option string
-val include_                    : unit    -> list string
 val print_bound_var_types       : unit    -> bool
 val print_effect_args           : unit    -> bool
 val print_expected_failures     : unit    -> bool
@@ -266,7 +262,6 @@ val use_nbe                     : unit    -> bool
 val use_nbe_for_extraction      : unit    -> bool
 val trivial_pre_for_unannotated_effectful_fns
                                 : unit    -> bool
-val with_fstarc                 : unit    -> bool
 
 (* List of enabled debug toggles. *)
 val debug_keys                  : unit    -> list string

--- a/src/basic/FStarC.Plugins.fst
+++ b/src/basic/FStarC.Plugins.fst
@@ -60,7 +60,7 @@ let dynlink (fname:string) : unit =
 let load_plugin tac =
   if not (!loaded_plugin_lib) then (
     pout "Loading fstar.pluginlib before first plugin\n";
-    do_dynlink (BU.normalize_file_path <| BU.get_exec_dir () ^ "/../lib/fstar/pluginlib/fstar_pluginlib.cmxs");
+    do_dynlink (Filepath.normalize_file_path <| BU.get_exec_dir () ^ "/../lib/fstar/pluginlib/fstar_pluginlib.cmxs");
     pout "Loaded fstar.pluginlib OK\n";
     loaded_plugin_lib := true
   );
@@ -72,7 +72,7 @@ let load_plugins tacs =
 let load_plugins_dir dir =
   (* Dynlink all .cmxs files in the given directory *)
   (* fixme: confusion between FStarC.String and FStar.String *)
-  BU.readdir dir
+  Filepath.readdir dir
   |> List.filter (fun s -> String.length s >= 5 && FStar.String.sub s (String.length s - 5) 5 = ".cmxs")
   |> List.map (fun s -> dir ^ "/" ^ s)
   |> load_plugins

--- a/src/basic/FStarC.Range.Ops.fst
+++ b/src/basic/FStarC.Range.Ops.fst
@@ -138,3 +138,13 @@ instance showable_range = {
 instance pretty_range = {
   pp = (fun r -> Pprint.doc_of_string (string_of_range r));
 }
+
+(* See FStarC.Find.refind_file, this just applies it to both filename
+components. *)
+let refind_rng (r:rng) : rng =
+  { r with file_name = FStarC.Find.refind_file r.file_name }
+
+let refind_range (r:range) : range =
+  { r with
+    def_range = refind_rng r.def_range;
+    use_range = refind_rng r.use_range }

--- a/src/basic/FStarC.Range.Ops.fsti
+++ b/src/basic/FStarC.Range.Ops.fsti
@@ -56,3 +56,7 @@ val bound_range (r : range) (bound : range) : range
 
 instance val showable_range : showable range
 instance val pretty_range : pretty range
+
+(* See FStarC.Find.refind_file, this just applies it to both filename
+components. *)
+val refind_range (r:range) : range

--- a/src/basic/FStarC.Range.Type.fst
+++ b/src/basic/FStarC.Range.Type.fst
@@ -94,7 +94,7 @@ let mk_range f b e = let r = mk_rng f b e in range_of_rng r r
 
 let string_of_file_name f =
   if Options.Ext.enabled "fstar:no_absolute_paths" then
-    BU.basename f
+    Filepath.basename f
   else
     f
 

--- a/src/basic/FStarC.Range.Type.fst
+++ b/src/basic/FStarC.Range.Type.fst
@@ -95,14 +95,8 @@ let mk_range f b e = let r = mk_rng f b e in range_of_rng r r
 let string_of_file_name f =
   if Options.Ext.enabled "fstar:no_absolute_paths" then
     BU.basename f
-  else if Options.ide () then
-    try
-        match Find.find_file (BU.basename f) with
-        | None -> f //couldn't find file; just return the relative path
-        | Some absolute_path ->
-            absolute_path
-    with _ -> f
-  else f
+  else
+    f
 
 open FStarC.Json
 let json_of_pos (r: pos): json

--- a/src/basic/FStarC.Util.fsti
+++ b/src/basic/FStarC.Util.fsti
@@ -165,18 +165,7 @@ val kill_all: unit -> unit
 val proc_prog : proc -> string
 val system_run : string -> int (* a less refined launching, implemented by Sys.command *)
 
-val get_file_extension: string -> string
-val is_path_absolute: string -> bool
-val join_paths: string -> string -> string
-val normalize_file_path: string -> string
-val basename: string -> string (* name of file without directory *)
-val dirname : string -> string
 val getcwd: unit -> string
-val readdir: string -> list string
-val paths_to_same_file: string -> string -> bool
-
-val file_exists: string -> Tot bool
-val is_directory: string -> Tot bool
 
 val int_of_string: string -> int
 val safe_int_of_string: string -> option int

--- a/src/basic/FStarC.Util.fsti
+++ b/src/basic/FStarC.Util.fsti
@@ -318,6 +318,8 @@ val print_endline: string -> unit
 
 val map_option: ('a -> 'b) -> option 'a -> option 'b
 
+(* for a filepath, create the parent directory if it doesn't exist (and leading directories too) *)
+val maybe_create_parent : string -> unit
 val save_value_to_file: string -> 'a -> unit
 val load_value_from_file: string -> option 'a
 val save_2values_to_file: string -> 'a -> 'b -> unit

--- a/src/extraction/FStarC.Extraction.ML.Code.fst
+++ b/src/extraction/FStarC.Extraction.ML.Code.fst
@@ -656,7 +656,7 @@ and doc_of_loc (lineno, file) =
     if (Options.no_location_info()) || Util.codegen_fsharp () || file=" dummy" then
         empty
     else
-        let file = BU.basename file in
+        let file = Filepath.basename file in
         reduce1 [ text "#"; num lineno; text ("\"" ^ file ^ "\"") ]
 
 (* -------------------------------------------------------------------- *)

--- a/src/extraction/FStarC.Extraction.ML.Util.fst
+++ b/src/extraction/FStarC.Extraction.ML.Util.fst
@@ -77,7 +77,7 @@ let mlexpr_of_range (r:Range.range) : mlexpr' =
     let cstr (s : string) : mlexpr =
         MLC_String s |> MLE_Const |> with_ty ml_string_ty
     in
-    let drop_path = BU.basename in
+    let drop_path = Filepath.basename in
 
     // This is not being fully faithful since it disregards
     // the use_range, but I assume that's not too bad.

--- a/src/fstar/FStarC.CheckedFiles.fst
+++ b/src/fstar/FStarC.CheckedFiles.fst
@@ -213,7 +213,7 @@ let load_checked_file (fn:string) (checked_fn:string) :cache_t =
     elt |> must
   ) else
     let add_and_return elt = SMap.add mcache checked_fn elt; elt in
-    if not (BU.file_exists checked_fn)
+    if not (Filepath.file_exists checked_fn)
     then let msg = BU.format1 "checked file %s does not exist" checked_fn in
          add_and_return (Invalid msg, Inl msg)
     else let entry :option checked_file_entry_stage1 = BU.load_value_from_file checked_fn in

--- a/src/fstar/FStarC.Main.fst
+++ b/src/fstar/FStarC.Main.fst
@@ -89,7 +89,7 @@ let load_native_tactics () =
                 text (format1 "Extracted module %s not found." (ml_file m))
               ]
             | Some ml ->
-              let dir = Util.dirname ml in
+              let dir = Filepath.dirname ml in
               Plugins.compile_modules dir [ml_module_name m];
               begin match Find.find_file_odir cmxs with
                 | None ->
@@ -246,7 +246,7 @@ let go_normal () =
         Util.print1_error "File %s was not found in include path.\n" f;
         exit 1
       | Some fn ->
-        Util.print1 "%s\n" (Util.normalize_file_path fn);
+        Util.print1 "%s\n" (Filepath.normalize_file_path fn);
         exit 0
     )
 

--- a/src/fstar/FStarC.Main.fst
+++ b/src/fstar/FStarC.Main.fst
@@ -137,6 +137,14 @@ let print_help_for (o : string) : unit =
 (* Normal mode with some flags, files, etc *)
 let go_normal () =
   let res, filenames = process_args () in
+
+  (* Compat: create the --odir and --cache_dir if they don't exist.
+  F* has done this for a long time, only sinc it simplified
+  the handling of options. I think this should probably be removed,
+  but a few makefiles here and there rely on it. *)
+  iter_opt (Find.get_odir ()) (mkdir false true);
+  iter_opt (Find.get_cache_dir ()) (mkdir false true);
+
   let check_no_filenames opt =
     if Cons? filenames then (
       Util.print1_error "error: No filenames should be passed with option %s\n" opt;

--- a/src/fstar/FStarC.Main.fst
+++ b/src/fstar/FStarC.Main.fst
@@ -253,12 +253,12 @@ let go_normal () =
     | Success when Some? (Options.locate_z3 ()) -> (
       check_no_filenames "--locate_z3";
       let v = Some?.v (Options.locate_z3 ()) in
-      match Find.locate_z3 v with
+      match Find.Z3.locate_z3 v with
       | None ->
         // Use an actual error to reuse the pretty printing.
         Errors.log_issue0 Errors.Error_Z3InvocationError ([
           Errors.Msg.text <| Util.format1 "Z3 version '%s' was not found." v;
-          ] @ Find.z3_install_suggestion v);
+          ] @ Find.Z3.z3_install_suggestion v);
         report_errors []; // but make sure to report.
         exit 1
       | Some fn ->
@@ -274,7 +274,7 @@ let go_normal () =
         Util.print3 "- F* version %s -- %s (on %s)\n"  !Options._version !Options._commit (Platform.kernel ());
         Util.print1 "- Executable: %s\n" (Util.exec_name);
         Util.print1 "- Library root: %s\n" (Util.dflt "<none>" (Find.lib_root ()));
-        Util.print1 "- Full include path: %s\n" (show (Find.include_path ()));
+        Util.print1 "- Full include path: %s\n" (show (Find.full_include_path ()));
         Util.print_string "\n";
         ()
       );

--- a/src/fstar/FStarC.Universal.fst
+++ b/src/fstar/FStarC.Universal.fst
@@ -561,8 +561,8 @@ let needs_interleaving intf impl =
   let m1 = Parser.Dep.lowercase_module_name intf in
   let m2 = Parser.Dep.lowercase_module_name impl in
   m1 = m2 &&
-  List.mem (FStarC.Util.get_file_extension intf) ["fsti"; "fsi"] &&
-  List.mem (FStarC.Util.get_file_extension impl) ["fst"; "fs"]
+  List.mem (Filepath.get_file_extension intf) ["fsti"; "fsi"] &&
+  List.mem (Filepath.get_file_extension impl) ["fst"; "fs"]
 
 let tc_one_file_from_remaining (remaining:list string) (env:uenv)
                                (deps:FStarC.Parser.Dep.deps)  //used to query parsing data

--- a/src/fstar/FStarC.Universal.fst
+++ b/src/fstar/FStarC.Universal.fst
@@ -321,7 +321,7 @@ let emit dep_graph (mllibs:list (uenv & MLSyntax.mllib)) =
          FStarC.Extraction.ML.Code for both OCaml and F# extraction.
          When bootstarpped in OCaml, this will use the old printer
          for F# extraction and the new printer for OCaml extraction. *)
-      let outdir = Options.output_dir() in
+      let outdir = Find.get_odir () in
       List.iter (FStarC.Extraction.ML.PrintML.print outdir ext) (List.map snd mllibs)
 
     | Some Options.Extension ->

--- a/src/interactive/FStarC.Interactive.Ide.Types.fst
+++ b/src/interactive/FStarC.Interactive.Ide.Types.fst
@@ -173,6 +173,7 @@ let json_of_issue_level i =
            | EError -> "error")
 
 let json_of_issue issue =
+  let r = map_opt issue.issue_range Range.refind_range in
   JsonAssoc <|
      [("level", json_of_issue_level issue.issue_level)]
     @(match issue.issue_number with
@@ -180,10 +181,10 @@ let json_of_issue issue =
       | Some n -> [("number", JsonInt n)])
     @[("message", JsonStr (format_issue' false issue));
       ("ranges", JsonList
-                   ((match issue.issue_range with
+                   ((match r with
                      | None -> []
                      | Some r -> [json_of_use_range r]) @
-                    (match issue.issue_range with
+                    (match r with
                      | Some r when def_range r <> use_range r ->
                        [json_of_def_range r]
                      | _ -> [])))]

--- a/src/interactive/FStarC.Interactive.Ide.fst
+++ b/src/interactive/FStarC.Interactive.Ide.fst
@@ -324,7 +324,7 @@ let json_of_opt json_of_a opt_a =
 
 let alist_of_symbol_lookup_result lr symbol symrange_opt=
   [("name", JsonStr lr.slr_name);
-   ("defined-at", json_of_opt json_of_def_range lr.slr_def_range);
+   ("defined-at", json_of_opt (fun r -> json_of_def_range (Range.refind_range r)) lr.slr_def_range);
    ("type", json_of_opt JsonStr lr.slr_typ);
    ("documentation", json_of_opt JsonStr lr.slr_doc);
    ("definition", json_of_opt JsonStr lr.slr_def)] @ (

--- a/src/ml/FStarC_Extraction_ML_PrintML.ml
+++ b/src/ml/FStarC_Extraction_ML_PrintML.ml
@@ -542,6 +542,7 @@ let build_ast (out_dir: string option) (ext: string) (ml: mllib) =
 
 (* printing the AST to the correct path *)
 let print_module ((path, m): string * structure) =
+  FStarC_Util.maybe_create_parent path;
   Format.set_formatter_out_channel (open_out_bin path);
   structure Format.std_formatter m;
   Format.pp_print_flush Format.std_formatter ()

--- a/src/ml/FStarC_Filepath.ml
+++ b/src/ml/FStarC_Filepath.ml
@@ -39,7 +39,7 @@ let dirname = Filename.dirname
 
 let getcwd = Sys.getcwd
 
-let readdir dir = "." :: ".." :: Array.to_list (Sys.readdir dir)
+let readdir dir = Array.to_list (Sys.readdir dir)
 
 let paths_to_same_file f g =
   let open Unix in

--- a/src/ml/FStarC_Filepath.ml
+++ b/src/ml/FStarC_Filepath.ml
@@ -1,0 +1,53 @@
+
+let get_file_extension (fn:string) : string = snd (BatString.rsplit fn ".")
+
+(* NOTE: Working around https://github.com/ocaml-batteries-team/batteries-included/issues/1136 *)
+let is_absolute_windows (path_str : string) : bool =
+  if FStarC_Platform.windows then
+    match BatString.to_list path_str with
+    | '\\' :: _ -> true
+    | letter :: ':' :: '\\' :: _ -> BatChar.is_letter letter
+    | _ -> false
+  else
+    false
+
+let is_path_absolute path_str =
+  let open Batteries.Incubator in
+  let open BatPathGen.OfString in
+  let path = of_string path_str in
+  is_absolute path || is_absolute_windows path_str
+
+let join_paths path_str0 path_str1 =
+  let open Batteries.Incubator in
+  let open BatPathGen.OfString in
+  let open BatPathGen.OfString.Operators in
+  to_string ((of_string path_str0) //@ (of_string path_str1))
+
+let normalize_file_path (path_str:string) =
+  if is_path_absolute path_str then
+    path_str
+  else
+    let open Batteries.Incubator in
+    let open BatPathGen.OfString in
+    let open BatPathGen.OfString.Operators in
+    let path = of_string path_str in
+    let cwd = of_string (BatSys.getcwd ()) in
+    to_string (normalize_in_tree (cwd //@ path))
+
+let basename = Filename.basename
+let dirname = Filename.dirname
+
+let getcwd = Sys.getcwd
+
+let readdir dir = "." :: ".." :: Array.to_list (Sys.readdir dir)
+
+let paths_to_same_file f g =
+  let open Unix in
+  let { st_dev = i; st_ino = j } = stat f in
+  let { st_dev = i'; st_ino = j' } = stat g in
+  (i,j) = (i',j')
+
+let file_exists = Sys.file_exists
+(* Sys.is_directory raises Sys_error if the path does not exist *)
+let is_directory f = Sys.file_exists f && Sys.is_directory f
+

--- a/src/ml/FStarC_Filepath.ml
+++ b/src/ml/FStarC_Filepath.ml
@@ -23,16 +23,28 @@ let join_paths path_str0 path_str1 =
   let open BatPathGen.OfString.Operators in
   to_string ((of_string path_str0) //@ (of_string path_str1))
 
+let canonicalize path_str =
+  let open Batteries.Incubator in
+  let open BatPathGen.OfString in
+  let open BatPathGen.OfString.Operators in
+  let path = of_string path_str in
+  to_string (normalize_in_tree path)
+
 let normalize_file_path (path_str:string) =
-  if is_path_absolute path_str then
-    path_str
-  else
-    let open Batteries.Incubator in
-    let open BatPathGen.OfString in
-    let open BatPathGen.OfString.Operators in
-    let path = of_string path_str in
-    let cwd = of_string (BatSys.getcwd ()) in
-    to_string (normalize_in_tree (cwd //@ path))
+  let open Batteries.Incubator in
+  let open BatPathGen.OfString in
+  let open BatPathGen.OfString.Operators in
+  let path = of_string path_str in
+  let path =
+    (* If not absolute, prepend the cwd *)
+    if is_path_absolute path_str
+    then path
+    else
+      let cwd = of_string (BatSys.getcwd ()) in
+      cwd //@ path
+  in
+  (* Normalize *)
+  to_string (normalize_in_tree path)
 
 let basename = Filename.basename
 let dirname = Filename.dirname

--- a/src/ml/FStarC_Parser_LexFStar.ml
+++ b/src/ml/FStarC_Parser_LexFStar.ml
@@ -9,6 +9,7 @@ module L = Sedlexing
 module E = FStarC_Errors
 module Codes = FStarC_Errors_Codes
 module BU = FStarC_Util
+module Filepath = FStarC_Filepath
 
 let ba_of_string s = Array.init (String.length s) (fun i -> Char.code (String.get s i))
 let array_trim_both a n m = Array.sub a n (Array.length a - n - m)
@@ -472,9 +473,9 @@ match%sedlex lexbuf with
  | "#pop-options" -> PRAGMA_POP_OPTIONS
  | "#restart-solver" -> PRAGMA_RESTART_SOLVER
  | "#print-effects-graph" -> PRAGMA_PRINT_EFFECTS_GRAPH
- | "__SOURCE_FILE__" -> STRING (BU.basename (L.source_file lexbuf))
+ | "__SOURCE_FILE__" -> STRING (Filepath.basename (L.source_file lexbuf))
  | "__LINE__" -> INT (string_of_int (L.current_line lexbuf), false)
- | "__FILELINE__"   -> STRING (BU.basename (L.source_file lexbuf) ^ "(" ^ (string_of_int (L.current_line lexbuf)) ^ ")")
+ | "__FILELINE__"   -> STRING (Filepath.basename (L.source_file lexbuf) ^ "(" ^ (string_of_int (L.current_line lexbuf)) ^ ")")
 
  | Plus anywhite -> token lexbuf
  | newline -> L.new_line lexbuf; token lexbuf

--- a/src/ml/FStarC_Parser_ParseIt.ml
+++ b/src/ml/FStarC_Parser_ParseIt.ml
@@ -7,6 +7,7 @@ open FStarC_Sedlexing
 open FStarC_Errors_Codes
 module Codes = FStarC_Errors_Codes
 module Msg = FStarC_Errors_Msg
+module Filepath = FStarC_Filepath
 
 type filename = string
 
@@ -41,10 +42,10 @@ let find_file filename =
 let vfs_entries : (U.time_of_day * string) smap = smap_create (Z.of_int 1)
 
 let read_vfs_entry fname =
-  smap_try_find vfs_entries (U.normalize_file_path fname)
+  smap_try_find vfs_entries (Filepath.normalize_file_path fname)
 
 let add_vfs_entry fname contents =
-  smap_add vfs_entries (U.normalize_file_path fname) (U.get_time_of_day (), contents)
+  smap_add vfs_entries (Filepath.normalize_file_path fname) (U.get_time_of_day (), contents)
 
 let get_file_last_modification_time filename =
   match read_vfs_entry filename with

--- a/src/ml/FStarC_Util.ml
+++ b/src/ml/FStarC_Util.ml
@@ -345,41 +345,6 @@ let ask_process
   with e -> (* Ensure that reader_fn gets an EOF and exits *)
     kill_process p; raise e
 
-let get_file_extension (fn:string) : string = snd (BatString.rsplit fn ".")
-
-(* NOTE: Working around https://github.com/ocaml-batteries-team/batteries-included/issues/1136 *)
-let is_absolute_windows (path_str : string) : bool =
-  if FStarC_Platform.windows then
-    match BatString.to_list path_str with
-    | '\\' :: _ -> true
-    | letter :: ':' :: '\\' :: _ -> BatChar.is_letter letter
-    | _ -> false
-  else
-    false
-
-let is_path_absolute path_str =
-  let open Batteries.Incubator in
-  let open BatPathGen.OfString in
-  let path = of_string path_str in
-  is_absolute path || is_absolute_windows path_str
-
-let join_paths path_str0 path_str1 =
-  let open Batteries.Incubator in
-  let open BatPathGen.OfString in
-  let open BatPathGen.OfString.Operators in
-  to_string ((of_string path_str0) //@ (of_string path_str1))
-
-let normalize_file_path (path_str:string) =
-  if is_path_absolute path_str then
-    path_str
-  else
-    let open Batteries.Incubator in
-    let open BatPathGen.OfString in
-    let open BatPathGen.OfString.Operators in
-    let path = of_string path_str in
-    let cwd = of_string (BatSys.getcwd ()) in
-    to_string (normalize_in_tree (cwd //@ path))
-
 type stream_reader = BatIO.input
 let open_stdin () = BatIO.stdin
 let read_line s =
@@ -958,21 +923,6 @@ let get_oreader (filename:string) : oReader = {
 
 let getcwd = Sys.getcwd
 
-let readdir dir = "." :: ".." :: Array.to_list (Sys.readdir dir)
-
-let paths_to_same_file f g =
-  let open Unix in
-  let { st_dev = i; st_ino = j } = stat f in
-  let { st_dev = i'; st_ino = j' } = stat g in
-  (i,j) = (i',j')
-
-let file_exists = Sys.file_exists
-(* Sys.is_directory raises Sys_error if the path does not exist *)
-let is_directory f = Sys.file_exists f && Sys.is_directory f
-
-
-let basename = Filename.basename
-let dirname = Filename.dirname
 let print_endline = print_endline
 
 let map_option f opt = BatOption.map f opt

--- a/src/parser/FStarC.Parser.Dep.fst
+++ b/src/parser/FStarC.Parser.Dep.fst
@@ -472,7 +472,7 @@ let safe_readdir_for_include (d:string) : list string =
     Return a list of pairs of long names and full paths. *)
 (* In public interface *)
 let build_inclusion_candidates_list (): list (string & string) =
-  let include_directories = Find.include_path () in
+  let include_directories = Find.full_include_path () in
   let include_directories = List.map Filepath.normalize_file_path include_directories in
   (* Note that [BatList.unique] keeps the last occurrence, that way one can
    * always override the precedence order. *)
@@ -1436,7 +1436,7 @@ let topological_dependences_of
     topological_dependences_of' file_system_map dep_graph interfaces_needing_inlining root_files widened
 
 let all_files_in_include_paths () =
-  let paths = Find.include_path () in
+  let paths = Find.full_include_path () in
   List.collect
     (fun path -> 
       let files = safe_readdir_for_include path in

--- a/src/parser/FStarC.Parser.Dep.fst
+++ b/src/parser/FStarC.Parser.Dep.fst
@@ -41,6 +41,7 @@ let profile f c = Profiling.profile f None c
 (* Meant to write to a file as an out_channel. If an exception is raised,
 the file is deleted. *)
 let with_file_outchannel (fn : string) (k : out_channel -> 'a) : 'a =
+  BU.maybe_create_parent fn;
   let outc = BU.open_file_for_writing fn in
   let r =
     try k outc

--- a/src/parser/FStarC.Parser.Dep.fst
+++ b/src/parser/FStarC.Parser.Dep.fst
@@ -115,7 +115,7 @@ let list_of_pair (intf, impl) =
   list_of_option intf @ list_of_option impl
 
 (* In public interface *)
-let maybe_module_name_of_file f = check_and_strip_suffix (basename f)
+let maybe_module_name_of_file f = check_and_strip_suffix (Filepath.basename f)
 let module_name_of_file f =
     match maybe_module_name_of_file f with
     | Some longname ->
@@ -311,13 +311,13 @@ let cache_file_name =
         else fn ^".checked"
       in
       let mname = fn |> module_name_of_file in
-      match Find.find_file (cache_fn |> Util.basename) with
+      match Find.find_file (cache_fn |> Filepath.basename) with
       | Some path ->
         let expected_cache_file = Find.prepend_cache_dir cache_fn in
         if Option.isSome (Options.dep()) //if we're in the dependence analysis
         && not (Options.should_be_already_cached mname) //and checked file is in the
-        && (not (BU.file_exists expected_cache_file) //wrong spot ... complain
-            || not (BU.paths_to_same_file path expected_cache_file))
+        && (not (Filepath.file_exists expected_cache_file) //wrong spot ... complain
+            || not (Filepath.paths_to_same_file path expected_cache_file))
         then (
           let open FStarC.Pprint in
           let open FStarC.Errors.Msg in
@@ -335,12 +335,12 @@ let cache_file_name =
          * preference to relative filenames. This is mostly since
          * GNU make doesn't resolve paths in targets, so we try
          * to keep target paths relative. See issue #1978. *)
-        if BU.file_exists expected_cache_file && BU.paths_to_same_file path expected_cache_file
+        if Filepath.file_exists expected_cache_file && Filepath.paths_to_same_file path expected_cache_file
         then expected_cache_file
         else path
       | None ->
         if !dbg_CheckedFiles then
-          BU.print1 "find_file(%s) returned None\n" (cache_fn |> Util.basename);
+          BU.print1 "find_file(%s) returned None\n" (cache_fn |> Filepath.basename);
         if mname |> Options.should_be_already_cached then
           raise_error0 FStarC.Errors.Error_AlreadyCachedAssertionFailure [
              text (BU.format1 "Expected %s to be already checked but could not find it." mname)
@@ -444,8 +444,8 @@ let print_graph (outc : out_channel) (fn : string) (graph:dependence_graph)
   List.unique (deps_keys graph) |> List.iter (fun k ->
     let deps = (must (deps_try_find graph k)).edges in
     List.iter (fun dep ->
-      let l = basename k in
-      let r = basename <| file_of_dep file_system_map cmd_lined_files dep in
+      let l = Filepath.basename k in
+      let r = Filepath.basename <| file_of_dep file_system_map cmd_lined_files dep in
       if not <| Options.should_be_already_cached (module_name_of_dep dep) then
         pr (Util.format2 "  \"%s\" -> \"%s\"\n" l r)
     ) deps
@@ -454,7 +454,7 @@ let print_graph (outc : out_channel) (fn : string) (graph:dependence_graph)
   fprint outc "%s" [FStarC.StringBuffer.contents sb]
 
 let safe_readdir_for_include (d:string) : list string =
-  try readdir d
+  try Filepath.readdir d
   with
   | _ ->
     let open FStarC.Pprint in
@@ -472,18 +472,18 @@ let safe_readdir_for_include (d:string) : list string =
 (* In public interface *)
 let build_inclusion_candidates_list (): list (string & string) =
   let include_directories = Find.include_path () in
-  let include_directories = List.map normalize_file_path include_directories in
+  let include_directories = List.map Filepath.normalize_file_path include_directories in
   (* Note that [BatList.unique] keeps the last occurrence, that way one can
    * always override the precedence order. *)
   let include_directories = List.unique include_directories in
-  let cwd = normalize_file_path (getcwd ()) in
+  let cwd = Filepath.normalize_file_path (getcwd ()) in
   include_directories |> List.concatMap (fun d ->
     let files = safe_readdir_for_include d in
     files |> List.filter_map (fun f ->
-      let f = basename f in
+      let f = Filepath.basename f in
       check_and_strip_suffix f
       |> Util.map_option (fun longname ->
-            let full_path = if d = cwd then f else join_paths d f in
+            let full_path = if d = cwd then f else Filepath.join_paths d f in
             (longname, full_path))
     )
   )
@@ -534,7 +534,7 @@ let namespace_of_lid l =
 
 let check_module_declaration_against_filename (lid: lident) (filename: string): unit =
   let k' = string_of_lid lid true in
-  if must (check_and_strip_suffix (basename filename)) <> k' then
+  if must (check_and_strip_suffix (Filepath.basename filename)) <> k' then
     log_issue lid Errors.Error_ModuleFileNameMismatch [
         Errors.Msg.text (Util.format2 "The module declaration \"module %s\" \
           found in file %s does not match its filename." (string_of_lid lid true) filename);
@@ -1440,7 +1440,7 @@ let all_files_in_include_paths () =
     (fun path -> 
       let files = safe_readdir_for_include path in
       let files = List.filter (fun f -> Util.ends_with f ".fst" || Util.ends_with f ".fsti") files in
-      List.map (fun file -> Util.join_paths path file) files)
+      List.map (fun file -> Filepath.join_paths path file) files)
     paths
 
 (** Collect the dependencies for a list of given files.
@@ -1785,7 +1785,7 @@ let print_full (outc : out_channel) (deps:deps) : unit =
         s
     in
     let output_file ext fst_file =
-        let basename = Option.get (check_and_strip_suffix (BU.basename fst_file)) in
+        let basename = Option.get (check_and_strip_suffix (Filepath.basename fst_file)) in
         let basename = no_fstar_stubs_file basename in
         let ml_base_name = replace_chars basename '.' "_" in
         Find.prepend_output_dir (ml_base_name ^ ext)
@@ -2020,7 +2020,7 @@ let do_print (outc : out_channel) (fn : string) deps : unit =
     BU.fprint outc "# This .depend was generated by F* %s\n" [!Options._version];
     BU.fprint outc "# Executable: %s\n" [show BU.exec_name];
     BU.fprint outc "# Hash: %s\n" [!Options._commit];
-    BU.fprint outc "# Running in directory %s\n" [show (normalize_file_path (BU.getcwd ()))];
+    BU.fprint outc "# Running in directory %s\n" [show (Filepath.normalize_file_path (BU.getcwd ()))];
     BU.fprint outc "# Command line arguments: \"%s\"\n" [show (BU.get_cmd_args ())];
     BU.fprint outc "\n" [];
     ()

--- a/src/parser/FStarC.Parser.Driver.fst
+++ b/src/parser/FStarC.Parser.Driver.fst
@@ -24,7 +24,7 @@ open FStarC.Util
 open FStarC.Errors
 open FStarC.Class.Show
 
-let is_cache_file (fn: string) = Util.get_file_extension fn = ".cache"
+let is_cache_file (fn: string) = Filepath.get_file_extension fn = ".cache"
 
 let parse_fragment lang_opt (frag: ParseIt.input_frag) : fragment =
     match ParseIt.parse lang_opt (Toplevel frag) with

--- a/src/smtencoding/FStarC.SMTEncoding.Solver.fst
+++ b/src/smtencoding/FStarC.SMTEncoding.Solver.fst
@@ -75,7 +75,7 @@ let initialize_hints_db filename (refresh:bool) : unit =
     recorded_hints := [];
     refreshing_hints := refresh;
 
-    let norm_src_filename = BU.normalize_file_path filename in
+    let norm_src_filename = Filepath.normalize_file_path filename in
     src_filename := norm_src_filename;
     (*
      * Read the hints file into replaying_hints

--- a/src/smtencoding/FStarC.SMTEncoding.Z3.fst
+++ b/src/smtencoding/FStarC.SMTEncoding.Z3.fst
@@ -125,7 +125,7 @@ let query_logging =
 let z3_cmd_and_args () =
   let ver = Options.z3_version () in
   let cmd =
-    match Find.locate_z3 ver with
+    match Find.Z3.locate_z3 ver with
     | Some fn -> fn
     | None ->
       let open FStarC.Pprint in
@@ -133,7 +133,7 @@ let z3_cmd_and_args () =
       FStarC.Errors.raise_error0 Errors.Error_Z3InvocationError (
         [ text "Z3 solver not found.";
           prefix 2 1 (text "Required version: ") (doc_of_string ver)]
-        @ Find.z3_install_suggestion ver)
+        @ Find.Z3.z3_install_suggestion ver)
   in
   let cmd_args =
     List.append ["-smt2";
@@ -171,7 +171,7 @@ let check_z3version (p:proc) : unit =
     let open FStarC.Errors.Msg in
     Errors.log_issue0 Errors.Warning_SolverMismatch ([
       text <| BU.format1 "Unexpected SMT solver: expected to be talking to Z3, got %s." name;
-    ] @ Find.z3_install_suggestion (Options.z3_version ())
+    ] @ Find.Z3.z3_install_suggestion (Options.z3_version ())
     );
     _already_warned_solver_mismatch := true
   );
@@ -189,7 +189,7 @@ let check_z3version (p:proc) : unit =
     Errors.log_issue0 Errors.Warning_SolverMismatch ([
       text (BU.format3 "Unexpected Z3 version for '%s': expected '%s', got '%s'."
                   (proc_prog p) ver_conf ver_found);
-      ] @ Find.z3_install_suggestion ver_conf
+      ] @ Find.Z3.z3_install_suggestion ver_conf
     );
     Errors.stop_if_err(); (* stop now if this was a hard error *)
     _already_warned_version_mismatch := true

--- a/src/tactics/FStarC.Tactics.Printing.fst
+++ b/src/tactics/FStarC.Tactics.Printing.fst
@@ -161,7 +161,7 @@ let ps_to_json (msg, ps) =
                 ("goals", JsonList (List.map goal_to_json ps.goals));
                 ("smt-goals", JsonList (List.map goal_to_json ps.smt_goals))] @
                 (if ps.entry_range <> Range.dummyRange
-                 then [("location", Range.json_of_def_range ps.entry_range)]
+                 then [("location", Range.json_of_def_range (Range.refind_range ps.entry_range))]
                  else []))
 
 let do_dump_proofstate ps msg =

--- a/src/tosyntax/FStarC.ToSyntax.ToSyntax.fst
+++ b/src/tosyntax/FStarC.ToSyntax.ToSyntax.fst
@@ -4333,7 +4333,7 @@ let desugar_modul_common (curmod: option S.modul) env (m:AST.modul) : env_t & Sy
 let desugar_partial_modul curmod (env:env_t) (m:AST.modul) : env_t & Syntax.modul =
   let m =
     if Options.interactive () &&
-      List.mem (get_file_extension (List.hd (Options.file_list ()))) ["fsti"; "fsi"]
+      List.mem (Filepath.get_file_extension (List.hd (Options.file_list ()))) ["fsti"; "fsi"]
     then as_interface m
     else m
   in

--- a/src/typechecker/FStarC.TypeChecker.Err.fst
+++ b/src/typechecker/FStarC.TypeChecker.Err.fst
@@ -133,7 +133,8 @@ let errors_smt_detail env
                 let msg = msg @ smt_detail in
                 if r = dummyRange
                 then e, msg, Env.get_range env, ctx
-                else let r' = Range.set_def_range r (Range.use_range r) in
+                else let r = Range.refind_range r in
+                     let r' = Range.set_def_range r (Range.use_range r) in
                      if Range.file_of_range r' <> Range.file_of_range (Env.get_range env) //r points to another file
                      then
                        let msg =

--- a/tests/ide/emacs/Makefile
+++ b/tests/ide/emacs/Makefile
@@ -3,6 +3,8 @@ NOVERIFY=1
 FSTAR_ROOT ?= ../../..
 include $(FSTAR_ROOT)/mk/test.mk
 
+_ != mkdir -p $(OUTPUT_DIR)
+
 JSON_CLEANUP=python ../cleanup.py
 
 # Feed .in to F* and record output as .ideout.  Output is passed through cleanup.py

--- a/tests/ide/lsp/Makefile
+++ b/tests/ide/lsp/Makefile
@@ -3,6 +3,8 @@ NOVERIFY=1
 FSTAR_ROOT ?= ../../..
 include $(FSTAR_ROOT)/mk/test.mk
 
+_ != mkdir -p $(OUTPUT_DIR)
+
 JSON_CLEANUP=python ../cleanup.py
 
 # Feed .in to F* and record output as .ideout.  Output is passed through cleanup.py


### PR DESCRIPTION
This can be incredibly slow, particularly as we do not cache failures. In the IDE, tons of ranges have the filename "dummy" or "<input>", making things much worse.