### PR TITLE
Rel: fix bad transaction scope

### DIFF
--- a/src/typechecker/FStarC.TypeChecker.Rel.fst
+++ b/src/typechecker/FStarC.TypeChecker.Rel.fst
@@ -3730,6 +3730,7 @@ and solve_t' (problem:tprob) (wl:worklist) : ML solution =
     let try_match_heuristic orig wl s1 s2 t1t2_opt =
         let env = p_env wl orig in
         let try_solve_branch scrutinee p =
+            let tx = UF.new_transaction () in
             let (Flex (_t, uv, _args), wl) = destruct_flex_t scrutinee wl  in
             //
             // We add g_pat_as_exp implicits to the worklist later
@@ -3807,7 +3808,6 @@ and solve_t' (problem:tprob) (wl:worklist) : ML solution =
                                   g_pat_term.deferred
                                   g_pat_term.deferred_to_tac
                                   (Listlike.empty) in
-              let tx = UF.new_transaction () in
               match solve wl' with
               | Success (_, defer_to_tac, imps) ->
                   let wl' = {wl' with attempting=[orig]} in
@@ -3826,7 +3826,7 @@ and solve_t' (problem:tprob) (wl:worklist) : ML solution =
                 UF.rollback tx;
                 None
             end
-            else None
+            else (UF.rollback tx; None)
         in
         match t1t2_opt with
         | None -> Inr None

--- a/tests/micro-benchmarks/UvarPatternBug.fst
+++ b/tests/micro-benchmarks/UvarPatternBug.fst
@@ -1,0 +1,51 @@
+module UvarPatternBug
+
+noeq
+[@@erasable]
+type injection (a b : Type) = {
+  f : a -> GTot b;
+
+  is_inj : x:_ -> y:_ -> squash (f x == f y ==> x == y);
+}
+
+// Terrible symbol, but F* is limited in operator support.
+[@@erasable]
+let ( @~> ) a b = injection a b
+
+[@@erasable]
+noeq
+type idesc : nat -> Type =
+  | INil : idesc 0
+  | ICons : #n:nat -> w:nat -> tl:(idesc n) -> idesc (n+1)
+
+inline_for_extraction noextract
+let rec abs #n (i : idesc n) : eqtype =
+  match i with
+  | INil -> unit
+  | ICons h ts -> nat & abs ts
+
+[@@erasable]
+noeq
+type mlayout (rows cols : nat) = {
+  len : nat;
+  map : nat & nat @~> nat;
+}
+
+[@@erasable]
+noeq
+type tlayout (#r : Ghost.erased nat) (d : idesc r) = {
+  (* Underlying length of base array (Kuiper.Array) *)
+  ulen : nat;
+  (* Injection from (abstract) index space into base array. *)
+  imap : abs d @~> nat;
+}
+
+let col_flayout (#rows #cols : nat) (l : mlayout rows cols) (j : nat)
+  : tlayout (ICons rows INil)
+  = {
+      ulen = l.len;
+      imap = {
+        f = (fun (i, ()) -> l.map.f (i, j));
+        is_inj = (fun (x, ()) (y, ()) -> l.map.is_inj (x, j) (y, j));
+      };
+    }


### PR DESCRIPTION
The call to destruct_flex_t can modify the UF graph. This must be covered by the transaction so, when the heuristic fails, everything is rolled back. Add a testcase that used to crash with:
```
Unexpected error: Failure("(Repro.fst(46,6-50,8)) CheckNoUvars: Unexpected unification variable remains: (*?u155*)_")
Please file a bug report, ideally with a minimized version of the source program that triggered the error.
```