### PR TITLE
Warn on nonexisting --include

### DIFF
--- a/src/basic/FStarC.Errors.fst
+++ b/src/basic/FStarC.Errors.fst
@@ -730,3 +730,11 @@ let raise_error_doc rng code msg = raise_error rng code msg
 let log_issue_doc rng code msg = log_issue rng code msg
 let raise_error_text rng code msg = raise_error rng code msg
 let log_issue_text rng code msg = log_issue rng code msg
+
+let _ = Options.check_include_dir := (fun s ->
+          if not (Filepath.is_directory s) then
+            log_issue dummyRange Fatal_NotValidIncludeDirectory [
+              Pprint.prefix 2 1 (text "Not a valid include directory:")
+                (Pprint.doc_of_string s)
+            ]
+)

--- a/src/basic/FStarC.Options.fst
+++ b/src/basic/FStarC.Options.fst
@@ -32,6 +32,10 @@ open FStarC.SMap
 module Util = FStarC.Util
 module List = FStarC.List
 
+(* Set externally, checks if the directory exists and otherwise
+logs an issue. Cannot do it here due to circular deps. *)
+let check_include_dir = mk_ref (fun (s:string) -> ())
+
 exception NotSettable of string
 
 module Ext = FStarC.Options.Ext
@@ -1035,6 +1039,7 @@ let rec specs_with_types warn_unsafe : list (char & string & opt_type & Pprint.d
   ( noshort,
     "include",
     PostProcessed ((fun (Path s) ->
+      !check_include_dir s;
       Find.set_include_path (Find.get_include_path () @ [s]);
       Unset), PathStr "dir"),
     text "A directory in which to search for files included on the command line");

--- a/src/basic/FStarC.Options.fsti
+++ b/src/basic/FStarC.Options.fsti
@@ -21,6 +21,10 @@ open FStarC.Getopt
 open FStarC.BaseTypes
 open FStarC.VConfig
 
+(* Set externally, checks if the directory exists and otherwise
+logs an issue. Cannot do it here due to circular deps. *)
+val check_include_dir : ref (string -> unit)
+
 (* Raised when a processing a pragma an a non-settable option
 appears there. *)
 exception NotSettable of string

--- a/src/parser/FStarC.Parser.Dep.fst
+++ b/src/parser/FStarC.Parser.Dep.fst
@@ -457,16 +457,7 @@ let print_graph (outc : out_channel) (fn : string) (graph:dependence_graph)
 let safe_readdir_for_include (d:string) : list string =
   try Filepath.readdir d
   with
-  | _ ->
-    let open FStarC.Pprint in
-    if false then
-    // fixme: only warn if given in --include, not for transitive fstar.include
-    // I'd say it's legit to fstar.include a .cache dir that may not exist yet.
-      log_issue0 Errors.Fatal_NotValidIncludeDirectory [
-        prefix 2 1 (text "Not a valid include directory:")
-          (doc_of_string d);
-      ];
-    []
+  | _ -> []
 
 (** Enumerate all F* files in include directories.
     Return a list of pairs of long names and full paths. *)


### PR DESCRIPTION
But not on non-existing directories included via `fstar.include`, we sometimes add cache directories there that may not yet exist.