### PR TITLE
Allow using `..` to match any number of constructor arguments

### DIFF
--- a/src/ml/FStarC_Parser_LexFStar.ml
+++ b/src/ml/FStarC_Parser_LexFStar.ml
@@ -597,6 +597,8 @@ match%sedlex lexbuf with
  | "<|" -> PIPE_LEFT
  | "|>" -> PIPE_RIGHT
 
+ | ".." -> DOT_DOT
+
  | op_token_1
  | op_token_2
  | op_token_3

--- a/src/ml/FStarC_Parser_Parse.mly
+++ b/src/ml/FStarC_Parser_Parse.mly
@@ -122,7 +122,7 @@ let parse_use_lang_blob (extension_name:string)
 %token INCLUDE
 %token WHEN AS RETURNS RETURNS_EQ WITH HASH AMP LPAREN RPAREN LPAREN_RPAREN COMMA LONG_LEFT_ARROW LARROW RARROW
 %token IFF IMPLIES CONJUNCTION DISJUNCTION
-%token DOT COLON COLON_COLON SEMICOLON
+%token DOT COLON DOT_DOT COLON_COLON SEMICOLON
 %token QMARK_DOT
 %token QMARK
 %token EQUALS PERCENT_LBRACK LBRACK_AT LBRACK_AT_AT LBRACK_AT_AT_AT DOT_LBRACK
@@ -702,6 +702,10 @@ constructorPattern:
       { pat }
 
 atomicPattern:
+  | DOT_DOT
+      {
+        mk_pattern PatRest (rr $loc)
+      }
   | LPAREN pat=tuplePattern COLON t=simpleArrow phi_opt=refineOpt RPAREN
       {
         let pos_t = rr2 $loc(pat) $loc(t) in

--- a/src/ml/FStarC_Parser_ParseIt.ml
+++ b/src/ml/FStarC_Parser_ParseIt.ml
@@ -470,6 +470,7 @@ let string_of_token =
   | BLOB _ -> "BLOB _"
   | USE_LANG_BLOB _ -> "USE_LANG_BLOB _"
   | EOF -> "EOF"
+  | DOT_DOT -> "DOT_DOT"
   | _ -> "(unknown token)"
 
 let parse_fstar_incrementally

--- a/src/parser/FStarC.Parser.AST.Diff.fst
+++ b/src/parser/FStarC.Parser.AST.Diff.fst
@@ -135,6 +135,8 @@ and eq_pattern' (p1 p2:pattern')
       eq_ident i1 i2
     | PatVQuote t1, PatVQuote t2 ->
       eq_term t1 t2
+    | PatRest, PatRest ->
+      true
     | _ -> false
 
 and eq_term' (t1 t2:term')

--- a/src/parser/FStarC.Parser.AST.Util.fst
+++ b/src/parser/FStarC.Parser.AST.Util.fst
@@ -109,6 +109,7 @@ and lidents_of_pattern p =
   | PatOr ps -> concat_map lidents_of_pattern ps
   | PatOp _ -> []
   | PatVQuote t -> lidents_of_term t
+  | PatRest -> []
 and lidents_of_binder b =
   match b.b with
   | Annotated (_, t)

--- a/src/parser/FStarC.Parser.AST.fst
+++ b/src/parser/FStarC.Parser.AST.fst
@@ -740,6 +740,7 @@ and pat_to_string x = match x.pat with
   | PatOp op ->  Util.format1 "(%s)" (Ident.string_of_id op)
   | PatAscribed(p,(t, None)) -> Util.format2 "(%s:%s)" (p |> pat_to_string) (t |> term_to_string)
   | PatAscribed(p,(t, Some tac)) -> Util.format3 "(%s:%s by %s)" (p |> pat_to_string) (t |> term_to_string) (tac |> term_to_string)
+  | PatRest -> ".."
 
 and attrs_opt_to_string = function
   | None -> ""

--- a/src/parser/FStarC.Parser.AST.fsti
+++ b/src/parser/FStarC.Parser.AST.fsti
@@ -137,6 +137,7 @@ and pattern' =
   | PatName     of lid
   | PatTvar     of ident & aqual & attributes_
   | PatList     of list pattern
+  | PatRest     (* For '..', which matches all extra args *)
   | PatTuple    of list pattern & bool (* dependent if flag is set *)
   | PatRecord   of list (lid & pattern)
   | PatAscribed of pattern & (term & option term)
@@ -383,4 +384,4 @@ instance val showable_term : showable term
 val as_interface (m:modul) : modul
 
 val inline_let_attribute : term
-val inline_let_vc_attribute : term 
+val inline_let_vc_attribute : term

--- a/src/parser/FStarC.Parser.Dep.fst
+++ b/src/parser/FStarC.Parser.Dep.fst
@@ -1178,6 +1178,7 @@ let collect_one
             collect_aqual aqual;
             attrs |> List.iter collect_term
 
+        | PatRest
         | PatOp _
         | PatConst _ ->
             ()

--- a/src/parser/FStarC.Parser.ToDocument.fst
+++ b/src/parser/FStarC.Parser.ToDocument.fst
@@ -1110,6 +1110,8 @@ and p_constructorPattern p = match p.pat with
       p_atomicPattern p
 
 and p_atomicPattern p = match p.pat with
+  | PatRest ->
+    str ".."
   | PatAscribed (pat, (t, None)) ->
     (* This inverts the first rule of atomicPattern (LPAREN tuplePattern COLON
      * simpleArrow RPAREN). *)

--- a/src/syntax/FStarC.Syntax.DsEnv.fst
+++ b/src/syntax/FStarC.Syntax.DsEnv.fst
@@ -858,16 +858,16 @@ let try_lookup_lid_with_attributes_no_resolve (env: env) l :option (term & list 
 let try_lookup_lid_no_resolve (env: env) l :option term = try_lookup_lid_with_attributes_no_resolve env l |> drop_attributes
 
 let try_lookup_datacon env (lid:lident) =
-  let k_global_def lid se =
+  let k_global_def lid (se, _) =
       match se with
-      | ({ sigel = Sig_declare_typ _; sigquals = quals }, _) ->
+      | { sigel = Sig_declare_typ _; sigquals = quals } ->
         if quals |> BU.for_some (function Assumption -> true | _ -> false)
-        then Some (lid_and_dd_as_fv lid None)
+        then Some (lid_and_dd_as_fv lid None, se)
         else None
-      | ({ sigel = Sig_splice _ }, _) (* A spliced datacon *)
-      | ({ sigel = Sig_datacon _ }, _) ->
-         let qual = fv_qual_of_se (fst se) in
-         Some (lid_and_dd_as_fv lid qual)
+      | { sigel = Sig_splice _ } (* A spliced datacon *)
+      | { sigel = Sig_datacon _ } ->
+         let qual = fv_qual_of_se se in
+         Some (lid_and_dd_as_fv lid qual, se)
       | _ -> None in
   resolve_in_open_namespaces' env lid (fun _ -> None) (fun _ -> None) k_global_def
 

--- a/src/syntax/FStarC.Syntax.DsEnv.fsti
+++ b/src/syntax/FStarC.Syntax.DsEnv.fsti
@@ -93,7 +93,7 @@ val try_lookup_effect_defn: env -> lident -> option eff_decl
 once indexed effects are in, also track how indices and other
 arguments are instantiated. *)
 val try_lookup_root_effect_name: env -> lident -> option lident
-val try_lookup_datacon: env -> lident -> option fv
+val try_lookup_datacon: env -> lident -> option (fv & sigelt)
 val try_lookup_record_by_field_name: env -> lident -> option record_or_dc
 val try_lookup_record_type: env -> lident -> option record_or_dc
 val belongs_to_record: env -> lident -> record_or_dc -> bool

--- a/src/syntax/FStarC.Syntax.Syntax.fst
+++ b/src/syntax/FStarC.Syntax.Syntax.fst
@@ -627,6 +627,15 @@ instance hasRange_ctx_uvar : hasRange ctx_uvar = {
   setPos = (fun r u -> { u with ctx_uvar_range = r });
 }
 
+let sli (l:lident) : string =
+    if Options.print_real_names()
+    then string_of_lid l
+    else string_of_id (ident_of_lid l)
+
+instance showable_fv : showable fv = {
+  show = (fun fv -> sli fv.fv_name.v);
+}
+
 instance showable_lazy_kind = {
   show = (function
           | BadLazy -> "BadLazy"
@@ -657,6 +666,24 @@ instance showable_lazy_kind = {
 instance showable_restriction: showable restriction = {
   show = (function | Unrestricted -> "Unrestricted"
                    | AllowList l  -> "AllowList " ^ show l);
+}
+
+instance showable_unresolved_constructor : showable unresolved_constructor = {
+  show = (fun uc ->
+           "{ uc_base_term = " ^ show uc.uc_base_term ^
+           "; uc_typename = " ^ show uc.uc_typename ^
+           "; uc_fields = " ^ show uc.uc_fields ^ " }"
+  );
+}
+
+instance showable_fv_qual : showable fv_qual = {
+  show = (function
+          | Data_ctor -> "Data_ctor"
+          | Record_projector p -> "Record_projector (" ^ show p ^ ")"
+          | Record_ctor      p -> "Record_ctor (" ^ show p ^ ")"
+          | Unresolved_projector p -> "Unresolved_projector (" ^ show p^ ")"
+          | Unresolved_constructor p -> "Unresolved_constructor (" ^ show p ^ ")"
+  );
 }
 
 instance deq_lazy_kind : deq lazy_kind = {

--- a/src/syntax/FStarC.Syntax.Syntax.fsti
+++ b/src/syntax/FStarC.Syntax.Syntax.fsti
@@ -940,6 +940,7 @@ instance val hasRange_bv     : hasRange bv
 instance val hasRange_binder : hasRange binder
 instance val hasRange_ctx_uvar : hasRange ctx_uvar
 
+instance val showable_fv : showable fv
 instance val showable_emb_typ : showable emb_typ
 instance val showable_delta_depth : showable delta_depth
 instance val showable_should_check_uvar : showable should_check_uvar
@@ -947,6 +948,8 @@ instance val showable_should_check_uvar : showable should_check_uvar
 instance val showable_lazy_kind : showable lazy_kind
 
 instance val showable_restriction: showable restriction
+instance val showable_unresolved_constructor : showable unresolved_constructor
+instance val showable_fv_qual : showable fv_qual
 
 instance val deq_lazy_kind   : deq lazy_kind
 instance val deq_bv          : deq bv

--- a/src/syntax/print/FStarC.Syntax.Print.fsti
+++ b/src/syntax/print/FStarC.Syntax.Print.fsti
@@ -28,7 +28,6 @@ instance val showable_univ      : showable universe
 instance val showable_comp      : showable comp
 instance val showable_sigelt    : showable sigelt
 instance val showable_bv        : showable bv
-instance val showable_fv        : showable fv
 instance val showable_binder    : showable binder
 instance val showable_uvar      : showable uvar
 instance val showable_ctxu      : showable ctx_uvar

--- a/tests/micro-benchmarks/MatchRest.fst
+++ b/tests/micro-benchmarks/MatchRest.fst
@@ -1,0 +1,25 @@
+module MatchRest
+
+type t (z : int) : bool -> Type =
+  | A : int -> int -> t z true
+  | B : int -> t z false
+  | C : #_:int -> int -> t z true
+  | D : #_:int -> #_:int -> t z false
+
+let tag (#b:bool) : t 123 b -> int =
+  function
+  | A .. -> 1
+  | B .. -> 2
+  | C .. -> 3
+  | D .. -> 4
+
+[@@expect_failure [203]]
+let bad (#b:bool) : t 123 b -> int =
+  function
+  | .. -> 1
+
+let deep (x : option (option int)) : int =
+  match x with
+  | Some (Some ..) -> 2
+  | Some None -> 1
+  | None -> 0

--- a/tests/micro-benchmarks/MatchRest.fst.output.expected
+++ b/tests/micro-benchmarks/MatchRest.fst.output.expected
@@ -1,0 +1,6 @@
+>> Got issues: [
+* Error 203 at MatchRest.fst(19,4-19,6):
+  - Unexpected pattern.
+  - Using `..` is only allowed as argument to a data constructor, e.g. `C ..`.
+
+>>]


### PR DESCRIPTION
See example:
```fstar
type t (z : int) : bool -> Type =
  | A : int -> int -> t z true
  | B : int -> t z false
  | C : #_:int -> int -> t z true
  | D : #_:int -> #_:int -> t z false

let tag (#b:bool) : t 123 b -> int =
  function
  | A .. -> 1
  | B .. -> 2
  | C .. -> 3
  | D .. -> 4
```