### PR TITLE
All: simplify fuel settings

### DIFF
--- a/.scripts/FStar.IntN.fstip
+++ b/.scripts/FStar.IntN.fstip
@@ -1,7 +1,7 @@
 open FStar.Int
 open FStar.Mul
 
-#set-options "--max_fuel 0 --max_ifuel 0"
+#set-options "--fuel 0 --ifuel 0"
 
 (* NOTE: anything that you fix/update here should be reflected in [FStar.UIntN.fstp], which is mostly
  * a copy-paste of this module. *)

--- a/.scripts/FStar.IntN.fstp
+++ b/.scripts/FStar.IntN.fstp
@@ -1,7 +1,7 @@
 open FStar.Int
 open FStar.Mul
 
-#set-options "--max_fuel 0 --max_ifuel 0"
+#set-options "--fuel 0 --ifuel 0"
 
 (* NOTE: anything that you fix/update here should be reflected in [FStar.UIntN.fstp], which is mostly
  * a copy-paste of this module. *)

--- a/.scripts/FStar.UIntN.fstip
+++ b/.scripts/FStar.UIntN.fstip
@@ -22,7 +22,7 @@
 open FStar.UInt
 open FStar.Mul
 
-#set-options "--max_fuel 0 --max_ifuel 0"
+#set-options "--fuel 0 --ifuel 0"
 
 (** Abstract type of machine integers, with an underlying
     representation using a bounded mathematical integer *)
@@ -227,7 +227,7 @@ let minus (a:t) = add_mod (lognot a) (uint_to_t 1)
 inline_for_extraction
 let n_minus_one = UInt32.uint_to_t (n - 1)
 
-#set-options "--z3rlimit 80 --initial_fuel 1 --max_fuel 1"
+#set-options "--z3rlimit 80 --fuel 1"
 
 (** A constant-time way to compute the equality of
     two machine integers.

--- a/.scripts/FStar.UIntN.fstp
+++ b/.scripts/FStar.UIntN.fstp
@@ -1,7 +1,7 @@
 open FStar.UInt
 open FStar.Mul
 
-#set-options "--max_fuel 0 --max_ifuel 0"
+#set-options "--fuel 0 --ifuel 0"
 
 type t : eqtype =
   | Mk: v:uint_t n -> t

--- a/doc/old/tutorial/code/exercises/Ex11a.fst
+++ b/doc/old/tutorial/code/exercises/Ex11a.fst
@@ -216,7 +216,7 @@ assume val fly_robot_army: #rs:set rid -> bs:bots rs -> ST unit
 val main: unit -> ST unit
     (requires (fun _ -> True))
     (ensures (fun m0 _ m1 -> modifies_transitively Set.empty m0 m1))
-#set-options "--z3rlimit 20 --initial_fuel 1 --max_fuel 1 --initial_ifuel 1 --max_ifuel 1"
+#set-options "--z3rlimit 20 --fuel 1 --ifuel 1"
 let main () =
   witness_region root;
   let b1 = new_robot root in

--- a/doc/old/tutorial/code/solutions/EtM.AE.fst
+++ b/doc/old/tutorial/code/solutions/EtM.AE.fst
@@ -111,7 +111,7 @@ let keygen parent =
      /\ invariant h1 k)))
 
 
-#set-options "--initial_fuel 0 --max_fuel 0 --initial_ifuel 1 --max_ifuel 1 --z3rlimit 100"
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 100"
 // BEGIN: EtMAEEncrypt
 let encrypt k plain =
   (* let h0 = ST.get () in *)

--- a/doc/old/tutorial/code/solutions/Ex05b.fst
+++ b/doc/old/tutorial/code/solutions/Ex05b.fst
@@ -50,7 +50,7 @@ let fib_inner_aux n =
    nested recursive aux function.
    Here's one way to do it. *)
 
-#set-options "--initial_fuel 1 --max_fuel 1 --initial_ifuel 0 --max_ifuel 0"
+#set-options "--fuel 1 --ifuel 0"
 
 val fib_inner_aux_2: n:nat -> Tot (f:nat{f = fibonacci n})
 let fib_inner_aux_2 n =

--- a/examples/algorithms/QuickSort.Array.fst
+++ b/examples/algorithms/QuickSort.Array.fst
@@ -19,7 +19,7 @@ open FStar.Array
 open FStar.Seq
 open FStar.Heap
 open FStar.ST
-#set-options "--initial_fuel 1 --initial_ifuel 0 --max_fuel 1 --max_ifuel 0"
+#set-options "--initial_fuel 1 --initial_ifuel 0 --max_fuel 1 --ifuel 0"
 
 (* 2016-11-22: Due to the QuickSort namespace being opened *after* the
 FStar namespace,Array resolves to QuickSort.Array instead of
@@ -58,7 +58,7 @@ type partition_post (a:eqtype) (f:tot_ord a) (start:nat) (len:nat{start <= len} 
                       (index (Array.sel h1 x) i)
                       (slice (Array.sel h1 x) i len)))
 
-#reset-options "--z3rlimit 20 --initial_fuel 1 --initial_ifuel 0 --max_fuel 1 --max_ifuel 0"
+#reset-options "--z3rlimit 20 --initial_fuel 1 --initial_ifuel 0 --max_fuel 1 --ifuel 0"
 val partition: #a:eqtype -> f:tot_ord a
                -> start:nat -> len:nat{start <= len}
                -> pivot:nat{start <= pivot /\ pivot < len}
@@ -141,7 +141,7 @@ let lemma_slice_cons_pv #a s i pivot j pv =
   cut (Seq.equal (slice s i j) (append lo (cons pv hi)))
 
 #reset-options
-#set-options "--initial_fuel 1 --initial_ifuel 0 --max_fuel 1 --max_ifuel 0 --z3rlimit 50"
+#set-options "--initial_fuel 1 --initial_ifuel 0 --max_fuel 1 --ifuel 0 --z3rlimit 50"
 val sort: #a:eqtype -> f:tot_ord a -> i:nat -> j:nat{i <= j} -> x:array a
           -> ST unit
   (requires (fun h -> Array.contains h x /\ j <= length (Array.sel h x)))

--- a/examples/algorithms/QuickSort.Seq.fst
+++ b/examples/algorithms/QuickSort.Seq.fst
@@ -21,7 +21,7 @@ FStar namespace, Seq resolves to QuickSort.Seq instead of FStar.Seq,
 so we have to fix this explicitly as a module abbrev. *)
 module Seq = FStar.Seq
 
-#reset-options "--z3rlimit 100 --max_fuel 0 --initial_fuel 0 --initial_ifuel 0 --max_ifuel 0"
+#reset-options "--z3rlimit 100 --fuel 0 --initial_fuel 0 --ifuel 0"
 
 val partition: #a:eqtype -> f:(a -> a -> Tot bool){total_order a f}
     -> s:seq a -> pivot:nat{pivot < length s} -> back:nat{pivot <= back /\ back < length s} ->
@@ -62,7 +62,7 @@ let rec partition #a f s pivot back =
 
 #reset-options
 
-#set-options "--initial_fuel 1 --max_fuel 1 --initial_ifuel 1 --max_ifuel 1"
+#set-options "--fuel 1 --ifuel 1"
 val sort: #a:eqtype -> f:(a -> a -> Tot bool){total_order a f}
        -> s1:seq a
        -> Tot (s2:seq a{sorted f s2 /\ permutation a s1 s2})

--- a/examples/data_structures/BinarySearchTreeBasic.fst
+++ b/examples/data_structures/BinarySearchTreeBasic.fst
@@ -96,13 +96,13 @@ let rec insert'' x t =
                     else if x < n then Node n (insert'' x t1) t2
                     else               Node n t1 (insert'' x t2)
 
-#push-options "--initial_fuel 1 --max_fuel 1 --initial_ifuel 1 --max_ifuel 1"
+#push-options "--fuel 1 --ifuel 1"
 
 val insert_lemma : x:int -> t:tree{is_bst t} -> Lemma
       (is_bst (insert'' x t) /\
       (forall y. in_tree y (insert'' x t) <==> in_tree y t \/ x = y))
 //AR: tightening a bit here, since works locally but fails on CI
-#push-options "--initial_fuel 1 --max_fuel 1 --initial_ifuel 1 --max_ifuel 1"
+#push-options "--fuel 1 --ifuel 1"
 let rec insert_lemma x t = match t with
   | Leaf -> ()
   | Node _ t1 t2 -> insert_lemma x t1; insert_lemma x t2

--- a/examples/data_structures/BinaryTreesEnumeration.fsti
+++ b/examples/data_structures/BinaryTreesEnumeration.fsti
@@ -283,7 +283,7 @@ let unfold_tos (s: nat) :
 
 (*> The error message if I omit this isn't the best.
     Could the resource exhaustion be detected and reported? *)
-#set-options "--z3rlimit 40 --initial_fuel 1 --max_fuel 1"
+#set-options "--z3rlimit 40 --fuel 1"
 
 (*> I ran into a few problems while writing this proof:
     - I had trouble supplying the right arguments for each lemma: In Coq I can just

--- a/examples/dm4free/DelimitedRelease.fst
+++ b/examples/dm4free/DelimitedRelease.fst
@@ -17,7 +17,7 @@ module DelimitedRelease
 open FStar.List.Tot
 open FStar.DM4F.Heap
 open FStar.DM4F.Heap.ST
-#reset-options "--initial_fuel 0 --max_fuel 0 --initial_ifuel 0 --max_ifuel 0"
+#reset-options "--fuel 0 --ifuel 0"
 
 
 let wallet (hi:ref int) (lo:ref int) (k:int) 

--- a/examples/dm4free/Effects.Def.fst
+++ b/examples/dm4free/Effects.Def.fst
@@ -72,7 +72,7 @@ val morphism_laws_via_eq: m:(Type -> Type)
 			        (ensures  (forall (a:Type) (x:a). lift a (return_m a x) == return_n a x)                          //lift-unit
 					/\ (forall (a:Type) (b:Type) (f:m a) (g: a -> Tot (m b)).
 					      lift b (bind_m a b f g) == bind_n a b (lift a f) (fun x -> lift b (g x))))         //lift-bind
-#set-options "--initial_fuel 0 --max_fuel 0 --initial_ifuel 0 --max_ifuel 0 --z3rlimit 100"
+#set-options "--fuel 0 --ifuel 0 --z3rlimit 100"
 let morphism_laws_via_eq m n eqn return_m bind_m return_n bind_n lift = ()
 #reset-options
 

--- a/examples/kv_parsing/PureValidator.fst
+++ b/examples/kv_parsing/PureValidator.fst
@@ -101,7 +101,7 @@ let rec validate_many' n v =
   | 0 -> validate_accept
   | _ -> v `seq` validate_many' (n-1) v
 
-#reset-options "--max_fuel 0 --z3rlimit 20"
+#reset-options "--fuel 0 --z3rlimit 20"
 
 val intro_validator_checks (#t:Type) (v: validator) (p:parser t)
   (pf : (b:bytes{length b < pow2 32} -> Lemma (validator_checks_on v p b))) :

--- a/examples/layeredeffects/HoareST.fst
+++ b/examples/layeredeffects/HoareST.fst
@@ -23,7 +23,7 @@ module P = FStar.Preorder
 
 /// ST effect implemented as a layered effect over STATE
 
-#set-options "--max_fuel 0 --max_ifuel 0"
+#set-options "--fuel 0 --ifuel 0"
 
 type pre_t = heap -> Type0
 type post_t (a:Type) = heap -> a -> heap -> Type0

--- a/examples/layeredeffects/HoareSTPolyBind.fst
+++ b/examples/layeredeffects/HoareSTPolyBind.fst
@@ -28,7 +28,7 @@ module P = FStar.Preorder
 ///
 /// See the `copy_aux` function below for some limitations of the polymonadic bind
 
-#set-options "--max_fuel 0 --max_ifuel 0"
+#set-options "--fuel 0 --ifuel 0"
 
 type pre_t = heap -> Type0
 type post_t (a:Type) = heap -> a -> heap -> Type0

--- a/examples/layeredeffects/TestHoareST.fst
+++ b/examples/layeredeffects/TestHoareST.fst
@@ -22,7 +22,7 @@ open HoareST
 
 /// Note that we don't need FStar.ST since the layered effects abstraction does not need it for verification
 
-#set-options "--max_fuel 0 --initial_ifuel 4 --max_ifuel 4 --using_facts_from '* -FStar.ST'"
+#set-options "--fuel 0 --ifuel 4 --using_facts_from '* -FStar.ST'"
 
 
 /// In this test:
@@ -131,7 +131,7 @@ assume val proof_of_pred : unit -> Tot (squash some_pred)
 assume val test10 : unit -> Pure unit (requires some_pred) (ensures fun _ -> True)
 
 //#restart-solver
-//#set-options "--max_fuel 0 --max_ifuel 0 --log_queries"
+//#set-options "--fuel 0 --ifuel 0 --log_queries"
 let test11 () : Tot unit =
   let _ : squash some_pred = proof_of_pred () in
   test10 ()

--- a/examples/low-mitls-experiments/ImmutableBuffer.fst
+++ b/examples/low-mitls-experiments/ImmutableBuffer.fst
@@ -107,7 +107,7 @@ let test_ub () :HST.St unit =
 
 
 (***** Tests for bigops in the buffer library *****)
-#push-options "--max_fuel 0 --max_ifuel 0"
+#push-options "--fuel 0 --ifuel 0"
 let test_bigops (b1:UB.ubuffer int) (b2:IB.ibuffer int) (b3:B.buffer int) (h h0 h1:HS.mem) : unit =
   let open LowStar.Buffer in
   let l1, l2, l3 = loc_buffer b1, loc_buffer b2, loc_buffer b3 in
@@ -124,7 +124,7 @@ let test_bigops (b1:UB.ubuffer int) (b2:IB.ibuffer int) (b3:B.buffer int) (h h0 
 
 module PF = LowStar.PrefixFreezableBuffer
 
-#push-options "--max_fuel 0 --max_ifuel 0"
+#push-options "--fuel 0 --ifuel 0"
 
 assume val havoc_pf (b:PF.buffer)
   : HST.ST unit (requires (fun _ -> True))

--- a/examples/metatheory/LambdaOmega.fst
+++ b/examples/metatheory/LambdaOmega.fst
@@ -1102,7 +1102,7 @@ let rec tss_tequiv #s #t h =
     | TssSym h1 -> EqSymm (tss_tequiv h1)
     | TssTran h1 h2 -> EqTran (tss_tequiv h1) (tss_tequiv h2)
 
-#set-options "--initial_ifuel 2 --max_ifuel 2"
+#set-options "--ifuel 2"
 irreducible val tred_tarr_preserved : #s1:typ -> #s2:typ -> #t:typ ->
       h:(tred_star (TArr s1 s2) t) ->
       Tot (cexists (fun t1 -> (cexists (fun t2 ->

--- a/examples/native_tactics/Imp.Fun.fst
+++ b/examples/native_tactics/Imp.Fun.fst
@@ -171,7 +171,7 @@ let norm_assert (p:Type) : Lemma (requires (normal p)) (ensures True) = ()
 // let _ = norm_assert (forall (x:int) rm. R.sel (eval' (Seq [Const x (reg 0)]) rm) 0 == x) // eval' (Seq [Const x (reg 0)]) rm == rm)
 let _ = norm_assert (forall x y. equiv_norm (long_zero x) (long_zero y))
 // let _ = norm_assert (forall x y. equiv_norm (long_zero x) (long_zero y))
-// #reset-options "--max_fuel 0"
+// #reset-options "--fuel 0"
 // let _ = norm_assert (forall x. eval (x_times_42 x) == 42 * x)
 
 
@@ -214,11 +214,11 @@ let _ = norm_assert (forall x y. equiv_norm (long_zero x) (long_zero y))
 // let _ = norm_assert (eval (poly5 3) == 3*3*3*3*3 + 3*3*3*3 + 3*3*3 + 3*3 + 3 + 1)
 
 // (* Bunch of fuel to even prove ground facts *)
-// #reset-options "--initial_fuel 20 --max_fuel 20"
+// #reset-options "--fuel 20"
 // let _ = assert (eval (poly5 1) == 6)
 // let _ = assert (eval (poly5 2) == 63)
 // let _ = assert (eval (poly5 3) == 3*3*3*3*3 + 3*3*3*3 + 3*3*3 + 3*3 + 3 + 1)
-// #reset-options "--max_fuel 0"
+// #reset-options "--fuel 0"
 
 // (* A different way of computing it *)
 // [@@unfold_defs]
@@ -245,12 +245,12 @@ let _ = norm_assert (forall x y. equiv_norm (long_zero x) (long_zero y))
 // let _ = norm_assert (forall x. eval (poly5 x) == eval (poly5' x))
 
 // (* Same *)
-// #reset-options "--initial_fuel 20 --max_fuel 20"
+// #reset-options "--fuel 20"
 // let _ = assert (eval (poly5' 1) == 6)
 // let _ = assert (eval (poly5' 2) == 63)
 // let _ = assert (eval (poly5' 3) == 3*3*3*3*3 + 3*3*3*3 + 3*3*3 + 3*3 + 3 + 1)
 // let _ = assert (forall x. (eval (poly5 x) == eval (poly5' x)))
-// #reset-options "--max_fuel 0"
+// #reset-options "--fuel 0"
 
 // //--------------------------------------------------------------------------------
 
@@ -264,7 +264,7 @@ let _ = norm_assert (forall x y. equiv_norm (long_zero x) (long_zero y))
 // // #set-options "--z3rlimit 10"
 // // let _ = assert_norm (forall x. (poly5 (eval (poly5 x)) `equiv` poly5' (eval (poly5' x))))
 
-// // #set-options "--max_fuel 0"
+// // #set-options "--fuel 0"
 // // // --tactic_trace"
 // // let _ = assert (forall x. poly5 x `equiv` poly5' x)
 // //           by (let _ = forall_intros () in

--- a/examples/native_tactics/Imp.List.fst
+++ b/examples/native_tactics/Imp.List.fst
@@ -137,7 +137,7 @@ let x_times_42 x : prog = [
 ]
 
 // let _ = norm_assert (forall x y. equiv_norm (long_zero x) (long_zero y))
-// #reset-options "--max_fuel 0"
+// #reset-options "--fuel 0"
 // let _ = norm_assert (forall x. eval (x_times_42 x) == 42 * x)
 
 
@@ -180,11 +180,11 @@ let x_times_42 x : prog = [
 // let _ = norm_assert (eval (poly5 3) == 3*3*3*3*3 + 3*3*3*3 + 3*3*3 + 3*3 + 3 + 1)
 
 // (* Bunch of fuel to even prove ground facts *)
-// #reset-options "--initial_fuel 20 --max_fuel 20"
+// #reset-options "--fuel 20"
 // let _ = assert (eval (poly5 1) == 6)
 // let _ = assert (eval (poly5 2) == 63)
 // let _ = assert (eval (poly5 3) == 3*3*3*3*3 + 3*3*3*3 + 3*3*3 + 3*3 + 3 + 1)
-// #reset-options "--max_fuel 0"
+// #reset-options "--fuel 0"
 
 // (* A different way of computing it *)
 // [@@unfold_defs]
@@ -211,12 +211,12 @@ let x_times_42 x : prog = [
 // let _ = norm_assert (forall x. eval (poly5 x) == eval (poly5' x))
 
 // (* Same *)
-// #reset-options "--initial_fuel 20 --max_fuel 20"
+// #reset-options "--fuel 20"
 // let _ = assert (eval (poly5' 1) == 6)
 // let _ = assert (eval (poly5' 2) == 63)
 // let _ = assert (eval (poly5' 3) == 3*3*3*3*3 + 3*3*3*3 + 3*3*3 + 3*3 + 3 + 1)
 // let _ = assert (forall x. (eval (poly5 x) == eval (poly5' x)))
-// #reset-options "--max_fuel 0"
+// #reset-options "--fuel 0"
 
 // //--------------------------------------------------------------------------------
 
@@ -230,7 +230,7 @@ let x_times_42 x : prog = [
 // // #set-options "--z3rlimit 10"
 // // let _ = assert_norm (forall x. (poly5 (eval (poly5 x)) `equiv` poly5' (eval (poly5' x))))
 
-// // #set-options "--max_fuel 0"
+// // #set-options "--fuel 0"
 // // // --tactic_trace"
 // // let _ = assert (forall x. poly5 x `equiv` poly5' x)
 // //           by (let _ = forall_intros () in

--- a/examples/native_tactics/Registers.Imp.fst
+++ b/examples/native_tactics/Registers.Imp.fst
@@ -171,7 +171,7 @@ let norm_assert (p:Type) : Lemma (requires (normal p)) (ensures True) = ()
 // let _ = norm_assert (forall (x:int) rm. R.sel (eval' (Seq [Const x (reg 0)]) rm) 0 == x) // eval' (Seq [Const x (reg 0)]) rm == rm)
 let _ = norm_assert (forall x y. equiv_norm (long_zero x) (long_zero y))
 // let _ = norm_assert (forall x y. equiv_norm (long_zero x) (long_zero y))
-// #reset-options "--max_fuel 0"
+// #reset-options "--fuel 0"
 // let _ = norm_assert (forall x. eval (x_times_42 x) == 42 * x)
 
 
@@ -214,11 +214,11 @@ let _ = norm_assert (forall x y. equiv_norm (long_zero x) (long_zero y))
 // let _ = norm_assert (eval (poly5 3) == 3*3*3*3*3 + 3*3*3*3 + 3*3*3 + 3*3 + 3 + 1)
 
 // (* Bunch of fuel to even prove ground facts *)
-// #reset-options "--initial_fuel 20 --max_fuel 20"
+// #reset-options "--fuel 20"
 // let _ = assert (eval (poly5 1) == 6)
 // let _ = assert (eval (poly5 2) == 63)
 // let _ = assert (eval (poly5 3) == 3*3*3*3*3 + 3*3*3*3 + 3*3*3 + 3*3 + 3 + 1)
-// #reset-options "--max_fuel 0"
+// #reset-options "--fuel 0"
 
 // (* A different way of computing it *)
 // [@@unfold_defs]
@@ -245,12 +245,12 @@ let _ = norm_assert (forall x y. equiv_norm (long_zero x) (long_zero y))
 // let _ = norm_assert (forall x. eval (poly5 x) == eval (poly5' x))
 
 // (* Same *)
-// #reset-options "--initial_fuel 20 --max_fuel 20"
+// #reset-options "--fuel 20"
 // let _ = assert (eval (poly5' 1) == 6)
 // let _ = assert (eval (poly5' 2) == 63)
 // let _ = assert (eval (poly5' 3) == 3*3*3*3*3 + 3*3*3*3 + 3*3*3 + 3*3 + 3 + 1)
 // let _ = assert (forall x. (eval (poly5 x) == eval (poly5' x)))
-// #reset-options "--max_fuel 0"
+// #reset-options "--fuel 0"
 
 // //--------------------------------------------------------------------------------
 
@@ -264,7 +264,7 @@ let _ = norm_assert (forall x y. equiv_norm (long_zero x) (long_zero y))
 // // #set-options "--z3rlimit 10"
 // // let _ = assert_norm (forall x. (poly5 (eval (poly5 x)) `equiv` poly5' (eval (poly5' x))))
 
-// // #set-options "--max_fuel 0"
+// // #set-options "--fuel 0"
 // // // --tactic_trace"
 // // let _ = assert (forall x. poly5 x `equiv` poly5' x)
 // //           by (let _ = forall_intros () in

--- a/examples/old/csl/SepLogic.Heap.fst
+++ b/examples/old/csl/SepLogic.Heap.fst
@@ -367,7 +367,7 @@ let lemma_fresh_or_old_disjoint (h0 h1 h2:heap)
       FStar.Classical.forall_to_exists #memory (fun m_fresh -> 
         lemma_fresh_or_old_disjoint'' h0 h1 h2 m_old m_fresh))
 
-#set-options "--max_fuel 0 --max_ifuel 0"
+#set-options "--fuel 0 --ifuel 0"
 
 private let lemma_fresh_or_old_sep' (h0 h1 h2:heap) (m_old m_fresh:memory) 
   : Lemma (requires (fresh_or_old' h0 h1 m_old m_fresh /\ 

--- a/examples/old/csl/Shallow.fst
+++ b/examples/old/csl/Shallow.fst
@@ -97,7 +97,7 @@ let frame #a #wp f =
                          lemma_join_comm h0' h1;
                          S.return_squash res)))
 
-#set-options "--z3rlimit_factor 1 --max_fuel 0 --max_ifuel 0"
+#set-options "--z3rlimit_factor 1 --fuel 0 --ifuel 0"
 
 val bind_without_framing (#a:Type) (#wp1:st_wp a)
          (#b:Type) (#wp2:a -> st_wp b)

--- a/examples/old/seplogic/SL.Examples.fst
+++ b/examples/old/seplogic/SL.Examples.fst
@@ -196,7 +196,7 @@ let split_lem #a #b sa sb = ()
 private let get_to_the_next_frame () :Tac unit =
   ignore (repeat (fun () -> apply_lemma (`split_lem); smt ()))
 
-#reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection' --max_fuel 0 --initial_fuel 0 --max_ifuel 0 --initial_ifuel 0 --print_full_names"
+#reset-options "--using_facts_from '* -FStar.Tactics -FStar.Reflection' --fuel 0 --initial_fuel 0 --ifuel 0 --initial_ifuel 0 --print_full_names"
 
 (*
  * two commands

--- a/examples/old/seplogic/SepLogic.Heap.fst
+++ b/examples/old/seplogic/SepLogic.Heap.fst
@@ -367,7 +367,7 @@ let lemma_fresh_or_old_disjoint (h0 h1 h2:heap)
       FStar.Classical.forall_to_exists #memory (fun m_fresh -> 
         lemma_fresh_or_old_disjoint'' h0 h1 h2 m_old m_fresh))
 
-#set-options "--max_fuel 0 --max_ifuel 0"
+#set-options "--fuel 0 --ifuel 0"
 
 private let lemma_fresh_or_old_sep' (h0 h1 h2:heap) (m_old m_fresh:memory) 
   : Lemma (requires (fresh_or_old' h0 h1 m_old m_fresh /\ 

--- a/examples/old/seplogic/Shallow.fst
+++ b/examples/old/seplogic/Shallow.fst
@@ -97,7 +97,7 @@ let frame #a #wp f =
                          lemma_join_comm h0' h1;
                          S.return_squash res)))
 
-#set-options "--z3rlimit_factor 1 --max_fuel 0 --max_ifuel 0"
+#set-options "--z3rlimit_factor 1 --fuel 0 --ifuel 0"
 
 val bind_without_framing (#a:Type) (#wp1:st_wp a)
          (#b:Type) (#wp2:a -> st_wp b)

--- a/examples/old/tls-record-layer/Utils.fst
+++ b/examples/old/tls-record-layer/Utils.fst
@@ -22,7 +22,7 @@ open FStar.HyperStack
 open FStar.Buffer
 open Low.Bytes
 
-#set-options "--max_fuel 0 --initial_fuel 0 --initial_ifuel 0 --max_ifuel 0"
+#set-options "--fuel 0 --initial_fuel 0 --ifuel 0"
 
 let lemma_slice_sub_1 (#a:Type{hasEq a}) (s:Seq.seq a) (s':Seq.seq a) (a:nat) (b:nat{a <= b /\ b <= Seq.length s /\ b <= Seq.length s'}) : Lemma
   (requires (s == s'))
@@ -102,7 +102,7 @@ let rec f_seq_lemma_0 #a f s1 s2 s1' s2' len =
     assert(Seq.index (Seq.slice s1 0 len) (len-1) == Seq.index (Seq.slice s1' 0 len) (len-1));
     assert(Seq.index (Seq.slice s2 0 len) (len-1) == Seq.index (Seq.slice s2' 0 len) (len-1))
 
-#set-options "--max_fuel 0 --initial_fuel 0 --initial_ifuel 0 --max_ifuel 0"
+#set-options "--fuel 0 --initial_fuel 0 --ifuel 0"
 
 val lemma_slice_append: #a:Type -> s:Seq.seq a -> i:nat{i < Seq.length s} -> Lemma
   (Seq.slice s 0 (i+1) == Seq.append (Seq.slice s 0 i) (Seq.create 1 (Seq.index s i)))

--- a/examples/old/tls-record-layer/crypto/Buffer.Utils.fst
+++ b/examples/old/tls-record-layer/crypto/Buffer.Utils.fst
@@ -72,7 +72,7 @@ val lemma_euclidean_division: r:nat -> b:nat -> q:pos -> Lemma
   (ensures  (r + q * b < q * (b+1)))
 let lemma_euclidean_division r b q = ()
 
-#reset-options "--initial_fuel 0 --max_fuel 0"
+#reset-options "--fuel 0"
 
 let lemma_uint32_of_bytes (a:t) (b:t) (c:t) (d:t) : Lemma
   (requires (v a < pow2 8 /\ v b < pow2 8 /\ v c < pow2 8 /\ v d < pow2 8))

--- a/examples/old/tls-record-layer/crypto/Crypto.AEAD.AES256GCM.fst
+++ b/examples/old/tls-record-layer/crypto/Crypto.AEAD.AES256GCM.fst
@@ -24,7 +24,7 @@ open FStar.Int.Cast
 open Crypto.Symmetric.AES
 open Crypto.Symmetric.GCM
 
-#reset-options "--initial_fuel 0 --max_fuel 0 --z3rlimit 100"
+#reset-options "--fuel 0 --z3rlimit 100"
 
 module U32 = FStar.UInt32
 

--- a/examples/old/tls-record-layer/crypto/Crypto.AEAD.BufferUtils.fst
+++ b/examples/old/tls-record-layer/crypto/Crypto.AEAD.BufferUtils.fst
@@ -108,7 +108,7 @@ val chain_mods_enc: #a:Type ->
    		     let h_final = HS.pop h_ideal in
    		     HS.modifies_transitively (Set.as_set [prf_region; frameOf cipher]) h_init h_final /\
 		     Buffer.modifies_buf_1 (frameOf cipher) cipher h_init h_final)))
-#reset-options "--initial_fuel 0 --initial_ifuel 0 --max_fuel 0 --max_ifuel 0 --z3rlimit 200"
+#reset-options "--initial_fuel 0 --initial_ifuel 0 --fuel 0 --ifuel 0 --z3rlimit 200"
 let chain_mods_enc #a acc cond prf_region mac_region cipher h_init h_push h_prf h_enx h_acc h_mac h_ideal =
     FStar.Classical.move_requires (Buffer.lemma_reveal_modifies_2 acc cipher h_acc) h_mac;
     modifies_drop_tip h_init h_push h_ideal (Set.as_set [prf_region; frameOf cipher])

--- a/examples/old/tls-record-layer/crypto/Crypto.AEAD.Decrypt.fst
+++ b/examples/old/tls-record-layer/crypto/Crypto.AEAD.Decrypt.fst
@@ -46,7 +46,7 @@ module PRF_MAC    = Crypto.AEAD.Wrappers.PRF
 let decrypt_modifies (#i:id) (#len:u32) (st:aead_state i Reader) (pb:plainBuffer i (v len)) (h0:mem) (h1:mem) =
    Crypto.AEAD.BufferUtils.decrypt_modifies st.log_region st.prf.mac_rgn (as_buffer pb) h0 h1
 
-#reset-options "--z3rlimit 100 --initial_fuel 0 --max_fuel 0 --initial_ifuel 0 --max_ifuel 0"
+#reset-options "--z3rlimit 100 --fuel 0 --ifuel 0"
 let post_pop (#i:id) (n:Cipher.iv (alg i)) (st:aead_state i Reader) 
 	     (#aadlen:aadlen) (aad:lbuffer (v aadlen))
 	     (#plainlen:txtlen_32) 
@@ -113,7 +113,7 @@ val decrypt:
     inv st h1 /\
     decrypt_modifies st plain h0 h1 /\
     (verified ==> Dexor.decrypt_ok n st aad plain cipher_tagged h1)))
-#reset-options "--z3rlimit 1000 --initial_fuel 0 --max_fuel 0 --initial_ifuel 0 --max_ifuel 0"
+#reset-options "--z3rlimit 1000 --fuel 0 --ifuel 0"
 let decrypt i st iv aadlen aad plainlen plain cipher_tagged =
   let h_init = get() in
   push_frame();

--- a/examples/old/tls-record-layer/crypto/Crypto.AEAD.Encoding.fst
+++ b/examples/old/tls-record-layer/crypto/Crypto.AEAD.Encoding.fst
@@ -215,7 +215,7 @@ val lemma_encode_final: b:Seq.seq UInt8.t{0 <> Seq.length b /\ Seq.length b < 16
 let lemma_encode_final b = ()
 
 
-#reset-options "--z3rlimit 140 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 140 --fuel 0"
 
 let rec add_bytes #i st acc len txt =
   let h0 = ST.get() in 
@@ -286,7 +286,7 @@ let rec add_bytes #i st acc len txt =
   if not mac_log then
     Buffer.lemma_intro_modifies_1 (MAC.as_buffer (CMA.abuf acc)) h0 h6
 
-#reset-options "--initial_fuel 0 --max_fuel 0 --initial_ifuel 0 --max_ifuel 0"
+#reset-options "--fuel 0 --ifuel 0"
 private let encode_lengths_poly1305 (aadlen:UInt32.t) (plainlen:UInt32.t) : b:lbytes 16
   { v aadlen = little_endian (Seq.slice b 0 4) /\
     v plainlen = little_endian (Seq.slice b 8 12) } = 
@@ -419,7 +419,7 @@ val accumulate:
 
 // 20170313 JP: this verifies on my OSX laptop but not on the CI machine. See
 // #893
-#reset-options "--initial_fuel 0 --max_fuel 0 --initial_ifuel 0 --max_ifuel 0 --z3rlimit 2048 --admit_smt_queries true"
+#reset-options "--fuel 0 --ifuel 0 --z3rlimit 2048 --admit_smt_queries true"
 let accumulate #i st aadlen aad txtlen cipher  = 
   let h = ST.get() in 
   let acc = CMA.start st in

--- a/examples/old/tls-record-layer/crypto/Crypto.AEAD.Encrypt.Aux.fst
+++ b/examples/old/tls-record-layer/crypto/Crypto.AEAD.Encrypt.Aux.fst
@@ -36,7 +36,7 @@ module CMA = Crypto.Symmetric.UF1CMA
 module Seq = FStar.Seq
 
 
-#reset-options "--z3rlimit 400 --initial_fuel 0 --max_fuel 0 --initial_ifuel 0 --max_ifuel 0"
+#reset-options "--z3rlimit 400 --fuel 0 --ifuel 0"
 val extend_refines_aux: (i:id) -> (st:state i Writer) -> (nonce:Cipher.iv (alg i)) ->
 		       (aadlen: UInt32.t {aadlen <=^ aadmax}) ->
 		       (aad: lbuffer (v aadlen)) ->
@@ -86,7 +86,7 @@ let extend_refines_aux i st nonce aadlen aad len plain cipher h0 h1 =
      let entry = Entry nonce ad len p c_tagged in
      extend_refines h0 i mac_rgn entries_0 blocks_0 entry blocks_1 h1
 
-#reset-options "--z3rlimit 400 --initial_fuel 0 --max_fuel 0 --initial_ifuel 0 --max_ifuel 0"
+#reset-options "--z3rlimit 400 --fuel 0 --ifuel 0"
 let encrypt_ensures' (regions:Set.set HH.rid)
 		     (i:id) (st:state i Writer)
 		     (n: Cipher.iv (alg i))
@@ -174,7 +174,7 @@ val finish_after_mac: h0:mem -> h3:mem -> i:id -> st:state i Writer ->
    (ensures (fun _ _ h5 -> 
               encrypt_ensures_tip i st n aadlen aad plainlen plain cipher_tagged h0 h5))
 
-#reset-options "--z3rlimit 1000 --initial_fuel 0 --max_fuel 0 --initial_ifuel 0 --max_ifuel 0"
+#reset-options "--z3rlimit 1000 --fuel 0 --ifuel 0"
 let finish_after_mac h0 h3 i st n aadlen aad plainlen plain cipher_tagged ak acc tag = 
   if prf i then recall (itable i st.prf);
   if safeId i then recall st.log;

--- a/examples/old/tls-record-layer/crypto/Crypto.AEAD.Encrypt.Ideal.Invariant.fst
+++ b/examples/old/tls-record-layer/crypto/Crypto.AEAD.Encrypt.Ideal.Invariant.fst
@@ -34,7 +34,7 @@ module HS  = FStar.HyperStack
 module PRF = Crypto.Symmetric.PRF
 module Cipher = Crypto.Symmetric.Cipher
 
-#reset-options "--z3rlimit 100 --initial_fuel 0 --max_fuel 0 --initial_ifuel 0 --max_ifuel 0"      
+#reset-options "--z3rlimit 100 --fuel 0 --ifuel 0"
 let safeMac_ideal_writes 
   (#i:id)
   (#rw:rw)

--- a/examples/old/tls-record-layer/crypto/Crypto.AEAD.Encrypt.fst
+++ b/examples/old/tls-record-layer/crypto/Crypto.AEAD.Encrypt.fst
@@ -45,7 +45,7 @@ module PRF_MAC     = Crypto.AEAD.Wrappers.PRF
 module EncodingWrapper = Crypto.AEAD.Wrappers.Encoding
 module CMAWrapper = Crypto.AEAD.Wrappers.CMA
 
-#reset-options "--z3rlimit 40 --initial_fuel 0 --max_fuel 0 --initial_ifuel 0 --max_ifuel 0"
+#reset-options "--z3rlimit 40 --fuel 0 --ifuel 0"
 let ideal_ensures
 	 (#i: id)
  	 (st: aead_state i Writer)
@@ -90,7 +90,7 @@ let do_ideal #i st n #aadlen aad #plainlen plain cipher_tag =
     ST.recall (st_ilog st);
     st_ilog st := Seq.snoc !(st_ilog st) entry
 
-#reset-options "--z3rlimit 400 --initial_fuel 0 --max_fuel 0 --initial_ifuel 0 --max_ifuel 0"
+#reset-options "--z3rlimit 400 --fuel 0 --ifuel 0"
 let encrypt_ensures  (#i:id) (st:aead_state i Writer)
 		     (n: Cipher.iv (alg i))
 		     (#aadlen:aadlen)
@@ -200,7 +200,7 @@ val encrypt_write_effect :
 	      let h_final = HS.pop h_ideal in
 	      encrypt_ensures st n aad plain cipher_tag h_init h_final /\
 	      encrypt_modifies st cipher_tag h_init h_final)))
-#reset-options "--z3rlimit 400 --initial_fuel 0 --max_fuel 0 --initial_ifuel 0 --max_ifuel 0"
+#reset-options "--z3rlimit 400 --fuel 0 --ifuel 0"
 let encrypt_write_effect i st n #aadlen aad #plainlen plain cipher_tag k_0 ak acc
 			 h_init h_push h_prf h_enx h_acc h_mac h_ideal =
   let open HS in			 

--- a/examples/old/tls-record-layer/crypto/Crypto.AEAD.Enxor.Invariant.fst
+++ b/examples/old/tls-record-layer/crypto/Crypto.AEAD.Enxor.Invariant.fst
@@ -54,7 +54,7 @@ private val frame_aead_entries_enxor
   (requires (enxor_h0_h1 aead_st nonce aad plain ct h0 h1))
   (ensures  (HS.sel #(aead_entries i) h0 (st_ilog aead_st) ==              
              HS.sel #(aead_entries i) h1 (st_ilog aead_st)))
-#reset-options "--z3rlimit 64 --initial_fuel 0 --max_fuel 0 --initial_ifuel 0 --max_ifuel 0"
+#reset-options "--z3rlimit 64 --fuel 0 --ifuel 0"
 let frame_aead_entries_enxor #i #rw #aadlen #plainlan aead_st nonce aad plain ct h0 h1 = ()
 
 (*
@@ -97,7 +97,7 @@ private val frame_unused_mac_exists_enxor
              (let table = HS.sel h1 (itable i aead_st.prf) in
 	      let dom_0 = {iv=nonce; ctr=PRF.ctr_0 i} in
 	      unused_mac_exists table dom_0 h1)))
-#reset-options "--z3rlimit 100 --initial_fuel 0 --max_fuel 0 --initial_ifuel 0 --max_ifuel 0"
+#reset-options "--z3rlimit 100 --fuel 0 --ifuel 0"
 let frame_unused_mac_exists_enxor #i #rw #aadlen #plainlen aead_st nonce aad plain ct h0 h1 =
   let cipher = cbuf ct in
   if safeMac i then begin
@@ -132,7 +132,7 @@ private val intro_fresh_nonces_are_unused_except_enxor
 	      let entries_1   = HS.sel #(aead_entries i) h1 (st_ilog aead_st) in
 	      let table_1     = HS.sel h1 (itable i aead_st.prf) in
 	      fresh_nonces_are_unused_except nonce table_1 entries_1 h1)))
-#reset-options "--z3rlimit 200 --initial_fuel 0 --max_fuel 0 --initial_ifuel 0 --max_ifuel 0"
+#reset-options "--z3rlimit 200 --fuel 0 --ifuel 0"
 let intro_fresh_nonces_are_unused_except_enxor
   (#i:id)
   (#rw:rw)

--- a/examples/old/tls-record-layer/crypto/Crypto.AEAD.EnxorDexor.fst
+++ b/examples/old/tls-record-layer/crypto/Crypto.AEAD.EnxorDexor.fst
@@ -105,7 +105,7 @@ let modifies_table_above_x_and_buffer (#i:id) (#l:nat) (t:PRF.state i)
      HS.modifies_one rid h0 h1 /\ 
      Buffer.modifies_buf_1 rid b h0 h1))
 
-#reset-options "--initial_fuel 0 --max_fuel 0 --initial_ifuel 0 --max_ifuel 0 --z3rlimit 100"
+#reset-options "--fuel 0 --ifuel 0 --z3rlimit 100"
 let weaken_modifies (#i:id) (#l:nat) (t:PRF.state i)
 		    (x:PRF.domain i) (b:lbuffer l)
 		    (h0:HS.mem) (h1:HS.mem)
@@ -187,7 +187,7 @@ val prf_enxor_leaves_none_strictly_above_x:
 		     modifies_x_buffer_1 t x c h_0 h_1 /\ 
 		     Buffer.frameOf c <> t.rgn)
            (ensures none_above_prf_st (PRF.incr i x) t h_1)
-#reset-options "--initial_fuel 0 --max_fuel 0 --initial_ifuel 0 --max_ifuel 0"
+#reset-options "--fuel 0 --ifuel 0"
 let prf_enxor_leaves_none_strictly_above_x #i t x len remaining_len c h_0 h_1
     = if prf i then
 	let r = itable i t in
@@ -211,7 +211,7 @@ let prf_enxor_leaves_none_strictly_above_x #i t x len remaining_len c h_0 h_1
 
 (*+ Working towards a main auxiliary lemma:  extending_counter_blocks **)
 
-#set-options "--initial_fuel 0 --max_fuel 0 --initial_ifuel 0 --max_ifuel 0 --z3rlimit 100"
+#set-options "--fuel 0 --ifuel 0 --z3rlimit 100"
 (*+ frame_counterblocks_snoc:
 	 modifying a single entry in the prf table and the cipher
 	 carries counterblocks forward by snoc'ing a single OTP block **)
@@ -270,7 +270,7 @@ let frame_counterblocks_snoc i t x k len completed_len plain cipher h0 h1 =
   counterblocks_slice #i t.mac_rgn initial_x len 0 completed_len p c;
   counterblocks_slice #i t.mac_rgn initial_x len 0 completed_len p0 c0
 
-#set-options "--initial_ifuel 1 --max_ifuel 1 --initial_fuel 2 --max_fuel 2"
+#set-options "--ifuel 1 --fuel 2"
 let invert_contains_plain_and_cipher_block   (#i:id) (#r:rid) (#l:u32{l <=^ PRF.blocklen i})
 					     (x:domain i{safeId i /\ ctr_0 i <^ x.ctr})
 					     (plain:plain i (v l))
@@ -281,7 +281,7 @@ let invert_contains_plain_and_cipher_block   (#i:id) (#r:rid) (#l:u32{l <=^ PRF.
             (ensures (b == PRF.Entry #r #i x (PRF.OTP l plain cipher)))
     = ()
 
-#reset-options "--initial_fuel 0 --max_fuel 0 --initial_ifuel 0 --max_ifuel 0 --z3rlimit 400"
+#reset-options "--fuel 0 --ifuel 0 --z3rlimit 400"
 (*+ extending_counter_blocks: 
 	 A main auxiliary lemma
 	 Shows that each iteration of counter_enxor extends the counterblocks
@@ -438,7 +438,7 @@ val counter_enxor:
     // in all cases, we extend the table only at x and its successors.
     modifies_table_above_x_and_buffer t x cipher h0 h1 /\
     enxor_invariant t x len 0ul plain cipher h_init h1))
-#set-options "--z3rlimit 200 --initial_fuel 0 --max_fuel 0 --initial_ifuel 0 --max_ifuel 0"
+#set-options "--z3rlimit 200 --fuel 0 --ifuel 0"
 let rec counter_enxor #i t x len remaining_len plain cipher h_init =
   let completed_len = len -^ remaining_len in
   let h0 = get () in
@@ -538,7 +538,7 @@ let dexor_modifies (#i:id) (#len:u32) (t:PRF.state i) (x:PRF.domain i)
    then Buffer.modifies_1 (as_buffer pb) h0 h1
    else modifies_table_above_x_and_buffer t x (as_buffer pb) h0 h1
 
-#reset-options "--z3rlimit 100 --initial_fuel 0 --max_fuel 0 --initial_ifuel 0 --max_ifuel 0"
+#reset-options "--z3rlimit 100 --fuel 0 --ifuel 0"
 let dexor_of_prf_dexor_modifies (#i:id) (#len:u32) (t:PRF.state i) 
 				(x:PRF.domain i{ctr_0 i <^ x.ctr}) 
 				(pb:plainBuffer i (v len)) (h0:mem) (h1:mem)
@@ -666,7 +666,7 @@ let frame_prf_contains_all_otp_blocks_st (#i:id)
 	Contexts that use 0 fuel must invoke this lemma to reason
 	about prf_contains_all_otp_blocks
  **)
-#reset-options "--z3rlimit 200 --initial_fuel 1 --max_fuel 1 --initial_ifuel 0 --max_ifuel 0"
+#reset-options "--z3rlimit 200 --fuel 1 --ifuel 0"
 val invert_prf_contains_all_otp_blocks_st 
     (i:id) 
     (x:PRF.domain i{PRF.ctr_0 i <^ x.ctr})
@@ -727,7 +727,7 @@ val extend_decrypted_up_to: #i:id -> (t:PRF.state i) -> (x:PRF.domain i) ->
 		      Plain.live h1 pb /\
 		      (safeId i ==> 
 			   decrypted_up_to (starting_pos +^ l) pb p h1)))
-#reset-options "--z3rlimit 100 --initial_fuel 0 --max_fuel 0 --initial_ifuel 0 --max_ifuel 0"
+#reset-options "--z3rlimit 100 --fuel 0 --ifuel 0"
 let extend_decrypted_up_to #i t x #len remaining_len pb p cipher h0 h1 = 
   let starting_pos = len -^ remaining_len in
   let l = min remaining_len (PRF.blocklen i) in
@@ -788,7 +788,7 @@ val counter_dexor:
   p:maybe_plain i (v len) ->
   ST unit (requires (fun h -> dexor_requires t x remaining_len plain cipher p h))
  	  (ensures (fun h0 _ h1 -> dexor_ensures t x plain cipher p h0 h1))
-#reset-options "--z3rlimit 200 --initial_fuel 0 --max_fuel 0 --initial_ifuel 0 --max_ifuel 0"
+#reset-options "--z3rlimit 200 --fuel 0 --ifuel 0"
 let rec counter_dexor i t x len remaining_len plain cipher p =
   let completed_len = len -^ remaining_len in
   let h0 = get () in
@@ -899,7 +899,7 @@ val dexor:
 	    dexor_modifies st.prf x_1 plain h0 h1 /\
 	    inv st h1 /\
 	    decrypt_ok iv st aad plain cipher_tagged h1))
-#reset-options "--z3rlimit 200 --initial_fuel 0 --max_fuel 0 --initial_ifuel 0 --max_ifuel 0"
+#reset-options "--z3rlimit 200 --fuel 0 --ifuel 0"
 open Crypto.AEAD.Encoding 
 let dexor #i st iv #aadlen aad #len plain cipher_tagged p =
   let x_1 = {iv=iv; ctr=otp_offset i} in

--- a/examples/old/tls-record-layer/crypto/Crypto.AEAD.MAC_Wrapper.Invariant.fst
+++ b/examples/old/tls-record-layer/crypto/Crypto.AEAD.MAC_Wrapper.Invariant.fst
@@ -39,7 +39,7 @@ module Plain  = Crypto.Plain
 open Crypto.AEAD.Invariant
 open Crypto.AEAD.Encrypt.Invariant
 
-#set-options "--initial_ifuel 0 --max_ifuel 0"
+#set-options "--ifuel 0"
 
 (*
  * framing of aead_entries_are_refined by mac_wrapper
@@ -122,7 +122,7 @@ private val frame_unused_aead_id_for_prf_mac_wrapper
 	     nonce <> nonce'))
   (ensures  (let table_0 = HS.sel h0 (itable i aead_st.prf) in
              unused_aead_iv_for_prf table_0 nonce' h1))
-#reset-options "--z3rlimit 100 --initial_fuel 0 --max_fuel 0 --initial_ifuel 0 --max_ifuel 0"
+#reset-options "--z3rlimit 100 --fuel 0 --ifuel 0"
 let frame_unused_aead_id_for_prf_mac_wrapper #i #rw #aadlen #plainlen aead_st nonce aad plain ct mac_st h0 h1 nonce' =
    let dom_0 = {iv=nonce'; ctr=PRF.ctr_0 i} in
    let prf_table = HS.sel h0 (itable i aead_st.prf) in
@@ -134,7 +134,7 @@ let frame_unused_aead_id_for_prf_mac_wrapper #i #rw #aadlen #plainlen aead_st no
       MAC.frame_norm h0 h1 CMA.(mac_range.r);
       lemma_mac_log_framing mac_st h0 h1 mac_range)
 
-#reset-options "--z3rlimit 100 --initial_fuel 0 --max_fuel 0 --initial_ifuel 0 --max_ifuel 0"      
+#reset-options "--z3rlimit 100 --fuel 0 --ifuel 0"
 private val frame_unused_aead_id_for_prf_mac_wrapper_forall
   (#i:id)
   (#rw:rw)
@@ -180,7 +180,7 @@ private val frame_entries_and_table_mac_wrapper
 let frame_entries_and_table_mac_wrapper #i #rw #aadlen #plainlen aead_st nonce aad plain cipher_tagged mac_st h0 h1 = 
   frame_aead_entries_are_refined_mac_wrapper aead_st nonce aad plain cipher_tagged mac_st h0 h1
 
-#reset-options "--z3rlimit 200 --initial_fuel 0 --max_fuel 0 --initial_ifuel 0 --max_ifuel 0"      
+#reset-options "--z3rlimit 200 --fuel 0 --ifuel 0"
 (*
  * mac_wrapper does not modify the plain text buffer and the ciphertext part of the ciphertext buffer
  *)

--- a/examples/old/tls-record-layer/crypto/Crypto.AEAD.Wrappers.Encoding.fst
+++ b/examples/old/tls-record-layer/crypto/Crypto.AEAD.Wrappers.Encoding.fst
@@ -134,7 +134,7 @@ val accumulate_enc
 	      CMA.mac_is_unset i PRF.(aead_st.prf.mac_rgn) ak h1) /\
 	  accumulate_modifies_nothing h0 h1 /\
 	  accumulate_ensures ak aad cipher h0 acc h1))
-#reset-options "--z3rlimit 400 --initial_fuel 0 --max_fuel 0 --initial_ifuel 0 --max_ifuel 0"
+#reset-options "--z3rlimit 400 --fuel 0 --ifuel 0"
 let accumulate_freshness (#i:mac_id) (acc:CMA.accBuffer i) (h0:mem) (h1:mem) = 
     (mac_log ==> fresh_sref h0 h1 (CMA.alog acc)) /\
     (fresh_sref h0 h1 (Buffer.content (MAC.as_buffer (CMA.abuf acc))))

--- a/examples/old/tls-record-layer/crypto/Crypto.AEAD.Wrappers.PRF.fst
+++ b/examples/old/tls-record-layer/crypto/Crypto.AEAD.Wrappers.PRF.fst
@@ -350,7 +350,7 @@ let prf_mac_0 #i #rw aead_st k_0 x =
 (*+ prf_mac_enc:
       A wrapper for PRF.prf_mac, specialized for its use in AEAD.Encrypt.encrypt
 **)      
-#reset-options "--z3rlimit 100 --initial_fuel 0 --max_fuel 0 --initial_ifuel 0 --max_ifuel 0"
+#reset-options "--z3rlimit 100 --fuel 0 --ifuel 0"
 val prf_mac_enc
   (#i:id)
   (#rw:rw)

--- a/examples/old/tls-record-layer/crypto/Crypto.Symmetric.AES.fst
+++ b/examples/old/tls-record-layer/crypto/Crypto.Symmetric.AES.fst
@@ -437,7 +437,7 @@ let mixColumns_ state c =
   s.(2ul) <- H8.(multiply 0x2uy s2 ^^ multiply 0x3uy s3 ^^ s0 ^^ s1);
   s.(3ul) <- H8.(multiply 0x2uy s3 ^^ multiply 0x3uy s0 ^^ s1 ^^ s2)
 
-#reset-options "--initial_fuel 0 --max_fuel 0"
+#reset-options "--fuel 0"
 
 val mixColumns: state:block -> Stack unit
   (requires (fun h -> live h state))
@@ -448,7 +448,7 @@ let mixColumns state =
   mixColumns_ state 2ul;
   mixColumns_ state 3ul
 
-#reset-options "--z3rlimit 10 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 10 --fuel 0"
 
 val addRoundKey_: state:block -> w:xkey{disjoint state w} -> rnd -> c:UInt32.t{v c < 4} -> Stack unit
   (requires (fun h -> live h state /\ live h w))
@@ -486,7 +486,7 @@ let rec cipher_loop state w sbox round =
     cipher_loop   state w sbox (round+^1ul)
   end
 
-#reset-options "--initial_fuel 0 --max_fuel 0 --z3rlimit 20"
+#reset-options "--fuel 0 --z3rlimit 20"
 
 val cipher: out:block -> input:block -> w:xkey -> sb:sbox -> Stack unit
   (requires (fun h -> live h out /\ live h input /\ live h w /\ live h sb /\ 
@@ -529,7 +529,7 @@ let subWord word sbox =
   word.(2ul) <- access sbox word.(2ul);
   word.(3ul) <- access sbox word.(3ul)
 
-#reset-options "--z3rlimit 40 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 40 --fuel 0"
 
 val rcon: i:UInt32.t{v i >= 1} -> byte -> Tot byte (decreases (v i))
 let rec rcon i tmp =
@@ -539,7 +539,7 @@ let rec rcon i tmp =
     rcon (U32.(i-^1ul)) tmp
   end
 
-#reset-options "--z3rlimit 20 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 20 --fuel 0"
 
 val keyExpansion_aux_0:w:xkey -> temp:lbytes 4 -> sbox:sbox -> i:UInt32.t{v i < (v xkeylen / 4) /\ v i >= v nk} -> Stack unit
   (requires (fun h -> live h w /\ live h temp /\ live h sbox /\ 
@@ -560,7 +560,7 @@ let keyExpansion_aux_0 w temp sbox j =
     subWord temp sbox
   
 
-#reset-options "--z3rlimit 50 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 50 --fuel 0"
 
 val keyExpansion_aux_1: w:xkey -> temp:lbytes 4 -> sbox:sbox -> i:UInt32.t{v i < (v xkeylen / 4) /\ v i >= v nk} -> Stack unit
   (requires (fun h -> live h w /\ live h temp /\ live h sbox
@@ -670,7 +670,7 @@ let invMixColumns_ state c =
   s.(2ul) <- mix s2 s3 s0 s1;
   s.(3ul) <- mix s3 s0 s1 s2
 
-#reset-options "--initial_fuel 0 --max_fuel 0"
+#reset-options "--fuel 0"
 
 val invMixColumns: state:block -> Stack unit
   (requires (fun h -> live h state))

--- a/examples/old/tls-record-layer/crypto/Crypto.Symmetric.AES128.fst
+++ b/examples/old/tls-record-layer/crypto/Crypto.Symmetric.AES128.fst
@@ -277,7 +277,7 @@ let shiftRows state =
   state.(i+^ 8ul) <- state.(i+^ 4ul);
   state.(i+^ 4ul) <- tmp
 
-#reset-options "--z3rlimit 50 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 50 --fuel 0"
 
 val mixColumns_: state:block -> c:UInt32.t{v c < 4} -> STL unit
   (requires (fun h -> live h state))
@@ -293,7 +293,7 @@ let mixColumns_ state c =
   s.(2ul) <- H8.(multiply 0x2uy s2 ^^ multiply 0x3uy s3 ^^ s0 ^^ s1);
   s.(3ul) <- H8.(multiply 0x2uy s3 ^^ multiply 0x3uy s0 ^^ s1 ^^ s2)
 
-#reset-options "--initial_fuel 0 --max_fuel 0"
+#reset-options "--fuel 0"
 
 val mixColumns: state:block -> STL unit
   (requires (fun h -> live h state))
@@ -304,7 +304,7 @@ let mixColumns state =
   mixColumns_ state 2ul;
   mixColumns_ state 3ul
 
-#reset-options "--z3rlimit 10 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 10 --fuel 0"
 
 val addRoundKey_: state:block -> w:xkey{disjoint state w} -> rnd -> c:UInt32.t{v c < 4} -> STL unit
   (requires (fun h -> live h state /\ live h w))
@@ -342,7 +342,7 @@ let rec cipher_loop state w sbox round =
     cipher_loop   state w sbox (round+^1ul)
   end
 
-#reset-options "--initial_fuel 0 --max_fuel 0 --z3rlimit 20"
+#reset-options "--fuel 0 --z3rlimit 20"
 
 val cipher: out:block -> input:block -> w:xkey -> sb:sbox -> STL unit
   (requires (fun h -> live h out /\ live h input /\ live h w /\ live h sb /\
@@ -395,7 +395,7 @@ let rec rcon i tmp =
     rcon (U32.(i-^1ul)) tmp
   end
 
-#reset-options "--z3rlimit 100 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 100 --fuel 0"
 
 val keyExpansion_aux_0:w:xkey -> temp:lbytes 4 -> sbox:sbox -> i:UInt32.t{v i < (v xkeylen / 4) /\ v i >= v nk} -> STL unit
   (requires (fun h -> live h w /\ live h temp /\ live h sbox /\
@@ -416,7 +416,7 @@ let keyExpansion_aux_0 w temp sbox j =
     subWord temp sbox
 
 
-#reset-options "--z3rlimit 50 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 50 --fuel 0"
 
 val keyExpansion_aux_1: w:xkey -> temp:lbytes 4 -> sbox:sbox -> i:UInt32.t{v i < (v xkeylen / 4) /\ v i >= v nk} -> STL unit
   (requires (fun h -> live h w /\ live h temp /\ live h sbox
@@ -511,7 +511,7 @@ let invShiftRows state =
   state.(i+^8ul)  <- state.(i+^4ul);
   state.(i+^4ul)  <- tmp
 
-#reset-options "--z3rlimit 100 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 100 --fuel 0"
 
 val invMixColumns_: state:block -> c:UInt32.t{v c < 4} -> STL unit
   (requires (fun h -> live h state))
@@ -528,7 +528,7 @@ let invMixColumns_ state c =
   s.(2ul) <- mix s2 s3 s0 s1;
   s.(3ul) <- mix s3 s0 s1 s2
 
-#reset-options "--initial_fuel 0 --max_fuel 0"
+#reset-options "--fuel 0"
 
 val invMixColumns: state:block -> STL unit
   (requires (fun h -> live h state))
@@ -553,7 +553,7 @@ let rec inv_cipher_loop state w sbox round =
     inv_cipher_loop state w sbox (round -^ 1ul)
   end
 
-#reset-options "--initial_fuel 0 --max_fuel 0 --z3rlimit 100"
+#reset-options "--fuel 0 --z3rlimit 100"
 
 val inv_cipher: out:block -> input:block -> w:xkey -> sb:sbox -> STL unit
   (requires (fun h -> live h out /\ live h input /\ live h w /\ live h sb /\

--- a/examples/old/tls-record-layer/crypto/Crypto.Symmetric.Bytes.fst
+++ b/examples/old/tls-record-layer/crypto/Crypto.Symmetric.Bytes.fst
@@ -61,7 +61,7 @@ let rec big_endian (b:bytes) : Tot (n:nat) (decreases (length b)) =
   else
     UInt8.v (last b) + pow2 8 * big_endian (slice b 0 (length b - 1))
 
-#reset-options "--initial_fuel 1 --max_fuel 1"
+#reset-options "--fuel 1"
 
 val little_endian_null: len:nat{len < 16} -> Lemma (little_endian (Seq.create len 0uy) == 0)
 let rec little_endian_null len =
@@ -82,7 +82,7 @@ let little_endian_singleton n =
     little_endian (slice (create 1 n) 1 1))
 
 
-#reset-options "--initial_fuel 1 --max_fuel 1 --z3rlimit 50"
+#reset-options "--fuel 1 --z3rlimit 50"
 
 val little_endian_append: w1:bytes -> w2:bytes -> Lemma
   (requires True)
@@ -168,7 +168,7 @@ let rec lemma_big_endian_is_bounded b =
     end
 
 
-#reset-options "--initial_fuel 0 --max_fuel 0"
+#reset-options "--fuel 0"
 
 val lemma_little_endian_lt_2_128: b:bytes {Seq.length b <= 16} -> Lemma
   (requires True)
@@ -200,7 +200,7 @@ let rec little_bytes len n =
     assert(Seq.equal b' (tail b));
     b
 
-#reset-options "--initial_fuel 1 --max_fuel 1 --initial_ifuel 0 --max_ifuel 0"
+#reset-options "--fuel 1 --ifuel 0"
 
 
 (* injectivity proofs for byte encodings *) 

--- a/examples/old/tls-record-layer/crypto/Crypto.Symmetric.GCM.fst
+++ b/examples/old/tls-record-layer/crypto/Crypto.Symmetric.GCM.fst
@@ -25,7 +25,7 @@ open FStar.Buffer
 module U32 = FStar.UInt32
 type u32 = FStar.UInt32.t
 
-#set-options "--z3rlimit 10 --max_fuel 0 --initial_fuel 0"
+#set-options "--z3rlimit 10 --fuel 0 --initial_fuel 0"
 
 type bytes = buffer byte
 
@@ -111,7 +111,7 @@ let authenticate #k alg ciphertext tag key nonce cnt ad adlen len =
   auth_body #k alg ciphertext tag key nonce cnt ad adlen len tmp;
   pop_frame()
 
-#reset-options "--initial_fuel 0 --max_fuel 0 --z3rlimit 50"
+#reset-options "--fuel 0 --z3rlimit 50"
 
 private val encrypt_loop: #k:pos -> alg:cipher_alg k ->
     ciphertext:bytes ->
@@ -152,7 +152,7 @@ let rec encrypt_loop #k alg ciphertext key cnt plaintext len tmp dep =
     assert(live h1 ciphertext /\ live h1 key /\ live h1 plaintext /\ live h1 tmp /\ modifies_2 ciphertext tmp h0 h1)
   end
 
-#reset-options "--initial_fuel 0 --max_fuel 0 --z3rlimit 20"
+#reset-options "--fuel 0 --z3rlimit 20"
 
 private val encrypt_body: #k:pos -> alg:cipher_alg k ->
     ciphertext:bytes ->
@@ -176,7 +176,7 @@ let encrypt_body #k alg ciphertext tag key nonce cnt ad adlen plaintext len =
   authenticate #k alg ciphertext tag key nonce cnt ad adlen len;
   pop_frame()
 
-#reset-options "--initial_fuel 0 --max_fuel 0"
+#reset-options "--fuel 0"
 
 (* * In GCM, an initialization vector is used to generate a 96-bit nonce, and can have any length. **)
 (* * This version only allows 96-bit iv. This needs to be fixed.                                   **)

--- a/examples/old/tls-record-layer/crypto/Crypto.Symmetric.GF128.fst
+++ b/examples/old/tls-record-layer/crypto/Crypto.Symmetric.GF128.fst
@@ -189,7 +189,7 @@ let finish a s =
 //16-09-23 Instead of the code below, we should re-use existing AEAD encodings
 //16-09-23 and share their injectivity proofs and crypto model.
 
-#reset-options "--initial_fuel 0 --max_fuel 0 --z3rlimit 20"
+#reset-options "--fuel 0 --z3rlimit 20"
 
 private val ghash_loop_:
   tag:elemB ->
@@ -260,7 +260,7 @@ let mk_len_info len_info len_1 len_2 =
   upd len_info 11ul (uint32_to_uint8 len_2)
 // relying on outer initialization?
 
-#reset-options "--initial_fuel 0 --max_fuel 0 --z3rlimit 20"
+#reset-options "--fuel 0 --z3rlimit 20"
 
 (* A hash function used in authentication. It will authenticate additional data first, *)
 (* then ciphertext and at last length information. The result is stored in tag.        *)

--- a/examples/old/tls-record-layer/crypto/Crypto.Symmetric.MAC.fst
+++ b/examples/old/tls-record-layer/crypto/Crypto.Symmetric.MAC.fst
@@ -311,7 +311,7 @@ let poly_cons #i x xs r =
     PL.poly_cons x (text_to_PS_text xs) r
   | GHASH    ->  GS.poly_cons x xs r; GS.add_comm (poly #i xs r) (encode i x)
 
-#set-options "--z3rlimit 20 --initial_fuel 0 --max_fuel 0"
+#set-options "--z3rlimit 20 --fuel 0"
 
 (** Process one message block and update the accumulator *)
 val update: #i:id -> r:elemB i -> a:elemB i -> w:wordB_16 -> Stack unit

--- a/examples/old/tls-record-layer/crypto/Crypto.Symmetric.PRF.fst
+++ b/examples/old/tls-record-layer/crypto/Crypto.Symmetric.PRF.fst
@@ -366,7 +366,7 @@ let prf_sk0 #i t =
     keyBuffer
 
 
-#reset-options "--initial_fuel 0 --max_fuel 0 --z3rlimit 20"
+#reset-options "--fuel 0 --z3rlimit 20"
 
 let extends (#rgn:region) (#i:id) (s0:Seq.seq (entry rgn i))
       (s1:Seq.seq (entry rgn i)) (x:domain i{ctr_0 i <^ x.ctr}) =

--- a/examples/old/tls-record-layer/crypto/Crypto.Symmetric.Poly1305.Bignum.Lemmas.Part1.fst
+++ b/examples/old/tls-record-layer/crypto/Crypto.Symmetric.Poly1305.Bignum.Lemmas.Part1.fst
@@ -65,7 +65,7 @@ let w : U32.t -> Tot int = U32.v
 
 (*** Addition ***)
 
-#reset-options "--z3rlimit 5 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 5 --fuel 0"
 
 val lemma_fsum_0:
   a0:U64.t -> a1:U64.t -> a2:U64.t -> a3:U64.t -> a4:U64.t ->
@@ -80,7 +80,7 @@ let lemma_fsum_0 a0 a1 a2 a3 a4 b0 b1 b2 b3 b4 =
   pow2_double_sum 26;
   pow2_lt_compat 64 27
 
-#reset-options "--z3rlimit 5 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 5 --fuel 0"
 
 val lemma_bitweight_values: unit ->
   Lemma (bitweight templ 0 = 0 /\ bitweight templ 1 = 26
@@ -100,7 +100,7 @@ let lemma_bitweight_values () =
   bitweight_def templ 8;
   bitweight_def templ 9
 
-#reset-options "--z3rlimit 20 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 20 --fuel 0"
 
 val lemma_eval_bigint_5:
   h:mem ->
@@ -120,7 +120,7 @@ let lemma_eval_bigint_5 h b =
   eval_def h b 4;
   eval_def h b 5
 
-#reset-options "--z3rlimit 20 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 20 --fuel 0"
 
 val lemma_eval_bigint_6:
   h:mem ->
@@ -142,7 +142,7 @@ let lemma_eval_bigint_6 h b =
   eval_def h b 5;
   eval_def h b 6
 
-#reset-options "--z3rlimit 20 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 20 --fuel 0"
 
 val lemma_eval_bigint_9:
   h:mem ->
@@ -170,14 +170,14 @@ let lemma_eval_bigint_9 h b =
   eval_def h b 8;
   eval_def h b 9
 
-#reset-options "--z3rlimit 5 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 5 --fuel 0"
 
 val factorization_lemma: unit ->
   Lemma (requires (True))
 	(ensures  (forall a b c. {:pattern (a * (b+c))} a * (b + c) = a * b + a * c))
 let factorization_lemma () = ()
 
-#reset-options "--z3rlimit 20 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 20 --fuel 0"
 
 val lemma_fsum: h0:mem -> h1:mem -> a:bigint -> b:bigint -> Lemma
   (requires (norm h0 a /\ norm h0 b /\ isSum h0 h1 a b))
@@ -190,7 +190,7 @@ let lemma_fsum h0 h1 a b =
   factorization_lemma ();
   lemma_eval_bigint_5 h1 a
 
-#reset-options "--z3rlimit 20 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 20 --fuel 0"
 
 let isMultiplication (h0:mem) (h1:mem) (a:bigint) (b:bigint) (c:bigint) : GTot Type0 =
   live h0 a /\ live h0 b /\ live h1 c
@@ -234,7 +234,7 @@ let isMultiplication_
 	/\ c7 = a3 * b4 + a4 * b3
 	/\ c8 = a4 * b4 ) )
 
-#reset-options "--z3rlimit 20 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 20 --fuel 0"
 
 val lemma_multiplication_0:
   a0:U64.t -> a1:U64.t -> a2:U64.t -> a3:U64.t -> a4:U64.t ->
@@ -280,7 +280,7 @@ let lemma_multiplication_0 a0 a1 a2 a3 a4 b0 b1 b2 b3 b4 =
   pow2_double_sum 55;
   pow2_lt_compat 64 56
 
-#reset-options "--z3rlimit 20 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 20 --fuel 0"
 
 let u27 = x:FStar.UInt64.t{v x < pow2 27}
 let u26 = x:FStar.UInt64.t{v x < pow2 26}
@@ -315,7 +315,7 @@ private let lemma_multiplication04 a0 a1 a2 a3 a4 b0 b1 b2 b3 b4 :
     lemma_multiplication03 a3 b0 b1 b2 b3 b4;
     lemma_multiplication03 a4 b0 b1 b2 b3 b4
 
-#reset-options "--z3rlimit 5 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 5 --fuel 0"
 
 let lemma_multiplication05
   (a0:int) (a1:int) (a2:int) (a3:int) (a4:int)
@@ -332,7 +332,7 @@ let lemma_multiplication05
 
 
 (*
-#reset-options "--z3rlimit 20 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 20 --fuel 0"
 
 private let lemma_multiplication060
   (a0:int) (a1:int) (a2:int) (a3:int) (a4:int)
@@ -342,7 +342,7 @@ private let lemma_multiplication060
     = a0 * b0 + pow2 26  * (a0 * b1) + pow2 52  * (a0 * b2) + pow2 78  * (a0 * b3) + pow2 104 * (a0 * b4) )
   = ()
 
-#reset-options "--z3rlimit 20 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 20 --fuel 0"
 
 let lemma_swap p1 a p2 b : Lemma ((p1 * a) * (p2 * b) = p1 * p2 * (a * b)) = ()
 
@@ -361,7 +361,7 @@ private let lemma_multiplication061
     lemma_swap (pow2 26) a1 (pow2 78) b3;
     lemma_swap (pow2 26) a1 (pow2 104) b4
 
-#reset-options "--z3rlimit 20 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 20 --fuel 0"
 
 private let lemma_multiplication062
   (a0:int) (a1:int) (a2:int) (a3:int) (a4:int)
@@ -378,7 +378,7 @@ private let lemma_multiplication062
     lemma_swap (pow2 52) a2 (pow2 78) b3;
     lemma_swap (pow2 52) a2 (pow2 104) b4
 
-#reset-options "--z3rlimit 20 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 20 --fuel 0"
 
 private let lemma_multiplication063
   (a0:int) (a1:int) (a2:int) (a3:int) (a4:int)
@@ -395,7 +395,7 @@ private let lemma_multiplication063
     lemma_swap (pow2 78) a3 (pow2 78) b3;
     lemma_swap (pow2 78) a3 (pow2 104) b4
 
-#reset-options "--z3rlimit 20 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 20 --fuel 0"
 
 private let lemma_multiplication064
   (a0:int) (a1:int) (a2:int) (a3:int) (a4:int)
@@ -412,7 +412,7 @@ private let lemma_multiplication064
     lemma_swap (pow2 104) a4 (pow2 78) b3;
     lemma_swap (pow2 104) a4 (pow2 104) b4
 
-#reset-options "--z3rlimit 20 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 20 --fuel 0"
 
 private let lemma_multiplication06
   (a0:int) (a1:int) (a2:int) (a3:int) (a4:int)
@@ -434,7 +434,7 @@ private let lemma_multiplication06
     lemma_multiplication063 a0 a1 a2 a3 a4 b0 b1 b2 b3 b4;
     lemma_multiplication064 a0 a1 a2 a3 a4 b0 b1 b2 b3 b4
 
-#reset-options "--z3rlimit 20 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 20 --fuel 0"
 
 private let lemma_multiplication07
   (a0:int) (a1:int) (a2:int) (a3:int) (a4:int)
@@ -449,7 +449,7 @@ private let lemma_multiplication07
   = lemma_multiplication05 a0 a1 a2 a3 a4 b0 b1 b2 b3 b4;
     lemma_multiplication06 a0 a1 a2 a3 a4 b0 b1 b2 b3 b4
 
-#reset-options "--z3rlimit 20 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 20 --fuel 0"
 
 private let lemma_multiplication08
   (a0:int) (a1:int) (a2:int) (a3:int) (a4:int)
@@ -477,7 +477,7 @@ private let lemma_multiplication08
     lemma_multiplication00 (pow2 182) (a4 * b3) (a3 * b4)
 
 
-#reset-options "--z3rlimit 20 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 20 --fuel 0"
 
 private let lemma_multiplication0
   (a0:int) (a1:int) (a2:int) (a3:int) (a4:int)
@@ -497,7 +497,7 @@ private let lemma_multiplication0
     lemma_multiplication08 a0 a1 a2 a3 a4 b0 b1 b2 b3 b4
 
 
-#reset-options "--z3rlimit 20 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 20 --fuel 0"
 
 val lemma_multiplication1:
   h0:mem -> h1:mem ->
@@ -523,7 +523,7 @@ let lemma_multiplication1 h0 h1 c a b =
   lemma_multiplication0 a0 a1 a2 a3 a4 b0 b1 b2 b3 b4
 
 
-#reset-options "--z3rlimit 100 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 100 --fuel 0"
 
 let lemma_mul_ineq (a:nat) (b:nat) c d : Lemma (requires (a < c /\ b < d))
 					    (ensures  (a * b < c * d))
@@ -585,7 +585,7 @@ let lemma_multiplication2 h0 h1 c a b =
   maxValue_bound_lemma_aux h1 c (2*norm_length-1) (5*pow2 53)
 
 
-#reset-options "--z3rlimit 5 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 5 --fuel 0"
 
 val lemma_multiplication:
   h0:mem ->

--- a/examples/old/tls-record-layer/crypto/Crypto.Symmetric.Poly1305.Bignum.Lemmas.Part2.fst
+++ b/examples/old/tls-record-layer/crypto/Crypto.Symmetric.Poly1305.Bignum.Lemmas.Part2.fst
@@ -33,7 +33,7 @@ open Crypto.Symmetric.Poly1305.Bigint
 open Crypto.Symmetric.Poly1305.Bignum.Lemmas.Part1
 
 
-#reset-options "--z3rlimit 20 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 20 --fuel 0"
 
 private let lemma_multiplication060
   (a0:int) (a1:int) (a2:int) (a3:int) (a4:int)
@@ -43,7 +43,7 @@ private let lemma_multiplication060
     = a0 * b0 + pow2 26  * (a0 * b1) + pow2 52  * (a0 * b2) + pow2 78  * (a0 * b3) + pow2 104 * (a0 * b4) )
   = ()
 
-#reset-options "--z3rlimit 20 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 20 --fuel 0"
 
 let lemma_swap p1 a p2 b : Lemma ((p1 * a) * (p2 * b) = p1 * p2 * (a * b)) = ()
 
@@ -62,7 +62,7 @@ private let lemma_multiplication061
     lemma_swap (pow2 26) a1 (pow2 78) b3;
     lemma_swap (pow2 26) a1 (pow2 104) b4
 
-#reset-options "--z3rlimit 20 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 20 --fuel 0"
 
 private let lemma_multiplication062
   (a0:int) (a1:int) (a2:int) (a3:int) (a4:int)
@@ -79,7 +79,7 @@ private let lemma_multiplication062
     lemma_swap (pow2 52) a2 (pow2 78) b3;
     lemma_swap (pow2 52) a2 (pow2 104) b4
 
-#reset-options "--z3rlimit 20 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 20 --fuel 0"
 
 private let lemma_multiplication063
   (a0:int) (a1:int) (a2:int) (a3:int) (a4:int)
@@ -96,7 +96,7 @@ private let lemma_multiplication063
     lemma_swap (pow2 78) a3 (pow2 78) b3;
     lemma_swap (pow2 78) a3 (pow2 104) b4
 
-#reset-options "--z3rlimit 20 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 20 --fuel 0"
 
 private let lemma_multiplication064
   (a0:int) (a1:int) (a2:int) (a3:int) (a4:int)
@@ -113,7 +113,7 @@ private let lemma_multiplication064
     lemma_swap (pow2 104) a4 (pow2 78) b3;
     lemma_swap (pow2 104) a4 (pow2 104) b4
 
-#reset-options "--z3rlimit 40 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 40 --fuel 0"
 
 private let lemma_multiplication06
   (a0:int) (a1:int) (a2:int) (a3:int) (a4:int)
@@ -135,7 +135,7 @@ private let lemma_multiplication06
     lemma_multiplication063 a0 a1 a2 a3 a4 b0 b1 b2 b3 b4;
     lemma_multiplication064 a0 a1 a2 a3 a4 b0 b1 b2 b3 b4
 
-#reset-options "--z3rlimit 20 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 20 --fuel 0"
 
 private let lemma_multiplication07
   (a0:int) (a1:int) (a2:int) (a3:int) (a4:int)
@@ -150,7 +150,7 @@ private let lemma_multiplication07
   = lemma_multiplication05 a0 a1 a2 a3 a4 b0 b1 b2 b3 b4;
     lemma_multiplication06 a0 a1 a2 a3 a4 b0 b1 b2 b3 b4
 
-#reset-options "--z3rlimit 20 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 20 --fuel 0"
 
 private let lemma_multiplication08
   (a0:int) (a1:int) (a2:int) (a3:int) (a4:int)
@@ -178,7 +178,7 @@ private let lemma_multiplication08
     lemma_multiplication00 (pow2 182) (a4 * b3) (a3 * b4)
 
 
-#reset-options "--z3rlimit 20 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 20 --fuel 0"
 
 private let lemma_multiplication0
   (a0:int) (a1:int) (a2:int) (a3:int) (a4:int)
@@ -198,7 +198,7 @@ private let lemma_multiplication0
     lemma_multiplication08 a0 a1 a2 a3 a4 b0 b1 b2 b3 b4
 
 
-#reset-options "--z3rlimit 20 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 20 --fuel 0"
 
 val lemma_multiplication1:
   h0:mem -> h1:mem ->
@@ -224,7 +224,7 @@ let lemma_multiplication1 h0 h1 c a b =
   lemma_multiplication0 a0 a1 a2 a3 a4 b0 b1 b2 b3 b4
 
 
-#reset-options "--z3rlimit 100 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 100 --fuel 0"
 
 let lemma_mul_ineq (a:nat) (b:nat) c d : Lemma (requires (a < c /\ b < d))
 					    (ensures  (a * b < c * d))
@@ -286,7 +286,7 @@ let lemma_multiplication2 h0 h1 c a b =
   maxValue_bound_lemma_aux h1 c (2*norm_length-1) (5*pow2 53)
 
 
-#reset-options "--z3rlimit 5 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 5 --fuel 0"
 
 val lemma_multiplication:
   h0:mem ->

--- a/examples/old/tls-record-layer/crypto/Crypto.Symmetric.Poly1305.Bignum.Lemmas.Part3.fst
+++ b/examples/old/tls-record-layer/crypto/Crypto.Symmetric.Poly1305.Bignum.Lemmas.Part3.fst
@@ -34,7 +34,7 @@ open Crypto.Symmetric.Poly1305.Bignum.Lemmas.Part2
 
 
 
-#reset-options "--z3rlimit 5 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 5 --fuel 0"
 
 val lemma_div_def: a:nat -> b:pos -> Lemma (a = b * (a / b) + a % b)
 let lemma_div_def a b = ()
@@ -50,14 +50,14 @@ let lemma_modulo_add a b p =
   lemma_mod_plus_distr_l a b p
 
 
-#reset-options "--initial_fuel 0 --max_fuel 0 --z3rlimit 20"
+#reset-options "--fuel 0 --z3rlimit 20"
 
 val lemma_2_130_modulo_prime: unit -> Lemma (pow2 130 % (pow2 130 - 5) = 5)
 let lemma_2_130_modulo_prime () =
   assert_norm(pow2 130 > 5);
   assert_norm(pow2 130 % (pow2 130 - 5) = 5)
 
-#reset-options "--z3rlimit 5 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 5 --fuel 0"
 
 let isDegreeReduced (h0:mem) (h1:mem) (b:bigint) =
   live h0 b /\ live h1 b /\ length b >= 2*norm_length-1
@@ -91,7 +91,7 @@ let bound63 (h:heap) (b:bigint) : GTot Type0 =
   /\ v (get h b 3) < pow2 63 /\ v (get h b 4) < pow2 63
 
 
-#reset-options "--z3rlimit 5 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 5 --fuel 0"
 
 val lemma_freduce_degree1:
   h0:mem -> h1:mem ->
@@ -148,7 +148,7 @@ let lemma_2_26_p (a:nat) : Lemma (requires (a < pow2 26)) (ensures  (a < reveal 
     lemma_modulo_00 a (reveal prime)
 
 
-#reset-options "--z3rlimit 2000 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 2000 --fuel 0"
 
 private val lemma_freduce_degree2_0:
   a:nat -> b:nat -> n:nat{n >= 130} ->
@@ -179,7 +179,7 @@ private val lemma_freduce_degree2_2:
 private let lemma_freduce_degree2_2 a b n =
   lemma_freduce_degree2_0 a b n; lemma_freduce_degree2_1 a b n
 
-#reset-options "--z3rlimit 100 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 100 --fuel 0"
 
 val lemma_freduce_degree2_3:
   b0:nat -> b1:nat -> b2:nat -> b3:nat -> b4:nat -> b5:nat -> b6:nat -> b7:nat -> b8:nat ->
@@ -203,7 +203,7 @@ val lemma_freduce_degree2_4_no_prime:
   Lemma ((b0 + 5 * b5 + pow2 26 * (b1 + 5 * b6) + pow2 52 * (b2 + 5 * b7) + pow2 78 * (b3 + 5 * b8) + pow2 104 * b4) =
       (b0 + pow2 26 * b1 + pow2 52 * b2 + pow2 78 * b3 + pow2 104 * b4
       + 5 * b5 + 5 * pow2 26 * b6 + 5 * pow2 52 * b7 + 5 * pow2 78 * b8))
-#reset-options "--z3rlimit 100 --initial_fuel 0 --max_fuel 0 --initial_ifuel 0 --max_ifuel 0"
+#reset-options "--z3rlimit 100 --fuel 0 --ifuel 0"
 let lemma_freduce_degree2_4_no_prime b0 b1 b2 b3 b4 b5 b6 b7 b8 =
   distributivity_add_right (pow2 26) b1 (5*b6);
   distributivity_add_right (pow2 52) b2 (5*b7);
@@ -233,7 +233,7 @@ let lemma_freduce_degree2 h0 h1 b =
   lemma_freduce_degree2_3 b0 b1 b2 b3 b4 b5 b6 b7 b8;
   lemma_freduce_degree2_4_no_prime b0 b1 b2 b3 b4 b5 b6 b7 b8
 
-#reset-options "--z3rlimit 20 --initial_fuel 0 --max_fuel 0 --initial_ifuel 0 --max_ifuel 0"
+#reset-options "--z3rlimit 20 --fuel 0 --ifuel 0"
 val lemma_freduce_degree:
   h0:mem ->
   h1:mem ->

--- a/examples/old/tls-record-layer/crypto/Crypto.Symmetric.Poly1305.Bignum.Lemmas.Part4.fst
+++ b/examples/old/tls-record-layer/crypto/Crypto.Symmetric.Poly1305.Bignum.Lemmas.Part4.fst
@@ -35,7 +35,7 @@ open Crypto.Symmetric.Poly1305.Bignum.Lemmas.Part3
 
 module U64 = FStar.UInt64
 
-#reset-options "--z3rlimit 20 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 20 --fuel 0"
 
 let isCarried (h0:mem) (h1:mem) (b:bigint) : GTot Type0 =
   live h0 b /\ live h1 b /\ length b >= norm_length+1
@@ -57,7 +57,7 @@ let isCarried (h0:mem) (h1:mem) (b:bigint) : GTot Type0 =
       /\ v (get h1 b 4) = (b4 + r3)  % pow2 26
     )
 
-#reset-options "--z3rlimit 10000 --initial_fuel 4 --max_fuel 4"
+#reset-options "--z3rlimit 10000 --fuel 4"
 
 
 let u633 = x:U64.t{v x < pow2 63}
@@ -81,7 +81,7 @@ let isCarried_
       /\ v (get h1 b 4) = (v b4 + r3)  % pow2 26
     )
 
-#reset-options "--z3rlimit 5 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 5 --fuel 0"
 
 let carried_1 (h:mem) (b:bigint) : GTot Type0 =
   live h b /\ length b >= norm_length+1
@@ -146,7 +146,7 @@ let lemma_carry_10 h0 h1 b =
   lemma_carry_10_2 (b4+r3)
 
 
-#reset-options "--z3rlimit 10 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 10 --fuel 0"
 
 let lemma_carry_110_0 (x:int) (y:int) (z:nat) :
   Lemma (pow2 z * (x + pow2 26 * y) = pow2 z * x + pow2 (z+26) * y)
@@ -187,7 +187,7 @@ let lemma_carry_1101 b0 b1 b2 b3 b4 c0 c1 c2 c3 c4 c5 =
   distributivity_add_right (pow2 104) ((((b0 / p26 + b1) / p26 + b2) / p26 + b3) / p26) b4
 
 
-#reset-options "--z3rlimit 20 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 20 --fuel 0"
 
 val lemma_carry_1102:
   b0:nat -> b1:nat -> b2:nat -> b3:nat -> b4:nat ->
@@ -222,7 +222,7 @@ let lemma_carry_1102 b0 b1 b2 b3 b4 c0 c1 c2 c3 c4 c5 =
   distributivity_add_right (pow2 78) (((b0 / p26 + b1) / p26 + b2) / pow2 26) b3
 
 
-#reset-options "--z3rlimit 20 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 20 --fuel 0"
 
 val lemma_carry_1103:
   b0:nat -> b1:nat -> b2:nat -> b3:nat -> b4:nat ->
@@ -257,7 +257,7 @@ let lemma_carry_1103 b0 b1 b2 b3 b4 c0 c1 c2 c3 c4 c5 =
   distributivity_add_right (pow2 52) (((b0 / p26 + b1) / p26)) b2
 
 
-#reset-options "--z3rlimit 10 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 10 --fuel 0"
 
 val lemma_carry_1104:
   b0:nat -> b1:nat -> b2:nat -> b3:nat -> b4:nat ->
@@ -292,7 +292,7 @@ let lemma_carry_1104 b0 b1 b2 b3 b4 c0 c1 c2 c3 c4 c5 =
   distributivity_add_right (pow2 26) (((b0 / p26))) b1
 
 
-#reset-options "--z3rlimit 20 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 20 --fuel 0"
 
 val lemma_carry_110:
   b0:nat -> b1:nat -> b2:nat -> b3:nat -> b4:nat ->
@@ -325,7 +325,7 @@ let lemma_carry_110 b0 b1 b2 b3 b4 c0 c1 c2 c3 c4 c5 =
   lemma_div_mod b0 (pow2 26)
 
 
-#reset-options "--z3rlimit 20 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 20 --fuel 0"
 
 val lemma_carry_11:
   h0:mem -> h1:mem ->
@@ -362,7 +362,7 @@ let lemma_carry_11 h0 h1 b =
   lemma_carry_110 b0 b1 b2 b3 b4 (v (get h1 b 0)) (v (get h1 b 1)) (v (get h1 b 2)) (v (get h1 b 3)) (v (get h1 b 4)) (v (get h1 b 5))
 
 
-#reset-options "--z3rlimit 5 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 5 --fuel 0"
 
 val lemma_carry_1:
   h0:mem -> h1:mem ->
@@ -376,7 +376,7 @@ let lemma_carry_1 h0 h1 b =
   lemma_carry_11 h0 h1 b
 
 
-#reset-options "--z3rlimit 5 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 5 --fuel 0"
 
 let carried_2 (h:mem) (b:bigint) : GTot Type0 =
   live h b /\ length b >= norm_length+1
@@ -413,7 +413,7 @@ let lemma_div_rest a m n =
 let lemma_mod_0 (a:nat) (b:pos) : Lemma (a % b < b) = ()
 
 
-#reset-options "--z3rlimit 20 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 20 --fuel 0"
 
 val lemma_carry_20:
   h0:mem -> h1:mem ->
@@ -470,7 +470,7 @@ let lemma_carry_20 h0 h1 b =
   )
 
 
-#reset-options "--z3rlimit 5 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 5 --fuel 0"
 
 val lemma_carry_2:
   h0:mem -> h1:mem ->

--- a/examples/old/tls-record-layer/crypto/Crypto.Symmetric.Poly1305.Bignum.Lemmas.Part5.fst
+++ b/examples/old/tls-record-layer/crypto/Crypto.Symmetric.Poly1305.Bignum.Lemmas.Part5.fst
@@ -35,7 +35,7 @@ open Crypto.Symmetric.Poly1305.Bignum.Lemmas.Part3
 open Crypto.Symmetric.Poly1305.Bignum.Lemmas.Part4
 
 
-#reset-options "--z3rlimit 20 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 20 --fuel 0"
 
 
 let carriedTopBottom (h0:mem) (h1:mem) (b:bigint) : GTot Type0 =
@@ -115,7 +115,7 @@ let carried_4 (h:mem) (b:bigint) : GTot Type0 =
   /\ v (get h b 4) < pow2 26
 
 
-#reset-options "--z3rlimit 5 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 5 --fuel 0"
 
 val lemma_carry_top_20:
   h0:mem -> h1:mem ->
@@ -125,7 +125,7 @@ val lemma_carry_top_20:
 let lemma_carry_top_20 h0 h1 b = ()
 
 
-#reset-options "--z3rlimit 5 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 5 --fuel 0"
 
 val lemma_carry_top_2:
   h0:mem -> h1:mem ->
@@ -139,7 +139,7 @@ let lemma_carry_top_2 h0 h1 b =
   lemma_carry_top_11 h0 h1 b
 
 
-#reset-options "--z3rlimit 5 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 5 --fuel 0"
 
 let isCarried01 (h0:mem) (h1:mem) (b:bigint) =
   live h0 b /\ live h1 b
@@ -160,7 +160,7 @@ let lemma_norm_5 h (b:bigint) :
     = ()
 
 
-#reset-options "--z3rlimit 10 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 10 --fuel 0"
 
 val lemma_carry_0_to_10:
   h0:mem -> h1:mem ->

--- a/examples/old/tls-record-layer/crypto/Crypto.Symmetric.Poly1305.Bignum.Lemmas.Part6.fst
+++ b/examples/old/tls-record-layer/crypto/Crypto.Symmetric.Poly1305.Bignum.Lemmas.Part6.fst
@@ -47,7 +47,7 @@ let bound27 h b = bound27 h b
 let w : U32.t -> Tot int = U32.v
 
 
-#reset-options "--initial_fuel 0 --max_fuel 0 --z3rlimit 5"
+#reset-options "--fuel 0 --z3rlimit 5"
 
 let u26 = x:U64.t{v x < pow2 26}
 
@@ -65,7 +65,7 @@ let lemma_mult_le_left (a:pos) (b:nat) (c:nat) : Lemma (requires (b <= c)) (ensu
   = ()
 
 
-#reset-options "--initial_fuel 0 --max_fuel 0 --z3rlimit 20"
+#reset-options "--fuel 0 --z3rlimit 20"
 
 val lemma_finalize_1:
   b0:u26 -> b1:u26 -> b2:u26 -> b3:u26 -> b4:u26 ->
@@ -129,7 +129,7 @@ let lemma_finalize_1 b0 b1 b2 b3 b4 b0' b1' b2' b3' b4' mask =
 
 
 
-#reset-options "--initial_fuel 0 --max_fuel 0 --z3rlimit 20"
+#reset-options "--fuel 0 --z3rlimit 20"
 
 val lemma_finalize_2:
   b0:u26 -> b1:u26 -> b2:u26 -> b3:u26 -> b4:u26 ->
@@ -186,7 +186,7 @@ let lemma_finalize_0 b0 b1 b2 b3 b4 b0' b1' b2' b3' b4' mask =
   Math.Lemmas.modulo_lemma (v b0' + pow2 26 * v b1' + pow2 52 * v b2' + pow2 78 * v b3' + pow2 104 * v b4') (pow2 130 - 5)
 
 
-#reset-options "--initial_fuel 0 --max_fuel 0 --z3rlimit 20"
+#reset-options "--fuel 0 --z3rlimit 20"
 
 val lemma_eval_5: h:HyperStack.mem -> b:bigint{live h b} -> Lemma
   (eval h b 5 = v (get h b 0) + pow2 26 * v (get h b 1) + pow2 52 * v (get h b 2) + pow2 78 * v (get h b 3) + pow2 104 * v (get h b 4))
@@ -211,7 +211,7 @@ val lemma_norm_5: h:HyperStack.mem -> b:bigint{live h b} -> Lemma
 let lemma_norm_5 h b = ()
 
 
-#reset-options "--initial_fuel 0 --max_fuel 0 --z3rlimit 20"
+#reset-options "--fuel 0 --z3rlimit 20"
 
 val lemma_finalize:
   h:HyperStack.mem ->

--- a/examples/old/tls-record-layer/crypto/Crypto.Symmetric.Poly1305.Bignum.fst
+++ b/examples/old/tls-record-layer/crypto/Crypto.Symmetric.Poly1305.Bignum.fst
@@ -52,7 +52,7 @@ let w : U32.t -> Tot int = U32.v
 
 (*** Addition ***)
 
-#reset-options "--z3rlimit 40 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 40 --fuel 0"
 
 private val fsum_: a:bigint -> b:bigint{disjoint a b} -> Stack unit
   (requires (fun h -> norm h a /\ norm h b))
@@ -85,7 +85,7 @@ let fsum_ a b =
   a.(3ul) <- ab3;
   a.(4ul) <- ab4
 
-#reset-options "--z3rlimit 20 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 20 --fuel 0"
 
 val fsum': a:bigint -> b:bigint{disjoint a b} -> Stack unit
     (requires (fun h -> norm h a /\ norm h b))
@@ -99,7 +99,7 @@ let fsum' a b =
   let h1 = ST.get() in
   lemma_fsum h0 h1 a b
 
-#reset-options "--z3rlimit 80 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 80 --fuel 0"
 
 private val update_9: c:bigint{length c >= 2*norm_length-1} ->
   c0:U64.t -> c1:U64.t -> c2:U64.t ->
@@ -122,7 +122,7 @@ let update_9 c c0 c1 c2 c3 c4 c5 c6 c7 c8 =
   c.(7ul) <- c7;
   c.(8ul) <- c8
 
-#reset-options "--z3rlimit 20 --initial_fuel 0 --max_fuel 0 --initial_ifuel 0"
+#reset-options "--z3rlimit 20 --fuel 0 --initial_ifuel 0"
 
 private val multiplication_0:
   c:bigint{length c >= 2*norm_length-1} ->
@@ -211,7 +211,7 @@ let multiplication c a b =
   let h1 = ST.get() in
   lemma_multiplication h0 h1 c a b
 
-#reset-options "--z3rlimit 20 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 20 --fuel 0"
 
 val times_5: b:U64.t{5 * v b < pow2 64} -> Tot (b':U64.t{v b' = 5 * v b})
 let times_5 b = assert_norm(pow2 2 = 4); (b <<^ 2ul) +^ b
@@ -262,7 +262,7 @@ let mod2_26 x =
   y
 
 private val div2_26: x:U64.t -> Tot (y:U64.t{v y = v x / pow2 26 /\ v y <= pow2 38})
-#reset-options "--z3rlimit 40 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 40 --fuel 0"
 let div2_26 x =
     pow2_minus 64 26;
     let y = x >>^ 26ul in
@@ -287,7 +287,7 @@ let update_5 c c0 c1 c2 c3 c4 =
   c.(3ul) <- c3;
   c.(4ul) <- c4
 
-#reset-options "--z3rlimit 40 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 40 --fuel 0"
 
 private val update_6: c:bigint{length c >= norm_length+1} ->
   c0:U64.t -> c1:U64.t -> c2:U64.t ->
@@ -330,7 +330,7 @@ let carry_1_0 b b0 b1 b2 b3 b4 =
   update_6 b b0' b1' b2' b3' b4' b5'
 
 
-#reset-options "--z3rlimit 20 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 20 --fuel 0"
 
 private val carry_1_:
   b:bigint{length b >= norm_length+1} ->
@@ -465,7 +465,7 @@ let modulo b =
   freduce_coefficients b
 
 
-#reset-options "--initial_fuel 0 --max_fuel 0 --z3rlimit 100"
+#reset-options "--fuel 0 --z3rlimit 100"
 
 val finalize: b:bigint -> Stack unit
   (requires (fun h -> norm h b))

--- a/examples/old/tls-record-layer/crypto/Crypto.Symmetric.Poly1305.Lemmas.fst
+++ b/examples/old/tls-record-layer/crypto/Crypto.Symmetric.Poly1305.Lemmas.fst
@@ -36,7 +36,7 @@ open Crypto.Symmetric.Bytes
 module U8 = FStar.UInt8
 module U64 = FStar.UInt64
 
-#set-options "--initial_fuel 0 --max_fuel 0 --z3rlimit 5"
+#set-options "--fuel 0 --z3rlimit 5"
 
 val pow2_8_lemma: n:nat ->
   Lemma
@@ -59,7 +59,7 @@ val pow2_64_lemma: n:nat ->
     [SMTPat (pow2 n)]
 let pow2_64_lemma n = assert_norm(pow2 64 = 18446744073709551616)
 
-#set-options "--initial_fuel 0 --max_fuel 0 --z3rlimit 5"
+#set-options "--fuel 0 --z3rlimit 5"
 
 private val mk_mask: nbits:FStar.UInt32.t{FStar.UInt32.v nbits < 64} ->
   Tot (z:U64.t{v z == pow2 (FStar.UInt32.v nbits) - 1})
@@ -68,7 +68,7 @@ let mk_mask nbits =
   U64.((1uL <<^ nbits) -^ 1uL)
 
 
-#set-options "--initial_fuel 0 --max_fuel 0 --z3rlimit 5"
+#set-options "--fuel 0 --z3rlimit 5"
 
 let u64_32 = u:U64.t{U64.v u < pow2 32}
 
@@ -158,7 +158,7 @@ let lemma_toField_2_1 x =
   Math.Lemmas.distributivity_add_right (pow2 32) (x % pow2 20) (pow2 20 * (x / pow2 20))
 
 
-#set-options "--initial_fuel 0 --max_fuel 0 --z3rlimit 10"
+#set-options "--fuel 0 --z3rlimit 10"
 
 val lemma_toField_2_2: x:nat{x < pow2 32} -> Lemma
   (pow2 52 * ((x * pow2 12) % pow2 26) + pow2 78 * (x / pow2 14) = pow2 64 * x)
@@ -204,7 +204,7 @@ let lemma_toField_2_4 n0 n1 n2 n3 n0' n1' n2' n3' n4' =
   lemma_toField_2_3 v3
 
 
-#set-options "--initial_fuel 0 --max_fuel 0 --z3rlimit 5"
+#set-options "--fuel 0 --z3rlimit 5"
 
 val lemma_toField_2: n0:u64_32 -> n1:u64_32 -> n2:u64_32 -> n3:u64_32 ->
   n0':U64.t -> n1':U64.t -> n2':U64.t -> n3':U64.t -> n4':U64.t -> Lemma
@@ -268,7 +268,7 @@ let lemma_mod_pow2 a b c =
   Math.Lemmas.lemma_mod_plus 0 (q * pow2 (b - c)) (pow2 c)
 
 
-#set-options "--initial_fuel 0 --max_fuel 0 --z3rlimit 20"
+#set-options "--fuel 0 --z3rlimit 20"
 
 private val add_disjoint: #z:pos -> a:UInt.uint_t z -> b:UInt.uint_t z -> n:nat -> m:nat{m < z} -> Lemma
   (requires (a % pow2 m = 0 /\ b < pow2 m /\ a < pow2 n /\ n >= m))
@@ -299,7 +299,7 @@ let lemma_disjoint_bounded b0 b1 l m n =
   Math.Lemmas.lemma_mod_plus_distr_l (v b0) (v b1) (pow2 l);
   Math.Lemmas.lemma_mod_plus_distr_l (v b1) ((v b0) % pow2 l) (pow2 l)
 
-#set-options "--initial_fuel 0 --max_fuel 0 --z3rlimit 20"
+#set-options "--fuel 0 --z3rlimit 20"
 
 val lemma_toField_3: n0:u64_32 -> n1:u64_32 -> n2:u64_32 -> n3:u64_32 ->
   n0':U64.t -> n1':U64.t -> n2':U64.t -> n3':U64.t -> n4':U64.t -> Lemma
@@ -338,7 +338,7 @@ let lemma_toField_3 n0 n1 n2 n3 n0' n1' n2' n3' n4' =
   lemma_div_pow2_lt (v n3) 32 8
 
 
-#set-options "--initial_fuel 1 --max_fuel 1 --z3rlimit 5"
+#set-options "--fuel 1 --z3rlimit 5"
 
 (* The little_endian function but computed from the most significant bit, makes the
    enrolling of the function to concrete values easier for math *)
@@ -347,7 +347,7 @@ let rec little_endian_from_top (s:Seq.seq U8.t) (len:nat{len <= Seq.length s}) :
     else pow2 (8 * (len - 1)) * U8.v (Seq.index s (len-1)) + little_endian_from_top s (len-1)
 
 
-#set-options "--z3rlimit 50 --initial_fuel 1 --max_fuel 1"
+#set-options "--z3rlimit 50 --fuel 1"
 
 val lemma_little_endian_from_top_:
   s:Seq.seq U8.t{Seq.length s > 0} -> len:nat{len <= Seq.length s} ->
@@ -366,7 +366,7 @@ let rec lemma_little_endian_from_top_ s len =
     end
 
 
-#set-options "--z3rlimit 5 --initial_fuel 0 --max_fuel 0"
+#set-options "--z3rlimit 5 --fuel 0"
 
 val lemma_little_endian_from_top: s:Seq.seq U8.t{Seq.length s > 0} -> Lemma
   (little_endian s = little_endian_from_top s (Seq.length s))
@@ -374,7 +374,7 @@ let lemma_little_endian_from_top s =
   Seq.lemma_eq_intro s (Seq.slice s 0 (Seq.length s));
   lemma_little_endian_from_top_ s (Seq.length s)
 
-#set-options "--z3rlimit 5 --initial_fuel 1 --max_fuel 1"
+#set-options "--z3rlimit 5 --fuel 1"
 
 val lemma_little_endian_from_top_def: s:Seq.seq U8.t -> len:nat{Seq.length s >= len} ->
   Lemma ((len = 0 ==> little_endian_from_top s len = 0)
@@ -384,7 +384,7 @@ val lemma_little_endian_from_top_def: s:Seq.seq U8.t -> len:nat{Seq.length s >= 
 let lemma_little_endian_from_top_def s len = ()
 
 
-#set-options "--initial_fuel 0 --max_fuel 0 --z3rlimit 20"
+#set-options "--fuel 0 --z3rlimit 20"
 
 val lemma_little_endian_of_u64: u:U64.t -> w:Seq.seq U8.t{Seq.length w = 4} ->
   Lemma (requires  (U64.v u == U8.v (Seq.index w 0) + pow2 8 * U8.v (Seq.index w 1) + pow2 16 * U8.v (Seq.index w 2) + pow2 24 * U8.v (Seq.index w 3)))
@@ -399,13 +399,13 @@ let lemma_little_endian_of_u64 u w =
   lemma_little_endian_from_top_def w 0
 
 
-#set-options "--initial_fuel 0 --max_fuel 0 --z3rlimit 5"
+#set-options "--fuel 0 --z3rlimit 5"
 
 private let lemma_get_word #a (b:Buffer.buffer a) (h:HyperStack.mem{live h b}) (i:nat{i < Buffer.length b}) :
   Lemma (Seq.index (as_seq h b) i == get h b i)
   = ()
 
-#set-options "--initial_fuel 0 --max_fuel 0 --z3rlimit 40"
+#set-options "--fuel 0 --z3rlimit 40"
 
 private let lemma_word_vals (w:Buffer.buffer U8.t{Buffer.length w = 16}) (h:HyperStack.mem{live h w}) :
   Lemma (
@@ -467,7 +467,7 @@ private let lemma_seq_append_16_to_4 #a (s:Seq.seq a{Seq.length s = 16}) : Lemma
     Seq.lemma_eq_intro (Seq.append (Seq.slice s 0 8) (Seq.slice s 8 12)) (Seq.slice s 0 12);
     Seq.lemma_eq_intro (Seq.append (Seq.slice s 0 4) (Seq.slice s 4 8)) (Seq.slice s 0 8)
 
-#set-options "--initial_fuel 0 --max_fuel 0 --z3rlimit 10"
+#set-options "--fuel 0 --z3rlimit 10"
 
 val lemma_toField_1:
   s:Buffer.buffer U8.t{Buffer.length s = 16} ->
@@ -497,7 +497,7 @@ let lemma_toField_1 s h n0 n1 n2 n3 =
   little_endian_append (Seq.append (Seq.append s04 s48) s812) s1216
 
 
-#set-options "--initial_fuel 0 --max_fuel 0 --z3rlimit 20"
+#set-options "--fuel 0 --z3rlimit 20"
 
 val lemma_eval_5: h:HyperStack.mem -> a:Buffer.buffer U64.t{live h a /\ length a >= 5} ->
   Lemma (Crypto.Symmetric.Poly1305.Bigint.eval h a 5 =
@@ -517,7 +517,7 @@ let lemma_eval_5 h a =
   Crypto.Symmetric.Poly1305.Bigint.bitweight_def Crypto.Symmetric.Poly1305.Parameters.templ 0;
   assert_norm (pow2 0 = 1)
 
-#set-options "--initial_fuel 0 --max_fuel 0 --z3rlimit 20"
+#set-options "--fuel 0 --z3rlimit 20"
 
 
 val lemma_little_endian_16: h:HyperStack.mem -> a:Buffer.buffer U8.t{live h a /\ length a = 16} ->
@@ -550,7 +550,7 @@ let lemma_little_endian_16 h a =
   assert_norm (pow2 0 = 1)
 
 
-#set-options "--initial_fuel 0 --max_fuel 0 --z3rlimit 5"
+#set-options "--fuel 0 --z3rlimit 5"
 
 
 let lemma_mul_mod (a:nat) (b:pos) : Lemma ((b * a) % b = 0) = Math.Lemmas.lemma_mod_plus 0 a b
@@ -765,7 +765,7 @@ val lemma_norm_5:
 let lemma_norm_5 h b = ()
 
 
-#set-options "--initial_fuel 0 --max_fuel 0 --z3rlimit 20"
+#set-options "--fuel 0 --z3rlimit 20"
 
 val lemma_mod_sum_mul: x:nat -> y:nat -> l:nat -> m:nat -> Lemma
   (requires (x % pow2 l = 0 /\ y < pow2 l /\ m >= l))
@@ -783,7 +783,7 @@ let lemma_mod_sum_mul x y l m =
     Math.Lemmas.pow2_plus (m-l) l; Math.Lemmas.modulo_lemma (((c%pow2 (m-l))*pow2 l) + y) (pow2 m)
 
 
-#set-options "--initial_fuel 0 --max_fuel 0 --z3rlimit 50"
+#set-options "--fuel 0 --z3rlimit 50"
 
 let lemma_b3 (a0:U64.t{v a0 < pow2 26}) (a1:U64.t{v a1 < pow2 26}) : Lemma
   (pow2 24 * (U8.v (uint64_to_uint8 ((a0 >>^ 24ul) |^ (a1 <<^ 2ul)))) = pow2 24 * ((v a0 / pow2 24) % pow2 8) + pow2 24 * ((v a1*pow2 2)%pow2 8))
@@ -869,7 +869,7 @@ let lemma_b03a0 (a0:U64.t{v a0 < pow2 26}) (a1:UInt64.t{v a1 < pow2 26}) b0 b1 b
   = lemma_trunc1305_0 a0
 
 
-#set-options "--initial_fuel 0 --max_fuel 0 --z3rlimit 20"
+#set-options "--fuel 0 --z3rlimit 20"
 
 let lemma_b46a1 (a1:U64.t{v a1 < pow2 26}) (a2:UInt64.t{v a2 < pow2 26}) v3 b4 b5 b6 : Lemma
   (requires (let open FStar.UInt8 in
@@ -890,7 +890,7 @@ let lemma_b46a1 (a1:U64.t{v a1 < pow2 26}) (a2:UInt64.t{v a2 < pow2 26}) v3 b4 b
     Math.Lemmas.paren_mul_right (pow2 24) (pow2 2) (v a1 % pow2 30)
 
 
-#set-options "--initial_fuel 0 --max_fuel 0 --z3rlimit 20"
+#set-options "--fuel 0 --z3rlimit 20"
 
 let lemma_b79a2 (a2:U64.t{v a2 < pow2 26}) (a3:UInt64.t{v a3 < pow2 26}) v6 b7 b8 b9 : Lemma
   (requires (let open FStar.UInt8 in
@@ -911,7 +911,7 @@ let lemma_b79a2 (a2:U64.t{v a2 < pow2 26}) (a3:UInt64.t{v a3 < pow2 26}) v6 b7 b
     Math.Lemmas.paren_mul_right (pow2 48) (pow2 4) (v a2 % pow2 28)
 
 
-#set-options "--initial_fuel 0 --max_fuel 0 --z3rlimit 20"
+#set-options "--fuel 0 --z3rlimit 20"
 
 let lemma_b1012a3 (a3:U64.t{v a3 < pow2 26}) v9 b10 b11 b12 : Lemma
   (requires (let open FStar.UInt8 in
@@ -929,7 +929,7 @@ let lemma_b1012a3 (a3:U64.t{v a3 < pow2 26}) v9 b10 b11 b12 : Lemma
     Math.Lemmas.paren_mul_right (pow2 72) (pow2 6) (v a3 % pow2 26)
 
 
-#set-options "--initial_fuel 0 --max_fuel 0 --z3rlimit 20"
+#set-options "--fuel 0 --z3rlimit 20"
 
 let lemma_b1315a4 (a4:U64.t{v a4 < pow2 26}) b13 b14 b15 : Lemma
   (requires (let open FStar.UInt8 in
@@ -943,7 +943,7 @@ let lemma_b1315a4 (a4:U64.t{v a4 < pow2 26}) b13 b14 b15 : Lemma
 
 let u26 = x:U64.t{v x < pow2 26}
 
-#set-options "--initial_fuel 0 --max_fuel 0 --z3rlimit 20"
+#set-options "--fuel 0 --z3rlimit 20"
 
 val lemma_trunc1305_:
   a0:u26 -> a1:u26 -> a2:u26 -> a3:u26 -> a4:u26 ->
@@ -978,7 +978,7 @@ let lemma_sum_ a b c d e f g h : Lemma ((a-b)+((b+c)-d)+((d+e)-f)+(f+g)+h=a+c+e+
 let lemma_sum' b0 b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 b12 b13 b14 b15 : Lemma
   (b0+b1+b2+b3+b4+b5+b6+b7+b8+b9+b10+b11+b12+b13+b14+b15 = (b0+b1+b2+b3)+(b4+b5+b6)+(b7+b8+b9)+(b10+b11+b12)+(b13+b14+b15)) = ()
 
-#set-options "--initial_fuel 0 --max_fuel 0 --z3rlimit 100"
+#set-options "--fuel 0 --z3rlimit 100"
 
 let lemma_trunc1305_ a0 a1 a2 a3 a4 b0 b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 b12 b13 b14 b15 =
   lemma_b3 a0 a1;
@@ -1031,7 +1031,7 @@ let lemma_trunc1305_ a0 a1 a2 a3 a4 b0 b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 b12 b1
    Math.Lemmas.modulo_lemma (v a3) (pow2 26)
 
 
-#set-options "--initial_fuel 0 --max_fuel 0 --z3rlimit 20"
+#set-options "--fuel 0 --z3rlimit 20"
 
 let lemma_mult_le_left (a:nat) (b:nat) (c:nat) : Lemma (requires (b <= c)) (ensures (a * b <= a * c)) = ()
 
@@ -1086,7 +1086,7 @@ val lemma_trunc1305: hb:HyperStack.mem ->
           = little_endian (as_seq hb b)))
 
 
-#set-options "--initial_fuel 0 --max_fuel 0 --z3rlimit 20"
+#set-options "--fuel 0 --z3rlimit 20"
 
 let lemma_trunc1305 hb b ha a =
   lemma_little_endian_16 hb b;
@@ -1109,7 +1109,7 @@ let lemma_trunc1305 hb b ha a =
   lemma_eval_mod a0 a1 a2 a3 a4
 
 
-#reset-options "--initial_fuel 0 --max_fuel 0 --z3rlimit 10"
+#reset-options "--fuel 0 --z3rlimit 10"
 
 val lemma_little_endian_4: h:HyperStack.mem -> b:Buffer.buffer U8.t{live h b /\ length b = 4} ->
   Lemma (little_endian (as_seq h b) = U8.(v (get h b 0) + pow2 8 * v (get h b 1)+ pow2 16 * v (get h b 2)+ pow2 24 * v (get h b 3)))
@@ -1346,7 +1346,7 @@ val lemma_add_word2_1:
       /\ U8.v (get h4 b3 2) = (U32.v z3 / pow2 16) % pow2 8
       /\ U8.v (get h4 b3 3) = (U32.v z3 / pow2 24)  % pow2 8 ))
 
-#reset-options "--initial_fuel 0 --max_fuel 0 --z3rlimit 5"
+#reset-options "--fuel 0 --z3rlimit 5"
 
 let lemma_add_word2_1 h0 h1 h2 h3 h4 b z0 z1 z2 z3 =
   let b0 = sub b 0ul 4ul in
@@ -1396,7 +1396,7 @@ let lemma_add_word2_2_1 z =
   cut (va32 % pow2 16 = pow2 8 * ((va32/pow2 8)%pow2 8) + (va32 % pow2 8))
 
 
-#reset-options "--initial_fuel 0 --max_fuel 0 --z3rlimit 20"
+#reset-options "--fuel 0 --z3rlimit 20"
 
 val lemma_add_word2_2:
   h:HyperStack.mem ->
@@ -1453,7 +1453,7 @@ let lemma_add_word2_2 ha a z0 z1 z2 z3 =
   little_endian_append (Seq.append (Seq.append s04 s48) s812) (s1216)
 
 
-#reset-options "--initial_fuel 0 --max_fuel 0 --z3rlimit 5"
+#reset-options "--fuel 0 --z3rlimit 5"
 
 val lemma_add_word2:
   h0:HyperStack.mem ->

--- a/examples/old/tls-record-layer/crypto/Crypto.Symmetric.Poly1305.Standalone.fst
+++ b/examples/old/tls-record-layer/crypto/Crypto.Symmetric.Poly1305.Standalone.fst
@@ -41,7 +41,7 @@ let log_t = if mac_log then text else unit
 val ilog: l:log_t{mac_log} -> Tot text
 let ilog l = l
 
-#set-options "--initial_fuel 1 --max_fuel 1"
+#set-options "--fuel 1"
 
 val poly_cons: x:word -> xs:text -> r:elem ->
   Lemma (poly (Seq.cons x xs) r == (encode x +@ poly xs r) *@ r)
@@ -54,7 +54,7 @@ val poly_empty: t:text{Seq.length t == 0} -> r:elem ->
   Lemma (poly t r == 0)
 let poly_empty t r = ()
 
-#set-options "--z3rlimit 60 --initial_fuel 0 --max_fuel 0"
+#set-options "--z3rlimit 60 --fuel 0"
 
 (**
    Update function:
@@ -156,7 +156,7 @@ let rec encode_bytes txt =
     Seq.snoc (encode_bytes txt) w // snoc, not cons!
 (***)
 
-#set-options "--initial_fuel 1 --max_fuel 1"
+#set-options "--fuel 1"
 
 (** Auxiliary lemmas *)
 
@@ -239,7 +239,7 @@ let rec encode_bytes_append len s w =
     end
 
 
-#set-options "--z3rlimit 60 --initial_fuel 0 --max_fuel 0"
+#set-options "--z3rlimit 60 --fuel 0"
 
 (* Loop over Poly1305_update; could go below MAC *)
 val poly1305_loop: log:log_t -> msg:bytes -> acc:elemB{disjoint msg acc} ->
@@ -300,7 +300,7 @@ val div_aux: a:UInt32.t -> b:UInt32.t{w b <> 0} -> Lemma
   [SMTPat (FStar.UInt32(UInt.size (v a / v b) n))]
 let div_aux a b = ()
 
-#reset-options "--z3rlimit 200 --initial_fuel 0 --max_fuel 0 --max_ifuel 0 --initial_ifuel 0"
+#reset-options "--z3rlimit 200 --fuel 0 --ifuel 0 --initial_ifuel 0"
 
 val poly1305_process:
     msg:bytes

--- a/examples/old/tls-record-layer/crypto/Crypto.Symmetric.Poly1305.fst
+++ b/examples/old/tls-record-layer/crypto/Crypto.Symmetric.Poly1305.fst
@@ -52,7 +52,7 @@ namespace, so we need to make the following abbrevs explicit *)
 module Spec = Crypto.Symmetric.Poly1305.Spec
 module Parameters = Crypto.Symmetric.Poly1305.Parameters
 
-#set-options "--initial_fuel 0 --max_fuel 0 --initial_ifuel 0 --max_ifuel 0 --z3rlimit 20"
+#set-options "--fuel 0 --ifuel 0 --z3rlimit 20"
 
 // we may separate field operations, so that we don't
 // need to open the bignum modules elsewhere
@@ -118,7 +118,7 @@ let sel_int h b = eval h b norm_length
 (* *          Encoding-related lemmas            *)
 (* * *********************************************)
 
-#set-options "--initial_fuel 1 --max_fuel 1"
+#set-options "--fuel 1"
 
 (* TODO: Move to Crypto.Symmetric.Poly1305.Bignum *)
 val lemma_bitweight_templ_values: n:nat -> Lemma (bitweight templ n == 26 * n)
@@ -148,7 +148,7 @@ let rec lemma_eval_norm_is_bounded ha a len =
     Math.Lemmas.pow2_plus (26 * (len-1)) 26
     end
 
-#set-options "--initial_fuel 0 --max_fuel 0"
+#set-options "--fuel 0"
 
 val lemma_elemB_equality: ha:mem -> hb:mem -> a:elemB -> b:elemB 
   -> len:pos{len <= norm_length} -> Lemma
@@ -303,7 +303,7 @@ let mk_mask nbits =
   Math.Lemmas.pow2_lt_compat 64 (FStar.UInt32.v nbits);
   U64.((1uL <<^ nbits) -^ 1uL)
 
-#set-options "--z3rlimit 5 --initial_fuel 0 --max_fuel 0"
+#set-options "--z3rlimit 5 --fuel 0"
 
 let lemma_toField_1 (b:elemB) (s:wordB_16{disjoint b s}) h n0 n1 n2 n3 : Lemma
   (requires (let open FStar.UInt8 in
@@ -315,7 +315,7 @@ let lemma_toField_1 (b:elemB) (s:wordB_16{disjoint b s}) h n0 n1 n2 n3 : Lemma
   (ensures  (live h b /\ live h s /\ v n0 + pow2 32 * v n1 + pow2 64 * v n2 + pow2 96 * v n3 == little_endian (sel_word h s)))
   = Crypto.Symmetric.Poly1305.Lemmas.lemma_toField_1 s h n0 n1 n2 n3
 
-#set-options "--z3rlimit 50 --initial_fuel 0 --max_fuel 0"
+#set-options "--z3rlimit 50 --fuel 0"
 
 val upd_elemB: b:elemB{length b == norm_length} -> n0:U64.t -> n1:U64.t -> n2:U64.t -> n3:U64.t -> n4:U64.t -> Stack unit
   (requires (fun h -> live h b
@@ -346,7 +346,7 @@ let upd_elemB b n0 n1 n2 n3 n4 =
   pow2_lt_compat 26 24
 
 
-#set-options "--z3rlimit 5 --initial_fuel 0 --max_fuel 0"
+#set-options "--z3rlimit 5 --fuel 0"
 
 let lemma_toField_2 n0 n1 n2 n3 n0' n1' n2' n3' n4': Lemma
   (requires (let mask_26 = mk_mask 26ul in
@@ -380,7 +380,7 @@ let sel_int_sel_elem h a w =
   lemma_little_endian_is_bounded w;
   modulo_lemma (little_endian w) p_1305
 
-#set-options "--z3rlimit 20 --initial_fuel 0 --max_fuel 0"
+#set-options "--z3rlimit 20 --fuel 0"
 
 (* Formats a wordB into an elemB *)
 val toField: a:elemB{length a == norm_length} -> b:wordB_16{disjoint a b} -> Stack unit
@@ -424,7 +424,7 @@ let toField b s =
   upd_elemB b n0' n1' n2' n3' n4'
 
 
-#set-options "--z3rlimit 20 --initial_fuel 1 --max_fuel 1"
+#set-options "--z3rlimit 20 --fuel 1"
 
 val lemma_toField_plus_2_128_0: ha:mem -> a:elemB{live ha a} -> Lemma
   (requires True)
@@ -445,7 +445,7 @@ let lemma_toField_plus_2_128_0 ha a =
   eval_def ha a 0;
   assert_norm (pow2 0 = 1)
 
-#set-options "--initial_fuel 0 --max_fuel 0"
+#set-options "--fuel 0"
 
 val lemma_toField_plus_2_128_1: unit -> Lemma (v (1uL <<^ 24ul) == pow2 24)
 let lemma_toField_plus_2_128_1 () =
@@ -502,7 +502,7 @@ val toField_plus:
     modifies_1 a h0 h1 /\ // Only a was modified
     sel_int h1 a == pow2 (8 * w len) + little_endian (sel_word h0 b) ))
 
-#set-options "--z3rlimit 100 --initial_fuel 0 --max_fuel 0"
+#set-options "--z3rlimit 100 --fuel 0"
 
 let toField_plus len a b =
   let h0 = ST.get() in
@@ -570,7 +570,7 @@ let upd_wordB_16 s s0 s1 s2 s3 s4 s5 s6 s7 s8 s9 s10 s11 s12 s13 s14 s15 =
   s.(15ul) <- s15
 
 
-#set-options "--z3rlimit 100 --initial_fuel 0 --max_fuel 0"
+#set-options "--z3rlimit 100 --fuel 0"
 
 val trunc1305: a:elemB -> b:wordB_16{disjoint a b} -> Stack unit
   (requires (fun h -> norm h a /\ live h b /\ disjoint a b))
@@ -756,7 +756,7 @@ let log_t = if mac_log then text else unit
 val ilog: l:log_t{mac_log} -> Tot text
 let ilog l = l
 
-#set-options "--initial_fuel 1 --max_fuel 1"
+#set-options "--fuel 1"
 
 val poly_cons: x:word -> xs:text -> r:elem ->
   Lemma (poly (Seq.cons x xs) r == (encode x +@ poly xs r) *@ r)
@@ -874,7 +874,7 @@ let rec encode_bytes txt =
     Seq.snoc (encode_bytes txt) w // snoc, not cons!
 (***)
 
-#set-options "--initial_fuel 1 --max_fuel 1"
+#set-options "--fuel 1"
 
 (** Auxiliary lemmas *)
 
@@ -900,7 +900,7 @@ let snoc_cons #a s x y = ()
 val append_assoc: #a:Type -> s1:Seq.seq a -> s2:Seq.seq a -> s3:Seq.seq a -> Lemma
   (FStar.Seq.(equal (append s1 (append s2 s3)) (append (append s1 s2) s3)))
 let append_assoc #a s1 s2 s3 = ()
-#set-options "--z3rlimit 40 --initial_fuel 0 --max_fuel 0 --initial_ifuel 0 --max_ifuel 0"
+#set-options "--z3rlimit 40 --fuel 0 --ifuel 0"
 
 (* 2016-11-23: n shadowed by U32.n by local open, so rename into n' *)
 val append_as_seq_sub: h:mem -> n':UInt32.t -> m:UInt32.t -> msg:bytes{live h msg /\ w m <= w n' /\ w n' <= length msg} -> Lemma
@@ -961,7 +961,7 @@ let rec encode_bytes_append len s w =
     end
 
 
-#set-options "--z3rlimit 60 --initial_fuel 0 --max_fuel 0"
+#set-options "--z3rlimit 60 --fuel 0"
 
 (* Loop over Poly1305_update; could go below MAC *)
 val poly1305_loop: log:log_t -> msg:bytes -> acc:elemB{disjoint msg acc} ->
@@ -979,7 +979,7 @@ val poly1305_loop: log:log_t -> msg:bytes -> acc:elemB{disjoint msg acc} ->
         /\ sel_elem h1 acc == poly (ilog updated_log) (sel_elem h0 r)) ))
     (decreases (w ctr))
 
-#set-options "--z3rlimit 300 --initial_fuel 0 --max_fuel 0 --initial_ifuel 0 --max_ifuel 0"
+#set-options "--z3rlimit 300 --fuel 0 --ifuel 0"
 
 let rec poly1305_loop log msg acc r ctr =
   let h0 = ST.get () in
@@ -1025,7 +1025,7 @@ val div_aux: a:UInt32.t -> b:UInt32.t{w b <> 0} -> Lemma
   [SMTPat (FStar.UInt32.(UInt.size (v a / v b) n))]
 let div_aux a b = ()
 
-#reset-options "--z3rlimit 1000 --initial_fuel 1 --max_fuel 10"
+#reset-options "--z3rlimit 1000 --fuel 10"
 
 val poly1305_process:
     msg:bytes
@@ -1094,7 +1094,7 @@ private let modifies_mac (#a1:Type) (#a2:Type) (#a3:Type) (#a4:Type)
     lemma_reveal_modifies_2 b4 b3 h4 h5;
     lemma_intro_modifies_1 b4 h0 h6
 
-#reset-options "--z3rlimit 200 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 200 --fuel 0"
 (** Computes the Poly1305 MAC on a buffer *)
 val poly1305_mac:
   tag:wordB{length tag == 16} ->

--- a/examples/old/tls-record-layer/crypto/Crypto.Symmetric.UF1CMA.fst
+++ b/examples/old/tls-record-layer/crypto/Crypto.Symmetric.UF1CMA.fst
@@ -191,7 +191,7 @@ let genPost (i:id) (region:erid) m0 (st:state i) m1 =
   mac_is_fresh i region m0 st m1 /\
   mac_is_unset i region st m1
 
-#set-options "--z3rlimit 100 --initial_fuel 0 --max_fuel 0 --initial_ifuel 0 --max_ifuel 0"
+#set-options "--z3rlimit 100 --fuel 0 --ifuel 0"
 
 val alloc: region:erid -> i:id
   -> ak:akey region (fst i)

--- a/examples/old/tls-record-layer/old/sieveFun.fst
+++ b/examples/old/tls-record-layer/old/sieveFun.fst
@@ -54,7 +54,7 @@ let marked n f m = (f m)
 (*li is the counter for the inner loop; lo is for the outer one*)
 (*the inner loop invariant says that cells lo*2, lo*3, lo*4 ....lo*(li-1) (first li non-trivial multiples of lo) are marked.*)
 
-(*#set-options "--initial_fuel 100 --max_fuel 100 --initial_ifuel 100 --max_ifuel 100"*)
+(*#set-options "--fuel 100 --ifuel 100"*)
 
 val mark : n:nat -> ((k:nat{k<n}) -> Tot bool) -> index:nat{index<n} -> Tot ((k:nat{k<n}) -> Tot bool)
 let mark n f index =

--- a/examples/old/tls-record-layer/old/ulib/FStar.StackArray.fst
+++ b/examples/old/tls-record-layer/old/ulib/FStar.StackArray.fst
@@ -15,7 +15,7 @@
 *)
 module FStar.StackArray
 
-//#set-options "--max_fuel 0 --initial_fuel 0 --initial_ifuel 0 --max_ifuel 0" ... NEED TO MAKE THIS as_ref, as_ref, as_rref, ... a bit simpler
+//#set-options "--fuel 0 --initial_fuel 0 --ifuel 0" ... NEED TO MAKE THIS as_ref, as_ref, as_rref, ... a bit simpler
 
 open FStar.Seq
 open FStar.StackHeap2

--- a/examples/old/tls-record-layer/old/ulib/hyperstack/FStar.StackArray.fst
+++ b/examples/old/tls-record-layer/old/ulib/hyperstack/FStar.StackArray.fst
@@ -15,7 +15,7 @@
 *)
 module FStar.StackArray
 
-//#set-options "--max_fuel 0 --initial_fuel 0 --initial_ifuel 0 --max_ifuel 0" ... NEED TO MAKE THIS as_ref, as_ref, as_rref, ... a bit simpler
+//#set-options "--fuel 0 --initial_fuel 0 --ifuel 0" ... NEED TO MAKE THIS as_ref, as_ref, as_rref, ... a bit simpler
 
 open FStar.Seq
 open FStar.HyperStack

--- a/examples/old/tls-record-layer/parsing/FStar.Format.fst
+++ b/examples/old/tls-record-layer/parsing/FStar.Format.fst
@@ -25,7 +25,7 @@ open ImmBuffer
 type lsize = n:int{n = 1 \/ n = 2 \/ n = 3}
 type csize = n:t{v n = 1 \/ v n = 2 \/ v n = 3}
 
-#reset-options "--initial_fuel 2 --max_fuel 2"
+#reset-options "--fuel 2"
 
 assume val aux_lemma_1: a:t -> b:t -> Lemma
   (requires (v a < pow2 8 /\ v b < pow2 8))
@@ -84,7 +84,7 @@ assume HasSizeVLBytes: forall (n:lsize).
 val vlb_length: n:csize -> b:vlbytes (v n) -> Tot UInt32.t
 let vlb_length n b = read_length (sub b 0ul n) n
 
-#reset-options "--initial_fuel 0 --max_fuel 0 --z3timeout 5"
+#reset-options "--fuel 0 --z3timeout 5"
 
 val read_length_lemma: #n:csize -> b:vlbytes (v n) -> j:UInt32.t{v j <= length b /\ v j >= v n} -> 
   Lemma (requires True)
@@ -101,7 +101,7 @@ let vlb_content (n:csize) (b:vlbytes (v n)) : Tot (buffer u8) =
 val vlserialize: n:csize -> Tot (lserializer (vlbytes (v n)))
 let vlserialize n = fun b -> (| read_length b n, b |)
 
-#reset-options "--initial_fuel 0 --max_fuel 0 --z3timeout 20"
+#reset-options "--fuel 0 --z3timeout 20"
 
 let vlparse n : lparser (vlserialize n) = 
   fun (b:lbytes) ->
@@ -117,7 +117,7 @@ let vlparse n : lparser (vlserialize n) =
       else Correct (sub bytes 0ul (n +^ l), n +^ l)
     )
 
-#reset-options "--initial_fuel 0 --max_fuel 0 --z3timeout 5"
+#reset-options "--fuel 0 --z3timeout 5"
 
 let rec valid_seq (#t:Type0) (ty:lserializable t) (b:lbytes) : Tot bool (decreases (v (lb_length b))) =  
   let len = lb_length b in
@@ -138,7 +138,7 @@ type vlbuffer (#t:Type0) (n:lsize) (ty:lserializable t) = b:buffer u8{
 val vlbuffer_serialize: #t:Type0 -> ty:lserializable t -> n:csize -> Tot (lserializer (vlbuffer (v n) ty))
 let vlbuffer_serialize #t ty n = fun b -> (| read_length b n, b |)
 
-#reset-options "--initial_fuel 0 --max_fuel 0 --z3timeout 20"
+#reset-options "--fuel 0 --z3timeout 20"
 
 let vlbuffer_parse (#t:Type0) (ty:lserializable t) (n:csize) : lparser (vlbuffer_serialize ty n) 
   = fun b ->
@@ -158,7 +158,7 @@ let vlbuffer_parse (#t:Type0) (ty:lserializable t) (n:csize) : lparser (vlbuffer
       )
     )
 
-#reset-options "--initial_fuel 0 --max_fuel 0 --z3timeout 5"
+#reset-options "--fuel 0 --z3timeout 5"
 
 noeq type key_share : Type0 = {
   ks_group_name: UInt16.t;
@@ -180,7 +180,7 @@ let vlserialize_key_share: lserializer key_share =
   fun ks -> (| 2ul +^ read_length ks.ks_public_key 2ul, 
     concat_buf #byte #u8 #byte #u8 (u16_to_buf ks.ks_group_name) (ks.ks_public_key) |)
 
-#reset-options "--initial_fuel 0 --max_fuel 0 --z3timeout 20"
+#reset-options "--fuel 0 --z3timeout 20"
 
 val vlparse_key_share: p:lparser (vlserialize_key_share){inverse vlserialize_key_share p}
 let vlparse_key_share

--- a/examples/old/tls-record-layer/parsing/FStar.ImmBuffer.fst
+++ b/examples/old/tls-record-layer/parsing/FStar.ImmBuffer.fst
@@ -352,7 +352,7 @@ let u32 : serializable UInt32.t = Serializable le_uint32_serializer le_uint32_pa
 let u64 : serializable UInt64.t = Serializable le_uint64_serializer le_uint64_parser
 let ptr = Serializable ptr_serializer ptr_parser
 
-#reset-options "--initial_fuel 0 --max_fuel 0"
+#reset-options "--fuel 0"
 
 assume val lemma_bytes_to_buffer: b:bytes ->
   Lemma (length_bytes b % sizeof byte = 0 

--- a/examples/preorders/Protocol.fst
+++ b/examples/preorders/Protocol.fst
@@ -407,7 +407,7 @@ let lemma_sender_connection_ctr_equals_length_log
   :Lemma (ctr c h == Seq.length (log c h))
   = ()
 
-#push-options "--z3rlimit 200 --max_fuel 0 --max_ifuel 0"
+#push-options "--z3rlimit 200 --fuel 0 --ifuel 0"
 val send_aux 
           (#n:nat) 
           (file:iarray byte n) 
@@ -561,7 +561,7 @@ val receive_aux
                    h1 `live_connection` c /\
                    receive_aux_post #n file c h_init from pos ropt h1))
 
-#reset-options "--max_fuel 0 --max_ifuel 0 --z3rlimit 20 --using_facts_from '* -ArrayUtils.lemma_get_some_equivalent_append'"
+#reset-options "--fuel 0 --ifuel 0 --z3rlimit 20 --using_facts_from '* -ArrayUtils.lemma_get_some_equivalent_append'"
 let rec receive_aux #n file c h_init from pos
    = let h0 = ST.get() in
      let filled0 = prefix file pos in

--- a/examples/printf/SimplePrintf.fst
+++ b/examples/printf/SimplePrintf.fst
@@ -109,6 +109,6 @@ let sprintf
     : normalize_term (dir_type (Some?.v (parse_format_string s)))
     = string_of_dirs (Some?.v (parse_format_string s)) (fun s -> s)
 
-#set-options "--max_fuel 0" //no SMT reasoning about recursive functions
+#set-options "--fuel 0" //no SMT reasoning about recursive functions
 let test () = sprintf "%d: Hello %s, sprintf %s" 0 "#fstar-hackery" "works!"
 // let test2 () = sprintf "%d: Hello %s, sprintf %s" "huh?" "#fstar-hackery" "works!"

--- a/examples/rel/Benton2004.RHL.Examples2.fst
+++ b/examples/rel/Benton2004.RHL.Examples2.fst
@@ -37,7 +37,7 @@ let lemma_included_helper ()
            included phi2 (gsubst (gsubst phi2 i Left (exp_to_gexp asi_e Left)) i Right (exp_to_gexp asi_e Right)))
   = ()
 
-#set-options "--max_fuel 3 --max_ifuel 0 --initial_fuel 3 --z3rlimit_factor 4"
+#set-options "--max_fuel 3 --ifuel 0 --initial_fuel 3 --z3rlimit_factor 4"
 
 let proof () : Lemma
   (related l r (phi ()) (phi ()))

--- a/examples/rel/Benton2004.fst
+++ b/examples/rel/Benton2004.fst
@@ -353,7 +353,7 @@ let exec_equiv_sym
   [SMTPat (exec_equiv p p' f f')]
 = ()
 
-#push-options "--z3rlimit 5 --max_fuel 0 --max_ifuel 0"
+#push-options "--z3rlimit 5 --fuel 0 --ifuel 0"
 let eval_equiv_trans
   (#t: Type0)
   (p: sttype)

--- a/examples/rel/IfcDelimitedReleaseReify.fst
+++ b/examples/rel/IfcDelimitedReleaseReify.fst
@@ -144,7 +144,7 @@ let verify_sum x1 x2 x3 x4 x5 y = ()
 val length6 (x1 x2 x3 x4 x5 x6 : id) : Lemma (List.length[x1;x2;x3;x4;x5;x6] = 6)
 let length6 _ _ _ _ _ _ = ()
 
-#set-options "--initial_fuel 8 --max_fuel 8 --initial_ifuel 2"
+#set-options "--fuel 8 --initial_ifuel 2"
 val sum_swap_help (x1 x2 x3 x4 x5 : id) (y:id{List.noRepeats [y;x1;x2;x3;x4;x5]}) (h:heap):
   Lemma
   (forall z. (z <> x1 /\ z <> x2 /\ z <> x3 /\ z <> x4 /\ z <> x5 /\ z <> y ==>

--- a/examples/rel/IfcMonitor.fst
+++ b/examples/rel/IfcMonitor.fst
@@ -182,14 +182,14 @@ type high_pc_type (c:com) (h:heap) (env:label_fun) (pc:label) =
     (Some? o ==> no_sensitive_upd h env pc (Some?.v o))
   end
 
-#set-options "--z3rlimit 10 "
+#set-options "--z3rlimit 10"
 val high_pc_assign : (x:id) -> (e:exp) -> (h:heap) -> (env:label_fun) -> (pc:label) ->
   Lemma (high_pc_type (Assign x e) h env pc)
 let high_pc_assign x e h env pc = ()
 #reset-options
 
 
-#set-options "--z3rlimit 50 --initial_fuel 1 --max_fuel 1"
+#set-options "--z3rlimit 50 --fuel 1"
 val high_pc_while : (e:exp) -> (body:com) -> (v:exp) -> (h:heap) -> (env:label_fun) -> (pc:label) -> 
   Lemma 
     (requires 
@@ -260,7 +260,7 @@ let high_pc_while e body v h env pc =
 
 #reset-options
     
-#set-options "--z3rlimit 50 --initial_fuel 1 --max_fuel 1"
+#set-options "--z3rlimit 50 --fuel 1"
 val high_pc : (c:com) -> (h:heap) -> (env:label_fun) -> (pc:label) ->
   Lemma
     (requires True)
@@ -347,7 +347,7 @@ type ifc_type (c:com) (env:label_fun) (pc:label) (h:rel heap) =
   end
 
 
-#set-options "--z3rlimit 30 "
+#set-options "--z3rlimit 30"
 val dyn_ifc_assign : (x:id) -> (e:exp) -> (env:label_fun) -> (pc:label) -> (h:rel heap) -> 
   Lemma
       (requires (low_equiv env h))
@@ -356,7 +356,7 @@ let dyn_ifc_assign x e env pc h = dyn_ifc_exp e h env
 #reset-options
 
 
-#set-options "--z3rlimit 50 --initial_fuel 1 --max_fuel 2 "
+#set-options "--z3rlimit 50 --initial_fuel 1 --max_fuel 2"
 val dyn_ifc_while : (e:exp) -> (body:com) -> (v:exp) -> (env:label_fun) -> (pc:label) -> (h:rel heap) -> 
    Lemma
       (requires (low_equiv env h /\
@@ -476,7 +476,7 @@ let dyn_ifc_while e body v env pc h =
 
 #reset-options
 
-#set-options "--z3rlimit 50 --initial_fuel 1 --max_fuel 1" 
+#set-options "--z3rlimit 50 --fuel 1"
 val dyn_ifc' : (c:com) -> (env:label_fun) -> (pc:label) -> (h:(rel heap)) ->
     Lemma
       (requires (low_equiv env h))

--- a/examples/rel/Loops.fst
+++ b/examples/rel/Loops.fst
@@ -18,7 +18,7 @@ module Loops
 open FStar.List.Tot
 open FStar.DM4F.Heap
 open FStar.DM4F.Heap.ST
-#reset-options "--initial_fuel 1 --max_fuel 1 --initial_ifuel 0 --max_ifuel 0 --z3rlimit 100"
+#reset-options "--fuel 1 --ifuel 0 --z3rlimit 100"
 
 let v (r:ref int) (res: (unit & heap)) : GTot int = sel (snd res) r
 
@@ -74,7 +74,7 @@ let rec sum_up_commute (r:ref int)
                   = v r (reify (sum_up r from to) h4))
         end
 
-#reset-options "--initial_fuel 1 --max_fuel 1 --initial_ifuel 0 --max_ifuel 0 --z3rlimit 100"
+#reset-options "--fuel 1 --ifuel 0 --z3rlimit 100"
 
 let rec sum_dn (r:ref int) (from:int) (to:int{from <= to})
     : ST unit (requires (fun h -> h `contains_a_well_typed` r))

--- a/examples/rel/OneTimePad.fst
+++ b/examples/rel/OneTimePad.fst
@@ -16,7 +16,7 @@
 module OneTimePad
 
 open Bijection
-#reset-options "--z3rlimit 100 --initial_fuel 0 --max_fuel 0 --initial_ifuel 4 --max_ifuel 4"
+#reset-options "--z3rlimit 100 --fuel 0 --ifuel 4"
 let nib = bool & bool & bool & bool
 let xor_b (b1:bool) (b2:bool) = b1 <> b2
 let xor (a, b, c, d) (w, x, y, z) = (a `xor_b` w,  b `xor_b` x, c `xor_b` y, d `xor_b` z)

--- a/examples/rel/Point.fst
+++ b/examples/rel/Point.fst
@@ -165,7 +165,7 @@ let lemma (h:heap) =
 (*       This is a relation between n invocations of incr  *)
 (*                         and a single invocation of get *)
 (*  *\) *)
-(* #set-options "--initial_fuel 1 --max_fuel 1 --initial_ifuel 0 --max_ifuel 0 --z3rlimit 20" *)
+(* #set-options "--fuel 1 --ifuel 0 --z3rlimit 20" *)
 (* let rec counts_even_numbers (c_0:counter_0) (h:heap{live c_0 h}) (m:nat) *)
 (*   :Lemma (requires True) *)
 (* 	 (ensures  (let n, h' = reify (increment_m m c_0) h in *)

--- a/examples/rel/ProgramEquivalence.fst
+++ b/examples/rel/ProgramEquivalence.fst
@@ -162,7 +162,7 @@ let rec observational_equivalence'
       This is a relation between n invocations of incr 
                         and a single invocation of get
  *)
-#set-options "--initial_fuel 1 --max_fuel 1 --initial_ifuel 0 --max_ifuel 0 --z3rlimit 20"
+#set-options "--fuel 1 --ifuel 0 --z3rlimit 20"
 let rec counts_even_numbers (c_0:counter_0) (h:heap{live c_0 h}) (m:nat)
   :Lemma (requires True)
 	 (ensures  (let n, h' = reify (increment_m m c_0) h in

--- a/examples/rel/Swap.fst
+++ b/examples/rel/Swap.fst
@@ -17,7 +17,7 @@ module Swap
 open FStar.List.Tot
 open FStar.DM4F.Heap
 open FStar.DM4F.Heap.ST
-#reset-options "--initial_fuel 0 --max_fuel 0 --initial_ifuel 0 --max_ifuel 0 --z3rlimit 100"
+#reset-options "--fuel 0 --ifuel 0 --z3rlimit 100"
 
 // Heap relies on sets with decidable equality... we follow suit.
 module S = FStar.Set

--- a/examples/rel/UnionFind.fst
+++ b/examples/rel/UnionFind.fst
@@ -151,7 +151,7 @@ let rec lemma_find_find_opt_equivalence (#n:nat) (uf:uf_forest n) (i:id n) (h:he
 #reset-options
 
 (* condensing the behavior of merge and merge_opt *)
-#set-options "--initial_fuel 0 --max_fuel 0 --initial_ifuel 1 --max_ifuel 1 --z3rlimit 40"
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 40"
 let lemma_merge_helper (#n:nat) (uf:uf_forest n) (i_1:id n) (i_2:id n) (h:heap{live uf h /\ well_formed uf h})
   :Lemma (requires True)
          (ensures  (let r_1, _ = reify (find uf i_1 h) h in
@@ -169,7 +169,7 @@ let lemma_merge_helper (#n:nat) (uf:uf_forest n) (i_1:id n) (i_2:id n) (h:heap{l
     ()
 #reset-options
 
-#set-options "--initial_fuel 0 --max_fuel 0 --initial_ifuel 4 --max_ifuel 4 --z3rlimit 80"
+#set-options "--fuel 0 --ifuel 4 --z3rlimit 80"
 let lemma_merge_opt_helper (#n:nat) (uf:uf_forest n) (i_1:id n) (i_2:id n) (h:heap{live uf h /\ well_formed uf h})
   :Lemma (requires True)
          (ensures  (let r_1, _ = reify (find uf i_1 h) h in

--- a/examples/tactics/Imp.fst
+++ b/examples/tactics/Imp.fst
@@ -124,7 +124,7 @@ let _ = assert_norm (forall x y. equiv (add2 x y) (add4 x y))
 let _ = assert_norm (forall x y. equiv (add3 x y) (add4 x y))
 
 (* Without normalizing, they require fuel, or else fail *)
-#push-options "--max_fuel 0"
+#push-options "--fuel 0"
 [@@expect_failure] let _ = assert (forall x y. equiv (add1 x y) (add2 x y))
 [@@expect_failure] let _ = assert (forall x y. equiv (add1 x y) (add3 x y))
 [@@expect_failure] let _ = assert (forall x y. equiv (add1 x y) (add4 x y))
@@ -196,7 +196,7 @@ let _ = assert_norm (eval (poly5' 3) == 3*3*3*3*3 + 3*3*3*3 + 3*3*3 + 3*3 + 3 + 
 //#set-options "--z3rlimit 10"
 //let _ = assert_norm (forall x. (poly5 (eval (poly5 x)) `equiv` poly5' (eval (poly5' x))))
 
-#set-options "--max_fuel 0"
+#set-options "--fuel 0"
 // --tactic_trace"
 let _ = assert (forall x. poly5 x `equiv` poly5' x)
             by (let _ = forall_intros () in

--- a/examples/tactics/SigeltOpts.fst
+++ b/examples/tactics/SigeltOpts.fst
@@ -2,7 +2,7 @@ module SigeltOpts
 
 open FStar.Tactics.V2
 
-#set-options "--max_fuel 0"
+#set-options "--fuel 0"
 
 #push-options "--max_fuel 2 --record_options"
 let sp1 = assert (List.length [1] == 1)

--- a/examples/tactics/bench/Poly1.fst
+++ b/examples/tactics/bench/Poly1.fst
@@ -21,7 +21,7 @@ open FStar.Mul
 assume val modulo_addition_lemma (a:int) (n:pos) (b:int) : Lemma ((a + b * n) % n = a % n)
 assume val lemma_div_mod (a:int) (n:pos) : Lemma (a == (a / n) * n + a % n)
 
-#set-options "--z3rlimit 150 --max_fuel 0 --max_ifuel 0 --using_facts_from '* -FStar.Tactics'"
+#set-options "--z3rlimit 150 --fuel 0 --ifuel 0 --using_facts_from '* -FStar.Tactics'"
 
 // To print timing
 #set-options "--query_stats"

--- a/examples/tactics/bench/Poly2.fst
+++ b/examples/tactics/bench/Poly2.fst
@@ -21,7 +21,7 @@ open FStar.Mul
 assume val modulo_addition_lemma (a:int) (n:pos) (b:int) : Lemma ((a + b * n) % n = a % n)
 assume val lemma_div_mod (a:int) (n:pos) : Lemma (a == (a / n) * n + a % n)
 
-#set-options "--z3rlimit 100 --max_fuel 0 --max_ifuel 0 --using_facts_from '* -FStar.Tactics'"
+#set-options "--z3rlimit 100 --fuel 0 --ifuel 0 --using_facts_from '* -FStar.Tactics'"
 
 // To print timing
 #set-options "--query_stats --tactics_info"

--- a/tests/bug-reports/closed/Bug1029.fst
+++ b/tests/bug-reports/closed/Bug1029.fst
@@ -16,4 +16,4 @@
 module Bug1029
 
 [@@expect_failure] // we can attach this to pragmas too :-)
-#reset-options "-z3rlimit 20 --initial_fuel 1 --max_fuel 1"
+#reset-options "-z3rlimit 20 --fuel 1"

--- a/tests/bug-reports/closed/Bug1470.fst
+++ b/tests/bug-reports/closed/Bug1470.fst
@@ -34,7 +34,7 @@ assume val bar (_:unit) :St (x:int{x == 42})
 
 assume val foo (x:int) :Pure int (requires True) (ensures (fun r -> r == x))
 
-#set-options "--max_fuel 0 --max_ifuel 0"
+#set-options "--fuel 0 --ifuel 0"
 let test () :St unit =
   let y = foo (bar ()) in
   assert (y == 42)

--- a/tests/bug-reports/closed/Bug1502.fst
+++ b/tests/bug-reports/closed/Bug1502.fst
@@ -15,7 +15,7 @@
 *)
 module Bug1502
 
-#set-options "--initial_fuel 0 --initial_ifuel 0 --max_fuel 0 --max_ifuel 0"
+#set-options "--initial_fuel 0 --initial_ifuel 0 --fuel 0 --ifuel 0"
 
 type ty =
   | TGhost

--- a/tests/bug-reports/closed/Bug1592.fst
+++ b/tests/bug-reports/closed/Bug1592.fst
@@ -12,7 +12,7 @@ assume val f: b:buffer UInt8.t -> Stack unit
   (requires fun h -> live h b)
   (ensures  fun h0 _ h1 -> modifies (loc_buffer b) h0 h1)
 
-#reset-options "--max_fuel 0 --max_ifuel 0 --z3rlimit 10"
+#reset-options "--fuel 0 --ifuel 0 --z3rlimit 10"
 
 let test (a:buffer UInt8.t) (b:buffer UInt8.t) : Stack unit
   (requires fun h0 -> live h0 a /\ live h0 b /\ disjoint a b)

--- a/tests/bug-reports/closed/Bug1750.Aux.fst
+++ b/tests/bug-reports/closed/Bug1750.Aux.fst
@@ -13,7 +13,7 @@ noeq
 type ilog_entry (i:pre_dhi) =
   | Corrupt
 
-#reset-options "--max_fuel 0 --max_ifuel 0"
+#reset-options "--fuel 0 --ifuel 0"
 let test (log:MDM.map pre_dhi ilog_entry) (k:pre_dhi) (v:ilog_entry k) : Tot unit =
   let log1 = MDM.upd #pre_dhi #ilog_entry log k v in
   assert (Some? (MDM.sel #pre_dhi #ilog_entry log1 k))

--- a/tests/bug-reports/closed/Bug1855.fst
+++ b/tests/bug-reports/closed/Bug1855.fst
@@ -1,6 +1,6 @@
 module Bug1855
 
-#set-options "--max_fuel 0 --max_ifuel 0"
+#set-options "--fuel 0 --ifuel 0"
 
 /// Some helpers
 /// ============

--- a/tests/bug-reports/closed/Bug771.fsti
+++ b/tests/bug-reports/closed/Bug771.fsti
@@ -15,7 +15,7 @@
 *)
 module Bug771
 
-#set-options "--initial_fuel 1 --max_fuel 1 --initial_ifuel 1 --max_ifuel 1"
+#set-options "--fuel 1 --ifuel 1"
 
 val len: pos
 val clen: l:FStar.UInt32.t{FStar.UInt32.v l = len}

--- a/tests/bug-reports/closed/Bug771b.fsti
+++ b/tests/bug-reports/closed/Bug771b.fsti
@@ -15,7 +15,7 @@
 *)
 module Bug771b
 
-#set-options "--initial_fuel 1 --max_fuel 1 --initial_ifuel 1 --max_ifuel 1"
+#set-options "--fuel 1 --ifuel 1"
 
 val len: pos
 val clen: l:FStar.UInt32.t{FStar.UInt32.v l = len}

--- a/tests/bug-reports/closed/Bug989.fst
+++ b/tests/bug-reports/closed/Bug989.fst
@@ -19,8 +19,8 @@ let rec g (n:nat) =
   if n = 0 then true
   else g (n - 1)
 
-#set-options "--initial_fuel 0 --max_fuel 1 --initial_ifuel 0 --max_ifuel 0"
-//#set-options "--initial_fuel 1 --max_fuel 1 --initial_ifuel 0 --max_ifuel 0"
+#set-options "--initial_fuel 0 --max_fuel 1 --ifuel 0"
+//#set-options "--fuel 1 --ifuel 0"
 let foo = assert (g 0 == true)
 
 
@@ -28,8 +28,8 @@ type t =
  | A
  | B
 
-#set-options "--initial_fuel 0 --max_fuel 0 --initial_ifuel 0 --max_ifuel 1"
-#set-options "--initial_fuel 0 --max_fuel 0 --initial_ifuel 1 --max_ifuel 1"
+#set-options "--fuel 0 --initial_ifuel 0 --max_ifuel 1"
+#set-options "--fuel 0 --ifuel 1"
 let f (x:t) =
   match x with
   | A -> ()

--- a/tests/bug-reports/open/Bug065.fst
+++ b/tests/bug-reports/open/Bug065.fst
@@ -48,7 +48,7 @@ let unsound () : nat =
 (*   | Node n t1 t2 -> f t1 t2 n (ind ta f a t1) (ind ta f a t2) *)
 
 (* (\* subtyping gets terribly confused here *\) *)
-(* #set-options "--initial_fuel 10 --max_fuel 10 --initial_ifuel 10 --max_ifuel 10" *)
+(* #set-options "--fuel 10 --ifuel 10" *)
 (* val find' : f:(int -> Tot bool) -> t:tree -> Tot (option (x:int{f x && in_tree x t})) *)
 (* let find' f = ind (fun t -> option (x:int{f x && in_tree x t})) *)
 (*                   (fun t1 t2 n o1 o2 -> if f n then Some n else *)

--- a/tests/error-messages/TestErrorLocations.fst
+++ b/tests/error-messages/TestErrorLocations.fst
@@ -14,7 +14,7 @@
    limitations under the License.
 *)
 module TestErrorLocations
-#set-options "--initial_fuel 0 --max_fuel 0 --initial_ifuel 0 --max_ifuel 0"
+#set-options "--fuel 0 --ifuel 0"
 //reports failing call to assert, and the failing formula
 [@@expect_failure [19]]
 let test0 = assert (0==1)

--- a/tests/hacl/Lib.IntTypes.fsti
+++ b/tests/hacl/Lib.IntTypes.fsti
@@ -2,7 +2,7 @@ module Lib.IntTypes
 
 open FStar.Mul
 
-#set-options "--max_fuel 0 --max_ifuel 1 --z3rlimit 20"
+#set-options "--fuel 0 --max_ifuel 1 --z3rlimit 20"
 
 // Other instances frollow from `FStar.UInt.pow2_values` which is in
 // scope of every module depending on Lib.IntTypes

--- a/tests/hacl/Lib.Sequence.Lemmas.fst
+++ b/tests/hacl/Lib.Sequence.Lemmas.fst
@@ -4,7 +4,7 @@ open FStar.Mul
 open Lib.IntTypes
 open Lib.Sequence
 
-#set-options "--z3rlimit 30 --max_fuel 0 --max_ifuel 0 \
+#set-options "--z3rlimit 30 --fuel 0 --ifuel 0 \
   --using_facts_from '-* +Prims +FStar.Pervasives +FStar.Math.Lemmas +FStar.Seq \
     +Lib.IntTypes +Lib.Sequence +Lib.Sequence.Lemmas +Lib.LoopCombinators'"
 #set-options "--z3refresh"

--- a/tests/hacl/Lib.Sequence.Lemmas.fsti
+++ b/tests/hacl/Lib.Sequence.Lemmas.fsti
@@ -6,7 +6,7 @@ open Lib.Sequence
 
 module Loops = Lib.LoopCombinators
 
-#set-options "--z3rlimit 50 --max_fuel 0 --max_ifuel 0 \
+#set-options "--z3rlimit 50 --fuel 0 --ifuel 0 \
   --using_facts_from '-* +Prims +FStar.Math.Lemmas +FStar.Seq +Lib.IntTypes +Lib.Sequence +Lib.Sequence.Lemmas'"
 #set-options "--z3refresh"
 

--- a/tests/hacl/Lib.Sequence.fsti
+++ b/tests/hacl/Lib.Sequence.fsti
@@ -3,7 +3,7 @@ module Lib.Sequence
 open FStar.Mul
 open Lib.IntTypes
 
-#set-options "--z3rlimit 30 --max_fuel 0 --max_ifuel 0 --using_facts_from '-* +Prims +FStar.Math.Lemmas +FStar.Seq +Lib.IntTypes +Lib.Sequence'"
+#set-options "--z3rlimit 30 --fuel 0 --ifuel 0 --using_facts_from '-* +Prims +FStar.Math.Lemmas +FStar.Seq +Lib.IntTypes +Lib.Sequence'"
 #set-options "--z3refresh"
 /// Variable length Sequences, derived from FStar.Seq
 

--- a/tests/hacl/Lib.Vec.Lemmas.fst
+++ b/tests/hacl/Lib.Vec.Lemmas.fst
@@ -1,6 +1,6 @@
 module Lib.Vec.Lemmas
 
-#set-options "--z3rlimit 30 --max_fuel 0 --max_ifuel 0 \
+#set-options "--z3rlimit 30 --fuel 0 --ifuel 0 \
   --using_facts_from '-* +Prims +FStar.Pervasives +FStar.Math.Lemmas +FStar.Seq -FStar.Seq.Properties.slice_slice \
     +Lib.IntTypes +Lib.Sequence +Lib.Sequence.Lemmas +Lib.LoopCombinators +Lib.Vec.Lemmas'"
 #set-options "--z3refresh"

--- a/tests/hacl/Lib.Vec.Lemmas.fsti
+++ b/tests/hacl/Lib.Vec.Lemmas.fsti
@@ -7,7 +7,7 @@ open Lib.Sequence.Lemmas
 
 module Loops = Lib.LoopCombinators
 
-#set-options "--z3rlimit 30 --max_fuel 0 --max_ifuel 0 \
+#set-options "--z3rlimit 30 --fuel 0 --ifuel 0 \
   --using_facts_from '-* +Prims +FStar.Pervasives +FStar.Math.Lemmas +FStar.Seq -FStar.Seq.Properties.slice_slice \
     +Lib.IntTypes +Lib.Sequence +Lib.Sequence.Lemmas +Lib.LoopCombinators +Lib.Vec.Lemmas'"
 #set-options "--z3refresh"

--- a/tests/micro-benchmarks/FirstProofs.fst
+++ b/tests/micro-benchmarks/FirstProofs.fst
@@ -44,13 +44,13 @@ let rec factorial_is_doubling x = match x with
    non-linear theory. You can try to provide an more explicit proof
    using FStar.Math.Lemmas *)
 
-(* #set-options "--z3rlimit 100 --max_fuel 5 --initial_fuel 5 --max_ifuel 0" *)
+(* #set-options "--z3rlimit 100 --max_fuel 5 --initial_fuel 5 --ifuel 0" *)
 (* val factorial_is_squaring: x:nat{x >= 4} -> Lemma (factorial x > x * x) *)
 (* let rec factorial_is_squaring = function *)
 (*   | 4 -> () *)
 (*   | x -> factorial_is_squaring (x - 1) *)
 
-(* #set-options "--z3rlimit 100 --max_fuel 7 --initial_fuel 7 --max_ifuel 0" *)
+(* #set-options "--z3rlimit 100 --max_fuel 7 --initial_fuel 7 --ifuel 0" *)
 (* val factorial_is_cubing: x:nat{x > 5} -> Tot (u:unit{factorial x >= x * x * x}) *)
 (* let rec factorial_is_cubing = function *)
 (*   | 6 -> () *)

--- a/tests/micro-benchmarks/Normalization.fst
+++ b/tests/micro-benchmarks/Normalization.fst
@@ -14,7 +14,7 @@
    limitations under the License.
 *)
 module Normalization
-#set-options "--initial_fuel 0 --max_fuel 0 --initial_ifuel 0 --max_ifuel 0"
+#set-options "--fuel 0 --ifuel 0"
 
 val test : unit -> Lemma (FStar.List.Tot.length [1;2;3;1;2;3;1;2;3;1;2;3;1;2;3;1;2;3] == 18)
 let test _ = assert_norm (FStar.List.Tot.length [1;2;3;1;2;3;1;2;3;1;2;3;1;2;3;1;2;3] == 18)

--- a/tests/micro-benchmarks/Test.NBE.fst
+++ b/tests/micro-benchmarks/Test.NBE.fst
@@ -47,4 +47,4 @@ let test3 =
   assert (norm [primops; delta; zeta; nbe] (List.append [1;2;3;4;5;6;7] [8;9])
           = [1;2;3;4;5;6;7;8;9])
 
-// #set-options "--debug NBE --max_fuel 0"
+// #set-options "--debug NBE --fuel 0"

--- a/tests/micro-benchmarks/TwoPhaseTC.fst
+++ b/tests/micro-benchmarks/TwoPhaseTC.fst
@@ -19,7 +19,7 @@ module TwoPhaseTC
 
 open FStar.Classical
 
-#set-options "--max_fuel 0 --max_ifuel 0 --initial_fuel 0 --initial_ifuel 0"
+#set-options "--fuel 0 --ifuel 0 --initial_fuel 0 --initial_ifuel 0"
 
 (** Definition of a monoid *)
 

--- a/tests/semiring/CanonCommSemiring.Test.fst
+++ b/tests/semiring/CanonCommSemiring.Test.fst
@@ -5,7 +5,7 @@ open CanonCommSemiring
 open FStar.Tactics.V2
 open FStar.Mul
 
-#set-options "--max_fuel 0 --max_ifuel 0 --z3rlimit 10 --tactics_info"
+#set-options "--fuel 0 --ifuel 0 --z3rlimit 10 --tactics_info"
 
 ///
 ///  Ring of integers

--- a/tests/tactics/Map.OpaqueToSMT.Test.fst
+++ b/tests/tactics/Map.OpaqueToSMT.Test.fst
@@ -19,7 +19,7 @@ let imap = map int string
 let upd (n:imap) (k:int) (v:string) = upd n k v
 let sel (n:imap) (k:int) = sel n k
 
-#reset-options "--initial_fuel 0 --max_fuel 0 --initial_ifuel 0 --max_ifuel 0"
+#reset-options "--fuel 0 --ifuel 0"
 //expect no Z3 query
 let test1 (m:imap) =
   let unfold n = upd (upd m 0 "hello") 1 "goodbye" in

--- a/tests/vale/X64.Vale.Decls.fst
+++ b/tests/vale/X64.Vale.Decls.fst
@@ -24,7 +24,7 @@ module P = X64.Print_s
 
 #reset-options "--z3smtopt '(set-option :smt.arith.nl true)' --using_facts_from Prims --using_facts_from FStar.Math"
 let lemma_mul_nat (x:nat) (y:nat) : Lemma (ensures 0 <= (x `op_Multiply` y)) = ()
-#reset-options "--initial_fuel 2 --max_fuel 2 --initial_ifuel 1 --z3rlimit_factor 10 --retry 5 --query_stats"
+#reset-options "--fuel 2 --initial_ifuel 1 --z3rlimit_factor 10 --retry 5 --query_stats"
 let cf = Lemmas_i.cf
 let ins = S.ins
 type ocmp = S.ocmp

--- a/tests/vale/X64.Vale.Lemmas_i.fst
+++ b/tests/vale/X64.Vale.Lemmas_i.fst
@@ -19,7 +19,7 @@ open X64.Vale.State_i
 open FStar.UInt
 module S = X64.Semantics_s
 
-#reset-options "--initial_fuel 2 --max_fuel 2"
+#reset-options "--fuel 2"
 
 let eval_while b c n s0 s1 : Type0 = admit ()
 

--- a/tests/vale/X64.Vale.StateLemmas_i.fst
+++ b/tests/vale/X64.Vale.StateLemmas_i.fst
@@ -22,7 +22,7 @@ open TransparentMap {} // lemmas
 
 module F = FStar.FunctionalExtensionality
 
-#reset-options "--initial_fuel 2 --max_fuel 2"
+#reset-options "--fuel 2"
 
 let state_to_S (s:state) : S.state = {
   S.ok = s.ok;

--- a/tests/vale/X64.Vale.StrongPost_i.fst
+++ b/tests/vale/X64.Vale.StrongPost_i.fst
@@ -18,7 +18,7 @@ open X64.Machine_s
 open X64.Vale.State_i
 open X64.Vale.Decls
 
-#reset-options "--initial_fuel 1 --max_fuel 1 --initial_ifuel 1 --max_ifuel 1 --z3rlimit 20"
+#reset-options "--fuel 1 --ifuel 1 --z3rlimit 20"
 
 let empty = ()
 

--- a/ulib/FStar.Endianness.fst
+++ b/ulib/FStar.Endianness.fst
@@ -218,7 +218,7 @@ let rec be_of_seq_uint64 s =
 /// Pure indexing & update over sequences
 /// -------------------------------------
 
-#set-options "--max_fuel 1 --max_ifuel 0 --z3rlimit 50"
+#set-options "--max_fuel 1 --ifuel 0 --z3rlimit 50"
 
 let rec offset_uint32_be (b: bytes) (n: nat) (i: nat) =
   if S.length b = 0 then

--- a/ulib/FStar.GSet.fst
+++ b/ulib/FStar.GSet.fst
@@ -16,7 +16,7 @@
 *)
 module FStar.GSet
 (** Computational sets (on Types): membership is a boolean function *)
-#set-options "--initial_fuel 0 --max_fuel 0 --initial_ifuel 0 --max_ifuel 0"
+#set-options "--fuel 0 --ifuel 0"
 open FStar.FunctionalExtensionality
 module F = FStar.FunctionalExtensionality
 

--- a/ulib/FStar.GSet.fsti
+++ b/ulib/FStar.GSet.fsti
@@ -16,7 +16,7 @@
 *)
 module FStar.GSet
 (** Computational sets (on Types): membership is a boolean function *)
-#set-options "--initial_fuel 0 --max_fuel 0 --initial_ifuel 0 --max_ifuel 0"
+#set-options "--fuel 0 --ifuel 0"
 
 (*
  * AR: mark it must_erase_for_extraction temporarily until CMI comes in

--- a/ulib/FStar.GhostSet.fst
+++ b/ulib/FStar.GhostSet.fst
@@ -16,7 +16,7 @@
 *)
 module FStar.GhostSet
 (** Ghost computational sets: membership is a ghost boolean function *)
-#set-options "--initial_fuel 0 --max_fuel 0 --initial_ifuel 0 --max_ifuel 0"
+#set-options "--fuel 0 --ifuel 0"
 open FStar.FunctionalExtensionality
 module F = FStar.FunctionalExtensionality
 

--- a/ulib/FStar.GhostSet.fsti
+++ b/ulib/FStar.GhostSet.fsti
@@ -16,7 +16,7 @@
 *)
 module FStar.GhostSet
 (** Ghost computational sets: membership is a ghost boolean function *)
-#set-options "--initial_fuel 0 --max_fuel 0 --initial_ifuel 0 --max_ifuel 0"
+#set-options "--fuel 0 --ifuel 0"
 
 [@@must_erase_for_extraction; erasable]
 val set (a: Type u#a) : Type u#a

--- a/ulib/FStar.Int.fst
+++ b/ulib/FStar.Int.fst
@@ -64,7 +64,7 @@ let to_vec_lemma_1 #n a b = ()
 let to_vec_lemma_2 #n a b = 
   UInt.to_vec_lemma_2 #n (to_uint a) (to_uint b)
 
-#push-options "--initial_fuel 1 --max_fuel 1"
+#push-options "--fuel 1"
 let rec inverse_aux #n vec i =
   if i = n - 1 then 
     assert((from_vec vec) % 2 = (if index vec (n - 1) then 1 else 0)) 

--- a/ulib/FStar.Int.fsti
+++ b/ulib/FStar.Int.fsti
@@ -62,7 +62,7 @@ let op_At_Percent (v:int) (p:int{p>0/\ p%2=0}) : Tot int =
 
 let zero (n:pos) : Tot (int_t n) = 0
 
-#push-options "--initial_fuel 1 --max_fuel 1"
+#push-options "--fuel 1"
 
 let pow2_n (#n:pos) (p:nat{p < n-1}) : Tot (int_t n) =
   pow2_le_compat (n - 2) p; pow2 p
@@ -114,7 +114,7 @@ val add_underspec: #n:pos -> a:int_t n -> b:int_t n -> Pure (int_t n)
   (ensures (fun c ->
     size (a + b) n ==> a + b = c))
 
-#push-options "--initial_fuel 1 --max_fuel 1"
+#push-options "--fuel 1"
 
 let add_mod (#n:pos) (a:int_t n) (b:int_t n) : Tot (int_t n) =
   (a + b) @% (pow2 n)

--- a/ulib/FStar.Int128.fst
+++ b/ulib/FStar.Int128.fst
@@ -20,7 +20,7 @@ module FStar.Int128
 open FStar.Int
 open FStar.Mul
 
-#set-options "--max_fuel 0 --max_ifuel 0"
+#set-options "--fuel 0 --ifuel 0"
 
 (* NOTE: anything that you fix/update here should be reflected in [FStar.UIntN.fstp], which is mostly
  * a copy-paste of this module. *)

--- a/ulib/FStar.Int128.fsti
+++ b/ulib/FStar.Int128.fsti
@@ -22,7 +22,7 @@ unfold let n = 128
 open FStar.Int
 open FStar.Mul
 
-#set-options "--max_fuel 0 --max_ifuel 0"
+#set-options "--fuel 0 --ifuel 0"
 
 (* NOTE: anything that you fix/update here should be reflected in [FStar.UIntN.fstp], which is mostly
  * a copy-paste of this module. *)

--- a/ulib/FStar.Int16.fst
+++ b/ulib/FStar.Int16.fst
@@ -20,7 +20,7 @@ module FStar.Int16
 open FStar.Int
 open FStar.Mul
 
-#set-options "--max_fuel 0 --max_ifuel 0"
+#set-options "--fuel 0 --ifuel 0"
 
 (* NOTE: anything that you fix/update here should be reflected in [FStar.UIntN.fstp], which is mostly
  * a copy-paste of this module. *)

--- a/ulib/FStar.Int16.fsti
+++ b/ulib/FStar.Int16.fsti
@@ -22,7 +22,7 @@ unfold let n = 16
 open FStar.Int
 open FStar.Mul
 
-#set-options "--max_fuel 0 --max_ifuel 0"
+#set-options "--fuel 0 --ifuel 0"
 
 (* NOTE: anything that you fix/update here should be reflected in [FStar.UIntN.fstp], which is mostly
  * a copy-paste of this module. *)

--- a/ulib/FStar.Int32.fst
+++ b/ulib/FStar.Int32.fst
@@ -20,7 +20,7 @@ module FStar.Int32
 open FStar.Int
 open FStar.Mul
 
-#set-options "--max_fuel 0 --max_ifuel 0"
+#set-options "--fuel 0 --ifuel 0"
 
 (* NOTE: anything that you fix/update here should be reflected in [FStar.UIntN.fstp], which is mostly
  * a copy-paste of this module. *)

--- a/ulib/FStar.Int32.fsti
+++ b/ulib/FStar.Int32.fsti
@@ -22,7 +22,7 @@ unfold let n = 32
 open FStar.Int
 open FStar.Mul
 
-#set-options "--max_fuel 0 --max_ifuel 0"
+#set-options "--fuel 0 --ifuel 0"
 
 (* NOTE: anything that you fix/update here should be reflected in [FStar.UIntN.fstp], which is mostly
  * a copy-paste of this module. *)

--- a/ulib/FStar.Int64.fst
+++ b/ulib/FStar.Int64.fst
@@ -20,7 +20,7 @@ module FStar.Int64
 open FStar.Int
 open FStar.Mul
 
-#set-options "--max_fuel 0 --max_ifuel 0"
+#set-options "--fuel 0 --ifuel 0"
 
 (* NOTE: anything that you fix/update here should be reflected in [FStar.UIntN.fstp], which is mostly
  * a copy-paste of this module. *)

--- a/ulib/FStar.Int64.fsti
+++ b/ulib/FStar.Int64.fsti
@@ -22,7 +22,7 @@ unfold let n = 64
 open FStar.Int
 open FStar.Mul
 
-#set-options "--max_fuel 0 --max_ifuel 0"
+#set-options "--fuel 0 --ifuel 0"
 
 (* NOTE: anything that you fix/update here should be reflected in [FStar.UIntN.fstp], which is mostly
  * a copy-paste of this module. *)

--- a/ulib/FStar.Int8.fst
+++ b/ulib/FStar.Int8.fst
@@ -20,7 +20,7 @@ module FStar.Int8
 open FStar.Int
 open FStar.Mul
 
-#set-options "--max_fuel 0 --max_ifuel 0"
+#set-options "--fuel 0 --ifuel 0"
 
 (* NOTE: anything that you fix/update here should be reflected in [FStar.UIntN.fstp], which is mostly
  * a copy-paste of this module. *)

--- a/ulib/FStar.Int8.fsti
+++ b/ulib/FStar.Int8.fsti
@@ -22,7 +22,7 @@ unfold let n = 8
 open FStar.Int
 open FStar.Mul
 
-#set-options "--max_fuel 0 --max_ifuel 0"
+#set-options "--fuel 0 --ifuel 0"
 
 (* NOTE: anything that you fix/update here should be reflected in [FStar.UIntN.fstp], which is mostly
  * a copy-paste of this module. *)

--- a/ulib/FStar.Integers.fst
+++ b/ulib/FStar.Integers.fst
@@ -15,7 +15,7 @@
 *)
 module FStar.Integers
 
-#set-options "--initial_ifuel 2 --max_ifuel 2 --initial_fuel 0 --max_fuel 0"
+#set-options "--ifuel 2 --fuel 0"
 
 irreducible
 let mark_for_norm = ()

--- a/ulib/FStar.ModifiesGen.fst
+++ b/ulib/FStar.ModifiesGen.fst
@@ -1030,7 +1030,7 @@ let modifies_loc_includes #al #c s1 h h' s2 =
 
 let modifies_preserves_liveness #al #c s1 s2 h h' #t #pre r = ()
 
-#push-options "--z3rlimit 20 --max_fuel 0 --max_ifuel 0"
+#push-options "--z3rlimit 20 --fuel 0 --ifuel 0"
 let modifies_preserves_liveness_strong #al #c s1 s2 h h' #t #pre r x =
   let rg = HS.frameOf r in
   let ad = HS.as_addr r in
@@ -1534,7 +1534,7 @@ let modifies_address_liveness_insensitive_unused_in #al c h h' =
 #pop-options
 #pop-options
 
-#push-options "--max_fuel 0 --max_ifuel 0 --z3rlimit 16 --retry 5 --z3cliopt 'smt.qi.eager_threshold=5'"
+#push-options "--fuel 0 --ifuel 0 --z3rlimit 16 --retry 5 --z3cliopt 'smt.qi.eager_threshold=5'"
 #restart-solver
 let modifies_only_not_unused_in #al #c l h h' =
   assert (modifies_preserves_regions l h h');

--- a/ulib/FStar.Monotonic.Seq.fst
+++ b/ulib/FStar.Monotonic.Seq.fst
@@ -213,7 +213,7 @@ val map_append: f:('a -> Tot 'b) -> s1:seq 'a -> s2:seq 'a -> Lemma
   (requires True)
   (ensures (map f (s1@s2) == (map f s1 @ map f s2)))
   (decreases (Seq.length s2))
-#reset-options "--z3rlimit 10 --initial_fuel 1 --max_fuel 1 --initial_ifuel 1 --max_ifuel 1"
+#reset-options "--z3rlimit 10 --fuel 1 --ifuel 1"
 let rec map_append f s_1 s_2 =
   if Seq.length s_2 = 0
   then (cut (Seq.equal (s_1@s_2) s_1);
@@ -307,7 +307,7 @@ let collect_snoc f s a =
   let prefix, last = un_snoc (Seq.snoc s a) in
   cut (Seq.equal prefix s)
 
-#reset-options "--z3rlimit 20 --initial_fuel 1 --max_fuel 1 --initial_ifuel 1 --max_ifuel 1"
+#reset-options "--z3rlimit 20 --fuel 1 --ifuel 1"
 
 let collect_grows (f:'a -> Tot (seq 'b))
 		  (s1:seq 'a) (s2:seq 'a)

--- a/ulib/FStar.Reflection.V2.Arith.fst
+++ b/ulib/FStar.Reflection.V2.Arith.fst
@@ -121,7 +121,7 @@ private val fail : (#a:Type) -> string -> tm a
 private let fail #a s = fun i -> Inl s
 
 val as_arith_expr : term -> tm expr
-#push-options "--initial_fuel 4 --max_fuel 4"
+#push-options "--fuel 4"
 let rec as_arith_expr (t:term) =
     let hd, tl = collect_app_ln t in
     // Invoke [collect_app_order]: forall (arg, qual) ∈ tl, (arg, qual) << t

--- a/ulib/FStar.ReflexiveTransitiveClosure.fst
+++ b/ulib/FStar.ReflexiveTransitiveClosure.fst
@@ -16,7 +16,7 @@
 module FStar.ReflexiveTransitiveClosure
 
 open FStar.Tactics.V2
-#set-options "--max_ifuel 1 --max_fuel 0"
+#set-options "--max_ifuel 1 --fuel 0"
 
 noeq
 type _closure (#a:Type u#a) (r:binrel u#a u#r a) : a -> a -> Type u#(max a r) =

--- a/ulib/FStar.Seq.Base.fst
+++ b/ulib/FStar.Seq.Base.fst
@@ -16,7 +16,7 @@
 
 (* A logical theory of sequences indexed by natural numbers in [0, n) *)
 module FStar.Seq.Base
-//#set-options "--initial_fuel 0 --max_fuel 0 --initial_ifuel 1 --max_ifuel 1"
+//#set-options "--fuel 0 --ifuel 1"
 
 module List = FStar.List.Tot
 

--- a/ulib/FStar.Seq.Base.fsti
+++ b/ulib/FStar.Seq.Base.fsti
@@ -16,7 +16,7 @@
 
 (* A logical theory of sequences indexed by natural numbers in [0, n) *)
 module FStar.Seq.Base
-//#set-options "--initial_fuel 0 --max_fuel 0 --initial_ifuel 1 --max_ifuel 1"
+//#set-options "--fuel 0 --ifuel 1"
 
 module List = FStar.List.Tot.Base
 

--- a/ulib/FStar.Set.fst
+++ b/ulib/FStar.Set.fst
@@ -16,7 +16,7 @@
 *)
 module FStar.Set
 (** Computational sets (on eqtypes): membership is a boolean function *)
-#set-options "--initial_fuel 0 --max_fuel 0 --initial_ifuel 0 --max_ifuel 0"
+#set-options "--fuel 0 --ifuel 0"
 open FStar.FunctionalExtensionality
 module F = FStar.FunctionalExtensionality
 

--- a/ulib/FStar.Set.fsti
+++ b/ulib/FStar.Set.fsti
@@ -17,7 +17,7 @@
 
 module FStar.Set
 (** Computational sets (on eqtypes): membership is a boolean function *)
-#set-options "--initial_fuel 0 --max_fuel 0 --initial_ifuel 0 --max_ifuel 0"
+#set-options "--fuel 0 --ifuel 0"
 
 val set (a:eqtype)
   : Type0

--- a/ulib/FStar.TSet.fst
+++ b/ulib/FStar.TSet.fst
@@ -17,7 +17,7 @@
 (** Propositional sets (on any types): membership is a predicate *)
 module FStar.TSet
 
-#set-options "--initial_fuel 0 --max_fuel 0 --initial_ifuel 0 --max_ifuel 0"
+#set-options "--fuel 0 --ifuel 0"
 module F = FStar.FunctionalExtensionality
 
 (*

--- a/ulib/FStar.TSet.fsti
+++ b/ulib/FStar.TSet.fsti
@@ -17,7 +17,7 @@
 (** Propositional sets (on any types): membership is a predicate *)
 module FStar.TSet
 
-#set-options "--initial_fuel 0 --max_fuel 0 --initial_ifuel 0 --max_ifuel 0"
+#set-options "--fuel 0 --ifuel 0"
 
 (*
  * AR: mark it must_erase_for_extraction temporarily until CMI comes in

--- a/ulib/FStar.UInt.fst
+++ b/ulib/FStar.UInt.fst
@@ -96,7 +96,7 @@ let from_vec_aux #n a s1 s2 =
 
 let seq_slice_lemma #n a s1 t1 s2 t2 = ()
 
-#push-options "--initial_fuel 1 --max_fuel 1"
+#push-options "--fuel 1"
 let rec from_vec_propriety #n a s =
   if s = n - 1 then () else begin
     from_vec_propriety #n a (s + 1);
@@ -416,7 +416,7 @@ let lemma_msb_gte #n a b =
 
 (* Lemmas toward showing ~n + 1 = -a *)
 
-// #set-options "--initial_fuel 1 --max_fuel 1 --initial_ifuel 1 --max_ifuel 1"
+// #set-options "--fuel 1 --ifuel 1"
 
 #push-options "--z3rlimit 80"
 let lemma_uint_mod #n a = ()

--- a/ulib/FStar.UInt128.fst
+++ b/ulib/FStar.UInt128.fst
@@ -35,7 +35,7 @@ module T = FStar.Stubs.Tactics.V2.Builtins
 module TD = FStar.Tactics.V2.Derived
 module TM = FStar.Tactics.MApply
 
-#set-options "--max_fuel 0 --max_ifuel 0 --split_queries no"
+#set-options "--fuel 0 --ifuel 0 --split_queries no"
 #set-options "--using_facts_from '*,-FStar.Tactics,-FStar.Reflection'"
 
 (* TODO: explain why exactly this is needed? It leads to failures in

--- a/ulib/FStar.UInt16.fst
+++ b/ulib/FStar.UInt16.fst
@@ -20,7 +20,7 @@ module FStar.UInt16
 open FStar.UInt
 open FStar.Mul
 
-#set-options "--max_fuel 0 --max_ifuel 0"
+#set-options "--fuel 0 --ifuel 0"
 
 type t : eqtype =
   | Mk: v:uint_t n -> t

--- a/ulib/FStar.UInt16.fsti
+++ b/ulib/FStar.UInt16.fsti
@@ -43,7 +43,7 @@ unfold let n = 16
 open FStar.UInt
 open FStar.Mul
 
-#set-options "--max_fuel 0 --max_ifuel 0"
+#set-options "--fuel 0 --ifuel 0"
 
 (** Abstract type of machine integers, with an underlying
     representation using a bounded mathematical integer *)
@@ -248,7 +248,7 @@ let minus (a:t) = add_mod (lognot a) (uint_to_t 1)
 inline_for_extraction
 let n_minus_one = UInt32.uint_to_t (n - 1)
 
-#set-options "--z3rlimit 80 --initial_fuel 1 --max_fuel 1"
+#set-options "--z3rlimit 80 --fuel 1"
 
 (** A constant-time way to compute the equality of
     two machine integers.

--- a/ulib/FStar.UInt32.fst
+++ b/ulib/FStar.UInt32.fst
@@ -20,7 +20,7 @@ module FStar.UInt32
 open FStar.UInt
 open FStar.Mul
 
-#set-options "--max_fuel 0 --max_ifuel 0"
+#set-options "--fuel 0 --ifuel 0"
 
 type t : eqtype =
   | Mk: v:uint_t n -> t

--- a/ulib/FStar.UInt32.fsti
+++ b/ulib/FStar.UInt32.fsti
@@ -43,7 +43,7 @@ unfold let n = 32
 open FStar.UInt
 open FStar.Mul
 
-#set-options "--max_fuel 0 --max_ifuel 0"
+#set-options "--fuel 0 --ifuel 0"
 
 (** Abstract type of machine integers, with an underlying
     representation using a bounded mathematical integer *)
@@ -248,7 +248,7 @@ let minus (a:t) = add_mod (lognot a) (uint_to_t 1)
 inline_for_extraction
 let n_minus_one = uint_to_t (n - 1)
 
-#set-options "--z3rlimit 80 --initial_fuel 1 --max_fuel 1"
+#set-options "--z3rlimit 80 --fuel 1"
 
 (** A constant-time way to compute the equality of
     two machine integers.

--- a/ulib/FStar.UInt64.fst
+++ b/ulib/FStar.UInt64.fst
@@ -20,7 +20,7 @@ module FStar.UInt64
 open FStar.UInt
 open FStar.Mul
 
-#set-options "--max_fuel 0 --max_ifuel 0"
+#set-options "--fuel 0 --ifuel 0"
 
 type t : eqtype =
   | Mk: v:uint_t n -> t

--- a/ulib/FStar.UInt64.fsti
+++ b/ulib/FStar.UInt64.fsti
@@ -43,7 +43,7 @@ unfold let n = 64
 open FStar.UInt
 open FStar.Mul
 
-#set-options "--max_fuel 0 --max_ifuel 0"
+#set-options "--fuel 0 --ifuel 0"
 
 (** Abstract type of machine integers, with an underlying
     representation using a bounded mathematical integer *)
@@ -248,7 +248,7 @@ let minus (a:t) = add_mod (lognot a) (uint_to_t 1)
 inline_for_extraction
 let n_minus_one = UInt32.uint_to_t (n - 1)
 
-#set-options "--z3rlimit 80 --initial_fuel 1 --max_fuel 1"
+#set-options "--z3rlimit 80 --fuel 1"
 
 (** A constant-time way to compute the equality of
     two machine integers.

--- a/ulib/FStar.UInt8.fst
+++ b/ulib/FStar.UInt8.fst
@@ -20,7 +20,7 @@ module FStar.UInt8
 open FStar.UInt
 open FStar.Mul
 
-#set-options "--max_fuel 0 --max_ifuel 0"
+#set-options "--fuel 0 --ifuel 0"
 
 type t : eqtype =
   | Mk: v:uint_t n -> t

--- a/ulib/FStar.UInt8.fsti
+++ b/ulib/FStar.UInt8.fsti
@@ -43,7 +43,7 @@ unfold let n = 8
 open FStar.UInt
 open FStar.Mul
 
-#set-options "--max_fuel 0 --max_ifuel 0"
+#set-options "--fuel 0 --ifuel 0"
 
 (** Abstract type of machine integers, with an underlying
     representation using a bounded mathematical integer *)
@@ -248,7 +248,7 @@ let minus (a:t) = add_mod (lognot a) (uint_to_t 1)
 inline_for_extraction
 let n_minus_one = UInt32.uint_to_t (n - 1)
 
-#set-options "--z3rlimit 80 --initial_fuel 1 --max_fuel 1"
+#set-options "--z3rlimit 80 --fuel 1"
 
 (** A constant-time way to compute the equality of
     two machine integers.

--- a/ulib/LowStar.BufferView.Down.fst
+++ b/ulib/LowStar.BufferView.Down.fst
@@ -24,7 +24,7 @@ module Math=FStar.Math.Lemmas
 #set-options "--smtencoding.l_arith_repr native"
 #set-options "--smtencoding.nl_arith_repr wrapped"
 #set-options "--z3rlimit_factor 4" //just being conservative
-#set-options "--initial_fuel 1 --max_fuel 1"
+#set-options "--fuel 1"
 
 noeq
 type buffer_view (src:Type0) (rrel rel:B.srel src) (dest:Type u#b) : Type u#b =
@@ -194,7 +194,7 @@ let as_seq #b h vb =
   as_seq'_len es v;
   bs
 
-#push-options "--max_ifuel 0"
+#push-options "--ifuel 0"
 val sel'_tail (#a #b:_) (v:view a b) (es:Seq.seq a{Seq.length es > 0})
               (i:nat{View?.n v <= i /\ i < Seq.length es * View?.n v})
   : Lemma (let j = i - View?.n v in

--- a/ulib/LowStar.BufferView.Up.fst
+++ b/ulib/LowStar.BufferView.Up.fst
@@ -34,7 +34,7 @@ let length #b vb =
 
 let length_eq #_ _ = ()
 
-//#reset-options "--max_fuel 0 --max_ifuel 1"
+//#reset-options "--fuel 0 --max_ifuel 1"
 let view_indexing #b vb i
   = let n = View?.n (get_view vb) in
     length_eq vb;
@@ -200,6 +200,6 @@ let as_seq_sel (#b: _) (h:HS.mem) (vb:buffer b) (i:nat{i < length vb})
       in
       as_seq'_as_seq' 0 i
 
-#set-options "--max_fuel 0 --max_ifuel 1"
+#set-options "--fuel 0 --max_ifuel 1"
 let get_sel (#b: _) (h:HS.mem) (vb:buffer b) (i:nat{i < length vb}) = ()
 let put_sel (#b: _) (h:HS.mem) (vb:buffer b) (i:nat{i < length vb}) = ()

--- a/ulib/LowStar.BufferView.fst
+++ b/ulib/LowStar.BufferView.fst
@@ -35,7 +35,7 @@ let length #b vb = B.length (as_buffer vb) / View?.n (get_view vb)
 
 let length_eq #_ _ = ()
 
-#reset-options "--max_fuel 0 --max_ifuel 1"
+#reset-options "--fuel 0 --max_ifuel 1"
 let view_indexing #b vb i
   = let n = View?.n (get_view vb) in
     length_eq vb;
@@ -202,6 +202,6 @@ let as_seq_sel (#b: _) (h:HS.mem) (vb:buffer b) (i:nat{i < length vb})
       in
       as_seq'_as_seq' 0 i
 
-#set-options "--max_fuel 0 --max_ifuel 1"
+#set-options "--fuel 0 --max_ifuel 1"
 let get_sel (#b: _) (h:HS.mem) (vb:buffer b) (i:nat{i < length vb}) = ()
 let put_sel (#b: _) (h:HS.mem) (vb:buffer b) (i:nat{i < length vb}) = ()

--- a/ulib/LowStar.Endianness.fst
+++ b/ulib/LowStar.Endianness.fst
@@ -423,7 +423,7 @@ let store128_be
 /// over the underlying sequence of bytes interpreted as a sequence of (little|big)-endian
 /// integers.
 
-#set-options "--z3rlimit 20 --max_fuel 0 --max_ifuel 0"
+#set-options "--z3rlimit 20 --fuel 0 --ifuel 0"
 
 inline_for_extraction
 let index_32_be
@@ -485,7 +485,7 @@ let interval_4_disjoint (i j: nat)
     (ensures  (let open FStar.Mul in 4 * i + 4 <= 4 * j \/ 4 * j + 4 <= 4 * i))
   = ()
 
-#reset-options "--z3rlimit 16 --max_fuel 0 --max_ifuel 0"
+#reset-options "--z3rlimit 16 --fuel 0 --ifuel 0"
 
 open FStar.Mul
 

--- a/ulib/LowStar.Monotonic.Buffer.fst
+++ b/ulib/LowStar.Monotonic.Buffer.fst
@@ -1827,7 +1827,7 @@ let mmalloc_drgn_and_blit #a #rrel #_ #_ d src id_src len =
   in
   Buffer len content 0ul len
 
-#push-options "--max_fuel 0 --initial_ifuel 1 --max_ifuel 1 --z3rlimit 128 --split_queries no"
+#push-options "--fuel 0 --ifuel 1 --z3rlimit 128 --split_queries no"
 #restart-solver
 let blit #a #rrel1 #rrel2 #rel1 #rel2 src idx_src dst idx_dst len =
   let open HST in
@@ -1877,7 +1877,7 @@ let blit #a #rrel1 #rrel2 #rel1 #rel2 src idx_src dst idx_dst len =
 #pop-options
 
 #restart-solver
-#push-options "--z3rlimit 256 --max_fuel 0 --max_ifuel 1 --initial_ifuel 1 --z3cliopt smt.qi.EAGER_THRESHOLD=4"
+#push-options "--z3rlimit 256 --fuel 0 --max_ifuel 1 --initial_ifuel 1 --z3cliopt smt.qi.EAGER_THRESHOLD=4"
 let fill' (#t:Type) (#rrel #rel: srel t)
   (b: mbuffer t rrel rel)
   (z:t)

--- a/ulib/LowStar.PrefixFreezableBuffer.fst
+++ b/ulib/LowStar.PrefixFreezableBuffer.fst
@@ -34,7 +34,7 @@ module LE = LowStar.Endianness
  * Implementation for LowStar.PrefixfreezableBuffer
  *)
 
-#set-options "--max_fuel 0 --max_ifuel 0"
+#set-options "--fuel 0 --ifuel 0"
 
 let le_to_n s = E.le_to_n s
 

--- a/ulib/LowStar.PrefixFreezableBuffer.fsti
+++ b/ulib/LowStar.PrefixFreezableBuffer.fsti
@@ -43,7 +43,7 @@ module HS = FStar.HyperStack
 type u8 = UInt8.t
 type u32 = U32.t
 
-#set-options "--max_fuel 0 --max_ifuel 0"
+#set-options "--fuel 0 --ifuel 0"
 
 
 /// This is the frozen until index in the sequence representation of a PrefixFreezableBuffer

--- a/ulib/legacy/FStar.Array.fst
+++ b/ulib/legacy/FStar.Array.fst
@@ -20,7 +20,7 @@ F* standard library mutable arrays module.
 @summary Mutable arrays
 *)
 module FStar.Array
-#set-options "--max_fuel 0 --initial_fuel 0 --initial_ifuel 0 --max_ifuel 0"
+#set-options "--fuel 0 --initial_fuel 0 --ifuel 0"
 open FStar.All
 open FStar.Seq
 open FStar.Ref

--- a/ulib/legacy/FStar.Array.fsti
+++ b/ulib/legacy/FStar.Array.fsti
@@ -26,7 +26,7 @@ open FStar.All
 open FStar.Seq
 open FStar.Ref
 
-#set-options "--max_fuel 0 --initial_fuel 0 --initial_ifuel 0 --max_ifuel 0"
+#set-options "--fuel 0 --initial_fuel 0 --ifuel 0"
 
 val array (a:Type0) : Type0
 

--- a/ulib/legacy/FStar.Buffer.Quantifiers.fst
+++ b/ulib/legacy/FStar.Buffer.Quantifiers.fst
@@ -22,7 +22,7 @@ open FStar.Ghost
 open FStar.Buffer
 open FStar.Classical
 
-#set-options "--initial_fuel 0 --max_fuel 0"
+#set-options "--fuel 0"
 
 val lemma_sub_quantifiers: #a:Type -> h:mem -> b:buffer a -> b':buffer a -> i:FStar.UInt32.t -> len:FStar.UInt32.t{v len <= length b /\ v i + v len <= length b} -> Lemma
   (requires (live h b /\ live h b' /\ Seq.slice (as_seq h b) (v i) (v i + v len) == as_seq h b'))
@@ -74,7 +74,7 @@ val lemma_upd_quantifiers: #a:Type -> h0:mem -> h1:mem -> b:buffer a -> n:FStar.
 let lemma_upd_quantifiers #a h0 h1 b n z =
   assert(forall (i:nat). i < length b ==> get h1 b i == Seq.index (as_seq h1 b) i)
 
-#reset-options "--initial_fuel 0 --max_fuel 0 --z3rlimit 8"
+#reset-options "--fuel 0 --z3rlimit 8"
 
 val lemma_blit_quantifiers: #a:Type -> h0:mem -> h1:mem -> b:buffer a -> bi:UInt32.t{v bi <= length b} ->
   b':buffer a{disjoint b b'} -> bi':UInt32.t{v bi' <= length b'} -> len:UInt32.t{v bi+v len <= length b /\ v bi'+v len <= length b'} -> Lemma

--- a/ulib/legacy/FStar.Buffer.fst
+++ b/ulib/legacy/FStar.Buffer.fst
@@ -25,7 +25,7 @@ module L = FStar.List.Tot.Base
 module HS = FStar.HyperStack
 module HST = FStar.HyperStack.ST
 
-#set-options "--initial_fuel 0 --max_fuel 0"
+#set-options "--fuel 0"
 
 //17-01-04 usage? move to UInt? 
 let lemma_size (x:int) : Lemma (requires (UInt.size x n))
@@ -580,7 +580,7 @@ let lemma_reveal_modifies_region (rid:rid) bufs h0 h1 : Lemma
   (ensures  (modifies_one rid h0 h1 /\ modifies_bufs rid bufs h0 h1 /\ HS.get_tip h0 == HS.get_tip h1))
   = ()
 
-#reset-options "--z3rlimit 100 --max_fuel 0 --max_ifuel 0 --initial_fuel 0 --initial_ifuel 0"
+#reset-options "--z3rlimit 100 --fuel 0 --ifuel 0 --initial_fuel 0 --initial_ifuel 0"
 
 (* Stack effect specific lemmas *)
 let lemma_stack_1 (#a:Type) (b:buffer a) h0 h1 h2 h3 : Lemma
@@ -682,7 +682,7 @@ val lemma_modifies_0_0: h0:mem -> h1:mem -> h2:mem -> Lemma
   [SMTPat (modifies_0 h0 h1); SMTPat (modifies_0 h1 h2)]
 let lemma_modifies_0_0 h0 h1 h2 = ()
 
-#reset-options "--z3rlimit 20 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 20 --fuel 0"
 
 let lemma_modifies_1_0 (#a:Type) (b:buffer a) h0 h1 h2 : Lemma
   (requires (live h0 b /\ modifies_1 b h0 h1 /\ modifies_0 h1 h2))
@@ -702,7 +702,7 @@ let lemma_modifies_0_1' (#a:Type) (b:buffer a) h0 h1 h2 : Lemma
   [SMTPat (modifies_0 h0 h1); SMTPat (modifies_1 b h1 h2)]
   = ()
 
-#reset-options "--z3rlimit 100 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 100 --fuel 0"
 
 let lemma_modifies_1_1 (#a:Type) (#a':Type) (b:buffer a) (b':buffer a') h0 h1 h2 : Lemma
   (requires (live h0 b /\ live h0 b' /\ modifies_1 b h0 h1 /\ modifies_1 b' h1 h2))
@@ -711,7 +711,7 @@ let lemma_modifies_1_1 (#a:Type) (#a':Type) (b:buffer a) (b':buffer a') h0 h1 h2
   = if frameOf b = frameOf b' then modifies_trans_1_1' (frameOf b) b b' h0 h1 h2
     else ()
 
-#reset-options "--z3rlimit 200 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 200 --fuel 0"
 
 let lemma_modifies_0_2 (#t:Type) (#t':Type) (b:buffer t) (b':buffer t') h0 h1 h2 : Lemma
   (requires (live h0 b /\ b' `unused_in` h0 /\ modifies_0 h0 h1 /\ live h1 b'
@@ -801,7 +801,7 @@ let lemma_modifies_0_none_trans h0 h1 h2 : Lemma
   (ensures (modifies_0 h0 h2))
   = ()
 
-#reset-options "--initial_fuel 0 --max_fuel 0"
+#reset-options "--fuel 0"
 
 (** Concrete getters and setters *)
 val create: #a:Type -> init:a -> len:UInt32.t -> StackInline (buffer a)
@@ -820,7 +820,7 @@ let create #a init len =
   assert (Seq.equal (as_seq h b) (sel h b));
   b
 
-#reset-options "--initial_fuel 0 --max_fuel 0"
+#reset-options "--fuel 0"
 
 unfold let p (#a:Type0) (init:list a) : GTot Type0 =
   normalize (0 < L.length init) /\
@@ -842,7 +842,7 @@ val createL: #a:Type0 -> init:list a -> StackInline (buffer a)
      /\ modifies_0 h0 h1
      /\ as_seq h1 b == Seq.seq_of_list init
      /\ q #a len b))
-#set-options "--initial_fuel 1 --max_fuel 1" //the normalize_term (length init) in the pre-condition will be unfolded
+#set-options "--fuel 1" //the normalize_term (length init) in the pre-condition will be unfolded
 	                                     //whereas the L.length init below will not
 let createL #a init =
   let len = UInt32.uint_to_t (L.length init) in
@@ -855,7 +855,7 @@ let createL #a init =
   b
 
 
-#reset-options "--initial_fuel 0 --max_fuel 0"
+#reset-options "--fuel 0"
 let lemma_upd (#a:Type) (h:mem) (x:reference a{live_region h (HS.frameOf x)}) (v:a) : Lemma
   (requires True)
   (ensures  (Map.domain (HS.get_hmap h) == Map.domain (HS.get_hmap (upd h x v))))
@@ -919,7 +919,7 @@ let rfree (#a:Type) (b:buffer a)
            (ensures  (fun h0 _ h1 -> is_mm (content b) /\ is_eternal_region (frameOf b) /\ h1 == HS.free (content b) h0))
   = rfree b.content
 
-(* #reset-options "--z3rlimit 100 --initial_fuel 0 --max_fuel 0" *)
+(* #reset-options "--z3rlimit 100 --fuel 0" *)
 
 (* val create_null: #a:Type -> init:a -> len:UInt32.t -> Stack (buffer a) *)
 (*   (requires (fun h -> True)) *)
@@ -931,7 +931,7 @@ let rfree (#a:Type) (b:buffer a)
 (*   r *)
 
 
-#reset-options "--initial_fuel 0 --max_fuel 0"
+#reset-options "--fuel 0"
 
 // ocaml-only, used for conversions to Platform.bytes
 val to_seq: #a:Type -> b:buffer a -> l:UInt32.t{v l <= length b} -> STL (seq a)
@@ -984,7 +984,7 @@ private let lemma_aux_1
   = let open FStar.Classical in
     forall_intro (move_requires (lemma_aux_0 b n z h0 tt))
 
-#reset-options "--initial_fuel 0 --max_fuel 0"
+#reset-options "--fuel 0"
 
 private let lemma_aux_2
   (#a:Type) (b:buffer a) (n:UInt32.t{v n < length b}) (z:a) (h0:mem)
@@ -1169,7 +1169,7 @@ val blit: #t:Type
       /\ Seq.slice (as_seq h1 b) (v idx_b+v len) (length b) ==
         Seq.slice (as_seq h0 b) (v idx_b+v len) (length b) ))
 
-#push-options "--z3rlimit 150 --max_fuel 0 --max_ifuel 0 --initial_fuel 0 --initial_ifuel 0"
+#push-options "--z3rlimit 150 --fuel 0 --ifuel 0 --initial_fuel 0 --initial_ifuel 0"
 #restart-solver
 let rec blit #t a idx_a b idx_b len =
   let h0 = HST.get () in
@@ -1233,7 +1233,7 @@ val no_upd_lemma_1: #t:Type -> #t':Type -> h0:mem -> h1:mem -> a:buffer t -> b:b
   [SMTPat (modifies_1 a h0 h1); SMTPat (live h0 b)]
 let no_upd_lemma_1 #t #t' h0 h1 a b = ()
 
-#reset-options "--z3rlimit 30 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 30 --fuel 0"
 
 val no_upd_lemma_2: #t:Type -> #t':Type -> #t'':Type -> h0:mem -> h1:mem -> a:buffer t -> a':buffer t' -> b:buffer t'' -> Lemma
   (requires (live h0 b /\ disjoint a b /\ disjoint a' b /\ modifies_2 a a' h0 h1))
@@ -1284,7 +1284,7 @@ let lemma_modifies_sub_2_1 #t h0 h1 (b:buffer t) : Lemma
   [SMTPat (live h0 b); SMTPat (modifies_2_1 b h0 h1)]
   = ()
 
-#reset-options "--z3rlimit 100 --initial_fuel 0 --max_fuel 0"
+#reset-options "--z3rlimit 100 --fuel 0"
 
 let modifies_subbuffer_1 (#t:Type) h0 h1 (sub:buffer t) (a:buffer t) : Lemma
   (requires (live h0 a /\ modifies_1 sub h0 h1 /\ includes a sub))

--- a/ulib/legacy/FStar.BufferNG.fst
+++ b/ulib/legacy/FStar.BufferNG.fst
@@ -181,7 +181,7 @@ val createL
      q #a len b
    ))
  
-#set-options "--initial_fuel 1 --max_fuel 1" //the normalize_term (length init) in the pre-condition will be unfolded
+#set-options "--fuel 1" //the normalize_term (length init) in the pre-condition will be unfolded
 	                                     //whereas the L.length init below will not
 
 let createL #a init =
@@ -190,7 +190,7 @@ let createL #a init =
   let content = P.screate (P.TArray len a) (Some s) in
   P.buffer_of_array_pointer content
 
-#reset-options "--initial_fuel 0 --max_fuel 0"
+#reset-options "--fuel 0"
 
 val rcreate
   (#a: typ)

--- a/ulib/legacy/FStar.Matrix2.fsti
+++ b/ulib/legacy/FStar.Matrix2.fsti
@@ -15,7 +15,7 @@
 *)
 module FStar.Matrix2
 
-#set-options "--initial_fuel 0 --max_fuel 0 --initial_ifuel 0 --max_ifuel 0"
+#set-options "--fuel 0 --ifuel 0"
 
 assume new type matrix2 : nat -> nat -> Type -> Type
 open FStar.Seq

--- a/ulib/legacy/FStar.Pointer.Base.fst
+++ b/ulib/legacy/FStar.Pointer.Base.fst
@@ -2922,14 +2922,14 @@ let live_gpointer_of_buffer_cell
   i h
 = ()
 
-#set-options "--initial_ifuel 2 --max_ifuel 2"
+#set-options "--ifuel 2"
 let gpointer_of_buffer_cell_gsingleton_buffer_of_pointer
   (#t: typ)
   (p: pointer t)
   i
 = ()
 
-#set-options "--initial_ifuel 1 --max_ifuel 1"
+#set-options "--ifuel 1"
 let gpointer_of_buffer_cell_gbuffer_of_array_pointer
   (#length: array_length_t)
   (#t: typ)


### PR DESCRIPTION
Mostly generated by these sed calls:

    sed 's/--initial_fuel \([0-9]*\) --max_fuel \1\>/--fuel \1/g'
    sed 's/--initial_ifuel \([0-9]*\) --max_ifuel \1\>/--ifuel \1/g'
    sed 's/--max_fuel 0\>/--fuel 0/g'
    sed 's/--max_ifuel 0\>/--ifuel 0/g'

I.e. use the `--fuel`/`--ifuel` options to set the initial and max fuels at once. Also, setting the max to zero is equivalent to using the shorter option.