### PR TITLE
Parser: tweak error_message type for extension parsers

### DIFF
--- a/src/ml/FStarC_Parser_ParseIt.ml
+++ b/src/ml/FStarC_Parser_ParseIt.ml
@@ -323,13 +323,12 @@ let parse_fstar_incrementally
           Inr (decls @ [err_decl])
       with
       | FStarC_Errors.Error(e, msg, r, _ctx) ->
-        let msg = FStarC_Errors_Msg.rendermsg msg in
         let err : FStarC_Parser_AST_Util.error_message = { message = msg; range = r } in
         Inl err
       | e ->
         let pos = FStarC_Parser_Util.pos_of_lexpos (lexbuf.cur_p) in
         let r = FStarC_Range.mk_range filename pos pos in
-        let err : FStarC_Parser_AST_Util.error_message = { message = "Syntax error parsing #lang-fstar block: "; range = r } in
+        let err : FStarC_Parser_AST_Util.error_message = { message = FStarC_Errors_Msg.mkmsg "Syntax error parsing #lang-fstar block: "; range = r } in
         Inl err
   in
   { parse_decls = f }

--- a/src/parser/FStarC.Parser.AST.Util.fsti
+++ b/src/parser/FStarC.Parser.AST.Util.fsti
@@ -35,7 +35,7 @@ type open_namespaces_and_abbreviations = {
 }
 
 type error_message = {
-   message: string;
+   message: list FStarC.Pprint.document;
    range: FStarC.Range.range;
 }
 


### PR DESCRIPTION
Now extension parsers can provide structured errors. Needs a Pulse patch.