### PR TITLE
Some fixes for FV qualifiers

### DIFF
--- a/src/fstar/FStarC.Main.fst
+++ b/src/fstar/FStarC.Main.fst
@@ -253,7 +253,7 @@ let go_normal () =
         (* Just "show decls" would print it, we just format this a bit *)
         files |> List.iter (fun (name, decls) ->
           print1 "%s:\n" name;
-          decls |> List.iter (fun d -> print1 "  %s\n" (show d))
+          decls |> List.iter (fun d -> print1 "%s\n\n" (show d))
         )
     )
 

--- a/src/reflection/FStarC.Reflection.V2.Builtins.fst
+++ b/src/reflection/FStarC.Reflection.V2.Builtins.fst
@@ -112,11 +112,15 @@ let pack_fv (ns:list string) : fv =
     let lid = PC.p2l ns in
     let fallback () =
         let quals =
-            (* This an awful hack *)
-            if Ident.lid_equals lid PC.cons_lid then Some Data_ctor else
-            if Ident.lid_equals lid PC.nil_lid  then Some Data_ctor else
-            if Ident.lid_equals lid PC.some_lid then Some Data_ctor else
-            if Ident.lid_equals lid PC.none_lid then Some Data_ctor else
+          let id = Ident.ident_of_lid lid in
+          let c = String.get (Ident.string_of_id id) 0 in
+          (* This an awful hack: if lowercase c <> c then c is uppercase.
+          Also we should not be doing this at all, and just rely on the
+          typechecker to fill these in. But note, we could be splicing-in
+          the definition for this here, so we also cannot just look it up. *)
+          if FStar.Char.lowercase c <> c then
+            Some Data_ctor
+          else
             None
         in
         lid_as_fv (PC.p2l ns) quals

--- a/src/typechecker/FStarC.TypeChecker.TcTerm.fst
+++ b/src/typechecker/FStarC.TypeChecker.TcTerm.fst
@@ -1791,8 +1791,17 @@ and tc_value env (e:term) : term
                  "Universe applications are only allowed on top-level identifiers"
 
   | Tm_fvar fv ->
+    let maybe_set_fv_qual env fv =
+      (* The Data_ctor qualifier is mostly set by desugaring, but
+         may be missing in tactic-generated terms. In general,
+         we should try to not rely on desugaring. *)
+      if None? fv.fv_qual && Env.is_datacon env fv.fv_name.v
+      then { fv with fv_qual = Some Data_ctor }
+      else fv
+    in
     let (us, t), range = Env.lookup_lid env fv.fv_name.v in
     let fv = S.set_range_of_fv fv range in
+    let fv = maybe_set_fv_qual env fv in
     maybe_warn_on_use env fv;
     if !dbg_Range
     then BU.print5 "Lookup up fvar %s at location %s (lid range = defined at %s, used at %s); got universes type %s\n"


### PR DESCRIPTION
The Data_ctor fv qualifier may be missing from some tactic generated terms. This PR makes 1) the implemenation of `pack_fv` set it more eagerly, though still in a hacky way, by checking the case of the name we are packing, and 2) the typechecker set this qualifier when checking a name that is a constructor in the environment.

This reduces the dependency on the desugarer to insert this. Maybe we could fully remove that logic from desugaring.