### PR TITLE
NormSteps: fix delta_qualifier definition, was completely wrong

### DIFF
--- a/src/basic/FStarC.NormSteps.fst
+++ b/src/basic/FStarC.NormSteps.fst
@@ -74,7 +74,7 @@ irreducible
 let delta_attr s = UnfoldAttr s
 
 irreducible
-let delta_qualifier s = UnfoldAttr s
+let delta_qualifier s = UnfoldQual s
 
 irreducible
 let delta_namespace s = UnfoldNamespace s

--- a/ulib/FStar.NormSteps.fst
+++ b/ulib/FStar.NormSteps.fst
@@ -73,7 +73,7 @@ irreducible
 let delta_attr s = UnfoldAttr s
 
 irreducible
-let delta_qualifier s = UnfoldAttr s
+let delta_qualifier s = UnfoldQual s
 
 irreducible
 let delta_namespace s = UnfoldNamespace s


### PR DESCRIPTION
Apparently no one is using this from a plugin, or we would have noticed it's completely broken there. In interpreted mode, the `delta_qualifier` is blocked from unfolding since it's behind an interface, and we interpret it properly when unembedding.