### PR TITLE
FStarC.Main: make sure to kill background Z3 processes before exiting

### DIFF
--- a/src/fstar/FStarC.Main.fst
+++ b/src/fstar/FStarC.Main.fst
@@ -29,6 +29,8 @@ open FStarC.Class.Show
 module E = FStarC.Errors
 module UF = FStarC.Syntax.Unionfind
 
+let cleanup () = Util.kill_all ()
+
 let print_stats () =
   if !Stats.ever_enabled then
     print1_error "Stats:\n%s\n" (Stats.print_all ())
@@ -70,6 +72,7 @@ let report_errors fmods =
   if nerrs > 0 then begin
     finished_message fmods nerrs;
     print_stats ();
+    cleanup ();
     exit 1
   end
 
@@ -429,6 +432,7 @@ let main () =
               (FStarC.Util.string_of_int time)
               (String.concat " " (FStarC.Getopt.cmdline()));
     print_stats();
+    cleanup ();
     exit 0
   with
   | e ->


### PR DESCRIPTION
Particularly for the IDE mode, background Z3 processes remain after F* is killed. This does not usually happen in the terminal as all processes get the same signal.