### PR TITLE
Perf fixes

### DIFF
--- a/src/basic/FStarC.Options.fst
+++ b/src/basic/FStarC.Options.fst
@@ -71,8 +71,6 @@ let as_comma_string_list = function
   | List ls -> List.flatten <| List.map (fun l -> split (as_string l) ",") ls
   | _ -> failwith "Impos: expected String (comma list)"
 
-let copy_optionstate m = SMap.copy m
-
 (* The option state is a stack of stacks. Why? First, we need to
  * support #push-options and #pop-options, which provide the user with
  * a stack-like option control, useful for rlimits and whatnot. Second,

--- a/src/basic/FStarC.PSMap.fsti
+++ b/src/basic/FStarC.PSMap.fsti
@@ -14,6 +14,7 @@ val find_map: t 'value -> (string -> 'value -> option 'a) -> option 'a
 val modify: t 'value -> string -> (option 'value -> 'value) -> t 'value
 val merge: t 'value -> t 'value -> t 'value
 val remove: t 'value -> string -> t 'value
+val keys : t 'value -> list string
 
 (* aliases *)
 type psmap = t

--- a/src/ml/FStarC_PSMap.ml
+++ b/src/ml/FStarC_PSMap.ml
@@ -33,6 +33,8 @@ let merge (m1: 'value t) (m2: 'value t) : 'value t =
 let remove (m: 'value t)  (key:string)
   : 'value t = StringMap.remove key m
 
+let keys m = fold m (fun k _ acc -> k::acc) []
+
 type 'v psmap = 'v t
 let psmap_empty = empty
 let psmap_add = add

--- a/src/syntax/FStarC.Syntax.Embeddings.fst
+++ b/src/syntax/FStarC.Syntax.Embeddings.fst
@@ -37,8 +37,6 @@ module Z     = FStarC.BigInt
 open FStarC.Syntax.Print {}
 open FStarC.Syntax.Embeddings.Base
 
-friend FStar.Pervasives (* To expose norm_step *)
-
 (*********************************************************************
 
              A NOTE ON FUNCTIONS AND SHADOW TERMS

--- a/src/tactics/FStarC.Tactics.V1.Basic.fst
+++ b/src/tactics/FStarC.Tactics.V1.Basic.fst
@@ -34,8 +34,6 @@ open FStarC.Class.Show
 open FStarC.Class.Tagged
 module Listlike = FStarC.Class.Listlike
 
-friend FStar.Pervasives (* to use Delta below *)
-
 module BU     = FStarC.Util
 module Cfg    = FStarC.TypeChecker.Cfg
 module Env    = FStarC.TypeChecker.Env

--- a/src/tactics/FStarC.Tactics.V2.Basic.fst
+++ b/src/tactics/FStarC.Tactics.V2.Basic.fst
@@ -34,8 +34,6 @@ open FStarC.VConfig
 open FStarC.Errors.Msg
 module Listlike = FStarC.Class.Listlike
 
-friend FStar.Pervasives (* to expose norm_step *)
-
 module BU     = FStarC.Util
 module Cfg    = FStarC.TypeChecker.Cfg
 module Env    = FStarC.TypeChecker.Env

--- a/src/typechecker/FStarC.TypeChecker.Cfg.fst
+++ b/src/typechecker/FStarC.TypeChecker.Cfg.fst
@@ -18,8 +18,6 @@ module PC  = FStarC.Parser.Const
 module U   = FStarC.Syntax.Util
 module I   = FStarC.Ident
 
-friend FStar.Pervasives (* to expose norm_step *)
-
 let steps_to_string f =
   let format_opt (f:'a -> string) (o:option 'a) =
     match o with

--- a/src/typechecker/FStarC.TypeChecker.NBETerm.fst
+++ b/src/typechecker/FStarC.TypeChecker.NBETerm.fst
@@ -22,8 +22,6 @@ open FStarC.Errors
 open FStar.Char
 open FStar.String
 
-friend FStar.Pervasives (* To expose norm_step *)
-
 module PC = FStarC.Parser.Const
 module S = FStarC.Syntax.Syntax
 module U = FStarC.Syntax.Util

--- a/src/typechecker/FStarC.TypeChecker.Tc.fst
+++ b/src/typechecker/FStarC.TypeChecker.Tc.fst
@@ -1251,15 +1251,11 @@ let load_checked_module_sigelts (en:env) (m:modul) : env =
   env
 
 let load_checked_module (en:env) (m:modul) :env =
-  (* Another compression pass to make sure we are not loading a corrupt
-  module. *)
-
   (* Reset debug flags *)
   let dsnap = Debug.snapshot () in
   if not (Options.should_check (string_of_lid m.name)) && not (Options.debug_all_modules ())
   then Debug.disable_all ();
 
-  let m = deep_compress_modul m in
   let env = load_checked_module_sigelts en m in
   //And then call finish_partial_modul, which is the normal workflow of tc_modul below
   //except with the flag `must_check_exports` set to false, since this is already a checked module
@@ -1269,7 +1265,6 @@ let load_checked_module (en:env) (m:modul) :env =
   env
 
 let load_partial_checked_module (en:env) (m:modul) : env =
-  let m = deep_compress_modul m in
   load_checked_module_sigelts en m
 
 let check_module env0 m b =


### PR DESCRIPTION
I recently introduced a pretty serious performance regression by tweaking the include path logic. It's now extended as a side-effect by the parsing of the options, and then cached as long as this list does not change. The problem is that the command line options are re-parsed multiple times to reset them (which we do between modules), extending this list into the thousands of elements. This made the overhead of F* before starting to check a module really huge, sometimes into the tens of seconds.

This patch fixes this, and adds a few other performance improvements. There is a green check-world here https://github.com/mtzguido/FStar/actions/runs/13416038731 (with one extra patch that I'm opening another PR for). Note HACL* building in 1h38 instead of the 2h50m as in here https://github.com/FStarLang/FStar/actions/runs/13403971237. (This problem was particularly exacerbated for HACL* due to the large include path and many modules in the dep graph).