### PR TITLE
Implement FStar.Parse module (fixes #4103)

### DIFF
--- a/mk/lib.mk
+++ b/mk/lib.mk
@@ -26,6 +26,7 @@ EXTRACT_NS += -FStar.IO
 EXTRACT_NS += -FStar.List
 EXTRACT_NS += -FStar.List.Tot.Base
 EXTRACT_NS += -FStar.Option
+EXTRACT_NS += -FStar.Parse
 EXTRACT_NS += -FStar.Pervasives.Native
 EXTRACT_NS += -FStar.ST
 EXTRACT_NS += -FStar.Exn

--- a/stage0/ulib/ml/app/FStar_Parse.ml
+++ b/stage0/ulib/ml/app/FStar_Parse.ml
@@ -1,0 +1,13 @@
+open Prims
+let bool_of_string (s : Prims.string) :
+  Prims.bool FStar_Pervasives_Native.option =
+  match s with
+  | "true" -> Some true
+  | "false" -> Some false
+  | _ -> None
+
+let int_of_string (s : Prims.string) :
+  Prims.int FStar_Pervasives_Native.option =
+  if String.length s = 0 then None
+  else try Some (Z.of_string s)
+  with Invalid_argument _ -> None

--- a/tests/extraction/Makefile
+++ b/tests/extraction/Makefile
@@ -13,6 +13,7 @@ endif
 
 RUN += ExtractAs.fst
 RUN += InlineLet.fst
+RUN += ParseTest.fst
 
 include $(FSTAR_ROOT)/mk/test.mk
 

--- a/tests/extraction/ParseTest.fst
+++ b/tests/extraction/ParseTest.fst
@@ -1,0 +1,43 @@
+module ParseTest
+
+(** Regression test for GitHub issue #4103:
+    FStar.Parse module was not implemented at runtime. *)
+
+open FStar.IO
+open FStar.All
+open FStar.Parse
+
+let check (name: string) (b: bool) : ML unit =
+  if b then
+    print_string ("OK: " ^ name ^ "\n")
+  else begin
+    print_string ("FAIL: " ^ name ^ "\n");
+    failwith ("Test failed: " ^ name)
+  end
+
+(* Use a helper to prevent F* from reducing the calls at verification time,
+   so the extracted code actually exercises FStar_Parse at runtime. *)
+let parse_int (s: string) : ML (option int) = int_of_string s
+let parse_bool (s: string) : ML (option bool) = bool_of_string s
+
+let _ =
+  (* int_of_string tests *)
+  check "int_of_string empty" (parse_int "" = None);
+  check "int_of_string 1" (parse_int "1" = Some 1);
+  check "int_of_string -1" (parse_int "-1" = Some (0 - 1));
+  check "int_of_string 1234567890" (parse_int "1234567890" = Some 1234567890);
+  check "int_of_string 15x1" (parse_int "15x1" = None);
+  check "int_of_string x1" (parse_int "x1" = None);
+  check "int_of_string 0x100" (parse_int "0x100" = Some 256);
+  check "int_of_string 0b100" (parse_int "0b100" = Some 4);
+
+  (* bool_of_string tests *)
+  check "bool_of_string true" (parse_bool "true" = Some true);
+  check "bool_of_string false" (parse_bool "false" = Some false);
+  check "bool_of_string empty" (parse_bool "" = None);
+  check "bool_of_string yes" (parse_bool "yes" = None);
+
+  (* The repro from issue #4103: using int_of_string at runtime *)
+  (match parse_int "35" with
+   | None -> failwith "int_of_string 35 returned None"
+   | Some n -> print_string (string_of_int n ^ "\n"))

--- a/ulib/ml/app/FStar_Parse.ml
+++ b/ulib/ml/app/FStar_Parse.ml
@@ -1,0 +1,13 @@
+open Prims
+let bool_of_string (s : Prims.string) :
+  Prims.bool FStar_Pervasives_Native.option =
+  match s with
+  | "true" -> Some true
+  | "false" -> Some false
+  | _ -> None
+
+let int_of_string (s : Prims.string) :
+  Prims.int FStar_Pervasives_Native.option =
+  if String.length s = 0 then None
+  else try Some (Z.of_string s)
+  with Invalid_argument _ -> None


### PR DESCRIPTION
Provide native OCaml implementations for FStar.Parse.int_of_string and FStar.Parse.bool_of_string, which were previously extracted as 'Not yet implemented' stubs.

- ulib/ml/app/FStar_Parse.ml: native OCaml implementation using Z.of_string (supports decimal, hex 0x, binary 0b) and pattern matching for bool
- mk/lib.mk: exclude FStar.Parse from extraction to avoid duplicate module conflict with the native impl
- tests/extraction/ParseTest.fst: regression test that exercises both functions at runtime via extraction