### PR TITLE
PrettifyType: some tweaks

### DIFF
--- a/tests/tactics/Prettify.fst
+++ b/tests/tactics/Prettify.fst
@@ -32,6 +32,8 @@ type named_ty =
     (named "Case1" ((named "x" int & int) & (named "y" int & string)))
     (named "Case2" (named "b" bool))
 
+// bijection record disabled for now
+(*
 %splice[
   named_ty_pretty;
   Case1;
@@ -43,6 +45,7 @@ type named_ty =
 
 let _ = assert (Inl ((1, 2), (3, "a")) >> named_ty_pretty_bij == Case1 1 2 3 "a")
 let _ = assert (Case2 false << named_ty_pretty_bij == Inr false)
+*)
 
 (* This test doesn't work.. apparently the projectors from a spliced
 type can't be called? *)

--- a/ulib/FStar.Tactics.PrettifyType.fst
+++ b/ulib/FStar.Tactics.PrettifyType.fst
@@ -5,8 +5,6 @@ as the body of a splice. We could make this a plugin eventually,
 not doing it now to now complicate the build (and this is pretty
 fast anyway). *)
 
-//#set-options "--print_implicits --print_full_names --print_universes"
-
 open FStar.Tactics.V2.Bare
 open FStar.List.Tot { (@), unsnoc }
 
@@ -483,7 +481,7 @@ let entry (suf nm : string) : Tac decls =
   let ds = ds @ mk_left cfg in
   let ds = ds @ mk_left_right cfg in
   let ds = ds @ mk_right_left cfg in
-  let ds = ds @ mk_bij cfg in
+  // let ds = ds @ mk_bij cfg in
   let post_type (se : sigelt) : Tac sigelt =
     let quals = filter (fun q -> not (Unfold_for_unification_and_vcgen? q)) quals in
     let se = set_sigelt_quals quals se in
@@ -493,6 +491,7 @@ let entry (suf nm : string) : Tac decls =
   let post_other (se : sigelt) : Tac sigelt =
     let quals = filter (fun q -> not (Noeq? q || Unopteq? q)) quals in
     let se = set_sigelt_quals quals se in
+    let attrs = attrs @ [`"KrmlPrivate"] in
     let se = set_sigelt_attrs attrs se in
     se
   in

--- a/ulib/FStar.Tactics.PrettifyType.fsti
+++ b/ulib/FStar.Tactics.PrettifyType.fsti
@@ -11,6 +11,7 @@ them directly. *)
 (* Use this alias to generate field and constructor names.
 Place it around an atom for field name, and around (the outer) tuple2
 of a case to choose a constructor name. *)
+inline_for_extraction
 type named (s:string) (a:Type) = a
 
 let fakeunit = `unit


### PR DESCRIPTION
Most of these tweaks are needed to use this from Everparse, and do not really belong here, but there is (currently) no way to change extraction behavior as a client of this module.