### PR TITLE
Tweak generation of ML lets

### DIFF
--- a/src/extraction/FStarC.Extraction.ML.Term.fst
+++ b/src/extraction/FStarC.Extraction.ML.Term.fst
@@ -376,12 +376,10 @@ let check_pats_for_ite (l:list (pat & option term & term)) : (bool   //if l is p
         let (p1, w1, e1) = List.hd l in
         let (p2, w2, e2) = List.hd (List.tl l) in
         match (w1, w2, p1.v, p2.v) with
+            | (None, None, Pat_constant (Const_bool true), Pat_var _)
             | (None, None, Pat_constant (Const_bool true), Pat_constant (Const_bool false)) -> true, Some e1, Some e2
+            | (None, None, Pat_constant (Const_bool false), Pat_var _)
             | (None, None, Pat_constant (Const_bool false), Pat_constant (Const_bool true)) -> true, Some e2, Some e1
-//            | (None, None, Pat_constant (Const_bool false), Pat_wild _)
-//            | (None, None, Pat_constant (Const_bool false), Pat_var _)
-//            | (None, None, Pat_constant (Const_bool true), Pat_wild _)
-//            | (None, None, Pat_constant (Const_bool true), Pat_var _)
             | _ -> def
 
 

--- a/src/ml/FStarC_Extraction_ML_PrintML.ml
+++ b/src/ml/FStarC_Extraction_ML_PrintML.ml
@@ -274,17 +274,6 @@ let resugar_prims_ops path: expression =
   | path -> path_to_ident path)
   |> pexp_ident ~loc
 
-let resugar_if_stmts ep cases =
-  if List.length cases = 2 then
-    let case1 = List.hd cases in
-    let case2 = BatList.last cases in
-    (match case1.pc_lhs.ppat_desc with
-     | Ppat_construct({txt=Lident "true"}, None) ->
-         pexp_ifthenelse ~loc ep case1.pc_rhs (Some case2.pc_rhs)
-     | _ -> pexp_match ~loc ep cases)
-  else
-    pexp_match ~loc ep cases
-
 let rec build_expr (e: mlexpr): expression =
   match e.expr with
   | MLE_Const c -> build_constant_expr c
@@ -309,7 +298,7 @@ let rec build_expr (e: mlexpr): expression =
    | MLE_Match (e, branches) ->
       let ep = build_expr e in
       let cases = map build_case branches in
-      resugar_if_stmts ep cases
+      pexp_match ~loc ep cases
    | MLE_Coerce (e, _, _) ->
       let r = pexp_ident ~loc (mk_lident "Obj.magic") in
       pexp_apply ~loc r [(Nolabel, build_expr e)]

--- a/tests/extraction/If.fst
+++ b/tests/extraction/If.fst
@@ -1,0 +1,11 @@
+module If
+
+#push-options "--admit_smt_queries true"
+let test (x:bool) : int =
+  match x with
+  | true when false -> 10
+  | _ -> 20
+#pop-options
+
+let x = test true
+let _ = assert (x == 20)

--- a/tests/extraction/If.ml.expected
+++ b/tests/extraction/If.ml.expected
@@ -1,0 +1,6 @@
+open Prims
+let test (x : Prims.bool) : Prims.int=
+  match x with
+  | true when false -> Prims.of_int 10
+  | uu___ -> Prims.of_int 20
+let x : Prims.int= test true


### PR DESCRIPTION
I noticed several EMatch in karamel files that could be EIfThenElse, this fixes that. Also removes some custom logic in PrintML to detect such matches and print them as if-then-elses. This logic was in fact inconsistent, but I think only when admitting queries.