### PR TITLE
Tactics: fix detection of equalities to account for metas

### DIFF
--- a/src/syntax/FStarC.Syntax.Formula.fst
+++ b/src/syntax/FStarC.Syntax.Formula.fst
@@ -84,7 +84,7 @@ let lookup_arity_lid table target_lid args =
     BU.find_map table aux
 
 let destruct_base_conn t =
-    let hd, args = U.head_and_args t in
+    let hd, args = U.head_and_args_full t in
     match (U.un_uinst hd).n with
     | Tm_fvar fv -> lookup_arity_lid destruct_base_table fv.fv_name args
     | _ -> None
@@ -110,7 +110,7 @@ let destruct_q_conn t =
         else U.is_exists fv.fv_name
     in
     let flat t =
-        let t, args = U.head_and_args t in
+        let t, args = U.head_and_args_full t in
         U.un_uinst t, args |> List.map (fun (t, imp) -> U.unascribe t, imp)
     in
     let rec aux qopt out t = match qopt, flat t with

--- a/src/syntax/FStarC.Syntax.Util.fst
+++ b/src/syntax/FStarC.Syntax.Util.fst
@@ -1138,7 +1138,7 @@ let mk_auto_squash u p =
     mk_app (mk_Tm_uinst sq [u]) [as_arg p]
 
 let un_squash t =
-    let head, args = head_and_args t in
+    let head, args = head_and_args_full t in
     let head = unascribe head in
     let head = un_uinst head in
     match (compress head).n, args with

--- a/src/syntax/FStarC.Syntax.Util.fsti
+++ b/src/syntax/FStarC.Syntax.Util.fsti
@@ -137,8 +137,8 @@ val is_lemma_comp (c:comp) : bool
 val is_lemma (t:typ) : bool
 
 val head_of (t : term) : term
-val head_and_args (t : term) : term & args
-val head_and_args_full (t : term) : term & args
+val head_and_args (t : term) : term & args  // Destructs a single Tm_app
+val head_and_args_full (t : term) : term & args // Collects all Tm_app nodes
 val head_and_args_full_unmeta (t : term) : term & args
 
 val leftmost_head (t : term) : term

--- a/src/tactics/FStarC.Tactics.V1.Basic.fst
+++ b/src/tactics/FStarC.Tactics.V1.Basic.fst
@@ -196,6 +196,11 @@ let fail4 msg x y z w = fail (Format.fmt4 msg x y z w)
 
 let destruct_eq' (typ : typ) : option (term & term) =
     let open FStarC.Syntax.Formula in
+    (* destruct_typ_as_formula will do a very conservative unmeta, removing
+    Meta_monadic and Meta_monadic_lift nodes, but not Meta_labeled, since that
+    leads to bad error messages elsewhere. We don't care about that here, so do
+    an aggressive unmeta before calling it. *)
+    let typ = U.unmeta typ in
     match destruct_typ_as_formula typ with
     | Some (BaseConn(l, [_; (e1, None); (e2, None)]))
       when Ident.lid_equals l PC.eq2_lid

--- a/src/tactics/FStarC.Tactics.V2.Basic.fst
+++ b/src/tactics/FStarC.Tactics.V2.Basic.fst
@@ -184,6 +184,11 @@ let fail4 msg x y z w = fail (Format.fmt4 msg x y z w)
 
 let destruct_eq' (typ : typ) : option (term & term) =
     let open FStarC.Syntax.Formula in
+    (* destruct_typ_as_formula will do a very conservative unmeta, removing
+    Meta_monadic and Meta_monadic_lift nodes, but not Meta_labeled, since that
+    leads to bad error messages elsewhere. We don't care about that here, so do
+    an aggressive unmeta before calling it. *)
+    let typ = U.unmeta typ in
     match destruct_typ_as_formula typ with
     | Some (BaseConn(l, [_; (e1, None); (e2, None)]))
       when Ident.lid_equals l PC.eq2_lid
@@ -195,7 +200,7 @@ let destruct_eq' (typ : typ) : option (term & term) =
       | None -> None
       | Some t ->
         begin
-        let hd, args = U.head_and_args t in
+        let hd, args = U.head_and_args_full t in
         match (SS.compress hd).n, args with
         | Tm_fvar fv, [(_, Some ({ aqual_implicit = true })); (e1, None); (e2, None)] when S.fv_eq_lid fv PC.op_Eq ->
             Some (e1, e2)


### PR DESCRIPTION
This fixes a bug when the goal is wrapped by several Meta_labeled nodes.
It is quite hard to write a testcase for it.

Also make sure to use head_and_args_full to defend against nested
application nodes.