### PR TITLE
No surface projector definitions

### DIFF
--- a/examples/rel/Benton2004.RHL.fsti
+++ b/examples/rel/Benton2004.RHL.fsti
@@ -332,7 +332,6 @@ val r_while_terminates'
   (ensures (
     terminates_on (reify_computation (while b' c')) s0'
   ))
-  (decreases fuel)
 
 let flip (phi: gexp bool) : Tot (gexp bool) =
   let g s1 s2 = phi s2 s1 in
@@ -380,7 +379,6 @@ val r_while_correct
   (ensures (
     holds (interp (gand p (gnot (gor (exp_to_gexp b Left) (exp_to_gexp b' Right))))) (snd (reify_computation (while b c) fuel s0)) (snd (reify_computation (while b' c') fuel s0'))
   ))
-  (decreases fuel)
 
 val r_while
   (b b' : exp bool)

--- a/src/tosyntax/FStarC.ToSyntax.ToSyntax.fst
+++ b/src/tosyntax/FStarC.ToSyntax.ToSyntax.fst
@@ -2657,17 +2657,8 @@ let mk_indexed_projector_names iquals fvq attrs env lid (fields:list S.binder) =
     fields |> List.mapi (fun i fld ->
         let x = fld.binder_bv in
         let field_name = U.mk_field_projector_name lid x i in
-        let only_decl =
-            lid_equals C.prims_lid  (Env.current_module env)
-            || fvq<>Data_ctor
-            || U.has_attribute attrs C.no_auto_projectors_attr
-        in
         let no_decl = Syntax.is_type x.sort in
-        let quals q =
-            if only_decl
-            then S.Assumption::q
-            else q
-        in
+        let quals q = S.Assumption::q in
         let quals =
             let iquals = iquals |> List.filter (function
                 | S.NoExtract
@@ -2684,28 +2675,8 @@ let mk_indexed_projector_names iquals fvq attrs env lid (fields:list S.binder) =
                      sigattrs = attrs;
                      sigopts = None;
                      sigopens_and_abbrevs = opens_and_abbrevs env } in
-        if only_decl
-        then [decl] //only the signature
-        else
-            let lb = {
-                lbname=Inr (S.lid_and_dd_as_fv field_name None);
-                lbunivs=[];
-                lbtyp=tun;
-                lbeff=C.effect_Tot_lid;
-                lbdef=tun;
-                lbattrs=[];
-                lbpos=Range.dummyRange;
-            } in
-            let impl = { sigel = Sig_let {lbs=(false, [lb]);
-                                          lids=[lb.lbname |> Inr?.v |> (fun fv -> fv.fv_name.v)]};
-                         sigquals = quals;
-                         sigrng = p;
-                         sigmeta = default_sigmeta;
-                         sigattrs = attrs;
-                         sigopts = None;
-                         sigopens_and_abbrevs = opens_and_abbrevs env
-                        } in
-            if no_decl then [impl] else [decl;impl]) |> List.flatten
+        [decl] //only the signature
+    ) |> List.flatten
 
 let mk_data_projector_names iquals env se : list sigelt =
   match se.sigel with

--- a/tests/error-messages/Bug3227.fst.json_output.expected
+++ b/tests/error-messages/Bug3227.fst.json_output.expected
@@ -7,7 +7,6 @@ let proj b = x (x (x b)) <: Prims.int
 type box2 (a: Type) = | Box2 : x: a -> Bug3227.box2 a
 
 
-
 let test b = Box2? b && Box2? b.x
 noeq
 type boxf (a: Type) = { ff:_: a -> a }
@@ -27,7 +26,6 @@ type box (a: Type) = { x:a }
 
 let proj b = x (x (x b)) <: Prims.int
 type box2 (a: Type) = | Box2 : x: a -> Bug3227.box2 a
-
 
 
 let test b = Box2? b && Box2? b.x

--- a/tests/error-messages/Bug3227.fst.output.expected
+++ b/tests/error-messages/Bug3227.fst.output.expected
@@ -7,7 +7,6 @@ let proj b = x (x (x b)) <: Prims.int
 type box2 (a: Type) = | Box2 : x: a -> Bug3227.box2 a
 
 
-
 let test b = Box2? b && Box2? b.x
 noeq
 type boxf (a: Type) = { ff:_: a -> a }
@@ -27,7 +26,6 @@ type box (a: Type) = { x:a }
 
 let proj b = x (x (x b)) <: Prims.int
 type box2 (a: Type) = | Box2 : x: a -> Bug3227.box2 a
-
 
 
 let test b = Box2? b && Box2? b.x

--- a/tests/error-messages/Monoid.fst.json_output.expected
+++ b/tests/error-messages/Monoid.fst.json_output.expected
@@ -19,11 +19,6 @@ type monoid (m: Type) =
 
 
 
-
-
-
-
-
 let intro_monoid m u15 mult = Monoid.Monoid u15 mult () () () <: Prims.Pure (Monoid.monoid m)
 let nat_plus_monoid =
   let add x y = x + y <: Prims.nat in
@@ -117,8 +112,6 @@ type monoid_morphism (f: (_: a -> b)) (ma: Monoid.monoid a) (mb: Monoid.monoid b
 
 
 
-
-
 let intro_monoid_morphism f ma mb =
   Monoid.MonoidMorphism () () <: Prims.Pure (Monoid.monoid_morphism f ma mb)
 let embed_nat_int n = n <: Prims.int
@@ -160,9 +153,6 @@ type left_action (mm: Monoid.monoid m) (a: Type) =
       mult_lemma: Prims.squash (Monoid.mult_act_lemma m a mm.mult act) ->
       unit_lemma: Prims.squash (Monoid.unit_act_lemma m a mm.unit act)
     -> Monoid.left_action mm a
-
-
-
 
 
 
@@ -191,11 +181,6 @@ type monoid (m: Type) =
 
 
 
-
-
-
-
-
 let intro_monoid m u15 mult = Monoid.Monoid u15 mult () () () <: Prims.Pure (Monoid.monoid m)
 let nat_plus_monoid =
   let add x y = x + y <: Prims.nat in
@@ -289,8 +274,6 @@ type monoid_morphism (f: (_: a -> b)) (ma: Monoid.monoid a) (mb: Monoid.monoid b
 
 
 
-
-
 let intro_monoid_morphism f ma mb =
   Monoid.MonoidMorphism () () <: Prims.Pure (Monoid.monoid_morphism f ma mb)
 let embed_nat_int n = n <: Prims.int
@@ -332,9 +315,6 @@ type left_action (mm: Monoid.monoid m) (a: Type) =
       mult_lemma: Prims.squash (Monoid.mult_act_lemma m a mm.mult act) ->
       unit_lemma: Prims.squash (Monoid.unit_act_lemma m a mm.unit act)
     -> Monoid.left_action mm a
-
-
-
 
 
 

--- a/tests/error-messages/Monoid.fst.output.expected
+++ b/tests/error-messages/Monoid.fst.output.expected
@@ -19,11 +19,6 @@ type monoid (m: Type) =
 
 
 
-
-
-
-
-
 let intro_monoid m u15 mult = Monoid.Monoid u15 mult () () () <: Prims.Pure (Monoid.monoid m)
 let nat_plus_monoid =
   let add x y = x + y <: Prims.nat in
@@ -117,8 +112,6 @@ type monoid_morphism (f: (_: a -> b)) (ma: Monoid.monoid a) (mb: Monoid.monoid b
 
 
 
-
-
 let intro_monoid_morphism f ma mb =
   Monoid.MonoidMorphism () () <: Prims.Pure (Monoid.monoid_morphism f ma mb)
 let embed_nat_int n = n <: Prims.int
@@ -160,9 +153,6 @@ type left_action (mm: Monoid.monoid m) (a: Type) =
       mult_lemma: Prims.squash (Monoid.mult_act_lemma m a mm.mult act) ->
       unit_lemma: Prims.squash (Monoid.unit_act_lemma m a mm.unit act)
     -> Monoid.left_action mm a
-
-
-
 
 
 
@@ -191,11 +181,6 @@ type monoid (m: Type) =
 
 
 
-
-
-
-
-
 let intro_monoid m u15 mult = Monoid.Monoid u15 mult () () () <: Prims.Pure (Monoid.monoid m)
 let nat_plus_monoid =
   let add x y = x + y <: Prims.nat in
@@ -289,8 +274,6 @@ type monoid_morphism (f: (_: a -> b)) (ma: Monoid.monoid a) (mb: Monoid.monoid b
 
 
 
-
-
 let intro_monoid_morphism f ma mb =
   Monoid.MonoidMorphism () () <: Prims.Pure (Monoid.monoid_morphism f ma mb)
 let embed_nat_int n = n <: Prims.int
@@ -332,9 +315,6 @@ type left_action (mm: Monoid.monoid m) (a: Type) =
       mult_lemma: Prims.squash (Monoid.mult_act_lemma m a mm.mult act) ->
       unit_lemma: Prims.squash (Monoid.unit_act_lemma m a mm.unit act)
     -> Monoid.left_action mm a
-
-
-
 
 
 

--- a/tests/error-messages/PatImps.fst.json_output.expected
+++ b/tests/error-messages/PatImps.fst.json_output.expected
@@ -11,7 +11,6 @@ noeq
 type t2 = | A : PatImps.t2
 
 
-
 let f2 x =
   (let PatImps.A #i = x in
     i)
@@ -21,8 +20,6 @@ noeq
 type t3 =
   | B : PatImps.t3
   | C : PatImps.t3
-
-
 
 
 
@@ -48,7 +45,6 @@ noeq
 type t2 = | A : PatImps.t2
 
 
-
 let f2 x =
   (let PatImps.A #i = x in
     i)
@@ -58,8 +54,6 @@ noeq
 type t3 =
   | B : PatImps.t3
   | C : PatImps.t3
-
-
 
 
 

--- a/tests/error-messages/PatImps.fst.output.expected
+++ b/tests/error-messages/PatImps.fst.output.expected
@@ -11,7 +11,6 @@ noeq
 type t2 = | A : PatImps.t2
 
 
-
 let f2 x =
   (let PatImps.A #i = x in
     i)
@@ -21,8 +20,6 @@ noeq
 type t3 =
   | B : PatImps.t3
   | C : PatImps.t3
-
-
 
 
 
@@ -48,7 +45,6 @@ noeq
 type t2 = | A : PatImps.t2
 
 
-
 let f2 x =
   (let PatImps.A #i = x in
     i)
@@ -58,8 +54,6 @@ noeq
 type t3 =
   | B : PatImps.t3
   | C : PatImps.t3
-
-
 
 
 

--- a/tests/tactics/Postprocess.fst.output.expected
+++ b/tests/tactics/Postprocess.fst.output.expected
@@ -45,13 +45,9 @@ assume OnlyName (Discriminator B1) val Postprocess.uu___is_B1  : _
 [@ (discriminator)]
 assume OnlyName (Discriminator C1) val Postprocess.uu___is_C1  : _
 [@ (projector)]
-OnlyName (Projector B1 _0) val Postprocess.__proj__B1__item___0  : _
+assume OnlyName (Projector B1 _0) val Postprocess.__proj__B1__item___0  : _
 [@ (projector)]
-OnlyName (Projector B1 _0) let  __proj__B1__item___0  : _ = _
-[@ (projector)]
-OnlyName (Projector C1 _0) val Postprocess.__proj__C1__item___0  : _
-[@ (projector)]
-OnlyName (Projector C1 _0) let  __proj__C1__item___0  : _ = _
+assume OnlyName (Projector C1 _0) val Postprocess.__proj__C1__item___0  : _
 [@ ]
 (* Sig_bundle *)[@ ]
 noeq type Postprocess.t2  : Type
@@ -68,13 +64,9 @@ assume OnlyName (Discriminator B2) val Postprocess.uu___is_B2  : _
 [@ (discriminator)]
 assume OnlyName (Discriminator C2) val Postprocess.uu___is_C2  : _
 [@ (projector)]
-OnlyName (Projector B2 _0) val Postprocess.__proj__B2__item___0  : _
+assume OnlyName (Projector B2 _0) val Postprocess.__proj__B2__item___0  : _
 [@ (projector)]
-OnlyName (Projector B2 _0) let  __proj__B2__item___0  : _ = _
-[@ (projector)]
-OnlyName (Projector C2 _0) val Postprocess.__proj__C2__item___0  : _
-[@ (projector)]
-OnlyName (Projector C2 _0) let  __proj__C2__item___0  : _ = _
+assume OnlyName (Projector C2 _0) val Postprocess.__proj__C2__item___0  : _
 [@ ]
 let rec lift  : _ = (fun uu___1 -> (match uu___1@0:(Tm_unknown) with
 	| (A1 )  -> A2
@@ -217,13 +209,9 @@ assume OnlyName (Discriminator B1) val Postprocess.uu___is_B1  : _
 [@ (discriminator)]
 assume OnlyName (Discriminator C1) val Postprocess.uu___is_C1  : _
 [@ (projector)]
-OnlyName (Projector B1 _0) val Postprocess.__proj__B1__item___0  : _
+assume OnlyName (Projector B1 _0) val Postprocess.__proj__B1__item___0  : _
 [@ (projector)]
-OnlyName (Projector B1 _0) let  __proj__B1__item___0  : _ = _
-[@ (projector)]
-OnlyName (Projector C1 _0) val Postprocess.__proj__C1__item___0  : _
-[@ (projector)]
-OnlyName (Projector C1 _0) let  __proj__C1__item___0  : _ = _
+assume OnlyName (Projector C1 _0) val Postprocess.__proj__C1__item___0  : _
 [@ ]
 (* Sig_bundle *)[@ ]
 noeq type Postprocess.t2  : Type
@@ -240,13 +228,9 @@ assume OnlyName (Discriminator B2) val Postprocess.uu___is_B2  : _
 [@ (discriminator)]
 assume OnlyName (Discriminator C2) val Postprocess.uu___is_C2  : _
 [@ (projector)]
-OnlyName (Projector B2 _0) val Postprocess.__proj__B2__item___0  : _
+assume OnlyName (Projector B2 _0) val Postprocess.__proj__B2__item___0  : _
 [@ (projector)]
-OnlyName (Projector B2 _0) let  __proj__B2__item___0  : _ = _
-[@ (projector)]
-OnlyName (Projector C2 _0) val Postprocess.__proj__C2__item___0  : _
-[@ (projector)]
-OnlyName (Projector C2 _0) let  __proj__C2__item___0  : _ = _
+assume OnlyName (Projector C2 _0) val Postprocess.__proj__C2__item___0  : _
 [@ ]
 let rec lift  : _ = (fun uu___1 -> (match uu___1@0:(Tm_unknown) with
 	| (A1 )  -> A2


### PR DESCRIPTION
The desugaring adds val declaration for projectors and discriminators, which are later filled in by the typechecker. For projectors, it also adds a dummy definition (let), but this seems to be completely unneeded, and will be overriden later.

Check world here: https://github.com/mtzguido/FStar/actions/runs/16838005996. My one concern is whether Vale relies on this in the --dump_module output. F* CI passed locally.