### PR TITLE
Record ctor: find type candidate using all field names

### DIFF
--- a/src/syntax/FStarC.Syntax.DsEnv.fsti
+++ b/src/syntax/FStarC.Syntax.DsEnv.fsti
@@ -95,6 +95,8 @@ arguments are instantiated. *)
 val try_lookup_root_effect_name: env -> lident -> option lident
 val try_lookup_datacon: env -> lident -> option (fv & sigelt)
 val try_lookup_record_by_field_name: env -> lident -> option record_or_dc
+(* [try_lookup_record_by_field_name_many] finds a record type that includes all of the given fields *)
+val try_lookup_record_by_field_name_many: env -> list lident -> option record_or_dc
 val try_lookup_record_type: env -> lident -> option record_or_dc
 val belongs_to_record: env -> lident -> record_or_dc -> bool
 val try_lookup_dc_by_field_name: env -> lident -> option (lident & bool)

--- a/src/tosyntax/FStarC.ToSyntax.ToSyntax.fst
+++ b/src/tosyntax/FStarC.ToSyntax.ToSyntax.fst
@@ -807,7 +807,7 @@ let rec desugar_data_pat
           match fields with
           | [] -> None, field_names
           | (f, _)::_ ->
-            match try_lookup_record_by_field_name env f with
+            match try_lookup_record_by_field_name_many env field_names with
             | None -> None, field_names
             | Some r -> Some r.typename, qualify_field_names r.typename field_names
         in
@@ -1677,8 +1677,8 @@ and desugar_term_maybe_top (top_level:bool) (env:env_t) (top:term) : S.term & an
     | Record(eopt, fields) ->
       (* Record literals have to wait for type information to be fully resolved *)
       let record_opt =
-        let (f, _) = List.hd fields in
-        try_lookup_record_by_field_name env f
+        let fns = List.map fst fields in
+        try_lookup_record_by_field_name_many env fns
       in
       let fields, aqs =
           List.map

--- a/tests/micro-benchmarks/RecordCtor.fst
+++ b/tests/micro-benchmarks/RecordCtor.fst
@@ -1,0 +1,11 @@
+module RecordCtor
+
+type a_t = { a: bool }
+type ab_t = { a: bool; b: int }
+type abc_t = { a: bool; b: int; c: nat }
+
+let a = { a = true }
+let ab = { a = false; b = 42 }
+let ba = { b = 42; a = false; }
+let abc = { a = true; b = 0; c = 100 }
+


### PR DESCRIPTION
When constructing a record `{ a = ... ; b = ... }`, the ToSyntax conversion was previously only finding the most recently declared record with a field called `a`. If you have multiple structs with overlapping fields, this often chooses the wrong record type.

This change searches for all records with exactly the specified fields. If there is no exact match, it falls back to the old behaviour. I included this fallback because the typechecker seems to have logic for instantiating default values. Maybe there's some better fallback behaviour, like finding only records with at least the specified fields.

@nikswamy 