### PR TITLE
Allow native extraction of reifiable effects.

### DIFF
--- a/src/typechecker/FStarC.TypeChecker.TcEffect.fst
+++ b/src/typechecker/FStarC.TypeChecker.TcEffect.fst
@@ -1907,39 +1907,33 @@ Errors.with_ctx (BU.format1 "While checking layered effect definition `%s`" (str
       U.has_attribute ed.eff_attrs PC.primitive_extraction_attr in
     let is_reifiable = List.contains Reifiable quals in
 
-    if has_primitive_extraction && is_reifiable
-    then raise_error ed.mname Errors.Fatal_UnexpectedEffect
-                      (BU.format1 "Effect %s is declared to be both primitive extraction and reifiable"
-                        (show ed.mname)) 
-    else begin
-      if has_primitive_extraction
-      then S.Extract_primitive
-      else
-        let us, a_b, rest_bs =
-          let us, t = let us, t, _ = signature in us, t in
-          match (SS.compress t).n with
-          | Tm_arrow {bs} ->
-            let a_b::rest_bs = SS.open_binders bs in
-            us, a_b, rest_bs
-          | _ -> failwith "Impossible!"  // there are multiple places above where we have relied on sig being an arrow
-        in
-        let env = Env.push_univ_vars env0 us in
-        let env = Env.push_binders env [a_b] in
-        let _, r = List.fold_left (fun (env, r) b ->
-          let r = r && N.non_info_norm env b.binder_bv.sort in
-          Env.push_binders env [b], r) (env, true) rest_bs in
-        if r &&
-           Substitutive_combinator? bind_kind &&
-           (is_reifiable || lid_equals ed.mname PC.effect_TAC_lid)
-        then S.Extract_reify
-        else let m =
-               if not r
-               then "one or more effect indices are informative"
-               else if not (Substitutive_combinator? bind_kind)
-               then "bind is not substitutive"
-               else "the effect is not reifiable" in      
-             S.Extract_none m
-    end
+    if has_primitive_extraction
+    then S.Extract_primitive
+    else
+      let us, a_b, rest_bs =
+        let us, t = let us, t, _ = signature in us, t in
+        match (SS.compress t).n with
+        | Tm_arrow {bs} ->
+          let a_b::rest_bs = SS.open_binders bs in
+          us, a_b, rest_bs
+        | _ -> failwith "Impossible!"  // there are multiple places above where we have relied on sig being an arrow
+      in
+      let env = Env.push_univ_vars env0 us in
+      let env = Env.push_binders env [a_b] in
+      let _, r = List.fold_left (fun (env, r) b ->
+        let r = r && N.non_info_norm env b.binder_bv.sort in
+        Env.push_binders env [b], r) (env, true) rest_bs in
+      if r &&
+         Substitutive_combinator? bind_kind &&
+         (is_reifiable || lid_equals ed.mname PC.effect_TAC_lid)
+      then S.Extract_reify
+      else let m =
+             if not r
+             then "one or more effect indices are informative"
+             else if not (Substitutive_combinator? bind_kind)
+             then "bind is not substitutive"
+             else "the effect is not reifiable" in
+           S.Extract_none m
   in
 
   if !dbg_LayeredEffectsTc

--- a/tests/extraction/ReifNativ.fst
+++ b/tests/extraction/ReifNativ.fst
@@ -1,0 +1,46 @@
+module ReifNativ
+
+#set-options "--warn_error -272" // top-level effect
+
+let repr (a:Type) : Type0 = int -> Dv a
+
+let return (a:Type) (x:a) : Tot (repr a) =
+  fun _ -> x
+
+let bind a b (x:repr a) (f:a -> Tot (repr b)) : Tot (repr b) =
+  fun _ ->
+    let v = x 0 in
+    f v 0
+
+[@@ top_level_effect; primitive_extraction]
+total
+reifiable
+effect {
+  EE (a:Type)
+  with { repr; return; bind; }
+}
+
+let lift (a:Type) (w : pure_wp a) (f : unit -> PURE a w) : repr a =
+  fun _ -> admit(); f ()
+
+sub_effect PURE ~> EE = lift
+
+let test () : EE bool =
+  true
+
+let test2 () : EE bool =
+  let b1 = test () in
+  let b2 = test () in
+  b1 && b2
+
+let top : int =
+  if test2 () then
+    1
+  else
+    0
+
+(* Reifying is ghost *)
+[@@expect_failure [34]]
+let top2 () : Tot (repr bool) = reify (test2 ())
+
+let top3 () : GTot (repr bool) = reify (test2 ())

--- a/tests/extraction/ReifNativ.ml.expected
+++ b/tests/extraction/ReifNativ.ml.expected
@@ -1,0 +1,14 @@
+open Prims
+type 'a repr = Prims.int -> 'a
+let return : 'a . 'a -> 'a repr = fun x -> fun uu___ -> x
+let bind : 'a 'b . 'a repr -> ('a -> 'b repr) -> 'b repr =
+  fun x ->
+    fun f -> fun uu___ -> let v = x Prims.int_zero in f v Prims.int_zero
+let __proj__EE__item__return = return
+let __proj__EE__item__bind = bind
+let lift : 'a 'w . (unit -> 'a) -> 'a repr = fun f -> fun uu___ -> f ()
+let (test : unit -> Prims.bool) = fun uu___ -> true
+let (test2 : unit -> Prims.bool) =
+  fun uu___ -> let b1 = test () in let b2 = test () in b1 && b2
+let (top : Prims.int) =
+  let uu___ = test2 () in if uu___ then Prims.int_one else Prims.int_zero


### PR DESCRIPTION
Currently, we disallow marking any `reifiable` effect as `@@primitive_extraction`. This PR allows the combination, enabling users to define an effect with a reifiable representation (useful for modeling and proving) but extract natively. This PR also makes reifying a term in this effect now incur a ghost effect, to prevent the user from mixing the two representations. Something similar should be done for reflect, perhaps, but there is not a way to mark the result as ghost.

The main use case here is defining custom extraction rules for actions in the effect, that are implemented natively in OCaml. For instance, the state could be a representation of the OCaml heap and references with some invariants on them, and the extraction rules would simply extract them to the native ones.

https://github.com/mtzguido/FStar/actions/runs/15547790719