### PR TITLE
Tc: make 'new' and 'inline_for_extraction'/'noextract' compatible

### DIFF
--- a/src/typechecker/FStarC.TypeChecker.Quals.fst
+++ b/src/typechecker/FStarC.TypeChecker.Quals.fst
@@ -93,12 +93,14 @@ let check_sigelt_quals_pre (env:FStarC.TypeChecker.Env.env) se =
         || q2=NoExtract
 
       | New -> //no definition provided
-        inferred q2 || visibility q2 || assumption q2
+        inferred q2 || visibility q2 || assumption q2 ||
+        q2=Inline_for_extraction || q2=NoExtract
 
       | Inline_for_extraction ->
          q2=Logic || visibility q2 || reducibility q2 ||
          reification q2 || inferred q2 || has_eq q2 ||
-         (env.is_iface && q2=Assumption) || q2=NoExtract
+         (env.is_iface && q2=Assumption) || q2=NoExtract ||
+         q2=New
 
       | Unfold_for_unification_and_vcgen
       | Visible_default

--- a/tests/micro-benchmarks/Qualifiers.fst
+++ b/tests/micro-benchmarks/Qualifiers.fst
@@ -1,0 +1,10 @@
+module Qualifiers
+
+(* 'new' and 'inline_for_extraction' are compatible.
+They may both appear in an interface, in order to declare
+the type as new and also make it inline with --cmi. *)
+inline_for_extraction noextract
+new
+val foo : Type0
+
+type foo = | Foo


### PR DESCRIPTION
It is sensible to attach both of these attributes to a type in an interface, to declare that it is in fact new and also make it inline with cross-module inlining. One may also want `noextract`, if the type need not appear in the extracted code.