### PR TITLE
Fix sedlex rules

### DIFF
--- a/fstar.opam
+++ b/fstar.opam
@@ -16,7 +16,7 @@ depends: [
   "menhir" {build & >= "20230415"}
   "mtime" {>= "2.1.0"}
   "pprint"
-  "sedlex"
+  "sedlex" {>= "3.5}
   "ppxlib" {>= "0.36.0" }
   "process"
   "ppx_deriving" {build}

--- a/fstar.opam
+++ b/fstar.opam
@@ -16,7 +16,7 @@ depends: [
   "menhir" {build & >= "20230415"}
   "mtime" {>= "2.1.0"}
   "pprint"
-  "sedlex" {>= "3.5}
+  "sedlex" {>= "3.5" }
   "ppxlib" {>= "0.36.0" }
   "process"
   "ppx_deriving" {build}

--- a/src/ml/FStarC_Parser_LexFStar.ml
+++ b/src/ml/FStarC_Parser_LexFStar.ml
@@ -513,7 +513,7 @@ match%sedlex lexbuf with
         | s  -> EXISTS_OP s
       )
 
- | "∃", Plus op_char ->
+ | Utf8 "∃", Plus op_char ->
     ensure_no_comment lexbuf (fun s ->
         match BatString.lchop ~n:1 s with
         | "" -> EXISTS false
@@ -527,7 +527,7 @@ match%sedlex lexbuf with
         | s  -> FORALL_OP s
       )
 
- | "∀", Plus op_char ->
+ | Utf8 "∀", Plus op_char ->
     ensure_no_comment lexbuf (fun s ->
         match BatString.lchop ~n:1 s with
         | "" -> FORALL false

--- a/stage0/dune/fstar-guts/ml/FStarC_Parser_LexFStar.ml
+++ b/stage0/dune/fstar-guts/ml/FStarC_Parser_LexFStar.ml
@@ -513,7 +513,7 @@ match%sedlex lexbuf with
         | s  -> EXISTS_OP s
       )
 
- | "∃", Plus op_char ->
+ | Utf8 "∃", Plus op_char ->
     ensure_no_comment lexbuf (fun s ->
         match BatString.lchop ~n:1 s with
         | "" -> EXISTS false
@@ -527,7 +527,7 @@ match%sedlex lexbuf with
         | s  -> FORALL_OP s
       )
 
- | "∀", Plus op_char ->
+ | Utf8 "∀", Plus op_char ->
     ensure_no_comment lexbuf (fun s ->
         match BatString.lchop ~n:1 s with
         | "" -> FORALL false


### PR DESCRIPTION
Using `∃` or `∀` literals in sedlex patterns was not working as excepted. Sedlex `< 3.5` was expecting source files to be encoded in Latin1 (`∃` would be interpreted as three latin1 chars \226\136\131) .https://github.com/ocaml-community/sedlex/pull/127 adds support for utf8 literals. It's included in sedlex.3.5.

This PR upgrade the sedlex to version 3.5 and fix the two lexing rules for  `∃` or `∀`.

Check https://github.com/ocaml/opam-repository/pull/27959 for sedlex.3.5 release into opam.