### PR TITLE
Core: fixup use ranges after cache hit

### DIFF
--- a/src/tactics/FStarC.Tactics.V2.Basic.fst
+++ b/src/tactics/FStarC.Tactics.V2.Basic.fst
@@ -2521,8 +2521,7 @@ let refl_core_check_term (g:env) (e:term) (t:typ) (eff:Core.tot_or_ghost)
          let g = Env.set_range g e.pos in
          dbg_refl g (fun _ ->
            BU.format3 "refl_core_check_term: term: %s, type: %s, eff: %s\n"
-             (show e) (show t)
-             (tot_or_ghost_to_string eff));
+             (show e) (show t) (show eff));
          let must_tot = to_must_tot eff in
          match Core.check_term g e t must_tot with
          | Inl None ->

--- a/src/typechecker/FStarC.TypeChecker.Core.fst
+++ b/src/typechecker/FStarC.TypeChecker.Core.fst
@@ -733,6 +733,12 @@ let debug g f =
   if !dbg
   then f ()
 
+instance showable_tot_or_ghost = {
+    show = (function
+            | E_Total -> "E_Total"
+            | E_Ghost -> "E_Ghost");
+}
+
 instance showable_side = {
     show = (function
             | Left -> "Left"
@@ -1934,7 +1940,7 @@ let check_term_top_gh g e topt (must_tot:bool) (gh:option guard_handler_t)
         if !dbg || !dbg_Top || !dbg_Exit
         then begin
           BU.print3 "(%s) Exiting core: Simplified guard from {{%s}} to {{%s}}\n"
-            (BU.string_of_int (get_goal_ctr()))
+            (show (get_goal_ctr()))
             (show guard0)
             (show guard);
           let guard_names = Syntax.Free.names guard |> elems in

--- a/src/typechecker/FStarC.TypeChecker.Core.fsti
+++ b/src/typechecker/FStarC.TypeChecker.Core.fsti
@@ -9,6 +9,8 @@ type tot_or_ghost =
   | E_Total
   | E_Ghost
 
+instance val showable_tot_or_ghost : Class.Show.showable tot_or_ghost
+
 val clear_memo_table (_:unit)
   : unit
 


### PR DESCRIPTION
(I'm not too happy with this patch, but not sure what a better solution would be. Maybe @nikswamy has an opinion?)

When we cache the type of a term, we are also caching all the internal
ranges of this type. The def ranges should be fine, they are meant to be
the original location where terms are defined, but the use ranges can
vary.

For example, we have
```
val foo : x:int{ref x} -> int

let x = foo 1 + foo 2
```
We may cache the type of the first `foo` to be `x:int{ref x} -> Type`.
Here, the `ref` inside the refinement has use range equal to the
position of the first foo. When we reuse this cached type for the second
ocurrence, the range will be wrong.

This doesn't quite happen in F* source code as we are not using the
core checker, which is the one that is cached. It does happen in Pulse,
though, which uses reflection typing pritimives that make use of the
core checker.

The patch here simply overrides the use ranges of the cached type for
the use range of the term being checked. This at least guarantees that
the ranges are not pointing to random places

Fixes https://github.com/FStarLang/pulse/issues/416