### PR TITLE
nix: bump to 5.3

### DIFF
--- a/.github/workflows/build-opam.yml
+++ b/.github/workflows/build-opam.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         ocamlv:
-          - 4.14.2
+          # - 4.14.2
           - 5.3
     runs-on: ubuntu-latest
     steps:

--- a/.nix/fstar.nix
+++ b/.nix/fstar.nix
@@ -44,7 +44,6 @@ buildDunePackage {
   prePatch = ''
     patchShebangs .scripts/*.sh
     patchShebangs ulib/ml/app/ints/mk_int_file.sh
-    sed -i 's/Ast_502/Ast_500/' stage0/dune/fstar-guts/ml/FStarC_Extraction_ML_PrintML.ml src/ml/FStarC_Extraction_ML_PrintML.ml
   '';
 
   src = lib.sourceByRegex ./.. [

--- a/.nix/z3.nix
+++ b/.nix/z3.nix
@@ -1,9 +1,8 @@
-{ stdenv, callPackage, z3, python310 }:
+{ stdenv, callPackage }:
 
 let
-  z3_python310 = z3.override { python = python310; };
   z3_4_8_5 = callPackage (import ./z3_4_8_5.nix) { };
-  z3_4_13_3 = callPackage (import ./z3_4_13_3.nix) { z3 = z3_python310; };
+  z3_4_13_3 = callPackage (import ./z3_4_13_3.nix) { };
 in
 stdenv.mkDerivation {
   pname = "fstar-z3";

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1692799911,
-        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -19,11 +19,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1751011381,
-        "narHash": "sha256-krGXKxvkBhnrSC/kGBmg5MyupUUT5R6IBCLEzx9jhMM=",
+        "lastModified": 1759381078,
+        "narHash": "sha256-gTrEEp5gEspIcCOx9PD8kMaF1iEmfBcTbO0Jag2QhQs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "30e2e2857ba47844aa71991daa6ed1fc678bcbb7",
+        "rev": "7df7ff7d8e00218376575f0acdcc5d66741351ee",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,7 @@
         pkgs = import nixpkgs {
           inherit system;
         };
-        ocamlPackages = pkgs.ocaml-ng.ocamlPackages_4_14;
+        ocamlPackages = pkgs.ocaml-ng.ocamlPackages_5_3;
 
         z3 = pkgs.callPackage (import ./.nix/z3.nix) { };
         version = self.rev or "dirty";

--- a/src/ml/FStarC_Extraction_ML_PrintML.ml
+++ b/src/ml/FStarC_Extraction_ML_PrintML.ml
@@ -1,11 +1,11 @@
 open List
 open Lexing
 open Ppxlib_ast
-open Astlib.Ast_502.Parsetree
+open Parsetree
 open Location
 open Pprintast
 open Ast_helper
-open Astlib.Ast_502.Asttypes
+open Ast
 open Longident
 
 open FStarC_Extraction_ML_Syntax

--- a/stage0/dune/fstar-guts/ml/FStarC_Extraction_ML_PrintML.ml
+++ b/stage0/dune/fstar-guts/ml/FStarC_Extraction_ML_PrintML.ml
@@ -1,11 +1,11 @@
 open List
 open Lexing
 open Ppxlib_ast
-open Astlib.Ast_502.Parsetree
+open Parsetree
 open Location
 open Pprintast
 open Ast_helper
-open Astlib.Ast_502.Asttypes
+open Ast
 open Longident
 
 open FStarC_Extraction_ML_Syntax


### PR DESCRIPTION
Nixpkgs uses a different ppxlib version depending on the ocaml version.  For old pre-5 ocaml, it uses ppxlib 0.33.0.  However we require ppxlib 0.36.0 in our fstar.opam and the nix build should respect that.

This PR updates the nix build to ocaml 5 so that it uses ppxlib 0.36.0.