### PR TITLE
Fix #4209

### DIFF
--- a/src/typechecker/FStarC.TypeChecker.TcTerm.fst
+++ b/src/typechecker/FStarC.TypeChecker.TcTerm.fst
@@ -2936,7 +2936,10 @@ and check_application_args env head (chead:comp) ghead args expected_topt : ML (
 (******************************************************************************)
 and maybe_elaborate_short_circuit_args env0 head args
   : ML (option (term & lcomp & guard_t))
-  = match (U.un_uinst head).n with
+  = (* Make sure to collect args in the head. *)
+    let head, args' = U.head_and_args head in
+    let args = args'@args in
+    match (U.un_uinst head).n with
     | Tm_fvar fv when S.fv_eq_lid fv Const.op_And || S.fv_eq_lid fv Const.op_Or ->
       begin match args with
       | [(e1, _aq1); (e2, _aq2)] ->
@@ -2945,7 +2948,6 @@ and maybe_elaborate_short_circuit_args env0 head args
         let env1 = Env.set_expected_typ env0 U.t_bool in
         let e1, c1, g1 = tc_term env1 e1 in
         let e2, c2, g2 = tc_term env1 e2 in
-        let is_pure = TcComm.is_tot_or_gtot_lcomp c1 || TcComm.is_tot_or_gtot_lcomp c2 in
         let c = TcUtil.bind r false env0 (Some e1) c1 (None, c2) in
         let c = TcComm.set_result_typ_lc c U.t_bool in
         if not (TcComm.is_tot_or_gtot_lcomp c1) then

--- a/src/typechecker/FStarC.TypeChecker.TcTerm.fst
+++ b/src/typechecker/FStarC.TypeChecker.TcTerm.fst
@@ -2950,7 +2950,7 @@ and maybe_elaborate_short_circuit_args env0 head args
         let e2, c2, g2 = tc_term env1 e2 in
         let c = TcUtil.bind r false env0 (Some e1) c1 (None, c2) in
         let c = TcComm.set_result_typ_lc c U.t_bool in
-        if not (TcComm.is_tot_or_gtot_lcomp c1) then
+        if not (TcComm.is_pure_or_ghost_lcomp c1) then
           let x1 = S.new_bv None U.t_bool in
           let e =
             let x1 = S.bv_to_name x1 in
@@ -2962,7 +2962,7 @@ and maybe_elaborate_short_circuit_args env0 head args
           let e = mk (Tm_let {lbs=(false, [lb]); body=SS.close [S.mk_binder x1] e}) e.pos in
           // TODO: maybe_lift??
           Some (e, c, g1 ++ g2)
-        else if not (TcComm.is_tot_or_gtot_lcomp c2) then
+        else if not (TcComm.is_pure_or_ghost_lcomp c2) then
           let e =
             if is_and
             then U.if_then_else e1 e2 U.exp_false_bool

--- a/src/typechecker/FStarC.TypeChecker.Util.fst
+++ b/src/typechecker/FStarC.TypeChecker.Util.fst
@@ -3170,7 +3170,8 @@ let short_circuit (head:term) (seen_args:args) : ML guard_formula =
         | _ -> Trivial
 
 let short_circuit_head l : ML _ =
-    match (U.un_uinst l).n with
+    let hd, _ = U.head_and_args l in
+    match (U.un_uinst hd).n with
         | Tm_fvar fv ->
            BU.for_some (S.fv_eq_lid fv)
                    [C.op_And;

--- a/tests/bug-reports/closed/Bug4209.fst
+++ b/tests/bug-reports/closed/Bug4209.fst
@@ -1,0 +1,17 @@
+module Bug4209
+
+#lang-pulse
+open Pulse
+
+assume val p : bool -> slprop
+let even (x:nat) : GTot bool = x % 2 = 0
+unfold let foo (x : nat) : slprop = p (even x && true)
+
+fn test
+  (x : nat)
+  preserves foo x
+{
+  assert foo x;
+  assert p (even x && true);
+  ();
+}


### PR DESCRIPTION
This makes sure to detect nested applications in the hoisting logic for arguments to &&/||. Also, only hoist arguments that are not PURE or GHOST, instead of just Tot and GTot.

Fixes #4209