### PR TITLE
Rel: do not simplify guards to true for tactics

### DIFF
--- a/src/tactics/FStarC.Tactics.V2.Basic.fst
+++ b/src/tactics/FStarC.Tactics.V2.Basic.fst
@@ -1213,7 +1213,7 @@ let t_apply_lemma (noinst:bool) (noinst_lhs:bool)
         let sub_goals = filter' (fun g goals -> not (checkone (goal_witness g) goals)) sub_goals in
         proc_guard "apply_lemma guard" env guard None (Some goal_sc) (rangeof goal) ;!
         let pre_u = env.universe_of env pre in
-        (match (Rel.simplify_guard env (Env.guard_of_guard_formula (NonTrivial pre))).guard_f with
+        (match Env.check_trivial (Rel.simplify_vc false env pre) with
          | Trivial -> return ()
          | NonTrivial _ -> add_irrelevant_goal goal "apply_lemma precondition" env pre (Some goal_sc)) ;!//AR: should we use the normalized pre instead?
         add_goals sub_goals

--- a/src/typechecker/FStarC.TypeChecker.Rel.fst
+++ b/src/typechecker/FStarC.TypeChecker.Rel.fst
@@ -1901,8 +1901,9 @@ let run_meta_arg_tac (env:env_t) (ctx_u:ctx_uvar) : term =
   | _ ->
     failwith "run_meta_arg_tac must have been called with a uvar that has a meta tac"
 
+(* This function is also called by tactics during phase1, and should not drop
+the guards if so (like simplify_guard does). *)
 let simplify_vc full_norm_allowed env t =
-  if env.phase1 then Util.t_true else
   Stats.record "simplify_vc" fun () ->
   if !dbg_Simplification then
     Format.print1 "Simplifying guard %s\n" (show t);
@@ -1919,6 +1920,8 @@ let simplify_vc full_norm_allowed env t =
 
 let __simplify_guard full_norm_allowed env g = match g.guard_f with
   | Trivial -> g
+  | _ when env.phase1 ->
+    { g with guard_f = Trivial }
   | NonTrivial f ->
     let f = simplify_vc full_norm_allowed env f in
     let f = check_trivial f in

--- a/src/typechecker/FStarC.TypeChecker.Rel.fsti
+++ b/src/typechecker/FStarC.TypeChecker.Rel.fsti
@@ -48,6 +48,7 @@ val flex_prob_closing         : env -> binders -> prob -> bool
 val head_matches_delta (env:env) (logical:bool) (smt_ok:bool) (t1 t2:typ) : (match_result & option (typ & typ))
 val may_relate_with_logical_guard (env:env) (is_equality:bool) (head:typ) : bool
 val guard_to_string           : env -> guard_t -> string
+val simplify_vc               : full_norm_allowed:bool -> env -> term -> term (* the inner simplification of simplify_guard. *)
 val simplify_guard            : env -> guard_t -> guard_t
 val solve_deferred_constraints: env -> guard_t -> guard_t
 val solve_non_tactic_deferred_constraints: maybe_defer_flex_flex:bool -> env -> guard_t -> guard_t


### PR DESCRIPTION
When running a tactic in phase1 (like any tactic that solves implicits),
this patch would make the preconditions of the lemma become trivial and
disappear as goals, breaking code that expected them to be there. This
is a limitation of the tactics engine, which presents goals as a stack
without a good way of obtaining labels or handles for them. This broke
the Steel tactic as it is contains many applications of lemmas followed
by just the right combination of calls to subtactics or `dismiss`. A
better way of writing robust tactics would be ideal.

Fixes https://github.com/FStarLang/FStar/commit/41ffe463e7834677d70b8b6deab8ee089070b645

cc @cmovcc, this fixes most of Steel.