### PR TITLE
Parser: allowing refinements on multibinders

### DIFF
--- a/src/ml/FStarC_Parser_Parse.mly
+++ b/src/ml/FStarC_Parser_Parse.mly
@@ -787,12 +787,24 @@ patternOrMultibinder:
       }
 
   | pat=atomicPattern { [pat] }
-  | LPAREN qual_id0=aqualifiedWithAttrs(lident) qual_ids=nonempty_list(aqualifiedWithAttrs(lident)) COLON t=simpleArrow r=refineOpt RPAREN
+  | LPAREN
+      qual_id0=aqualifiedWithAttrs(lident)
+      qual_ids=nonempty_list(aqualifiedWithAttrs(lident))
+      COLON
+      t=simpleArrow r=refineOpt
+    RPAREN
       {
         let pos = rr $loc in
         let t_pos = rr $loc(t) in
         let qual_ids = qual_id0 :: qual_ids in
-        List.map (fun ((aq, attrs), x) -> mkRefinedPattern (mk_pattern (PatVar (x, aq, attrs)) pos) t false r t_pos pos) qual_ids
+        let n = List.length qual_ids in
+        List.mapi (fun idx ((aq, attrs), x) ->
+          let pat = mk_pattern (PatVar (x, aq, attrs)) pos in
+          (* Only the last binder carries the refinement, if any. *)
+          let refine_opt = if idx = Int.sub n 1 then r else None in
+          (*                    ^ The - symbol resolves to F* addition. *)
+          mkRefinedPattern pat t true refine_opt t_pos pos
+        ) qual_ids
       }
 
 binder:
@@ -818,8 +830,11 @@ multiBinder:
   | LPAREN qual_ids=nonempty_list(aqualifiedWithAttrs(lidentOrUnderscore)) COLON t=simpleArrow r=refineOpt RPAREN
      {
        let should_bind_var = match qual_ids with | [ _ ] -> true | _ -> false in
-       List.map (fun ((q, attrs), x) ->
-         mkRefinedBinder x t should_bind_var r (rr $loc) q attrs) qual_ids
+       let n = List.length qual_ids in
+       List.mapi (fun idx ((q, attrs), x) ->
+         let refine_opt = if idx = Int.sub n 1 then r else None in
+         mkRefinedBinder x t true refine_opt (rr $loc) q attrs
+       ) qual_ids
      }
 
   | LPAREN_RPAREN

--- a/src/parser/FStarC.Parser.AST.fsti
+++ b/src/parser/FStarC.Parser.AST.fsti
@@ -343,7 +343,7 @@ val mkFsTypApp : term -> list term -> range -> term
 val mkTuple : list term -> range -> term
 val mkDTuple : list term -> range -> term
 val mkRefinedBinder : ident -> term -> bool -> option term -> range -> aqual -> list term -> binder
-val mkRefinedPattern : pattern -> term -> bool -> option term -> range -> range -> pattern
+val mkRefinedPattern : pattern -> term -> (*should_bind_pat:*)bool -> option term -> range -> range -> pattern
 val extract_named_refinement : bool -> term -> option (ident & term & option term)
 
 val as_frag : list decl -> inputFragment

--- a/tests/micro-benchmarks/MultiRef.fst
+++ b/tests/micro-benchmarks/MultiRef.fst
@@ -1,0 +1,13 @@
+module MultiRef
+
+(* The refinement is present only in the binder for y. *)
+let sub (x y : int{x >= y}) : nat =
+  x - y
+
+val sub2 (x y : int{x >= y}) : nat
+let sub2 x y = x - y
+
+// Multibinders are not supported here, regardless
+// of the refinement.
+// val sub3 : (x y : int{x >= y}) -> nat
+// let sub3 x y = x - y


### PR DESCRIPTION
This allows to define a function like:

```fstar
let sub (x y : int{x >= y}) : nat =
  x - y
```

where the refinement is only attached to the second binder. This makes it simple to state relations between several binders of the same type. This currently fails due to trying to attach the refinement to *all* binders, which has scoping problems (and would anyway imply repetition).