### PR TITLE
Replace O(n) List.length emptiness checks with O(1) Nil?/Cons?

### DIFF
--- a/src/extraction/FStarC.Extraction.Krml.fst
+++ b/src/extraction/FStarC.Extraction.Krml.fst
@@ -747,7 +747,7 @@ let rec translate_type_without_decay' env t: ML typ =
       TTuple (List.map (translate_type_without_decay env) args)
   
   | MLTY_Named (args, lid) ->
-      if List.length args > 0 then
+      if Cons? args then
         TApp (lid, List.map (translate_type_without_decay env) args)
       else
         TQualified lid
@@ -1196,7 +1196,7 @@ and translate_expr' env e: ML expr =
 and assert_lid env t : ML typ =
   match t with
   | MLTY_Named (ts, lid) ->
-      if List.length ts > 0 then
+      if Cons? ts then
         TApp (lid, List.map (translate_type env) ts)
       else
         TQualified lid
@@ -1358,7 +1358,7 @@ let translate_let' env flavor lb: ML (option decl) =
         | MLE_Fun (bs, _) -> List.map (fun {mlbinder_name} -> mlbinder_name) bs
         | _ -> []
       in
-      if List.length tvars = 0 then
+      if Nil? tvars then
         Some (DExternal (translate_cc meta, translate_flags meta, name, translate_type env t0, arg_names))
       else begin
         if not (Options.silent ()) then

--- a/src/extraction/FStarC.Extraction.ML.Code.fst
+++ b/src/extraction/FStarC.Extraction.ML.Code.fst
@@ -133,7 +133,7 @@ let ptsym_of_symbol (s : mlsymbol) : ML mlsymbol =
     else s
 
 let ptsym (currentModule : mlsymbol) (mlp : mlpath) : ML mlsymbol =
-    if (List.isEmpty (fst mlp))
+    if (Nil? (fst mlp))
     then ptsym_of_symbol (snd  mlp)
     else
         let (p, s) = mlpath_of_mlpath currentModule mlp in
@@ -716,7 +716,7 @@ let doc_of_mltydecl (currentModule : mlsymbol) (decls : mltydecl) =
     in
 
     let doc = List.map for1 decls in
-    let doc = if (List.length doc >0) then reduce1 [text "type"; combine (text " \n and ") doc] else text "" in
+    let doc = if (Cons? doc) then reduce1 [text "type"; combine (text " \n and ") doc] else text "" in
     doc
 
 (* -------------------------------------------------------------------- *)

--- a/src/extraction/FStarC.Extraction.ML.Modul.fst
+++ b/src/extraction/FStarC.Extraction.ML.Modul.fst
@@ -870,7 +870,7 @@ let rec extract_sigelt_iface (g:uenv) (se:sigelt) : ML (uenv & iface) =
 
     | Sig_new_effect ed ->
       if TcUtil.effect_extraction_mode (tcenv_of_uenv g) ed.mname = S.Extract_reify
-      && List.isEmpty ed.binders //we do not extract parameterized effects
+      && Nil? ed.binders //we do not extract parameterized effects
       then let env, iface, _ = extract_reifiable_effect g ed in
            env, iface
       else g, empty_iface
@@ -961,7 +961,7 @@ let extract_bundle env se : ML (env_t & list mlmodule1) =
                    ([], env)
              in
              Some (MLTD_Record fields), g
-         | _ when List.length ctors = 0 ->
+         | _ when Nil? ctors ->
              None, env
          | _ ->
              Some (MLTD_DType ctors), env

--- a/src/extraction/FStarC.Extraction.ML.RegEmb.fst
+++ b/src/extraction/FStarC.Extraction.ML.RegEmb.fst
@@ -713,7 +713,7 @@ let __do_handle_plugin (g: uenv) (arity_opt: option int) (se: sigelt) : ML (list
     let mutual_lids = List.map (fun se -> match se.sigel with | Sig_inductive_typ {lid} -> lid ) mutual_sigelts in
     let proc_one (typ_sigelt:sigelt) =
       let Sig_inductive_typ {lid=tlid; params=ps} = typ_sigelt.sigel in
-      if List.length ps > 0 then
+      if Cons? ps then
         raise (Unsupported "parameters on inductive");
       let ns = Ident.ns_of_lid tlid in
       let name = Ident.string_of_id (List.last (Ident.ids_of_lid tlid)) in

--- a/src/parser/FStarC.Parser.Dep.fst
+++ b/src/parser/FStarC.Parser.Dep.fst
@@ -1292,7 +1292,7 @@ let deps_from_parsing_data (pd:parsing_data) (original_map:files_for_module_name
   in
 
   let begin_module lid =
-    if List.length (ns_of_lid lid) > 0 then (
+    if Cons? (ns_of_lid lid) then (
       if !dbg then Format.print1 "Begin module %s ..\n" (show lid);
       ignore (enter_namespace original_map working_map (String.lowercase (namespace_of_lid lid)))
     )

--- a/src/parser/FStarC.Parser.ToDocument.fst
+++ b/src/parser/FStarC.Parser.ToDocument.fst
@@ -73,7 +73,7 @@ let rec all (f: 'a -> bool) (l: list 'a): bool =
   | x :: xs -> if f x then all f xs else false
 
 let all1_explicit (args:list (term&imp)) : ML bool =
-    not (List.isEmpty args) &&
+    Cons? args &&
     BU.for_all (function
                 | (_, Nothing) -> true
                 | _ -> false) args
@@ -1811,7 +1811,7 @@ and format_sig style terms ret_d no_last_op flat_space : ML _ =
     | Binders (n, ln, parens) ->
         n, ln, break1, colon ^^ space
   in
-  let last_op = if List.length terms > 0 && (not no_last_op) then last_op else empty in
+  let last_op = if Cons? terms && (not no_last_op) then last_op else empty in
   let one_line_space = if not (ret_d = empty) || not no_last_op then space else empty in
   let single_line_arg_indent = repeat n space in
   let fs = if flat_space then space else empty in
@@ -2310,7 +2310,7 @@ let extract_decl_range (d: decl): decl_meta =
   in
   { r = d.drange;
     has_qs = has_qs;
-    has_attrs = not (List.isEmpty d.attrs); }
+    has_attrs = not (Nil? d.attrs); }
 
 let decls_with_comments_to_document (decls:list decl) comments =
   match decls with

--- a/src/reflection/FStarC.Reflection.V1.Builtins.fst
+++ b/src/reflection/FStarC.Reflection.V1.Builtins.fst
@@ -335,7 +335,7 @@ let pack_comp (cv : comp_view) : ML comp =
     | C_Eff (us, ef, res, args, decrs) ->
         let pack_arg (a, q) = (a, pack_aqual q) in
         let flags =
-          if List.length decrs = 0
+          if Nil? decrs
           then []
           else [DECREASES (Decreases_lex decrs)] in
         let ct = { comp_univs  = us

--- a/src/reflection/FStarC.Reflection.V2.Builtins.fst
+++ b/src/reflection/FStarC.Reflection.V2.Builtins.fst
@@ -334,7 +334,7 @@ let pack_comp (cv : comp_view) : ML comp =
     | C_Eff (us, ef, res, args, decrs) ->
         let pack_arg (a, q) = (a, pack_aqual q) in
         let flags =
-          if List.length decrs = 0
+          if Nil? decrs
           then []
           else [DECREASES (Decreases_lex decrs)] in
         let ct = { comp_univs  = us

--- a/src/smtencoding/FStarC.SMTEncoding.Encode.fst
+++ b/src/smtencoding/FStarC.SMTEncoding.Encode.fst
@@ -467,7 +467,7 @@ let encode_free_var uninterpreted env fv us tt t_norm quals : ML (decls_t & env_
          let dd = Term.DeclFun(vtok, univ_sorts, Term_sort, Some "Uninterpreted name for impure function") in
          [d;dd] |> mk_decls_trivial, env
     else if prims.is lid
-         then let _ = if List.length us <> 0 then failwith "Impossible: unexpected universe-polymorphic primitive function" in
+         then let _ = if Cons? us then failwith "Impossible: unexpected universe-polymorphic primitive function" in
               let vname = varops.new_fvar lid in
               let tok, arity, definition = prims.mk lid vname in
               let env = push_free_var env lid arity 0 vname (Some tok) in
@@ -536,7 +536,7 @@ let encode_free_var uninterpreted env fv us tt t_norm quals : ML (decls_t & env_
                 in
                 // Thunk if ...
                 nsstr lid <> "Prims"  //not in prims
-                && List.length us = 0 //has no universe binders
+                && Nil? us //has no universe binders
                 && not (quals |> List.contains Logic) //not logic qualified terms
                 && not (is_squash t_norm) //not ambient squashed properties
                 && not (is_type t_norm) //not : Type terms, since ambient typing hypotheses for these are cheap
@@ -1291,7 +1291,7 @@ let encode_sig_inductive (env:env_t) (se:sigelt)
   let kindingAx =
     let k, decls = encode_term_pred None res env' tapp in
     let karr =
-      if List.length formals > 0
+      if Cons? formals
       then [Util.mkAssume(
           mkForall (Ident.range_of_lid t) ([[ttok_tm]], univ_vars, mk_tester "Tm_arrow" (mk_PreType ttok_tm)),
           Some "pretyping", ("pre_kinding_"^ttok))]

--- a/src/smtencoding/FStarC.SMTEncoding.Term.fst
+++ b/src/smtencoding/FStarC.SMTEncoding.Term.fst
@@ -535,13 +535,13 @@ let mkQuant r check_pats (qop, pats, wopt, vars, body) =
             []
            end
     in
-    if List.length vars = 0 then body
+    if Nil? vars then body
     else match body.tm with
          | App(TrueOp, _) -> body
          | _ -> mk (Quant(qop, all_pats_ok pats, wopt, vars, body)) r
 
 let mkLet (es, body) r =
-  if List.length es = 0 then body
+  if Nil? es then body
   else mk (Let (es,body)) r
 
 (*****************************************************)

--- a/src/syntax/FStarC.Syntax.DsEnv.fst
+++ b/src/syntax/FStarC.Syntax.DsEnv.fst
@@ -61,7 +61,7 @@ let rec list_sep2 #a (s1 s2 : a) (xs : list a) : list a =
 let typo_msg (x : string) (xs : list string) : ML Pprint.document =
   let open FStarC.Pprint in
   let cands = typo_candidates x xs in
-  if List.length cands = 0
+  if Nil? cands
   then empty
   else
     nest 2 <| text "Hint: Did you mean" ^/^
@@ -98,7 +98,7 @@ type scope_mod =
 | Record_or_dc             of record_or_dc    (* to honor interleavings of "open" and record definitions *)
 
 let namespace_scope_of_module mname : ML _ =
-  if List.length (ns_of_lid mname) > 0
+  if Cons? (ns_of_lid mname)
   then [ (lid_of_ids (ns_of_lid mname), Open_namespace, Unrestricted) ]
   else []
 
@@ -615,7 +615,7 @@ let shorten_module_path env ids is_full_path : ML _ =
       | None -> ([], ids)
       | Some (stripped_ids, rev_kept_ids) -> (stripped_ids, List.rev rev_kept_ids) in
 
-  if is_full_path && List.length ids > 0 then
+  if is_full_path && Cons? ids then
     // Try to strip the entire prefix.  This is the cheap common case.
     match resolve_module_name env (FStarC.Ident.lid_of_ids ids) true with
     | Some m when module_is_open env m -> (ids, [])
@@ -1760,7 +1760,7 @@ let fail_or env lookup lid : ML _ =
     (* We couldn't find it. Try to report a nice error. *)
     let opened_modules = List.map (fun (lid, _) -> string_of_lid lid) env.modules in
     let open FStarC.Class.PP in
-    if List.length (ns_of_lid lid) = 0 then begin
+    if Nil? (ns_of_lid lid) then begin
       if Debug.any()
       then Format.print2 "Dump env (is iface=%s):\n%s\n" (show env.iface) (show env);
       raise_error lid Errors.Fatal_IdentifierNotFound [

--- a/src/syntax/FStarC.Syntax.Resugar.fst
+++ b/src/syntax/FStarC.Syntax.Resugar.fst
@@ -431,7 +431,7 @@ let rec resugar_term_base' (env: DsEnv.env) (t : S.term) : ML A.term =
       in
       let body = resugar_term' env body in
       (* If no binders/patterns remain after filtering, drop the Abs node *)
-      if List.isEmpty patterns
+      if Nil? patterns
       then body
       else mk (A.Abs(patterns, body))
 
@@ -533,7 +533,7 @@ let rec resugar_term_base' (env: DsEnv.env) (t : S.term) : ML A.term =
       in
       (* We have a projector, applied to at least one argument, and the first argument
       is explicit (so not one of the parameters of the type). In this case we resugar nicely. *)
-      if Some? (is_projector e) && List.length args >= 1 && None? (snd (List.hd args)) then
+      if Some? (is_projector e) && Cons? args && None? (snd (List.hd args)) then
         let arg1 :: rest_args = args in
         let (_, fi) = Some?.v (is_projector e) in
         let arg = resugar_term' env (fst arg1) in
@@ -770,7 +770,7 @@ let rec resugar_term_base' (env: DsEnv.env) (t : S.term) : ML A.term =
           in
           (* only the last arg is from original AST terms, others are added by typechecker *)
           (* TODO: we need a place to store the information in the args added by the typechecker *)
-          if List.length args > 0 then
+          if Cons? args then
             let args = last args in
             begin match args with
               | [(b, _)] -> resugar_forall_body b

--- a/src/tactics/FStarC.Tactics.Hooks.fst
+++ b/src/tactics/FStarC.Tactics.Hooks.fst
@@ -868,7 +868,7 @@ let splice
             // For spliced vals, their lids is set to []
             //   (see ToSyntax.fst:desugar_decl, splice case)
             //
-            if List.length lids = 0
+            if Nil? lids
             then None, None
             else
               match Env.try_lookup_val_decl env (List.hd lids) with

--- a/src/tactics/FStarC.Tactics.V1.Basic.fst
+++ b/src/tactics/FStarC.Tactics.V1.Basic.fst
@@ -2308,7 +2308,7 @@ let refl_typing_builtin_wrapper (f:unit -> 'a)  : ML (tac (option 'a & issues)) 
       [issue], None
   in
   UF.rollback tx;
-  if List.length errs > 0
+  if Cons? errs
   then ret (None, errs)
   else ret (r, errs)
 

--- a/src/tactics/FStarC.Tactics.V2.Basic.fst
+++ b/src/tactics/FStarC.Tactics.V2.Basic.fst
@@ -2306,7 +2306,7 @@ let __refl_typing_builtin_wrapper (f:unit -> ML ('a & list refl_guard_and_tok_t)
   UF.rollback tx;
 
   (* Make sure to return None if any error was logged. *)
-  if List.length errs > 0
+  if Cons? errs
   then return (None, errs)
   else (
     (* Try to discharge the guards, but if any of them fails, return a decent error. *)

--- a/src/tosyntax/FStarC.ToSyntax.ToSyntax.fst
+++ b/src/tosyntax/FStarC.ToSyntax.ToSyntax.fst
@@ -1053,7 +1053,7 @@ and desugar_term_maybe_top (top_level:bool) (env:env_t) (top:term) : ML (S.term 
                     ("Unexpected or unbound operator: " ^
                      Ident.string_of_id s)
       | Some op ->
-            if List.length args > 0 then
+            if Cons? args then
               let args, aqs = args |> List.map (fun t -> let t', s = desugar_term_aq env t in
                                                          (t', None), s) |> List.unzip in
               mk (Tm_app {hd=op; args}), join_aqs aqs
@@ -1147,7 +1147,7 @@ and desugar_term_maybe_top (top_level:bool) (env:env_t) (top:term) : ML (S.term 
                   arg_withimp_t imp te, aq) args |> List.unzip in
                 let head = if universes = [] then head else mk (Tm_uinst(head, universes)) in
                 let tm =
-                  if List.length args = 0
+                  if Nil? args
                   then head
                   else mk (Tm_app {hd=head; args}) in
                 tm, join_aqs aqs
@@ -2370,7 +2370,7 @@ and desugar_comp r (allow_type_promotion:bool) env t : ML _ =
         raise_error t Errors.Fatal_EffectNotFound "Expected an effect constructor"
     in
     let (eff, cattributes), args = pre_process_comp_typ t in
-    if List.length args = 0 then
+    if Nil? args then
       fail Errors.Fatal_NotEnoughArgsToEffect (Format.fmt1 "Not enough args to effect %s" (show eff));
     let is_universe (_, imp) = imp = UnivApp in
     let universes, args = BU.take is_universe args in
@@ -3805,7 +3805,7 @@ and desugar_decl_core env (d_attrs:list S.term) (d:decl) : ML (env_t & sigelts) 
        * which will trigger a check for completeness of pat
        * wrt the body. (See issues #829 and #1903)
        *)
-      if List.isEmpty bvs && not (is_var_pattern pat)
+      if Nil? bvs && not (is_var_pattern pat)
       then build_coverage_check main_let
       else List.fold_left build_projection main_let bvs
 

--- a/src/typechecker/FStarC.TypeChecker.DMFF.fst
+++ b/src/typechecker/FStarC.TypeChecker.DMFF.fst
@@ -297,7 +297,7 @@ let gen_wps_for_free
 
   let ret_tot_wp_a = Some (U.residual_tot wp_a) in
   let mk_generic_app c =
-    if List.length binders > 0 then
+    if Cons? binders then
       mk (Tm_app {hd=c; args=args_of_binders binders})
     else
       c
@@ -1519,7 +1519,7 @@ let cps_and_elaborate (env:FStarC.TypeChecker.Env.env) (ed:S.eff_decl)
   in
 
   let apply_close t =
-    if List.length effect_binders = 0 then
+    if Nil? effect_binders then
       t
     else
       close effect_binders (mk (Tm_app {hd=t; args=snd (U.args_of_binders effect_binders)}))
@@ -1687,7 +1687,7 @@ let cps_and_elaborate (env:FStarC.TypeChecker.Env.env) (ed:S.eff_decl)
     Format.print_string (show ed);
 
   let lift_from_pure_opt =
-    if List.length effect_binders = 0 then begin
+    if Nil? effect_binders then begin
       // Won't work with parameterized effect
       let lift_from_pure = {
           source = PC.effect_PURE_lid;

--- a/src/typechecker/FStarC.TypeChecker.Env.fst
+++ b/src/typechecker/FStarC.TypeChecker.Env.fst
@@ -1224,7 +1224,7 @@ let get_lid_valued_effect_attr env
     match attr_args with
     | None -> None
     | Some args ->
-      if List.length args = 0
+      if Nil? args
       then default_if_attr_has_no_arg
       else args
            |> List.hd

--- a/src/typechecker/FStarC.TypeChecker.PatternUtils.fst
+++ b/src/typechecker/FStarC.TypeChecker.PatternUtils.fst
@@ -251,7 +251,7 @@ let pat_as_exp (introduce_bv_uvars:bool)
                || Some? us_opt
                then inst_head hd us_opt, us_opt
                else let us, _ = Env.lookup_datacon env (Syntax.lid_of_fv fv) in
-                    if List.length us = 0 then hd, Some []
+                    if Nil? us then hd, Some []
                     else Syntax.mk_Tm_uinst hd us, Some us
              in
              let e = mk_Tm_app hd (args |> List.rev) p.p in

--- a/src/typechecker/FStarC.TypeChecker.Rel.fst
+++ b/src/typechecker/FStarC.TypeChecker.Rel.fst
@@ -998,7 +998,7 @@ let ensure_no_uvar_subst env (t0:term) (wl:worklist)
       (* No subst, nothing to do *)
       t0, wl
 
-    | Tm_uvar (uv, _) when List.isEmpty uv.ctx_uvar_binders ->
+    | Tm_uvar (uv, _) when Nil? uv.ctx_uvar_binders ->
       (* No binders in scope, also good *)
       t0, wl
 
@@ -1254,7 +1254,7 @@ let restrict_ctx env (tgt:ctx_uvar) (bs:binders) (src:ctx_uvar) wl : ML worklist
     (src.ctx_uvar_binders |> List.existsb (fun ({binder_bv=bv2}) -> S.bv_eq bv1 bv2)) &&  //binder exists in G_t
     (not (pfx |> List.existsb (fun ({binder_bv=bv2}) -> S.bv_eq bv1 bv2)))) in  //but not in the maximal prefix
 
-  if List.length bs = 0 then aux (U.ctx_uvar_typ src) (fun src' -> src')  //no abstraction over bs
+  if Nil? bs then aux (U.ctx_uvar_typ src) (fun src' -> src')  //no abstraction over bs
   else begin
     aux
       (let t = U.ctx_uvar_typ src in t |> S.mk_Total |> U.arrow bs)  //bs -> Tot t_t

--- a/src/typechecker/FStarC.TypeChecker.Tc.fst
+++ b/src/typechecker/FStarC.TypeChecker.Tc.fst
@@ -208,7 +208,7 @@ let tc_inductive' env ses quals attrs lids =
       //assuming that we have already propagated attrs from the bundle to its elements
       let is_erasable () = U.has_attribute (List.hd tcs).sigattrs FStarC.Parser.Const.erasable_attr in
 
-      List.length tcs = 0 ||
+      Nil? tcs ||
       (lid_equals env.curmodule PC.prims_lid && skip_prims_type ()) ||
       is_noeq ||
       is_erasable () in

--- a/src/typechecker/FStarC.TypeChecker.TcEffect.fst
+++ b/src/typechecker/FStarC.TypeChecker.TcEffect.fst
@@ -559,7 +559,7 @@ let subcomp_combinator_kind (env:env)
 
   // peel off the f:repr a is binder
   let? rest_bs, f_b =
-    if List.length rest_bs >= 1
+    if Cons? rest_bs
     then let rest_bs, [f_b] = List.splitAt (List.length rest_bs - 1) rest_bs in
          (rest_bs, f_b) |> Some
     else None in
@@ -1058,7 +1058,7 @@ let lift_combinator_kind (env:env)
     (f_bs, f_bs_kinds, rest_bs) |> Some in
 
   let? rest_bs, f_b =
-    if List.length rest_bs >= 1
+    if Cons? rest_bs
     then let rest_bs, [f_b] = List.splitAt (List.length rest_bs - 1) rest_bs in
          (rest_bs, f_b) |> Some
     else None in
@@ -2499,14 +2499,14 @@ let tc_lift env sub r : ML _ =
       | lift, Some (uvs, lift_wp) ->
         //AR: open the universes, if present (two phases)
         let env, lift_wp =
-          if List.length uvs > 0 then
+          if Cons? uvs then
             let usubst, uvs = SS.univ_var_opening uvs in
             Env.push_univ_vars env uvs, SS.subst usubst lift_wp
           else env, lift_wp
         in
         (* Covers both the "classic" format and the reifiable case. *)
         //AR: if universes are already annotated, simply close, else generalize
-        let lift_wp = if List.length uvs = 0 then check_and_gen env lift_wp expected_k
+        let lift_wp = if Nil? uvs then check_and_gen env lift_wp expected_k
                       else let lift_wp = tc_check_trivial_guard env lift_wp expected_k in uvs, SS.close_univ_vars uvs lift_wp
         in
         lift, lift_wp
@@ -2514,7 +2514,7 @@ let tc_lift env sub r : ML _ =
       | Some (what, lift), None ->
         //AR: open the universes if present (two phases)
         let uvs, lift =
-          if List.length what > 0
+          if Cons? what
           then let usubst, uvs = SS.univ_var_opening what in
                uvs, SS.subst usubst lift
           else [], lift
@@ -2527,7 +2527,7 @@ let tc_lift env sub r : ML _ =
         let _, lift_wp, lift_elab = DMFF.star_expr dmff_env lift in
         let lift_wp = DMFF.recheck_debug "lift-wp" env lift_wp in
         let lift_elab = DMFF.recheck_debug "lift-elab" env lift_elab in
-        if List.length uvs = 0 then Some (Gen.generalize_universes env lift_elab), Gen.generalize_universes env lift_wp
+        if Nil? uvs then Some (Gen.generalize_universes env lift_elab), Gen.generalize_universes env lift_wp
         else Some (uvs, SS.close_univ_vars uvs lift_elab), (uvs, SS.close_univ_vars uvs lift_wp)
     in
     (* we do not expect the lift to verify, *)
@@ -2555,7 +2555,7 @@ let tc_lift env sub r : ML _ =
       let expected_k, _, _ =
         tc_tot_or_gtot_term env expected_k in
       let lift =
-        if List.length uvs = 0 then check_and_gen env lift expected_k
+        if Nil? uvs then check_and_gen env lift expected_k
         else
           let lift = tc_check_trivial_guard env lift expected_k in
           uvs, SS.close_univ_vars uvs lift in
@@ -2581,7 +2581,7 @@ let tc_effect_abbrev env (lid_uvs_tps_c: lident & univ_names & binders & comp) r
 
   //AR: open universes in tps and c if needed
   let env, uvs, tps, c =
-    if List.length uvs = 0 then env, uvs, tps, c
+    if Nil? uvs then env, uvs, tps, c
     else
       let usubst, uvs = SS.univ_var_opening uvs in
       let tps = SS.subst_binders usubst tps in

--- a/src/typechecker/FStarC.TypeChecker.TcInductive.fst
+++ b/src/typechecker/FStarC.TypeChecker.TcInductive.fst
@@ -839,7 +839,7 @@ let check_inductive_well_typedness (env:env_t) (ses:list sigelt) (quals:list qua
   //    we record whether the universes were already annotated
   //    and later use it to decide if we should generalize
   let univs =
-    if List.length tys = 0 then []
+    if Nil? tys then []
     else
       match (List.hd tys).sigel with
       | Sig_inductive_typ {us=uvs} -> uvs
@@ -875,7 +875,7 @@ let check_inductive_well_typedness (env:env_t) (ses:list sigelt) (quals:list qua
     then Format.print1 "@@@@@@Guard before (possible) generalization: %s\n" (Rel.guard_to_string env g);
 
     Rel.force_trivial_guard env0 g;
-    if List.length univs = 0 then generalize_and_inst_within env0 tcs datas
+    if Nil? univs then generalize_and_inst_within env0 tcs datas
     else (List.map fst tcs), datas
   in
 

--- a/src/typechecker/FStarC.TypeChecker.TcTerm.fst
+++ b/src/typechecker/FStarC.TypeChecker.TcTerm.fst
@@ -473,7 +473,7 @@ let check_no_smt_theory_symbols (en:env) (t:term) : ML unit =
     | Tm_meta {tm=t} -> aux t
   in
   let tlist = t |> pat_terms |> List.collect aux in
-  if List.length tlist = 0 then ()  //did not find any offending term
+  if Nil? tlist then ()  //did not find any offending term
   else
     let open FStarC.Pprint in
     let open FStarC.Class.PP in
@@ -4265,7 +4265,7 @@ and build_let_rec_env _top_level env lbs : ML (list letbinding & env_t & guard_t
 
      // TODO: There's a similar error in check_let_recs, would be nice
      // to remove this one.
-     if List.isEmpty formals || List.isEmpty actuals then
+     if Nil? formals || Nil? actuals then
        // TODO: GM: maybe point to the one that's actually empty?
        raise_error lbtyp Errors.Fatal_RecursiveFunctionLiteral [
          text "Only function literals with arrow types can be defined recursively.";
@@ -4373,7 +4373,7 @@ and check_let_recs env lbts : ML _ =
         in
         let bs0, bs1 = List.splitAt arity bs in
         let def =
-            if List.isEmpty bs1
+            if Nil? bs1
             then U.abs bs0 t lcomp
             else let inner = U.abs bs1 t lcomp in
                  let inner = SS.close bs0 inner in
@@ -4415,7 +4415,7 @@ and check_let_bound_def top_level env lb
 
     (* 2. type-check e1 *)
     (* Only toplevel terms should have universe openings *)
-    assert ( top_level || List.length univ_opening = 0 );
+    assert ( top_level || Nil? univ_opening );
     let e1 = subst univ_opening e1 in
     let e1, c1, g1 = tc_maybe_toplevel_term ({env1 with top_level=top_level}) e1 in
 
@@ -4644,7 +4644,7 @@ let level_of_type env e t : ML _ =
 
 (* private *)
 let rec apply_well_typed env (t_hd:typ) (args:args) : ML (option typ) =
-  if List.length args = 0
+  if Nil? args
   then Some t_hd
   else match (N.unfold_whnf env t_hd).n with
        | Tm_arrow {bs; comp=c} ->

--- a/src/typechecker/FStarC.TypeChecker.Util.fst
+++ b/src/typechecker/FStarC.TypeChecker.Util.fst
@@ -3507,7 +3507,7 @@ let lift_tf_layered_effect_term env (sub:sub_eff)
   let rest_bs =
     let lift_t = sub.lift_wp |> Option.must in
     match (lift_t |> snd |> SS.compress).n with
-    | Tm_arrow {bs=_::bs} when List.length bs >= 1 ->
+    | Tm_arrow {bs=_::bs} when Cons? bs ->
       bs |> List.splitAt (List.length bs - 1) |> fst
     | _ ->
       raise_error (snd lift_t) Errors.Fatal_UnexpectedEffect


### PR DESCRIPTION
Systematically replace patterns like:
  - List.length x = 0  →  Nil? x
  - List.length x > 0  →  Cons? x
  - List.length x <> 0 →  Cons? x
  - List.length x >= 1 →  Cons? x

List.length traverses the entire list (O(n)) just to check if it is empty. Nil?/Cons? are O(1) discriminators.

48 replacements across 25 files in the compiler source.