### PR TITLE
Make ForExtraction imply EraseUniverses

### DIFF
--- a/src/typechecker/FStarC.TypeChecker.Cfg.fst
+++ b/src/typechecker/FStarC.TypeChecker.Cfg.fst
@@ -209,7 +209,8 @@ let fstep_add_one s fs =
     | Unmeta ->  { fs with unmeta = true }
     | Unascribe ->  { fs with unascribe = true }
     | NBE -> {fs with nbe_step = true }
-    | ForExtraction -> {fs with for_extraction = true }
+    // for_extraction requires erase_universes, otherwise @@extract_as fails on universe-polymorphic applications
+    | ForExtraction -> {fs with for_extraction = true; erase_universes = true }
     | Unrefine -> {fs with unrefine = true }
     | NormDebug -> fs // handled above, affects only dbg flags
     | DefaultUnivsToZero -> {fs with default_univs_to_zero = true}


### PR DESCRIPTION
I could not reproduce this in a short example, but there are several places in the ML extraction code where we call normalization with ForExtraction set, but *not* EraseUniverses.  This predictably breaks extract_as on universe-polymorphic functions (because normalizes the fvar to an abstraction and then the abstraction is applied to universe instances).

The most robust fix seems to be to have ForExtraction imply EraseUniverses, then you can't forget the flag at all.  This is what I'm doing in this PR.