### PR TITLE
Respect extract_as for recursive definitions too

### DIFF
--- a/src/extraction/FStarC.Extraction.ML.Modul.fst
+++ b/src/extraction/FStarC.Extraction.ML.Modul.fst
@@ -757,7 +757,7 @@ let mark_sigelt_erased (se:sigelt) (g:uenv) : uenv =
 // If the definition has an [@@extract_as impl] attribute,
 // replace the lbdef with the specified impl:
 let fixup_sigelt_extract_as se =
-  match se.sigel, find_map se.sigattrs N.is_extract_as_attr with
+  match se.sigel, find_map se.sigattrs Parser.Const.ExtractAs.is_extract_as_attr with
   | Sig_let {lids; lbs=(_, [lb])}, Some impl ->
     // The specified implementation can be recursive,
     // to be on the safe side we always mark the replaced sigelt as recursive.

--- a/src/parser/FStarC.Parser.Const.ExtractAs.fst
+++ b/src/parser/FStarC.Parser.Const.ExtractAs.fst
@@ -1,0 +1,38 @@
+(*
+   Copyright 2008-2025 Nikhil Swamy and Microsoft Research
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR C  ONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*)
+module FStarC.Parser.Const.ExtractAs
+
+open FStarC
+open FStarC.Effect
+open FStarC.Util
+open FStarC.Ident
+open FStarC.Range.Type
+open FStarC.Const
+open FStarC.Syntax
+open FStarC.Syntax.Syntax
+
+let p2l l = lid_of_path l dummyRange
+let extract_as_lid = p2l ["FStar"; "ExtractAs"; "extract_as"]
+
+let is_extract_as_attr (attr: attribute) : option term =
+  let head, args = Syntax.Util.head_and_args attr in
+  match (Subst.compress head).n, args with
+  | Tm_fvar fv, [t, _] when Syntax.fv_eq_lid fv extract_as_lid ->
+    (match (Subst.compress t).n with
+    | Tm_quoted(impl, _) -> Some impl
+    | _ -> None)
+  | _ -> None
+

--- a/src/parser/FStarC.Parser.Const.ExtractAs.fsti
+++ b/src/parser/FStarC.Parser.Const.ExtractAs.fsti
@@ -1,0 +1,25 @@
+(*
+   Copyright 2008-2025 Nikhil Swamy and Microsoft Research
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR C  ONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*)
+module FStarC.Parser.Const.ExtractAs
+
+open FStarC
+open FStarC.Effect
+open FStarC.Ident
+open FStarC.Syntax.Syntax
+
+val extract_as_lid : lid
+
+val is_extract_as_attr (attr: attribute) : option term

--- a/src/parser/FStarC.Parser.Const.fst
+++ b/src/parser/FStarC.Parser.Const.fst
@@ -524,5 +524,4 @@ let tref_lid        = p2l ["FStar"; "Stubs"; "Tactics"; "Types"; "tref"]
 let document_lid = p2l ["FStar"; "Pprint"; "document"]
 let issue_lid = p2l ["FStar"; "Issue"; "issue"]
 
-let extract_as_lid = p2l ["FStar"; "ExtractAs"; "extract_as"]
 let extract_as_impure_effect_lid = attr "extract_as_impure_effect"

--- a/src/typechecker/FStarC.TypeChecker.Normalize.Unfolding.fst
+++ b/src/typechecker/FStarC.TypeChecker.Normalize.Unfolding.fst
@@ -87,6 +87,10 @@ let should_unfold cfg should_reify fv qninfo : should_unfold_res =
         log_unfolding cfg (fun () -> BU.print_string " >> UnfoldOnce\n");
         once
 
+    | Some (Inr ({sigattrs=attrs}, _), _), _ when cfg.steps.for_extraction && Some? (BU.find_map attrs Parser.Const.ExtractAs.is_extract_as_attr) ->
+        log_unfolding cfg (fun () -> BU.print_string " >> Has extract_as attribute and we're extracting, unfold!");
+        yes
+
     // Recursive lets may only be unfolded when Zeta is on
     | Some (Inr ({sigquals=qs; sigel=Sig_let {lbs=(is_rec, _)}}, _), _), _ when
             is_rec && not cfg.steps.zeta && not cfg.steps.zeta_full ->

--- a/src/typechecker/FStarC.TypeChecker.Normalize.fst
+++ b/src/typechecker/FStarC.TypeChecker.Normalize.fst
@@ -870,20 +870,6 @@ let is_forall_const cfg (phi : term) : option term =
 
     | _ -> None
 
-let is_extract_as_attr (attr: attribute) : option term =
-  let head, args = head_and_args attr in
-  match (Subst.compress head).n, args with
-  | Tm_fvar fv, [t, _] when Syntax.fv_eq_lid fv PC.extract_as_lid ->
-    (match (Subst.compress t).n with
-    | Tm_quoted(impl, _) -> Some impl
-    | _ -> None)
-  | _ -> None
-
-let has_extract_as_attr (g: Env.env) (lid: I.lid) : option term =
-  match Env.lookup_attrs_of_lid g lid with
-  | Some attrs -> find_map attrs is_extract_as_attr
-  | None -> None
-
 (* GM: Please consider this function private outside of this recursive
  * group, and call `normalize` instead. `normalize` will print timing
  * information when --debug NormTop is given, which makes it a
@@ -1524,7 +1510,7 @@ and do_unfold_fv (cfg:Cfg.cfg) stack (t0:term) (qninfo : qninfo) (f:fv) : term =
       if cfg.steps.for_extraction then
         match qninfo with
         | Some (Inr (se, None), _) when Env.visible_with cfg.delta_level se.sigquals ->
-          (match find_map se.sigattrs is_extract_as_attr with
+          (match find_map se.sigattrs Parser.Const.ExtractAs.is_extract_as_attr with
           | Some impl -> Some ([], impl)
           | None -> defn ())
         | _ -> defn ()

--- a/src/typechecker/FStarC.TypeChecker.Normalize.fsti
+++ b/src/typechecker/FStarC.TypeChecker.Normalize.fsti
@@ -67,9 +67,6 @@ val remove_uvar_solutions: Env.env -> term -> term
 val unfold_head_once: Env.env -> term -> option term
 val unembed_binder_knot : ref (option (FStarC.Syntax.Embeddings.embedding binder))
 
-val is_extract_as_attr : attribute -> option term
-val has_extract_as_attr : Env.env -> Ident.lid -> option term
-
 val reflection_env_hook : ref (option Env.env)
 
 (* Destructs the term as an arrow type and returns its binders and

--- a/tests/extraction/ExtractAs.fst
+++ b/tests/extraction/ExtractAs.fst
@@ -16,3 +16,11 @@ let bar_2 y = 2 + y
 let bar z = bar_2 z
 
 let _ = fail_unless (bar 1 = 11)
+
+
+// It also works if the definition is recursive
+
+[@@extract_as (`(fun (x: nat) -> x))]
+let rec loopid (x:nat) : Dv nat = loopid x
+
+let two = loopid 2

--- a/tests/extraction/ExtractAs.ml.expected
+++ b/tests/extraction/ExtractAs.ml.expected
@@ -1,0 +1,11 @@
+open Prims
+let (fail_unless : Prims.bool -> Prims.string) =
+  fun b -> if b then "ok" else Prims.magic ()
+let rec (frob : Prims.int -> Prims.int) = fun x -> x + (Prims.of_int (10))
+let (uu___0 : Prims.string) =
+  fail_unless ((frob Prims.int_one) = (Prims.of_int (11)))
+let (bar : Prims.int -> Prims.int) = fun z -> z + (Prims.of_int (10))
+let (uu___1 : Prims.string) =
+  fail_unless ((bar Prims.int_one) = (Prims.of_int (11)))
+let rec (loopid : Prims.nat -> Prims.nat) = fun x -> x
+let (two : Prims.nat) = loopid (Prims.of_int (2))


### PR DESCRIPTION
I noticed some `later_credit_buy` calls appearing in Pulse code when using --cmi. This happened since --cmi exposes the fact that this function is recursive, and then the unfolding is blocked as zeta reductions are not allowed. This adds a case in decide_unfolding to allow make sure we unfold a function marked with `@@extract_as` when we are extracting.

@gebner wondering if you see any gotchas