### PR TITLE
Fix Nix build

### DIFF
--- a/.nix/fstar.nix
+++ b/.nix/fstar.nix
@@ -44,6 +44,7 @@ buildDunePackage {
   prePatch = ''
     patchShebangs .scripts/*.sh
     patchShebangs ulib/ml/app/ints/mk_int_file.sh
+    sed -i 's/Ast_502/Ast_500/' stage0/dune/fstar-guts/ml/FStarC_Extraction_ML_PrintML.ml src/ml/FStarC_Extraction_ML_PrintML.ml
   '';
 
   src = lib.sourceByRegex ./.. [


### PR DESCRIPTION
The version of ppxlib in nixpkgs is old (0.33), so we need to adjust for it.