### PR TITLE
Separate the --warn_error parser, fix crash on ill-formed options

### DIFF
--- a/src/basic/FStarC.Errors.fsti
+++ b/src/basic/FStarC.Errors.fsti
@@ -49,7 +49,7 @@ val warn_on_use_errno    : int
 val defensive_errno      : int
 val call_to_erased_errno : int
 
-val update_flags : list (error_flag & string) -> list error_setting
+val update_flags : list (error_flag & (int & int)) -> list error_setting
 
 type context_t = list string
 
@@ -114,7 +114,7 @@ val set_handler : error_handler -> unit
 val get_ctx : unit -> list string
 
 val set_option_warning_callback_range : ropt:option FStarC.Range.range -> unit
-val set_parse_warn_error : (string -> list error_setting) -> unit
+val set_parse_warn_error : (string -> option (list error_setting)) -> unit
 
 val lookup : error_code -> error_setting
 

--- a/src/ml/FStarC_Parser_LexFStar.ml
+++ b/src/ml/FStarC_Parser_LexFStar.ml
@@ -573,7 +573,6 @@ match%sedlex lexbuf with
  | uint64 -> UINT64 (clean_number (L.lexeme lexbuf))
  | int64 -> INT64 (clean_number (L.lexeme lexbuf))
  | sizet -> SIZET (clean_number (L.lexeme lexbuf))
- | range -> RANGE (L.lexeme lexbuf)
  | real -> REAL(trim_right lexbuf 1)
  | (integer | xinteger | ieee64 | xieee64), Plus ident_char ->
    fail lexbuf (Codes.Fatal_SyntaxError, "This is not a valid numeric literal: " ^ L.lexeme lexbuf)

--- a/src/ml/FStarC_Parser_Parse.mly
+++ b/src/ml/FStarC_Parser_Parse.mly
@@ -92,8 +92,6 @@ type tc_constraint = {
 
 %token <string> REAL
 
-%token <string> RANGE
-
 %token <FStar_Char.char> CHAR
 %token LET
 %token <string> LET_OP
@@ -179,13 +177,11 @@ type tc_constraint = {
 
 %start inputFragment
 %start term
-%start warn_error_list
 %start oneDeclOrEOF
 %type <FStarC_Parser_AST.inputFragment> inputFragment
 %type <(FStarC_Parser_AST.decl list * FStarC_Sedlexing.snap option) option> oneDeclOrEOF
 %type <FStarC_Parser_AST.term> term
 %type <FStarC_Ident.ident> lident
-%type <(FStarC_Errors_Codes.error_flag * string) list> warn_error_list
 %%
 
 (* inputFragment is used at the same time for whole files and fragment of codes (for interactive mode) *)
@@ -1606,27 +1602,15 @@ constant:
   | TRUE { Const_bool true }
   | FALSE { Const_bool false }
   | r=REAL { Const_real r }
-  | n=UINT8 { Const_int (n, Some (Unsigned, Int8)) }
-  | n=INT8
-      {
-        Const_int (n, Some (Signed, Int8))
-      }
+  | n=UINT8  { Const_int (n, Some (Unsigned, Int8)) }
+  | n=INT8   { Const_int (n, Some (Signed,   Int8)) }
   | n=UINT16 { Const_int (n, Some (Unsigned, Int16)) }
-  | n=INT16
-      {
-        Const_int (n, Some (Signed, Int16))
-      }
+  | n=INT16  { Const_int (n, Some (Signed,   Int16)) }
   | n=UINT32 { Const_int (n, Some (Unsigned, Int32)) }
-  | n=INT32
-      {
-        Const_int (n, Some (Signed, Int32))
-      }
+  | n=INT32  { Const_int (n, Some (Signed,   Int32)) }
   | n=UINT64 { Const_int (n, Some (Unsigned, Int64)) }
-  | n=INT64
-      {
-        Const_int (n, Some (Signed, Int64))
-      }
-  | n=SIZET { Const_int (n, Some (Unsigned, Sizet)) }
+  | n=INT64  { Const_int (n, Some (Signed,   Int64)) }
+  | n=SIZET  { Const_int (n, Some (Unsigned, Sizet)) }
   (* TODO : What about reflect ? There is also a constant representing it *)
   | REIFY   { Const_reify None }
   | RANGE_OF     { Const_range_of }
@@ -1665,30 +1649,6 @@ atomicUniverse:
   | u=lident { mk_term (Uvar u) (range_of_id u) Expr }
   | LPAREN u=universeFrom RPAREN
     { u (*mk_term (Paren u) (rr2 $loc($1) $loc($3)) Expr*) }
-
-warn_error_list:
-  | e=warn_error EOF { e }
-
-warn_error:
-  | f=flag r=range
-    { [(f, r)] }
-  | f=flag r=range e=warn_error
-    { (f, r) :: e }
-
-flag:
-  | op=OPINFIX1
-    { if op = "@" then CAlwaysError else failwith (format1 "unexpected token %s in warn-error list" op)}
-  | op=OPINFIX2
-    { if op = "+" then CWarning else failwith (format1 "unexpected token %s in warn-error list" op)}
-  | MINUS
-          { CSilent }
-
-range:
-  | i=INT
-    { format2 "%s..%s" i i }
-  | r=RANGE
-    { r }
-
 
 /******************************************************************************/
 /*                       Miscellanous, tools                                   */

--- a/src/ml/FStarC_Parser_WarnError.mly
+++ b/src/ml/FStarC_Parser_WarnError.mly
@@ -1,0 +1,38 @@
+%{
+(* This is just a simple parser for the arguments
+to --warn_error. *)
+open Prims
+open FStarC_Errors_Codes
+module Z = FStarC_BigInt
+
+%}
+
+%token <Z.t> INT
+
+%token MINUS
+%token PLUS
+%token AT
+%token DOT_DOT
+%token EOF
+
+%start warn_error_list
+%type <(FStarC_Errors_Codes.error_flag * (Z.t * Z.t)) list> warn_error_list
+%%
+
+warn_error_list:
+  | e=warn_error EOF { e }
+
+warn_error:
+  | l=list(flag range { ($1, $2) })
+    { l }
+
+flag:
+  | AT    { CAlwaysError }
+  | PLUS  { CWarning }
+  | MINUS { CSilent }
+
+range:
+  | i1=INT DOT_DOT i2=INT
+    { (i1, i2) }
+  | i=INT
+    { (i, i) }

--- a/src/ml/FStarC_Parser_WarnError_Lex.ml
+++ b/src/ml/FStarC_Parser_WarnError_Lex.ml
@@ -1,0 +1,31 @@
+(* This is just a simple lexer to parse the arguments
+to --warn_error. *)
+
+open FStarC_Parser_WarnError
+
+module Sedlexing = FStarC_Sedlexing
+module L     = FStarC_Sedlexing
+module E     = FStarC_Errors
+module Codes = FStarC_Errors_Codes
+module Z     = FStarC_BigInt
+
+let digit   = [%sedlex.regexp? '0'..'9']
+let integer = [%sedlex.regexp? Plus digit]
+
+let current_range lexbuf =
+  FStarC_Parser_Util.mksyn_range (fst (L.range lexbuf)) (snd (L.range lexbuf))
+
+let fail lexbuf (e, msg) =
+  let m = current_range lexbuf in
+  E.raise_error_text m e msg
+
+let rec token lexbuf =
+  match%sedlex lexbuf with
+  | zs -> token lexbuf (* ignore whitespace *)
+  | integer -> INT (Z.of_int (int_of_string (L.lexeme lexbuf)))
+  | "-"  -> MINUS
+  | "+"  -> PLUS
+  | "@"  -> AT
+  | ".." -> DOT_DOT
+  | eof  -> EOF
+  | _ -> fail lexbuf (Codes.Fatal_SyntaxError, "unexpected char")

--- a/src/parser/FStarC.Parser.ParseIt.fsti
+++ b/src/parser/FStarC.Parser.ParseIt.fsti
@@ -63,7 +63,7 @@ val parse (ext_lang:lang_opts)
 : parse_result
 val find_file: string -> string
 
-val parse_warn_error: string -> list FStarC.Errors.error_setting
+val parse_warn_error: string -> option (list FStarC.Errors.error_setting)
 
 (* useful for unit testing and registered a #lang-fstar parser *)
 val parse_fstar_incrementally : AU.extension_lang_parser

--- a/stage1/dune/fstar-guts/FStarC_Parser_WarnError.mly
+++ b/stage1/dune/fstar-guts/FStarC_Parser_WarnError.mly
@@ -1,0 +1,1 @@
+../../../src/ml/FStarC_Parser_WarnError.mly

--- a/stage1/dune/fstar-guts/dune
+++ b/stage1/dune/fstar-guts/dune
@@ -21,6 +21,8 @@
 
 (menhir
  (modules FStarC_Parser_Parse))
+(menhir
+ (modules FStarC_Parser_WarnError))
 
 (rule
   (target FStarC_Version.ml)

--- a/stage2/dune/fstar-guts/FStarC_Parser_WarnError.mly
+++ b/stage2/dune/fstar-guts/FStarC_Parser_WarnError.mly
@@ -1,0 +1,1 @@
+../../../src/ml/FStarC_Parser_WarnError.mly

--- a/stage2/dune/fstar-guts/dune
+++ b/stage2/dune/fstar-guts/dune
@@ -21,6 +21,8 @@
 
 (menhir
  (modules FStarC_Parser_Parse))
+(menhir
+ (modules FStarC_Parser_WarnError))
 
 (rule
   (target FStarC_Version.ml)

--- a/tests/error-messages/WarnError.fst
+++ b/tests/error-messages/WarnError.fst
@@ -1,0 +1,4 @@
+module WarnError
+
+[@@expect_failure [65]] // gracefully fail
+#set-options "--warn_error @"

--- a/tests/error-messages/WarnError.fst.output.expected
+++ b/tests/error-messages/WarnError.fst.output.expected
@@ -1,0 +1,6 @@
+>> Got issues: [
+* Error 65 at WarnError.fst(4,0-4,29):
+  - Failed to process pragma: Invalid --warn_error setting: Parsing of
+    warn_error string failed
+
+>>]


### PR DESCRIPTION
The parsing of the arguments to --warn_error was done via the same Menhir grammar as normal F*, and the same lexer. This coupling is needless and slightly confusing. So separate it into a new Menhir parser and lexer.

Also fix a crash when the string fails to parse, providing a more reasonale error instead.

This will need a Pulse patch as it uses F* tokens, and RANGE is gone.

https://github.com/mtzguido/FStar/actions/runs/16227072077