### PR TITLE
Context pruning is set by default

### DIFF
--- a/examples/layeredeffects/Queens.fst
+++ b/examples/layeredeffects/Queens.fst
@@ -14,7 +14,7 @@ let quit = geneff quitOp
 
 (* But... we should be careful since if we make a typo above we could become
 inconsistent, so we add a sanity check. *)
-#push-options "--ext 'context_pruning='"
+#push-options "--ext 'context_pruning=false'"
 //disable context pruning so that we really get Z3 to explore all assertions for inconsistency
 [@@expect_failure] let _ = assert False
 #pop-options

--- a/src/basic/FStarC.Options.Ext.fst
+++ b/src/basic/FStarC.Options.Ext.fst
@@ -23,9 +23,15 @@ open FStarC.PSMap
 type ext_state =
   | E : map : psmap string -> ext_state
 
-(* If we ever want to set any defaults, this is the place to do it.  *)
+(* Default extension options *)
+let defaults = [
+  ("context_pruning", "true");
+]
+
 let init : ext_state =
-  E (psmap_empty ())
+  E <| List.fold_right (fun (k,v) m -> psmap_add m k v)
+         defaults
+         (psmap_empty ())
 
 let cur_state = alloc init
 

--- a/src/smtencoding/FStarC.SMTEncoding.SolverState.fst
+++ b/src/smtencoding/FStarC.SMTEncoding.SolverState.fst
@@ -169,22 +169,27 @@ let filter_using_facts_from
         then (add_assumption a; [d])
         else []
       )
-      | RetainAssumptions names ->
-        // Add all assumptions that are mentioned here, making sure to not add duplicates
-        let assumptions = 
-          names |>
-          List.collect (fun name ->
-            match PSMap.try_find named_assumptions name with
-            | None -> []
-            | Some a ->
-              if already_given a then [] else (add_assumption a; [Assume a]))
-        in
-        assumptions
       | _ ->
         [d]
     in
-    let ds = List.collect map_decl ds in
-    ds
+    let ds' = List.collect map_decl ds in
+    if Options.Ext.get "debug_using_facts_from" <> ""
+    then (
+      let orig_n = List.length ds in
+      let new_n = List.length ds' in
+      if orig_n <> new_n
+      then (
+        BU.print4
+          "Pruned using facts from:\n\t\
+            Original (%s): [%s];\n\t\
+            Pruned (%s): [%s]\n"
+          (show orig_n)
+          (show (List.map decl_to_string_short ds))
+          (show new_n)
+          (show (List.map decl_to_string_short ds'))
+      )
+    );
+    ds'
 
 let already_given_decl (s:solver_state) (aname:string)
 : bool


### PR DESCRIPTION
This works on check-world: https://github.com/FStarLang/FStar/actions/runs/13314182570

I have a patch for test-steel that I just merged too.

I also fixed the way using_facts_from and context_pruning interact: if you have both set, then context_pruning applies first, and then we filter whatever facts remain with the using_facts_from_setting.