### PR TITLE
Fix bump-stage0: exclude karamel from stage0 and fix stage1 exe names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -652,6 +652,7 @@ stage0_new: .stage2.src.touch
 	rm -rf "$(TO)/dune/libplugin" # idem
 	rm -rf "$(TO)/dune/libapp"    # we won't even build apps
 	rm -rf "$(TO)/dune/tests"     # we won't build tests
+	rm -rf "$(TO)/karamel"        # only needed in source packages
 
 bump-stage0: stage0_new
 	$(call bold_msg, "BUMP!")
@@ -669,6 +670,14 @@ bump-stage0: stage0_new
 	sed -i 's,include mk/generic-1.mk,include mk/generic-0.mk,' mk/fstar-01.mk
 	rm -rf stage1
 	cp -r stage2 stage1
+	rm -rf stage1/dune/_build
+	# Rename dune executables: stage1 must use fstarc1_*, not fstarc2_*
+	sed -i 's/fstarc2_/fstarc1_/g' stage1/dune/fstarc-bare/dune
+	sed -i 's/fstarc2_/fstarc1_/g' stage1/dune/fstarc-full/dune
+	sed -i 's/fstarc2_/fstarc1_/g' stage1/dune/tests/dune
+	mv stage1/dune/fstarc-bare/fstarc2_bare.ml stage1/dune/fstarc-bare/fstarc1_bare.ml
+	mv stage1/dune/fstarc-full/fstarc2_full.ml stage1/dune/fstarc-full/fstarc1_full.ml
+	mv stage1/dune/tests/fstarc2_tests.ml      stage1/dune/tests/fstarc1_tests.ml
 	rm -f stage1/dune/fstar-guts/app
 	ln -Trsf stage0/ulib/ml/app stage1/dune/fstar-guts/app
 


### PR DESCRIPTION
Two issues in the bump-stage0 target:

1. src-install.sh now copies karamel/ into the snapshot, but stage0 doesn't need it. Add rm -rf karamel to the stage0_new trimming.

2. When copying stage2 to stage1, the dune files retain fstarc2_* executable names (both in dune configs and .ml entry points), but the top-level Makefile expects fstarc1_*. This causes the build to fail after bumping. Fix by:
   - Removing the stale _build directory from the copy
   - Renaming fstarc2_ to fstarc1_ in the three dune files
   - Renaming the .ml entry point files to match