### PR TITLE
Introducing `(#a : Type | deq)` syntax for types + constraints

### DIFF
--- a/src/ml/FStarC_Parser_Parse.mly
+++ b/src/ml/FStarC_Parser_Parse.mly
@@ -67,6 +67,65 @@ type tc_constraint = {
   r: FStarC_Range.t;
 }
 
+let pattern_must_be_binder (p : pattern) : binder =
+  match p.pat with
+  | PatConst Const_unit ->
+    (* A unit pattern: `()`. Unsure if this is the right place to look
+    for it. *)
+    let x = gen p.prange in
+    let u =
+      unit_type p.prange
+      (* mk_term (Const Const_unit) p.prange Expr *)
+    in
+    mk_binder (Annotated (x, u)) p.prange Expr None
+
+  | PatAscribed ({ pat = PatVar (x, aq, attrs)}, (t, _tac_opt)) ->
+    mk_binder_with_attrs (Annotated (x, t)) p.prange Expr aq attrs
+
+  | PatVar (x, aq, attrs) ->
+    mk_binder_with_attrs (Variable x) p.prange Expr aq attrs
+
+  | PatAscribed ({ pat = PatWild (aq, attrs)}, (t, _tac_opt)) ->
+    let x = gen p.prange in
+    mk_binder_with_attrs (Annotated (x, t)) p.prange Expr aq attrs
+
+  | PatWild (aq, attrs) ->
+    let x = gen p.prange in
+    mk_binder_with_attrs (Variable x) p.prange Expr aq attrs
+
+  | _ ->
+    raise_error_text p.prange Fatal_SyntaxError
+      ("Must be a simple binder: " ^ pat_to_string p)
+
+(* For a multibinder like `(a b c : Type | eq, ord)`, this generates
+   binders
+     {| _ : eq a |} {| _ : ord a |}
+     {| _ : eq b |} {| _ : ord b |}
+     {| _ : eq c |} {| _ : ord c |}
+  in that order.
+*)
+let expand_inline_constraints (cts : term list) (xs : ident list) : pattern list =
+  List.concat_map (fun x ->
+    List.concat_map (fun ct ->
+      let r = ct.range in
+      let x_t = mk_term (Var (lid_of_ids [x])) r Expr in
+      let ct = mk_term (App (ct, x_t, Nothing)) r Expr in
+      let id = gen r in
+      [ mk_pattern (PatAscribed(mk_pattern (PatVar (id, Some TypeClassArg, [])) r, (ct, None))) r ]
+    ) cts
+  ) xs
+
+let rec pat_names (bs : pattern list) : ident list =
+  match bs with
+  | [] -> []
+  | b::bs' ->
+    match b.pat with
+    | PatAscribed ({pat = PatVar (x, _, _)}, _)
+    | PatVar (x, _, _) -> x :: pat_names bs'
+    | _ ->
+      raise_error_text b.prange Fatal_SyntaxError
+        ("Inline constraints require simple variable binders, got: " ^ pat_to_string b)
+
 %}
 
 %token <string> STRING
@@ -508,7 +567,7 @@ letoperatorbinding:
     }
 
 letbinding:
-  | focus_opt=maybeFocus lid=lidentOrOperator lbp=nonempty_list(patternOrMultibinder) ascr_opt=ascribeTyp? EQUALS tm=term
+  | focus_opt=maybeFocus lid=lidentOrOperator lbp=nonempty_list(genBinder) ascr_opt=ascribeTyp? EQUALS tm=term
       {
         let pat = mk_pattern (PatVar(lid, None, [])) (rr $loc(lid)) in
         let pat = mk_pattern (PatApp (pat, flatten lbp)) (rr2 $loc(focus_opt) $loc(lbp)) in
@@ -690,15 +749,16 @@ constructorPattern:
       { pat }
 
 atomicPattern:
-  | DOT_DOT
-      {
-        mk_pattern PatRest (rr $loc)
-      }
   | LPAREN pat=tuplePattern COLON t=simpleArrow phi_opt=refineOpt RPAREN
       {
         let pos_t = rr2 $loc(pat) $loc(t) in
         let pos = rr $loc in
         mkRefinedPattern pat t true phi_opt pos_t pos
+      }
+  | LPAREN pat=tuplePattern RPAREN   { pat }
+  | DOT_DOT
+      {
+        mk_pattern PatRest (rr $loc)
       }
   | LBRACK pats=right_flexible_list(SEMICOLON, tuplePattern) RBRACK
       { mk_pattern (PatList pats) (rr2 $loc($1) $loc($3)) }
@@ -706,13 +766,8 @@ atomicPattern:
       { mk_pattern (PatRecord record_pat) (rr $loc) }
   | LENS_PAREN_LEFT pat0=constructorPattern COMMA pats=separated_nonempty_list(COMMA, constructorPattern) LENS_PAREN_RIGHT
       { mk_pattern (PatTuple(pat0::pats, true)) (rr $loc) }
-  | LPAREN pat=tuplePattern RPAREN   { pat }
   | LPAREN op=operator RPAREN
       { mk_pattern (PatOp op) (rr $loc) }
-  | UNDERSCORE
-      { mk_pattern (PatWild (None, [])) (rr $loc) }
-  | HASH UNDERSCORE
-      { mk_pattern (PatWild (Some Implicit, [])) (rr $loc) }
   | c=constant
       { mk_pattern (PatConst c) (rr $loc(c)) }
   | tok=MINUS c=constant
@@ -733,6 +788,10 @@ atomicPattern:
     {
       let (aqual, attrs), lid = qual_id in
       mk_pattern (PatVar (lid, aqual, attrs)) (rr $loc(qual_id)) }
+  | qual_id=aqualifiedWithAttrs(UNDERSCORE)
+    {
+      let (aqual, attrs), _ = qual_id in
+      mk_pattern (PatWild (aqual, attrs)) (rr $loc(qual_id)) }
   | uid=quident
       { mk_pattern (PatName uid) (rr $loc(uid)) }
 
@@ -749,51 +808,21 @@ tc_constraint:
       {id; t; r}
     }
 
+(* Typeclass constraints: what appears inside a {| ... |}. They can
+be named or anonymous *)
 tc_constraints:
   | constraints=right_flexible_nonempty_list(COMMA, tc_constraint) { constraints }
 
-  (* (x : t) is already covered by atomicPattern *)
-  (* we do *NOT* allow _ in multibinder () since it creates reduce/reduce conflicts when*)
-  (* preprocessing to ocamlyacc/fsyacc (which is expected since the macro are expanded) *)
-patternOrMultibinder:
-  | LBRACE_BAR constraints=tc_constraints BAR_RBRACE
-      {
-        let constraint_as_pat (c:tc_constraint) =
-          let w = mk_pattern (PatVar (c.id, Some TypeClassArg, [])) c.r in
-          let asc = (c.t, None) in
-          mk_pattern (PatAscribed(w, asc)) c.r
-        in
-        List.map constraint_as_pat constraints
-      }
+(* Constraints on binders: like (#a : Type | deq) *)
+type_tc_constraints:
+  | BAR constraints=right_flexible_nonempty_list(COMMA, tmEqNoRefinement) { constraints }
+  | { [] }
 
-  | pat=atomicPattern { [pat] }
-  | LPAREN
-      qual_id0=aqualifiedWithAttrs(lident)
-      qual_ids=nonempty_list(aqualifiedWithAttrs(lident))
-      COLON
-      t=simpleArrow r=refineOpt
-    RPAREN
-      {
-        let pos = rr $loc in
-        let t_pos = rr $loc(t) in
-        let qual_ids = qual_id0 :: qual_ids in
-        let n = List.length qual_ids in
-        List.mapi (fun idx ((aq, attrs), x) ->
-          let pat = mk_pattern (PatVar (x, aq, attrs)) pos in
-          (* Only the last binder carries the refinement, if any. *)
-          let refine_opt = if idx = Int.sub n 1 then r else None in
-          (*                    ^ The - symbol resolves to F* addition. *)
-          mkRefinedPattern pat t true refine_opt t_pos pos
-        ) qual_ids
-      }
-
-binder:
-  | aqualifiedWithAttrs_lid=aqualifiedWithAttrs(lidentOrUnderscore)
-     {
-       let (q, attrs), lid = aqualifiedWithAttrs_lid in
-       mk_binder_with_attrs (Variable lid) (rr $loc(aqualifiedWithAttrs_lid)) Type_level q attrs
-     }
-
+(* NOTE: multiBinder and genBinder have parallel structure for {| ... |}
+   and multi-identifier (x y : t | constraints) cases, but produce different
+   types (binder list vs pattern list). Keep them in sync when modifying
+   constraint handling. Both use expand_inline_constraints for the shared
+   logic. *)
 %public
 multiBinder:
   | LBRACE_BAR constraints=tc_constraints BAR_RBRACE
@@ -804,27 +833,37 @@ multiBinder:
         List.map constraint_as_binder constraints
       }
 
-  | LPAREN qual_ids=nonempty_list(aqualifiedWithAttrs(lidentOrUnderscore)) COLON t=simpleArrow r=refineOpt RPAREN
+  | LPAREN
+      qual_ids=nonempty_list(aqualifiedWithAttrs(lidentOrUnderscore))
+      COLON t=simpleArrow r=refineOpt cts=type_tc_constraints
+    RPAREN
      {
-       let should_bind_var = match qual_ids with | [ _ ] -> true | _ -> false in
        let n = List.length qual_ids in
-       List.mapi (fun idx ((q, attrs), x) ->
+       let bs = List.mapi (fun idx ((q, attrs), x) ->
          let refine_opt = if idx = Int.sub n 1 then r else None in
          mkRefinedBinder x t true refine_opt (rr $loc) q attrs
-       ) qual_ids
+       ) qual_ids in
+       let names = List.map (fun ((_, _), x) -> x) qual_ids in
+       let cts_binders = List.map pattern_must_be_binder
+                           (expand_inline_constraints cts names) in
+       bs @ cts_binders
      }
 
   | LPAREN_RPAREN
     {
       let r = rr $loc in
-      let unit_t = mk_term (Var (lid_of_ids [(mk_ident("unit", r))])) r Un in
-      [mk_binder (Annotated (gen r, unit_t)) r Un None]
+      let unit_t = unit_type r in
+      [mk_binder (Annotated (gen r, unit_t)) r Type_level None]
     }
 
-  | b=binder { [b] }
+  | aqualifiedWithAttrs_lid=aqualifiedWithAttrs(lidentOrUnderscore)
+     {
+       let (q, attrs), lid = aqualifiedWithAttrs_lid in
+       [mk_binder_with_attrs (Variable lid) (rr $loc(aqualifiedWithAttrs_lid)) Type_level q attrs]
+     }
 
 %public
-binders: bss=list(bs=multiBinder {bs}) { flatten bss }
+binders: bss=list(multiBinder) { flatten bss }
 
 aqualifiedWithAttrs(X):
   | aq=aqual attrs=binderAttributes x=X { (Some aq, attrs), x }
@@ -1470,7 +1509,7 @@ trailingTerm:
     { x }
 
 onlyTrailingTerm:
-  | FUN pats=nonempty_list(patternOrMultibinder) RARROW e=term
+  | FUN pats=nonempty_list(genBinder) RARROW e=term
       { mk_term (Abs(flatten pats, e)) (rr2 $loc($1) $loc(e)) Un }
   | q=quantifier bs=binders DOT trigger=trigger e=term
       {
@@ -1689,3 +1728,50 @@ reverse_left_flexible_nonempty_list(delim, X):
 %inline left_flexible_nonempty_list(delim, X):
  xs = reverse_left_flexible_nonempty_list(delim, X)
    { List.rev xs }
+
+(* See note on multiBinder about keeping these in sync. *)
+genBinder:
+  (* Typeclass constraints {| ... |} *)
+  | LBRACE_BAR constraints=tc_constraints BAR_RBRACE
+      {
+        let constraint_as_pat (c:tc_constraint) =
+          let w = mk_pattern (PatVar (c.id, Some TypeClassArg, [])) c.r in
+          let asc = (c.t, None) in
+          mk_pattern (PatAscribed(w, asc)) c.r
+        in
+        List.map constraint_as_pat constraints
+      }
+
+  | pat=atomicPattern { [pat] }
+
+  (* Multi-binder: (x y : t | constraints) — 2+ identifiers with annotation *)
+  | LPAREN
+      qual_id0=aqualifiedWithAttrs(lidentOrUnderscore)
+      qual_ids=nonempty_list(aqualifiedWithAttrs(lidentOrUnderscore))
+      COLON t=simpleArrow r=refineOpt cts=type_tc_constraints
+    RPAREN
+      {
+        let qual_ids = qual_id0 :: qual_ids in
+        let pos = rr $loc in
+        let n = List.length qual_ids in
+        let pats = List.mapi (fun idx ((aq, attrs), x) ->
+          let pat = mk_pattern (PatVar (x, aq, attrs)) pos in
+          let refine_opt = if idx = Int.sub n 1 then r else None in
+          mkRefinedPattern pat t true refine_opt (rr $loc(t)) pos
+        ) qual_ids in
+        let names = List.map (fun ((_, _), x) -> x) qual_ids in
+        pats @ expand_inline_constraints cts names
+      }
+
+  (* Single pattern with inline constraints: (x : t | constraints) *)
+  | LPAREN
+      pat=tuplePattern
+      COLON t=simpleArrow r=refineOpt
+      BAR cts=right_flexible_nonempty_list(COMMA, tmEqNoRefinement)
+    RPAREN
+      {
+        let pos_t = rr2 $loc(pat) $loc(t) in
+        let p = mkRefinedPattern pat t true r pos_t (rr $loc) in
+        let names = pat_names [p] in
+        [p] @ expand_inline_constraints cts names
+      }

--- a/src/parser/FStarC.Parser.AST.fst
+++ b/src/parser/FStarC.Parser.AST.fst
@@ -166,6 +166,7 @@ let consPat r hd tl = PatApp(mk_pattern (PatName C.cons_lid) r, [hd;tl])
 let consTerm r hd tl = mk_term (Construct(C.cons_lid, [(hd, Nothing);(tl, Nothing)])) r Expr
 
 let unit_const r = mk_term(Const Const_unit) r Expr
+let unit_type  r = mk_term (Var (Ident.lid_of_str (`%unit))) r Expr
 
 let ml_comp t : ML term =
     let lid = C.effect_ML_lid () in

--- a/src/parser/FStarC.Parser.AST.fsti
+++ b/src/parser/FStarC.Parser.AST.fsti
@@ -325,6 +325,7 @@ val consPat : range -> pattern -> pattern -> pattern'
 val consTerm : range -> term -> term -> term
 
 val unit_const : range -> term
+val unit_type  : range -> ML term
 val ml_comp : term -> ML term
 val tot_comp : term -> term
 

--- a/tests/micro-benchmarks/MinusVsNegParsing.fst
+++ b/tests/micro-benchmarks/MinusVsNegParsing.fst
@@ -1,0 +1,42 @@
+module MinusVsNegParsing
+
+let test (x:int) : bool =
+  match x with
+  | (-5) -> true
+  | -3 -> true
+  | _ -> false
+
+// Parses as a match against (-5)
+val x : (y:int{y == -5}) -> int
+let x - 5 = 1
+
+// Parses as a match against (-5)
+val y : (y:int{y == -5}) -> int
+let y -5 = 1
+
+(* Make sure we fail for negative *unsigned* machine ints. *)
+[@@expect_failure] let _ = -1uy
+[@@expect_failure] let _ = -1us
+[@@expect_failure] let _ = -1ul
+[@@expect_failure] let _ = -1uL
+[@@expect_failure] let _ = -1sz
+[@@expect_failure] let _ = -1z
+
+let _ = 1uy
+let _ = 1us
+let _ = 1ul
+let _ = 1uL
+let _ = 1sz
+let _ = 1z
+
+(* All good for signed variants. *)
+
+let _ = -1y
+let _ = -1s
+let _ = -1l
+let _ = -1L
+
+let _ = 1y
+let _ = 1s
+let _ = 1l
+let _ = 1L

--- a/tests/micro-benchmarks/Parsing.fst
+++ b/tests/micro-benchmarks/Parsing.fst
@@ -1,0 +1,71 @@
+module Parsing
+
+(* Miscellaneous parsing tests, mostly about patterns
+for now. *)
+
+let foo (x,y : int & int) = x + y
+
+// Currently parses (-1) as a pattern... odd but ok
+val bar : (x:int{x == -1}) -> int
+let bar - 1 = 2
+
+type t = | A
+
+let baz A = ()
+
+type box t = | Box of t
+
+let unbox (Box x) = x
+
+let buz2 (Box x, Box y) = x + y
+
+let buz1 (Box x) = x
+
+let bub p =
+  let (x, y) = p in
+  x + y
+
+let bub2 p =
+  let x, y = p in
+  x + y
+
+let bab (x y : int {x >= y}) : nat = x - y
+
+// Should fail and does
+// val bab_box (Box x : box int) : nat
+// Should fail and does
+// val bab_box (Box x) : nat
+// Should fail and does
+// val bab_box : (Box x : int) -> nat
+
+val bab_box (x y : box int {unbox x >= unbox y}) : nat
+let bab_box (Box x) (Box y) : nat = x - y
+
+// These require parentheses around each tuple.
+let many_tuples_ok    ((x,y)) ((z,w))             = x+y+z+w
+let many_tuples_t_ok  ((x,y)) ((z,w) : int & int) = x+y+z+w
+let many_tuples_ok'    (x,y)   (z,w)              = x+y+z+w
+let many_tuples_t_ok'  (x,y)  ((z,w) : int & int) = x+y+z+w
+
+val equality1 ($x : unit) : unit
+let equality1 ($x : unit) : unit = ()
+
+// Should parse, but fail
+let test_eq_match (x : int) : int =
+  match x with
+  | $x -> x
+
+// Should parse, but fail later
+let test_eq_match2 (x : int) : int =
+  match x with
+  | $_ -> x
+
+// Should work
+val equality2 ($_ : unit) : unit
+let equality2 ($_ : unit) : unit = ()
+
+// Should not work? It parses and desugars, and then
+// fails to infer the type of wildcard. It makes sense, just
+// maybe nicer to fail earlier?
+[@@expect_failure [66]]
+val noparens _ : unit

--- a/tests/micro-benchmarks/TcSyntax.fst
+++ b/tests/micro-benchmarks/TcSyntax.fst
@@ -1,6 +1,15 @@
 module TcSyntax
 
-open FStar.Class.Eq
+open FStar.Class.Eq.Raw
+open FStar.Class.Ord.Raw
+
+let has_eq (a : Type | deq) (x : a) = x = x
+
+let _ = has_eq int 1
+
+let has_eq2 (a b : Type | deq) (x : a) = x = x
+
+let has_ord (a : Type | ord) : unit = ()
 
 let foo1
   (#a #b : Type)
@@ -12,7 +21,7 @@ let foo1
 
 let foo2
   (#a #b : Type)
-  {| deq a, deq b |}
+  {| _ : deq a, db : deq b |}
   (a1 a2 : a)
   (b1 b2 : b)
   : Tot bool
@@ -25,3 +34,55 @@ let foo3
   (b1 b2 : b)
   : Tot bool
   = a1 = a2 && b1 = b2
+
+let foo4
+  (#a #b : Type | deq)
+  (a1 a2 : a)
+  (b1 b2 : b)
+  : Tot bool
+  = a1 = a2 && b1 = b2
+
+let foo5
+  (#a #b : Type | deq, ord, )
+  (a1 a2 : a)
+  (b1 b2 : b)
+  : Tot bool
+  = a1 = a2 && b1 = b2
+
+let foo6
+  (a b : Type | deq)
+  (a1 a2 : a)
+  (b1 b2 : b)
+  : Tot bool
+  = a1 = a2 && b1 = b2
+
+let _ = foo6 int int #_ #_ 1 2 3 4
+
+let foo7
+  (#a : Type | deq)
+  (a1 a2 : a)
+  : Tot bool
+  = (a1 = a2) = (a2 = a1)
+
+(* Negative tests for inline constraints *)
+
+(* Using a constraint that is not satisfied: has deq but not ord *)
+[@@expect_failure]
+let foo_neg1
+  (#a : Type | deq)
+  (a1 a2 : a)
+  : bool
+  = a1 <= a2
+
+(* Constraint on a value variable makes no sense:
+   `(x : int | deq)` generates `deq x` but x:int, not a Type *)
+[@@expect_failure]
+let foo_neg3 (x : int | deq) : bool = x = x
+
+(* Multi-binder: only deq requested, but ord used *)
+[@@expect_failure]
+let foo_neg2
+  (#a #b : Type | deq)
+  (a1 a2 : a)
+  : bool
+  = a1 <= a2


### PR DESCRIPTION
This syntax simplifies writing several constraints over the same type. The constraints can just be added to the set after the bar, and many of them can be given. E.g.
```fstar
let foo5
  (#a #b : Type | deq, ord)
  ...
```
This has two implicit arguments for the types, then `deq` and `ord` constraints for `a`, and then for `b`. The constraints could also be partially applied

This needs a Pulse patch, and it's not trivial, so marking as a draft.