### PR TITLE
Use our Z3 install script in nightly CI.

### DIFF
--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Install Z3
         # Note: the packages built by build-packages.yml don't include Z3.
-        run: sudo ./fstar/get_fstar_z3.sh /usr/local/bin
+        run: curl -fsSL https://raw.githubusercontent.com/FStarLang/FStar/refs/heads/master/.scripts/get_fstar_z3.sh | sudo bash -s -- /usr/local/bin
 
       - name: Smoke test
         run: |

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -30,13 +30,11 @@ jobs:
         with:
           name: fstar.tar.gz
 
-      # Install Z3. Note: the packages built by build-packages.yml
-      # don't include Z3.
-      - uses: cda-tum/setup-z3@main
-        with:
-          version: 4.13.3
-
       - run: tar xzf fstar.tar.gz
+
+      - name: Install Z3
+        # Note: the packages built by build-packages.yml don't include Z3.
+        run: sudo ./fstar/get_fstar_z3.sh /usr/local/bin
 
       - name: Smoke test
         run: |
@@ -57,15 +55,14 @@ jobs:
           - ubuntu-latest
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: cda-tum/setup-z3@main
-        with:
-          version: 4.13.3
-
       - name: Get fstar package
         uses: actions/download-artifact@v8
         with:
           name: ${{ matrix.pak }}
       - run: tar xzf ${{ matrix.pak }}
+
+      - name: Install Z3
+        run: sudo ./fstar/get_fstar_z3.sh /usr/local/bin
 
       - name: Set-up OCaml
         uses: ocaml/setup-ocaml@v3


### PR DESCRIPTION
Nightly CI has been failing because the workflow can't install Z3, maybe because the cda-tum/setup-z3 action uses a rate-limited github API.  No matter the root cause, our Z3 install script works just fine right now.  See also #4206 and #4226.