### PR TITLE
Introduce --stats

### DIFF
--- a/src/basic/FStarC.Find.fst
+++ b/src/basic/FStarC.Find.fst
@@ -128,6 +128,7 @@ let lib_paths () =
   @ fstarc_paths ()
 
 let full_include_path () =
+  // Stats.record "Find.full_include_path" fun () ->
   match !_full_include with
   | Some paths -> paths
   | None ->
@@ -144,6 +145,7 @@ let full_include_path () =
     res
 
 let do_find (paths : list string) (filename : string) : option string =
+  // Stats.record "Find.do_find" fun () ->
   if Filepath.is_path_absolute filename then
     if Filepath.file_exists filename then
       Some filename

--- a/src/basic/FStarC.Options.fsti
+++ b/src/basic/FStarC.Options.fsti
@@ -232,6 +232,7 @@ val smtencoding_l_arith_native  : unit    -> bool
 val smtencoding_valid_intro     : unit    -> bool
 val smtencoding_valid_elim      : unit    -> bool
 val split_queries               : unit    -> split_queries_t
+val stats                       : unit    -> bool
 val tactic_raw_binders          : unit    -> bool
 val tactics_failhard            : unit    -> bool
 val tactics_info                : unit    -> bool

--- a/src/basic/FStarC.Profiling.fst
+++ b/src/basic/FStarC.Profiling.fst
@@ -67,6 +67,7 @@ let create_or_lookup_counter cid =
 
 (* Time an operation, if the the profiler is enabled *)
 let profile  (f: unit -> 'a) (module_name:option string) (cid:string) : 'a =
+  // Stats.record cid fun () ->
   if Options.profile_enabled module_name cid
   then let c = create_or_lookup_counter cid in
        if !c.running //if the counter is already running

--- a/src/basic/FStarC.Stats.fst
+++ b/src/basic/FStarC.Stats.fst
@@ -1,0 +1,142 @@
+(*
+   Copyright 2008-2025 Nikhil Swamy and Microsoft Research
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*)
+module FStarC.Stats
+
+open FStarC.Effect
+open FStarC.Class.Monoid
+
+let enabled = alloc false
+let ever_enabled = alloc false
+
+type stat = {
+  ns_tree  : int;
+  ns_exn   : int;
+  ns_sub   : int;
+  ncalls   : int;
+}
+
+instance _ : monoid stat = {
+  mzero = {
+    ns_tree = 0;
+    ns_exn = 0;
+    ns_sub = 0;
+    ncalls = 0;
+  };
+  mplus = (fun s1 s2 ->
+    {
+      ns_tree  = s1.ns_tree + s2.ns_tree;
+      ns_exn   = s1.ns_exn + s2.ns_exn;
+      ns_sub   = s1.ns_sub + s2.ns_sub;
+      ncalls   = s1.ncalls + s2.ncalls;
+    });
+}
+
+(* the ref bool marks whether a given key is currently
+   being recorded. This is so we avoid double counting
+   the time taken by reentrant calls. *)
+let st : SMap.t (ref bool & stat) = SMap.create 10
+
+(* Current stats we are logging. This is used to distinguish
+   "tree" time (all the time taken by some call)
+   vs "point" time (time taken by some call, subtracting
+   the time in subcalls, if any). *)
+let stack : ref (list string) = mk_ref []
+
+let r_running (k : string) : ref bool =
+  match SMap.try_find st k with
+  | None ->
+    let r = alloc false in
+    SMap.add st k (r, mzero);
+    r
+  | Some (r, _) ->
+    r
+
+let add (k : string) (s1 : stat) : unit =
+  let (r, s0) =
+    match SMap.try_find st k with
+    | None -> (alloc false, mzero)
+    | Some rs -> rs
+  in
+  SMap.add st k (r, mplus s0 s1)
+
+let do_record
+  (key : string)
+  (f : unit -> 'a)
+  : 'a
+=
+  stack := key :: !stack;
+  let running = r_running key in
+  let was_running = !running in
+  running := true;
+  let t0 = Timing.now_ns () in
+  let resexn =
+    try Inr (f ())
+    with | e -> Inl e
+  in
+  running := was_running;
+  let t1 = Timing.now_ns () in
+  let ns = Timing.diff_ns t0 t1 in
+  stack := List.tl !stack;
+  if not was_running then (
+    add key { mzero with ns_tree = ns };
+    (* Take time out of the parent, if any. *)
+    begin match !stack with
+    | [] -> ()
+    | k_par::_ -> add k_par { mzero with ns_sub = ns }
+    end
+  );
+  add key { mzero with ncalls = 1 };
+  match resexn with
+  | Inr r ->
+    r
+  | Inl e ->
+    add key { mzero with ns_exn = ns };
+    raise e
+
+let record key f =
+  if !enabled then
+    do_record key f
+  else
+    f ()
+
+let lpad (len:int) (s:string) : string =
+  let l = String.length s in
+  if l >= len then s else String.make (len - l) ' ' ^ s
+
+let max x y =
+  if x > y then x else y
+
+let print_all () : string =
+  let keys = SMap.keys st in
+  let points = List.map (fun k -> k, snd <| Some?.v <| SMap.try_find st k) keys in
+  (* Sort by (point) time. *)
+  let points =
+    points |>
+    Class.Ord.sort_by (fun (_, s1) (_, s2) ->
+      (s2.ns_tree - s2.ns_sub) `Class.Ord.cmp` (s1.ns_tree - s1.ns_sub))
+  in
+  let longest_key = List.fold_left (fun acc (k, _) -> max acc (String.length k)) 20 points in
+  let pr1 (p : (string & stat)) : string =
+    let k, st = p in
+    Util.format5 "  %s  %s %s ms %s ms %s ms"
+      (lpad longest_key k)
+      (lpad 8 (string_of_int st.ncalls))
+      (lpad 6 (string_of_int (st.ns_tree  / 1000000)))
+      (lpad 6 (string_of_int ((st.ns_tree - st.ns_sub) / 1000000)))
+      (lpad 6 (string_of_int (st.ns_exn   / 1000000)))
+  in
+  Util.format5 "  %s  %s %s %s %s" (lpad longest_key "key") (lpad 8 "calls") (lpad 9 "tree") (lpad 9 "point") (lpad 9 "exn") ^ "\n" ^
+  (points |> List.map pr1 |> String.concat "\n")

--- a/src/basic/FStarC.Stats.fsti
+++ b/src/basic/FStarC.Stats.fsti
@@ -1,0 +1,37 @@
+(*
+   Copyright 2008-2025 Nikhil Swamy and Microsoft Research
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*)
+module FStarC.Stats
+
+open FStarC.Effect
+
+(* We only record stats when this is set to true. This is
+set by the Options module. *)
+val enabled : ref bool
+
+(* This is set to true by the Options module whenever
+--stats true is passed, and never set to false. We use it
+to decide whether to print the stats at the end of
+the run. *)
+val ever_enabled : ref bool
+
+(* Count the time taken by `f ()` under a given stats key. *)
+val record
+  (key : string)
+  (f : unit -> 'a)
+  : 'a
+
+(* Generates a message with a table for all stat keys. *)
+val print_all () : string

--- a/src/class/FStarC.Class.Ord.fst
+++ b/src/class/FStarC.Class.Ord.fst
@@ -24,6 +24,17 @@ let rec sort #a xs =
   | [] -> []
   | x::xs -> insert x (sort xs)
 
+(* An advantage of not having instance canonicity:
+we can just construct a dictionary with this new function
+without to use a newtype (which would involve a traversal
+of the list to convert into!). *)
+let sort_by #a (f : a -> a -> order) xs =
+  let d : ord a = {
+    super = { (=?) = (fun a b -> f a b = Eq) };
+    cmp = f;
+  } in
+  sort #a #d xs
+
 let dedup #a xs =
   let open FStarC.List in
   let out = fold_left (fun out x -> if existsb (fun y -> x =? y) out then out else x :: out) [] xs in

--- a/src/class/FStarC.Class.Ord.fsti
+++ b/src/class/FStarC.Class.Ord.fsti
@@ -15,6 +15,11 @@ val sort
   (xs : list a)
   : list a
 
+val sort_by
+  (#a:Type) (f : a -> a -> order)
+  (xs : list a)
+  : list a
+
 (* Deduplicate elements, preserving order as determined by the leftmost
 occurrence. So dedup [a,b,c,a,f,e,c] = [a,b,c,f,e] *)
 val dedup

--- a/src/fstar/FStarC.CheckedFiles.fst
+++ b/src/fstar/FStarC.CheckedFiles.fst
@@ -114,6 +114,7 @@ let mcache : smap cache_t = SMap.create 50
  *   or the list of dep string, as defined in the checked_file_entry above
  *)
 let hash_dependences (deps:Dep.deps) (fn:string) :either string (list (string & string)) =
+  Stats.record "hash_dependences" fun () ->
   let fn =
     match Find.find_file fn with
     | Some fn -> fn

--- a/src/fstar/FStarC.Main.fst
+++ b/src/fstar/FStarC.Main.fst
@@ -29,6 +29,10 @@ open FStarC.Class.Show
 module E = FStarC.Errors
 module UF = FStarC.Syntax.Unionfind
 
+let print_stats () =
+  if !Stats.ever_enabled then
+    print1_error "Stats:\n%s\n" (Stats.print_all ())
+
 (* These modules only mentioned to put them in the dep graph
 and hence compile and link them in. They do not export anything,
 instead they register primitive steps in the normalizer during
@@ -65,6 +69,7 @@ let report_errors fmods =
   let nerrs = FStarC.Errors.get_err_count() in
   if nerrs > 0 then begin
     finished_message fmods nerrs;
+    print_stats ();
     exit 1
   end
 
@@ -125,6 +130,7 @@ let set_error_trap () =
     Errors.diag Range.dummyRange [
       text "GOT SIGINT! Exiting";
     ];
+    print_stats ();
     exit 1
   in
   set_sigint_handler (sigint_handler_f h')
@@ -422,8 +428,10 @@ let main () =
     then Util.print2_error "TOTAL TIME %s ms: %s\n"
               (FStarC.Util.string_of_int time)
               (String.concat " " (FStarC.Getopt.cmdline()));
+    print_stats();
     exit 0
   with
   | e ->
     handle_error e;
+    print_stats();
     exit 1

--- a/src/fstar/FStarC.Universal.fst
+++ b/src/fstar/FStarC.Universal.fst
@@ -402,6 +402,7 @@ let tc_one_file
     : tc_result
     & option MLSyntax.mlmodule
     & uenv =
+  Stats.record "tc_one_file" fun () ->
   GenSym.reset_gensym();
 
   (*

--- a/src/ml/FStarC_Parser_ParseIt.ml
+++ b/src/ml/FStarC_Parser_ParseIt.ml
@@ -541,6 +541,7 @@ let parse_lang lang fn =
       ParseError (e, msg, r)
 
 let parse (lang_opt:lang_opts) fn =
+  FStarC_Stats.record "parse" @@ fun () ->
   FStarC_Parser_Util.warningHandler := (function
     | e -> Printf.printf "There was some warning (TODO)\n");
   match lang_opt with

--- a/src/parser/FStarC.Parser.Dep.fst
+++ b/src/parser/FStarC.Parser.Dep.fst
@@ -1451,6 +1451,7 @@ let collect (all_cmd_line_files: list file_name)
     : list file_name
     & deps //topologically sorted transitive dependences of all_cmd_line_files
     =
+  Stats.record "Parser.Dep.collect" fun () ->
   let all_cmd_line_files =
     match all_cmd_line_files with
     | [] -> all_files_in_include_paths ()

--- a/src/syntax/FStarC.Syntax.Compress.fst
+++ b/src/syntax/FStarC.Syntax.Compress.fst
@@ -72,6 +72,7 @@ looks like a big identity function.
 makes .checked files more brittle, so we don't do it.
 *)
 let deep_compress (allow_uvars:bool) (allow_names: bool) (tm : term) : term =
+  Stats.record "deep_compress" fun () ->
   Err.with_ctx ("While deep-compressing a term") (fun () ->
     Visit.visit_term_univs true
       (compress1_t allow_uvars allow_names)
@@ -93,6 +94,7 @@ let deep_compress_if_no_uvars (tm : term) : option term =
   )
 
 let deep_compress_se (allow_uvars:bool) (allow_names:bool) (se : sigelt) : sigelt =
+  Stats.record "deep_compress_se" fun () ->
   Err.with_ctx (format1 "While deep-compressing %s" (Syntax.Print.sigelt_to_string_short se)) (fun () ->
     Visit.visit_sigelt true
       (compress1_t allow_uvars allow_names)

--- a/src/tosyntax/FStarC.ToSyntax.ToSyntax.fst
+++ b/src/tosyntax/FStarC.ToSyntax.ToSyntax.fst
@@ -4298,6 +4298,7 @@ and desugar_decl_core env (d_attrs:list S.term) (d:decl) : (env_t & sigelts) =
   )
 
 let desugar_decls env decls =
+  Stats.record "desugar_decls" fun () ->
   let env, sigelts =
     List.fold_left (fun (env, sigelts) d ->
       let env, se = desugar_decl env d in

--- a/src/tosyntax/FStarC.ToSyntax.ToSyntax.fsti
+++ b/src/tosyntax/FStarC.ToSyntax.ToSyntax.fsti
@@ -31,7 +31,9 @@ module S = FStarC.Syntax.Syntax
 type extension_tosyntax_decl_t = env -> FStarC.Dyn.dyn -> lids:list lident -> Range.range -> list sigelt'
 val register_extension_tosyntax (lang_name:string) (cb:extension_tosyntax_decl_t) : unit
 
+(* Only called from tactics *)
 val desugar_term:            env -> term -> S.term
+
 val desugar_machine_integer: env -> repr:string
                            -> (FStarC.Const.signedness & FStarC.Const.width)
                            -> Range.range -> Syntax.term

--- a/src/typechecker/FStarC.TypeChecker.Normalize.fst
+++ b/src/typechecker/FStarC.TypeChecker.Normalize.fst
@@ -2718,6 +2718,7 @@ and norm_residual_comp cfg env (rc:residual_comp) : residual_comp =
 let reflection_env_hook = mk_ref None
 
 let normalize_with_primitive_steps ps s e (t:term) =
+  Stats.record "norm_term" fun () ->
   let is_nbe = is_nbe_request s in
   let maybe_nbe = if is_nbe then " (NBE)" else "" in
   Errors.with_ctx ("While normalizing a term" ^ maybe_nbe) (fun () ->
@@ -2748,6 +2749,7 @@ let normalize s e t =
                       "FStarC.TypeChecker.Normalize.normalize"
 
 let normalize_comp s e c =
+  Stats.record "norm_comp" fun () ->
   Profiling.profile (fun () ->
     let cfg = config s e in
     reflection_env_hook := Some e;

--- a/src/typechecker/FStarC.TypeChecker.Rel.fst
+++ b/src/typechecker/FStarC.TypeChecker.Rel.fst
@@ -1904,6 +1904,7 @@ let run_meta_arg_tac (env:env_t) (ctx_u:ctx_uvar) : term =
     failwith "run_meta_arg_tac must have been called with a uvar that has a meta tac"
 
 let simplify_vc full_norm_allowed env t =
+  Stats.record "simplify_vc" fun () ->
   if !dbg_Simplification then
     BU.print1 "Simplifying guard %s\n" (show t);
   let steps = [Env.Beta;


### PR DESCRIPTION
This adds a --stats option to print out the time spent in several places of the compiler (we should add more). It displays the number of calls to a given "key", the total time taken by the calls, the time taken by the calls *ignoring subcalls*, and the time spent before raising an exception.
Example for the report in #3800:
```
$ ./bin/fstar.exe Bug3800.fst --stats --admit_smt_queries true
Verified module: Bug3800
All verification conditions discharged successfully
Stats:
                   key     calls      tree     point       exn
             norm_term   1471862  28148 ms  28148 ms      0 ms
           tc_one_file         8  40820 ms   8011 ms      0 ms
             norm_comp         4   4658 ms   4658 ms      0 ms
    Parser.Dep.collect         1      4 ms      3 ms      0 ms
                 parse         2      0 ms      0 ms      0 ms
           simplify_vc      1290  21075 ms      0 ms      0 ms
         desugar_decls         1      0 ms      0 ms      0 ms
      hash_dependences         7      0 ms      0 ms      0 ms
      deep_compress_se        15      0 ms      0 ms      0 ms
```
So out of 40 seconds it takes to check the file, 28 are spent in normalizing terms. 21s are spent under `simplify_vc`, but they are completely accounted by measured subcalls (in this case normalization).

There is support for profiling already. I wrote this since I wanted an easy way to see where time is being spent without having to look up the profiling tags. Also, --profile requires a module name, which is not really useful. We could coallesce profiling into these new stats? 

Also, uncommenting this line
```
let profile  (f: unit -> 'a) (module_name:option string) (cid:string) : 'a =
  //Stats.record cid fun () ->
```
will cause all profiling events to be recorded as stats. And that makes the example above look something like:
```
Stats:
                                                          key     calls      tree     point       exn
  FStarC.TypeChecker.Normalize.normalize_with_primitive_steps   1471862  29453 ms  29453 ms      0 ms
                  FStarC.TypeChecker.Normalize.normalize_comp         4   4663 ms   4663 ms      0 ms
                             FStarC.TypeChecker.Tc.encode_sig        15  10016 ms   4149 ms      0 ms
                        FStarC.Universal.tc_source_file.check         1  44139 ms   4092 ms      0 ms
           FStarC.SMTEncoding.EncodeTerm.normalize_refinement   1441772   6146 ms    601 ms      0 ms
                                                    norm_term   1471862  30037 ms    583 ms      0 ms
                       FStarC.TypeChecker.Normalize.normalize   1471862  30603 ms    566 ms      0 ms
                                FStarC.Universal.extend_tcenv         7     19 ms     19 ms      0 ms
                                          FStarC.CheckedFiles         8     18 ms     18 ms      0 ms
                                  FStarC.TypeChecker.Rel.whnf     24326     48 ms      9 ms      0 ms
        FStarC.TypeChecker.Rel.try_solve_deferred_constraints       320     40 ms      5 ms      0 ms
                   FStarC.TypeChecker.Tc.tc_sig_let-tc-phase1         1  17751 ms      4 ms      0 ms
                       FStarC.TypeChecker.Rel.check_subtyping      1096     23 ms      4 ms      0 ms
                                           Parser.Dep.collect         1      3 ms      2 ms      0 ms
                   FStarC.TypeChecker.Tc.tc_sig_let-tc-phase2         1   8520 ms      1 ms      0 ms
                                   FStarC.Parser.Dep.discover         1      1 ms      0 ms      0 ms
                                                        parse         2      0 ms      0 ms      0 ms
                  FStarC.TypeChecker.Rel.normalize_refinement       186      0 ms      0 ms      0 ms
                           FStarC.TypeChecker.Util.generalize         2      0 ms      0 ms      0 ms
                       FStarC.TypeChecker.Tc.process_one_decl        15  36291 ms      0 ms      0 ms
                           FStarC.TypeChecker.Rel.simplify_vc      1290  21534 ms      0 ms      0 ms
                                                desugar_decls         1      0 ms      0 ms      0 ms
                                                  simplify_vc      1290  21534 ms      0 ms      0 ms
        FStarC.TypeChecker.Rel.solve_deferred_to_tactic_goals       318      0 ms      0 ms      0 ms
                               FStarC.TypeChecker.Rel.try_teq        32      0 ms      0 ms      0 ms
                                             hash_dependences         7      0 ms      0 ms      0 ms
                                             deep_compress_se        15      0 ms      0 ms      0 ms
                                                  tc_one_file         8  44178 ms      0 ms      0 ms
                              FStarC.TypeChecker.Rel.sub_comp         2  21530 ms      0 ms      0 ms
                FStarC.SMTEncoding.EncodeTerm.norm_with_steps        76      0 ms      0 ms      0 ms
                                    FStarC.TypeChecker.Rel.sn        66      0 ms      0 ms      0 ms
                        FStarC.Universal.tc_source_file.parse         1      0 ms      0 ms      0 ms
                     FStarC.TypeChecker.Rel.norm_with_steps.8        66      0 ms      0 ms      0 ms
               FStarC.SMTEncoding.Encode.norm_before_encoding        32   3475 ms      0 ms      0 ms
                 FStarC.Parser.Dep.topological_dependences_of         1      0 ms      0 ms      0 ms
                             FStarC.TypeChecker.Tc.tc_sig_let         1  26271 ms      0 ms      0 ms
                                                    norm_comp         4   4663 ms      0 ms      0 ms
```
(see also the 10s in encode_sig!)