### PR TITLE
Some cleanup on machine integers

### DIFF
--- a/.scripts/FStar.IntN.fstip
+++ b/.scripts/FStar.IntN.fstip
@@ -100,23 +100,23 @@ let lt ( a:t) (b:t) : Tot bool = lt  #n (v a) (v b)
 let lte (a:t) (b:t) : Tot bool = lte #n (v a) (v b)
 
 (* Infix notations *)
-unfold let op_Plus_Hat = add
-unfold let op_Subtraction_Hat = sub
-unfold let op_Star_Hat = mul
-unfold let op_Slash_Hat = div
-unfold let op_Percent_Hat = rem
-unfold let op_Hat_Hat = logxor
-unfold let op_Amp_Hat = logand
-unfold let op_Bar_Hat = logor
-unfold let op_Less_Less_Hat = shift_left
-unfold let op_Greater_Greater_Hat = shift_right
-unfold let op_Greater_Greater_Greater_Hat = shift_arithmetic_right
-unfold let op_Equals_Hat = eq
-unfold let op_Not_Equals_Hat = ne
-unfold let op_Greater_Hat = gt
-unfold let op_Greater_Equals_Hat = gte
-unfold let op_Less_Hat = lt
-unfold let op_Less_Equals_Hat = lte
+unfold let ( +^ )  = add
+unfold let ( -^ )  = sub
+unfold let ( *^ )  = mul
+unfold let ( /^ )  = div
+unfold let ( %^ )  = rem
+unfold let ( ^^ )  = logxor
+unfold let ( &^ )  = logand
+unfold let ( |^ )  = logor
+unfold let ( <<^ ) = shift_left
+unfold let ( >>^ ) = shift_right
+unfold let ( >>>^) = shift_arithmetic_right
+unfold let ( =^ )  = eq
+unfold let ( <>^ ) = ne
+unfold let ( >^ )  = gt
+unfold let ( >=^ ) = gte
+unfold let ( <^ )  = lt
+unfold let ( <=^ ) = lte
 
 inline_for_extraction
 let ct_abs (a:t{min_int n < v a}) : Tot (b:t{v b = abs (v a)}) =

--- a/.scripts/FStar.IntN.fstip
+++ b/.scripts/FStar.IntN.fstip
@@ -92,10 +92,11 @@ val shift_arithmetic_right (a:t) (s:UInt32.t) : Pure t
   (ensures (fun c -> FStar.Int.shift_arithmetic_right (v a) (UInt32.v s) = v c))
 
 (* Comparison operators *)
-let eq (a:t) (b:t) : Tot bool = eq #n (v a) (v b)
-let gt (a:t) (b:t) : Tot bool = gt #n (v a) (v b)
+let eq  (a:t) (b:t) : Tot bool = eq  #n (v a) (v b)
+let ne  (a:t) (b:t) : Tot bool = ne  #n (v a) (v b)
+let gt  (a:t) (b:t) : Tot bool = gt  #n (v a) (v b)
 let gte (a:t) (b:t) : Tot bool = gte #n (v a) (v b)
-let lt (a:t) (b:t) : Tot bool = lt #n (v a) (v b)
+let lt ( a:t) (b:t) : Tot bool = lt  #n (v a) (v b)
 let lte (a:t) (b:t) : Tot bool = lte #n (v a) (v b)
 
 (* Infix notations *)
@@ -111,6 +112,7 @@ unfold let op_Less_Less_Hat = shift_left
 unfold let op_Greater_Greater_Hat = shift_right
 unfold let op_Greater_Greater_Greater_Hat = shift_arithmetic_right
 unfold let op_Equals_Hat = eq
+unfold let op_Not_Equals_Hat = ne
 unfold let op_Greater_Hat = gt
 unfold let op_Greater_Equals_Hat = gte
 unfold let op_Less_Hat = lt

--- a/.scripts/FStar.UIntN.fstip
+++ b/.scripts/FStar.UIntN.fstip
@@ -297,28 +297,28 @@ let gte_mask (a:t) (b:t)
 #reset-options
 
 (*** Infix notations *)
-unfold let op_Plus_Hat = add
-unfold let op_Plus_Question_Hat = add_underspec
-unfold let op_Plus_Percent_Hat = add_mod
-unfold let op_Subtraction_Hat = sub
-unfold let op_Subtraction_Question_Hat = sub_underspec
-unfold let op_Subtraction_Percent_Hat = sub_mod
-unfold let op_Star_Hat = mul
-unfold let op_Star_Question_Hat = mul_underspec
-unfold let op_Star_Percent_Hat = mul_mod
-unfold let op_Slash_Hat = div
-unfold let op_Percent_Hat = rem
-unfold let op_Hat_Hat = logxor
-unfold let op_Amp_Hat = logand
-unfold let op_Bar_Hat = logor
-unfold let op_Less_Less_Hat = shift_left
-unfold let op_Greater_Greater_Hat = shift_right
-unfold let op_Equals_Hat = eq
-unfold let op_Not_Equals_Hat = ne
-unfold let op_Greater_Hat = gt
-unfold let op_Greater_Equals_Hat = gte
-unfold let op_Less_Hat = lt
-unfold let op_Less_Equals_Hat = lte
+unfold let ( +^ )  = add
+unfold let ( +?^ ) = add_underspec
+unfold let ( +%^ ) = add_mod
+unfold let ( -^ )  = sub
+unfold let ( -?^ ) = sub_underspec
+unfold let ( -%^ ) = sub_mod
+unfold let ( *^ ) = mul
+unfold let ( *?^ )= mul_underspec
+unfold let ( *%^ )= mul_mod
+unfold let ( /^ )  = div
+unfold let ( %^ )  = rem
+unfold let ( ^^ )  = logxor
+unfold let ( &^ )  = logand
+unfold let ( |^ )  = logor
+unfold let ( <<^ ) = shift_left
+unfold let ( >>^ ) = shift_right
+unfold let ( =^ )  = eq
+unfold let ( <>^ ) = ne
+unfold let ( >^ )  = gt
+unfold let ( >=^ ) = gte
+unfold let ( <^ )  = lt
+unfold let ( <=^ ) = lte
 
 (**** To input / output constants *)
 (** In decimal representation *)

--- a/.scripts/FStar.UIntN.fstip
+++ b/.scripts/FStar.UIntN.fstip
@@ -203,6 +203,9 @@ val shift_left (a:t) (s:UInt32.t) : Pure t
     operator [=] *)
 let eq (a:t) (b:t) : Tot bool = eq #n (v a) (v b)
 
+(** Inequality *)
+let ne (a:t) (b:t) : Tot bool = ne #n (v a) (v b)
+
 (** Greater than *)
 let gt (a:t) (b:t) : Tot bool = gt #n (v a) (v b)
 
@@ -311,6 +314,7 @@ unfold let op_Bar_Hat = logor
 unfold let op_Less_Less_Hat = shift_left
 unfold let op_Greater_Greater_Hat = shift_right
 unfold let op_Equals_Hat = eq
+unfold let op_Not_Equals_Hat = ne
 unfold let op_Greater_Hat = gt
 unfold let op_Greater_Equals_Hat = gte
 unfold let op_Less_Hat = lt

--- a/src/typechecker/FStarC.TypeChecker.Normalize.Unfolding.fst
+++ b/src/typechecker/FStarC.TypeChecker.Normalize.Unfolding.fst
@@ -10,7 +10,6 @@ open FStarC.Syntax.Print
 module Common = FStarC.TypeChecker.Common
 module BU = FStarC.Util
 module Path = FStarC.Path
-module PC = FStarC.Parser.Const
 module S = FStarC.Syntax.Syntax
 module U = FStarC.Syntax.Util
 

--- a/src/typechecker/FStarC.TypeChecker.Tc.fst
+++ b/src/typechecker/FStarC.TypeChecker.Tc.fst
@@ -49,7 +49,6 @@ module TcInductive = FStarC.TypeChecker.TcInductive
 module TcEff = FStarC.TypeChecker.TcEffect
 module PC = FStarC.Parser.Const
 module EMB = FStarC.Syntax.Embeddings
-module ToSyntax = FStarC.ToSyntax.ToSyntax
 
 let dbg_TwoPhases = Debug.get_toggle "TwoPhases"
 let dbg_IdInfoOn  = Debug.get_toggle "IdInfoOn"

--- a/ulib/FStar.Int.fsti
+++ b/ulib/FStar.Int.fsti
@@ -177,10 +177,11 @@ let mod (#n:pos) (a:int_t n) (b:int_t n{b <> 0}) : Tot (int_t n) =
   a - ((a/b) * b)
 
 (* Comparison operators *)
-let eq #n (a:int_t n) (b:int_t n) : Tot bool = a = b
-let gt #n (a:int_t n) (b:int_t n) : Tot bool = a > b
+let eq  #n (a:int_t n) (b:int_t n) : Tot bool = a = b
+let ne  #n (a:int_t n) (b:int_t n) : Tot bool = a <> b
+let gt  #n (a:int_t n) (b:int_t n) : Tot bool = a > b
 let gte #n (a:int_t n) (b:int_t n) : Tot bool = a >= b
-let lt #n (a:int_t n) (b:int_t n) : Tot bool = a < b
+let lt  #n (a:int_t n) (b:int_t n) : Tot bool = a < b
 let lte #n (a:int_t n) (b:int_t n) : Tot bool = a <= b
 
 /// Casts

--- a/ulib/FStar.Int128.fsti
+++ b/ulib/FStar.Int128.fsti
@@ -121,23 +121,23 @@ let lt ( a:t) (b:t) : Tot bool = lt  #n (v a) (v b)
 let lte (a:t) (b:t) : Tot bool = lte #n (v a) (v b)
 
 (* Infix notations *)
-unfold let op_Plus_Hat = add
-unfold let op_Subtraction_Hat = sub
-unfold let op_Star_Hat = mul
-unfold let op_Slash_Hat = div
-unfold let op_Percent_Hat = rem
-unfold let op_Hat_Hat = logxor
-unfold let op_Amp_Hat = logand
-unfold let op_Bar_Hat = logor
-unfold let op_Less_Less_Hat = shift_left
-unfold let op_Greater_Greater_Hat = shift_right
-unfold let op_Greater_Greater_Greater_Hat = shift_arithmetic_right
-unfold let op_Equals_Hat = eq
-unfold let op_Not_Equals_Hat = ne
-unfold let op_Greater_Hat = gt
-unfold let op_Greater_Equals_Hat = gte
-unfold let op_Less_Hat = lt
-unfold let op_Less_Equals_Hat = lte
+unfold let ( +^ )  = add
+unfold let ( -^ )  = sub
+unfold let ( *^ )  = mul
+unfold let ( /^ )  = div
+unfold let ( %^ )  = rem
+unfold let ( ^^ )  = logxor
+unfold let ( &^ )  = logand
+unfold let ( |^ )  = logor
+unfold let ( <<^ ) = shift_left
+unfold let ( >>^ ) = shift_right
+unfold let ( >>>^) = shift_arithmetic_right
+unfold let ( =^ )  = eq
+unfold let ( <>^ ) = ne
+unfold let ( >^ )  = gt
+unfold let ( >=^ ) = gte
+unfold let ( <^ )  = lt
+unfold let ( <=^ ) = lte
 
 inline_for_extraction
 let ct_abs (a:t{min_int n < v a}) : Tot (b:t{v b = abs (v a)}) =

--- a/ulib/FStar.Int128.fsti
+++ b/ulib/FStar.Int128.fsti
@@ -113,10 +113,11 @@ val shift_arithmetic_right (a:t) (s:UInt32.t) : Pure t
   (ensures (fun c -> FStar.Int.shift_arithmetic_right (v a) (UInt32.v s) = v c))
 
 (* Comparison operators *)
-let eq (a:t) (b:t) : Tot bool = eq #n (v a) (v b)
-let gt (a:t) (b:t) : Tot bool = gt #n (v a) (v b)
+let eq  (a:t) (b:t) : Tot bool = eq  #n (v a) (v b)
+let ne  (a:t) (b:t) : Tot bool = ne  #n (v a) (v b)
+let gt  (a:t) (b:t) : Tot bool = gt  #n (v a) (v b)
 let gte (a:t) (b:t) : Tot bool = gte #n (v a) (v b)
-let lt (a:t) (b:t) : Tot bool = lt #n (v a) (v b)
+let lt ( a:t) (b:t) : Tot bool = lt  #n (v a) (v b)
 let lte (a:t) (b:t) : Tot bool = lte #n (v a) (v b)
 
 (* Infix notations *)
@@ -132,6 +133,7 @@ unfold let op_Less_Less_Hat = shift_left
 unfold let op_Greater_Greater_Hat = shift_right
 unfold let op_Greater_Greater_Greater_Hat = shift_arithmetic_right
 unfold let op_Equals_Hat = eq
+unfold let op_Not_Equals_Hat = ne
 unfold let op_Greater_Hat = gt
 unfold let op_Greater_Equals_Hat = gte
 unfold let op_Less_Hat = lt

--- a/ulib/FStar.Int16.fsti
+++ b/ulib/FStar.Int16.fsti
@@ -121,23 +121,23 @@ let lt ( a:t) (b:t) : Tot bool = lt  #n (v a) (v b)
 let lte (a:t) (b:t) : Tot bool = lte #n (v a) (v b)
 
 (* Infix notations *)
-unfold let op_Plus_Hat = add
-unfold let op_Subtraction_Hat = sub
-unfold let op_Star_Hat = mul
-unfold let op_Slash_Hat = div
-unfold let op_Percent_Hat = rem
-unfold let op_Hat_Hat = logxor
-unfold let op_Amp_Hat = logand
-unfold let op_Bar_Hat = logor
-unfold let op_Less_Less_Hat = shift_left
-unfold let op_Greater_Greater_Hat = shift_right
-unfold let op_Greater_Greater_Greater_Hat = shift_arithmetic_right
-unfold let op_Equals_Hat = eq
-unfold let op_Not_Equals_Hat = ne
-unfold let op_Greater_Hat = gt
-unfold let op_Greater_Equals_Hat = gte
-unfold let op_Less_Hat = lt
-unfold let op_Less_Equals_Hat = lte
+unfold let ( +^ )  = add
+unfold let ( -^ )  = sub
+unfold let ( *^ )  = mul
+unfold let ( /^ )  = div
+unfold let ( %^ )  = rem
+unfold let ( ^^ )  = logxor
+unfold let ( &^ )  = logand
+unfold let ( |^ )  = logor
+unfold let ( <<^ ) = shift_left
+unfold let ( >>^ ) = shift_right
+unfold let ( >>>^) = shift_arithmetic_right
+unfold let ( =^ )  = eq
+unfold let ( <>^ ) = ne
+unfold let ( >^ )  = gt
+unfold let ( >=^ ) = gte
+unfold let ( <^ )  = lt
+unfold let ( <=^ ) = lte
 
 inline_for_extraction
 let ct_abs (a:t{min_int n < v a}) : Tot (b:t{v b = abs (v a)}) =

--- a/ulib/FStar.Int16.fsti
+++ b/ulib/FStar.Int16.fsti
@@ -113,10 +113,11 @@ val shift_arithmetic_right (a:t) (s:UInt32.t) : Pure t
   (ensures (fun c -> FStar.Int.shift_arithmetic_right (v a) (UInt32.v s) = v c))
 
 (* Comparison operators *)
-let eq (a:t) (b:t) : Tot bool = eq #n (v a) (v b)
-let gt (a:t) (b:t) : Tot bool = gt #n (v a) (v b)
+let eq  (a:t) (b:t) : Tot bool = eq  #n (v a) (v b)
+let ne  (a:t) (b:t) : Tot bool = ne  #n (v a) (v b)
+let gt  (a:t) (b:t) : Tot bool = gt  #n (v a) (v b)
 let gte (a:t) (b:t) : Tot bool = gte #n (v a) (v b)
-let lt (a:t) (b:t) : Tot bool = lt #n (v a) (v b)
+let lt ( a:t) (b:t) : Tot bool = lt  #n (v a) (v b)
 let lte (a:t) (b:t) : Tot bool = lte #n (v a) (v b)
 
 (* Infix notations *)
@@ -132,6 +133,7 @@ unfold let op_Less_Less_Hat = shift_left
 unfold let op_Greater_Greater_Hat = shift_right
 unfold let op_Greater_Greater_Greater_Hat = shift_arithmetic_right
 unfold let op_Equals_Hat = eq
+unfold let op_Not_Equals_Hat = ne
 unfold let op_Greater_Hat = gt
 unfold let op_Greater_Equals_Hat = gte
 unfold let op_Less_Hat = lt

--- a/ulib/FStar.Int32.fsti
+++ b/ulib/FStar.Int32.fsti
@@ -121,23 +121,23 @@ let lt ( a:t) (b:t) : Tot bool = lt  #n (v a) (v b)
 let lte (a:t) (b:t) : Tot bool = lte #n (v a) (v b)
 
 (* Infix notations *)
-unfold let op_Plus_Hat = add
-unfold let op_Subtraction_Hat = sub
-unfold let op_Star_Hat = mul
-unfold let op_Slash_Hat = div
-unfold let op_Percent_Hat = rem
-unfold let op_Hat_Hat = logxor
-unfold let op_Amp_Hat = logand
-unfold let op_Bar_Hat = logor
-unfold let op_Less_Less_Hat = shift_left
-unfold let op_Greater_Greater_Hat = shift_right
-unfold let op_Greater_Greater_Greater_Hat = shift_arithmetic_right
-unfold let op_Equals_Hat = eq
-unfold let op_Not_Equals_Hat = ne
-unfold let op_Greater_Hat = gt
-unfold let op_Greater_Equals_Hat = gte
-unfold let op_Less_Hat = lt
-unfold let op_Less_Equals_Hat = lte
+unfold let ( +^ )  = add
+unfold let ( -^ )  = sub
+unfold let ( *^ )  = mul
+unfold let ( /^ )  = div
+unfold let ( %^ )  = rem
+unfold let ( ^^ )  = logxor
+unfold let ( &^ )  = logand
+unfold let ( |^ )  = logor
+unfold let ( <<^ ) = shift_left
+unfold let ( >>^ ) = shift_right
+unfold let ( >>>^) = shift_arithmetic_right
+unfold let ( =^ )  = eq
+unfold let ( <>^ ) = ne
+unfold let ( >^ )  = gt
+unfold let ( >=^ ) = gte
+unfold let ( <^ )  = lt
+unfold let ( <=^ ) = lte
 
 inline_for_extraction
 let ct_abs (a:t{min_int n < v a}) : Tot (b:t{v b = abs (v a)}) =

--- a/ulib/FStar.Int32.fsti
+++ b/ulib/FStar.Int32.fsti
@@ -113,10 +113,11 @@ val shift_arithmetic_right (a:t) (s:UInt32.t) : Pure t
   (ensures (fun c -> FStar.Int.shift_arithmetic_right (v a) (UInt32.v s) = v c))
 
 (* Comparison operators *)
-let eq (a:t) (b:t) : Tot bool = eq #n (v a) (v b)
-let gt (a:t) (b:t) : Tot bool = gt #n (v a) (v b)
+let eq  (a:t) (b:t) : Tot bool = eq  #n (v a) (v b)
+let ne  (a:t) (b:t) : Tot bool = ne  #n (v a) (v b)
+let gt  (a:t) (b:t) : Tot bool = gt  #n (v a) (v b)
 let gte (a:t) (b:t) : Tot bool = gte #n (v a) (v b)
-let lt (a:t) (b:t) : Tot bool = lt #n (v a) (v b)
+let lt ( a:t) (b:t) : Tot bool = lt  #n (v a) (v b)
 let lte (a:t) (b:t) : Tot bool = lte #n (v a) (v b)
 
 (* Infix notations *)
@@ -132,6 +133,7 @@ unfold let op_Less_Less_Hat = shift_left
 unfold let op_Greater_Greater_Hat = shift_right
 unfold let op_Greater_Greater_Greater_Hat = shift_arithmetic_right
 unfold let op_Equals_Hat = eq
+unfold let op_Not_Equals_Hat = ne
 unfold let op_Greater_Hat = gt
 unfold let op_Greater_Equals_Hat = gte
 unfold let op_Less_Hat = lt

--- a/ulib/FStar.Int64.fsti
+++ b/ulib/FStar.Int64.fsti
@@ -121,23 +121,23 @@ let lt ( a:t) (b:t) : Tot bool = lt  #n (v a) (v b)
 let lte (a:t) (b:t) : Tot bool = lte #n (v a) (v b)
 
 (* Infix notations *)
-unfold let op_Plus_Hat = add
-unfold let op_Subtraction_Hat = sub
-unfold let op_Star_Hat = mul
-unfold let op_Slash_Hat = div
-unfold let op_Percent_Hat = rem
-unfold let op_Hat_Hat = logxor
-unfold let op_Amp_Hat = logand
-unfold let op_Bar_Hat = logor
-unfold let op_Less_Less_Hat = shift_left
-unfold let op_Greater_Greater_Hat = shift_right
-unfold let op_Greater_Greater_Greater_Hat = shift_arithmetic_right
-unfold let op_Equals_Hat = eq
-unfold let op_Not_Equals_Hat = ne
-unfold let op_Greater_Hat = gt
-unfold let op_Greater_Equals_Hat = gte
-unfold let op_Less_Hat = lt
-unfold let op_Less_Equals_Hat = lte
+unfold let ( +^ )  = add
+unfold let ( -^ )  = sub
+unfold let ( *^ )  = mul
+unfold let ( /^ )  = div
+unfold let ( %^ )  = rem
+unfold let ( ^^ )  = logxor
+unfold let ( &^ )  = logand
+unfold let ( |^ )  = logor
+unfold let ( <<^ ) = shift_left
+unfold let ( >>^ ) = shift_right
+unfold let ( >>>^) = shift_arithmetic_right
+unfold let ( =^ )  = eq
+unfold let ( <>^ ) = ne
+unfold let ( >^ )  = gt
+unfold let ( >=^ ) = gte
+unfold let ( <^ )  = lt
+unfold let ( <=^ ) = lte
 
 inline_for_extraction
 let ct_abs (a:t{min_int n < v a}) : Tot (b:t{v b = abs (v a)}) =

--- a/ulib/FStar.Int64.fsti
+++ b/ulib/FStar.Int64.fsti
@@ -113,10 +113,11 @@ val shift_arithmetic_right (a:t) (s:UInt32.t) : Pure t
   (ensures (fun c -> FStar.Int.shift_arithmetic_right (v a) (UInt32.v s) = v c))
 
 (* Comparison operators *)
-let eq (a:t) (b:t) : Tot bool = eq #n (v a) (v b)
-let gt (a:t) (b:t) : Tot bool = gt #n (v a) (v b)
+let eq  (a:t) (b:t) : Tot bool = eq  #n (v a) (v b)
+let ne  (a:t) (b:t) : Tot bool = ne  #n (v a) (v b)
+let gt  (a:t) (b:t) : Tot bool = gt  #n (v a) (v b)
 let gte (a:t) (b:t) : Tot bool = gte #n (v a) (v b)
-let lt (a:t) (b:t) : Tot bool = lt #n (v a) (v b)
+let lt ( a:t) (b:t) : Tot bool = lt  #n (v a) (v b)
 let lte (a:t) (b:t) : Tot bool = lte #n (v a) (v b)
 
 (* Infix notations *)
@@ -132,6 +133,7 @@ unfold let op_Less_Less_Hat = shift_left
 unfold let op_Greater_Greater_Hat = shift_right
 unfold let op_Greater_Greater_Greater_Hat = shift_arithmetic_right
 unfold let op_Equals_Hat = eq
+unfold let op_Not_Equals_Hat = ne
 unfold let op_Greater_Hat = gt
 unfold let op_Greater_Equals_Hat = gte
 unfold let op_Less_Hat = lt

--- a/ulib/FStar.Int8.fsti
+++ b/ulib/FStar.Int8.fsti
@@ -121,23 +121,23 @@ let lt ( a:t) (b:t) : Tot bool = lt  #n (v a) (v b)
 let lte (a:t) (b:t) : Tot bool = lte #n (v a) (v b)
 
 (* Infix notations *)
-unfold let op_Plus_Hat = add
-unfold let op_Subtraction_Hat = sub
-unfold let op_Star_Hat = mul
-unfold let op_Slash_Hat = div
-unfold let op_Percent_Hat = rem
-unfold let op_Hat_Hat = logxor
-unfold let op_Amp_Hat = logand
-unfold let op_Bar_Hat = logor
-unfold let op_Less_Less_Hat = shift_left
-unfold let op_Greater_Greater_Hat = shift_right
-unfold let op_Greater_Greater_Greater_Hat = shift_arithmetic_right
-unfold let op_Equals_Hat = eq
-unfold let op_Not_Equals_Hat = ne
-unfold let op_Greater_Hat = gt
-unfold let op_Greater_Equals_Hat = gte
-unfold let op_Less_Hat = lt
-unfold let op_Less_Equals_Hat = lte
+unfold let ( +^ )  = add
+unfold let ( -^ )  = sub
+unfold let ( *^ )  = mul
+unfold let ( /^ )  = div
+unfold let ( %^ )  = rem
+unfold let ( ^^ )  = logxor
+unfold let ( &^ )  = logand
+unfold let ( |^ )  = logor
+unfold let ( <<^ ) = shift_left
+unfold let ( >>^ ) = shift_right
+unfold let ( >>>^) = shift_arithmetic_right
+unfold let ( =^ )  = eq
+unfold let ( <>^ ) = ne
+unfold let ( >^ )  = gt
+unfold let ( >=^ ) = gte
+unfold let ( <^ )  = lt
+unfold let ( <=^ ) = lte
 
 inline_for_extraction
 let ct_abs (a:t{min_int n < v a}) : Tot (b:t{v b = abs (v a)}) =

--- a/ulib/FStar.Int8.fsti
+++ b/ulib/FStar.Int8.fsti
@@ -113,10 +113,11 @@ val shift_arithmetic_right (a:t) (s:UInt32.t) : Pure t
   (ensures (fun c -> FStar.Int.shift_arithmetic_right (v a) (UInt32.v s) = v c))
 
 (* Comparison operators *)
-let eq (a:t) (b:t) : Tot bool = eq #n (v a) (v b)
-let gt (a:t) (b:t) : Tot bool = gt #n (v a) (v b)
+let eq  (a:t) (b:t) : Tot bool = eq  #n (v a) (v b)
+let ne  (a:t) (b:t) : Tot bool = ne  #n (v a) (v b)
+let gt  (a:t) (b:t) : Tot bool = gt  #n (v a) (v b)
 let gte (a:t) (b:t) : Tot bool = gte #n (v a) (v b)
-let lt (a:t) (b:t) : Tot bool = lt #n (v a) (v b)
+let lt ( a:t) (b:t) : Tot bool = lt  #n (v a) (v b)
 let lte (a:t) (b:t) : Tot bool = lte #n (v a) (v b)
 
 (* Infix notations *)
@@ -132,6 +133,7 @@ unfold let op_Less_Less_Hat = shift_left
 unfold let op_Greater_Greater_Hat = shift_right
 unfold let op_Greater_Greater_Greater_Hat = shift_arithmetic_right
 unfold let op_Equals_Hat = eq
+unfold let op_Not_Equals_Hat = ne
 unfold let op_Greater_Hat = gt
 unfold let op_Greater_Equals_Hat = gte
 unfold let op_Less_Hat = lt

--- a/ulib/FStar.SizeT.fst
+++ b/ulib/FStar.SizeT.fst
@@ -79,6 +79,8 @@ let div x y =
   res
 
 let rem x y = Sz <| U64.rem x.x y.x
+let eq  x y = U64.eq  x.x y.x
+let ne  x y = U64.ne  x.x y.x
 let gt  x y = U64.gt  x.x y.x
 let gte x y = U64.gte x.x y.x
 let lt  x y = U64.lt  x.x y.x

--- a/ulib/FStar.SizeT.fsti
+++ b/ulib/FStar.SizeT.fsti
@@ -140,6 +140,16 @@ val rem (a:t) (b:t{v b <> 0}) : Pure t
   (requires True)
   (ensures (fun c -> mod_spec (v a) (v b) = v c))
 
+(** Equal *)
+val eq (x y:t) : Pure bool
+  (requires True)
+  (ensures (fun z -> z == (v x = v y)))
+
+(** Not equal *)
+val ne (x y:t) : Pure bool
+  (requires True)
+  (ensures (fun z -> z == (v x <> v y)))
+
 (** Greater than *)
 val gt (x y:t) : Pure bool
   (requires True)
@@ -166,9 +176,11 @@ unfold let ( +^ ) = add
 unfold let ( -^ ) = sub
 unfold let ( *^ ) = mul
 unfold let ( %^ ) = rem
-unfold let ( >^ ) = gt
+unfold let ( =^ )  = eq
+unfold let ( <>^ ) = ne
+unfold let ( >^ )  = gt
 unfold let ( >=^ ) = gte
-unfold let ( <^ ) = lt
+unfold let ( <^ )  = lt
 unfold let ( <=^ ) = lte
 
 //This private primitive is used internally by the

--- a/ulib/FStar.UInt.fsti
+++ b/ulib/FStar.UInt.fsti
@@ -163,10 +163,11 @@ let mod (#n:nat) (a:uint_t n) (b:uint_t n{b <> 0}) : Tot (uint_t n) =
   a - ((a/b) * b)
 
 (* Comparison operators *)
-let eq #n (a:uint_t n) (b:uint_t n) : Tot bool = (a = b)
-let gt #n (a:uint_t n) (b:uint_t n) : Tot bool = (a > b)
+let eq  #n (a:uint_t n) (b:uint_t n) : Tot bool = (a = b)
+let ne  #n (a:uint_t n) (b:uint_t n) : Tot bool = (a <> b)
+let gt  #n (a:uint_t n) (b:uint_t n) : Tot bool = (a > b)
 let gte #n (a:uint_t n) (b:uint_t n) : Tot bool = (a >= b)
-let lt #n (a:uint_t n) (b:uint_t n) : Tot bool = (a < b)
+let lt  #n (a:uint_t n) (b:uint_t n) : Tot bool = (a < b)
 let lte #n (a:uint_t n) (b:uint_t n) : Tot bool = (a <= b)
 
 /// Casts

--- a/ulib/FStar.UInt16.fsti
+++ b/ulib/FStar.UInt16.fsti
@@ -224,6 +224,9 @@ val shift_left (a:t) (s:UInt32.t) : Pure t
     operator [=] *)
 let eq (a:t) (b:t) : Tot bool = eq #n (v a) (v b)
 
+(** Inequality *)
+let ne (a:t) (b:t) : Tot bool = ne #n (v a) (v b)
+
 (** Greater than *)
 let gt (a:t) (b:t) : Tot bool = gt #n (v a) (v b)
 
@@ -332,6 +335,7 @@ unfold let op_Bar_Hat = logor
 unfold let op_Less_Less_Hat = shift_left
 unfold let op_Greater_Greater_Hat = shift_right
 unfold let op_Equals_Hat = eq
+unfold let op_Not_Equals_Hat = ne
 unfold let op_Greater_Hat = gt
 unfold let op_Greater_Equals_Hat = gte
 unfold let op_Less_Hat = lt

--- a/ulib/FStar.UInt16.fsti
+++ b/ulib/FStar.UInt16.fsti
@@ -318,28 +318,28 @@ let gte_mask (a:t) (b:t)
 #reset-options
 
 (*** Infix notations *)
-unfold let op_Plus_Hat = add
-unfold let op_Plus_Question_Hat = add_underspec
-unfold let op_Plus_Percent_Hat = add_mod
-unfold let op_Subtraction_Hat = sub
-unfold let op_Subtraction_Question_Hat = sub_underspec
-unfold let op_Subtraction_Percent_Hat = sub_mod
-unfold let op_Star_Hat = mul
-unfold let op_Star_Question_Hat = mul_underspec
-unfold let op_Star_Percent_Hat = mul_mod
-unfold let op_Slash_Hat = div
-unfold let op_Percent_Hat = rem
-unfold let op_Hat_Hat = logxor
-unfold let op_Amp_Hat = logand
-unfold let op_Bar_Hat = logor
-unfold let op_Less_Less_Hat = shift_left
-unfold let op_Greater_Greater_Hat = shift_right
-unfold let op_Equals_Hat = eq
-unfold let op_Not_Equals_Hat = ne
-unfold let op_Greater_Hat = gt
-unfold let op_Greater_Equals_Hat = gte
-unfold let op_Less_Hat = lt
-unfold let op_Less_Equals_Hat = lte
+unfold let ( +^ )  = add
+unfold let ( +?^ ) = add_underspec
+unfold let ( +%^ ) = add_mod
+unfold let ( -^ )  = sub
+unfold let ( -?^ ) = sub_underspec
+unfold let ( -%^ ) = sub_mod
+unfold let ( *^ ) = mul
+unfold let ( *?^ )= mul_underspec
+unfold let ( *%^ )= mul_mod
+unfold let ( /^ )  = div
+unfold let ( %^ )  = rem
+unfold let ( ^^ )  = logxor
+unfold let ( &^ )  = logand
+unfold let ( |^ )  = logor
+unfold let ( <<^ ) = shift_left
+unfold let ( >>^ ) = shift_right
+unfold let ( =^ )  = eq
+unfold let ( <>^ ) = ne
+unfold let ( >^ )  = gt
+unfold let ( >=^ ) = gte
+unfold let ( <^ )  = lt
+unfold let ( <=^ ) = lte
 
 (**** To input / output constants *)
 (** In decimal representation *)

--- a/ulib/FStar.UInt32.fsti
+++ b/ulib/FStar.UInt32.fsti
@@ -318,28 +318,28 @@ let gte_mask (a:t) (b:t)
 #reset-options
 
 (*** Infix notations *)
-unfold let op_Plus_Hat = add
-unfold let op_Plus_Question_Hat = add_underspec
-unfold let op_Plus_Percent_Hat = add_mod
-unfold let op_Subtraction_Hat = sub
-unfold let op_Subtraction_Question_Hat = sub_underspec
-unfold let op_Subtraction_Percent_Hat = sub_mod
-unfold let op_Star_Hat = mul
-unfold let op_Star_Question_Hat = mul_underspec
-unfold let op_Star_Percent_Hat = mul_mod
-unfold let op_Slash_Hat = div
-unfold let op_Percent_Hat = rem
-unfold let op_Hat_Hat = logxor
-unfold let op_Amp_Hat = logand
-unfold let op_Bar_Hat = logor
-unfold let op_Less_Less_Hat = shift_left
-unfold let op_Greater_Greater_Hat = shift_right
-unfold let op_Equals_Hat = eq
-unfold let op_Not_Equals_Hat = ne
-unfold let op_Greater_Hat = gt
-unfold let op_Greater_Equals_Hat = gte
-unfold let op_Less_Hat = lt
-unfold let op_Less_Equals_Hat = lte
+unfold let ( +^ )  = add
+unfold let ( +?^ ) = add_underspec
+unfold let ( +%^ ) = add_mod
+unfold let ( -^ )  = sub
+unfold let ( -?^ ) = sub_underspec
+unfold let ( -%^ ) = sub_mod
+unfold let ( *^ ) = mul
+unfold let ( *?^ )= mul_underspec
+unfold let ( *%^ )= mul_mod
+unfold let ( /^ )  = div
+unfold let ( %^ )  = rem
+unfold let ( ^^ )  = logxor
+unfold let ( &^ )  = logand
+unfold let ( |^ )  = logor
+unfold let ( <<^ ) = shift_left
+unfold let ( >>^ ) = shift_right
+unfold let ( =^ )  = eq
+unfold let ( <>^ ) = ne
+unfold let ( >^ )  = gt
+unfold let ( >=^ ) = gte
+unfold let ( <^ )  = lt
+unfold let ( <=^ ) = lte
 
 (**** To input / output constants *)
 (** In decimal representation *)

--- a/ulib/FStar.UInt32.fsti
+++ b/ulib/FStar.UInt32.fsti
@@ -224,6 +224,9 @@ val shift_left (a:t) (s:t) : Pure t
     operator [=] *)
 let eq (a:t) (b:t) : Tot bool = eq #n (v a) (v b)
 
+(** Inequality *)
+let ne (a:t) (b:t) : Tot bool = ne #n (v a) (v b)
+
 (** Greater than *)
 let gt (a:t) (b:t) : Tot bool = gt #n (v a) (v b)
 
@@ -332,6 +335,7 @@ unfold let op_Bar_Hat = logor
 unfold let op_Less_Less_Hat = shift_left
 unfold let op_Greater_Greater_Hat = shift_right
 unfold let op_Equals_Hat = eq
+unfold let op_Not_Equals_Hat = ne
 unfold let op_Greater_Hat = gt
 unfold let op_Greater_Equals_Hat = gte
 unfold let op_Less_Hat = lt

--- a/ulib/FStar.UInt64.fsti
+++ b/ulib/FStar.UInt64.fsti
@@ -224,6 +224,9 @@ val shift_left (a:t) (s:UInt32.t) : Pure t
     operator [=] *)
 let eq (a:t) (b:t) : Tot bool = eq #n (v a) (v b)
 
+(** Inequality *)
+let ne (a:t) (b:t) : Tot bool = ne #n (v a) (v b)
+
 (** Greater than *)
 let gt (a:t) (b:t) : Tot bool = gt #n (v a) (v b)
 
@@ -332,6 +335,7 @@ unfold let op_Bar_Hat = logor
 unfold let op_Less_Less_Hat = shift_left
 unfold let op_Greater_Greater_Hat = shift_right
 unfold let op_Equals_Hat = eq
+unfold let op_Not_Equals_Hat = ne
 unfold let op_Greater_Hat = gt
 unfold let op_Greater_Equals_Hat = gte
 unfold let op_Less_Hat = lt

--- a/ulib/FStar.UInt64.fsti
+++ b/ulib/FStar.UInt64.fsti
@@ -318,28 +318,28 @@ let gte_mask (a:t) (b:t)
 #reset-options
 
 (*** Infix notations *)
-unfold let op_Plus_Hat = add
-unfold let op_Plus_Question_Hat = add_underspec
-unfold let op_Plus_Percent_Hat = add_mod
-unfold let op_Subtraction_Hat = sub
-unfold let op_Subtraction_Question_Hat = sub_underspec
-unfold let op_Subtraction_Percent_Hat = sub_mod
-unfold let op_Star_Hat = mul
-unfold let op_Star_Question_Hat = mul_underspec
-unfold let op_Star_Percent_Hat = mul_mod
-unfold let op_Slash_Hat = div
-unfold let op_Percent_Hat = rem
-unfold let op_Hat_Hat = logxor
-unfold let op_Amp_Hat = logand
-unfold let op_Bar_Hat = logor
-unfold let op_Less_Less_Hat = shift_left
-unfold let op_Greater_Greater_Hat = shift_right
-unfold let op_Equals_Hat = eq
-unfold let op_Not_Equals_Hat = ne
-unfold let op_Greater_Hat = gt
-unfold let op_Greater_Equals_Hat = gte
-unfold let op_Less_Hat = lt
-unfold let op_Less_Equals_Hat = lte
+unfold let ( +^ )  = add
+unfold let ( +?^ ) = add_underspec
+unfold let ( +%^ ) = add_mod
+unfold let ( -^ )  = sub
+unfold let ( -?^ ) = sub_underspec
+unfold let ( -%^ ) = sub_mod
+unfold let ( *^ ) = mul
+unfold let ( *?^ )= mul_underspec
+unfold let ( *%^ )= mul_mod
+unfold let ( /^ )  = div
+unfold let ( %^ )  = rem
+unfold let ( ^^ )  = logxor
+unfold let ( &^ )  = logand
+unfold let ( |^ )  = logor
+unfold let ( <<^ ) = shift_left
+unfold let ( >>^ ) = shift_right
+unfold let ( =^ )  = eq
+unfold let ( <>^ ) = ne
+unfold let ( >^ )  = gt
+unfold let ( >=^ ) = gte
+unfold let ( <^ )  = lt
+unfold let ( <=^ ) = lte
 
 (**** To input / output constants *)
 (** In decimal representation *)

--- a/ulib/FStar.UInt8.fsti
+++ b/ulib/FStar.UInt8.fsti
@@ -224,6 +224,9 @@ val shift_left (a:t) (s:UInt32.t) : Pure t
     operator [=] *)
 let eq (a:t) (b:t) : Tot bool = eq #n (v a) (v b)
 
+(** Inequality *)
+let ne (a:t) (b:t) : Tot bool = ne #n (v a) (v b)
+
 (** Greater than *)
 let gt (a:t) (b:t) : Tot bool = gt #n (v a) (v b)
 
@@ -332,6 +335,7 @@ unfold let op_Bar_Hat = logor
 unfold let op_Less_Less_Hat = shift_left
 unfold let op_Greater_Greater_Hat = shift_right
 unfold let op_Equals_Hat = eq
+unfold let op_Not_Equals_Hat = ne
 unfold let op_Greater_Hat = gt
 unfold let op_Greater_Equals_Hat = gte
 unfold let op_Less_Hat = lt

--- a/ulib/FStar.UInt8.fsti
+++ b/ulib/FStar.UInt8.fsti
@@ -318,28 +318,28 @@ let gte_mask (a:t) (b:t)
 #reset-options
 
 (*** Infix notations *)
-unfold let op_Plus_Hat = add
-unfold let op_Plus_Question_Hat = add_underspec
-unfold let op_Plus_Percent_Hat = add_mod
-unfold let op_Subtraction_Hat = sub
-unfold let op_Subtraction_Question_Hat = sub_underspec
-unfold let op_Subtraction_Percent_Hat = sub_mod
-unfold let op_Star_Hat = mul
-unfold let op_Star_Question_Hat = mul_underspec
-unfold let op_Star_Percent_Hat = mul_mod
-unfold let op_Slash_Hat = div
-unfold let op_Percent_Hat = rem
-unfold let op_Hat_Hat = logxor
-unfold let op_Amp_Hat = logand
-unfold let op_Bar_Hat = logor
-unfold let op_Less_Less_Hat = shift_left
-unfold let op_Greater_Greater_Hat = shift_right
-unfold let op_Equals_Hat = eq
-unfold let op_Not_Equals_Hat = ne
-unfold let op_Greater_Hat = gt
-unfold let op_Greater_Equals_Hat = gte
-unfold let op_Less_Hat = lt
-unfold let op_Less_Equals_Hat = lte
+unfold let ( +^ )  = add
+unfold let ( +?^ ) = add_underspec
+unfold let ( +%^ ) = add_mod
+unfold let ( -^ )  = sub
+unfold let ( -?^ ) = sub_underspec
+unfold let ( -%^ ) = sub_mod
+unfold let ( *^ ) = mul
+unfold let ( *?^ )= mul_underspec
+unfold let ( *%^ )= mul_mod
+unfold let ( /^ )  = div
+unfold let ( %^ )  = rem
+unfold let ( ^^ )  = logxor
+unfold let ( &^ )  = logand
+unfold let ( |^ )  = logor
+unfold let ( <<^ ) = shift_left
+unfold let ( >>^ ) = shift_right
+unfold let ( =^ )  = eq
+unfold let ( <>^ ) = ne
+unfold let ( >^ )  = gt
+unfold let ( >=^ ) = gte
+unfold let ( <^ )  = lt
+unfold let ( <=^ ) = lte
 
 (**** To input / output constants *)
 (** In decimal representation *)

--- a/ulib/ml/app/ints/FStar_Ints.ml.body
+++ b/ulib/ml/app/ints/FStar_Ints.ml.body
@@ -62,6 +62,7 @@ let shift_arithmetic_right = shift_right
 
 (* Comparison operators *)
 let eq  (a:t) (b:t) : bool = a = b
+let ne  (a:t) (b:t) : bool = a <> b
 let gt  (a:t) (b:t) : bool = a > b
 let gte (a:t) (b:t) : bool = a >= b
 let lt  (a:t) (b:t) : bool = a < b


### PR DESCRIPTION
- add `ne` to all of them
- use operator syntax instead of mangled names