### PR TITLE
Parser: simplify, remove always-false boolean

### DIFF
--- a/src/ml/FStarC_Parser_LexFStar.ml
+++ b/src/ml/FStarC_Parser_LexFStar.ml
@@ -474,7 +474,7 @@ match%sedlex lexbuf with
  | "#restart-solver" -> PRAGMA_RESTART_SOLVER
  | "#print-effects-graph" -> PRAGMA_PRINT_EFFECTS_GRAPH
  | "__SOURCE_FILE__" -> STRING (Filepath.basename (L.source_file lexbuf))
- | "__LINE__" -> INT (string_of_int (L.current_line lexbuf), false)
+ | "__LINE__" -> INT (string_of_int (L.current_line lexbuf))
  | "__FILELINE__"   -> STRING (Filepath.basename (L.source_file lexbuf) ^ "(" ^ (string_of_int (L.current_line lexbuf)) ^ ")")
 
  | Plus anywhite -> token lexbuf
@@ -559,19 +559,19 @@ match%sedlex lexbuf with
    Hashtbl.find_option constructors id |> Option.default (NAME id)
 
  | tvar -> TVAR (L.lexeme lexbuf)
- | (integer | xinteger) -> INT (clean_number (L.lexeme lexbuf), false)
+ | (integer | xinteger) -> INT (clean_number (L.lexeme lexbuf))
  | (uint8 | char8) ->
    let c = clean_number (L.lexeme lexbuf) in
    let cv = int_of_string c in
    if cv < 0 || cv > 255 then fail lexbuf (Codes.Fatal_SyntaxError, "Out-of-range character literal")
    else UINT8 (c)
- | int8 -> INT8 (clean_number (L.lexeme lexbuf), false)
+ | int8 -> INT8 (clean_number (L.lexeme lexbuf))
  | uint16 -> UINT16 (clean_number (L.lexeme lexbuf))
- | int16 -> INT16 (clean_number (L.lexeme lexbuf), false)
+ | int16 -> INT16 (clean_number (L.lexeme lexbuf))
  | uint32 -> UINT32 (clean_number (L.lexeme lexbuf))
- | int32 -> INT32 (clean_number (L.lexeme lexbuf), false)
+ | int32 -> INT32 (clean_number (L.lexeme lexbuf))
  | uint64 -> UINT64 (clean_number (L.lexeme lexbuf))
- | int64 -> INT64 (clean_number (L.lexeme lexbuf), false)
+ | int64 -> INT64 (clean_number (L.lexeme lexbuf))
  | sizet -> SIZET (clean_number (L.lexeme lexbuf))
  | range -> RANGE (L.lexeme lexbuf)
  | real -> REAL(trim_right lexbuf 1)

--- a/src/ml/FStarC_Parser_Parse.mly
+++ b/src/ml/FStarC_Parser_Parse.mly
@@ -79,20 +79,21 @@ type tc_constraint = {
 %token <string> TVAR
 %token <string> TILDE
 
-/* bool indicates if INT8 was 'bad' max_int+1, e.g. '128'  */
-%token <string * bool> INT8
-%token <string * bool> INT16
-%token <string * bool> INT32
-%token <string * bool> INT64
-%token <string * bool> INT
-%token <string> RANGE
-
+%token <string> INT
+%token <string> INT8
 %token <string> UINT8
+%token <string> INT16
 %token <string> UINT16
+%token <string> INT32
 %token <string> UINT32
+%token <string> INT64
 %token <string> UINT64
 %token <string> SIZET
+
 %token <string> REAL
+
+%token <string> RANGE
+
 %token <FStar_Char.char> CHAR
 %token <bool> LET
 %token <string> LET_OP
@@ -1583,9 +1584,7 @@ constant:
   | LPAREN_RPAREN { Const_unit }
   | n=INT
      {
-        if snd n then
-          log_issue_text (rr $loc) Error_OutOfRange "This number is outside the allowable range for representable integer constants";
-        Const_int (fst n, None)
+        Const_int (n, None)
      }
   | c=CHAR { Const_char c }
   | s=STRING { Const_string (s, rr $loc) }
@@ -1595,30 +1594,22 @@ constant:
   | n=UINT8 { Const_int (n, Some (Unsigned, Int8)) }
   | n=INT8
       {
-        if snd n then
-          log_issue_text (rr $loc) Error_OutOfRange "This number is outside the allowable range for 8-bit signed integers";
-        Const_int (fst n, Some (Signed, Int8))
+        Const_int (n, Some (Signed, Int8))
       }
   | n=UINT16 { Const_int (n, Some (Unsigned, Int16)) }
   | n=INT16
       {
-        if snd n then
-          log_issue_text (rr $loc) Error_OutOfRange "This number is outside the allowable range for 16-bit signed integers";
-        Const_int (fst n, Some (Signed, Int16))
+        Const_int (n, Some (Signed, Int16))
       }
   | n=UINT32 { Const_int (n, Some (Unsigned, Int32)) }
   | n=INT32
       {
-        if snd n then
-          log_issue_text (rr $loc) Error_OutOfRange "This number is outside the allowable range for 32-bit signed integers";
-        Const_int (fst n, Some (Signed, Int32))
+        Const_int (n, Some (Signed, Int32))
       }
   | n=UINT64 { Const_int (n, Some (Unsigned, Int64)) }
   | n=INT64
       {
-        if snd n then
-          log_issue_text (rr $loc) Error_OutOfRange "This number is outside the allowable range for 64-bit signed integers";
-        Const_int (fst n, Some (Signed, Int64))
+        Const_int (n, Some (Signed, Int64))
       }
   | n=SIZET { Const_int (n, Some (Unsigned, Sizet)) }
   (* TODO : What about reflect ? There is also a constant representing it *)
@@ -1654,9 +1645,7 @@ atomicUniverse:
       { mk_term Wild (rr $loc) Expr }
   | n=INT
       {
-        if snd n then
-          log_issue_text (rr $loc) Error_OutOfRange ("This number is outside the allowable range for representable integer constants");
-        mk_term (Const (Const_int (fst n, None))) (rr $loc(n)) Expr
+        mk_term (Const (Const_int (n, None))) (rr $loc(n)) Expr
       }
   | u=lident { mk_term (Uvar u) (range_of_id u) Expr }
   | LPAREN u=universeFrom RPAREN
@@ -1681,7 +1670,7 @@ flag:
 
 range:
   | i=INT
-    { format2 "%s..%s" (fst i) (fst i) }
+    { format2 "%s..%s" i i }
   | r=RANGE
     { r }
 

--- a/src/ml/FStarC_Parser_ParseIt.ml
+++ b/src/ml/FStarC_Parser_ParseIt.ml
@@ -298,19 +298,19 @@ let string_of_token =
   | NAME s -> "NAME " ^ s
   | TVAR s -> "TVAR " ^ s
   | TILDE s -> "TILDE " ^ s
-  | INT8 (s, b) -> "INT8 (" ^ s ^ ", " ^ string_of_bool b ^ ")"
-  | INT16 (s, b) -> "INT16 (" ^ s ^ ", " ^ string_of_bool b ^ ")"
-  | INT32 (s, b) -> "INT32 (" ^ s ^ ", " ^ string_of_bool b ^ ")"
-  | INT64 (s, b) -> "INT64 (" ^ s ^ ", " ^ string_of_bool b ^ ")"
-  | INT (s, b) -> "INT (" ^ s ^ ", " ^ string_of_bool b ^ ")"
-  | RANGE s -> " RANGE " ^ s
-  | UINT8 s -> "UINT8 " ^ s
+  | INT8 s   -> "INT8 " ^ s
+  | INT16 s  -> "INT16 " ^ s
+  | INT32 s  -> "INT32 " ^ s
+  | INT64 s  -> "INT64 " ^ s
+  | INT s    -> "INT " ^ s
+  | RANGE s  -> "RANGE " ^ s
+  | UINT8 s  -> "UINT8 " ^ s
   | UINT16 s -> "UINT16 " ^ s
   | UINT32 s -> "UINT32 " ^ s
   | UINT64 s -> "UINT64 " ^ s
-  | SIZET s -> "SIZET " ^ s
-  | REAL s -> "REAL " ^ s
-  | CHAR c -> "CHAR c"
+  | SIZET s  -> "SIZET " ^ s
+  | REAL s   -> "REAL " ^ s
+  | CHAR c   -> "CHAR c"
   | LET b -> "LET b"
   | LET_OP s -> "LET_OP " ^ s
   | AND_OP s -> "AND_OP " ^ s


### PR DESCRIPTION
The bounds checks is performed by desugaring.