### PR TITLE
FStarC.Range: always use basenames

### DIFF
--- a/src/basic/FStarC.Range.Ops.fst
+++ b/src/basic/FStarC.Range.Ops.fst
@@ -50,12 +50,10 @@ let rng_included r1 r2 =
 
 let string_of_pos pos =
     format2 "%s,%s" (string_of_int pos.line) (string_of_int pos.col)
-let file_of_range r       =
-    let f = r.def_range.file_name in
-    string_of_file_name f
-let set_file_of_range r (f:string) = {r with def_range = {r.def_range with file_name = f}}
+let file_of_range r = r.def_range.file_name
+let set_file_of_range r (f:string) = {r with def_range = {r.def_range with file_name = Filepath.basename f}}
 let string_of_rng r =
-    format3 "%s(%s-%s)" (string_of_file_name r.file_name) (string_of_pos r.start_pos) (string_of_pos r.end_pos)
+    format3 "%s(%s-%s)" r.file_name (string_of_pos r.start_pos) (string_of_pos r.end_pos)
 let string_of_def_range r = string_of_rng r.def_range
 let string_of_use_range r = string_of_rng r.use_range
 let string_of_range r     = string_of_def_range r
@@ -142,7 +140,11 @@ instance pretty_range = {
 (* See FStarC.Find.refind_file, this just applies it to both filename
 components. *)
 let refind_rng (r:rng) : rng =
-  { r with file_name = FStarC.Find.refind_file r.file_name }
+  { r with file_name =
+      if Options.Ext.enabled "fstar:no_absolute_paths"
+      then r.file_name (* already a basename *)
+      else FStarC.Find.refind_file r.file_name
+  }
 
 let refind_range (r:range) : range =
   { r with

--- a/src/basic/FStarC.Range.Type.fst
+++ b/src/basic/FStarC.Range.Type.fst
@@ -45,6 +45,8 @@ instance ord_pos : ord pos = {
 [@@ PpxDerivingYoJson; PpxDerivingShow ]
 type rng = {
   file_name:file_name;
+  (* ^ Note: this must be a basename, without any directory components. The
+  interface should protect this fact. *)
   start_pos:pos;
   end_pos:pos;
 }
@@ -85,18 +87,12 @@ let mk_pos l c = {
     col=max 0 c
 }
 let mk_rng file_name start_pos end_pos = {
-    file_name = file_name;
+    file_name = Filepath.basename file_name;
     start_pos = start_pos;
     end_pos   = end_pos
 }
 
 let mk_range f b e = let r = mk_rng f b e in range_of_rng r r
-
-let string_of_file_name f =
-  if Options.Ext.enabled "fstar:no_absolute_paths" then
-    Filepath.basename f
-  else
-    f
 
 open FStarC.Json
 let json_of_pos (r: pos): json
@@ -106,7 +102,7 @@ let json_of_pos (r: pos): json
     ]
 let json_of_rng (r: rng): json
   = JsonAssoc [
-      "file_name", JsonStr (string_of_file_name r.file_name);
+      "file_name", JsonStr r.file_name;
       "start_pos", json_of_pos r.start_pos;
       "end_pos", json_of_pos r.end_pos;
     ]


### PR DESCRIPTION
In #3740 we discovered a nasty perf bug caused by trying to resolve filenames in ranges to actual files, triggering the removal of that feature and moving that logic to error reporting.

Given that, there is no reason to store full paths in ranges, and we can just save the basenames of files. This also gets us closer to reproducible, location-independent checked files, which we currently lack.

For instance, we now don't have any absolute paths (and privacy leaks!) in the stage2 checked files.

$ strings stage1/fstarc.checked/* | grep guido | wc
   9709    9709  664844
$ strings stage2/fstarc.checked/* | grep guido | wc
      0       0       0

The --ext fstar:no_absolute_paths option is retained, but only affects how we print out the ranges, not their internals or what goes into checked files.