### PR TITLE
Allowing implicit fields in records

### DIFF
--- a/src/syntax/FStarC.Syntax.DsEnv.fst
+++ b/src/syntax/FStarC.Syntax.DsEnv.fst
@@ -360,7 +360,7 @@ let find_in_record ns id record (cont: record_or_dc -> ML (cont_t 'a)) : ML (con
  if lid_equals typename' record.typename
  then
       let fname = lid_of_ids (ns_of_lid record.typename @ [id]) in
-      let find = BU.find_map record.fields (fun (f, _) ->
+      let find = BU.find_map record.fields (fun (f, _, _) ->
         if string_of_id id = string_of_id f
         then Some record
         else None)
@@ -373,7 +373,7 @@ let find_in_record ns id record (cont: record_or_dc -> ML (cont_t 'a)) : ML (con
 
 let find_in_record_many ids record (cont: record_or_dc -> ML (cont_t 'a)) : ML (cont_t 'a) =
   let found = BU.multiset_equiv
-      (fun (fn,_) id -> string_of_id id = string_of_id fn)
+      (fun (fn, _, _) id -> string_of_id id = string_of_id fn)
       record.fields ids
   in
   if found
@@ -1005,16 +1005,7 @@ let extract_record (e:env) (new_globs: ref (list scope_mod)) : sigelt -> ML unit
                 (* Ignore parameters, we don't create projectors for them *)
                 let _params, formals = BU.first_N n all_formals in
                 let is_rec = is_record typename_quals in
-                let formals' = formals |> List.collect (fun f ->
-                        if S.is_null_bv f.binder_bv
-                        || (is_rec && S.is_bqual_implicit f.binder_qual)
-                        then []
-                        else [f] )
-                in
-                let fields' = formals' |> List.map (fun f -> (f.binder_bv.ppname, f.binder_bv.sort))
-                in
-                let fields = fields'
-                in
+                let fields = formals |> List.map (fun f -> (f.binder_bv.ppname, S.is_bqual_implicit_or_meta f.binder_qual, f.binder_bv.sort)) in
                 let record = {typename=typename;
                               constrname=ident_of_lid constrname;
                               parms=parms;
@@ -1027,7 +1018,7 @@ let extract_record (e:env) (new_globs: ref (list scope_mod)) : sigelt -> ML unit
                 let () = new_globs := Record_or_dc record :: !new_globs in
                 (* the field names are added into the set of exported fields for "include" *)
                 let () =
-                  let add_field (id, _) =
+                  let add_field (id, _, _) =
                     let modul = string_of_lid (lid_of_ids (ns_of_lid constrname)) in
                     match get_exported_id_set e modul with
                     | Some my_ex ->
@@ -1042,7 +1033,7 @@ let extract_record (e:env) (new_globs: ref (list scope_mod)) : sigelt -> ML unit
                       ()
                     | None -> () (* current module was not prepared? should not happen *)
                   in
-                  List.iter add_field fields'
+                  List.iter add_field fields
                 in
                 insert_record_cache record
             | _ -> ()
@@ -1378,7 +1369,7 @@ let elab_restriction (f: env -> lident -> restriction -> ML env) env ns restrict
             |> List.filter (fun (x, _) -> name_exists x))
       // If `id` is a record, we include its fields
       @ ( match try_lookup_record_type env lid with
-        | Some {constrname; fields} -> List.map (fun (id, _) -> (id, None)) fields
+        | Some {constrname; fields} -> List.map (fun (id, _, _) -> (id, None)) fields
         | None -> [])
       end |> List.map (fun (id, renamed) -> (with_id_range id, Option.map with_renamed_range renamed))
     ) l |> List.flatten |> List.append l in

--- a/src/syntax/FStarC.Syntax.DsEnv.fsti
+++ b/src/syntax/FStarC.Syntax.DsEnv.fsti
@@ -32,7 +32,7 @@ type record_or_dc = {
   typename: lident; (* the namespace part applies to the constructor and fields as well *)
   constrname: ident;
   parms: binders;
-  fields: list (ident & typ);
+  fields: list (ident & bool & typ); (* bool: is it implicit or meta? *)
   is_private: bool;
   is_record:bool
 }

--- a/src/tosyntax/FStarC.ToSyntax.ToSyntax.fst
+++ b/src/tosyntax/FStarC.ToSyntax.ToSyntax.fst
@@ -1339,9 +1339,8 @@ and desugar_term_maybe_top (top_level:bool) (env:env_t) (top:term) : ML (S.term 
       let mk_pattern p = mk_pattern p r.range in
       let elab =
         let pat =
-          (* All of the fields are explicit arguments of the constructor, hence the None below *)
           mk_pattern (PatApp (mk_pattern (PatName constrname),
-                              List.map (fun (field, _) -> mk_pattern (PatVar (field, None, []))) record.fields))
+                              List.map (fun (field, is_imp, _) -> mk_pattern (PatVar (field, (if is_imp then Some Implicit else None), []))) record.fields))
         in
         let branch = (pat, None, e) in
         let r = mk_term (Ascribed (r, rty, None, false)) r.range Expr in

--- a/src/typechecker/FStarC.TypeChecker.TcTerm.fst
+++ b/src/typechecker/FStarC.TypeChecker.TcTerm.fst
@@ -1184,7 +1184,7 @@ and tc_maybe_toplevel_term env (e:term) : ML (term                  (* type-chec
     let rdc : DsEnv.record_or_dc = rdc in //for type-based disambiguation of rdc projectors below
     let open FStarC.Pprint in
     (if Some? (Env.expected_typ env) && not rdc.is_record then
-      let rdc_field_names = List.map (fun (i, _) -> Ident.string_of_id i) rdc.fields in
+      let rdc_field_names = List.map (fun (i, _, _) -> Ident.string_of_id i) rdc.fields in
       let bad_field = List.tryFind (fun i -> not (List.existsb (fun f -> f = Ident.string_of_id (Ident.ident_of_lid i)) rdc_field_names)) uc.uc_fields in
       match bad_field with
       | Some f ->
@@ -1201,18 +1201,20 @@ and tc_maybe_toplevel_term env (e:term) : ML (term                  (* type-chec
         let candidate = S.fvar (Ident.set_lid_range projname x.pos) qual in
         S.mk_Tm_app candidate [(x, None)] x.pos
     in
-    let fields =
+    let args =
         TcUtil.make_record_fields_in_order env uc topt
           rdc
           uc_fields
-          (fun field_name ->
+          (fun field_name is_imp ->
             match base_term with
             | Some x -> Some (mk_field_projector field_name x)
-            | _ -> None)
+            | None when is_imp ->
+              (* We're missing an implicit field, use a wildcard. *)
+              Some S.tun
+            | None -> None)
           top.pos
     in
-    let args = List.map (fun x -> x, None) fields in
-    let term = S.mk_Tm_app constructor args top.pos in
+    let term = S.mk_Tm_app constructor (List.map (fun (a, is_imp) -> a, as_aqual_implicit is_imp) args) top.pos in
     tc_term env term
 
   | Tm_app {hd={n=Tm_fvar {fv_name=field_name; fv_qual=Some (Unresolved_projector candidate)}};
@@ -1251,12 +1253,12 @@ and tc_maybe_toplevel_term env (e:term) : ML (term                  (* type-chec
       | Some rdc ->
         let i =
           List.tryFind
-            (fun (i, _) -> TcUtil.field_name_matches field_name rdc i)
+            (fun (i, _, _) -> TcUtil.field_name_matches field_name rdc i)
             rdc.fields
         in
         match i with
         | None -> proceed_with candidate
-        | Some (i, _) ->
+        | Some (i, _, _) ->
           let constrname = FStarC.Ident.lid_of_ids (Ident.ns_of_lid rdc.typename @ [rdc.constrname]) in
           let projname = mk_field_projector_name_from_ident constrname i in
           let qual = if rdc.is_record then Some (Record_projector (constrname, i)) else None in
@@ -3335,7 +3337,7 @@ and tc_pat env (pat_t:typ) (p0:pat) : ML (
           let f_sub_pats = List.zip uc.uc_fields sub_pats in
           let open FStarC.Pprint in
           if not rdc.is_record then begin
-            let rdc_field_names = List.map (fun (i, _) -> Ident.string_of_id i) rdc.fields in
+            let rdc_field_names = List.map (fun (i, _, _) -> Ident.string_of_id i) rdc.fields in
             let bad_field = List.tryFind (fun i -> not (List.existsb (fun f -> f = Ident.string_of_id (Ident.ident_of_lid i)) rdc_field_names)) uc.uc_fields in
             match bad_field with
             | Some f ->
@@ -3348,11 +3350,13 @@ and tc_pat env (pat_t:typ) (p0:pat) : ML (
           end;
           let sub_pats =
             TcUtil.make_record_fields_in_order env uc (Some (Inl t)) rdc f_sub_pats
-              (fun _ ->
+              (fun _ is_imp ->
                 let x = S.new_bv None S.tun in
                 Some (S.withinfo (Pat_var x) p.p, false))
               p.p
           in
+          let sub_pats = List.map (fun ((p, _), b) -> p, b) sub_pats in
+          (* ^ Respect the implicitness of the fields. *)
           let p = { p with v=Pat_cons(constructor_fv, us_opt, sub_pats) } in
           let p = PatternUtils.elaborate_pat env p in
           check_nested_pattern env p t

--- a/src/typechecker/FStarC.TypeChecker.TcTerm.fst
+++ b/src/typechecker/FStarC.TypeChecker.TcTerm.fst
@@ -1214,7 +1214,10 @@ and tc_maybe_toplevel_term env (e:term) : ML (term                  (* type-chec
             | None -> None)
           top.pos
     in
-    let term = S.mk_Tm_app constructor (List.map (fun (a, is_imp) -> a, as_aqual_implicit is_imp) args) top.pos in
+    (* First, apply the constructor to as many wildcards as it has parameters. Otherwise,
+       if its first field is implicit, we would construct a bad application. *)
+    let term = S.mk_Tm_app constructor (List.map (fun _ -> S.iarg S.tun) rdc.parms) top.pos in
+    let term = S.mk_Tm_app term (List.map (fun (a, is_imp) -> a, as_aqual_implicit is_imp) args) top.pos in
     tc_term env term
 
   | Tm_app {hd={n=Tm_fvar {fv_name=field_name; fv_qual=Some (Unresolved_projector candidate)}};

--- a/src/typechecker/FStarC.TypeChecker.Util.fst
+++ b/src/typechecker/FStarC.TypeChecker.Util.fst
@@ -3597,9 +3597,8 @@ let try_lookup_record_type env (typename:lident)
          | Some ({sigel=Sig_datacon {t; num_ty_params=nparms}}) ->
            let formals, c = U.arrow_formals t in
            if nparms < List.length formals
-           then let _, fields = List.splitAt nparms formals in //remove params
-                let fields = List.filter (fun b -> match b.binder_qual with | Some (Implicit _) -> false | _ -> true) fields in //remove implicits
-                let fields = List.map (fun b -> b.binder_bv.ppname, b.binder_bv.sort) fields in
+           then let _, fields = List.splitAt nparms formals in // Remove params. Whatever remains are fields.
+                let fields = List.map (fun b -> b.binder_bv.ppname, S.is_bqual_implicit_or_meta b.binder_qual, b.binder_bv.sort) fields in
                 let is_rec = Env.is_record env typename in
                 let r : DsEnv.record_or_dc =
                   {
@@ -3684,7 +3683,7 @@ let find_record_or_dc_from_head_fv env (head_fv:option fv) (uc:unresolved_constr
     let constructor =
         let qual =
           if rdc.is_record
-            then (Some (Record_ctor(rdc.typename, rdc.fields |> List.map fst)))
+            then (Some (Record_ctor(rdc.typename, rdc.fields |> List.map (fun (i, _, _) -> i))))
           else None
         in
         S.lid_as_fv constrname qual
@@ -3714,9 +3713,10 @@ let field_name_matches (field_name:lident) (rdc:DsEnv.record_or_dc) (field:ident
   The field assignments of a record constructor can be given out of
   order.
 
-  Given that we've committed to `rdc` as the record constructor, if
-  the user's field assignments are `fas`, then we order the alphas
-  by the order in which they appear in `rdc`.
+  Given that we've committed to `rdc` as the record constructor, if the user's
+  field assignments are `fas`, then we order the alphas by the order in which
+  they appear in `rdc`. This is the list we return, augmented with a boolean to
+  indicate whether the field was implicit or not.
 
   If a particular field cannot be found, then we call not_found, which
   an provide a default.
@@ -3724,18 +3724,21 @@ let field_name_matches (field_name:lident) (rdc:DsEnv.record_or_dc) (field:ident
   We raise errors if fields are not found and no default exists, or if
   redundant fields are present.
 *)
-let make_record_fields_in_order env uc topt
+let make_record_fields_in_order
+       (env : Env.env)
+       (uc : unresolved_constructor)
+       (topt : option (either typ typ))
        (rdc : DsEnv.record_or_dc)
        (fas : list (lident & 'a))
-       (not_found:ident -> ML (option 'a))
+       (not_found : (ident -> is_imp:bool -> ML (option 'a)))
        (rng : Range.t)
-  : ML (list 'a)
+  : ML (list ('a & bool))
   = let debug () =
       let print_rdc (rdc:DsEnv.record_or_dc) =
         Format.fmt3 "{typename=%s; constrname=%s; fields=[%s]}"
           (string_of_lid rdc.typename)
           (string_of_id rdc.constrname)
-          (List.map (fun (i, _) -> string_of_id i) rdc.fields |> String.concat "; ")
+          (List.map (fun (i, _, _) -> string_of_id i) rdc.fields |> String.concat "; ")
       in
       let print_topt topt =
         Format.fmt2 "topt=%s; rdc=%s" (show topt) (print_rdc rdc)
@@ -3749,7 +3752,7 @@ let make_record_fields_in_order env uc topt
     in
     let rest, as_rev, missing =
       List.fold_left
-        (fun (fields, as_rev, missing) (field_name, _) ->
+        (fun (fields, as_rev, missing) (field_name, is_imp, _) ->
            let matching, rest =
              List.partition
                (fun (fn, _) -> field_name_matches fn rdc field_name)
@@ -3757,15 +3760,15 @@ let make_record_fields_in_order env uc topt
            in
            match matching with
            | [(_, a)] ->
-             rest, a::as_rev, missing
+             rest, (a, is_imp) ::as_rev, missing
 
            | [] -> (
-             match not_found field_name with
+             match not_found field_name is_imp with
              | None ->
 //               debug();
-              rest, as_rev, field_name :: missing
+               rest, as_rev, field_name :: missing
              | Some a ->
-               rest, a::as_rev, missing
+               rest, (a, is_imp) ::as_rev, missing
              )
 
            | x1::x2::_ ->
@@ -3795,6 +3798,7 @@ let make_record_fields_in_order env uc topt
         ]
 
       | [], _ ->
+        // debug ();
         raise_error rng Errors.Fatal_MissingFieldInRecord [
             prefix 2 1 (text <| Format.fmt1 "Missing fields for record type '%s':" (show rdc.typename))
                 (pp_missing ())

--- a/src/typechecker/FStarC.TypeChecker.Util.fst
+++ b/src/typechecker/FStarC.TypeChecker.Util.fst
@@ -3597,14 +3597,14 @@ let try_lookup_record_type env (typename:lident)
          | Some ({sigel=Sig_datacon {t; num_ty_params=nparms}}) ->
            let formals, c = U.arrow_formals t in
            if nparms < List.length formals
-           then let _, fields = List.splitAt nparms formals in // Remove params. Whatever remains are fields.
+           then let parms, fields = List.splitAt nparms formals in // Remove params. Whatever remains are fields.
                 let fields = List.map (fun b -> b.binder_bv.ppname, S.is_bqual_implicit_or_meta b.binder_qual, b.binder_bv.sort) fields in
                 let is_rec = Env.is_record env typename in
                 let r : DsEnv.record_or_dc =
                   {
                     typename = typename;
                     constrname = Ident.ident_of_lid dc;
-                    parms = [];
+                    parms;
                     fields = fields;
                     is_private = false;
                     is_record = is_rec

--- a/src/typechecker/FStarC.TypeChecker.Util.fsti
+++ b/src/typechecker/FStarC.TypeChecker.Util.fsti
@@ -193,9 +193,28 @@ val try_lookup_record_type : env -> lident -> ML (option DsEnv.record_or_dc)
 val head_fv_of_typ (_:env) (t:typ) : ML (option fv)
 val find_record_or_dc_from_head_fv : env -> option fv -> unresolved_constructor -> Range.t -> ML (DsEnv.record_or_dc & lident & fv)
 val field_name_matches : lident -> DsEnv.record_or_dc -> ident -> ML bool
-val make_record_fields_in_order : env -> unresolved_constructor -> option (either typ typ) ->
-                                DsEnv.record_or_dc ->
-                                list (lident & 'a) ->
-                                not_found:(ident -> ML (option 'a)) ->
-                                Range.t ->
-                                ML (list 'a)
+
+(*
+  The field assignments of a record constructor can be given out of
+  order.
+
+  Given that we've committed to `rdc` as the record constructor, if the user's
+  field assignments are `fas`, then we order the alphas by the order in which
+  they appear in `rdc`. This is the list we return, augmented with a boolean to
+  indicate whether the field was implicit or not.
+
+  If a particular field cannot be found, then we call not_found, which
+  an provide a default.
+
+  We raise errors if fields are not found and no default exists, or if
+  redundant fields are present.
+*)
+val make_record_fields_in_order
+       (env : Env.env)
+       (uc : unresolved_constructor)
+       (topt : option (either typ typ))
+       (rdc : DsEnv.record_or_dc)
+       (fas : list (lident & 'a))
+       (not_found : (ident -> is_imp:bool -> ML (option 'a)))
+       (rng : Range.t)
+  : ML (list ('a & bool))

--- a/tests/micro-benchmarks/ImplicitRecordFields.fst
+++ b/tests/micro-benchmarks/ImplicitRecordFields.fst
@@ -1,0 +1,119 @@
+module ImplicitRecordFields
+
+(* An implicit field, to be solved by unification. *)
+noeq
+type dyn = {
+  #t : Type0;
+  x : t;
+}
+
+let xx : dyn = { x = 1; }
+let yy : dyn = { t = _; x = 1; }
+
+(* The constructor also has an implicit for the relevant field. *)
+let _ = assert (xx == Mkdyn 1)
+
+(* Projectors are still there. *)
+let _ = assert (xx.t == int)
+let _ = assert (xx.x == 1)
+let _ = assert (Mkdyn?.t xx == int)
+let _ = assert (Mkdyn?.x xx == 1)
+
+(* Any of the fields can be matched. *)
+let test0 () =
+  match xx with
+  | {x} -> assert (x == 1)
+  | {t; x} -> assert (x == 1)
+  | {t} -> ()
+
+(* In a typeclass, with a meta implicit for a field. *)
+open FStar.Tactics
+
+class deq (a : Type) = {
+  eq : a -> a -> bool;
+
+  #[easy_fill ()]
+  eq_ok : (x:a) -> (y:a) -> eq x y -> x == y;
+}
+
+let test #t {| deq t |} (x:t) (y:t) : unit =
+  if eq x y then (
+    eq_ok x y ();
+    assert (x == y)
+  )
+
+instance test1 : deq int = {
+  eq = (fun x y -> x = y);
+}
+
+[@@expect_failure [118]]
+instance test1' : deq int = {
+  eq_ok = (fun _ _ _ -> ());
+}
+
+instance test2 : deq int = {
+  eq = (fun x y -> x = y);
+  eq_ok = (fun _ _ _ -> ())
+}
+
+instance test3 : deq int = {
+  eq = (fun x y -> false);
+}
+
+[@@expect_failure [19]]
+instance test4 : deq int = {
+  eq = (fun x y -> true);
+}
+
+(* Multiple implicit fields. *)
+noeq
+type multi_imp = {
+  #a : Type0;
+  #b : Type0;
+  va : a;
+  vb : b;
+}
+
+let mi1 : multi_imp = { va = 1; vb = true; }
+let mi2 : multi_imp = { a = int; va = 1; vb = true; }
+let mi3 : multi_imp = { a = int; b = bool; va = 1; vb = true; }
+
+let _ = assert (mi1.va == 1)
+let _ = assert (mi1.vb == true)
+
+(* Record update syntax preserves implicit fields. *)
+let mi4 = { mi1 with va = 2; }
+let _ = assert (mi4.va == 2)
+let _ = assert (mi4.vb == true)
+
+(* Projecting the implicit field. *)
+let _ = assert (mi1.a == int)
+let _ = assert (mi1.b == bool)
+
+(* Missing explicit field should still be an error. *)
+[@@expect_failure [118]]
+let bad_missing_explicit : dyn = { t = int }
+
+(* Pattern matching: only match some fields. *)
+let match_multi (m : multi_imp{m.a == int}) : int =
+  match m with
+  | { va = v } -> v + 0  // only matching one explicit field
+
+(* Implicit field with a dependency on another field. *)
+noeq
+type dep_imp = {
+  #n : nat;
+  v : (x:nat{x < n});
+}
+
+let di1 : dep_imp = { n = 10; v = 5; }
+let _ = assert (di1.n == 10)
+
+(* If n cannot be inferred, it should fail. *)
+[@@expect_failure [66]]
+let di_bad : dep_imp = { v = 0; }
+
+(* Fields given out of order. *)
+let mi_ooo : multi_imp = { vb = "hello"; va = 42; }
+let _ = assert (mi_ooo.a == int)
+let _ = assert (mi_ooo.b == string)

--- a/tests/micro-benchmarks/ImplicitRecordFields.fst
+++ b/tests/micro-benchmarks/ImplicitRecordFields.fst
@@ -117,3 +117,29 @@ let di_bad : dep_imp = { v = 0; }
 let mi_ooo : multi_imp = { vb = "hello"; va = 42; }
 let _ = assert (mi_ooo.a == int)
 let _ = assert (mi_ooo.b == string)
+
+(* With a parameter and implicit field. The constructor
+has two implicits, the typechecker should consider that
+and elaborate xx to something like `Mkfoo #_ #1 (+)`. *)
+noeq
+type with_param (t : Type) = {
+  #x : t;
+  add : t -> t -> t;
+}
+
+let test_param : with_param int =
+  { x = 1; add = (+); }
+
+(* With a parameter and implicit field. The constructor
+has two implicits, the typechecker should consider that
+and elaborate xx to something like `Mkfoo #_ #int (+)`. *)
+noeq
+type with_param' (t' : Type) = {
+  #t : (t : Type{t == t'});
+  add : t -> t -> t;
+}
+
+let test_param' : with_param' int =
+  { add = (+); }
+let test_param'' : with_param' int =
+  { t = int; add = (+); }


### PR DESCRIPTION
This patch allows record fields to be marked implicit, and even with a meta tactic to be used to solve it. This is useful when some of the fields are types for the next ones, and hence solvable by unification, or if some of the fields are proofs that are usually trivial.

I would like for `#[exact (`(fun _ _ _ -> ()))]` to work too, but that fails when running the tactic.