### PR TITLE
Agents and skills for F* and Pulse

### DIFF
--- a/.github/agents/FStarCoder.md
+++ b/.github/agents/FStarCoder.md
@@ -1,3 +1,8 @@
+---
+name: FStarCoder
+description: An expert programmer in F* for proof-oriented programming tasks
+---
+
 # FStarCoder Agent
 
 ## Agent Identity
@@ -127,9 +132,7 @@ assert (pure (FS.cardinality (FS.remove x s) == FS.cardinality s - 1));
 
 ---
 
----
-
-## Pattern 4: OnRange Predicate Management
+## Pattern 3: OnRange Predicate Management
 
 ### Problem
 Working with iterated predicates over array ranges.
@@ -154,7 +157,7 @@ put_bucket_at ptrs contents 0 capacity idx;
 
 ---
 
-## Pattern 5: Bounds Checking for Machine Integers
+## Pattern 4: Bounds Checking for Machine Integers
 
 ### Problem
 Operations like `SZ.add` require proof that result fits.
@@ -176,7 +179,7 @@ let y = x `SZ.add` 1sz;  // Now this works
 
 ---
 
-## Pattern 6: Iterator State Management
+## Pattern 5: Iterator State Management
 
 ### Problem
 Iterators need to track position and remaining elements.
@@ -211,7 +214,7 @@ ensures exists* remaining'.
 
 ---
 
-## Pattern 7: Proof Debugging via Isolation
+## Pattern 6: Proof Debugging via Isolation
 
 ### Problem
 Complex proof fails; need to find specific failing assertion.
@@ -244,7 +247,7 @@ let complex_lemma () : Lemma (...) =
 
 ---
 
-## Pattern 8: Fractional Permission Accounting
+## Pattern 7: Fractional Permission Accounting
 
 ### Problem
 Need to track permissions distributed across multiple holders.
@@ -273,7 +276,7 @@ Need to track permissions distributed across multiple holders.
 
 ---
 
-## Pattern 9: Interface vs Implementation Verification
+## Pattern 8: Interface vs Implementation Verification
 
 ### Problem
 F* verifies files separately; interfaces constrain implementations.
@@ -292,7 +295,7 @@ fstar.exe --ext pulse Module.fst
 
 ---
 
-## Pattern 10: Rlimit Management
+## Pattern 9: Rlimit Management
 
 ### Problem
 High rlimits make proofs flaky and slow.

--- a/.github/agents/PulseCoder.md
+++ b/.github/agents/PulseCoder.md
@@ -1,3 +1,8 @@
+---
+name: PulseCoder
+description: An expert programmer in Pulse for concurrent separation logic programming
+---
+
 # PulseCoder Agent
 
 ## Agent Identity

--- a/.github/agents/USER_GUIDANCE_PATTERNS.md
+++ b/.github/agents/USER_GUIDANCE_PATTERNS.md
@@ -1,3 +1,8 @@
+---
+name: UserGuidancePatterns
+description: Patterns for guiding AI agents through F*/Pulse verification tasks
+---
+
 # User Guidance Patterns
 
 This document captures effective patterns for guiding an AI agent through complex F*/Pulse verification tasks, based on a 67-hour session.

--- a/.github/skills/fstarverifier/SKILL.md
+++ b/.github/skills/fstarverifier/SKILL.md
@@ -1,10 +1,7 @@
-# Skill: F* Verification
-
-## Skill Name
-fstarverifier
-
-## Description
-Use fstar.exe to verify F* code and interpret the errors reported.
+---
+name: fstarverifier
+description: Use fstar.exe to verify F* code and interpret the errors reported
+---
 
 ## Invocation
 This skill is used when:

--- a/.github/skills/pulseverifier/SKILL.md
+++ b/.github/skills/pulseverifier/SKILL.md
@@ -1,10 +1,7 @@
-# Skill: Pulse Verification
-
-## Skill Name
-pulseverifier
-
-## Description
-Use fstar.exe to verify Pulse code and interpret the errors reported.
+---
+name: pulseverifier
+description: Use fstar.exe to verify Pulse code and interpret the errors reported
+---
 
 ## Invocation
 This skill is used when:

--- a/.github/skills/smtprofiling/SKILL.md
+++ b/.github/skills/smtprofiling/SKILL.md
@@ -1,10 +1,7 @@
-# Skill: F* SMT profiling
-
-## Skill Name
-fstarsmtprofiling
-
-## Description
-Debug F* queries sent to Z3, diagnosing proof instability and performance issues
+---
+name: smtprofiling
+description: Debug F* queries sent to Z3, diagnosing proof instability and performance issues
+---
 
 ## Invocation
 This skill is used when:


### PR DESCRIPTION
I'm including agents and skills for F* and Pulse in the .github folder. I included Pulse here as well, since it is useful to have all agents and skills in a single .github folder, so that a session can cross references all the skills and capabilities. It's typical to have a clone of F* when working with Pulse anyway.