### PR TITLE
Remove wrong error clause about record updates

### DIFF
--- a/src/typechecker/FStarC.TypeChecker.Util.fst
+++ b/src/typechecker/FStarC.TypeChecker.Util.fst
@@ -3784,9 +3784,6 @@ let make_record_fields_in_order env uc topt
           (print_rdc rdc)
           (show (List.map fst fas))
     in
-    if not rdc.is_record then // This should not happen, there are external checks.
-      raise_error rng Errors.Error_CannotResolveRecord
-        (Format.fmt1 "Type '%s' is not a record type." (show topt));
     let rest, as_rev, missing =
       List.fold_left
         (fun (fields, as_rev, missing) (field_name, _) ->

--- a/tests/micro-benchmarks/RecordUpdate.fst
+++ b/tests/micro-benchmarks/RecordUpdate.fst
@@ -1,0 +1,5 @@
+module RecordUpdate
+
+(* This should work, even if `t` is not declared as a record.*)
+type t = | T : int -> t
+let f (x:t) = {x with _0 = 1}


### PR DESCRIPTION
This came from the fix to #3757, but it is excessive and forbids doing something like:
```fstar
type t = | T : int -> T
let f (x:t) = {x with _0 = 1}
```

Removing this error case is enough to allow this, and #3757 is still fixed. Reported by Karthik Bhargavan on Zulip:
https://fstar.zulipchat.com/#narrow/channel/184683-questions-and-help/topic/Functional.20update.20for.20datatypes/near/568973521