### PR TITLE
Parser/Resugar: introduce LitDoc node, and resugaring extension pass API

### DIFF
--- a/src/parser/FStarC.Parser.AST.fst
+++ b/src/parser/FStarC.Parser.AST.fst
@@ -97,6 +97,7 @@ instance tagged_term : tagged term = {
   | ElimAnd        _ -> "ElimAnd"
   | ListLiteral    _ -> "ListLiteral"
   | SeqLiteral     _ -> "SeqLiteral"
+  | LitDoc         _ -> "LitDoc"
   );
 }
 
@@ -757,6 +758,10 @@ let rec term_to_string (x:term) = match x.tm with
 
   | SeqLiteral ts ->
     Format.fmt1 "seq![%s]" (to_string_l "; " term_to_string ts)
+
+  | LitDoc d ->
+    Format.fmt1 "litdoc(%s)" (render d)
+
   | _ -> failwith ("AST.term_to_string missing case: " ^ tag_of x)
 
 and binders_to_string sep bs =
@@ -1155,6 +1160,8 @@ let rec pp_term (t:term) : document =
       ctor "ListLiteral" [pp_list' pp_term ts]
   | SeqLiteral ts ->
       ctor "SeqLiteral" [pp_list' pp_term ts]
+  | LitDoc d ->
+      ctor "LitDoc" [d]
 
 and pp_binder (b:binder) : document =
   match b.b with

--- a/src/parser/FStarC.Parser.AST.fsti
+++ b/src/parser/FStarC.Parser.AST.fsti
@@ -106,11 +106,9 @@ type term' =
   | ElimAnd of term & term & term & binder & binder & term        (* elim_and P Q to R with x y. e *)
   | ListLiteral of list term
   | SeqLiteral of list term
-
+  | LitDoc of Pprint.document (* Never parsed, used for resugaring extensions. *)
 
 and term = {tm:term'; range:range; level:level}
-
-
 
 (* (as y)? returns t *)
 and match_returns_annotation = option ident & term & bool

--- a/src/parser/FStarC.Parser.ToDocument.fst
+++ b/src/parser/FStarC.Parser.ToDocument.fst
@@ -1589,6 +1589,9 @@ and p_noSeqTerm' ps pb e = match e.tm with
     str "eliminate" ^^ space ^^ p ^^ space ^^ str "/\\" ^^ space ^^ q ^^ hardline ^^
     str "returns" ^^ space ^^ r ^^ hardline ^^
     str "with" ^^ space ^^ xy ^^ space ^^ str "." ^^ space ^^ e
+
+  | LitDoc d ->
+    d
     
   | _ -> p_typ ps pb e
 
@@ -2160,6 +2163,8 @@ and p_projectionLHS e = match e.tm with
               " arguments couldn't be handled by the pretty printer")
   | Uvar id ->
     failwith "Unexpected universe variable out of universe context"
+
+  | LitDoc d -> d
 
   (* All the cases are explicitly listed below so that a modification of the ast doesn't lead to a loop *)
   (* We must also make sure that all the constructors listed below are handled somewhere *)

--- a/src/syntax/FStarC.Syntax.Resugar.fsti
+++ b/src/syntax/FStarC.Syntax.Resugar.fsti
@@ -27,6 +27,13 @@ module S  = FStarC.Syntax.Syntax
 module A  = FStarC.Parser.AST
 module DsEnv = FStarC.Syntax.DsEnv
 
+exception SkipResugar
+
+(* May raise SkipResugar exn *)
+type resugar_pass_t = env:DsEnv.env -> S.term -> A.term
+
+val register_pass (_ : resugar_pass_t) : unit
+
 val resugar_term: S.term -> A.term
 val resugar_sigelt: S.sigelt -> option A.decl
 val resugar_comp: S.comp -> A.term


### PR DESCRIPTION
This allows plugins to extend resugaring with custom rules. To be used from Pulse, and others.