### PR TITLE
Syntax: allow writing TC constraints as groups

### DIFF
--- a/src/ml/FStarC_Parser_Parse.mly
+++ b/src/ml/FStarC_Parser_Parse.mly
@@ -759,20 +759,14 @@ fieldPattern:
   (* we do *NOT* allow _ in multibinder () since it creates reduce/reduce conflicts when*)
   (* preprocessing to ocamlyacc/fsyacc (which is expected since the macro are expanded) *)
 patternOrMultibinder:
-  | LBRACE_BAR id=lidentOrUnderscore COLON t=simpleArrow BAR_RBRACE
+  | LBRACE_BAR id=ioption(id=lidentOrUnderscore COLON {id}) t=simpleArrow BAR_RBRACE
       { let r = rr $loc in
+        let id = match id with | Some id -> id | None -> gen r in
         let w = mk_pattern (PatVar (id, Some TypeClassArg, [])) r in
         let asc = (t, None) in
         [mk_pattern (PatAscribed(w, asc)) r]
       }
 
-  | LBRACE_BAR t=simpleArrow BAR_RBRACE
-      { let r = rr $loc in
-        let id = gen r in
-        let w = mk_pattern (PatVar (id, Some TypeClassArg, [])) r in
-        let asc = (t, None) in
-        [mk_pattern (PatAscribed(w, asc)) r]
-      }
   | pat=atomicPattern { [pat] }
   | LPAREN qual_id0=aqualifiedWithAttrs(lident) qual_ids=nonempty_list(aqualifiedWithAttrs(lident)) COLON t=simpleArrow r=refineOpt RPAREN
       {
@@ -794,14 +788,9 @@ binder:
 
 %public
 multiBinder:
-  | LBRACE_BAR id=lidentOrUnderscore COLON t=simpleArrow BAR_RBRACE
+  | LBRACE_BAR id=ioption(id=lidentOrUnderscore COLON {id}) t=simpleArrow BAR_RBRACE
       { let r = rr $loc in
-        [mk_binder (Annotated (id, t)) r Type_level (Some TypeClassArg)]
-      }
-
-  | LBRACE_BAR t=simpleArrow BAR_RBRACE
-      { let r = rr $loc in
-        let id = gen r in
+        let id = match id with | Some id -> id | None -> gen r in
         [mk_binder (Annotated (id, t)) r Type_level (Some TypeClassArg)]
       }
 

--- a/tests/micro-benchmarks/TcSyntax.fst
+++ b/tests/micro-benchmarks/TcSyntax.fst
@@ -1,0 +1,27 @@
+module TcSyntax
+
+open FStar.Class.Eq
+
+let foo1
+  (#a #b : Type)
+  {| deq a |} {| deq b |}
+  (a1 a2 : a)
+  (b1 b2 : b)
+  : Tot bool
+  = a1 = a2 && b1 = b2
+
+let foo2
+  (#a #b : Type)
+  {| deq a, deq b |}
+  (a1 a2 : a)
+  (b1 b2 : b)
+  : Tot bool
+  = a1 = a2 && b1 = b2
+
+let foo3
+  (#a #b : Type)
+  {| deq a, deq b, |}
+  (a1 a2 : a)
+  (b1 b2 : b)
+  : Tot bool
+  = a1 = a2 && b1 = b2


### PR DESCRIPTION

See test case, this allows writing `{| deq a, deq b |}` which desugars
to two typeclass arguments.

I'll post a follow-up PR to allow syntax like `(#a #b : Type | eq)` to more easily constrain arguments.