### PR TITLE
Fix build of stage1 (and stage2 without release mode)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ $(FSTAR1_BARE_EXE): .bare1.src.touch .src.ml.touch $(MAYBEFORCE)
 
 $(TESTS1_EXE): .tests1.src.touch .src.ml.touch $(MAYBEFORCE)
 	$(call bold_msg, "BUILD", "STAGE 1 TESTS")
-	$(MAKE) -C stage1 tests
+	$(MAKE) -C stage1 tests BUILD_FSTAR_OCAML_TESTS=true
 	touch -c $@
 
 stage1-unit-tests: $(TESTS1_EXE)
@@ -230,7 +230,7 @@ $(FSTAR2_BARE_EXE): .bare2.src.touch .src.ml.touch $(MAYBEFORCE)
 
 $(TESTS2_EXE): .tests2.src.touch .src.ml.touch $(MAYBEFORCE)
 	$(call bold_msg, "BUILD", "STAGE 2 TESTS")
-	$(MAKE) -C stage2 tests
+	$(MAKE) -C stage2 tests BUILD_FSTAR_OCAML_TESTS=true
 	touch -c $@
 
 stage2-unit-tests: $(TESTS2_EXE)

--- a/stage1/dune/dune-project
+++ b/stage1/dune/dune-project
@@ -1,4 +1,4 @@
-(lang dune 3.8)
+(lang dune 3.15)
 (name fstar)
 (generate_opam_files false)
 (using menhir 2.1)

--- a/stage1/dune/tests/dune
+++ b/stage1/dune/tests/dune
@@ -7,4 +7,5 @@
  )
  (link_flags "-linkall")
  (modes (native exe))
+ (enabled_if (= %{env:BUILD_FSTAR_OCAML_TESTS=false} true))
 )

--- a/stage2/dune/dune-project
+++ b/stage2/dune/dune-project
@@ -1,4 +1,4 @@
-(lang dune 3.8)
+(lang dune 3.15)
 (name fstar)
 (generate_opam_files false)
 (using menhir 2.1)

--- a/stage2/dune/tests/dune
+++ b/stage2/dune/tests/dune
@@ -7,4 +7,5 @@
  )
  (link_flags "-linkall")
  (modes (native exe))
+ (enabled_if (= %{env:BUILD_FSTAR_OCAML_TESTS=false} true))
 )


### PR DESCRIPTION
Dune would attempt to build the tests when these files were not there. Ignore the subdir, and build this only when we ask to.