### PR TITLE
Fixing record resolution for `{e with f=v}`

### DIFF
--- a/src/typechecker/FStarC.TypeChecker.Util.fsti
+++ b/src/typechecker/FStarC.TypeChecker.Util.fsti
@@ -181,7 +181,8 @@ val update_env_polymonadic_bind :
   env -> lident -> lident -> lident -> tscheme -> indexed_effect_combinator_kind -> env
 
 val try_lookup_record_type : env -> lident -> option DsEnv.record_or_dc
-val find_record_or_dc_from_typ : env -> option typ -> unresolved_constructor -> Range.t -> DsEnv.record_or_dc & lident & fv
+val head_fv_of_typ (_:env) (t:typ) : option fv
+val find_record_or_dc_from_head_fv : env -> option fv -> unresolved_constructor -> Range.t -> DsEnv.record_or_dc & lident & fv
 val field_name_matches : lident -> DsEnv.record_or_dc -> ident -> bool
 val make_record_fields_in_order : env -> unresolved_constructor -> option (either typ typ) ->
                                 DsEnv.record_or_dc ->

--- a/tests/bug-reports/closed/BugRecordPoly.fst
+++ b/tests/bug-reports/closed/BugRecordPoly.fst
@@ -1,0 +1,14 @@
+module BugRecordPoly
+
+type record_ab 'a 'b = { a: 'a; b: 'b }
+type record_ac 'a 'b = { a: 'a; b: 'b }
+
+type record_r1 'rab = { r1_ab: 'rab }
+type record_r2 'rab = { r2_ab: 'rab }
+
+assume val rec1: record_r1 (record_ab string int)
+
+let rec2: record_r2 (record_ab string int) = {
+    r2_ab =
+      { rec1.r1_ab  with a = "AA" }
+}


### PR DESCRIPTION
To use the type of `e` instead of the expected type from the environment, when the latter is not an fvar.

Thanks to @amosr-msft for reporting and suggesting the fix

Also see issue #3937 