### PR TITLE
normalizer: fix wrong environment order for let rec

### DIFF
--- a/tests/bug-reports/closed/Bug4092.fst
+++ b/tests/bug-reports/closed/Bug4092.fst
@@ -1,0 +1,20 @@
+module Bug4092
+
+let is_zero (n: nat): bool =
+  let rec maybe_zero (n: nat): Tot bool (decreases n) =
+    if n = 0 then true
+    else not_zero (n - 1)
+  and not_zero (n: nat): Tot bool (decreases n) =
+    if n = 0 then false
+    else not_zero (n - 1)
+  in maybe_zero n
+
+let _ =
+  assert_norm (is_zero 0 = true);
+  assert_norm (is_zero 1 = false);
+  ()
+
+[@@expect_failure]
+let _ = assert_norm (is_zero 0 = false)
+[@@expect_failure]
+let _ = assert_norm (is_zero 1 = true)

--- a/tests/bug-reports/closed/Bug4092b.fst
+++ b/tests/bug-reports/closed/Bug4092b.fst
@@ -1,0 +1,17 @@
+module Bug4092b
+
+let is_even (n: nat): bool =
+  let rec even (n: nat): Tot bool (decreases n) =
+    if n = 0 then true
+    else odd (n - 1)
+  and odd (n: nat): Tot bool (decreases n) =
+    if n = 0 then false
+    else even (n - 1)
+  in even n
+
+let _ =
+  assert_norm (is_even 0 = true);
+  assert_norm (is_even 1 = false);
+  assert_norm (is_even 2 = true);
+  assert_norm (is_even 3 = false);
+  ()


### PR DESCRIPTION
Fixes #4092