### PR TITLE
Fix Pulse unsoundness due to interleaving

### DIFF
--- a/pulse/src/syntax_extension/PulseSyntaxExtension.ASTBuilder.fst
+++ b/pulse/src/syntax_extension/PulseSyntaxExtension.ASTBuilder.fst
@@ -185,7 +185,7 @@ let parse_extension_lang (contents:string) (r:FStarC.Range.range)
             lang_name="pulse";
             blob=mkdyn d;
             idents=[id];
-            to_string=(fun d -> "<TBD>");
+            to_string = (fun dyn -> let d : PulseSyntaxExtension.Sugar.decl = undyn dyn in show d);
             eq=(fun d1 d2 -> PulseSyntaxExtension.Sugar.eq_decl (undyn d1) (undyn d2));
             dep_scan=(fun cbs d -> PulseSyntaxExtension.Sugar.scan_decl cbs (undyn d));
           }

--- a/pulse/src/syntax_extension/PulseSyntaxExtension.Sugar.fst
+++ b/pulse/src/syntax_extension/PulseSyntaxExtension.Sugar.fst
@@ -391,6 +391,14 @@ type decl =
   | FnDefn of fn_defn
   | FnDecl of fn_decl
   | SlpropDefn of slprop_defn
+
+instance showable_decl : showable decl = {
+  show = (fun d -> match d with
+    | FnDefn f -> "FnDefn " ^ show f.id
+    | FnDecl f -> "FnDecl " ^ show f.id
+    | SlpropDefn f -> "SlpropDefn " ^ show f.id)
+}
+
 open FStarC.Class.Deq
 let eq_ident (i1 i2:Ident.ident) : ML bool = i1 =? i2
 let eq_lident (i1 i2:Ident.lident) : ML bool = i1 =? i2

--- a/src/parser/FStarC.Parser.AST.fst
+++ b/src/parser/FStarC.Parser.AST.fst
@@ -881,7 +881,7 @@ let restriction_to_string (r:FStarC.Syntax.Syntax.restriction) : ML string =
   match r with | Unrestricted -> ""
            | AllowList allow_list  -> " {" ^ String.concat ", " (List.map (fun (id, renamed) -> string_of_id id ^ Option.dflt "" (Option.map (fun renamed -> " as " ^ string_of_id renamed) renamed)) allow_list)  ^ "}"
 
-let decl_to_string (d:decl) : ML string = match d.d with
+let decl'_to_string (d:decl') : ML string = match d with
   | TopLevelModule l -> "module " ^ (string_of_lid l)
   | Open (l, r) -> "open " ^ string_of_lid l ^ restriction_to_string r
   | Friend l -> "friend " ^ (string_of_lid l)
@@ -916,6 +916,8 @@ let decl_to_string (d:decl) : ML string = match d.d with
     Format.fmt1 "#lang-%s" str
   | Unparseable ->
     "unparseable"
+
+let decl_to_string (d:decl) : ML string = decl'_to_string d.d
 
 let modul_to_string (m:modul) : ML string =
   match m with
@@ -967,6 +969,7 @@ instance showable_quote_kind : showable quote_kind = {
     | Dynamic -> "Dynamic"
 }
 
+instance showable_decl'   : showable decl'   = { show = decl'_to_string; }
 instance showable_decl    : showable decl    = { show = decl_to_string; }
 instance showable_term    : showable term    = { show = term_to_string; }
 instance showable_pattern : showable pattern = { show = pat_to_string; }
@@ -1255,8 +1258,8 @@ let pp_tycon (tc : tycon) : ML document =
     ctor "TyconVariant" [pp i; pp bs; pp knd; pp_list' pp_ctor ctors]
 instance pretty_tycon   : pretty tycon    = { pp = pp_tycon; }
 
-let pp_decl (d:decl) : ML document =
-  match d.d with
+let pp_decl' (d:decl') : ML document =
+  match d with
   | TopLevelModule l ->
       ctor "TopLevelModule" [pp l]
   | Open (l, r) ->
@@ -1304,6 +1307,9 @@ let pp_decl (d:decl) : ML document =
   | Unparseable ->
       ctor "Unparseable" []
 
+let pp_decl (d:decl) : ML document = pp_decl' d.d
+
+instance pretty_decl'   : pretty decl'    = { pp = pp_decl'; }
 instance pretty_decl    : pretty decl     = { pp = pp_decl; }
 
 let pp_modul (m:modul) : ML document =

--- a/src/parser/FStarC.Parser.AST.fsti
+++ b/src/parser/FStarC.Parser.AST.fsti
@@ -382,6 +382,7 @@ val inline_let_attribute : term
 val inline_let_vc_attribute : term
 
 instance val showable_quote_kind : showable quote_kind
+instance val showable_decl'   : showable decl'
 instance val showable_decl    : showable decl
 instance val showable_term    : showable term
 instance val showable_pattern : showable pattern
@@ -397,5 +398,6 @@ instance val pretty_term    : pretty term
 instance val pretty_binder  : pretty binder
 instance val pretty_pattern : pretty pattern
 instance val pretty_pragma  : pretty pragma
+instance val pretty_decl'   : pretty decl'
 instance val pretty_decl    : pretty decl
 instance val pretty_modul   : pretty modul

--- a/src/tosyntax/FStarC.ToSyntax.Interleave.fst
+++ b/src/tosyntax/FStarC.ToSyntax.Interleave.fst
@@ -217,20 +217,14 @@ let rec prefix_with_iface_decls
 
      //Extension declarations (e.g., Pulse fn) in the interface:
      //When the implementation defines the same name, consume the interface decl.
-     //If the implementation is also an extension decl, don't prefix the interface decl
-     //(since both will produce their own sigelts). Otherwise, prefix it so the val is available.
-     //This prevents the implementation from getting KrmlPrivate.
+     //Always prefix the interface decl so it produces a val declaration,
+     //which the implementation can then be checked against.
+     //This also prevents the implementation from getting KrmlPrivate.
      | DeclToBeDesugared { idents=[x] } ->
        let def_ids = definition_lids impl in
        let defines_x = Util.for_some (id_eq_lid x) def_ids in
        if defines_x then (
-         match impl.d with
-         | DeclToBeDesugared _ ->
-           //both interface and impl are extension decls; each produces its own sigelt
-           iface_tl, [impl]
-         | _ ->
-           //impl is a regular let; need the interface decl to provide the val
-           iface_tl, [iface_hd; impl]
+         iface_tl, [iface_hd; impl]
        ) else (
          //implementation doesn't define x; skip past this iface entry
          //and try to find a match further in the interface.

--- a/tests/bug-reports/closed/PulseRespectIx1.fst
+++ b/tests/bug-reports/closed/PulseRespectIx1.fst
@@ -1,0 +1,11 @@
+module PulseRespectIx1
+
+#lang-pulse
+open Pulse
+
+[@@expect_failure]
+ghost
+fn foo ()
+  requires pure False
+  ensures pure False
+{ (); }

--- a/tests/bug-reports/closed/PulseRespectIx1.fsti
+++ b/tests/bug-reports/closed/PulseRespectIx1.fsti
@@ -1,0 +1,8 @@
+module PulseRespectIx1
+
+#lang-pulse
+open Pulse
+
+ghost
+fn foo ()
+  ensures pure False

--- a/tests/bug-reports/closed/PulseRespectIx2.fst
+++ b/tests/bug-reports/closed/PulseRespectIx2.fst
@@ -1,0 +1,12 @@
+module PulseRespectIx2
+
+#lang-pulse
+open Pulse
+
+[@@expect_failure]
+ghost
+fn foo (x:squash False)
+  ensures pure False
+{
+  ();
+}

--- a/tests/bug-reports/closed/PulseRespectIx2.fsti
+++ b/tests/bug-reports/closed/PulseRespectIx2.fsti
@@ -1,0 +1,8 @@
+module PulseRespectIx2
+
+#lang-pulse
+open Pulse
+
+ghost
+fn foo ()
+  ensures pure False

--- a/tests/bug-reports/closed/PulseRespectIx3.fst
+++ b/tests/bug-reports/closed/PulseRespectIx3.fst
@@ -1,0 +1,11 @@
+module PulseRespectIx3
+
+#lang-pulse
+open Pulse
+
+// Postcondition mismatch: impl promises emp but interface promises pure (1 == 2)
+[@@expect_failure]
+ghost
+fn foo ()
+  ensures emp
+{ (); }

--- a/tests/bug-reports/closed/PulseRespectIx3.fsti
+++ b/tests/bug-reports/closed/PulseRespectIx3.fsti
@@ -1,0 +1,8 @@
+module PulseRespectIx3
+
+#lang-pulse
+open Pulse
+
+ghost
+fn foo ()
+  ensures pure (1 == 2)

--- a/tests/bug-reports/closed/PulseRespectIx4.fst
+++ b/tests/bug-reports/closed/PulseRespectIx4.fst
@@ -1,0 +1,22 @@
+module PulseRespectIx4
+
+#lang-pulse
+open Pulse
+
+// Swapped order: bar defined before foo.
+// Interface checking should match by name, not position.
+
+ghost
+fn bar ()
+  ensures emp
+{ (); }
+
+#lang-pulse
+open Pulse
+
+[@@expect_failure]
+ghost
+fn foo ()
+  requires pure False
+  ensures pure False
+{ (); }

--- a/tests/bug-reports/closed/PulseRespectIx4.fsti
+++ b/tests/bug-reports/closed/PulseRespectIx4.fsti
@@ -1,0 +1,15 @@
+module PulseRespectIx4
+
+#lang-pulse
+open Pulse
+
+ghost
+fn foo ()
+  ensures pure False
+
+#lang-pulse
+open Pulse
+
+ghost
+fn bar ()
+  ensures emp

--- a/tests/bug-reports/closed/PulseRespectIx5.fst
+++ b/tests/bug-reports/closed/PulseRespectIx5.fst
@@ -1,0 +1,11 @@
+module PulseRespectIx5
+
+#lang-pulse
+open Pulse
+
+// Non-ghost fn with precondition mismatch
+[@@expect_failure]
+fn foo ()
+  requires pure False
+  ensures pure False
+{ (); }

--- a/tests/bug-reports/closed/PulseRespectIx5.fsti
+++ b/tests/bug-reports/closed/PulseRespectIx5.fsti
@@ -1,0 +1,7 @@
+module PulseRespectIx5
+
+#lang-pulse
+open Pulse
+
+fn foo ()
+  ensures pure False


### PR DESCRIPTION
The interleaving logic was dropping to-be-desugared Pulse declarations from the fsti when hitting a definition for that name in the fst, essentially ignoring every declaration in the interface and allowing serious unsoundness.

Still looking and testing, but this seems to fix it and pass CI.

The bug comes from #4110. That patch was introduced to prevent functions in the fsti from getting a KrmlPrivate. This does not seem to happen any more, even removing this logic. The existing test `ExtractPulseFnIface.fst` still passes and produces the expected output.