### PR TITLE
chore: update nixpkgs, revert sedlex override

### DIFF
--- a/.nix/z3.nix
+++ b/.nix/z3.nix
@@ -2,7 +2,7 @@
 
 let
   z3_python310 = z3.override { python = python310; };
-  z3_4_8_5 = callPackage (import ./z3_4_8_5.nix) { z3 = z3_python310; };
+  z3_4_8_5 = callPackage (import ./z3_4_8_5.nix) { };
   z3_4_13_3 = callPackage (import ./z3_4_13_3.nix) { z3 = z3_python310; };
 in
 stdenv.mkDerivation {

--- a/.nix/z3_4_8_5.nix
+++ b/.nix/z3_4_8_5.nix
@@ -1,11 +1,36 @@
-{ fetchFromGitHub, z3 }:
+ { stdenv, lib
+, fetchzip
+, autoPatchelfHook
+}:
 
-z3.overrideAttrs (old: rec {
+stdenv.mkDerivation rec {
+  pname = "z3";
   version = "4.8.5";
-  src = fetchFromGitHub {
-    owner = "z3prover";
-    repo = "z3";
-    rev = "Z3-${version}";
-    sha256 = "ytG5O9HczbIVJAiIGZfUXC/MuYH7d7yLApaeTRlKXoc=";
+
+  src = fetchzip {
+    url = "https://github.com/Z3Prover/z3/releases/download/Z3-${version}/z3-${version}-x64-ubuntu-16.04.zip";
+    hash = "sha256-dgG4L77Y3+g10tO2pygmJ+XeGOhJrzuDxIzuZyJvMf0=";
   };
-})
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+  ];
+
+  buildInputs = [
+    stdenv.cc.cc.lib
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out
+    cp -r bin $out
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "High-performance theorem prover and SMT solver";
+    mainProgram = "z3";
+    homepage = "https://github.com/Z3Prover/z3";
+    platforms = platforms.linux;
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -19,11 +19,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1743588408,
-        "narHash": "sha256-WRZyK13yucGjwNBMOGjU8ljRJ8FYFv8MBru/bXqZUn0=",
+        "lastModified": 1751011381,
+        "narHash": "sha256-krGXKxvkBhnrSC/kGBmg5MyupUUT5R6IBCLEzx9jhMM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "88efe689298b1863db0310c0a22b3ebb4d04fbc3",
+        "rev": "30e2e2857ba47844aa71991daa6ed1fc678bcbb7",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -13,20 +13,11 @@
           inherit system;
         };
         ocamlPackages = pkgs.ocaml-ng.ocamlPackages_4_14;
-        # We need sedlex >= 3.5 for utf8 support.
-        sedlex = ocamlPackages.sedlex.overrideDerivation (_: {
-          src = pkgs.fetchFromGitHub {
-            owner = "ocaml-community";
-            repo = "sedlex";
-            rev = "v3.5";
-            sha256 = "sha256-TtxrlJtoKn7i2w8OVD3YDJ96MsmsFs4MA1CuNKpqSuU=";
-          };
-        });
 
         z3 = pkgs.callPackage (import ./.nix/z3.nix) { };
         version = self.rev or "dirty";
         fstar = ocamlPackages.callPackage ./.nix/fstar.nix {
-          inherit version z3 sedlex;
+          inherit version z3;
         };
 
         emacs = pkgs.writeScriptBin "emacs-fstar" ''


### PR DESCRIPTION
Now that nixpkgs' sedlex version is up-to-date, we can remove the override (see #3864). One problem though: Z3 4.8.5 doesn't build with the most recent version of nixpkgs, at least we cannot simply keep the derivation of z3 of nixpkgs and only change the source to Z3 4.8.5. Therefore, I changed the derivation of Z3 4.8.5 to use the binary release of Z3, this should be future-proof enough to let various projects that depend on it to update.