### PR TITLE
Tactics: return proper errors when guards fail for typing reflection

### DIFF
--- a/src/extraction/FStarC.Extraction.ML.Modul.fst
+++ b/src/extraction/FStarC.Extraction.ML.Modul.fst
@@ -750,7 +750,7 @@ let karamel_fixup_qual (se:sigelt) : sigelt =
 
 let mark_sigelt_erased (se:sigelt) (g:uenv) : uenv =
   debug g (fun u -> BU.print1 ">>>> NOT extracting %s \n" (Print.sigelt_to_string_short se));
-  // Cheating with delta levels and qualifiers below, but we don't ever use them.
+  // Cheating with fv qualifiers below, but we don't ever use them.
   List.fold_right (fun lid g -> extend_erased_fv g (S.lid_as_fv lid None))
                   (U.lids_of_sigelt se) g
 

--- a/src/tactics/FStarC.Tactics.Monad.fst
+++ b/src/tactics/FStarC.Tactics.Monad.fst
@@ -205,6 +205,13 @@ let rec iter_tac f l =
   | [] -> ret ()
   | hd::tl -> f hd ;! iter_tac f tl
 
+let rec fold_right f l x =
+  match l with
+  | [] -> return x
+  | hd::tl ->
+    let! r = fold_right f tl x in
+    f hd r
+
 exception Bad of string
 
 (* private *)

--- a/src/tactics/FStarC.Tactics.Monad.fsti
+++ b/src/tactics/FStarC.Tactics.Monad.fsti
@@ -66,6 +66,8 @@ val trytac_exn : tac 'a -> tac (option 'a)
 (* iter combinator *)
 val iter_tac (f: 'a -> tac unit) (l:list 'a) : tac unit
 
+val fold_right (f: 'a -> 'b -> tac 'b) (l:list 'a) (x:'b) : tac 'b
+
 (* Defensive checks. Will only do anything if --defensive is on. If so,
 and some goal is ill-scoped, they will log a warning. *)
 val check_valid_goal (g:goal) : unit

--- a/src/tactics/FStarC.Tactics.Types.fst
+++ b/src/tactics/FStarC.Tactics.Types.fst
@@ -26,6 +26,15 @@ module O       = FStarC.Options
 module Range   = FStarC.Range
 module U       = FStarC.Syntax.Util
 
+instance showable_guard_policy : showable guard_policy = {
+  show = (function | Goal -> "Goal"
+                   | SMT -> "SMT"
+                   | SMTSync -> "SMTSync"
+                   | Force -> "Force"
+                   | ForceSMT -> "ForceSMT"
+                   | Drop -> "Drop");
+}
+
 let goal_env g = g.goal_main_env
 let goal_range g = g.goal_main_env.range
 let goal_witness g =

--- a/src/tactics/FStarC.Tactics.Types.fsti
+++ b/src/tactics/FStarC.Tactics.Types.fsti
@@ -20,6 +20,7 @@ open FStarC.Effect
 open FStarC.Syntax.Syntax
 open FStarC.TypeChecker.Env
 open FStarC.Tactics.Common
+open FStarC.Class.Show
 
 module PO      = FStarC.TypeChecker.Primops
 module Range   = FStarC.Range
@@ -49,6 +50,8 @@ type guard_policy =
     | Force
     | ForceSMT
     | Drop // unsound
+
+instance val showable_guard_policy : showable guard_policy
 
 type proofstate = {
     main_context : env;          //the shared top-level context for all goals

--- a/src/tactics/FStarC.Tactics.V2.Basic.fst
+++ b/src/tactics/FStarC.Tactics.V2.Basic.fst
@@ -234,6 +234,9 @@ let proc_guard_formula
   (rng:Range.range)
 : tac unit
 = let! ps = get in
+  if !dbg_Tac then
+    BU.print2 "Guard policy is %s, trying to discharge %s\n"
+      (show ps.guard_policy) (show f);
   match ps.guard_policy with
   | Drop ->
     // should somehow taint the state instead of just printing a warning


### PR DESCRIPTION
When discharging a guard fails, reflection typing calls returned `None, []` i.e. an empty list of issues. This fixes it provide an issue for each failed guard.