### PR TITLE
SizeT: relax type of fits, prevents spurious queries about non-negati…

### DIFF
--- a/ulib/FStar.SizeT.fst
+++ b/ulib/FStar.SizeT.fst
@@ -13,7 +13,9 @@ type t : eqtype = | Sz : (x:U64.t { U64.v x < bound }) -> t
 
 let fits x =
   FStar.UInt.fits x U64.n == true /\
-  x < bound
+  0 <= x /\ x < bound
+
+let fits_nonneg x = ()
 
 let fits_at_least_16 _ = ()
 
@@ -25,7 +27,7 @@ let uint_to_t x =
   Sz (U64.uint_to_t x)
 
 let size_v_inj (x: t) = ()
-let size_uint_to_t_inj (x: nat) = ()
+let size_uint_to_t_inj (x: int) = ()
 
 
 /// These two predicates are only used for modeling purposes, and their definitions must
@@ -40,15 +42,15 @@ let fits_u64_implies_fits_32 ()
     (ensures fits_u32)
   = ()
 
-let fits_u32_implies_fits (x:nat)
+let fits_u32_implies_fits (x:int)
   : Lemma
-    (requires fits_u32 /\ x < pow2 32)
+    (requires fits_u32 /\ 0 <= x /\ x < pow2 32)
     (ensures fits x)
   = ()
 
-let fits_u64_implies_fits (x:nat)
+let fits_u64_implies_fits (x:int)
   : Lemma
-    (requires fits_u64 /\ x < pow2 64)
+    (requires fits_u64 /\ 0 <= x /\ x < pow2 64)
     (ensures fits x)
   = ()
 


### PR DESCRIPTION
…vity

When mentioning `SZ.fits x` in a specification, there is a guard generated for `x` being a nat. This is inconvenient in some settings, particularly if non-linear arithmetic is involved. For instance, a type like:
```fstar
let foo (x y z : nat{SZ.fits (x * y * z)} ...
```
requires a proof that a product of three nats is a nat, which can actually *fail* in contexts where the SMT is too overloaded. (Which is pretty bad, but an existing problem.)

However, there is no need to restrict `x` to be a nat to make the predicate well-defined. We can just push the `x >= 0` requirement into the definition of this predicate, making `SZ.fits (-1)` well-defined (and false).