### PR TITLE
Set new `EVERPARSE_USE_*` variables for new EverParse build

### DIFF
--- a/.github/workflows/check-friends.yml
+++ b/.github/workflows/check-friends.yml
@@ -336,6 +336,11 @@ jobs:
       # not the root of the repo
       - run: echo "PULSE_HOME=$PULSE_HOME/out" >> $GITHUB_ENV
 
+      # everparse expects more environment variables to opt out of
+      # in-tree dependencies
+      - run: echo "EVERPARSE_USE_KRML_HOME=1" >> $GITHUB_ENV
+      - run: echo "EVERPARSE_USE_PULSE_HOME=1" >> $GITHUB_ENV
+
       - name: Checkout everparse
         uses: actions/checkout@master
         with:
@@ -386,6 +391,11 @@ jobs:
       - uses: mtzguido/gci-download@master
         with:
           name: everparse
+
+      # everparse expects more environment variables to opt out of
+      # in-tree dependencies
+      - run: echo "EVERPARSE_USE_KRML_HOME=1" >> $GITHUB_ENV
+      - run: echo "EVERPARSE_USE_PULSE_HOME=1" >> $GITHUB_ENV
 
       - name: Test
         # NOTE: We do not check against the expected C/Rust

--- a/.github/workflows/check-friends.yml
+++ b/.github/workflows/check-friends.yml
@@ -338,6 +338,8 @@ jobs:
 
       # everparse expects more environment variables to opt out of
       # in-tree dependencies
+      - run: echo "EVERPARSE_USE_OPAMROOT=1" >> $GITHUB_ENV
+      - run: echo "EVERPARSE_USE_FSTAR_EXE=1" >> $GITHUB_ENV
       - run: echo "EVERPARSE_USE_KRML_HOME=1" >> $GITHUB_ENV
       - run: echo "EVERPARSE_USE_PULSE_HOME=1" >> $GITHUB_ENV
 
@@ -394,6 +396,8 @@ jobs:
 
       # everparse expects more environment variables to opt out of
       # in-tree dependencies
+      - run: echo "EVERPARSE_USE_OPAMROOT=1" >> $GITHUB_ENV
+      - run: echo "EVERPARSE_USE_FSTAR_EXE=1" >> $GITHUB_ENV
       - run: echo "EVERPARSE_USE_KRML_HOME=1" >> $GITHUB_ENV
       - run: echo "EVERPARSE_USE_PULSE_HOME=1" >> $GITHUB_ENV
 


### PR DESCRIPTION
In project-everest/everparse#232, I propose a new EverParse build system that pulls F*, Karamel and Pulse by default, unless the user explicitly sets environment variables `EVERPARSE_USE_FSTAR_EXE=1`, `EVERPARSE_USE_KRML_HOME=1` and `EVERPARSE_USE_PULSE_HOME=1` respectively.

This PR sets those variables accordingly, bearing in mind that either `EVERPARSE_USE_KRML_HOME=1` or `EVERPARSE_USE_PULSE_HOME=1` makes the EverParse Makefile automatically sets `EVERPARSE_USE_FSTAR_EXE=1`.

I have a green check-world using that EverParse PR: https://github.com/FStarLang/FStar/actions/runs/17810550164