### PR TITLE
Introduce FStar.Exception.string_of_exn to the library

### DIFF
--- a/tests/micro-benchmarks/StringOfExn.fst
+++ b/tests/micro-benchmarks/StringOfExn.fst
@@ -1,0 +1,17 @@
+module StringOfExn
+
+open FStar.All
+open FStar.Exception { string_of_exn }
+
+exception A
+
+// Top-level effects ok
+#set-options "--warn_error -272"
+
+let _ =
+  try
+    raise A
+  with
+  | e ->
+    IO.print_string (string_of_exn e ^ "\n");
+    ()

--- a/tests/micro-benchmarks/StringOfExn.out.expected
+++ b/tests/micro-benchmarks/StringOfExn.out.expected
@@ -1,0 +1,1 @@
+StringOfExn.A

--- a/ulib/FStar.Exception.fsti
+++ b/ulib/FStar.Exception.fsti
@@ -1,0 +1,6 @@
+module FStar.Exception
+
+(* This function is uninterpreted and will not evaluate in the
+normalizer. It is extracted to OCaml's Printexc.to_string. It
+can also be used from tactic plugins. *)
+val string_of_exn : exn -> string

--- a/ulib/ml/app/FStar_Exception.ml
+++ b/ulib/ml/app/FStar_Exception.ml
@@ -1,0 +1,1 @@
+let string_of_exn = Printexc.to_string


### PR DESCRIPTION
This allows user programs (including tactic plugins) to print exceptions. It is not trivial to make this work in interpreted mode too (i.e. provide a primop for this) since we do not have a complete embedding/unembedding for exceptions. There is an e_exn in FStarC.Tactics.Embeddings, but only handles (properly) a few exceptions.