### PR TITLE
dune: move away from deprecated package

### DIFF
--- a/stage1/dune/fstar-guts/dune
+++ b/stage1/dune/fstar-guts/dune
@@ -13,7 +13,7 @@
     pprint
     process
     sedlex
-    mtime.clock.os
+    mtime.clock
  )
  (modes native)
  (preprocess (pps ppx_deriving.show ppx_deriving_yojson sedlex.ppx))

--- a/stage2/dune/fstar-guts/dune
+++ b/stage2/dune/fstar-guts/dune
@@ -13,7 +13,7 @@
     pprint
     process
     sedlex
-    mtime.clock.os
+    mtime.clock
  )
  (modes native)
  (preprocess (pps ppx_deriving.show ppx_deriving_yojson sedlex.ppx))


### PR DESCRIPTION
> ocamlfind: [WARNING] Package `mtime.clock.os': Deprecated, use the mtime.clock library.