### PR TITLE
Simplify `reveal ?u =?= reveal t` to `?u =?= hide (reveal t)`.

### DIFF
--- a/tests/bug-reports/closed/PulseBug355.fst
+++ b/tests/bug-reports/closed/PulseBug355.fst
@@ -1,0 +1,9 @@
+module PulseBug355
+open FStar.Ghost
+
+assume val ref (t: Type0) : Type0
+assume val pts_to #t (x: ref t) (v: t) : prop
+assume val read #t (#x: ref t) (#v: erased t) (h: pts_to x v) : w:t { w == reveal v }
+
+let foo (x: ref int) (v: erased nat) (h: pts_to x v) =
+  read h


### PR DESCRIPTION
This adds a heuristic to the unifier that reduces `reveal #a ?u =?= reveal #b t` to `?u =?= hide #a (reveal #b t)`.  Fixes https://github.com/FStarLang/pulse/issues/355

I have added the heuristic step in rigid-rigid unification, where it does delta-reduction and retries unification.  (I hope that's a reasonable place to put it.)

 1. It might be better to first check whether `a` and `b` unify (without SMT), and then commit to the `?u =?= hide (reveal t)` branch, but I don't know how to do that.
 2. It might be even better to make `erased` covariant.  Then we could simplify `reveal x =?= reveal y` to `x =?= y` unconditionally.