### PR TITLE
Tweaking imprecise encoding of inner let recs

### DIFF
--- a/src/smtencoding/FStarC.SMTEncoding.Env.fst
+++ b/src/smtencoding/FStarC.SMTEncoding.Env.fst
@@ -33,8 +33,6 @@ open FStarC.Class.Show
 
 let dbg_PartialApp = Debug.get_toggle "PartialApp"
 
-exception Inner_let_rec of list (string & Range.t) //name of the inner let-rec(s) and their locations
-
 let add_fuel x tl = if (Options.unthrottle_inductives()) then tl else x::tl
 let withenv c (a, b) = (a,b,c)
 let vargs args = List.filter (function (Inl _, _) -> false | _ -> true) args

--- a/tests/bug-reports/closed/Bug1622.fst
+++ b/tests/bug-reports/closed/Bug1622.fst
@@ -9,8 +9,12 @@ let pred (args: list bool) : sprop =
   | a::q -> let out:sprop = fun s0 -> out s0 in aux q out
   in aux args (fun _ -> True)
 
-[@@(expect_failure [142])]  //could not encode the query since an inner let-rec aux appears in it
 let lemma_pred (args:list bool) : Lemma (pred args true) =
   match args with
   | [] -> assert_norm (pred args true)
+  | _ -> admit()
+
+let lemma_pred' (args:list bool) : Lemma (pred args true) =
+  match args with
+  | [] -> assert_norm (pred [] true)
   | _ -> admit()

--- a/tests/bug-reports/closed/Bug2876.fst
+++ b/tests/bug-reports/closed/Bug2876.fst
@@ -1,8 +1,6 @@
 module Bug2876
 
-// Fails since we cannot currently encode inner let-recs.
-// The original issue was that this crashed, though, so we are indeed
-// testing that we get a proper error.
-[@@expect_failure [142]]
+// Fails since we encode inner let-recs imprecisely.
+[@@expect_failure [19]]
 let test () =
   assert ((let rec f (x:nat) : Dv nat = f x in f) == (let rec f (x:nat) : Dv nat = f x in f))

--- a/tests/bug-reports/closed/Bug3991.fst
+++ b/tests/bug-reports/closed/Bug3991.fst
@@ -1,0 +1,10 @@
+module Bug3991
+
+noeq
+type mytc (#a:Type0) (s:a) = | X
+
+let mytc_let_rec : mytc (let rec f x = x in ()) = X
+
+let rec foo (x:int) : int = x
+
+let _ = assert (forall x. 1 + x > x)


### PR DESCRIPTION
Currently, if we reach an internal let-rec during SMT encoding, we raise an exception that is meant to be caught in order to display a warning. As #3991 shows, we sometimes fail to catch it, and crash. This PR changes this logic to simply encode them imprecisely (via a fresh new variable), and remove the use of the exception. This fixes the issue, and seems simpler. I removed the warning about the imprecise encoding but it can be easily added back too.

I also wonder (and don't remember) what is special about inner let recs: can't we encode them the same as top-level recursive lets,  just maybe after a closure conversion?

check-world here: https://github.com/mtzguido/FStar/actions/runs/17366789190, failures seem to be expected ones