### PR TITLE
Tc: do not disable admit for splice_t

### DIFF
--- a/src/tactics/FStarC.Tactics.Hooks.fst
+++ b/src/tactics/FStarC.Tactics.Hooks.fst
@@ -877,7 +877,7 @@ let splice
             : list goal & dsl_tac_result_t =
             run_tactic_on_ps tau.pos tau.pos false
               FStar.Tactics.Typeclasses.solve
-              ({env with admit=false; gamma=[]}, val_t)
+              ({env with gamma=[]}, val_t)
               FStar.Tactics.Typeclasses.solve
               tau
               tactic_already_typed


### PR DESCRIPTION
This was a stopgap measure for Pulse, which relied on backtracking over SMT queries and could not admit those. This is no longer the case, and this was also the wrong place to disable admitting anyway.