### PR TITLE
Tc: no need to refresh the solver when loading from cache

### DIFF
--- a/src/fstar/FStarC.Universal.fst
+++ b/src/fstar/FStarC.Universal.fst
@@ -535,7 +535,6 @@ let tc_one_file
         then BU.print1 "Module after type checking:\n%s\n" (show tcmod);
 
         let extend_tcenv tcmod tcenv =
-            FStarC.SMTEncoding.Z3.refresh None;
             let _, tcenv =
                 with_dsenv_of_tcenv tcenv <|
                     FStarC.ToSyntax.ToSyntax.add_modul_to_env


### PR DESCRIPTION
This can be very slow, since if we are loading 100 checked files we will incur in 100 restarts of Z3 including fact filtering.

@nikswamy I noticed this can take quite long when loading a bunch of modules, and it seems unnecessary to me but maybe you can confirm. The refresh entails restarting the z3 process and calling `SolverState.reset`, but we won't perform any queries when loading from cache.