### PR TITLE
fstar.opam: add upper bound for ppxlib

### DIFF
--- a/fstar.opam
+++ b/fstar.opam
@@ -17,7 +17,7 @@ depends: [
   "mtime" {>= "2.1.0"}
   "pprint"
   "sedlex"
-  "ppxlib" {>= "0.27.0"}
+  "ppxlib" {>= "0.27.0" && < "0.36"}
   "process"
   "ppx_deriving" {build}
   "ppx_deriving_yojson" {build}


### PR DESCRIPTION
See #3821 and https://github.com/ocaml/opam-repository/pull/27686.