### PR TITLE
Port ternary hoisting fix: stateful if/match conditions

### DIFF
--- a/pulse/src/checker/Pulse.Checker.Base.fst
+++ b/pulse/src/checker/Pulse.Checker.Base.fst
@@ -21,6 +21,7 @@ module T = FStar.Tactics.V2
 module RT = FStar.Reflection.Typing
 module CP = Pulse.Checker.Pure
 module RU = Pulse.RuntimeUtils
+module RB = Pulse.Readback
 open Pulse.Checker.Util
 open Pulse.Show
 
@@ -594,12 +595,78 @@ let bind_st_term (g:env) (s:st_term)
   let g = Pulse.Typing.Env.push_binding g x b.binder_ppname b.binder_ty in
   g, b, x, RT.var_as_term x
 
+(* Hoist a single F*-level Tv_Match branch body by delegating to maybe_hoist.
+   Returns the body as an st_term and whether any hoisting was done. *)
+let hoist_branch_body (g:env) (body:term) (rng:Range.range)
+  (maybe_hoist_fn: env -> T.argv -> T.Tac (env & list (binder & var & st_term) & T.argv))
+: T.Tac (st_term & bool)
+= let body_rng = RU.range_of_term body in
+  let (_g', binders, (body', _q)) = maybe_hoist_fn g (body, R.Q_Explicit) in
+  match binders with
+  | [] ->
+    (mk_term (Tm_Return {expected_type=tm_unknown;insert_eq=false;term=body}) body_rng, false)
+  | _ ->
+    let ret = mk_term (Tm_Return {expected_type=tm_unknown;insert_eq=false;term=body'}) body_rng in
+    let final_st = List.Tot.fold_right
+      (fun (b, v, arg) (acc:st_term) ->
+        let acc' = Pulse.Syntax.Naming.close_st_term acc v in
+        mk_term (Tm_Bind { binder = b; head = arg; body = acc' }) rng)
+      binders
+      ret
+    in
+    (final_st, true)
+
+(* Process all branches of an F*-level Tv_Match, hoisting stateful apps
+   in each branch body. Returns processed branches and whether any changed. *)
+let rec process_fstar_match_branches
+  (g:env) (rng:Range.range)
+  (brs: list (R.pattern & term))
+  (maybe_hoist_fn: env -> T.argv -> T.Tac (env & list (binder & var & st_term) & T.argv))
+: T.Tac (list (R.pattern & st_term) & bool)
+= match brs with
+  | [] -> ([], false)
+  | (pat, body) :: rest ->
+    let (body_st, changed) = hoist_branch_body g body rng maybe_hoist_fn in
+    let (rest_results, rest_changed) = process_fstar_match_branches g rng rest maybe_hoist_fn in
+    ((pat, body_st) :: rest_results, changed || rest_changed)
+
+(* Convert an F*-level Tv_Match with stateful branches into a Pulse st_term.
+   Produces Tm_If for 2-branch matches (F*-level if/then/else), Tm_Match otherwise. *)
+let convert_fstar_match (g:env) (t:term)
+  (maybe_hoist_fn: env -> T.argv -> T.Tac (env & list (binder & var & st_term) & T.argv))
+: T.Tac (option st_term)
+= match R.inspect_ln t with
+  | R.Tv_Match sc _ret brs ->
+    let rng = RU.range_of_term t in
+    let (results, any_changed) = process_fstar_match_branches g rng brs maybe_hoist_fn in
+    if any_changed then (
+      let sc_st = mk_term (Tm_Return {expected_type=tm_unknown;insert_eq=false;term=sc}) (RU.range_of_term sc) in
+      Some (match results with
+        | [(_pat1, body1); (_pat2, body2)] ->
+          mk_term (Tm_If { b = sc_st; then_ = body1; else_ = body2; post = None }) rng
+        | _ ->
+          let pulse_brs : list branch = T.map (fun (rpat, e) ->
+            match RB.readback_pat rpat with
+            | Some p -> { pat = p; e; norw = FStar.Sealed.seal false }
+            | None -> T.fail "Cannot readback pattern from F*-level match during hoisting"
+          ) results in
+          mk_term (Tm_Match { sc = sc_st; returns_ = None; brs = pulse_brs }) rng)
+    ) else None
+  | _ -> None
+
 let rec maybe_hoist (g:env) (arg:T.argv)
 : T.Tac (env & list (binder & var & st_term) & T.argv)
 = let t, q = arg in
   let head, args = T.collect_app_ln t in
   match args with
-  | [] -> g, [], arg //no args to hoist
+  | [] ->
+    // No application args. Check if the term is an F*-level Tv_Match
+    // with stateful operations in its branches (issue #443 "hard case").
+    (match convert_fstar_match g t maybe_hoist with
+     | Some st_cond ->
+       let g, b, x, var_t = bind_st_term g st_cond in
+       g, [b, x, st_cond], (var_t, q)
+     | None -> g, [], arg)
   | _ ->
   match is_stateful_application g t with
   | None -> (
@@ -664,7 +731,20 @@ let hoist_stateful_apps
   | Some (head, args, rebuild) ->
     let _, binders, args = maybe_hoist_args g args in
     match args with
-    | [] -> None
+    | [] ->
+      // No args after decomposition. Check if the term is an F*-level
+      // Tv_Match with stateful branches (the "hard case" from #443).
+      (match tt with
+       | Inl t ->
+         (match convert_fstar_match g t maybe_hoist with
+          | Some st_cond ->
+            let rng = RU.range_of_term t in
+            let _, b, v, var_t = bind_st_term g st_cond in
+            let bind_term = context (Inl var_t) in
+            let body = Pulse.Syntax.Naming.close_st_term bind_term v in
+            Some (mk_term (Tm_Bind { binder = b; head = st_cond; body }) rng)
+          | None -> None)
+       | _ -> None)
     | _ ->
       let tt' = rebuild args in
       let _, binders', tt' = maybe_hoist_top (hoist_top_level && Inl? tt) g tt' in 

--- a/pulse/src/checker/Pulse.Checker.If.fst
+++ b/pulse/src/checker/Pulse.Checker.If.fst
@@ -47,15 +47,18 @@ let check
   (pre:term)
   (post_hint:post_hint_opt g)
   (res_ppname:ppname)
-  (b:term)
+  (b:st_term)
   (e1 e2:st_term)
   (check:check_t)
   : T.Tac (checker_result_t g pre post_hint) =
   
   let g = Pulse.Typing.Env.push_context g "check_if" e1.range in
 
-  let b =
-    check_tot_term g b tm_bool in
+  let b : term =
+    match b.term with
+    | Tm_Return { term=bt } -> check_tot_term g bt tm_bool
+    | _ -> fail g (Some b.range) "check_if: expected a pure condition (Tm_Return); stateful conditions should have been elaborated away"
+  in
 
   let hyp = fresh g in
 
@@ -128,7 +131,8 @@ let check
 
   let c_typing = comp_typing_from_post_hint c post_hint' in
 
-  let if_st = wrst c (Tm_If { b; then_=e1; else_=e2; post=None }) in
+  let b_st = mk_term (Tm_Return { expected_type = tm_bool; insert_eq = false; term = b }) e1.range in
+  let if_st = wrst c (Tm_If { b=b_st; then_=e1; else_=e2; post=None }) in
   let d : st_typing_in_ctxt g pre (PostHint post_hint') =
     (| if_st, c |) in
 

--- a/pulse/src/checker/Pulse.Checker.If.fsti
+++ b/pulse/src/checker/Pulse.Checker.If.fsti
@@ -27,7 +27,7 @@ val check
   (pre:term)
   (post_hint:post_hint_opt g)
   (res_ppname:ppname)
-  (b:term)
+  (b:st_term)
   (e1 e2:st_term)
   (check:check_t)
   : T.Tac (checker_result_t g pre post_hint)

--- a/pulse/src/checker/Pulse.Checker.Match.fst
+++ b/pulse/src/checker/Pulse.Checker.Match.fst
@@ -22,6 +22,7 @@ open Pulse.Typing
 open Pulse.Checker.Pure
 open Pulse.Checker.Base
 open Pulse.Checker.Prover
+open Pulse.Readback
 
 module T = FStar.Tactics.V2
 module L = FStar.List.Tot.Base
@@ -30,153 +31,6 @@ module RT = FStar.Reflection.Typing
 module RU = Pulse.RuntimeUtils
 
 let br_typing_vis (g:env) (_:universe) (_:typ) (_:term) (_:pattern) (_:st_term) (_:comp_st) : Type = unit
-
-let rec readback_pat (p : R.pattern) : option pattern =
-  match p with
-  | R.Pat_Cons fv _ args ->
-    let fv = R.inspect_fv fv in
-    let? args = map_opt_dec p readback_sub_pat args in
-    Some (Pat_Cons {fv_name=fv; fv_range=Range.range_0} args)
-
-  | R.Pat_Constant c ->
-    Some (Pat_Constant c)
-
-  | R.Pat_Var st nm ->
-    Some (Pat_Var nm (RU.map_seal st RU.deep_compress))
-    
-  | R.Pat_Dot_Term None -> Some (Pat_Dot_Term None)
-  | R.Pat_Dot_Term (Some t) ->
-    if R.Tv_Unknown? (R.inspect_ln t)
-    then None
-    else
-      let t = RU.deep_compress t in
-      let t = wr t Range.range_0 in
-      Some (Pat_Dot_Term (Some t))
-
-  | _ -> None
-
-and readback_sub_pat (pb : R.pattern & bool) : option (pattern & bool) =
-  let (p, b) = pb in
-  let? p = readback_pat p in
-  Some (p, b)
-
-let rec lemma_map_len (f : 'a -> 'b) (xs : list 'a)
-  : Lemma (L.length (L.map f xs) == L.length xs)
-          [SMTPat (L.length (L.map f xs))]
-  = match xs with
-    | [] -> ()
-    | x::xs -> lemma_map_len f xs
-
-let rec lemma_map_index (f : 'a -> 'b) (xs : list 'a) (i : nat{i < L.length xs})
-  : Lemma (L.map f xs `L.index` i == f (xs `L.index` i))
-  = match i, xs with
-    | 0, _ -> ()
-    | _, x::xs -> lemma_map_index f xs (i-1)
-
-let rec __lemma_map_opt_lenx (f : 'a -> option 'b) (xs : list 'a) (ys : list 'b)
-  : Lemma (requires map_opt f xs == Some ys)
-          (ensures L.length xs == L.length ys)
-  = match xs, ys with
-    | [], [] -> ()
-    | x::xs, y::ys ->
-      __lemma_map_opt_lenx f xs ys
-    | _ -> assert False
-
-let lemma_map_opt_lenx (f : 'a -> option 'b) (xs : list 'a)
-  : Lemma (requires Some? (map_opt f xs))
-          (ensures L.length xs == L.length (Some?.v (map_opt f xs)))
-          [SMTPat (map_opt f xs)]
-  = let Some ys = map_opt f xs in
-    __lemma_map_opt_lenx f xs ys
-
-let rec __lemma_map_opt_dec_lenx (top:'z) (f : (x:'a{x << top}) -> option 'b) (xs : list 'a{xs << top}) (ys : list 'b)
-  : Lemma (requires map_opt_dec top f xs == Some ys)
-          (ensures L.length xs == L.length ys)
-  = match xs, ys with
-    | [], [] -> ()
-    | x::xs, y::ys ->
-      __lemma_map_opt_dec_lenx top f xs ys
-    | _ -> assert False
-
-let lemma_map_opt_dec_lenx (top:'z) (f : (x:'a{x << top}) -> option 'b) (xs : list 'a{xs << top})
-  : Lemma (requires Some? (map_opt_dec top f xs))
-          (ensures L.length xs == L.length (Some?.v (map_opt_dec top f xs)))
-          [SMTPat (map_opt_dec top f xs)]
-  = let Some ys = map_opt_dec top f xs in
-    __lemma_map_opt_dec_lenx top f xs ys
-
-let rec __lemma_map_opt_dec_index (top:'z) (f : (x:'a{x << top}) -> option 'b) (xs : list 'a{xs << top}) (ys : list 'b) (i:nat{i < L.length xs})
-  : Lemma (requires map_opt_dec top f xs == Some ys)
-          (ensures f (xs `L.index` i) == Some (ys `L.index` i))
-  = match xs, ys, i with
-    | _, _, 0 -> ()
-    | x::xs, y::ys, _ ->
-     __lemma_map_opt_dec_index top f xs ys (i-1)
-
-let lemma_map_opt_dec_index (top:'z) (f : (x:'a{x << top}) -> option 'b) (xs : list 'a{xs << top}) (ys : list 'b)
-  : Lemma (requires map_opt_dec top f xs == Some ys)
-          (ensures forall i. f (xs `L.index` i) == Some (ys `L.index` i))
-  = Classical.forall_intro (Classical.move_requires (__lemma_map_opt_dec_index top f xs ys))
-
-#push-options "--fuel 2 --ifuel 2 --z3rlimit_factor 2"
-#restart-solver
-let rec elab_readback_pat_x (rp : R.pattern) (p : pattern)
-  : Lemma (requires readback_pat rp == Some p)
-          (ensures elab_pat p == rp)
-  = match rp, p with
-  | R.Pat_Cons r_fv r_us_opt r_subpats, Pat_Cons {fv_name=fv_name} subpats ->
-    assert (fv_name == R.inspect_fv r_fv);
-    assert (Some? (readback_pat rp));
-    let fv = R.inspect_fv r_fv in
-    
-    // Unfold to definition, unsure why it's needed
-    assert (readback_pat rp ==
-             (let? args = map_opt_dec rp readback_sub_pat r_subpats in 
-              Some (Pat_Cons {fv_name=fv; fv_range=Range.range_0} args)))
-        by (T.norm [delta; zeta]);
-              
-    let aux1 (i:nat{i < L.length r_subpats}) 
-    : Lemma (r_subpats `L.index` i == (map_dec p subpats elab_sub_pat) `L.index` i) 
-    = 
-      lemma_map_opt_dec_index rp readback_sub_pat r_subpats subpats; 
-      calc (==) { 
-        map_dec p subpats elab_sub_pat `L.index` i; 
-        == { lemma_map_dec_index_i p elab_sub_pat subpats i } 
-        elab_sub_pat (subpats `L.index` i); 
-        == { () } 
-        elab_sub_pat (Some?.v (readback_sub_pat (r_subpats `L.index` i))); 
-        == { elab_readback_subpat (r_subpats `L.index` i) } 
-        r_subpats `L.index` i; 
-      }
-    in 
-    Classical.forall_intro aux1; 
-    FStar.List.Tot.Properties.index_extensionality  
-        (map_dec p subpats elab_sub_pat) 
-        r_subpats;
-
-    // Unfold to definition, unsure why it's needed
-    assert (elab_pat p ==
-             R.Pat_Cons (R.pack_fv fv_name) None (map_dec p subpats elab_sub_pat))
-        by (T.norm [delta; zeta]);
-
-    assert (R.pack_fv fv_name == r_fv);
-    // FIXME: readback will drop the universe annotation, so we cannot
-    // really prove this. Should we add it to pulse pattern syntax?
-    assume (r_us_opt == None);
-    assert (r_subpats == map_dec p subpats elab_sub_pat);
-    ()
-
-  | R.Pat_Constant _, Pat_Constant _ -> ()
-  | R.Pat_Var st nm, Pat_Var _ _ ->
-    Sealed.sealed_singl st (Sealed.seal RT.tun);
-    ()
-  | _ -> ()
-and elab_readback_subpat (pb : R.pattern & bool)
-  : Lemma (requires (Some? (readback_sub_pat pb)))
-          (ensures elab_sub_pat (Some?.v (readback_sub_pat pb)) == pb)
-  = let (p, b) = pb in
-    elab_readback_pat_x p (Some?.v (readback_pat p))
-#pop-options
 
 val tot_typing_weakening_n
    (#g:env) (#t:term) (#ty:term)
@@ -481,7 +335,7 @@ let check
         (pre:term)
         (post_hint:post_hint_for_env g)
         (res_ppname:ppname)
-        (sc:term)
+        (sc0:st_term)
         (brs:list branch)
         (check:check_t)
   : T.Tac (checker_result_t g pre (PostHint post_hint))
@@ -489,6 +343,11 @@ let check
 
   let g = Pulse.Typing.Env.push_context_no_range g "check_match" in
 
+  let sc : term =
+    match sc0.term with
+    | Tm_Return { term=sct } -> sct
+    | _ -> fail g (Some sc0.range) "check_match: expected a pure scrutinee (Tm_Return); stateful scrutinees should have been elaborated away"
+  in
   let sc_range = Pulse.RuntimeUtils.range_of_term sc in // save range, it gets lost otherwise
   let orig_brs = brs in
   let nbr = L.length brs in
@@ -538,7 +397,8 @@ let check
   (* Provable *)
   assume (L.map (fun br -> elab_pat br.pat) brs == elab_pats');
   let c_typing = comp_typing_from_post_hint c post_hint in
-  let t = wtag (Some (ctag_of_comp_st c)) (Tm_Match {sc; returns_=None; brs}) in
+  let sc_st = mk_term (Tm_Return { expected_type = sc_ty; insert_eq = false; term = sc }) sc_range in
+  let t = wtag (Some (ctag_of_comp_st c)) (Tm_Match {sc=sc_st; returns_=None; brs}) in
 
   checker_result_for_st_typing (| t, c |) res_ppname
 #pop-options

--- a/pulse/src/checker/Pulse.Checker.Match.fsti
+++ b/pulse/src/checker/Pulse.Checker.Match.fsti
@@ -31,7 +31,7 @@ val check
         (pre:term)
         (post_hint:post_hint_for_env g)
         (res_ppname:ppname)
-        (sc:term)
+        (sc:st_term)
         (brs:list branch)
         (check:check_t)
   : T.Tac (checker_result_t g pre (PostHint post_hint))

--- a/pulse/src/checker/Pulse.Checker.fst
+++ b/pulse/src/checker/Pulse.Checker.fst
@@ -187,19 +187,39 @@ let maybe_elaborate_stateful_head (g:env) (t:st_term)
       b in
     Pulse.Checker.Base.hoist g (Inr t) true rebuild
   | Tm_If {b; then_=e1; else_=e2; post} ->
-    let rebuild (b:either term st_term {Inl? b})
-    : T.Tac st_term
-    = let Inl b = b in
-      {t with term=Tm_If { b; then_=e1; else_=e2; post }}
-    in
-    Pulse.Checker.Base.hoist g (Inl b) true rebuild  
+    (match b.term with
+     | Tm_Return { expected_type; insert_eq; term=bt } ->
+       let rebuild (bt':either term st_term {Inl? bt'})
+       : T.Tac st_term
+       = let Inl bt' = bt' in
+         let b' = { b with term = Tm_Return { expected_type; insert_eq; term = bt' } } in
+         {t with term=Tm_If { b=b'; then_=e1; else_=e2; post }}
+       in
+       Pulse.Checker.Base.hoist g (Inl bt) true rebuild
+     | _ ->
+       // Stateful condition: transform into let _cond = b; if (return _cond) { e1 } else { e2 }
+       let binder = mk_binder_ppname Pulse.Typing.tm_bool (mk_ppname_no_range "_if_cond") in
+       let bv0 = Pulse.Syntax.Pure.tm_bvar { bv_index = 0; bv_ppname = ppname_default } in
+       let pure_b = mk_term (Tm_Return { expected_type = Pulse.Typing.tm_bool; insert_eq = false; term = bv0 }) b.range in
+       let inner_if = {t with term = Tm_If { b = pure_b; then_ = e1; else_ = e2; post }} in
+       Some (mk_term (Tm_Bind { binder; head = b; body = inner_if }) t.range))
   | Tm_Match {sc; returns_=post_match; brs} ->
-    let rebuild (sc:either term st_term {Inl? sc})
-    : T.Tac st_term
-    = let Inl sc = sc in
-      { t with term=Tm_Match {sc; returns_=post_match; brs} }
-    in
-    Pulse.Checker.Base.hoist g (Inl sc) true rebuild
+    (match sc.term with
+     | Tm_Return { expected_type; insert_eq; term=sct } ->
+       let rebuild (sct':either term st_term {Inl? sct'})
+       : T.Tac st_term
+       = let Inl sct' = sct' in
+         let sc' = { sc with term = Tm_Return { expected_type; insert_eq; term = sct' } } in
+         { t with term=Tm_Match {sc=sc'; returns_=post_match; brs} }
+       in
+       Pulse.Checker.Base.hoist g (Inl sct) true rebuild
+     | _ ->
+       // Stateful scrutinee: transform into let _sc = sc; match (return _sc) { brs }
+       let binder = mk_binder_ppname Pulse.Syntax.Pure.tm_unknown (mk_ppname_no_range "_match_sc") in
+       let bv0 = Pulse.Syntax.Pure.tm_bvar { bv_index = 0; bv_ppname = ppname_default } in
+       let pure_sc = mk_term (Tm_Return { expected_type = Pulse.Syntax.Pure.tm_unknown; insert_eq = false; term = bv0 }) sc.range in
+       let inner_match = {t with term = Tm_Match { sc = pure_sc; returns_ = post_match; brs }} in
+       Some (mk_term (Tm_Bind { binder; head = sc; body = inner_match }) t.range))
   | Tm_WithLocal { binder; initializer=Some initializer; body } ->
     let rebuild (sc:either term st_term {Inl? sc})
     : T.Tac st_term

--- a/pulse/src/checker/Pulse.Common.fst
+++ b/pulse/src/checker/Pulse.Common.fst
@@ -91,18 +91,50 @@ let rec lemma_map_opt_dec_len #a #b #z (top:z) (f : (x:a{x << top}) -> option b)
     | [] -> ()
     | x::xs -> lemma_map_opt_dec_len top f xs
 
-// let rec __lemma_map_opt_index (f : 'a -> option 'b) (xs : list 'a) (ys : list 'b) (i:nat{i < L.length xs})
-//   : Lemma (requires map_opt f xs == Some ys)
-//           (ensures f (xs `L.index` i) == Some (ys `L.index` i))
-//   = match xs, ys, i with
-//     | _, _, 0 -> ()
-//     | x::xs, y::ys, _ ->
-//      __lemma_map_opt_index f xs ys (i-1)
+let rec lemma_map_len (f : 'a -> 'b) (xs : list 'a)
+  : Lemma (L.length (L.map f xs) == L.length xs)
+          [SMTPat (L.length (L.map f xs))]
+  = match xs with
+    | [] -> ()
+    | x::xs -> lemma_map_len f xs
 
-// let lemma_map_opt_index (f : 'a -> option 'b) (xs : list 'a) (ys : list 'b)
-//   : Lemma (requires map_opt f xs == Some ys)
-//           (ensures forall i. f (xs `L.index` i) == Some (ys `L.index` i))
-//   = Classical.forall_intro (Classical.move_requires (__lemma_map_opt_index f xs ys))
+let rec lemma_map_index (f : 'a -> 'b) (xs : list 'a) (i : nat{i < L.length xs})
+  : Lemma (L.map f xs `L.index` i == f (xs `L.index` i))
+  = match i, xs with
+    | 0, _ -> ()
+    | _, x::xs -> lemma_map_index f xs (i-1)
+
+let rec __lemma_map_opt_lenx (f : 'a -> option 'b) (xs : list 'a) (ys : list 'b)
+  : Lemma (requires map_opt f xs == Some ys)
+          (ensures L.length xs == L.length ys)
+  = match xs, ys with
+    | [], [] -> ()
+    | x::xs, y::ys ->
+      __lemma_map_opt_lenx f xs ys
+    | _ -> assert False
+
+let lemma_map_opt_lenx (f : 'a -> option 'b) (xs : list 'a)
+  : Lemma (requires Some? (map_opt f xs))
+          (ensures L.length xs == L.length (Some?.v (map_opt f xs)))
+          [SMTPat (map_opt f xs)]
+  = let Some ys = map_opt f xs in
+    __lemma_map_opt_lenx f xs ys
+
+let rec __lemma_map_opt_dec_lenx (top:'z) (f : (x:'a{x << top}) -> option 'b) (xs : list 'a{xs << top}) (ys : list 'b)
+  : Lemma (requires map_opt_dec top f xs == Some ys)
+          (ensures L.length xs == L.length ys)
+  = match xs, ys with
+    | [], [] -> ()
+    | x::xs, y::ys ->
+      __lemma_map_opt_dec_lenx top f xs ys
+    | _ -> assert False
+
+let lemma_map_opt_dec_lenx (top:'z) (f : (x:'a{x << top}) -> option 'b) (xs : list 'a{xs << top})
+  : Lemma (requires Some? (map_opt_dec top f xs))
+          (ensures L.length xs == L.length (Some?.v (map_opt_dec top f xs)))
+          [SMTPat (map_opt_dec top f xs)]
+  = let Some ys = map_opt_dec top f xs in
+    __lemma_map_opt_dec_lenx top f xs ys
 
 
 let rec dec_index #a (top:'z) (l : list a{l << top}) (i : nat{i < L.length l})
@@ -111,6 +143,19 @@ let rec dec_index #a (top:'z) (l : list a{l << top}) (i : nat{i < L.length l})
 = match l, i with
   | _, 0 -> ()
   | _::l, _ -> dec_index top l (i-1)
+
+let rec __lemma_map_opt_dec_index (top:'z) (f : (x:'a{x << top}) -> option 'b) (xs : list 'a{xs << top}) (ys : list 'b) (i:nat{i < L.length xs})
+  : Lemma (requires map_opt_dec top f xs == Some ys)
+          (ensures f (xs `L.index` i) == Some (ys `L.index` i))
+  = match xs, ys, i with
+    | _, _, 0 -> ()
+    | x::xs, y::ys, _ ->
+     __lemma_map_opt_dec_index top f xs ys (i-1)
+
+let lemma_map_opt_dec_index (top:'z) (f : (x:'a{x << top}) -> option 'b) (xs : list 'a{xs << top}) (ys : list 'b)
+  : Lemma (requires map_opt_dec top f xs == Some ys)
+          (ensures forall i. f (xs `L.index` i) == Some (ys `L.index` i))
+  = Classical.forall_intro (Classical.move_requires (__lemma_map_opt_dec_index top f xs ys))
 
 
 

--- a/pulse/src/checker/Pulse.ElimGoto.fst
+++ b/pulse/src/checker/Pulse.ElimGoto.fst
@@ -86,7 +86,11 @@ let mk_if_cond (g: env) (t: st_term) (cond: nvar) : T.Tac st_term =
     binder = mk_binder_ppname_inline tm_bool (fst cond);
     head = mk_read u0 tm_bool (term_of_nvar cond);
     body = wtag t.effect_tag <| Tm_If {
-      b = close_term (term_of_nvar cond) (snd cond);
+      b = wtag (as_effect_hint STT) <| Tm_Return {
+        expected_type = tm_bool;
+        insert_eq = false;
+        term = close_term (term_of_nvar cond) (snd cond);
+      };
       then_ = wtag t.effect_tag <| Tm_Return {
         expected_type = tm_unit;
         insert_eq = false;
@@ -247,7 +251,11 @@ let rec conditionalize (g: env) (t: st_term) (cond: cond_params) : T.Tac (option
             binder = mk_binder_ppname_inline tm_bool ppname_default;
             body = (fun t -> close_st_term t y) <| wtag condition.effect_tag <|
               Tm_If {
-                b = term_of_nvar (ppname_default, y);
+                b = wtag (as_effect_hint STT) <| Tm_Return {
+                  expected_type = tm_bool;
+                  insert_eq = false;
+                  term = term_of_nvar (ppname_default, y);
+                };
                 then_ = wtag condition.effect_tag <| Tm_Return {
                   expected_type = tm_bool;
                   insert_eq = false;

--- a/pulse/src/checker/Pulse.Extract.Main.fst
+++ b/pulse/src/checker/Pulse.Extract.Main.fst
@@ -206,10 +206,10 @@ let rec simplify_st_term (g:env) (e:st_term) : T.Tac st_term =
     ret (Tm_TotBind { binder; head; body = with_open binder body })
 
   | Tm_If { b; then_; else_; post } ->
-    ret (Tm_If { b; then_ = simplify_st_term g then_; else_ = simplify_st_term g else_; post })
+    ret (Tm_If { b = simplify_st_term g b; then_ = simplify_st_term g then_; else_ = simplify_st_term g else_; post })
 
   | Tm_Match { sc; returns_; brs } ->
-    ret (Tm_Match { sc; returns_; brs = T.map (simplify_branch g) brs })
+    ret (Tm_Match { sc = simplify_st_term g sc; returns_; brs = T.map (simplify_branch g) brs })
 
   | Tm_While { invariant; loop_requires; meas; condition; body } ->
     let condition = simplify_st_term g condition in
@@ -298,11 +298,13 @@ let rec erase_ghost_subterms (g:env) (p:st_term) : T.Tac st_term =
            ret (Tm_TotBind { binder; head; body })
 
     | Tm_If { b; then_; else_; post } ->
+      let b = erase_ghost_subterms g b in
       let then_ = erase_ghost_subterms g then_ in
       let else_ = erase_ghost_subterms g else_ in
       ret (Tm_If { b; then_; else_; post })
 
     | Tm_Match { sc; brs; returns_ } ->
+      let sc = erase_ghost_subterms g sc in
       let brs = T.map (erase_ghost_subterms_branch g) brs in
       ret (Tm_Match { sc; brs; returns_ })
 
@@ -468,11 +470,17 @@ let rec extract_dv g (p:st_term) : T.Tac R.term =
       ECL.mk_let b' e1 (close_term e2 x._2)
 
     | Tm_If { b; then_; else_ } ->
+      let b = (match b.term with
+               | Tm_Return { term } -> term
+               | _ -> extract_dv g b) in
       let then_ = extract_dv g then_ in
       let else_ = extract_dv g else_ in
       ECL.mk_if b then_ else_
 
     | Tm_Match { sc; brs } ->
+      let sc = (match sc.term with
+                | Tm_Return { term } -> term
+                | _ -> extract_dv g sc) in
       R.pack_ln (R.Tv_Match sc None (T.map (extract_dv_branch g) brs))
 
     | Tm_While { condition; body } ->

--- a/pulse/src/checker/Pulse.Readback.fst
+++ b/pulse/src/checker/Pulse.Readback.fst
@@ -18,14 +18,12 @@ module Pulse.Readback
 module R = FStar.Reflection.V2
 open Pulse.Syntax.Base
 open Pulse.Reflection.Util
+open Pulse.Common
 module RU = Pulse.RuntimeUtils
+module RT = FStar.Reflection.Typing
 module T = FStar.Tactics.V2
+module L = FStar.List.Tot.Base
 let debug_log (f: unit -> T.Tac unit) : T.Tac unit = if RU.debug_at_level_no_module "readback" then f()
-
-let (let?) (f:option 'a) (g:'a -> option 'b) : option 'b =
-  match f with
-  | None -> None
-  | Some x -> g x
 
 let readback_observability (t:R.term)
 : option (obs:observability { elab_observability obs == t })
@@ -124,3 +122,85 @@ let readback_comp (t:R.term)
   | _ ->
     let t' = t in
     Some (C_Tot t' <: c:comp{ elab_comp c == t })
+
+let rec readback_pat (p : R.pattern) : option pattern =
+  match p with
+  | R.Pat_Cons fv _ args ->
+    let fv = R.inspect_fv fv in
+    let? args = map_opt_dec p readback_sub_pat args in
+    Some (Pat_Cons {fv_name=fv; fv_range=Range.range_0} args)
+  | R.Pat_Constant c ->
+    Some (Pat_Constant c)
+  | R.Pat_Var st nm ->
+    Some (Pat_Var nm (RU.map_seal st RU.deep_compress))
+  | R.Pat_Dot_Term None -> Some (Pat_Dot_Term None)
+  | R.Pat_Dot_Term (Some t) ->
+    if R.Tv_Unknown? (R.inspect_ln t)
+    then None
+    else
+      let t = RU.deep_compress t in
+      let t = RU.set_range t Range.range_0 in
+      Some (Pat_Dot_Term (Some t))
+  | _ -> None
+and readback_sub_pat (pb : R.pattern & bool) : option (pattern & bool) =
+  let (p, b) = pb in
+  let? p = readback_pat p in
+  Some (p, b)
+
+#push-options "--fuel 2 --ifuel 2 --z3rlimit_factor 2"
+#restart-solver
+let rec elab_readback_pat_x (rp : R.pattern) (p : pattern)
+  : Lemma (requires readback_pat rp == Some p)
+          (ensures elab_pat p == rp)
+  = match rp, p with
+  | R.Pat_Cons r_fv r_us_opt r_subpats, Pat_Cons {fv_name=fv_name} subpats ->
+    assert (fv_name == R.inspect_fv r_fv);
+    assert (Some? (readback_pat rp));
+    let fv = R.inspect_fv r_fv in
+
+    assert (readback_pat rp ==
+             (let? args = map_opt_dec rp readback_sub_pat r_subpats in
+              Some (Pat_Cons {fv_name=fv; fv_range=Range.range_0} args)))
+        by (T.norm [delta; zeta]);
+
+    let aux1 (i:nat{i < L.length r_subpats})
+    : Lemma (r_subpats `L.index` i == (map_dec p subpats elab_sub_pat) `L.index` i)
+    =
+      lemma_map_opt_dec_index rp readback_sub_pat r_subpats subpats;
+      calc (==) {
+        map_dec p subpats elab_sub_pat `L.index` i;
+        == { lemma_map_dec_index_i p elab_sub_pat subpats i }
+        elab_sub_pat (subpats `L.index` i);
+        == { () }
+        elab_sub_pat (Some?.v (readback_sub_pat (r_subpats `L.index` i)));
+        == { elab_readback_subpat (r_subpats `L.index` i) }
+        r_subpats `L.index` i;
+      }
+    in
+    Classical.forall_intro aux1;
+    FStar.List.Tot.Properties.index_extensionality
+        (map_dec p subpats elab_sub_pat)
+        r_subpats;
+
+    assert (elab_pat p ==
+             R.Pat_Cons (R.pack_fv fv_name) None (map_dec p subpats elab_sub_pat))
+        by (T.norm [delta; zeta]);
+
+    assert (R.pack_fv fv_name == r_fv);
+    // FIXME: readback will drop the universe annotation, so we cannot
+    // really prove this. Should we add it to pulse pattern syntax?
+    assume (r_us_opt == None);
+    assert (r_subpats == map_dec p subpats elab_sub_pat);
+    ()
+
+  | R.Pat_Constant _, Pat_Constant _ -> ()
+  | R.Pat_Var st nm, Pat_Var _ _ ->
+    Sealed.sealed_singl st (Sealed.seal RT.tun);
+    ()
+  | _ -> ()
+and elab_readback_subpat (pb : R.pattern & bool)
+  : Lemma (requires (Some? (readback_sub_pat pb)))
+          (ensures elab_sub_pat (Some?.v (readback_sub_pat pb)) == pb)
+  = let (p, b) = pb in
+    elab_readback_pat_x p (Some?.v (readback_pat p))
+#pop-options

--- a/pulse/src/checker/Pulse.Readback.fsti
+++ b/pulse/src/checker/Pulse.Readback.fsti
@@ -21,3 +21,17 @@ open Pulse.Elaborate.Pure
 
 val readback_comp (t:R.term)
   : option (c:comp{ elab_comp c == t})
+
+val readback_pat (p:R.pattern)
+  : option pattern
+
+val readback_sub_pat (pb:R.pattern & bool)
+  : option (pattern & bool)
+
+val elab_readback_pat_x (rp:R.pattern) (p:pattern)
+  : Lemma (requires readback_pat rp == Some p)
+          (ensures elab_pat p == rp)
+
+val elab_readback_subpat (pb:R.pattern & bool)
+  : Lemma (requires (Some? (readback_sub_pat pb)))
+          (ensures elab_sub_pat (Some?.v (readback_sub_pat pb)) == pb)

--- a/pulse/src/checker/Pulse.Syntax.Base.fst
+++ b/pulse/src/checker/Pulse.Syntax.Base.fst
@@ -215,14 +215,14 @@ let rec eq_st_term (t1 t2:st_term)
 
     | Tm_If { b=g1; then_=ethen1; else_=eelse1; post=p1},
       Tm_If { b=g2; then_=ethen2; else_=eelse2; post=p2} ->
-      eq_tm g1 g2 &&
+      eq_st_term g1 g2 &&
       eq_st_term ethen1 ethen2 &&
       eq_st_term eelse1 eelse2 &&
       eq_tm_opt p1 p2
     
     | Tm_Match {sc=sc1; returns_=r1; brs=br1},
       Tm_Match {sc=sc2; returns_=r2; brs=br2} ->
-      eq_tm sc1 sc2 &&
+      eq_st_term sc1 sc2 &&
       eq_tm_opt r1 r2 &&
       eq_list_dec t1 t2 eq_branch br1 br2
 

--- a/pulse/src/checker/Pulse.Syntax.Base.fsti
+++ b/pulse/src/checker/Pulse.Syntax.Base.fsti
@@ -241,13 +241,13 @@ type st_term' =
       body:st_term;
     }
   | Tm_If {
-      b:term;
+      b:st_term;
       then_:st_term;
       else_:st_term;
       post:option slprop;
     }
   | Tm_Match {
-      sc:term;
+      sc:st_term;
       returns_:option slprop;
       brs: list branch;
     }

--- a/pulse/src/checker/Pulse.Syntax.Naming.fst
+++ b/pulse/src/checker/Pulse.Syntax.Naming.fst
@@ -184,13 +184,13 @@ let rec close_open_inverse_st'  (t:st_term)
       close_open_inverse_st' body x i
 
     | Tm_If { b; then_; else_; post } ->
-      close_open_inverse' b x i;    
+      close_open_inverse_st' b x i;    
       close_open_inverse_st' then_ x i;    
       close_open_inverse_st' else_ x i;
       close_open_inverse_opt' post x (i + 1)
 
     | Tm_Match { sc; returns_; brs } ->
-      close_open_inverse' sc x i;
+      close_open_inverse_st' sc x i;
       close_open_inverse_opt' returns_ x i;
       admit(); // need map dec fusion
       ()

--- a/pulse/src/checker/Pulse.Syntax.Naming.fsti
+++ b/pulse/src/checker/Pulse.Syntax.Naming.fsti
@@ -109,12 +109,12 @@ let rec freevars_st (t:st_term)
       freevars head ++
       freevars_st body
     | Tm_If { b; then_; else_; post } ->
-      freevars b ++
+      freevars_st b ++
       freevars_st then_ ++
       (freevars_st else_ ++ freevars_term_opt post)
 
     | Tm_Match { sc ; returns_; brs } ->
-      freevars sc ++
+      freevars_st sc ++
       freevars_term_opt returns_ ++
       freevars_branches brs
 
@@ -297,13 +297,13 @@ let rec ln_st' (t:st_term) (i:int)
       ln_st' body (i + 1)
 
     | Tm_If { b; then_; else_; post } ->
-      ln' b i &&
+      ln_st' b i &&
       ln_st' then_ i &&
       ln_st' else_ i &&
       ln_opt' ln' post (i + 1)
   
     | Tm_Match {sc; returns_; brs } ->
-      ln' sc i &&
+      ln_st' sc i &&
       ln_opt' ln' returns_ i &&
       ln_branches' t brs i
 
@@ -547,13 +547,13 @@ let rec subst_st_term (t:st_term) (ss:subst)
                    body = subst_st_term body (shift_subst ss) }
 
     | Tm_If { b; then_; else_; post } ->
-      Tm_If { b = subst_term b ss;
+      Tm_If { b = subst_st_term b ss;
               then_ = subst_st_term then_ ss;
               else_ = subst_st_term else_ ss;
               post = subst_term_opt post (shift_subst ss) }
 
     | Tm_Match { sc; returns_; brs } ->
-      Tm_Match { sc = subst_term sc ss;
+      Tm_Match { sc = subst_st_term sc ss;
                  returns_ = subst_term_opt returns_ ss;
                  brs = subst_branches t ss brs }
 

--- a/pulse/src/checker/Pulse.Syntax.Printer.fst
+++ b/pulse/src/checker/Pulse.Syntax.Printer.fst
@@ -319,7 +319,7 @@ let rec st_term_to_string' (level:string) (t:st_term)
 
     | Tm_If { b; then_; else_ } ->
       sprintf "if (%s)\n%s{\n%s%s\n%s}\n%selse\n%s{\n%s%s\n%s}"
-        (term_to_string b)
+        (st_term_to_string' level b)
         level
         (indent level)
         (st_term_to_string' (indent level) then_)
@@ -332,7 +332,7 @@ let rec st_term_to_string' (level:string) (t:st_term)
 
     | Tm_Match {sc; brs} ->
       sprintf "match (%s) with %s"
-        (term_to_string sc)
+        (st_term_to_string' level sc)
         (branches_to_string brs)
 
     | Tm_IntroPure { p } ->

--- a/pulse/src/checker/Pulse.Typing.FV.fst
+++ b/pulse/src/checker/Pulse.Typing.FV.fst
@@ -157,7 +157,7 @@ let rec freevars_close_st_term' (t:st_term) (x:var) (i:index)
       freevars_close_st_term' body x (i + 1)
 
     | Tm_If { b; then_; else_; post } ->
-      freevars_close_term' b x i;    
+      freevars_close_st_term' b x i;    
       freevars_close_st_term' then_ x i;    
       freevars_close_st_term' else_ x i;          
       freevars_close_term_opt' post x (i + 1)      

--- a/pulse/src/ml/PulseSyntaxExtension_SyntaxWrapper.ml
+++ b/pulse/src/ml/PulseSyntaxExtension_SyntaxWrapper.ml
@@ -146,10 +146,10 @@ let tm_let_mut_array (x:binder) (v:term option) (n:term) (k:st_term) (r:range) :
 let tm_while (head:st_term) (invariant: slprop) (body:st_term) loop_requires meas r : st_term =
   PSB.(with_range (tm_while invariant head body loop_requires meas) r)
    
-let tm_if (head:term) (returns_annot:slprop option) (then_:st_term) (else_:st_term) r : st_term =
+let tm_if (head:st_term) (returns_annot:slprop option) (then_:st_term) (else_:st_term) r : st_term =
   PSB.(with_range (tm_if head then_ else_ returns_annot) r)
 
-let tm_match (sc:term) (returns_:slprop option) (brs:branch list) r : st_term =
+let tm_match (sc:st_term) (returns_:slprop option) (brs:branch list) r : st_term =
   PSB.(with_range (tm_match sc returns_ brs) r)
 
 let tm_intro_exists (p:slprop) (witnesses:term list) r : st_term =

--- a/pulse/src/ml/pulseparser.mly
+++ b/pulse/src/ml/pulseparser.mly
@@ -318,7 +318,7 @@ pulseStmtNoSeq:
 
 matchStmt:
   | MATCH tm=appTermNoRecordExp c=option(ensuresSLProp) LBRACE brs=list(pulseMatchBranch) RBRACE
-    { PulseSyntaxExtension_Sugar.mk_match tm c brs }
+    { PulseSyntaxExtension_Sugar.mk_match (PulseSyntaxExtension_Sugar.mk_stmt (PulseSyntaxExtension_Sugar.mk_expr tm []) (rr $loc(tm))) c brs }
 
 letMutInit:
   | EQUALS p=pulseBindableTerm { let p = PulseSyntaxExtension_Sugar.mk_stmt p (rr $loc) in Stmt_initializer p }
@@ -390,7 +390,7 @@ pulseStmt:
 
 ifStmt:
   | IF tm=appTermNoRecordExp vp=option(ensuresSLProp) LBRACE th=pulseStmt RBRACE e=option(elseBlock)
-    { PulseSyntaxExtension_Sugar.mk_if tm vp th e }
+    { PulseSyntaxExtension_Sugar.mk_if (PulseSyntaxExtension_Sugar.mk_stmt (PulseSyntaxExtension_Sugar.mk_expr tm []) (rr $loc(tm))) vp th e }
 
 elseBlock:
   | ELSE LBRACE p=pulseStmt RBRACE

--- a/pulse/src/syntax_extension/PulseSyntaxExtension.Desugar.fst
+++ b/pulse/src/syntax_extension/PulseSyntaxExtension.Desugar.fst
@@ -506,7 +506,7 @@ let rec desugar_stmt' (env:env_t) (s:Sugar.stmt)
         in
         let t_match =
           {
-          mk_stmt (Match { head = A.(mk_term (Var (Ident.id_as_lid id)) lb.pat.prange Expr);
+          mk_stmt (Match { head = mk_stmt (Expr { e = A.(mk_term (Var (Ident.id_as_lid id)) lb.pat.prange Expr); args = [] }) s1range;
                           returns_annot = None;
                           branches = [(lb.norw, pat, s2)] }) s1range
                           with source = false }
@@ -555,7 +555,7 @@ let rec desugar_stmt' (env:env_t) (s:Sugar.stmt)
       desugar_stmt env stmt
 
     | If { head; join_slprop; then_; else_opt } -> 
-      let! head = desugar_term env head in
+      let! head = desugar_stmt env head in
       let! join_slprop =
         match join_slprop with
         | None -> return None
@@ -574,7 +574,7 @@ let rec desugar_stmt' (env:env_t) (s:Sugar.stmt)
       return (SW.tm_if head join_slprop then_ else_ s.range)
 
     | Match { head; returns_annot; branches } ->
-      let! head = desugar_term env head in
+      let! head = desugar_stmt env head in
       let! returns_annot = map_err_opt (fun (_, t, _opens) -> desugar_slprop env t) returns_annot in
       let! branches = branches |> mapM (desugar_branch env) in
       return (SW.tm_match head returns_annot branches s.range)

--- a/pulse/src/syntax_extension/PulseSyntaxExtension.Sugar.fst
+++ b/pulse/src/syntax_extension/PulseSyntaxExtension.Sugar.fst
@@ -143,14 +143,14 @@ type stmt' =
     }
     
   | If {
-      head:A.term;
+      head:stmt;
       join_slprop:option ensures_slprop;
       then_:stmt;
       else_opt:option stmt;
     }
 
   | Match {
-      head:A.term;
+      head:stmt;
       returns_annot:option ensures_slprop;
       branches:list (bool & A.pattern & stmt);
       (* ^ boolean true for 'norewrite' *)
@@ -330,14 +330,14 @@ let rec stmt_to_string (s:stmt) : ML string =
     "Block {" ^ stmt_to_string stmt ^ "}"
   | If { head; join_slprop; then_; else_opt } ->
     "If " ^ record_string [
-      "head", show head;
+      "head", stmt_to_string head;
       "join_slprop", show join_slprop;
       "then_", stmt_to_string then_;
       "else_opt", FStarC.Common.string_of_option stmt_to_string else_opt;
     ]
   | Match { head; returns_annot; branches } ->
     "Match " ^ record_string [
-      "head", show head;
+      "head", stmt_to_string head;
       "returns_annot", show returns_annot;
       "branches", FStarC.Common.string_of_list branch_to_string branches;
     ]
@@ -479,12 +479,12 @@ and eq_stmt' (s1 s2:stmt') : ML bool =
     eq_opt eq_let_init init1 init2
   | Block { stmt=s1 }, Block { stmt=s2 } -> eq_stmt s1 s2
   | If { head=h1; join_slprop=j1; then_=t1; else_opt=e1 }, If { head=h2; join_slprop=j2; then_=t2; else_opt=e2 } ->
-    AD.eq_term h1 h2 &&
+    eq_stmt h1 h2 &&
     eq_opt eq_ensures_slprop j1 j2 &&
     eq_stmt t1 t2 &&
     eq_opt eq_stmt e1 e2
   | Match { head=h1; returns_annot=r1; branches=b1 }, Match { head=h2; returns_annot=r2; branches=b2 } ->
-    AD.eq_term h1 h2 &&
+    eq_stmt h1 h2 &&
     eq_opt eq_ensures_slprop r1 r2 &&
     forall2 (fun (norw1, p1, s1) (norw2, p2, s2) -> norw1 = norw2 && AD.eq_pattern p1 p2 && eq_stmt s1 s2) b1 b2
   | While { guard=g1; invariant=i1; body=b1 }, While { guard=g2; invariant=i2; body=b2 } ->
@@ -626,12 +626,12 @@ and scan_stmt (cbs:A.dep_scan_callbacks) (s:stmt) : ML unit =
     iopt cbs.scan_term t
   | Block { stmt=s } -> scan_stmt cbs s
   | If { head=h; join_slprop=j; then_=t; else_opt=e } ->
-    cbs.scan_term h;
+    scan_stmt cbs h;
     iopt (scan_ensures_slprop cbs) j;
     scan_stmt cbs t;
     iopt (scan_stmt cbs) e
   | Match { head=h; returns_annot=r; branches=b } ->
-    cbs.scan_term h;
+    scan_stmt cbs h;
     iopt (scan_ensures_slprop cbs) r;
     iter (fun (_, p, s) -> cbs.scan_pattern p; scan_stmt cbs s) b
   | While { guard=g; invariant=i; body=b } ->

--- a/pulse/src/syntax_extension/PulseSyntaxExtension.SyntaxWrapper.fsti
+++ b/pulse/src/syntax_extension/PulseSyntaxExtension.SyntaxWrapper.fsti
@@ -98,8 +98,8 @@ val tm_totbind (x:binder) (e1:term) (e2:st_term) (_:range) : st_term
 val tm_let_mut (x:binder) (v:option term) (k:st_term) (_:range) : st_term
 val tm_let_mut_array (x:binder) (v:option term) (n:term) (k:st_term) (_:range) : st_term
 val tm_while (head:st_term) (invariant: slprop) (body:st_term) (loop_requires: term) (meas: list term) (_:range) : st_term 
-val tm_if (head:term) (returns_annot:option slprop) (then_ else_:st_term) (_:range) : st_term
-val tm_match (head:term) (returns_:option slprop) (brs:list branch) (_:range) : st_term
+val tm_if (head:st_term) (returns_annot:option slprop) (then_ else_:st_term) (_:range) : st_term
+val tm_match (head:st_term) (returns_:option slprop) (brs:list branch) (_:range) : st_term
 val tm_intro_exists (vp:slprop) (witnesses:list term) (_:range) : st_term
 val is_tm_intro_exists (x:st_term) : bool
 val tm_protect (s:st_term) : st_term

--- a/pulse/test/StatefulIfCondition.fst
+++ b/pulse/test/StatefulIfCondition.fst
@@ -1,0 +1,81 @@
+module StatefulIfCondition
+
+#lang-pulse
+open Pulse
+
+(* Regression test for issue #443: stateful if/match conditions *)
+
+(* Pure conditions still work with backward-compatible syntax *)
+fn pure_condition (x : bool)
+  requires emp
+  ensures  emp
+{
+  if x {
+    ();
+  } else {
+    ();
+  }
+}
+
+(* Basic stateful condition — was already supported via hoisting *)
+fn basic_stateful_if (r : ref int)
+  requires r |-> 'v
+  ensures  r |-> 'v
+{
+  if (!r = 0) {
+    ();
+  } else {
+    ();
+  }
+}
+
+(* Nested stateful if in condition — the core of issue #443 *)
+fn nested_stateful_if (r : ref int)
+  requires r |-> 0
+  ensures  r |-> 0
+{
+  if (if true then !r = 0 else false) {
+    ();
+  } else {
+    ();
+  }
+}
+
+(* Stateful match scrutinee *)
+fn stateful_match (r : ref int)
+  requires r |-> 0
+  ensures  r |-> 0
+{
+  match (!r) {
+    0 -> { (); }
+    _ -> { (); }
+  }
+}
+
+(* Hard case from issue #443: stateful expression inside F*-level if in pure expression *)
+fn hard_case (r : ref int) (b : bool)
+  requires r |-> 'v
+  ensures  r |-> 'v
+{
+  let foo = (if b then !r + 42 else 67) + 10;
+  ()
+}
+
+fn consume (r : ref int)
+  requires r |-> 'v
+  returns b : bool
+  ensures (if b then emp else r |-> 'v)
+{
+  admit();
+}
+
+fn test (b : bool) (r : ref int)
+  requires r |-> 0
+{
+  if (consume r) {
+    ();
+  } else {
+    drop_ (r |-> _);
+  };
+  ()
+}


### PR DESCRIPTION
Porting from https://github.com/FStarLang/pulse/pull/589, addressing review feedback.

Comment 1: Hard hoisting case

Extended hoist_stateful_apps to descend into F*-level Tv_Match branches. This handles expressions like:

 let foo = (if b then !x + 42 else 67) + 10;

where stateful ops are buried inside F*-level if/then/else. Each branch is independently hoisted, and the Tv_Match is converted to a Pulse Tm_If
(2-branch) or Tm_Match (general case), bound to a fresh variable.

Comment 2: Grammar productions

Removed make_auto_paren_lexer token preprocessor. The grammar now uses a single appTermNoRecordExp production for if/match conditions, wrapping the term
as an Expr stmt. Adding a second LPAREN pulseStmt RPAREN production causes menhir reduce/reduce conflicts in the merged parser, so the single-production
approach is necessary.

Comment 3: CI branch

Updated Pulse CI to check out the fstar2 branch of F*.

Cleanup

 - Removed cond-hoisting.md design doc
 - Added hard_case regression test to StatefulIfCondition.fst