### PR TITLE
nix: Update nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -19,11 +19,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1693158576,
-        "narHash": "sha256-aRTTXkYvhXosGx535iAFUaoFboUrZSYb1Ooih/auGp0=",
+        "lastModified": 1743588408,
+        "narHash": "sha256-WRZyK13yucGjwNBMOGjU8ljRJ8FYFv8MBru/bXqZUn0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a999c1cc0c9eb2095729d5aa03e0d8f7ed256780",
+        "rev": "88efe689298b1863db0310c0a22b3ebb4d04fbc3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
As I mentioned in https://github.com/FStarLang/FStar/pull/3834, the projects I know about use `fstar/nixpkgs` by default and are needing a more recent nixpkgs version. Updating it here is the simplest solution for me and seems to make sense. I tested the build locally, I'm not sure if you PR CI runs nix.