### PR TITLE
Remove leftover z3version override.

### DIFF
--- a/mk/lib.mk
+++ b/mk/lib.mk
@@ -1,5 +1,4 @@
 FSTAR_OPTIONS += --ext optimize_let_vc
-FSTAR_OPTIONS += --z3version 4.13.3
 
 # Checking a library, make sure to not use the parent lib.
 FSTAR_OPTIONS += --no_default_includes


### PR DESCRIPTION
#3880 already removed all of the `--z3version` override flags except for this one.