### PR TITLE
lib: add a red-black tree implementation of sets and maps

### DIFF
--- a/tests/micro-benchmarks/UseRBMap.fst
+++ b/tests/micro-benchmarks/UseRBMap.fst
@@ -1,0 +1,24 @@
+module UseRBMap
+
+open FStar.RBMap
+open FStar.Class.Printable
+
+let _ =
+  let s = empty () in
+  let s = add 5 "5" s in
+  let s = add 1 "1" s in
+  let s = add 2 "2" s in
+  let s = add 4 "4" s in
+  IO.print_string (to_string (mem 0 s) ^ "\n");
+  IO.print_string (to_string (mem 1 s) ^ "\n");
+  IO.print_string (to_string (mem 2 s) ^ "\n");
+  IO.print_string (to_string (mem 3 s) ^ "\n");
+  IO.print_string (to_string (mem 4 s) ^ "\n");
+  IO.print_string (to_string (mem 5 s) ^ "\n");
+  IO.print_string (to_string (lookup 0 s) ^ "\n");
+  IO.print_string (to_string (lookup 1 s) ^ "\n");
+  IO.print_string (to_string (lookup 2 s) ^ "\n");
+  IO.print_string (to_string (lookup 3 s) ^ "\n");
+  IO.print_string (to_string (lookup 4 s) ^ "\n");
+  IO.print_string (to_string (lookup 5 s) ^ "\n");
+  ()

--- a/tests/micro-benchmarks/UseRBMap.out.expected
+++ b/tests/micro-benchmarks/UseRBMap.out.expected
@@ -1,0 +1,12 @@
+false
+true
+true
+false
+true
+true
+None
+(Some "1")
+(Some "2")
+None
+(Some "4")
+(Some "5")

--- a/tests/micro-benchmarks/UseRBSet.fst
+++ b/tests/micro-benchmarks/UseRBSet.fst
@@ -1,0 +1,18 @@
+module UseRBSet
+
+open FStar.RBSet
+open FStar.Class.Printable
+
+let _ =
+  let s = empty () in
+  let s = add 5 s in
+  let s = add 1 s in
+  let s = add 2 s in
+  let s = add 4 s in
+  IO.print_string (to_string (mem 0 s) ^ "\n");
+  IO.print_string (to_string (mem 1 s) ^ "\n");
+  IO.print_string (to_string (mem 2 s) ^ "\n");
+  IO.print_string (to_string (mem 3 s) ^ "\n");
+  IO.print_string (to_string (mem 4 s) ^ "\n");
+  IO.print_string (to_string (mem 5 s) ^ "\n");
+  ()

--- a/tests/micro-benchmarks/UseRBSet.out.expected
+++ b/tests/micro-benchmarks/UseRBSet.out.expected
@@ -1,0 +1,6 @@
+false
+true
+true
+false
+true
+true

--- a/ulib/FStar.Class.Eq.Raw.fst
+++ b/ulib/FStar.Class.Eq.Raw.fst
@@ -53,5 +53,13 @@ instance eq_option (_ : deq 'a) : deq (option 'a) = {
     | _, _ -> false);
 }
 
+instance eq_either (_ : deq 'a) (_ : deq 'b) : deq (either 'a 'b) = {
+  eq = (fun x y -> 
+    match x, y with
+    | Inl a1, Inl a2 -> eq a1 a2
+    | Inr b1, Inr b2 -> eq b1 b2
+    | _, _ -> false);
+}
+
 val (=) : #a:Type -> {| deq a |} -> a -> a -> bool
 let (=) = eq

--- a/ulib/FStar.Class.Ord.Raw.fst
+++ b/ulib/FStar.Class.Ord.Raw.fst
@@ -1,0 +1,160 @@
+module FStar.Class.Ord.Raw
+
+open FStar.Tactics.Typeclasses { solve }
+open FStar.Class.Eq.Raw { (=) as (=?) }
+
+instance ord_eq (a:Type) (d : ord a) : Tot (deq a) = d.super
+
+let (<?)  x y = Lt? (cmp x y)
+let (>?)  x y = Gt? (cmp x y)
+let (<=?) x y = not (x >? y)
+let (>=?) x y = not (x <? y)
+
+let min x y = if x <=? y then x else y
+let max x y = if x >=? y then x else y
+
+let rec sort (#a:Type) {| ord a |} xs =
+   let rec insert (x:a) (xs:list a) : list a =
+   match xs with
+   | [] -> [x]
+   | y::ys -> if x <=? y then x :: y :: ys else y :: insert x ys
+  in
+  match xs with
+  | [] -> []
+  | x::xs -> insert x (sort xs)
+
+(* An advantage of not having instance canonicity:
+we can just construct a dictionary with this new function
+without to use a newtype (which would involve a traversal
+of the list to convert into!). *)
+let sort_by #a (f : a -> a -> order) xs =
+  let d : ord a = {
+    super = { eq = (fun a b -> f a b = Eq) };
+    cmp = f;
+  } in
+  sort #a #d xs
+
+let dedup #a xs =
+  let out = List.Tot.fold_left (fun out x -> if List.Tot.existsb (fun y -> x =? y) out then out else x :: out) [] xs in
+  List.rev out
+
+let rec sort_dedup (#a:Type) {| ord a |} xs =
+   let rec insert (x:a) (xs:list a) : list a =
+   match xs with
+   | [] -> [x]
+   | y::ys ->
+     match cmp x y with
+     | Eq -> ys
+     | Lt -> x :: y :: ys
+     | Gt -> y :: insert x ys
+  in
+  match xs with
+  | [] -> []
+  | x::xs -> insert x (sort_dedup xs)
+
+let ord_list_diff (#a:Type0) {| ord a |} (xs ys : list a) : list a & list a =
+  let open FStar.Order in
+  let xs = xs |> sort_dedup in
+  let ys = ys |> sort_dedup in
+  let rec go xd yd xs ys : Tot (list a & list a) (decreases List.length xs + List.length ys) =
+    match xs, ys with
+    | x::xs, y::ys -> (
+      match cmp x y with
+      | Lt -> go (x::xd) yd      xs      (y::ys)
+      | Eq -> go xd      yd      xs      ys
+      | Gt -> go xd      (y::yd) (x::xs) ys
+    )
+    (* One of the two is empty, that's it *)
+    | xs, ys -> (List.Tot.rev_acc xd xs, List.rev_acc yd ys)
+  in
+  go [] [] xs ys
+
+instance ord_int : ord int = {
+   super = solve;
+   cmp = compare_int;
+}
+
+// instance ord_bool : ord bool = {
+//    super = solve;
+//    cmp = compare_bool;
+// }
+
+instance ord_unit : ord unit = {
+   super = solve;
+   cmp = (fun _ _ -> Eq);
+}
+
+instance ord_string : ord string = {
+   super = solve;
+   cmp = (fun x y -> order_from_int (String.compare x y));
+}
+
+instance ord_option #a (d : ord a) : Tot (ord (option a)) = {
+   super = solve;
+   cmp = (fun x y -> match x, y with
+          | None, None -> Eq
+          | Some _, None -> Gt
+          | None, Some _ -> Lt
+          | Some x, Some y -> cmp x y
+          );
+}
+
+instance ord_list #a (d : ord a) : Tot (ord (list a)) = {
+   super = solve;
+   cmp = (fun l1 l2 -> compare_list l1 l2 cmp);
+}
+
+instance ord_either #a #b (d1 : ord a) (d2 : ord b) : Tot (ord (either a b)) = {
+   super = solve;
+   cmp = (fun x y -> match x, y with
+          | Inl _, Inr _ -> Lt
+          | Inr _, Inl _ -> Gt
+          | Inl x, Inl y -> cmp x y
+          | Inr x, Inr y -> cmp x y
+          );
+}
+
+instance ord_tuple2 #a #b (d1 : ord a) (d2 : ord b) : Tot (ord (a & b)) = {
+   super = solve;
+   cmp = (fun (x1, x2) (y1, y2) -> 
+          lex (cmp x1 y1) (fun () ->
+          cmp x2 y2));
+}
+
+// instance ord_tuple3 #a #b #c (d1 : ord a) (d2 : ord b) (d3 : ord c): Tot (ord (a & b & c)) = {
+//    super = solve;
+//    cmp = (fun (x1, x2, x3) (y1, y2, y3) -> 
+//           lex (cmp x1 y1) (fun () ->
+//           lex (cmp x2 y2) (fun () ->
+//           cmp x3 y3)));
+// }
+
+// instance ord_tuple4 #a #b #c #d (d1 : ord a) (d2 : ord b) (d3 : ord c) (d4 : ord d): Tot (ord (a & b & c & d)) = {
+//    super = solve;
+//    cmp = (fun (x1, x2, x3, x4) (y1, y2, y3, y4) -> 
+//           lex (cmp x1 y1) (fun () ->
+//           lex (cmp x2 y2) (fun () ->
+//           lex (cmp x3 y3) (fun () ->
+//           cmp x4 y4))));
+// }
+
+// instance ord_tuple5 #a #b #c #d #e (d1 : ord a) (d2 : ord b) (d3 : ord c) (d4 : ord d) (d5 : ord e): Tot (ord (a & b & c & d & e)) = {
+//    super = solve;
+//    cmp = (fun (x1, x2, x3, x4, x5) (y1, y2, y3, y4, y5) -> 
+//           lex (cmp x1 y1) (fun () ->
+//           lex (cmp x2 y2) (fun () ->
+//           lex (cmp x3 y3) (fun () ->
+//           lex (cmp x4 y4) (fun () ->
+//           cmp x5 y5)))));
+// }
+
+// instance ord_tuple6 #a #b #c #d #e #f (d1 : ord a) (d2 : ord b) (d3 : ord c) (d4 : ord d) (d5 : ord e) (d6 : ord f): Tot (ord (a & b & c & d & e & f)) = {
+//    super = solve;
+//    cmp = (fun (x1, x2, x3, x4, x5, x6) (y1, y2, y3, y4, y5, y6) -> 
+//           lex (cmp x1 y1) (fun () ->
+//           lex (cmp x2 y2) (fun () ->
+//           lex (cmp x3 y3) (fun () ->
+//           lex (cmp x4 y4) (fun () ->
+//           lex (cmp x5 y5) (fun () ->
+//           cmp x6 y6))))));
+// }

--- a/ulib/FStar.Class.Ord.Raw.fsti
+++ b/ulib/FStar.Class.Ord.Raw.fsti
@@ -1,0 +1,102 @@
+module FStar.Class.Ord.Raw
+
+open FStar.Order
+open FStar.Class
+open FStar.Class.Eq.Raw { deq }
+
+// raw
+class ord (a:Type) = {
+  super : deq a;
+  cmp : a -> a -> order;
+}
+
+instance val ord_eq (a:Type) (d : ord a) : Tot (deq a)
+
+val (<?)  : #a:Type -> {| ord a |} -> a -> a -> bool
+val (>?)  : #a:Type -> {| ord a |} -> a -> a -> bool
+val (<=?) : #a:Type -> {| ord a |} -> a -> a -> bool
+val (>=?) : #a:Type -> {| ord a |} -> a -> a -> bool
+
+val min : #a:Type -> {| ord a |} -> a -> a -> a
+val max : #a:Type -> {| ord a |} -> a -> a -> a
+
+val sort
+  (#a:Type) {| ord a |}
+  (xs : list a)
+  : list a
+
+val sort_by
+  (#a:Type) (f : a -> a -> order)
+  (xs : list a)
+  : list a
+
+(* Deduplicate elements, preserving order as determined by the leftmost
+occurrence. So dedup [a,b,c,a,f,e,c] = [a,b,c,f,e] *)
+val dedup
+  (#a:Type) {| ord a |}
+  (xs : list a)
+  : list a
+
+(* Sort and deduplicate at once *)
+val sort_dedup
+  (#a:Type) {| ord a |}
+  (xs : list a)
+  : list a
+
+(* Returns the difference of two lists, modulo order and duplication.
+The first component is the elements only present in xs, and the second
+is the elements only present in ys. *)
+val ord_list_diff (#a:Type0) {| ord a |} (xs ys : list a) : list a & list a
+
+instance val ord_int    : ord int
+// instance val ord_bool   : ord bool
+instance val ord_unit   : ord unit
+instance val ord_string : ord string
+
+instance val ord_option
+   (_ : ord 'a)
+: Tot (ord (option 'a))
+
+instance val ord_list
+   (_ : ord 'a)
+: Tot (ord (list 'a))
+
+instance val ord_either
+   (_ : ord 'a)
+   (_ : ord 'b)
+: Tot (ord (either 'a 'b))
+
+instance val ord_tuple2
+   (_ : ord 'a)
+   (_ : ord 'b)
+: Tot (ord ('a & 'b))
+
+// instance val ord_tuple3
+//    (_ : ord 'a)
+//    (_ : ord 'b)
+//    (_ : ord 'c)
+// : Tot (ord ('a & 'b & 'c))
+
+// instance val ord_tuple4
+//    (_ : ord 'a)
+//    (_ : ord 'b)
+//    (_ : ord 'c)
+//    (_ : ord 'd)
+// : Tot (ord ('a & 'b & 'c & 'd))
+
+// instance val ord_tuple5
+//    (_ : ord 'a)
+//    (_ : ord 'b)
+//    (_ : ord 'c)
+//    (_ : ord 'd)
+//    (_ : ord 'e)
+// : Tot (ord ('a & 'b & 'c & 'd & 'e))
+
+// instance val ord_tuple6
+//    (_ : ord 'a)
+//    (_ : ord 'b)
+//    (_ : ord 'c)
+//    (_ : ord 'd)
+//    (_ : ord 'e)
+//    (_ : ord 'f)
+// : Tot (ord ('a & 'b & 'c & 'd & 'e & 'f))

--- a/ulib/FStar.RBMap.fst
+++ b/ulib/FStar.RBMap.fst
@@ -1,0 +1,154 @@
+(*
+   Copyright 2008-2025 Microsoft Research
+
+   Authors: Guido Martínez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*)
+
+module FStar.RBMap
+
+open FStar.Class.Ord.Raw
+open FStar.List
+
+type color = | R | B
+
+type t (a b :Type0) : Type0 =
+  | L
+  | N of color & t a b & a & b & t a b
+
+let empty () = L
+
+let singleton (x :'a) (y : 'b) : t 'a 'b = N (R, L, x, y, L)
+
+let is_empty = L?
+
+let balance c l x vx r =
+    match c, l, x, vx, r with
+    | B, N (R, N (R, a, x, vx, b), y, vy, c), z, vz, d
+    | B, a, x, vx, N (R, N (R, b, y, vy, c), z, vz, d)
+    | B, N (R, a, x, vx, N (R, b, y, vy, c)), z, vz, d
+    | B, a, x, vx, N (R, b, y, vy, N (R, c, z, vz, d)) ->
+        N (R, N (B, a, x, vx, b), y, vy, N (B, c, z, vz, d))
+    | c, l, x, vx, r -> N (c, l, x, vx, r)
+
+let blackroot (m : t 'a 'b{N? m}) : t 'a 'b =
+  let N (_, l, x, vx, r) = m in
+  N (B, l, x, vx, r)
+
+let add {| ord 'a |} (x:'a) (vx : 'b) (s:t 'a 'b) : t 'a 'b =
+  let rec add' (s:t 'a 'b) : r:(t 'a 'b){N? r} =
+    match s with
+    | L -> N (R, L, x, vx, L)
+    | N (c, a, y, vy, b) ->
+      if x <? y then balance c (add' a) y vy b
+      else if x >? y then balance c a y vy (add' b)
+      else s
+  in
+  blackroot (add' s)
+
+let filter {| ord 'a |} (predicate: 'a -> 'b -> bool) (set: t 'a 'b): t 'a 'b =
+  let rec aux (acc m : t 'a 'b) : Tot (t 'a 'b) (decreases m) =
+    match m with
+    | L -> acc
+    | N (_, l, v, vy, r) ->
+      aux (aux (if predicate v vy then add v vy acc else acc) l) r
+  in aux (empty ()) set
+
+let rec extract_min #a #b {| ord a |} (m : t a b{not (is_empty m)}) : t a b & (a & b) =
+  match m with
+  | N (_, L, x, vx, r) -> r, (x, vx)
+  | N (c, a, x, vx, b) ->
+    let (a', y) = extract_min a in
+    balance c a' x vx b, y
+
+(* This is not the right way, see https://www.cs.cornell.edu/courses/cs3110/2020sp/a4/deletion.pdf
+for how to do it. But if we reach that complexity, I would like for
+this whole module to be verified. *)
+let rec remove {| ord 'a |} (x : 'a) (m : t 'a 'b) : t 'a 'b =
+  match m with
+  | L -> L
+  | N (c, l, y, vy, r) ->
+    if x <? y then balance c (remove x l) y vy r
+    else if x >? y then balance c l y vy (remove x r)
+    else
+      if L? r
+      then
+        l
+      else
+        let (r', (y', vy')) = extract_min r in
+        balance c l y' vy' r'
+
+let rec mem {| ord 'a |} (x : 'a) (m : t 'a 'b) : bool =
+  match m with
+  | L -> false
+  | N (_, a, y, _, b) ->
+    if x <? y then mem x a
+    else if x >? y then mem x b
+    else true
+
+let rec lookup {| ord 'a |} (x : 'a) (m : t 'a 'b) : option 'b =
+  match m with
+  | L -> None
+  | N (_, a, y, vy, b) ->
+    if x <? y then lookup x a
+    else if x >? y then lookup x b
+    else Some vy
+
+let rec keys (s : t 'a 'b) : list 'a =
+  match s with
+  | L -> []
+  | N (_, a, x, _, b) -> keys a @ [x] @ keys b
+
+let rec to_list (s : t 'a 'b) : list ('a & 'b) =
+  match s with
+  | L -> []
+  | N (_, a, x, vx, b) -> to_list a @ [(x, vx)] @ to_list b
+
+let equal {| ord 'a, Class.Eq.Raw.deq 'b |} (s1 s2 : t 'a 'b) : bool =
+  let open FStar.Class.Eq.Raw in
+  to_list s1 = to_list s2
+
+let rec union {| ord 'a |} (s1 s2 : t 'a 'b) : t 'a 'b =
+  match s1 with
+  | L -> s2
+  | N (c, a, x, vx, b) -> union a (union b (add x vx s2))
+
+(* Intersect the maps. It's left-biased: prefer values on the first map. *)
+let inter {| ord 'a |} (s1 s2 : t 'a 'b) : t 'a 'b =
+  let rec aux (s1 acc : t 'a 'b) : t 'a 'b =
+    match s1 with
+    | L -> acc
+    | N (_, a, x, vx, b) ->
+      if mem x s2
+      then add x vx (aux a (aux b acc))
+      else aux a (aux b acc)
+  in
+  aux s1 L
+
+let rec for_all (p : 'a -> 'b -> bool) (s : t 'a 'b) : bool =
+  match s with
+  | L -> true
+  | N (_, a, x, vx, b) -> p x vx && for_all p a && for_all p b
+
+let rec for_any (p : 'a -> 'b -> bool) (s : t 'a 'b) : bool =
+  match s with
+  | L -> false
+  | N (_, a, x, vx, b) -> p x vx || for_all p a && for_all p b
+
+// Make this faster
+let from_list {| ord 'a |} (xs : list ('a & 'b)) : t 'a 'b =
+  List.Tot.fold_left (fun s (k, v) -> add k v s) L xs
+
+let addn {| ord 'a |} (xs : list ('a & 'b)) (s : t 'a 'b) : t 'a 'b =
+  List.Tot.fold_left (fun s (k, v) -> add k v s) s xs

--- a/ulib/FStar.RBMap.fsti
+++ b/ulib/FStar.RBMap.fsti
@@ -1,0 +1,60 @@
+(*
+   Copyright 2008-2025 Microsoft Research
+
+   Authors: Guido Martínez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*)
+
+module FStar.RBMap
+
+open FStar.Class.Ord.Raw
+
+new val t (a b :Type0) : Type0
+
+val empty () : t 'a 'b
+
+val singleton (x :'a) (y : 'b) : t 'a 'b
+
+val is_empty (s : t 'a 'b) : bool
+
+val add {| ord 'a |} (x:'a) (vx : 'b) (s:t 'a 'b) : t 'a 'b
+
+val filter {| ord 'a |} (predicate: 'a -> 'b -> bool) (set: t 'a 'b) : t 'a 'b
+
+val extract_min #a #b {| ord a |} (m : t a b{not (is_empty m)}) : t a b & (a & b)
+
+val remove {| ord 'a |} (x : 'a) (m : t 'a 'b) : t 'a 'b
+
+val mem {| ord 'a |} (x : 'a) (m : t 'a 'b) : bool
+
+val lookup {| ord 'a |} (x : 'a) (m : t 'a 'b) : option 'b
+
+val keys (s : t 'a 'b) : list 'a
+
+val to_list (s : t 'a 'b) : list ('a & 'b)
+
+val equal {| ord 'a, Class.Eq.Raw.deq 'b |} (s1 s2 : t 'a 'b) : bool
+
+val union {| ord 'a |} (s1 s2 : t 'a 'b) : t 'a 'b
+
+(* Intersect the maps. It's left-biased: prefer values on the first map. *)
+val inter {| ord 'a |} (s1 s2 : t 'a 'b) : t 'a 'b
+
+val for_all (p : 'a -> 'b -> bool) (s : t 'a 'b) : bool
+
+val for_any (p : 'a -> 'b -> bool) (s : t 'a 'b) : bool
+
+val from_list {| ord 'a |} (xs : list ('a & 'b)) : t 'a 'b
+
+val addn {| ord 'a |} (xs : list ('a & 'b)) (s : t 'a 'b) : t 'a 'b

--- a/ulib/FStar.RBSet.fst
+++ b/ulib/FStar.RBSet.fst
@@ -1,0 +1,154 @@
+(*
+   Copyright 2008-2025 Microsoft Research
+
+   Authors: Guido Martínez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*)
+
+module FStar.RBSet
+
+open FStar.Class.Ord.Raw
+open FStar.List
+
+type color = | R | B
+
+type t (a:Type0) : Type0 =
+  | L
+  | N of color & t a & a & t a
+
+let empty () = L
+
+let singleton (x:'a) : t 'a = N (R, L, x, L)
+
+let is_empty = L?
+
+let balance c l x r =
+    match c, l, x, r with
+    | B, N (R, N (R, a, x, b), y, c), z, d
+    | B, a, x, N (R, N (R, b, y, c), z, d)
+    | B, N (R, a, x, N (R, b, y, c)), z, d
+    | B, a, x, N (R, b, y, N (R, c, z, d)) ->
+        N (R, N (B, a, x, b), y, N (B, c, z, d))
+    | c, l, x, r -> N (c, l, x, r)
+
+let blackroot (s:t 'a{N? s}) : t 'a =
+  match s with
+  | N (_, l, x, r) -> N (B, l, x, r)
+
+let add {| ord 'a |} (x:'a) (s:t 'a) : t 'a =
+  let rec add' (s:t 'a) : r:(t 'a){N? r} =
+    match s with
+    | L -> N (R, L, x, L)
+    | N (c, a, y, b) ->
+      if x <? y then balance c (add' a) y b
+      else if x >? y then balance c a y (add' b)
+      else s
+  in
+  blackroot (add' s)
+
+let filter {| ord 'a |} (predicate: 'a -> bool) (set: t 'a): t 'a =
+  let rec aux (acc s : t 'a) : Tot (t 'a) (decreases s) =
+    match s with
+    | L -> acc
+    | N (_, l, v, r) ->
+      aux (aux (if predicate v then add v acc else acc) l) r
+  in aux (empty ()) set
+
+let rec extract_min #a {| ord a |} (s : t a{not (is_empty s)}) : t a & a =
+  match s with
+  | N (_, L, x, r) -> r, x
+  | N (c, a, x, b) ->
+    let (a', y) = extract_min a in
+    balance c a' x b, y
+
+(* This is not the right way, see https://www.cs.cornell.edu/courses/cs3110/2020sp/a4/deletion.pdf
+for how to do it. But if we reach that complexity, I would like for
+this whole module to be verified. *)
+let rec remove {| ord 'a |} (x:'a) (s : t 'a) : t 'a =
+  match s with
+  | L -> L
+  | N (c, l, y, r) ->
+    if x <? y then balance c (remove x l) y r
+    else if x >? y then balance c l y (remove x r)
+    else
+      if L? r
+      then
+        l
+      else
+        let (r', y') = extract_min r in
+        balance c l y' r'
+
+let rec mem {| ord 'a |} (x:'a) (s:t 'a) : bool =
+  match s with
+  | L -> false
+  | N (_, a, y, b) ->
+    if x <? y then mem x a
+    else if x >? y then mem x b
+    else true
+
+let rec elems (s:t 'a) : list 'a =
+  match s with
+  | L -> []
+  | N (_, a, x, b) -> elems a @ [x] @ elems b
+
+let equal {| ord 'a |} (s1:t 'a) (s2:t 'a) : bool =
+  let open FStar.Class.Eq.Raw in
+  elems s1 = elems s2
+
+let rec union {| ord 'a |} (s1:t 'a) (s2:t 'a) : t 'a =
+  match s1 with
+  | L -> s2
+  | N (c, a, x, b) -> union a (union b (add x s2))
+
+let inter {| ord 'a |} (s1:t 'a) (s2:t 'a) : t 'a =
+  let rec aux (s1:t 'a) (acc : t 'a) : t 'a =
+    match s1 with
+    | L -> acc
+    | N (_, a, x, b) ->
+      if mem x s2
+      then add x (aux a (aux b acc))
+      else aux a (aux b acc)
+  in
+  aux s1 L
+
+let rec diff {| ord 'a |} (s1 s2 : t 'a) : Tot (t 'a) (decreases s2) =
+  match s2 with
+  | L -> s1
+  | N (_, a, x, b) -> diff (diff (remove x s1) a) b
+
+let rec subset {| ord 'a |} (s1:t 'a) (s2:t 'a) : bool =
+  match s1 with
+  | L -> true
+  | N (_, a, x, b) -> mem x s2 && subset a s2 && subset b s2
+
+let rec for_all (p:'a -> bool) (s:t 'a) : bool =
+  match s with
+  | L -> true
+  | N (_, a, x, b) -> p x && for_all p a && for_all p b
+
+let rec for_any (p:'a -> bool) (s:t 'a) : bool =
+  match s with
+  | L -> false
+  | N (_, a, x, b) -> p x || for_any p a || for_any p b
+
+// Make this faster
+let from_list {| ord 'a |} (xs : list 'a) : t 'a =
+  List.Tot.fold_left (fun s e -> add e s) L xs
+
+let addn {| ord 'a |} (xs : list 'a) (s : t 'a) : t 'a =
+  List.Tot.fold_left (fun s e -> add e s) s xs
+
+let collect #a {| ord a |} (f : a -> t a)
+    (l : list a) : t a =
+    List.Tot.fold_left (fun s e -> union (f e) s) L l

--- a/ulib/FStar.RBSet.fsti
+++ b/ulib/FStar.RBSet.fsti
@@ -1,0 +1,65 @@
+(*
+   Copyright 2008-2025 Microsoft Research
+
+   Authors: Guido Martínez
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*)
+
+module FStar.RBSet
+
+(* This module implements sets based on red-black trees.
+   It does not expose functional properties, it is mostly
+   useful for unverified code. *)
+
+open FStar.Class.Ord.Raw
+
+new val t (a:Type0) : Type0
+
+val empty () : t 'a
+
+val singleton (x : 'a) : t 'a
+
+val is_empty (s : t 'a) : bool
+
+val add {| ord 'a |} (x:'a) (s : t 'a) : t 'a
+
+val filter {| ord 'a |} (predicate : 'a -> bool) (set : t 'a): t 'a
+
+val extract_min #a {| ord a |} (s : t a{not (is_empty s)}) : t a & a
+
+val remove {| ord 'a |} (x : 'a) (s : t 'a) : t 'a
+
+val mem {| ord 'a |} (x : 'a) (s : t 'a) : bool
+
+val elems (s : t 'a) : list 'a
+
+val equal {| ord 'a |} (s1 s2 : t 'a) : bool
+
+val union {| ord 'a |} (s1 s2 : t 'a) : t 'a
+
+val inter {| ord 'a |} (s1 s2 : t 'a) : t 'a
+
+val diff {| ord 'a |} (s1 s2 : t 'a) : t 'a
+
+val subset {| ord 'a |} (s1 s2 : t 'a) : bool
+
+val for_all (p:'a -> bool) (s:t 'a) : bool
+
+val for_any (p:'a -> bool) (s:t 'a) : bool
+
+val from_list {| ord 'a |} (xs : list 'a) : t 'a
+
+val addn {| ord 'a |} (xs : list 'a) (s : t 'a) : t 'a
+
+val collect #a {| ord a |} (f : a -> t a) (l : list a) : t a


### PR DESCRIPTION
Essentially what we have internally to the compiler (`FStarC.RBSet`) but also extended to maps. Not much is verified here, only match exhaustiveness. It would be nice to add some proofs here, and to use it from inside the compiler once we bump stage0 for more dogfooding.