### PR TITLE
Introduce `--ext extraction_inline_all`

### DIFF
--- a/src/extraction/FStarC.Extraction.ML.Term.fst
+++ b/src/extraction/FStarC.Extraction.ML.Term.fst
@@ -1939,7 +1939,7 @@ and term_as_mlexpr' (g:uenv) (top:term) : (mlexpr & e_tag & mlty) =
                   | E_ERASABLE, MLTY_Erased -> [Erased]
                   | _ -> []
               in
-              let meta = if has_c_inline then CInline :: meta else meta in
+              let meta = if has_c_inline || Options.Ext.get "extraction_inline_all" <> "" then CInline :: meta else meta in
               f, {mllb_meta = meta; mllb_attrs = []; mllb_name=nm; mllb_tysc=Some polytype; mllb_add_unit=add_unit; mllb_def=e; print_typ=true}
           in
           let lbs = extract_lb_sig g (is_rec, lbs) in


### PR DESCRIPTION
This extension will mark every local definition as CInline for karamel extraction. Karamel will then consider inlining the letbinding, whenever this is sound (e.g. it is a pure value) and desirable (e.g. there is no duplication).

This usually leads to C code that is much more compact. We have been using it in Kuiper and EverParse with good results.

Related karamel PRs:
- https://github.com/FStarLang/karamel/pull/469
- https://github.com/FStarLang/karamel/pull/470

This F* option behaves similarly to the proposed -faggresive-inlining option, but it's performed at the F* level instead of karamel.

fyi @msprotz 