### PR TITLE
get_fstar_z3: add command-line options to specify arch and kernel

### DIFF
--- a/.scripts/get_fstar_z3.sh
+++ b/.scripts/get_fstar_z3.sh
@@ -96,25 +96,53 @@ full_install_z3() {
 }
 
 usage() {
-  echo "Usage: get_fstar_z3.sh destination/directory/bin"
+  echo "Usage: get_fstar_z3.sh destination/directory/bin [--full] [--arch <x86_64|aarch64>] [--kernel <Linux|Darwin|Windows>]"
   exit 1
 }
 
-if [ $# -ge 1 ] && [ "$1" == "--full" ]; then
-  # Passing --full xyz/ will create a tree like
-  #  xyz/z3-4.8.5/bin/z3
-  #  xyz/z3-4.13.3/bin/z3
-  # (plus all other files in each package). This is used
-  # for our binary packages which include Z3.
-  full_install=true;
-  shift;
-fi
+dest_dir_set=false
+while [ $# -ge 1 ]; do
+  case "$1" in
+    --arch)
+      shift
+      if [ $# -lt 1 ]; then usage; fi
+      arch="$1"
+      ;;
+    --kernel)
+      shift
+      if [ $# -lt 1 ]; then usage; fi
+      kernel="$1"
+      ;;
+    --full)
+      # Passing --full xyz/ will create a tree like
+      #  xyz/z3-4.8.5/bin/z3
+      #  xyz/z3-4.13.3/bin/z3
+      # (plus all other files in each package). This is used
+      # for our binary packages which include Z3.
+      full_install=true;
+      ;;
+    --*)
+      usage
+      ;;
+    --)
+      if $dest_dir_set; then usage; fi
+      shift
+      if [ $# -lt 1 ]; then usage; fi
+      dest_dir="$1"
+      dest_dir_set=true
+      ;;
+    *)
+      if $dest_dir_set; then usage; fi
+      dest_dir="$1"
+      dest_dir_set=true
+      ;;
+  esac
+  shift
+done
 
-if [ $# -ne 1 ]; then
+if [ "$dest_dir_set" == "false" ]; then
   usage
 fi
-
-dest_dir="$1"
 
 mkdir -p "$dest_dir"
 


### PR DESCRIPTION
I need to make some Mac packages, but I don't have access to a corporation-blessed Mac machine. For cross-compiling or when we need to package up dependencies, it would be useful if the script to get Z3 could get specific architectures.
This PR adds --kernel and --arch options to get_fstar_z3.sh.

usage:
```
$ .scripts/get_fstar_z3.sh
Usage: get_fstar_z3.sh destination/directory/bin [--full] [--arch <x86_64|aarch64>] [--kernel <Linux|Darwin|Windows>]
```

example:
```
$ .scripts/get_fstar_z3.sh dest --arch x86_64 --kernel Windows
>>> Downloading Z3 4.8.5 from https://github.com/Z3Prover/z3/releases/download/Z3-4.8.5/z3-4.8.5-x64-win.zip ...
>>> Installed Z3 4.8.5 to dest/z3-4.8.5.exe
>>> Downloading Z3 4.13.3 from https://github.com/Z3Prover/z3/releases/download/z3-4.13.3/z3-4.13.3-x64-win.zip ...
>>> Installed Z3 4.13.3 to dest/z3-4.13.3.exe
>>> Downloading Z3 4.15.3 from https://github.com/Z3Prover/z3/releases/download/z3-4.15.3/z3-4.15.3-x64-win.zip ...
>>> Installed Z3 4.15.3 to dest/z3-4.15.3.exe

$ .scripts/get_fstar_z3.sh dest --arch x86_64 --kernel Linux
>>> Downloading Z3 4.8.5 from https://github.com/Z3Prover/z3/releases/download/Z3-4.8.5/z3-4.8.5-x64-ubuntu-16.04.zip ...
>>> Installed Z3 4.8.5 to dest/z3-4.8.5
>>> Downloading Z3 4.13.3 from https://github.com/Z3Prover/z3/releases/download/z3-4.13.3/z3-4.13.3-x64-glibc-2.35.zip ...
>>> Installed Z3 4.13.3 to dest/z3-4.13.3
>>> Downloading Z3 4.15.3 from https://github.com/Z3Prover/z3/releases/download/z3-4.15.3/z3-4.15.3-x64-glibc-2.39.zip ...
>>> Installed Z3 4.15.3 to dest/z3-4.15.3
```