### PR TITLE
Ignore top-level effect warnings when bootstrapping

### DIFF
--- a/mk/fstar-01.mk
+++ b/mk/fstar-01.mk
@@ -1,4 +1,5 @@
 FSTAR_OPTIONS += --lax
+FSTAR_OPTIONS += --warn_error -272 # top-level effects
 
 EXTRACT :=
 EXTRACT += --extract 'FStarC'

--- a/mk/fstar-12.mk
+++ b/mk/fstar-12.mk
@@ -1,4 +1,5 @@
 FSTAR_OPTIONS += --lax
+FSTAR_OPTIONS += --warn_error -272 # top-level effects
 
 EXTRACT :=
 EXTRACT += --extract 'FStarC'


### PR DESCRIPTION
There are several thousands of these.