### PR TITLE
nix: Pin the python version used by z3

### DIFF
--- a/.nix/z3.nix
+++ b/.nix/z3.nix
@@ -1,8 +1,9 @@
-{ pkgs, stdenv, callPackage }:
+{ stdenv, callPackage, z3, python310 }:
 
 let
-  z3_4_8_5 = callPackage (import ./z3_4_8_5.nix) {};
-  z3_4_13_3 = callPackage (import ./z3_4_13_3.nix) {};
+  z3_python310 = z3.override { python = python310; };
+  z3_4_8_5 = callPackage (import ./z3_4_8_5.nix) { z3 = z3_python310; };
+  z3_4_13_3 = callPackage (import ./z3_4_13_3.nix) { z3 = z3_python310; };
 in
 stdenv.mkDerivation {
   pname = "fstar-z3";


### PR DESCRIPTION
This makes fstar build with recent nixpkgs versions.