### PR TITLE
Parser: allow operators in restricted opens

### DIFF
--- a/src/ml/FStarC_Parser_Parse.mly
+++ b/src/ml/FStarC_Parser_Parse.mly
@@ -373,7 +373,7 @@ typeclassDecl:
       }
 
 restriction:
-  | LBRACE ids=separated_list(COMMA, id=ident renamed=option(AS id=ident {id} ) {(id, renamed)}) RBRACE
+  | LBRACE ids=separated_list(COMMA, id=identOrOperator renamed=option(AS id=identOrOperator {id} ) {(id, renamed)}) RBRACE
       { FStarC_Syntax_Syntax.AllowList ids }
   |   { FStarC_Syntax_Syntax.Unrestricted  }
 
@@ -850,6 +850,11 @@ qlidentOrOperator:
 
 %inline lidentOrOperator:
   | id=lident { id }
+  | LPAREN id=operator RPAREN
+    { mk_ident (compile_op' (string_of_id id) (range_of_id id), range_of_id id) }
+
+%inline identOrOperator:
+  | id=ident { id }
   | LPAREN id=operator RPAREN
     { mk_ident (compile_op' (string_of_id id) (range_of_id id), range_of_id id) }
 

--- a/tests/restricted_includes/OpenOperators.fst
+++ b/tests/restricted_includes/OpenOperators.fst
@@ -1,0 +1,9 @@
+module OpenOperators
+
+open FStar.Mul { ( * ) }
+
+let _ = assert (2 * 3 == 6)
+
+open FStar.Mul { ( * ) as ( ++ ) }
+
+let _ = assert (2 ++ 3 == 6)


### PR DESCRIPTION
Allows to open a single operator from a module, or rename them like so:

```fstar
open FStar.Mul { ( * ) }

let _ = assert (2 * 3 == 6)

open FStar.Mul { ( * ) as ( ++ ) }

let _ = assert (2 ++ 3 == 6)
```