### PR TITLE
Bump checked file version

### DIFF
--- a/src/fstar/FStarC.CheckedFiles.fst
+++ b/src/fstar/FStarC.CheckedFiles.fst
@@ -34,7 +34,7 @@ let dbg = Debug.get_toggle "CheckedFiles"
  * detect when loading the cache that the version number is same
  * It needs to be kept in sync with Prims.fst
  *)
-let cache_version_number = 75
+let cache_version_number = 76
 
 (*
  * Abbreviation for what we store in the checked files (stages as described below)

--- a/ulib/Prims.fst
+++ b/ulib/Prims.fst
@@ -731,4 +731,4 @@ val string_of_int: int -> Tot string
 (** THIS IS MEANT TO BE KEPT IN SYNC WITH FStar.CheckedFiles.fs
     Incrementing this forces all .checked files to be invalidated *)
 irreducible
-let __cache_version_number__ = 75
+let __cache_version_number__ = 76


### PR DESCRIPTION
The SMT encoding change makes old checked files not work.