### PR TITLE
Resugar: preserve order of datacons when printing

### DIFF
--- a/src/syntax/FStarC.Syntax.Resugar.fst
+++ b/src/syntax/FStarC.Syntax.Resugar.fst
@@ -1494,7 +1494,7 @@ let resugar_sigelt' env se : option A.decl =
       let datacon_ses, tyc = resugar_typ env datacon_ses se in
       datacon_ses, tyc::tycons
     in
-    let leftover_datacons, tycons = List.fold_left retrieve_datacons_and_resugar (datacon_ses, []) decl_typ_ses in
+    let leftover_datacons, tycons = List.fold_left retrieve_datacons_and_resugar (List.rev datacon_ses, []) decl_typ_ses in
     begin match leftover_datacons with
       | [] -> //true
         (* TODO : documentation should be retrieved from the desugaring environment at some point *)

--- a/tests/error-messages/PatImps.fst.json_output.expected
+++ b/tests/error-messages/PatImps.fst.json_output.expected
@@ -19,8 +19,8 @@ let f2 x =
   Prims.int
 noeq
 type t3 =
-  | C : PatImps.t3
   | B : PatImps.t3
+  | C : PatImps.t3
 
 
 
@@ -56,8 +56,8 @@ let f2 x =
   Prims.int
 noeq
 type t3 =
-  | C : PatImps.t3
   | B : PatImps.t3
+  | C : PatImps.t3
 
 
 
@@ -94,8 +94,8 @@ let f2 x =
   Prims.int
 noeq
 type t3 =
-  | C : PatImps.t3
   | B : PatImps.t3
+  | C : PatImps.t3
 
 
 

--- a/tests/error-messages/PatImps.fst.output.expected
+++ b/tests/error-messages/PatImps.fst.output.expected
@@ -19,8 +19,8 @@ let f2 x =
   Prims.int
 noeq
 type t3 =
-  | C : PatImps.t3
   | B : PatImps.t3
+  | C : PatImps.t3
 
 
 
@@ -56,8 +56,8 @@ let f2 x =
   Prims.int
 noeq
 type t3 =
-  | C : PatImps.t3
   | B : PatImps.t3
+  | C : PatImps.t3
 
 
 
@@ -94,8 +94,8 @@ let f2 x =
   Prims.int
 noeq
 type t3 =
-  | C : PatImps.t3
   | B : PatImps.t3
+  | C : PatImps.t3
 
 
 


### PR DESCRIPTION
Need to check if this affects Vale. https://github.com/mtzguido/FStar/actions/runs/14181437139