### PR TITLE
parser: desugar record puns as Var instead of Name

### DIFF
--- a/src/ml/FStarC_Parser_Parse.mly
+++ b/src/ml/FStarC_Parser_Parse.mly
@@ -1418,7 +1418,7 @@ recordExp:
 
 simpleDef:
   | e=separated_pair(qlidentOrOperator, EQUALS, noSeqTerm) { e }
-  | lid=qlidentOrOperator { lid, mk_term (Name (lid_of_ids [ ident_of_lid lid ])) (rr $loc(lid)) Un }
+  | lid=qlidentOrOperator { lid, mk_term (Var (lid_of_ids [ ident_of_lid lid ])) (rr $loc(lid)) Un }
 
 appTermArgs:
   | h=maybeHash a=onlyTrailingTerm { [h, a] }


### PR DESCRIPTION
Hi @nikswamy,

Currently, in the parser, record puns `{x}` are being desugared to `{ x = Name x }`, rather than a Var. I think this is a (very small, inconsequential) parser bug. It doesn't actually have any effect because ToSyntax treats Name and Var the same, but I hit it in consuming the pre-ToSyntax form.