### PR TITLE
Syntax: no need to add a range to `var`, a lident already has one

### DIFF
--- a/src/basic/FStarC.MachineInts.fst
+++ b/src/basic/FStarC.MachineInts.fst
@@ -158,8 +158,8 @@ instance nbe_machint (k : machint_kind) : Tot (NBE.embedding (machint k)) =
     in
     match a.nbe_t with
     | FV (fv1, [], [(a, _)])
-      when Ident.lid_equals (fv1.fv_name.v) (int_to_t_lid_for k)
-      || Ident.lid_equals (fv1.fv_name.v) (__int_to_t_lid_for k) ->
+      when Ident.lid_equals (fv1.fv_name) (int_to_t_lid_for k)
+      || Ident.lid_equals (fv1.fv_name) (__int_to_t_lid_for k) ->
       let! a : int = unembed e_int cbs a in
       Some (Mk a m)
     | _ -> None

--- a/src/extraction/FStarC.Extraction.ML.Modul.fst
+++ b/src/extraction/FStarC.Extraction.ML.Modul.fst
@@ -360,7 +360,7 @@ let extract_typ_abbrev env quals attrs lb
     //eta expansion is important; see issue #490, including unrefining and unascribing
     let lbdef = FStarC.TypeChecker.Normalize.eta_expand_with_type tcenv lbdef lbtyp in
     let fv = Inr?.v lb.lbname in
-    let lid = fv.fv_name.v in
+    let lid = fv.fv_name in
     let def = SS.compress lbdef |> U.unmeta |> U.un_uinst in
     let def =
         match def.n with
@@ -426,7 +426,7 @@ let extract_let_rec_type env quals attrs lb
     let bs, _ = U.arrow_formals lbtyp in
     let env1, ml_bs = binders_as_mlty_binders env bs in
     let fv = Inr?.v lb.lbname in
-    let lid = fv.fv_name.v in
+    let lid = fv.fv_name in
     let body = MLTY_Top in
     let metadata = extract_metadata attrs @ List.choose flag_of_qual quals in
     let assumed = false in
@@ -565,7 +565,7 @@ let extract_reifiable_effect g ed
         match (SS.compress tm).n with
         | Tm_uinst (tm, _) -> extract_fv tm
         | Tm_fvar fv ->
-            let mlp = mlpath_of_lident g fv.fv_name.v in
+            let mlp = mlpath_of_lident g fv.fv_name in
             let ({exp_b_tscheme=tysc}) = UEnv.lookup_fv tm.pos g fv in
             with_ty MLTY_Top <| MLE_Name mlp, tysc
         | _ -> failwith (Format.fmt2 "(%s) Not an fv: %s"
@@ -1254,7 +1254,7 @@ and extract_sig_let (g:uenv) (se:sigelt) : uenv & list mlmodule1 =
                   then env, ml_lbs
                   else
                       // debug g (fun () -> printfn "Translating source lb %s at type %s to %A" (show lbname) (show t) (must (mllb.mllb_tysc)));
-                      let lb_lid = (Inr?.v lbname).fv_name.v in
+                      let lb_lid = (Inr?.v lbname).fv_name in
                       let flags'' =
                           match (SS.compress t).n with
                           | Tm_arrow {comp={ n = Comp { effect_name = e }}}

--- a/src/extraction/FStarC.Extraction.ML.RegEmb.fst
+++ b/src/extraction/FStarC.Extraction.ML.RegEmb.fst
@@ -307,13 +307,13 @@ let rec embedding_for
   all of them, using a name prefix __knot_e, and later define the e_X at the
   top-level by unthunking.
   *)
-  | Tm_fvar fv when List.existsb (Ident.lid_equals fv.fv_name.v) mutuals ->
-    let head = mk <| MLE_Var ("__knot_e_" ^ Ident.string_of_id (Ident.ident_of_lid fv.fv_name.v)) in
+  | Tm_fvar fv when List.existsb (Ident.lid_equals fv.fv_name) mutuals ->
+    let head = mk <| MLE_Var ("__knot_e_" ^ Ident.string_of_id (Ident.ident_of_lid fv.fv_name)) in
     mk (MLE_App (head, [ml_unit]))
 
   (* An fv for which we have an embedding already registered. *)
-  | Tm_fvar fv when Some? (find_fv_embedding' fv.fv_name.v) ->
-    let emb_data = find_fv_embedding fv.fv_name.v in
+  | Tm_fvar fv when Some? (find_fv_embedding' fv.fv_name) ->
+    let emb_data = find_fv_embedding fv.fv_name in
     begin match k with
     | SyntaxTerm -> ml_name emb_data.syn_emb
     | NBETerm ->
@@ -332,7 +332,7 @@ let rec embedding_for
   | Tm_fvar fv when Env.fv_has_attr tcenv fv PC.plugin_attr ->
     begin match k with
     | SyntaxTerm ->
-      let lid = fv.fv_name.v in
+      let lid = fv.fv_name in
       as_name (List.map Ident.string_of_id (Ident.ns_of_lid lid),
                "e_" ^ Ident.string_of_id (Ident.ident_of_lid lid))
     | NBETerm ->
@@ -350,7 +350,7 @@ type wrapped_term = mlexpr & mlexpr & int & bool
 
 let interpret_plugin_as_term_fun (env:UEnv.uenv) (fv:fv) (t:typ) (arity_opt:option int) (ml_fv:mlexpr')
     : option wrapped_term =
-    let fv_lid = fv.fv_name.v in
+    let fv_lid = fv.fv_name in
     let tcenv = UEnv.tcenv_of_uenv env in
     let t = N.normalize [
       Env.EraseUniverses;
@@ -513,7 +513,7 @@ let interpret_plugin_as_term_fun (env:UEnv.uenv) (fv:fv) (t:typ) (arity_opt:opti
         | [] ->
           let arg_unembeddings = List.rev accum_embeddings in
           let res_embedding = embedding_for tcenv [] loc tvar_context result_typ in
-          let fv_lid = fv.fv_name.v in
+          let fv_lid = fv.fv_name in
           if U.is_pure_comp c
           then begin
             let cb = str_to_name "cb" in
@@ -572,7 +572,7 @@ let interpret_plugin_as_term_fun (env:UEnv.uenv) (fv:fv) (t:typ) (arity_opt:opti
         Some (w, w', a, b)
     with
     | NoEmbedding msg ->
-      not_implemented_warning (Ident.range_of_lid fv.fv_name.v)
+      not_implemented_warning (Ident.range_of_lid fv.fv_name)
                               (show fv)
                               msg;
       None
@@ -689,7 +689,7 @@ let __do_handle_plugin (g: uenv) (arity_opt: option int) (se: sigelt) : list mlm
   | Sig_let {lbs} ->
       let mk_registration lb : list mlmodule1 =
          let fv = Inr?.v lb.lbname in
-         let fv_lid = fv.fv_name.v in
+         let fv_lid = fv.fv_name in
          let fv_t = lb.lbtyp in
          let ml_name_str = MLE_Const (MLC_String (Ident.string_of_lid fv_lid)) in
          match interpret_plugin_as_term_fun g fv fv_t arity_opt ml_name_str with

--- a/src/extraction/FStarC.Extraction.ML.Term.fst
+++ b/src/extraction/FStarC.Extraction.ML.Term.fst
@@ -180,7 +180,7 @@ let rec is_arity_aux tcenv t =
         FStarC.TypeChecker.Env.lookup_definition
           [Env.Unfold delta_constant]
           tcenv
-          fv.fv_name.v
+          fv.fv_name
       in
       begin
       match topt with
@@ -732,7 +732,7 @@ let rec translate_term_to_mlty' (g:uenv) (t0:term) : mlty =
                  translate_term_to_mlty g a
             else (
               let formals, _ =
-                let (_, fvty), _ = FStarC.TypeChecker.Env.lookup_lid (tcenv_of_uenv g) fv.fv_name.v in
+                let (_, fvty), _ = FStarC.TypeChecker.Env.lookup_lid (tcenv_of_uenv g) fv.fv_name in
                 let fvty = N.normalize [Env.UnfoldUntil delta_constant; Env.ForExtraction] (tcenv_of_uenv g) fvty in
                 U.arrow_formals fvty in
               let mlargs = List.map (arg_as_mlty g) args in
@@ -742,7 +742,7 @@ let rec translate_term_to_mlty' (g:uenv) (t0:term) : mlty =
                 then let _, rest = BU.first_N n_args formals in
                      mlargs @ (List.map (fun _ -> MLTY_Erased) rest)
                 else mlargs in
-              let nm = UEnv.mlpath_of_lident g fv.fv_name.v in
+              let nm = UEnv.mlpath_of_lident g fv.fv_name in
               MLTY_Named (mlargs, nm)
             )
         )
@@ -1016,7 +1016,7 @@ let rec extract_one_pat (imp : bool)
           | Some ({exp_b_expr={expr=MLE_Name n}; exp_b_tscheme=ttys}) -> n, ttys
           | Some _ -> failwith "Expected a constructor"
           | None ->
-            Errors.raise_error f.fv_name.p  Errors.Error_ErasedCtor
+            Errors.raise_error f Errors.Error_ErasedCtor
               (Format.fmt1 "Cannot extract this pattern, the %s constructor was erased" (show f))
         in
         // The prefix of the pattern are dot patterns matching the type parameters

--- a/src/extraction/FStarC.Extraction.ML.UEnv.fst
+++ b/src/extraction/FStarC.Extraction.ML.UEnv.fst
@@ -181,9 +181,9 @@ let try_lookup_fv (r:Range.t) (g:uenv) (fv:fv) : option exp_binding =
     (* Log an error/warning and return None *)
     let open FStarC.Errors.Msg in
     Errors.log_issue r Errors.Error_CallToErased [
-       text <| Format.fmt1 "Will not extract reference to variable `%s` since it has the `noextract` qualifier." (string_of_lid fv.fv_name.v);
+       text <| Format.fmt1 "Will not extract reference to variable `%s` since it has the `noextract` qualifier." (string_of_lid fv.fv_name);
        text <| Format.fmt2 "Either remove the noextract qualifier from %s (defined in %s) or add it to this definition."
-                 (string_of_lid fv.fv_name.v) (show pos);
+                 (string_of_lid fv.fv_name) (show pos);
        text <| Format.fmt1 "This error can be ignored with `--warn_error -%s`." (show Errors.call_to_erased_errno)];
     None
   | NotFound ->
@@ -195,8 +195,8 @@ let lookup_fv (r:Range.t) (g:uenv) (fv:fv) : exp_binding =
   | Found t -> t
   | res ->
     failwith (Format.fmt3 "Internal error: (%s) free variable %s not found during extraction (res=%s)\n"
-              (Range.string_of_range fv.fv_name.p)
-              (show fv.fv_name.v)
+              (Range.string_of_range (pos fv))
+              (show fv.fv_name)
               (show res))
 
 (** An F* local variable (bv) can be mapped either to
@@ -546,7 +546,7 @@ let extend_fv (g:uenv) (x:fv) (t_x:mltyscheme) (add_unit:bool)
         let ml_ty = match t_x with
             | ([], t) -> t
             | _ -> MLTY_Top in
-        let mlpath, g = new_mlpath_of_lident g x.fv_name.v in
+        let mlpath, g = new_mlpath_of_lident g x.fv_name in
         let mlsymbol = snd mlpath in
         let mly = MLE_Name mlpath in
         let mly = if add_unit then with_ty MLTY_Top <| MLE_App(with_ty MLTY_Top mly, [ml_unit]) else with_ty ml_ty mly in
@@ -575,7 +575,7 @@ let extend_lb (g:uenv) (l:lbname) (t:typ) (t_x:mltyscheme) (add_unit:bool)
 (** Extend with an abbreviation [fv] for the type scheme [ts] *)
 let extend_tydef (g:uenv) (fv:fv) (ts:mltyscheme) (meta:FStarC.Extraction.ML.Syntax.metadata)
   : tydef & mlpath & uenv =
-    let name, g = new_mlpath_of_lident g fv.fv_name.v in
+    let name, g = new_mlpath_of_lident g fv.fv_name in
     let tydef = {
         tydef_fv = fv;
         tydef_mlmodule_name=fst name;
@@ -592,7 +592,7 @@ let extend_with_tydef_declaration u l =
 
 (** Extend with [fv], the identifer for an F* inductive type *)
 let extend_type_name (g:uenv) (fv:fv) : mlpath & uenv =
-  let name, g = new_mlpath_of_lident g fv.fv_name.v in
+  let name, g = new_mlpath_of_lident g fv.fv_name in
   name,
   {g with type_names=(fv,name)::g.type_names}
 

--- a/src/fstar/FStarC.CheckedFiles.fst
+++ b/src/fstar/FStarC.CheckedFiles.fst
@@ -34,7 +34,7 @@ let dbg = Debug.get_toggle "CheckedFiles"
  * detect when loading the cache that the version number is same
  * It needs to be kept in sync with Prims.fst
  *)
-let cache_version_number = 74
+let cache_version_number = 75
 
 (*
  * Abbreviation for what we store in the checked files (stages as described below)

--- a/src/reflection/FStarC.Reflection.V1.NBEEmbeddings.fst
+++ b/src/reflection/FStarC.Reflection.V1.NBEEmbeddings.fst
@@ -58,7 +58,7 @@ let mkFV fv us ts = mkFV fv (List.rev us) (List.rev ts)
 let mkConstruct fv us ts = mkConstruct fv (List.rev us) (List.rev ts)
 (* ^ We still need to match on them in reverse order though, so this is pretty dumb *)
 
-let fv_as_emb_typ fv = S.ET_app (FStarC.Ident.string_of_lid fv.fv_name.v, [])
+let fv_as_emb_typ fv = S.ET_app (FStarC.Ident.string_of_lid fv.fv_name, [])
 let mk_emb' x y fv = mk_emb x y (fun () -> mkFV fv [] []) (fun () -> fv_as_emb_typ fv)
 
 let mk_lazy cb obj ty kind =

--- a/src/reflection/FStarC.Reflection.V2.NBEEmbeddings.fst
+++ b/src/reflection/FStarC.Reflection.V2.NBEEmbeddings.fst
@@ -54,7 +54,7 @@ let mkFV fv us ts = mkFV fv (List.rev us) (List.rev ts)
 let mkConstruct fv us ts = mkConstruct fv (List.rev us) (List.rev ts)
 (* ^ We still need to match on them in reverse order though, so this is pretty dumb *)
 
-let fv_as_emb_typ fv = S.ET_app (FStarC.Ident.string_of_lid fv.fv_name.v, [])
+let fv_as_emb_typ fv = S.ET_app (FStarC.Ident.string_of_lid fv.fv_name, [])
 let mk_emb' x y fv = mk_emb x y (fun () -> mkFV fv [] []) (fun () -> fv_as_emb_typ fv)
 
 let mk_lazy cb obj ty kind =

--- a/src/smtencoding/FStarC.SMTEncoding.EncodeTerm.fst
+++ b/src/smtencoding/FStarC.SMTEncoding.EncodeTerm.fst
@@ -88,7 +88,7 @@ let head_normal env t =
     | Tm_abs _
     | Tm_constant _ -> true
     | Tm_fvar fv
-    | Tm_app {hd={n=Tm_fvar fv}} -> Env.lookup_definition [Env.Eager_unfolding_only] env.tcenv fv.fv_name.v |> None?
+    | Tm_app {hd={n=Tm_fvar fv}} -> Env.lookup_definition [Env.Eager_unfolding_only] env.tcenv fv.fv_name |> None?
     | _ -> false
 
 let head_redex env t =
@@ -99,7 +99,7 @@ let head_redex env t =
       || List.existsb (function TOTAL -> true | _ -> false) rc.residual_flags
 
     | Tm_fvar fv ->
-      Env.lookup_definition [Env.Eager_unfolding_only] env.tcenv fv.fv_name.v |> Some?
+      Env.lookup_definition [Env.Eager_unfolding_only] env.tcenv fv.fv_name |> Some?
 
     | _ -> false
 
@@ -1155,7 +1155,7 @@ and encode_term (t:typ) (env:env_t) : (term         (* encoding of t, expects t 
                 | Tm_uinst({n=Tm_name x}, _)
                 | Tm_name x -> Some x.sort
                 | Tm_uinst({n=Tm_fvar fv}, _)
-                | Tm_fvar fv -> Some (Env.lookup_lid env.tcenv fv.fv_name.v |> fst |> snd)
+                | Tm_fvar fv -> Some (Env.lookup_lid env.tcenv fv.fv_name |> fst |> snd)
                 | Tm_ascribed {asc=(Inl t, _, _)} -> Some t
                 | Tm_ascribed {asc=(Inr c, _, _)} -> Some (U.comp_result c)
                 | _ -> None
@@ -1413,13 +1413,13 @@ and encode_pat (env:env_t) (pat:S.pat) : (env_t & pattern) =
             mkEq(scrutinee, tm)
         | Pat_cons(f, _, args) ->
             let is_f =
-                let tc_name = Env.typ_of_datacon env.tcenv f.fv_name.v in
+                let tc_name = Env.typ_of_datacon env.tcenv f.fv_name in
                 match Env.datacons_of_typ env.tcenv tc_name with
                 | _, [_] -> mkTrue //single constructor type; no need for a test
-                | _ -> mk_data_tester env f.fv_name.v scrutinee
+                | _ -> mk_data_tester env f.fv_name scrutinee
             in
             let sub_term_guards = args |> List.mapi (fun i (arg, _) ->
-                let proj = primitive_projector_by_pos env.tcenv f.fv_name.v i in
+                let proj = primitive_projector_by_pos env.tcenv f.fv_name i in
                 mk_guard arg (mkApp(proj, [scrutinee]))) in //arity ok, primitive projector (#1383)
             mk_and_l (is_f::sub_term_guards)
     in
@@ -1434,7 +1434,7 @@ and encode_pat (env:env_t) (pat:S.pat) : (env_t & pattern) =
         | Pat_cons(f, _, args) ->
             args
             |> List.mapi (fun i (arg, _) ->
-                let proj = primitive_projector_by_pos env.tcenv f.fv_name.v i in
+                let proj = primitive_projector_by_pos env.tcenv f.fv_name i in
                 mk_projections arg (mkApp(proj, [scrutinee]))) //arity ok, primitive projector (#1383)
             |> List.flatten
     in

--- a/src/smtencoding/FStarC.SMTEncoding.Env.fst
+++ b/src/smtencoding/FStarC.SMTEncoding.Env.fst
@@ -327,13 +327,13 @@ let try_lookup_free_var env l =
         | _ -> None
         end
       end
-let lookup_free_var env a =
-    match try_lookup_free_var env a.v with
+let lookup_free_var env (a : lident) =
+    match try_lookup_free_var env a with
     | Some t -> t
-    | None -> fail_fvar_lookup env a.v
-let lookup_free_var_name env a = lookup_lid env a.v
-let lookup_free_var_sym env a =
-    let fvb = lookup_lid env a.v in
+    | None -> fail_fvar_lookup env a
+let lookup_free_var_name env (a : lident) = lookup_lid env a
+let lookup_free_var_sym env (a : lident) =
+    let fvb = lookup_lid env a in
     match fvb.smt_fuel_partial_app with
     | Some({tm=App(g, zf)}, _)
         when env.use_zfuel_name ->

--- a/src/smtencoding/FStarC.SMTEncoding.Solver.Cache.fst
+++ b/src/smtencoding/FStarC.SMTEncoding.Solver.Cache.fst
@@ -50,7 +50,7 @@ instance hashable_bv : hashable bv = {
 }
 
 instance hashable_fv : hashable fv = {
-  hash = (fun f -> hash f.fv_name.v);
+  hash = (fun f -> hash f.fv_name);
 }
 
 instance hashable_binder : hashable binder = {

--- a/src/syntax/FStarC.Syntax.DsEnv.fst
+++ b/src/syntax/FStarC.Syntax.DsEnv.fst
@@ -769,7 +769,7 @@ let resolve_to_fully_qualified_name (env:env) (l:lident) : option lident =
     match try_lookup_name true false env l with
     | Some (Term_name (e, attrs)) ->
       begin match (Subst.compress e).n with
-      | Tm_fvar fv -> Some fv.fv_name.v
+      | Tm_fvar fv -> Some fv.fv_name
       | _ -> None
       end
     | Some (Eff_name (o, l)) -> Some l
@@ -1440,7 +1440,7 @@ let finish env modul =
     | Sig_let {lbs=(_,lbs)} ->
       if List.contains Private quals
       then begin
-           lbs |> List.iter (fun lb -> SMap.remove (sigmap env) (string_of_lid (Inr?.v lb.lbname).fv_name.v))
+           lbs |> List.iter (fun lb -> SMap.remove (sigmap env) (string_of_lid (Inr?.v lb.lbname).fv_name))
       end
 
     | _ -> ());

--- a/src/syntax/FStarC.Syntax.Embeddings.Base.fst
+++ b/src/syntax/FStarC.Syntax.Embeddings.Base.fst
@@ -283,7 +283,7 @@ let mk_extracted_embedding (name: string) (u: string & list term -> option 'a) (
     let hd, args = U.head_and_args t in
     let? hd_lid =
       match (SS.compress (U.un_uinst hd)).n with
-      | Tm_fvar fv -> Some fv.fv_name.v
+      | Tm_fvar fv -> Some fv.fv_name
       | _ -> None
     in
     u (Ident.string_of_lid hd_lid, List.map fst args)

--- a/src/syntax/FStarC.Syntax.Formula.fst
+++ b/src/syntax/FStarC.Syntax.Formula.fst
@@ -86,7 +86,7 @@ let lookup_arity_lid table target_lid args =
 let destruct_base_conn t =
     let hd, args = U.head_and_args t in
     match (U.un_uinst hd).n with
-    | Tm_fvar fv -> lookup_arity_lid destruct_base_table fv.fv_name.v args
+    | Tm_fvar fv -> lookup_arity_lid destruct_base_table fv.fv_name args
     | _ -> None
 
 let destruct_sq_base_conn t =
@@ -94,7 +94,7 @@ let destruct_sq_base_conn t =
     let t = U.unmeta t in
     let hd, args = U.head_and_args_full t in
     match (U.un_uinst hd).n with
-    | Tm_fvar fv -> lookup_arity_lid destruct_sq_base_table fv.fv_name.v args
+    | Tm_fvar fv -> lookup_arity_lid destruct_sq_base_table fv.fv_name args
     | _ -> None
 
 let patterns t =
@@ -106,8 +106,8 @@ let patterns t =
 let destruct_q_conn t =
     let is_q (fa:bool) (fv:fv) : bool =
         if fa
-        then U.is_forall fv.fv_name.v
-        else U.is_exists fv.fv_name.v
+        then U.is_forall fv.fv_name
+        else U.is_exists fv.fv_name
     in
     let flat t =
         let t, args = U.head_and_args t in
@@ -121,8 +121,8 @@ let destruct_q_conn t =
 
         | None, ({n=Tm_fvar tc}, [({n=Tm_abs {bs=[b]; body=t2}}, _)])
         | None, ({n=Tm_fvar tc}, [_; ({n=Tm_abs {bs=[b]; body=t2}}, _)])
-            when (U.is_qlid tc.fv_name.v) ->
-          aux (Some (U.is_forall tc.fv_name.v)) (b::out) t2
+            when (U.is_qlid tc.fv_name) ->
+          aux (Some (U.is_forall tc.fv_name)) (b::out) t2
 
         | Some b, _ ->
           let bs = List.rev out in

--- a/src/syntax/FStarC.Syntax.Free.fst
+++ b/src/syntax/FStarC.Syntax.Free.fst
@@ -82,7 +82,7 @@ let no_free_vars : free_vars_and_fvars = {
 
 let singleton_fvar fv : free_vars_and_fvars =
     fst no_free_vars,
-    add fv.fv_name.v (empty ())
+    add fv.fv_name (empty ())
 
 let singleton_bv x =
   {fst no_free_vars with free_names = singleton x}, snd no_free_vars

--- a/src/syntax/FStarC.Syntax.Hash.fst
+++ b/src/syntax/FStarC.Syntax.Hash.fst
@@ -187,7 +187,7 @@ and hash_pat p =
 
 
 and hash_bv b = hash_term b.sort
-and hash_fv fv = of_string (Ident.string_of_lid fv.fv_name.v)
+and hash_fv fv = of_string (Ident.string_of_lid fv.fv_name)
 and hash_binder (b:binder) =
   mix_list_lit
     [hash_bv b.binder_bv;
@@ -465,7 +465,7 @@ and equal_bv b1 b2 =
 
 and equal_fv f1 f2 =
   if physical_equality f1 f2 then true else
-  Ident.lid_equals f1.fv_name.v f2.fv_name.v
+  Ident.lid_equals f1.fv_name f2.fv_name
 
 and equal_universe u1 u2 =
   if physical_equality u1 u2 then true else
@@ -591,7 +591,7 @@ and equal_arg_qualifier a1 a2 =
 and equal_lbname l1 l2 =
   match l1, l2 with
   | Inl b1, Inl b2 -> Ident.ident_equals b1.ppname b2.ppname
-  | Inr f1, Inr f2 -> Ident.lid_equals f1.fv_name.v f2.fv_name.v
+  | Inr f1, Inr f2 -> Ident.lid_equals f1.fv_name f2.fv_name
 
 and equal_subst_elt s1 s2 =
   match s1, s2 with

--- a/src/syntax/FStarC.Syntax.InstFV.fst
+++ b/src/syntax/FStarC.Syntax.InstFV.fst
@@ -137,7 +137,7 @@ let instantiate i t = match i with
     | [] -> t
     | _ ->
       let inst_fv (t: term) (fv: S.fv) : term =
-        begin match Option.find (fun (x, _) -> lid_equals x fv.fv_name.v) i with
+        begin match Option.find (fun (x, _) -> lid_equals x fv.fv_name) i with
             | None -> t
             | Some (_, us) -> mk t (Tm_uinst(t, us))
         end

--- a/src/syntax/FStarC.Syntax.MutRecTy.fst
+++ b/src/syntax/FStarC.Syntax.MutRecTy.fst
@@ -76,7 +76,7 @@ let disentangle_abbrevs_from_bundle
    | _ ->
 
     let type_abbrevs = type_abbrev_sigelts |> List.map begin fun x -> match x.sigel with
-        | Sig_let {lbs=(_, [ { lbname = Inr fv } ] )} -> fv.fv_name.v
+        | Sig_let {lbs=(_, [ { lbname = Inr fv } ] )} -> fv.fv_name
         | _ -> failwith "mutrecty: disentangle_abbrevs_from_bundle: type_abbrevs: impossible"
     end
     in
@@ -103,7 +103,7 @@ let disentangle_abbrevs_from_bundle
         let remove_not_unfolded lid =
             not_unfolded_yet := !not_unfolded_yet |> List.filter begin fun x -> match x.sigel with
                 | Sig_let {lbs=(_, [ { lbname = Inr fv } ] )} ->
-                  not (lid_equals lid fv.fv_name.v)
+                  not (lid_equals lid fv.fv_name)
                 | _ -> true
             end
         in
@@ -113,7 +113,7 @@ let disentangle_abbrevs_from_bundle
         let rec unfold_abbrev_fv (t: term) (fv : S.fv) : term =
             let replacee (x: sigelt) = match x.sigel with
                 | Sig_let {lbs=(_, [ { lbname = Inr fv' } ] )}
-                  when lid_equals fv'.fv_name.v fv.fv_name.v ->
+                  when lid_equals fv'.fv_name fv.fv_name ->
                   Some x
                 | _ -> None
             in
@@ -126,9 +126,9 @@ let disentangle_abbrevs_from_bundle
                 | None ->
                   begin match U.find_map type_abbrev_sigelts replacee with
                       | Some se ->
-                          if FStarC.List.existsb (fun x -> lid_equals x fv.fv_name.v) !in_progress
-                          then let msg = Format.fmt1 "Cycle on %s in mutually recursive type abbreviations" (string_of_lid fv.fv_name.v) in
-                               raise_error fv.fv_name.v Errors.Fatal_CycleInRecTypeAbbreviation msg
+                          if FStarC.List.existsb (fun x -> lid_equals x fv.fv_name) !in_progress
+                          then let msg = Format.fmt1 "Cycle on %s in mutually recursive type abbreviations" (string_of_lid fv.fv_name) in
+                               raise_error fv.fv_name Errors.Fatal_CycleInRecTypeAbbreviation msg
                           else unfold_abbrev se
                       | _ -> t
                   end
@@ -142,7 +142,7 @@ let disentangle_abbrevs_from_bundle
                 | _ -> true
                 end in
                 let lid = match lb.lbname with
-                    | Inr fv -> fv.fv_name.v
+                    | Inr fv -> fv.fv_name
                     | _ -> failwith "mutrecty: disentangle_abbrevs_from_bundle: rename_abbrev: lid: impossible"
                 in
                 let () = in_progress := lid :: !in_progress in  (* push *)
@@ -175,7 +175,7 @@ let disentangle_abbrevs_from_bundle
       let inductives_with_abbrevs_unfolded =
 
           let find_in_unfolded fv = U.find_map unfolded_type_abbrevs begin fun x -> match x.sigel with
-              | Sig_let {lbs=(_, [ { lbname = Inr fv' ; lbdef = tm } ] )} when (lid_equals fv'.fv_name.v fv.fv_name.v) ->
+              | Sig_let {lbs=(_, [ { lbname = Inr fv' ; lbdef = tm } ] )} when (lid_equals fv'.fv_name fv.fv_name) ->
                 Some tm
               | _ -> None
           end

--- a/src/syntax/FStarC.Syntax.Resugar.fst
+++ b/src/syntax/FStarC.Syntax.Resugar.fst
@@ -191,22 +191,22 @@ let rec resugar_term_as_op (t:S.term) : option (string&expected_arity) =
       Some (snd op, None)
     | _ ->
       (* Check that it is of the shape dtuple int, and return that arity *)
-      match C.get_dtuple_tycon_arity (string_of_lid fv.fv_name.v) with
+      match C.get_dtuple_tycon_arity (string_of_lid fv.fv_name) with
       | Some n -> Some ("dtuple", Some n)
       | None ->
-        match C.get_tuple_tycon_arity (string_of_lid fv.fv_name.v) with
+        match C.get_tuple_tycon_arity (string_of_lid fv.fv_name) with
         | Some n -> Some ("tuple", Some n)
         | None ->
-          let str = string_of_id (Ident.ident_of_lid fv.fv_name.v) in
+          let str = string_of_id (Ident.ident_of_lid fv.fv_name) in
           if BU.starts_with str "try_with" then Some ("try_with", None)
-          else if fv_eq_lid fv C.sread_lid then Some (string_of_lid fv.fv_name.v, None)
+          else if fv_eq_lid fv C.sread_lid then Some (string_of_lid fv.fv_name, None)
           else None
   in
   match (SS.compress t).n with
     | Tm_fvar fv ->
-      let length = String.length (nsstr fv.fv_name.v) in
-      let s = if length=0 then string_of_lid fv.fv_name.v
-              else BU.substring_from (string_of_lid fv.fv_name.v) (length+1) in
+      let length = String.length (nsstr fv.fv_name) in
+      let s = if length=0 then string_of_lid fv.fv_name
+              else BU.substring_from (string_of_lid fv.fv_name) (length+1) in
       begin match string_to_op s with
         | Some t -> Some t
         | _ -> fallback fv
@@ -235,7 +235,7 @@ let maybe_shorten_lid env lid : lident =
   if may_shorten lid then DsEnv.shorten_lid env lid else lid
 
 let maybe_shorten_fv env fv : lident =
-  let lid = fv.fv_name.v in
+  let lid = fv.fv_name in
   maybe_shorten_lid env lid
 
 (* Sizet handled below *)
@@ -337,8 +337,8 @@ let rec resugar_term' (env: DsEnv.env) (t : S.term) : A.term =
     | Tm_fvar fv -> //a top-level identifier, may be lowercase or upper case
       //should be A.Var if lowercase
       //and A.Name if uppercase
-      let a = fv.fv_name.v in
-      let length = String.length (nsstr fv.fv_name.v) in
+      let a = fv.fv_name in
+      let length = String.length (nsstr fv.fv_name) in
       let s = if length=0 then string_of_lid a
           else BU.substring_from (string_of_lid a) (length+1) in
       let is_prefix = I.reserved_prefix ^ "is_" in
@@ -493,8 +493,8 @@ let rec resugar_term' (env: DsEnv.env) (t : S.term) : A.term =
         (* Detect projectors and resugar them as t.x instead of Mkt?.x t *)
         match (U.un_uinst (SS.compress t)).n with
         | Tm_fvar fv ->
-          let a = fv.fv_name.v in
-          let length = String.length (nsstr fv.fv_name.v) in
+          let a = fv.fv_name in
+          let length = String.length (nsstr fv.fv_name) in
           let s = if length=0 then string_of_lid a
               else BU.substring_from (string_of_lid a) (length+1) in
           if BU.starts_with s U.field_projector_prefix then
@@ -624,8 +624,8 @@ let rec resugar_term' (env: DsEnv.env) (t : S.term) : A.term =
         | Some (ref_read, _) when (ref_read = string_of_lid C.sread_lid) ->
           let (t, _) = List.hd args in
           begin match (SS.compress t).n with
-            | Tm_fvar fv when (U.field_projector_contains_constructor (string_of_lid fv.fv_name.v)) ->
-              let f = lid_of_path [string_of_lid fv.fv_name.v] t.pos in
+            | Tm_fvar fv when (U.field_projector_contains_constructor (string_of_lid fv.fv_name)) ->
+              let f = lid_of_path [string_of_lid fv.fv_name] t.pos in
               mk (A.Project(resugar_term' env t, f))
             | _ -> resugar_term' env t
           end
@@ -859,7 +859,7 @@ let rec resugar_term' (env: DsEnv.env) (t : S.term) : A.term =
           | _ -> [], def, false
         in
         let pat, term = match bnd.lbname with
-          | Inr fv -> mk_pat (A.PatName fv.fv_name.v), term
+          | Inr fv -> mk_pat (A.PatName fv.fv_name), term
           | Inl bv ->
             mk_pat (A.PatVar (bv_as_unique_ident bv, None, [])), term
         in
@@ -1241,7 +1241,7 @@ and resugar_pat' env (p:S.pat) (branch_bv: FlatSet.t bv) : A.pattern =
       | _ -> false)
   in
   let resugar_plain_pat_cons' fv args =
-    mk (A.PatApp (mk (A.PatName fv.fv_name.v), args)) in
+    mk (A.PatApp (mk (A.PatName fv.fv_name), args)) in
   let rec resugar_plain_pat_cons fv args =
     let args =
       (* Special check here: if any of the args binds a variable used in
@@ -1258,14 +1258,14 @@ and resugar_pat' env (p:S.pat) (branch_bv: FlatSet.t bv) : A.pattern =
 
     (* List patterns. *)
     | Pat_cons(fv, _, args)
-      when lid_equals fv.fv_name.v C.nil_lid -> (
+      when lid_equals fv.fv_name C.nil_lid -> (
       match filter_pattern_imp args with
       | [] -> mk (A.PatList [])
       | _ -> resugar_plain_pat_cons fv args
     )
 
     | Pat_cons(fv, _, args)
-      when lid_equals fv.fv_name.v C.cons_lid -> (
+      when lid_equals fv.fv_name C.cons_lid -> (
       match filter_pattern_imp args with
        | [(hd, false); (tl, false)] ->
          let hd' = aux hd (Some false) in
@@ -1277,16 +1277,16 @@ and resugar_pat' env (p:S.pat) (branch_bv: FlatSet.t bv) : A.pattern =
     )
 
     | Pat_cons (fv, _, []) ->
-      mk (A.PatName fv.fv_name.v)
+      mk (A.PatName fv.fv_name)
 
 
-    | Pat_cons(fv, _, args) when (is_tuple_constructor_lid fv.fv_name.v
+    | Pat_cons(fv, _, args) when (is_tuple_constructor_lid fv.fv_name
                                && not (must_print args)) ->
       let args =
         args |>
         List.filter_map (fun (p, is_implicit) ->
             if is_implicit then None else Some (aux p (Some false))) in
-      let is_dependent_tuple = C.is_dtuple_datacon_lid fv.fv_name.v in
+      let is_dependent_tuple = C.is_dtuple_datacon_lid fv.fv_name in
       mk (A.PatTuple (args, is_dependent_tuple))
 
     | Pat_cons({fv_qual=Some (Record_ctor(name, fields))}, _, args) ->

--- a/src/syntax/FStarC.Syntax.Subst.fst
+++ b/src/syntax/FStarC.Syntax.Subst.fst
@@ -162,12 +162,9 @@ let tag_with_range t s =
       else begin
       let r = Range.set_use_range t.pos (Range.use_range r) in
       let t' = match t.n with
-        | Tm_bvar bv -> Tm_bvar (Syntax.set_range_of_bv bv r)
-        | Tm_name bv -> Tm_name (Syntax.set_range_of_bv bv r)
-        | Tm_fvar fv -> let l = Syntax.lid_of_fv fv in
-                        let v = {fv.fv_name with v=Ident.set_lid_range l r} in
-                        let fv = {fv with fv_name=v} in
-                        Tm_fvar fv
+        | Tm_bvar bv -> Tm_bvar (setPos r bv)
+        | Tm_name bv -> Tm_name (setPos r bv)
+        | Tm_fvar fv -> Tm_fvar (setPos r fv)
         | t' -> t' in
       {t with n=t'; pos=r}
       end

--- a/src/syntax/FStarC.Syntax.Syntax.fst
+++ b/src/syntax/FStarC.Syntax.Syntax.fst
@@ -232,7 +232,7 @@ let order_fv x y = String.compare (string_of_lid x) (string_of_lid y)
 
 let range_of_lbname (l:lbname) = match l with
     | Inl x -> range_of_id x.ppname
-    | Inr fv -> range_of_lid fv.fv_name.v
+    | Inr fv -> range_of_lid fv.fv_name
 let range_of_bv x = range_of_id x.ppname
 
 let set_range_of_bv x r = {x with ppname = set_id_range r x.ppname }
@@ -442,26 +442,26 @@ let lbname_eq l1 l2 = match l1, l2 with
   | Inl x, Inl y -> bv_eq x y
   | Inr l, Inr m -> lid_equals l m
   | _ -> false
-let fv_eq fv1 fv2 = lid_equals fv1.fv_name.v fv2.fv_name.v
-let fv_eq_lid fv lid = lid_equals fv.fv_name.v lid
+let fv_eq fv1 fv2 = lid_equals fv1.fv_name fv2.fv_name
+let fv_eq_lid fv lid = lid_equals fv.fv_name lid
 
 let set_bv_range bv r = {bv with ppname = set_id_range r bv.ppname}
 
 let lid_and_dd_as_fv l dq : fv = {
-    fv_name=withinfo l (range_of_lid l);
-    fv_qual =dq;
+    fv_name = l;
+    fv_qual = dq;
 }
 let lid_as_fv l dq : fv = {
-    fv_name=withinfo l (range_of_lid l);
-    fv_qual =dq;
+    fv_name = l;
+    fv_qual = dq;
 }
-let fv_to_tm (fv:fv) : term = mk (Tm_fvar fv) (range_of_lid fv.fv_name.v)
+let fv_to_tm (fv:fv) : term = mk (Tm_fvar fv) (range_of_lid fv.fv_name)
 let fvar_with_dd l dq =  fv_to_tm (lid_and_dd_as_fv l dq)
 let fvar l dq = fv_to_tm (lid_as_fv l dq)
-let lid_of_fv (fv:fv) = fv.fv_name.v
+let lid_of_fv (fv:fv) = fv.fv_name
 let range_of_fv (fv:fv) = range_of_lid (lid_of_fv fv)
 let set_range_of_fv (fv:fv) (r:Range.t) =
-    {fv with fv_name={fv.fv_name with v=Ident.set_lid_range (lid_of_fv fv) r}}
+    {fv with fv_name = Ident.set_lid_range fv.fv_name r}
 let has_simple_attribute (l: list term) s =
   List.existsb (function
     | { n = Tm_constant (Const_string (data, _)) } when data = s ->
@@ -632,7 +632,7 @@ let sli (l:lident) : string =
     else string_of_id (ident_of_lid l)
 
 instance showable_fv : showable fv = {
-  show = (fun fv -> sli fv.fv_name.v);
+  show = (fun fv -> sli fv.fv_name);
 }
 
 instance showable_lazy_kind = {

--- a/src/syntax/FStarC.Syntax.Syntax.fsti
+++ b/src/syntax/FStarC.Syntax.Syntax.fsti
@@ -40,7 +40,7 @@ type withinfo_t 'a = {
 
 (* Free term and type variables *)
 [@@ PpxDerivingYoJson; PpxDerivingShow ]
-type var  = withinfo_t lident
+type var  = lident
 
 (* Term language *)
 [@@ PpxDerivingYoJson; PpxDerivingShow ]

--- a/src/syntax/FStarC.Syntax.Util.fst
+++ b/src/syntax/FStarC.Syntax.Util.fst
@@ -451,7 +451,7 @@ let primops =
 let is_primop_lid l = primops |> U.for_some (lid_equals l)
 
 let is_primop f = match f.n with
-  | Tm_fvar fv -> is_primop_lid fv.fv_name.v
+  | Tm_fvar fv -> is_primop_lid fv.fv_name
   | _ -> false
 
 let rec unascribe e =
@@ -878,7 +878,7 @@ let close_univs_and_mk_letbinding recs lbname univ_vars typ eff def attrs pos =
         | _, [] -> def
         | Some fvs, _ ->
           let universes = univ_vars |> List.map U_name in
-          let inst = fvs |> List.map (fun fv -> fv.fv_name.v, universes) in
+          let inst = fvs |> List.map (fun fv -> fv.fv_name, universes) in
           FStarC.Syntax.InstFV.instantiate inst def
     in
     let typ = Subst.close_univ_vars univ_vars typ in
@@ -902,11 +902,11 @@ let open_univ_vars_binders_and_comp uvs binders c =
 (********************************************************************************)
 
 let is_tuple_constructor (t:typ) = match t.n with
-  | Tm_fvar fv -> PC.is_tuple_constructor_lid fv.fv_name.v
+  | Tm_fvar fv -> PC.is_tuple_constructor_lid fv.fv_name
   | _ -> false
 
 let is_dtuple_constructor (t:typ) = match t.n with
-  | Tm_fvar fv -> PC.is_dtuple_constructor_lid fv.fv_name.v
+  | Tm_fvar fv -> PC.is_dtuple_constructor_lid fv.fv_name
   | _ -> false
 
 let is_lid_equality x = lid_equals x PC.eq2_lid
@@ -922,7 +922,7 @@ let lid_is_connective =
 
 let is_constructor t lid =
   match (pre_typ t).n with
-    | Tm_fvar tc -> lid_equals tc.fv_name.v lid
+    | Tm_fvar tc -> lid_equals tc.fv_name lid
     | _ -> false
 
 let rec is_constructed_typ t lid =

--- a/src/syntax/print/FStarC.Syntax.Print.Ugly.fst
+++ b/src/syntax/print/FStarC.Syntax.Print.Ugly.fst
@@ -44,8 +44,8 @@ let sli (l:lident) : string =
 
 let lid_to_string (l:lid) = sli l
 
-// let fv_to_string fv = Printf.sprintf "%s@%A" (lid_to_string fv.fv_name.v) fv.fv_delta
-let fv_to_string fv = lid_to_string fv.fv_name.v //^ "(@@" ^ showfv.fv_delta ^ ")"
+// let fv_to_string fv = Printf.sprintf "%s@%A" (lid_to_string fv.fv_name) fv.fv_delta
+let fv_to_string fv = lid_to_string fv.fv_name //^ "(@@" ^ showfv.fv_delta ^ ")"
 let bv_to_string bv = (string_of_id bv.ppname) ^ "#" ^ (show bv.index)
 
 let nm_to_string bv =
@@ -71,7 +71,7 @@ let const_to_string = C.const_to_string
 
 let lbname_to_string = function
   | Inl l -> bv_to_string l
-  | Inr l -> lid_to_string l.fv_name.v
+  | Inr l -> lid_to_string l.fv_name
 
 let uvar_to_string u = if (Options.hide_uvar_nums()) then "?" else "?" ^ (Unionfind.uvar_id u |> show)
 let version_to_string v = Format.fmt2 "%s.%s" (show v.major) (show v.minor)

--- a/src/tactics/FStarC.Tactics.Embedding.fst
+++ b/src/tactics/FStarC.Tactics.Embedding.fst
@@ -151,7 +151,7 @@ let unfold_lazy_goal (i : lazyinfo) : term =
 (* On that note, we use this (inefficient, FIXME) hack in this module *)
 let mkFV fv us ts = NBETerm.mkFV fv (List.rev us) (List.rev ts)
 let mkConstruct fv us ts = NBETerm.mkConstruct fv (List.rev us) (List.rev ts)
-let fv_as_emb_typ fv = S.ET_app (show fv.fv_name.v, [])
+let fv_as_emb_typ fv = S.ET_app (show fv.fv_name, [])
 
 let e_proofstate_nbe =
     let embed_proofstate _cb (ps:proofstate) : NBETerm.t =

--- a/src/tactics/FStarC.Tactics.Hooks.fst
+++ b/src/tactics/FStarC.Tactics.Hooks.fst
@@ -929,7 +929,7 @@ let splice
         let r =
           (* If this name was provided in the definition list of the splice,
           prefer that range. Otherwise set range to the full splice. *)
-          match tryFind (fun i -> Ident.lid_equals i fv.fv_name.v) lids with
+          match tryFind (fun i -> Ident.lid_equals i fv.fv_name) lids with
           | Some i -> pos i
           | _ -> rng
         in

--- a/src/tosyntax/FStarC.ToSyntax.ToSyntax.fst
+++ b/src/tosyntax/FStarC.ToSyntax.ToSyntax.fst
@@ -2676,7 +2676,7 @@ let rec desugar_tycon env (d: AST.decl) (d_attrs_initial:list S.term) quals tcs 
                   let payload_typ = mkApp record_id_t (List.map (fun bd -> binder_to_term bd, Nothing) bds) (range_of_id record_id) in
                   let desugar_marker = 
                     let range = range_of_id record_id in
-                    let desugar_attr_fv = {fv_name = {v = FStarC.Parser.Const.desugar_of_variant_record_lid; p = range}; fv_qual = None} in
+                    let desugar_attr_fv = {fv_name = setPos range FStarC.Parser.Const.desugar_of_variant_record_lid; fv_qual = None} in
                     let desugar_attr = S.mk (Tm_fvar desugar_attr_fv) range in
                     let cid_as_constant = EMB.embed (string_of_lid (qualify env cid)) range None EMB.id_norm_cb in
                     S.mk_Tm_app desugar_attr [(cid_as_constant, None)] range
@@ -3670,7 +3670,7 @@ and desugar_decl_core env (d_attrs:list S.term) (d:decl) : (env_t & sigelts) =
           let fvs = snd lbs |> List.map (fun lb -> Inr?.v lb.lbname) in
           let val_quals, val_attrs =
             List.fold_right (fun fv (qs, ats) ->
-                let qs', ats' = Env.lookup_letbinding_quals_and_attrs env fv.fv_name.v in
+                let qs', ats' = Env.lookup_letbinding_quals_and_attrs env fv.fv_name in
                 (List.rev_append qs' qs, List.rev_append ats' ats))
                 fvs
                 ([], [])
@@ -3697,7 +3697,7 @@ and desugar_decl_core env (d_attrs:list S.term) (d:decl) : (env_t & sigelts) =
             then S.Logic::quals
             else quals
           in
-          let names = fvs |> List.map (fun fv -> fv.fv_name.v) in
+          let names = fvs |> List.map (fun fv -> fv.fv_name) in
           let s = { sigel = Sig_let {lbs; lids=names};
                     sigquals = quals;
                     sigrng = d.drange;

--- a/src/typechecker/FStarC.TypeChecker.Cfg.fst
+++ b/src/typechecker/FStarC.TypeChecker.Cfg.fst
@@ -268,10 +268,10 @@ instance showable_cfg : showable cfg = {
 let cfg_env cfg = cfg.tcenv
 
 let find_prim_step cfg fv =
-    PSMap.try_find cfg.primitive_steps (I.string_of_lid fv.fv_name.v)
+    PSMap.try_find cfg.primitive_steps (I.string_of_lid fv.fv_name)
 
 let is_prim_step cfg fv =
-    Some? (PSMap.try_find cfg.primitive_steps (I.string_of_lid fv.fv_name.v))
+    Some? (PSMap.try_find cfg.primitive_steps (I.string_of_lid fv.fv_name))
 
 let log cfg f =
     if cfg.debug.gen then f () else ()

--- a/src/typechecker/FStarC.TypeChecker.Core.fst
+++ b/src/typechecker/FStarC.TypeChecker.Core.fst
@@ -1332,7 +1332,7 @@ and do_check (g:env) (e:term)
 
   | Tm_fvar f ->
     begin
-    match Env.try_lookup_lid g.tcenv f.fv_name.v with
+    match Env.try_lookup_lid g.tcenv f.fv_name with
     | Some (([], t), _) ->
       return (E_Total, t)
 
@@ -1342,9 +1342,9 @@ and do_check (g:env) (e:term)
 
   | Tm_uinst ({n=Tm_fvar f}, us) ->
     begin
-    match Env.try_lookup_and_inst_lid g.tcenv us f.fv_name.v with
+    match Env.try_lookup_and_inst_lid g.tcenv us f.fv_name with
     | None ->
-      fail_str (Format.fmt1 "Top-level name not found: %s" (Ident.string_of_lid f.fv_name.v))
+      fail_str (Format.fmt1 "Top-level name not found: %s" (Ident.string_of_lid f.fv_name))
 
     | Some (t, _) ->
       return (E_Total, t)
@@ -1833,10 +1833,10 @@ and pattern_branch_condition (g:env)
         S.mk (Tm_match {scrutinee; ret_opt=None; brs=[eqn]; rc_opt=None}) scrutinee.pos
       in
       let discrimination =
-        let is_induc, datacons = Env.datacons_of_typ g.tcenv (Env.typ_of_datacon g.tcenv fv.fv_name.v) in
+        let is_induc, datacons = Env.datacons_of_typ g.tcenv (Env.typ_of_datacon g.tcenv fv.fv_name) in
         (* Why the `not is_induc`? We may be checking an exception pattern. See issue #1535. *)
         if not is_induc || List.length datacons > 1
-        then let discriminator = U.mk_discriminator fv.fv_name.v in
+        then let discriminator = U.mk_discriminator fv.fv_name in
              match Env.try_lookup_lid g.tcenv discriminator with
              | None ->
                // We don't use the discriminator if we are typechecking it

--- a/src/typechecker/FStarC.TypeChecker.DMFF.fst
+++ b/src/typechecker/FStarC.TypeChecker.DMFF.fst
@@ -633,7 +633,7 @@ and star_type' env t =
         ) ->
             true
         | Tm_fvar fv ->
-             let (_, ty), _ = Env.lookup_lid env.tcenv fv.fv_name.v in
+             let (_, ty), _ = Env.lookup_lid env.tcenv fv.fv_name in
              if is_non_dependent_arrow ty (List.length args)
              then
                // We need to check that the result of the application is a datatype
@@ -978,7 +978,7 @@ and infer (env: env) (e: term): nm & term & term =
 
       N t, s_term, u_term
 
-  | Tm_fvar { fv_name = { v = lid } } ->
+  | Tm_fvar { fv_name = lid } ->
       let _, t = fst <| Env.lookup_lid env.tcenv lid in
       // Need to erase universes here! This is an F* type that is fully annotated.
       N (normalize t), e, e

--- a/src/typechecker/FStarC.TypeChecker.Env.fst
+++ b/src/typechecker/FStarC.TypeChecker.Env.fst
@@ -835,7 +835,7 @@ let rec delta_depth_of_qninfo_lid env lid (qn:qninfo) : delta_depth =
       delta_constant
 
 and delta_depth_of_qninfo env (fv:fv) (qn:qninfo) : delta_depth =
-  delta_depth_of_qninfo_lid env fv.fv_name.v qn
+  delta_depth_of_qninfo_lid env fv.fv_name qn
 
 (* Computes the canonical delta_depth of a given fvar, by looking at its
 definition (and recursing) if needed. Results are memoized in the env.
@@ -845,7 +845,7 @@ if we memoize the delta_depth of a `val` before seeing the corresponding
 `let`, but I don't think that can happen. Before seeing the `let`, other code
 cannot refer to the name. *)
 and delta_depth_of_fv (env:env) (fv:S.fv) : delta_depth =
-  let lid = fv.fv_name.v in
+  let lid = fv.fv_name in
   (string_of_lid lid) |> SMap.try_find env.fv_delta_depths |> (function
   | Some dd -> dd
   | None ->
@@ -853,7 +853,7 @@ and delta_depth_of_fv (env:env) (fv:S.fv) : delta_depth =
     // ^ To prevent an infinite loop on recursive functions, we pre-seed the cache with
     // a delta_equational. If we run into the same function while computing its delta_depth,
     // we will return delta_equational. If not, we override the cache with the correct delta_depth.
-    let d = delta_depth_of_qninfo env fv (lookup_qname env fv.fv_name.v) in
+    let d = delta_depth_of_qninfo env fv (lookup_qname env fv.fv_name) in
     // if Debug.any () then
     //  Format.print2_error "Memoizing delta_depth_of_fv %s ->\t%s\n" (show lid) (show d);
     SMap.add env.fv_delta_depths (string_of_lid lid) d;
@@ -865,7 +865,7 @@ and fv_delta_depth (env:env) (fv:S.fv) : delta_depth =
     let d = delta_depth_of_fv env fv in
     match d with
     | Delta_abstract (Delta_constant_at_level l) ->
-      if string_of_lid env.curmodule = nsstr fv.fv_name.v && not env.is_iface
+      if string_of_lid env.curmodule = nsstr fv.fv_name && not env.is_iface
        //AR: TODO: this is to prevent unfolding of abstract symbols in the extracted interface
        //a better way would be create new fvs with appripriate delta_depth at extraction time
       then Delta_constant_at_level l //we're in the defining module
@@ -928,7 +928,7 @@ let fv_with_lid_has_attr env fv_lid attr_lid : bool =
   snd (fv_exists_and_has_attr env fv_lid attr_lid)
 
 let fv_has_attr env fv attr_lid =
-  fv_with_lid_has_attr env fv.fv_name.v attr_lid
+  fv_with_lid_has_attr env fv.fv_name attr_lid
 
 let cache_in_fv_tab (tab:SMap.t 'a) (fv:fv) (f:unit -> (bool & 'a)) : 'a =
   let s = string_of_lid (S.lid_of_fv fv) in
@@ -943,7 +943,7 @@ let cache_in_fv_tab (tab:SMap.t 'a) (fv:fv) (f:unit -> (bool & 'a)) : 'a =
 
 let fv_has_erasable_attr env fv =
   let f () =
-     let ex, erasable = fv_exists_and_has_attr env fv.fv_name.v Const.erasable_attr in
+     let ex, erasable = fv_exists_and_has_attr env fv.fv_name Const.erasable_attr in
      ex,erasable
      //unfortunately, treating the Const.must_erase_for_extraction_attr
      //in the same way here as erasable_attr leads to regressions in fragile proofs,
@@ -1125,7 +1125,7 @@ let is_interpreted =
     fun (env:env) head ->
         match (U.un_uinst head).n with
         | Tm_fvar fv ->
-          BU.for_some (Ident.lid_equals fv.fv_name.v) interpreted_symbols ||
+          BU.for_some (Ident.lid_equals fv.fv_name) interpreted_symbols ||
             (match delta_depth_of_fv env fv with
              | Delta_equational_at_level _ -> true
              | _ -> false)
@@ -1757,7 +1757,7 @@ let binding_of_lb (x:lbname) t = match x with
     let x = {x with sort=snd t} in
     Binding_var x
   | Inr fv ->
-    Binding_lid(fv.fv_name.v, t)
+    Binding_lid(fv.fv_name, t)
 
 let push_let_binding env lb ts =
     push_local_binding env (binding_of_lb lb ts)

--- a/src/typechecker/FStarC.TypeChecker.NBE.fst
+++ b/src/typechecker/FStarC.TypeChecker.NBE.fst
@@ -176,10 +176,10 @@ let zeta_false (cfg:config) =
       new_config cfg_core' //blow away cache
     else cfg
 let cache_add (cfg:config) (fv:fv) (v:t) =
-  let lid = fv.fv_name.v in
+  let lid = fv.fv_name in
   SMap.add cfg.fv_cache (string_of_lid lid) v
 let try_in_cache (cfg:config) (fv:fv) : option t =
-  let lid = fv.fv_name.v in
+  let lid = fv.fv_name in
   SMap.try_find cfg.fv_cache (string_of_lid lid)
 let debug cfg f = log_nbe cfg.core_cfg f
 
@@ -926,7 +926,7 @@ and translate_fv (cfg: config) (bs:list t) (fvar:fv): t =
      | NU.Should_unfold_yes ->
        let t =
          let is_qninfo_visible =
-           Some? (Env.lookup_definition_qninfo cfg.core_cfg.delta_level fvar.fv_name.v qninfo)
+           Some? (Env.lookup_definition_qninfo cfg.core_cfg.delta_level fvar.fv_name qninfo)
          in
          if is_qninfo_visible
          then begin
@@ -1137,7 +1137,7 @@ and translate_monadic (m, ty) cfg bs e : t =
 
         (* Fallback if it does not have a definition. This happens,
          * but I'm not sure why. *)
-        if None? (Env.lookup_definition_qninfo cfg.core_cfg.delta_level fv.fv_name.v qninfo)
+        if None? (Env.lookup_definition_qninfo cfg.core_cfg.delta_level fv.fv_name qninfo)
         then fallback2 ()
         else
 

--- a/src/typechecker/FStarC.TypeChecker.NBETerm.fst
+++ b/src/typechecker/FStarC.TypeChecker.NBETerm.fst
@@ -955,6 +955,6 @@ let e_order =
       | Construct (fv, _, []) when S.fv_eq_lid fv ord_Gt_lid -> Some Gt
       | _ -> None
   in
-  let fv_as_emb_typ fv = S.ET_app (FStarC.Ident.string_of_lid fv.fv_name.v, []) in
+  let fv_as_emb_typ fv = S.ET_app (FStarC.Ident.string_of_lid fv.fv_name, []) in
   let fv = lid_as_fv PC.order_lid None in
   mk_emb embed_order unembed_order (fun () -> mkFV fv [] []) (fun () -> fv_as_emb_typ fv)

--- a/src/typechecker/FStarC.TypeChecker.Normalize.Unfolding.fst
+++ b/src/typechecker/FStarC.TypeChecker.Normalize.Unfolding.fst
@@ -106,7 +106,7 @@ let should_unfold cfg should_reify fv qninfo : should_unfold_res =
         let meets_some_criterion =
             comb_or [
             (if cfg.steps.for_extraction
-             then yesno <| Some? (Env.lookup_definition_qninfo [Eager_unfolding_only; InliningDelta] fv.fv_name.v qninfo)
+             then yesno <| Some? (Env.lookup_definition_qninfo [Eager_unfolding_only; InliningDelta] fv.fv_name qninfo)
              else no)
            ;(match cfg.steps.unfold_only with
              | None -> no

--- a/src/typechecker/FStarC.TypeChecker.Normalize.fst
+++ b/src/typechecker/FStarC.TypeChecker.Normalize.fst
@@ -416,7 +416,7 @@ let reduce_primops norm_cb cfg (env:env) tm : term & bool =
                   let r =
                       if false
                       then begin let (r, ns) = Timing.record_ns (fun () -> prim_step.interpretation psc norm_cb universes args_1) in
-                                 primop_time_count (show fv.fv_name.v) ns;
+                                 primop_time_count (show fv.fv_name) ns;
                                  r
                            end
                       else prim_step.interpretation psc norm_cb universes args_1
@@ -1387,7 +1387,7 @@ let rec norm : cfg -> env -> stack -> term -> term =
  * have any free indices. Hence, we use empty_env as environment when needed. *)
 and do_unfold_fv (cfg:Cfg.cfg) stack (t0:term) (qninfo : qninfo) (f:fv) : term =
     // Second, try to unfold to the definition itself.
-    let defn () = Env.lookup_definition_qninfo cfg.delta_level f.fv_name.v qninfo in
+    let defn () = Env.lookup_definition_qninfo cfg.delta_level f.fv_name qninfo in
     let is_plugin () =
       match qninfo with
       | Some (Inr (se, None), _) -> BU.for_some (U.is_fvar PC.plugin_attr) se.sigattrs  // it is a plugin
@@ -1401,7 +1401,7 @@ and do_unfold_fv (cfg:Cfg.cfg) stack (t0:term) (qninfo : qninfo) (f:fv) : term =
      then begin
        // then warn about it
        let msg = Format.fmt1 "Unfolding name which is marked as a plugin: %s" (show f) in
-       Errors.log_issue f.fv_name.p Errors.Warning_UnfoldPlugin msg;
+       Errors.log_issue f Errors.Warning_UnfoldPlugin msg;
        plugin_unfold_warn_ctr := !plugin_unfold_warn_ctr - 1
      end
     in
@@ -1446,7 +1446,7 @@ and do_unfold_fv (cfg:Cfg.cfg) stack (t0:term) (qninfo : qninfo) (f:fv) : term =
                   norm cfg env stack t
                 | _ when cfg.steps.erase_universes || cfg.steps.allow_unbound_universes ->
                   norm cfg empty_env stack t
-                | _ -> failwith (Format.fmt1 "Impossible: missing universe instantiation on %s" (show f.fv_name.v))
+                | _ -> failwith (Format.fmt1 "Impossible: missing universe instantiation on %s" (show f.fv_name))
          else norm cfg empty_env stack t
          end
 
@@ -1811,7 +1811,7 @@ and do_reify_monadic fallback cfg env stack (top : term) (m : monad_name) (t : t
 
             (* Fallback if it does not have a definition. This happens,
              * but I'm not sure why. *)
-            if None? (Env.lookup_definition_qninfo cfg.delta_level fv.fv_name.v qninfo)
+            if None? (Env.lookup_definition_qninfo cfg.delta_level fv.fv_name qninfo)
             then fallback2 ()
             else
 
@@ -3197,7 +3197,7 @@ let erase_universes env t =
 
 let unfold_head_once env t =
   let aux f us args =
-      match Env.lookup_nonrec_definition [Env.Unfold delta_constant] env f.fv_name.v with
+      match Env.lookup_nonrec_definition [Env.Unfold delta_constant] env f.fv_name with
       | None -> None
       | Some head_def_ts ->
         let _, head_def = Env.inst_tscheme_with head_def_ts us in
@@ -3260,7 +3260,7 @@ let maybe_unfold_head_fv (env:Env.env) (head:term)
     match fv_us_opt with
     | None -> None
     | Some (fv, us) ->
-      match Env.lookup_nonrec_definition [Unfold delta_constant] env fv.fv_name.v with
+      match Env.lookup_nonrec_definition [Unfold delta_constant] env fv.fv_name with
       | None -> None
       | Some (us_formals, defn) ->
         let subst = mk_univ_subst us_formals us in

--- a/src/typechecker/FStarC.TypeChecker.PatternUtils.fst
+++ b/src/typechecker/FStarC.TypeChecker.PatternUtils.fst
@@ -56,13 +56,13 @@ let rec elaborate_pat env p = //Adds missing implicit patterns to constructor pa
 
     | Pat_cons(fv, us_opt, pats) ->
         let pats = List.map (fun (p, imp) -> elaborate_pat env p, imp) pats in
-        let _, t = Env.lookup_datacon env fv.fv_name.v in
+        let _, t = Env.lookup_datacon env fv.fv_name in
         let f, _ = U.arrow_formals t in
         let rec aux formals pats =
             match formals, pats with
             | [], [] -> []
             | [], _::_ ->
-                raise_error fv.fv_name.v Errors.Fatal_TooManyPatternArguments "Too many pattern arguments"
+                raise_error fv.fv_name Errors.Fatal_TooManyPatternArguments "Too many pattern arguments"
             | _::_, [] -> //fill the rest with dot patterns, if all the remaining formals are implicit
             formals |>
             List.map
@@ -71,11 +71,11 @@ let rec elaborate_pat env p = //Adds missing implicit patterns to constructor pa
                     match imp with
                     | Some (Implicit inaccessible) ->
                     let a = Syntax.new_bv (Some (Syntax.range_of_bv t)) tun in
-                    let r = range_of_lid fv.fv_name.v in
+                    let r = range_of_lid fv.fv_name in
                     maybe_dot inaccessible a r, true
 
                     | _ ->
-                    raise_error fv.fv_name.v Errors.Fatal_InsufficientPatternArguments
+                    raise_error fv.fv_name Errors.Fatal_InsufficientPatternArguments
                                 (Format.fmt1 "Insufficient pattern arguments (%s)"
                                             (show p)))
 
@@ -92,7 +92,7 @@ let rec elaborate_pat env p = //Adds missing implicit patterns to constructor pa
               // Only allow it if it won't be bound
               | Pat_var v when string_of_id (v.ppname) = Ident.reserved_prefix ->
                 let a = Syntax.new_bv (Some p.p) tun in
-                let p = maybe_dot inaccessible a (range_of_lid fv.fv_name.v) in
+                let p = maybe_dot inaccessible a (range_of_lid fv.fv_name) in
                 (p, true)::aux formals' pats'
 
               | _ ->
@@ -107,12 +107,12 @@ let rec elaborate_pat env p = //Adds missing implicit patterns to constructor pa
 
             | (_, Some (Implicit inaccessible)) ->
                 let a = Syntax.new_bv (Some p.p) tun in
-                let p = maybe_dot inaccessible a (range_of_lid fv.fv_name.v) in
+                let p = maybe_dot inaccessible a (range_of_lid fv.fv_name) in
                 (p, true)::aux formals' pats
 
             | (_, Some (Meta _)) ->
                 let a = Syntax.new_bv (Some p.p) tun in
-                let p = maybe_dot false a (range_of_lid fv.fv_name.v) in
+                let p = maybe_dot false a (range_of_lid fv.fv_name) in
                 (p, true)::aux formals' pats
 
             | (_, imp) ->

--- a/src/typechecker/FStarC.TypeChecker.Positivity.fst
+++ b/src/typechecker/FStarC.TypeChecker.Positivity.fst
@@ -457,7 +457,7 @@ let may_be_an_arity env (t:term)
         let head, args = U.head_and_args t in
         match (U.un_uinst head).n with
         | Tm_fvar fv ->
-          (match Env.lookup_sigelt env fv.fv_name.v with
+          (match Env.lookup_sigelt env fv.fv_name with
            | None ->
              //We couldn't find it; err conservatively ... this could be an arity
              true
@@ -555,7 +555,7 @@ let check_no_index_occurrences_in_arities env mutuals (t:term) =
   match (U.un_uinst head).n with
   | Tm_fvar fv -> 
     begin
-    match Env.num_inductive_uniform_ty_params env fv.fv_name.v with
+    match Env.num_inductive_uniform_ty_params env fv.fv_name with
     | None -> 
       //the head is not (visibly) a inductive type; nothing to check
       ()
@@ -563,15 +563,15 @@ let check_no_index_occurrences_in_arities env mutuals (t:term) =
       if List.length args <= n
       then () //they are all uniform parameters, nothing to check
       else (
-        match Env.try_lookup_lid env fv.fv_name.v with
-        | None -> no_occurrence_in_indexes fv.fv_name.v mutuals args
+        match Env.try_lookup_lid env fv.fv_name with
+        | None -> no_occurrence_in_indexes fv.fv_name mutuals args
         | Some ((_us, i_typ), _) ->
           debug_positivity env (fun _ -> 
             Format.fmt2 "Checking arity indexes of %s (num uniform params = %s)"
                      (show t)
                      (show n));
           let params, indices = List.splitAt n args in
-          let inst_i_typ = apply_constr_arrow fv.fv_name.v i_typ params in
+          let inst_i_typ = apply_constr_arrow fv.fv_name i_typ params in
           let formals, _sort = U.arrow_formals inst_i_typ in
           let rec aux subst formals indices =
             match formals, indices with
@@ -584,7 +584,7 @@ let check_no_index_occurrences_in_arities env mutuals (t:term) =
                   Format.fmt2 "Checking %s : %s (arity)"
                     (show (fst i))
                     (show f_t));
-                no_occurrence_in_index fv.fv_name.v mutuals i
+                no_occurrence_in_index fv.fv_name mutuals i
               )
               else (
                 debug_positivity env (fun _ ->
@@ -595,7 +595,7 @@ let check_no_index_occurrences_in_arities env mutuals (t:term) =
               let subst = NT(f.binder_bv, fst i)::subst in
               aux subst formals indices
             | [], _ ->
-              no_occurrence_in_indexes fv.fv_name.v mutuals indices
+              no_occurrence_in_indexes fv.fv_name mutuals indices
           in
           aux [] formals indices
         )
@@ -812,7 +812,7 @@ let rec ty_strictly_positive_in_type (env:env)
           
         | Some (Inl (fv, us)) ->
           begin
-          if FStarC.List.existsML (Ident.lid_equals fv.fv_name.v) mutuals
+          if FStarC.List.existsML (Ident.lid_equals fv.fv_name) mutuals
           then (
             //if the head is one of the mutually inductive types
             //then check that ty_lid does not occur in the arguments
@@ -824,7 +824,7 @@ let rec ty_strictly_positive_in_type (env:env)
                 Format.fmt1 
                   "Checking strict positivity in the Tm_app node where head lid is %s itself, \
                    checking that ty does not occur in the arguments"
-                  (Ident.string_of_lid fv.fv_name.v));
+                  (Ident.string_of_lid fv.fv_name));
               List.for_all (fun (t, _) -> mutuals_unused_in_type mutuals t) args
           )
           else (
@@ -840,7 +840,7 @@ let rec ty_strictly_positive_in_type (env:env)
               env
               mutuals
               in_type
-              fv.fv_name.v 
+              fv.fv_name 
               us
               args
               unfolded

--- a/src/typechecker/FStarC.TypeChecker.Quals.fst
+++ b/src/typechecker/FStarC.TypeChecker.Quals.fst
@@ -279,7 +279,7 @@ let check_must_erase_attribute env se =
        snd lbs |> List.iter (fun lb ->
            let lbname = Inr?.v lb.lbname in
            let has_iface_val =
-               iface_decls |> BU.for_some (Parser.AST.decl_is_val (ident_of_lid lbname.fv_name.v))
+               iface_decls |> BU.for_some (Parser.AST.decl_is_val (ident_of_lid lbname.fv_name))
            in
            if has_iface_val
            then

--- a/src/typechecker/FStarC.TypeChecker.Rel.fst
+++ b/src/typechecker/FStarC.TypeChecker.Rel.fst
@@ -1379,7 +1379,7 @@ let head_matches_delta env (logical:bool) smt_ok t1 t2 : (match_result & option 
                     [Env.Unfold delta_constant;
                      Env.Eager_unfolding_only]
                     env
-                    fv.fv_name.v
+                    fv.fv_name
           with
           | None ->
             if !dbg_RelDelta then

--- a/src/typechecker/FStarC.TypeChecker.Tc.fst
+++ b/src/typechecker/FStarC.TypeChecker.Tc.fst
@@ -394,12 +394,12 @@ let tc_sig_let env r se lbs lids : list sigelt & list sigelt & Env.env =
     let should_generalize, lbs', quals_opt =
        snd lbs |> List.fold_left (fun (gen, lbs, quals_opt) lb ->
           let lbname = Inr?.v lb.lbname in //this is definitely not a local let binding
-          let gen, lb, quals_opt = match Env.try_lookup_val_decl env lbname.fv_name.v with
+          let gen, lb, quals_opt = match Env.try_lookup_val_decl env lbname.fv_name with
             | None ->
                 gen, lb, quals_opt
 
             | Some ((uvs,tval), quals) ->
-              let quals_opt = check_quals_eq lbname.fv_name.v quals_opt quals in
+              let quals_opt = check_quals_eq lbname.fv_name quals_opt quals in
               let def = match lb.lbtyp.n with
                 | Tm_unknown -> lb.lbdef
                 | _ ->
@@ -571,7 +571,7 @@ let tc_sig_let env r se lbs lids : list sigelt & list sigelt & Env.env =
 
     if log env
     then Format.print1 "%s\n" (snd lbs |> List.map (fun lb ->
-          let should_log = match Env.try_lookup_val_decl env (Inr?.v lb.lbname).fv_name.v with
+          let should_log = match Env.try_lookup_val_decl env (Inr?.v lb.lbname).fv_name with
               | None -> true
               | _ -> false in
           if should_log

--- a/src/typechecker/FStarC.TypeChecker.TcInductive.fst
+++ b/src/typechecker/FStarC.TypeChecker.TcInductive.fst
@@ -629,7 +629,7 @@ let unoptimized_haseq_data (usubst:list subst_elt) (bs:binders) (haseq_ind:term)
   //TODO: we now have a get_free_names in Syntax.Free, use that
   let rec is_mutual (t:term) =  //TODO: this should handle more cases
     match (SS.compress t).n with
-    | Tm_fvar fv         -> List.existsb (fun lid -> lid_equals lid fv.fv_name.v) mutuals
+    | Tm_fvar fv         -> List.existsb (fun lid -> lid_equals lid fv.fv_name) mutuals
     | Tm_uinst (t', _)   -> is_mutual t'
     | Tm_refine {b=bv} -> is_mutual bv.sort
     | Tm_app {hd=t'; args}  -> if is_mutual t' then true else exists_mutual (List.map fst args)
@@ -1121,7 +1121,7 @@ let mk_discriminator_and_indexed_projectors iquals                   (* Qualifie
                             []
                             Range.dummyRange
                 in
-                let impl = { sigel = Sig_let {lbs=(false, [lb]); lids=[lb.lbname |> Inr?.v |> (fun fv -> fv.fv_name.v)]};
+                let impl = { sigel = Sig_let {lbs=(false, [lb]); lids=[lb.lbname |> Inr?.v |> (fun fv -> fv.fv_name)]};
                              sigquals = quals;
                              sigrng = p;
                              sigmeta = default_sigmeta;
@@ -1231,7 +1231,7 @@ let mk_discriminator_and_indexed_projectors iquals                   (* Qualifie
                   lbattrs=[];
                   lbpos=Range.dummyRange;
               } in
-              let impl = { sigel = Sig_let {lbs=(false, [lb]); lids=[lb.lbname |> Inr?.v |> (fun fv -> fv.fv_name.v)]};
+              let impl = { sigel = Sig_let {lbs=(false, [lb]); lids=[lb.lbname |> Inr?.v |> (fun fv -> fv.fv_name)]};
                            sigquals = quals;
                            sigrng = p;
                            sigmeta = default_sigmeta;

--- a/src/typechecker/FStarC.TypeChecker.TcTerm.fst
+++ b/src/typechecker/FStarC.TypeChecker.TcTerm.fst
@@ -189,7 +189,7 @@ let set_lcomp_result lc t =
 let memo_tk (e:term) (t:typ) = e
 
 let maybe_warn_on_use env fv : unit =
-    match Env.lookup_attrs_of_lid env fv.fv_name.v with
+    match Env.lookup_attrs_of_lid env fv.fv_name with
     | None -> ()
     | Some attrs ->
       attrs |>
@@ -205,23 +205,23 @@ let maybe_warn_on_use env fv : unit =
           in
           match head.n with
           | Tm_fvar attr_fv
-              when lid_equals attr_fv.fv_name.v Const.warn_on_use_attr ->
+              when lid_equals attr_fv.fv_name Const.warn_on_use_attr ->
             let m =
               Errors.text <|
               Format.fmt1 "Every use of %s triggers a warning"
-                         (Ident.string_of_lid fv.fv_name.v)
+                         (Ident.string_of_lid fv.fv_name)
             in
-            log_issue fv.fv_name.v Warning_WarnOnUse (msg_arg [m])
+            log_issue fv.fv_name Warning_WarnOnUse (msg_arg [m])
 
           | Tm_fvar attr_fv
-              when lid_equals attr_fv.fv_name.v Const.deprecated_attr ->
+              when lid_equals attr_fv.fv_name Const.deprecated_attr ->
             let m =
               Errors.text <|
               Format.fmt1
                 "%s is deprecated"
-                (Ident.string_of_lid fv.fv_name.v)
+                (Ident.string_of_lid fv.fv_name)
             in
-            log_issue fv.fv_name.v Warning_DeprecatedDefinition (msg_arg [m])
+            log_issue fv.fv_name Warning_DeprecatedDefinition (msg_arg [m])
 
           | _ -> ())
 
@@ -1204,7 +1204,7 @@ and tc_maybe_toplevel_term env (e:term) : term                  (* type-checked 
     let term = S.mk_Tm_app constructor args top.pos in
     tc_term env term
 
-  | Tm_app {hd={n=Tm_fvar {fv_name={v=field_name}; fv_qual=Some (Unresolved_projector candidate)}};
+  | Tm_app {hd={n=Tm_fvar {fv_name=field_name; fv_qual=Some (Unresolved_projector candidate)}};
             args=(e, None)::rest} ->
     (* ToSyntax left an unresolved projector, we have to use type info to disambiguate *)
     let proceed_with choice =
@@ -1235,7 +1235,7 @@ and tc_maybe_toplevel_term env (e:term) : term                  (* type-checked 
     );
     match (SS.compress (U.un_uinst thead)).n with
     | Tm_fvar type_name -> (
-      match TcUtil.try_lookup_record_type env type_name.fv_name.v with
+      match TcUtil.try_lookup_record_type env type_name.fv_name with
       | None -> proceed_with candidate
       | Some rdc ->
         let i =
@@ -1407,7 +1407,7 @@ and tc_match (env : Env.env) (top : term) : term & lcomp & guard_t =
         begin match p.v with
         | Pat_cons (fv, _, _) ->
           (* Wrapped in a try/catch, we may be looking up unresolved constructors. *)
-          let r = try Some (Env.lookup_datacon env fv.fv_name.v) with | _ -> None in
+          let r = try Some (Env.lookup_datacon env fv.fv_name) with | _ -> None in
           begin match r with
           | Some (us, t) ->
             let bs, c = U.arrow_formals_comp t in
@@ -1682,9 +1682,9 @@ and check_instantiated_fvar (env:Env.env) (v:S.var) (q:option S.fv_qual) (e:term
       | Some (Record_ctor _) -> true
       | _ -> false
   in
-  if is_data_ctor q && not (Env.is_datacon env v.v) then
+  if is_data_ctor q && not (Env.is_datacon env v) then
     raise_error env Errors.Fatal_MissingDataConstructor
-                (Format.fmt1 "Expected a data constructor; got %s" (string_of_lid v.v));
+                (Format.fmt1 "Expected a data constructor; got %s" (show v));
 
   (* remove inaccesible pattern implicits, make them regular implicits *)
   let t = U.remove_inacc t0 in
@@ -1765,7 +1765,7 @@ and tc_value env (e:term) : term
 
   | Tm_uinst({n=Tm_fvar fv}, us) ->
     let us = List.map (tc_universe env) us in
-    let (us', t), range = Env.lookup_lid env fv.fv_name.v in
+    let (us', t), range = Env.lookup_lid env fv.fv_name in
     let fv = S.set_range_of_fv fv range in
     maybe_warn_on_use env fv;
     if List.length us <> List.length us' then
@@ -1806,11 +1806,11 @@ and tc_value env (e:term) : term
       (* The Data_ctor qualifier is mostly set by desugaring, but
          may be missing in tactic-generated terms. In general,
          we should try to not rely on desugaring. *)
-      if None? fv.fv_qual && Env.is_datacon env fv.fv_name.v
+      if None? fv.fv_qual && Env.is_datacon env fv.fv_name
       then { fv with fv_qual = Some Data_ctor }
       else fv
     in
-    let (us, t), range = Env.lookup_lid env fv.fv_name.v in
+    let (us, t), range = Env.lookup_lid env fv.fv_name in
     let fv = S.set_range_of_fv fv range in
     let fv = maybe_set_fv_qual env fv in
     maybe_warn_on_use env fv;
@@ -2978,9 +2978,9 @@ and tc_pat env (pat_t:typ) (p0:pat) :
               if norm then t
               else aux true (N.normalize [Env.HNF; Env.Unmeta; Env.Unascribe; Env.UnfoldUntil delta_constant] env t)
         and unfold_once t f us args =
-            if Env.is_type_constructor env f.fv_name.v
+            if Env.is_type_constructor env f.fv_name
             then t
-            else match Env.lookup_definition [Env.Unfold delta_constant] env f.fv_name.v with
+            else match Env.lookup_definition [Env.Unfold delta_constant] env f.fv_name with
                  | None -> t
                  | Some head_def_ts ->
                    let _, head_def = Env.inst_tscheme_with head_def_ts us in
@@ -3069,21 +3069,21 @@ and tc_pat env (pat_t:typ) (p0:pat) :
             match head.n with
             | Tm_uinst (head, us) ->
               let Tm_fvar f = head.n in
-              let res = Env.try_lookup_and_inst_lid env us f.fv_name.v in
+              let res = Env.try_lookup_and_inst_lid env us f.fv_name in
               begin
               match res with
               | Some (t, _)
-                when Env.is_datacon env f.fv_name.v ->
+                when Env.is_datacon env f.fv_name ->
                 head, (us, t)
                 
               | _ ->
                 fail (Format.fmt1 "Could not find constructor: %s" 
-                                 (Ident.string_of_lid f.fv_name.v))
+                                 (Ident.string_of_lid f.fv_name))
               end
 
             | Tm_fvar f ->
               head,
-              Env.lookup_datacon env f.fv_name.v
+              Env.lookup_datacon env f.fv_name
           in
           let formals, t = U.arrow_formals t_f in
           //Data constructors are marked with the "erasable" attribute
@@ -3558,11 +3558,11 @@ and tc_eqn (scrutinee:bv) (env:Env.env) (ret_opt : option match_returns_ascripti
       else (* 5 (a) *)
           let rec build_branch_guard (scrutinee_tm:option term) (pattern:pat) pat_exp : list typ =
             let discriminate scrutinee_tm f =
-                let is_induc, datacons = Env.datacons_of_typ env (Env.typ_of_datacon env f.v) in
+                let is_induc, datacons = Env.datacons_of_typ env (Env.typ_of_datacon env f) in
                 (* Why the `not is_induc`? We may be checking an exception pattern. See issue #1535. *)
                 if not is_induc || List.length datacons > 1
                 then
-                    let discriminator = U.mk_discriminator f.v in
+                    let discriminator = U.mk_discriminator f in
                     match Env.try_lookup_lid env discriminator with
                         | None -> []  // We don't use the discriminator if we are typechecking it
                         | _ ->
@@ -3613,28 +3613,28 @@ and tc_eqn (scrutinee:bv) (env:Env.env) (ret_opt : option match_returns_ascripti
             | Pat_cons (_, _, []), Tm_fvar _ ->
                 //nullary pattern
                 let f = head_constructor pat_exp in
-                if not (Env.is_datacon env f.v)
+                if not (Env.is_datacon env f)
                 then failwith "Impossible: nullary patterns must be data constructors"
                 else discriminate (force_scrutinee ()) (head_constructor pat_exp)
 
             | Pat_cons (_, _, pat_args), Tm_app {hd=head; args} ->
                 //application pattern
                 let f = head_constructor head in
-                if not (Env.is_datacon env f.v)
+                if not (Env.is_datacon env f)
                 || List.length pat_args <> List.length args
                 then failwith "Impossible: application patterns must be fully-applied data constructors"
                 else let sub_term_guards =
                         List.zip pat_args args |>
                         List.mapi (fun i ((pi, _), (ei, _)) ->
-                            let projector = Env.lookup_projector env f.v i in
+                            let projector = Env.lookup_projector env f i in
                             //NS: TODO ... should this be a marked as a record projector? But it doesn't matter for extraction
                             let scrutinee_tm =
                                 match Env.try_lookup_lid env projector with
                                 | None ->
                                   None //no projector, e.g., because we are actually typechecking the projector itself
                                 | _ ->
-                                  let proj = S.fvar (Ident.set_lid_range projector f.p) None in
-                                  Some (mk_Tm_app proj [as_arg (force_scrutinee())] f.p)
+                                  let proj = S.fvar (Ident.set_lid_range projector (pos f)) None in
+                                  Some (mk_Tm_app proj [as_arg (force_scrutinee())] (pos f))
                             in
                             build_branch_guard scrutinee_tm pi ei) |>
                         List.flatten
@@ -4630,7 +4630,7 @@ let rec universe_of_aux env e : term =
      let (t, _rng) = Env.lookup_bv env n in
      t
    | Tm_fvar fv ->
-     let (_, t), _ = Env.lookup_lid env fv.fv_name.v in
+     let (_, t), _ = Env.lookup_lid env fv.fv_name in
      t
    | Tm_lazy i -> universe_of_aux env (U.unfold_lazy i)
    | Tm_ascribed {asc=(Inl t, _, _)} -> t
@@ -4641,7 +4641,7 @@ let rec universe_of_aux env e : term =
    | Tm_constant sc -> tc_constant env e.pos sc
    //slightly subtle, since fv is a type-scheme; instantiate it with us
    | Tm_uinst({n=Tm_fvar fv}, us) ->
-     let (us', t), _ = Env.lookup_lid env fv.fv_name.v in
+     let (us', t), _ = Env.lookup_lid env fv.fv_name in
      if List.length us <> List.length us' then
        raise_error env Errors.Fatal_UnexpectedNumberOfUniverse
           "Unexpected number of universe instantiations";

--- a/src/typechecker/FStarC.TypeChecker.TermEqAndSimplify.fst
+++ b/src/typechecker/FStarC.TypeChecker.TermEqAndSimplify.fst
@@ -98,7 +98,7 @@ let rec eq_tm (env:env_t) (t1:term) (t2:term) : eq_result =
                   (fun acc (a1, q1) (a2, q2) ->
                         //if q1 <> q2
                         //then failwith (Format.fmt1 "Arguments of %s mismatch on implicit qualifier\n"
-                        //                (Ident.string_of_lid f1.fv_name.v));
+                        //                (Ident.string_of_lid f1.fv_name));
                         //NS: 05/06/2018 ...this does not always hold
                         //    it's been succeeding because the assert is disabled in the non-debug builds
                         //assert (q1 = q2);

--- a/src/typechecker/FStarC.TypeChecker.Util.fst
+++ b/src/typechecker/FStarC.TypeChecker.Util.fst
@@ -412,14 +412,14 @@ let extract_let_rec_annotation env {lbname=lbname; lbunivs=univ_vars; lbtyp=t; l
 
 //            | Pat_cons(fv, []), Tm_fvar fv' ->
 //              if not (Syntax.fv_eq fv fv')
-//              then failwith (Format.fmt2 "Expected pattern constructor %s; got %s" (string_of_lid fv.fv_name.v) (string_of_lid fv'.fv_name.v));
+//              then failwith (Format.fmt2 "Expected pattern constructor %s; got %s" (string_of_lid fv.fv_name) (string_of_lid fv'.fv_name));
 //              pkg (Pat_cons(fv', []))
 
 //            | Pat_cons(fv, argpats), Tm_app({n=Tm_fvar(fv')}, args)
 //            | Pat_cons(fv, argpats), Tm_app({n=Tm_uinst({n=Tm_fvar(fv')}, _)}, args) ->
 
 //              if fv_eq fv fv' |> not
-//              then failwith (Format.fmt2 "Expected pattern constructor %s; got %s" (string_of_lid fv.fv_name.v) (string_of_lid fv'.fv_name.v));
+//              then failwith (Format.fmt2 "Expected pattern constructor %s; got %s" (string_of_lid fv.fv_name) (string_of_lid fv'.fv_name));
 
 //              let fv = fv' in
 //              let rec match_args matched_pats args argpats = match args, argpats with
@@ -3185,7 +3185,7 @@ let short_circuit (head:term) (seen_args:args) : guard_formula =
 
      match head.n with
         | Tm_fvar fv ->
-          let lid = fv.fv_name.v in
+          let lid = fv.fv_name in
           begin match BU.find_map table (fun (x, mk) -> if lid_equals x lid then Some (mk seen_args) else None) with
             | None ->   Trivial
             | Some g -> g
@@ -3698,7 +3698,7 @@ let find_record_or_dc_from_typ env (t:option typ) (uc:unresolved_constructor) rn
         match (SS.compress (U.un_uinst thead)).n with
         | Tm_fvar type_name ->
           begin
-          match try_lookup_record_type env type_name.fv_name.v with
+          match try_lookup_record_type env type_name.fv_name with
           | None -> default_rdc ()
           | Some r -> r
           end

--- a/ulib/Prims.fst
+++ b/ulib/Prims.fst
@@ -731,4 +731,4 @@ val string_of_int: int -> Tot string
 (** THIS IS MEANT TO BE KEPT IN SYNC WITH FStar.CheckedFiles.fs
     Incrementing this forces all .checked files to be invalidated *)
 irreducible
-let __cache_version_number__ = 74
+let __cache_version_number__ = 75


### PR DESCRIPTION
This is the main change:

	 (* Free term and type variables *)
	 [@@ PpxDerivingYoJson; PpxDerivingShow ]
	-type var  = withinfo_t lident
	+type var  = lident

and the rest is adjusting for it.