### PR TITLE
Weekly release workflow.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,13 +7,26 @@ on:
         description: 'Dry run: just build, do not publish'
         default: false
         type: boolean
+      target_sha:
+        description: 'Commit SHA to release (default: HEAD of default branch)'
+        default: ''
+        type: string
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+permissions:
+  contents: write
 
 env:
   DRY_RUN: ${{ github.event.inputs.dry_run || false }}
+  # Use the provided SHA, or fall back to the SHA that triggered the workflow.
+  TARGET_SHA: ${{ github.event.inputs.target_sha || github.sha }}
 
 jobs:
-  # Bump version number beforehand? I don't think the action can push
-  # that to master (easily). Just remember to do so manually.
+  # Bump version number beforehand, or use the weekly-release workflow
+  # which automates the bump + release cycle.
 
   # At least check for it, so we don't run this whole thing and fail
   # for an existing tag.
@@ -22,6 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          ref: ${{ env.TARGET_SHA }}
           submodules: true
       - if: env.DRY_RUN != 'true' # don't check on a dry run.
         run: |
@@ -35,6 +49,8 @@ jobs:
   build-all:
     needs: pre
     uses: ./.github/workflows/build-all.yml
+    with:
+      ref: ${{ github.event.inputs.target_sha || '' }}
 
   publish:
     runs-on: ubuntu-latest
@@ -54,6 +70,7 @@ jobs:
 
       - uses: actions/checkout@v6
         with:
+          ref: ${{ env.TARGET_SHA }}
           submodules: true
           path: FStar
       - name: Rename packages to have version number
@@ -80,7 +97,7 @@ jobs:
 
           TAG="v$V"
           # Create and push annotated tag to repo.
-          git tag -a -m "F* version $V" "$TAG" "${{github.sha}}"
+          git tag -a -m "F* version $V" "$TAG" "${{ env.TARGET_SHA }}"
           git push origin "$TAG"
 
           # Create github release.

--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -4,7 +4,7 @@ name: Weekly release
 #
 # Creates a PR to bump version.txt and fstar.opam to the current date,
 # enables auto-merge, waits for CI to pass and the PR to merge, then
-# dispatches the release workflow.
+# dispatches the release workflow on the exact merge commit.
 #
 # Requirements:
 #   - "Allow auto-merge" must be enabled in repo settings
@@ -15,6 +15,10 @@ on:
   schedule:
     - cron: '0 12 * * 0' # Every Sunday at noon UTC
   workflow_dispatch:
+
+concurrency:
+  group: weekly-release
+  cancel-in-progress: false
 
 permissions:
   contents: write
@@ -33,7 +37,7 @@ jobs:
       - name: Compute new version
         id: version
         run: |
-          NEW_VERSION=$(date +%Y.%m.%d)
+          NEW_VERSION=$(date -u +%Y.%m.%d)
           echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
 
           git fetch --tags
@@ -84,15 +88,19 @@ jobs:
 
       - name: Wait for PR merge
         if: steps.version.outputs.skip != 'true'
+        id: merged
         timeout-minutes: 180
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           BRANCH="auto/bump-v${{ steps.version.outputs.new_version }}"
           while true; do
-            STATE=$(gh pr view "$BRANCH" --json state -q .state)
+            PR_JSON=$(gh pr view "$BRANCH" --json state,mergeCommit)
+            STATE=$(echo "$PR_JSON" | jq -r '.state')
             if [[ "$STATE" == "MERGED" ]]; then
-              echo "PR merged successfully"
+              MERGE_SHA=$(echo "$PR_JSON" | jq -r '.mergeCommit.oid')
+              echo "PR merged at $MERGE_SHA"
+              echo "merge_sha=$MERGE_SHA" >> "$GITHUB_OUTPUT"
               break
             elif [[ "$STATE" == "CLOSED" ]]; then
               echo "::error::PR was closed without merging"
@@ -106,4 +114,7 @@ jobs:
         if: steps.version.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh workflow run release.yml
+        run: |
+          MERGE_SHA="${{ steps.merged.outputs.merge_sha }}"
+          echo "Dispatching release.yml for commit $MERGE_SHA"
+          gh workflow run release.yml -f target_sha="$MERGE_SHA"

--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -1,0 +1,109 @@
+name: Weekly release
+
+# Automated weekly version bump and release.
+#
+# Creates a PR to bump version.txt and fstar.opam to the current date,
+# enables auto-merge, waits for CI to pass and the PR to merge, then
+# dispatches the release workflow.
+#
+# Requirements:
+#   - "Allow auto-merge" must be enabled in repo settings
+#   - Branch protection must not require PR reviews (or the bot must
+#     be able to satisfy them)
+
+on:
+  schedule:
+    - cron: '0 12 * * 0' # Every Sunday at noon UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: write
+
+jobs:
+  bump-and-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: true
+          fetch-depth: 0
+
+      - name: Compute new version
+        id: version
+        run: |
+          NEW_VERSION=$(date +%Y.%m.%d)
+          echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+
+          git fetch --tags
+          if git tag -l "v$NEW_VERSION" | grep -q .; then
+            echo "::notice::Version v$NEW_VERSION already released, skipping"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Close stale auto-bump PRs
+        if: steps.version.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr list --state open --json number,headRefName \
+            -q '.[] | select(.headRefName | startswith("auto/bump-v")) | .number' \
+          | while read -r pr; do
+            echo "Closing stale auto-bump PR #$pr"
+            gh pr close "$pr" --comment "Superseded by weekly bump to v${{ steps.version.outputs.new_version }}."
+          done
+
+      - name: Bump version and create PR
+        if: steps.version.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NEW_VERSION: ${{ steps.version.outputs.new_version }}
+        run: |
+          BRANCH="auto/bump-v$NEW_VERSION"
+
+          git config user.name "Dzomo, the Everest Yak"
+          git config user.email "24394600+dzomo@users.noreply.github.com"
+
+          git checkout -b "$BRANCH"
+          echo "$NEW_VERSION" > version.txt
+          sed -i 's/^version: ".*"/version: "'"$NEW_VERSION"'~dev"/' fstar.opam
+          git add version.txt fstar.opam
+          git commit -m "Bump version to $NEW_VERSION"
+          git push origin "$BRANCH"
+
+          gh pr create \
+            --title "Bump version to $NEW_VERSION" \
+            --body "Automated weekly version bump for release v$NEW_VERSION." \
+            --base master \
+            --head "$BRANCH"
+
+          gh pr merge "$BRANCH" --auto --squash
+
+      - name: Wait for PR merge
+        if: steps.version.outputs.skip != 'true'
+        timeout-minutes: 180
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          BRANCH="auto/bump-v${{ steps.version.outputs.new_version }}"
+          while true; do
+            STATE=$(gh pr view "$BRANCH" --json state -q .state)
+            if [[ "$STATE" == "MERGED" ]]; then
+              echo "PR merged successfully"
+              break
+            elif [[ "$STATE" == "CLOSED" ]]; then
+              echo "::error::PR was closed without merging"
+              exit 1
+            fi
+            echo "PR state: $STATE, waiting..."
+            sleep 60
+          done
+
+      - name: Trigger release
+        if: steps.version.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run release.yml


### PR DESCRIPTION
This workflow, which runs every Sunday at noon UTC, automates generating a release.

It will bump the version number in fstar.opam and version.txt, post a PR with the update and enable automerge (the PR needs to pass CI due to branch protection) and, after it merges, it will kick off release.yml to build and publish the binaries and tags. The workflow can also be run manually, allowing us to create releases fully from the web and with a few clicks.

Generated by Claude Opus, reviewed by me (= the workflow looks sensible, I haven't tested it yet).