### PR TITLE
Simplifying command-line usage of F*

### DIFF
--- a/mk/generic-1.mk
+++ b/mk/generic-1.mk
@@ -69,24 +69,17 @@ FSTAR := $(WINWRAP) $(FSTAR_EXE) $(SIL) $(FSTAR_OPTIONS)
 	$(maybe_touch)
 
 %.$(EEXT): FF=$(notdir $(subst $(EXTENSION),,$<))
-%.$(EEXT): MM=$(basename $(FF))
-%.$(EEXT): LBL=$(notdir $@)
-# ^ HACK we use notdir to get the module name since we need to pass in
-# the fst (not the checked file), but we don't know where it is, so this
-# is relying on F* looking in its include path.
 %.$(EEXT):
-	$(call msg, "EXTRACT", $(LBL))
-	$(FSTAR) $(if $(findstring FStarC.,$<),--MLish,) $(FF) --already_cached '*,' --codegen $(CODEGEN) --extract_module $(MM)
+	$(call msg, "EXTRACT", $(FF))
+	$(FSTAR) $< $(if $(findstring FStarC.,$<),--MLish,) $(FF) --already_cached '*,' --codegen $(CODEGEN)
 	@# HACK: finding FStarC modules and passing --MLish
 	@# for them and only them.
 	$(maybe_touch)
 
 %.krml: FF=$(notdir $(subst $(EXTENSION),,$<))
-%.krml: MM=$(basename $(FF))
-%.krml: LBL=$(notdir $@)
 %.krml:
-	$(call msg, "EXTRACT", $(LBL))
-	$(FSTAR) $(FF) --already_cached ',*' --codegen krml --extract_module $(MM)
+	$(call msg, "EXTRACT", $(FF))
+	$(FSTAR) $< --already_cached ',*' --codegen krml
 
 DEPSTEM := $(CACHE_DIR)/.depend$(TAG)
 

--- a/mk/test.mk
+++ b/mk/test.mk
@@ -100,13 +100,13 @@ $(OUTPUT_DIR)/%.fsti.json_output: %.fsti
 	@mkdir -p $(dir $@)
 	$(FSTAR) --message_format json --silent -f --print_expected_failures $< >$@ 2>&1
 
-$(OUTPUT_DIR)/$(subst .,_,%).ml:
+$(OUTPUT_DIR)/%.ml:
 	$(call msg, "EXTRACT", $(basename $(notdir $@)))
-	$(FSTAR) $(subst .checked,,$(notdir $<)) --codegen OCaml --extract_module $(subst .fst.checked,,$(notdir $<))
+	$(FSTAR) $< --codegen OCaml
 
-$(OUTPUT_DIR)/$(subst .,_,%).fs:
+$(OUTPUT_DIR)/%.fs:
 	$(call msg, "EXTRACT FS", $(basename $(notdir $@)))
-	$(FSTAR) $(subst .checked,,$(notdir $<)) --codegen FSharp --extract_module $(subst .fst.checked,,$(notdir $<))
+	$(FSTAR) $< --codegen FSharp
 
 # No FSharp compilation in these makefiles, sorry.
 $(OUTPUT_DIR)/%.exe: $(OUTPUT_DIR)/%.ml

--- a/src/basic/FStarC.Options.fst
+++ b/src/basic/FStarC.Options.fst
@@ -1883,6 +1883,7 @@ let module_name_of_file_name f =
     let f = String.substring f 0 (String.length f - String.length (Filepath.get_file_extension f) - 1) in
     String.lowercase f
 
+(* Basically returns true when the module is in the command line *)
 let should_check m =
   let l = get_verify_module () in
   List.contains (String.lowercase m) l
@@ -2356,7 +2357,13 @@ let should_extract (m:string) (tgt:codegen_t) : bool =
         in
         not (no_extract m) &&
         (match get_extract_namespace (), get_extract_module() with
-        | [], [] -> true //neither is set; extract everything
+        | [], [] ->
+          // Neither is set; extract only files given in the command line.
+          // Except for krml: there we retain the behavior of extracting everything
+          // into a single krml output file.
+          if tgt = Krml
+          then true
+          else should_check m
         | _ -> should_extract_namespace m || should_extract_module m)
 
 let should_be_already_cached m =

--- a/tests/dune_hello/Makefile
+++ b/tests/dune_hello/Makefile
@@ -8,8 +8,11 @@ ifneq ($(OS),Windows_NT) # See comment in ../simple_hello/Makefile
 all: run.bc
 endif
 
-Hello.ml: Hello.fst
-	$(FSTAR_EXE) --codegen OCaml Hello.fst --extract Hello --z3version 4.13.3
+%.checked: %
+	$(FSTAR_EXE) $< --cache_checked_modules --z3version 4.13.3
+
+%.ml: %.fst.checked
+	$(FSTAR_EXE) --codegen OCaml $<
 
 bin/hello.exe: Hello.ml
 	$(FSTAR_EXE) --ocamlenv dune build @install --profile=release

--- a/tests/semiring/Makefile
+++ b/tests/semiring/Makefile
@@ -11,7 +11,7 @@ all: $(OUTPUT_DIR)/CanonCommSemiring.interpreted $(OUTPUT_DIR)/CanonCommSemiring
 # If you add explicit dependencies here, it will fall back to the default rule.
 $(OUTPUT_DIR)/%.ml:
 	$(call msg, "EXTRACT", $<)
-	$(FSTAR) --codegen Plugin --extract $* $*.fst
+	$(FSTAR) --codegen Plugin $<
 	cat $*.ml.fixup >> $@
 
 $(OUTPUT_DIR)/%.cmxs: $(OUTPUT_DIR)/%.ml

--- a/tests/simple_hello/Makefile
+++ b/tests/simple_hello/Makefile
@@ -20,8 +20,11 @@ endif
 Hello.%.test: Hello.%
 	./$< | grep "Hello F\*!"
 
-%.ml: %.fst
-	$(FSTAR_EXE) --codegen OCaml $< --extract $* --z3version 4.13.3
+%.checked: %
+	$(FSTAR_EXE) $< --cache_checked_modules --z3version 4.13.3
+
+%.ml: %.fst.checked
+	$(FSTAR_EXE) --codegen OCaml $<
 
 %.exe: %.ml
 	$(FSTAR_EXE) --ocamlopt $< -o $@


### PR DESCRIPTION
There are two really annoying aspects of the F* command line that have to worked around:

1- To extract a module that we've already checked, we must still call F* on the source file. So if we have `.cache/A.fst.checked` we cannot do `fstar.exe --codegen OCaml .cache/A.fst.checked` (complains about an invalid extension) and must instead call F* on `A.fst`. The problem is that `A.fst` can be anywhere on the include path, and an F*-generated .depend file does not help us find it as the rules look like:
```make
output/A.ml: .cache/A.fst.checked ....

.cache/A.fst.checked: foo/bar/A.fst ...
```
This means we have some awful makefile rules like:
```make
$(OUTPUT_DIR)/%.ml:
       $(FSTAR) $(subst .checked,,$(notdir $<)) --codegen OCaml --extract_module $(subst .fst.checked,,$(notdir $<))
 ```
where the `subst` turns the checked file into the source file name (not path!) and relies on F* finding paths in the command line across its include path, which we also want to remove (`fstar.exe Prims.fst` should not just work anywhere, it should only work if Prims is in the current directory). 

The first patch allows F* to take a checked file as argument, by performing a simple rewriting of it into its source file (which F* can indeed find in its configured include path). This turns the rule into:
```make
$(OUTPUT_DIR)/%.ml:
       $(FSTAR) $< --codegen OCaml --extract_module $(subst .fst.checked,,$(notdir $<))
```

2- `--codegen` will by default extract all modules, so we need to explicitly restrict in most makefiles, as we have rules to generate only the target we want. This also entails some chopping of the names involved to obtain only the module name, as above. The second patch makes F*, by default, only extract the modules that were given in the command line, though this behavior can be overriden with any of the `--extract` toggles. The rule now becomes:

```make
$(OUTPUT_DIR)/%.ml:
       $(FSTAR) $< --codegen OCaml
```