### PR TITLE
Update karamel submodule, now up-to-date with master

### DIFF
--- a/pulse/test/ANF.c.expected
+++ b/pulse/test/ANF.c.expected
@@ -7,14 +7,14 @@ extern krml_checked_int_t Prims_op_Addition(krml_checked_int_t x, krml_checked_i
 
 void ANF_test(void)
 {
-  krml_checked_int_t r = (krml_checked_int_t)0;
+  krml_checked_int_t r = 0;
   krml_checked_int_t __anf0 = r;
-  r = Prims_op_Addition(__anf0, (krml_checked_int_t)1);
+  r = Prims_op_Addition(__anf0, 1);
   krml_checked_int_t __anf01 = r;
-  r = Prims_op_Addition(__anf01, (krml_checked_int_t)1);
+  r = Prims_op_Addition(__anf01, 1);
   krml_checked_int_t __anf02 = r;
-  r = Prims_op_Addition(__anf02, (krml_checked_int_t)1);
+  r = Prims_op_Addition(__anf02, 1);
   krml_checked_int_t __anf03 = r;
-  r = Prims_op_Addition(__anf03, (krml_checked_int_t)1);
+  r = Prims_op_Addition(__anf03, 1);
 }
 

--- a/pulse/test/BangBang.c.expected
+++ b/pulse/test/BangBang.c.expected
@@ -8,10 +8,10 @@ int32_t BangBang_modify_nested_ptr(int32_t **x)
   int32_t *__anf2 = *x;
   int32_t *__anf01 = *x;
   int32_t __anf1 = *__anf01;
-  *__anf2 = __anf1 + (int32_t)2;
+  *__anf2 = __anf1 + 2;
   int32_t *__anf03 = *x;
   int32_t __anf11 = *__anf03;
-  return __anf11 + (int32_t)1;
+  return __anf11 + 1;
 }
 
 void BangBang_decr_uint(void)

--- a/pulse/test/Break.c.expected
+++ b/pulse/test/Break.c.expected
@@ -7,21 +7,8 @@ void Break_simple_break(void)
 {
   bool k = true;
   bool _break = false;
-  bool cond;
-  if (_break)
-    cond = false;
-  else
-    cond = k;
-  while (cond)
-  {
+  while (!_break && k)
     _break = true;
-    bool ite;
-    if (_break)
-      ite = false;
-    else
-      ite = k;
-    cond = ite;
-  }
 }
 
 void Break_break_continue_and_return(uint8_t which)
@@ -92,7 +79,7 @@ size_t Break_find_zero_with_break(int32_t *a, size_t sz)
   {
     size_t __anf01 = i;
     int32_t __anf1 = a[__anf01];
-    if (__anf1 == (int32_t)0)
+    if (__anf1 == 0)
       _break = true;
     bool _break1 = _break;
     if (!_break1)

--- a/pulse/test/Example_Hashtable.c.expected
+++ b/pulse/test/Example_Hashtable.c.expected
@@ -248,12 +248,7 @@ insert__size_t_Example_Hashtable_data(
   size_t off = (size_t)0U;
   size_t idx = (size_t)0U;
   bool _break = false;
-  bool cond;
-  if (_break)
-    cond = false;
-  else
-    cond = true;
-  while (cond)
+  while (!_break)
   {
     size_t voff = off;
     size_t sum = cidx + voff;
@@ -334,12 +329,6 @@ insert__size_t_Example_Hashtable_data(
         "unreachable (pattern matches are exhaustive in F*)");
       KRML_HOST_EXIT(255U);
     }
-    bool ite;
-    if (_break)
-      ite = false;
-    else
-      ite = true;
-    cond = ite;
   }
   size_t __anf0 = idx;
   write_ref__Pulse_Lib_HashTable_Spec_cell_size_t_Example_Hashtable_data(&contents,

--- a/pulse/test/Goto.c.expected
+++ b/pulse/test/Goto.c.expected
@@ -6,7 +6,7 @@
 void Goto_test1(int32_t *r)
 {
   bool fail = false;
-  *r = (int32_t)42;
+  *r = 42;
   uint32_t x;
   x = 1U;
   fail = true;
@@ -29,7 +29,7 @@ size_t Goto_find_zero(int32_t *a, size_t sz)
   {
     size_t __anf01 = i;
     int32_t __anf1 = a[__anf01];
-    if (__anf1 == (int32_t)0)
+    if (__anf1 == 0)
     {
       size_t __anf02 = i;
       _return = __anf02;
@@ -62,9 +62,9 @@ void Goto_test2_alt(int32_t *r)
   bool _return = false;
   bool fail = false;
   int32_t __anf0 = *r;
-  if (__anf0 == (int32_t)67)
+  if (__anf0 == 67)
   {
-    *r = (int32_t)42;
+    *r = 42;
     _return = true;
   }
   bool _return1 = _return;
@@ -72,6 +72,6 @@ void Goto_test2_alt(int32_t *r)
     fail = true;
   bool _return10 = _return;
   if (!_return10)
-    *r = (int32_t)17;
+    *r = 17;
 }
 

--- a/pulse/test/InlineArrayLen.c.expected
+++ b/pulse/test/InlineArrayLen.c.expected
@@ -7,7 +7,7 @@ int32_t InlineArrayLen_basic(void)
 {
   int32_t arr[2U];
   for (uint32_t _i = 0U; _i < (size_t)2U; ++_i)
-    arr[_i] = (int32_t)123;
+    arr[_i] = 123;
   return arr[0U];
 }
 
@@ -15,7 +15,7 @@ int32_t InlineArrayLen_use(void)
 {
   int32_t arr[2U];
   for (uint32_t _i = 0U; _i < (size_t)2U; ++_i)
-    arr[_i] = (int32_t)123;
+    arr[_i] = 123;
   return arr[0U];
 }
 
@@ -23,13 +23,13 @@ int32_t InlineArrayLen_use_gen_init(void)
 {
   int32_t arr[2U];
   for (uint32_t _i = 0U; _i < (size_t)2U; ++_i)
-    arr[_i] = (int32_t)123;
+    arr[_i] = 123;
   return arr[0U];
 }
 
 int32_t InlineArrayLen_use_gen_init_st(void)
 {
-  int32_t __anf0 = (int32_t)123;
+  int32_t __anf0 = 123;
   int32_t arr[2U];
   for (uint32_t _i = 0U; _i < (size_t)2U; ++_i)
     arr[_i] = __anf0;
@@ -40,7 +40,7 @@ int32_t InlineArrayLen_use_gen_len(void)
 {
   int32_t arr[2U];
   for (uint32_t _i = 0U; _i < (size_t)2U; ++_i)
-    arr[_i] = (int32_t)123;
+    arr[_i] = 123;
   return arr[0U];
 }
 
@@ -50,7 +50,7 @@ int32_t InlineArrayLen_use_gen_len_st(void)
   KRML_CHECK_SIZE(sizeof (int32_t), __anf0);
   int32_t arr[__anf0];
   for (uint32_t _i = 0U; _i < __anf0; ++_i)
-    arr[_i] = (int32_t)123;
+    arr[_i] = 123;
   return arr[0U];
 }
 

--- a/pulse/test/Null.c.expected
+++ b/pulse/test/Null.c.expected
@@ -17,9 +17,6 @@ krml_checked_int_t *Null_foo(void)
 
 krml_checked_int_t Null_test(krml_checked_int_t *x1)
 {
-  if (x1 == NULL)
-    return (krml_checked_int_t)0;
-  else
-    return *x1;
+  return x1 == NULL ? 0 : *x1;
 }
 

--- a/pulse/test/bug-reports/Bug166.c.expected
+++ b/pulse/test/bug-reports/Bug166.c.expected
@@ -5,6 +5,6 @@
 
 krml_checked_int_t Bug166_h2(void)
 {
-  return (krml_checked_int_t)42;
+  return 42;
 }
 


### PR DESCRIPTION
After https://github.com/FStarLang/karamel/pull/734, we can just use
vanilla karamel. Update to get ternary operators and more.