### PR TITLE
Reduce applied projections

### DIFF
--- a/pulse/lib/core/PulseCore.IndirectionTheorySep.fst
+++ b/pulse/lib/core/PulseCore.IndirectionTheorySep.fst
@@ -740,6 +740,7 @@ let timeless_ext (a b: (p:slprop {timeless p})) (h: (w: premem { level_ w == 0 }
     timeless_interp b w;
     h (age_to_ w 0)
 
+#push-options "--z3rlimit 20"
 let equiv_timeless (a b: slprop) :
     Lemma (requires timeless a /\ timeless b)
       (ensures timeless (equiv a b) /\ equiv a b == pure (a == b)) =
@@ -754,6 +755,7 @@ let equiv_timeless (a b: slprop) :
     introduce equiv a b w ==> a == b with _.
       timeless_ext a b fun w' ->
         eq_at_elim 1 a b w'
+#pop-options
 
 let equiv_star_congr (p q r: slprop) =
   let aux (q r: slprop) (n: nat { eq_at n q r }) (w: premem) =

--- a/pulse/src/checker/Pulse.Checker.Prover.Normalize.fst
+++ b/pulse/src/checker/Pulse.Checker.Prover.Normalize.fst
@@ -44,6 +44,8 @@ let __normalize_slprop
   let steps = steps @ [delta_qualifier ["unfold"]] in
   (* Unfold recursive definitions too, but only the ones that match the filters above. *)
   let steps = steps @ [zeta] in
+  (* Reduce applied projections like {x=1; ..}.x *)
+  let steps = steps @ [reduce_projections] in
 
   let v' = PCP.norm_well_typed_term (elab_env g) steps v in
   let v' = Pulse.Simplify.simplify v' in (* NOTE: the simplify stage is unverified *)

--- a/pulse/src/extraction/ExtractPulseOCaml.fst
+++ b/pulse/src/extraction/ExtractPulseOCaml.fst
@@ -31,21 +31,12 @@ module Ident = FStarC.Ident
 
 let dbg = Debug.get_toggle "extraction"
 
-let hua (t:term) : ML (option (S.fv & list S.universe & S.args)) =
-  let t = U.unmeta t in
-  let hd, args = U.head_and_args_full t in
-  let hd = U.unmeta hd in
-  match (SS.compress hd).n with
-  | Tm_fvar fv -> Some (fv, [], args)
-  | Tm_uinst ({ n = Tm_fvar fv }, us) -> Some (fv, us, args)
-  | _ -> None
-
 let tr_typ (g:uenv) (t:term) : ML mlty =
   (* Only enabled with an extension flag *)
   if Options.Ext.get "pulse:extract_ocaml_bare" = "" then
     raise NotSupportedByExtension;
   let cb = FStarC.Extraction.ML.Term.term_as_mlty in
-  let hua = hua t in
+  let hua = U.hua t in
   if None? hua then
     raise NotSupportedByExtension;
   let Some (fv, us, args) = hua in
@@ -78,7 +69,7 @@ let tr_expr (g:uenv) (t:term) : ML (mlexpr & e_tag & mlty) =
   if Options.Ext.get "pulse:extract_ocaml_bare" = "" then
     raise NotSupportedByExtension;
   let cb = FStarC.Extraction.ML.Term.term_as_mlexpr in
-  let hua = hua t in
+  let hua = U.hua t in
   if None? hua then
     raise NotSupportedByExtension;
   let Some (fv, us, args) = hua in

--- a/src/basic/FStarC.NormSteps.fst
+++ b/src/basic/FStarC.NormSteps.fst
@@ -27,6 +27,7 @@ type norm_step =
   | UnfoldNamespace : list string -> norm_step
   | Unmeta : norm_step
   | Unascribe // Remove type ascriptions [t <: ty ~> t]
+  | ReduceProjections : norm_step
 
 irreducible
 let simplify = Simpl
@@ -84,3 +85,6 @@ let unmeta = Unmeta
 
 irreducible
 let unascribe = Unascribe
+
+irreducible
+let reduce_projections = ReduceProjections

--- a/src/parser/FStarC.Parser.Const.fst
+++ b/src/parser/FStarC.Parser.Const.fst
@@ -331,6 +331,7 @@ let steps_unfoldnamespace = mk_norm_step_lid "delta_namespace"
 let steps_unascribe       = mk_norm_step_lid "unascribe"
 let steps_nbe             = mk_norm_step_lid "nbe"
 let steps_unmeta          = mk_norm_step_lid "unmeta"
+let steps_reduce_projections = mk_norm_step_lid "reduce_projections"
 
 (* attributes *)
 let deprecated_attr = pconst "deprecated"

--- a/src/syntax/FStarC.Syntax.Embeddings.fst
+++ b/src/syntax/FStarC.Syntax.Embeddings.fst
@@ -792,6 +792,7 @@ let steps_UnfoldNamespace = tconst PC.steps_unfoldnamespace
 let steps_Unascribe     = tconst PC.steps_unascribe
 let steps_NBE           = tconst PC.steps_nbe
 let steps_Unmeta        = tconst PC.steps_unmeta
+let steps_ReduceProjections = tconst PC.steps_reduce_projections
 
 let e_norm_step : embedding NormSteps.norm_step =
   let open FStarC.NormSteps in
@@ -852,6 +853,8 @@ let e_norm_step : embedding NormSteps.norm_step =
                     S.mk_Tm_app steps_UnfoldNamespace [S.as_arg (embed l rng None norm)]
                                 rng
 
+                | ReduceProjections ->
+                    steps_ReduceProjections
 
                 )
     in
@@ -908,6 +911,8 @@ let e_norm_step : embedding NormSteps.norm_step =
                 | Tm_fvar fv, [(l, _)] when S.fv_eq_lid fv PC.steps_unfoldnamespace ->
                     Option.bind (try_unembed l norm) (fun ss ->
                     Some <| UnfoldNamespace ss)
+                | Tm_fvar fv, [] when S.fv_eq_lid fv PC.steps_reduce_projections ->
+                    Some ReduceProjections
                 | _ -> None)
     in
     mk_emb_full

--- a/src/syntax/FStarC.Syntax.Util.fst
+++ b/src/syntax/FStarC.Syntax.Util.fst
@@ -2084,3 +2084,12 @@ let eq_binding b1 b2 =
     | Binding_lid (lid1, _), Binding_lid (lid2, _) -> lid_equals lid1 lid2
     | Binding_univ u1, Binding_univ u2 -> ident_equals u1 u2
     | _ -> false
+
+let hua (t:term) : ML (option (fv & list universe & args)) =
+  let t = unmeta t in
+  let hd, args = head_and_args_full t in
+  let hd = unmeta hd in
+  match (compress hd).n with
+  | Tm_fvar fv -> Some (fv, [], args)
+  | Tm_uinst ({ n = Tm_fvar fv }, us) -> Some (fv, us, args)
+  | _ -> None

--- a/src/syntax/FStarC.Syntax.Util.fsti
+++ b/src/syntax/FStarC.Syntax.Util.fsti
@@ -629,3 +629,6 @@ val is_binder_unused (b:binder) : bool
 val deduplicate_terms (l:list term) : ML (list term)
 
 val eq_binding (b1 b2 : binding) : ML bool
+
+(* Destruct application: head, universes, and args. *)
+val hua (t:term) : ML (option (fv & list universe & args))

--- a/src/typechecker/FStarC.TypeChecker.Cfg.fst
+++ b/src/typechecker/FStarC.TypeChecker.Cfg.fst
@@ -59,6 +59,7 @@ let steps_to_string f : ML string =
     unrefine = %s;\n\
     default_univs_to_zero = %s;\n\
     tactics = %s;\n\
+    reduce_projections = %s;\n\
   }"
   [ f.beta |> show;
     f.iota |> show;
@@ -92,6 +93,7 @@ let steps_to_string f : ML string =
     f.unrefine |> show;
     f.default_univs_to_zero |> show;
     f.tactics |> show;
+    f.reduce_projections |> show;
    ]
 
 instance deq_fsteps : deq fsteps = {
@@ -127,7 +129,8 @@ instance deq_fsteps : deq fsteps = {
             f1.for_extraction =? f2.for_extraction &&
             f1.unrefine =? f2.unrefine &&
             f1.default_univs_to_zero =? f2.default_univs_to_zero &&
-            f1.tactics =? f2.tactics
+            f1.tactics =? f2.tactics &&
+            f1.reduce_projections =? f2.reduce_projections
             );
 }
 
@@ -165,6 +168,7 @@ let default_steps : fsteps = {
     unrefine = false;
     default_univs_to_zero = false;
     tactics = false;
+    reduce_projections = false;
 }
 
 let fstep_add_one s fs : ML fsteps =
@@ -214,6 +218,7 @@ let fstep_add_one s fs : ML fsteps =
     | NormDebug -> fs // handled above, affects only dbg flags
     | DefaultUnivsToZero -> {fs with default_univs_to_zero = true}
     | Tactics -> { fs with tactics = true }
+    | ReduceProjections -> {fs with reduce_projections = true}
 
 let to_fsteps (s : list step) : ML fsteps =
     List.fold_right fstep_add_one s default_steps
@@ -470,6 +475,7 @@ let translate_norm_step s : ML (list Env.step) = match s with
     | NormSteps.Unascribe -> [Unascribe]
     | NormSteps.NBE -> [NBE]
     | NormSteps.Unmeta -> [Unmeta]
+    | NormSteps.ReduceProjections -> [ReduceProjections]
 
 let translate_norm_steps s : ML (list Env.step) =
     let s = List.concatMap translate_norm_step s in

--- a/src/typechecker/FStarC.TypeChecker.Cfg.fsti
+++ b/src/typechecker/FStarC.TypeChecker.Cfg.fsti
@@ -70,6 +70,7 @@ type fsteps = {
      unrefine:bool;
      default_univs_to_zero:bool; (* Default unresolved universe levels to zero *)
      tactics : bool;
+     reduce_projections : bool;
 }
 
 instance val deq_fsteps : deq fsteps

--- a/src/typechecker/FStarC.TypeChecker.Env.fst
+++ b/src/typechecker/FStarC.TypeChecker.Env.fst
@@ -84,7 +84,8 @@ let rec eq_step s1 s2 : ML bool =
   | Unrefine, Unrefine
   | NormDebug, NormDebug
   | DefaultUnivsToZero, DefaultUnivsToZero
-  | Tactics, Tactics -> true
+  | Tactics, Tactics
+  | ReduceProjections, ReduceProjections -> true
   | _ -> false
 
 instance deq_step : deq step = {
@@ -128,6 +129,7 @@ let rec step_to_string (s:step) : ML string =
   | NormDebug -> "NormDebug"
   | DefaultUnivsToZero -> "DefaultUnivsToZero"
   | Tactics -> "Tactics"
+  | ReduceProjections -> "ReduceProjections"
   | _ -> failwith "fixme: step_to_string incomplete"
 
 instance showable_step : showable step = {

--- a/src/typechecker/FStarC.TypeChecker.Env.fst
+++ b/src/typechecker/FStarC.TypeChecker.Env.fst
@@ -1105,6 +1105,7 @@ let lookup_projector env lid i : ML _ =
 
 let is_projector env (l:lident) : ML (bool) =
     match lookup_qname env l with
+        | Some (Inr ({ sigel = Sig_let _; sigquals=quals }, _), _)
         | Some (Inr ({ sigel = Sig_declare_typ _; sigquals=quals }, _), _) ->
           BU.for_some (function Projector _ -> true | _ -> false) quals
         | _ -> false

--- a/src/typechecker/FStarC.TypeChecker.Env.fsti
+++ b/src/typechecker/FStarC.TypeChecker.Env.fsti
@@ -63,6 +63,7 @@ type step =
   | NormDebug       //force debugging
   | DefaultUnivsToZero // default al unresolved universe uvars to zero
   | Tactics
+  | ReduceProjections
 and steps = list step
 
 instance val deq_step : deq step

--- a/src/typechecker/FStarC.TypeChecker.NBE.fst
+++ b/src/typechecker/FStarC.TypeChecker.NBE.fst
@@ -888,7 +888,7 @@ and translate_fv (cfg: config) (bs:list t) (fvar:fv): ML t =
    let qninfo = Env.lookup_qname (Cfg.cfg_env cfg.core_cfg) (S.lid_of_fv fvar) in
    if is_constr qninfo || is_constr_fv fvar then mkConstruct fvar [] []
    else
-     match NU.should_unfold cfg.core_cfg (fun _ -> cfg.core_cfg.reifying) fvar qninfo with
+     match NU.should_unfold false cfg.core_cfg (fun _ -> cfg.core_cfg.reifying) fvar qninfo with
      | NU.Should_unfold_fully  ->
        failwith "Not yet handled"
 

--- a/src/typechecker/FStarC.TypeChecker.Normalize.Unfolding.fst
+++ b/src/typechecker/FStarC.TypeChecker.Normalize.Unfolding.fst
@@ -15,7 +15,7 @@ module U = FStarC.Syntax.Util
 
 open FStarC.Class.Show
 
-let should_unfold cfg should_reify fv qninfo : ML should_unfold_res =
+let should_unfold (allow_strict : bool) cfg should_reify fv qninfo : ML should_unfold_res =
     let attrs =
       match Env.attrs_of_qninfo qninfo with
       | None -> []
@@ -65,6 +65,13 @@ let should_unfold cfg should_reify fv qninfo : ML should_unfold_res =
                                                (show fv)
                                                (show b));
         if b then reif else no
+
+    // If this definition is marked strict_on_arguments, we will not
+    // unfold standalone occurrences of it, only applications that
+    // pass the strictness check. Unless allow_strict is on.
+    | _ when not allow_strict && Some? (Env.fv_has_strict_args cfg.tcenv fv) ->
+        log_unfolding cfg (fun () -> Format.print_string " >> Not unfolding strict_on_arguments definition\n");
+        no
 
     // If it is handled primitively, then don't unfold
     | _ when Some? (find_prim_step cfg fv) ->

--- a/src/typechecker/FStarC.TypeChecker.Normalize.Unfolding.fsti
+++ b/src/typechecker/FStarC.TypeChecker.Normalize.Unfolding.fsti
@@ -13,8 +13,10 @@ type should_unfold_res =
     | Should_unfold_fully
     | Should_unfold_reify
 
-val should_unfold : cfg
-                 -> should_reify:(cfg -> ML bool)
-                 -> fv
-                 -> Env.qninfo
-                 -> ML should_unfold_res
+val should_unfold
+  (allow_strict:bool)
+  (c:cfg)
+  (should_reify : cfg -> ML bool)
+  (fv:fv)
+  (qninfo:Env.qninfo)
+  : ML should_unfold_res

--- a/src/typechecker/FStarC.TypeChecker.Normalize.fst
+++ b/src/typechecker/FStarC.TypeChecker.Normalize.fst
@@ -154,7 +154,7 @@ let set_memo cfg (r:memo (Cfg.cfg & 'a)) (t:'a) : ML unit =
 
 let closure_to_string = function
     | Clos (env, t, _, _) -> Format.fmt2 "(env=%s elts; %s)" (List.length env |> show) (show t)
-    | Univ _ -> "Univ"
+    | Univ u -> "Univ " ^ show u
     | Dummy -> "dummy"
 
 instance showable_closure : showable closure = {
@@ -166,7 +166,7 @@ instance showable_stack_elt : showable stack_elt = {
           | Arg (c, _, _) -> Format.fmt1 "Arg %s" (show c)
           | MemoLazy _ -> "MemoLazy"
           | Abs (_, bs, _, _, _) -> Format.fmt1 "Abs %s" (show <| List.length bs)
-          | UnivArgs _ -> "UnivArgs"
+          | UnivArgs us -> "UnivArgs " ^ show us
           | Match   _ -> "Match"
           | App (_, t,_,_) -> Format.fmt1 "App %s" (show t)
           | CBVApp (_, t,_,_) -> Format.fmt1 "CBVApp %s" (show t)

--- a/src/typechecker/FStarC.TypeChecker.Normalize.fst
+++ b/src/typechecker/FStarC.TypeChecker.Normalize.fst
@@ -224,17 +224,25 @@ let norm_universe cfg (env:env) u : ML universe =
         match u with
           | U_bvar x ->
             begin
-                try match (List.nth env x)._2 with
-                      | Univ u ->
-                           if !dbg_univ_norm then
-                               Format.print1 "Univ (in norm_universe): %s\n" (show u)
-                           else ();  aux u
-                      | Dummy -> [u]
-                      | _ -> failwith (Format.fmt1 "Impossible: universe variable u@%s bound to a term"
-                                                   (show x))
-                with _ -> if cfg.steps.allow_unbound_universes
-                          then [U_unknown]
-                          else failwith ("Universe variable not found: u@" ^ show x)
+              let vo =
+                try Some ((List.nth env x)._2)
+                with _ -> None
+              in
+              match vo with
+              | Some (Univ u) ->
+                if !dbg_univ_norm then
+                    Format.print1 "Univ (in norm_universe): %s\n" (show u);
+                aux u
+              | Some Dummy ->
+                [u]
+              | Some _ ->
+                if cfg.steps.allow_unbound_universes
+                then [U_unknown]
+                else failwith (Format.fmt1 "Impossible: universe variable u@%s bound to a term" (show x))
+              | None ->
+                if cfg.steps.allow_unbound_universes
+                then [U_unknown]
+                else failwith ("Universe variable not found: u@" ^ show x)
             end
           | U_unif _ when cfg.steps.default_univs_to_zero ->
             [U_zero]

--- a/src/typechecker/FStarC.TypeChecker.Normalize.fst
+++ b/src/typechecker/FStarC.TypeChecker.Normalize.fst
@@ -84,14 +84,70 @@ let cases f d = function
   | None -> d
 
 (* For strict_on_arguments *)
-let head_of_term_is_evaluated (t : term) : ML bool =
+let head_of_term_is_evaluated env (t : term) : ML bool =
   let h, _ = U.head_and_args_full t in
   let h = h |> unlazy |> unmeta |> un_uinst in
   match (SS.compress h).n with
   | Tm_constant _ -> true
-  | Tm_fvar fv -> Env.is_datacon cfg.tcenv fv.fv_name
+  | Tm_fvar fv -> Env.is_datacon env fv.fv_name
   (* TODO: consider machine integer literals evaluated? *)
   | _ -> false
+
+let guard (b : bool) : option unit =
+  if b
+  then Some ()
+  else None
+
+(* Is this a saturated and valid strict_on_arguments application? If so, return the deconstructed
+app + qninfo. *)
+let check_strict_app (cfg : Cfg.cfg) (hua : fv & universes & args) : ML bool =
+  let open FStarC.Class.Monad in
+  let (h, u, a) = hua in
+  match Env.fv_has_strict_args cfg.tcenv h with
+  | None -> false
+  | Some strict_indices ->
+    log cfg (fun () -> Format.print3 "Checking strict application for %s, head=%s, strict_indices=%s\n"
+                                  (show hua) (show h) (show strict_indices));
+    let len_a = List.length a in
+    let all_ok = strict_indices |> List.for_all (fun i ->
+                  if i >= len_a then false else head_of_term_is_evaluated cfg.tcenv (fst (List.nth a i))) in
+    all_ok
+
+(* If it is a projector, consider it strict if it's applied to a constructor on
+   its first explicit argument. *)
+let check_strict_projector (cfg : Cfg.cfg) (hua : fv & universes & args) : ML bool =
+  let open FStarC.Class.Monad in
+  let (h, u, a) = hua in
+  if not (Env.is_projector cfg.tcenv h.fv_name) then
+    false
+  else
+    (* Check that
+      1) Last argument is explicit
+      2) Last argument is evaluated (head is a constrctor)
+      3) All previous args are implicit.
+      In one pass. *)
+    let rec check (args : S.args) : ML bool =
+      match args with
+      | [] -> false
+      | [last, last_q] -> None? last_q && head_of_term_is_evaluated cfg.tcenv last
+      | a::args' -> Some? (snd a) && check args'
+    in
+    check a
+
+(* Check for strict applications (both strict_on_arguments and projectors, when
+the flag for reducing projections is set). The boolean is whether we
+should "force" then unfolding regardless of what delta says. We set it to true
+for projectors. *)
+let check_strict (cfg : Cfg.cfg) (hua : fv & universes & args) : ML (option bool) =
+  let open FStarC.Class.Monad in
+  if check_strict_app cfg hua then (
+    log cfg (fun () -> Format.print1 "Strict application detected for %s\n" (show hua));
+    Some false
+  ) else if cfg.steps.reduce_projections && cfg.steps.iota && check_strict_projector cfg hua then (
+    log cfg (fun () -> Format.print1 "Strict projector detected for %s\n" (show hua));
+    Some true
+  ) else
+    None
 
 (* We memoize the normal form of variables in the environment, in
  * order to implement call-by-need and avoid an exponential explosion,
@@ -2202,51 +2258,40 @@ and rebuild (cfg:cfg) (env:env) (stack:stack) (t:term) : ML term =
     if renorm
     then norm cfg env stack t
     else
-      (* Is this a saturated and valid strict_on_args application? If so,
-      try to unfold the head and keep normalizing. *)
-      let check_strict (t : term) : ML (option (fv & list universe & args & qninfo)) =
-        let open FStarC.Class.Monad in
-        let! (h, u, a) = U.hua t in
-        let! strict_indices = Env.fv_has_strict_args cfg.tcenv h in
-        log cfg (fun () -> Format.print3 "Checking strict application for %s, head=%s, strict_indices=%s\n"
-                                      (show t) (show h) (show strict_indices));
-        (* If there is no definition available for h at our delta level,
-           then just say no. We would go into an infinite loop otherwise. *)
-           // FIXME: this sucks, we're repeating a lot of the logic of do_unfold_fv
-        let qninfo = Env.lookup_qname cfg.tcenv (S.lid_of_fv h) in
-        let defn = Env.lookup_definition_qninfo cfg.delta_level h.fv_name qninfo in
-        match defn with
-        | None -> None
-        | Some _ ->
-        let len_a = List.length a in
-        let all_ok = strict_indices |> List.for_all (fun i ->
-                       if i >= len_a then false else head_of_term_is_evaluated (fst (List.nth a i))) in
-        if all_ok then
-          Some (h, u, a, qninfo)
-        else
-          None
-      in
-      match check_strict t with
-      | Some (h, u, a, qninfo) -> (
-        log cfg (fun () -> Format.print1 "Strict application detected, trying to unfold the head: %s\n" (show t));
-        let fv = S.lid_of_fv h in
-        let t0 = S.fvar fv None in // fake, but ok
-        (* strict_on_arguments makes recursive definitionis unfold even without zeta *)
-        let cfg_zeta = { cfg with steps = { cfg.steps with zeta = true } } in
-        match should_unfold true cfg_zeta (fun _ -> false) h qninfo with
-        | Should_unfold_yes ->
-          (* Just call do_unfold_fv, which keeps normalizing as needed.
-          We do need a proper stack, though. *)
-          let stack = List.fold_right (fun (arg : S.arg) acc ->
-            let memo = fresh_memo () in
-            Arg (Clos(env, fst arg, memo, false), snd arg, pos (fst arg))::acc)
-            a stack
-          in
-          let stack = if Cons? u then UnivArgs(u, t.pos)::stack else stack in
-          log cfg (fun () -> Format.print2 "Continuing with t=%s, stack=%s\n" (show t0) (show stack));
-          do_unfold_fv cfg stack t0 qninfo h
-        | _ ->
-          do_rebuild cfg env stack t
+      (* Check for strict applications. *)
+      match U.hua t with
+      | None -> do_rebuild cfg env stack t
+      | Some hua ->
+        match check_strict cfg hua with
+        | Some force -> (
+          let h, u, a = hua in
+          log cfg (fun () -> Format.print1 "Strict application detected, trying to unfold the head: %s\n" (show t));
+          let fv = S.lid_of_fv h in
+          (* First check if the head actually has a visible definition. *)
+          let qninfo = Env.lookup_qname cfg.tcenv fv in
+          let defn = Env.lookup_definition_qninfo cfg.delta_level h.fv_name qninfo in
+          if None? defn then
+            (* No definition, just continue *)
+            do_rebuild cfg env stack t
+          else
+            (* Here, go through should_unfold to see if we *should* unfold this definition,
+              unless check_strict returned force=true (e.g. due to ReduceProjections) *)
+            (* strict_on_arguments makes recursive definition unfold even without zeta *)
+            let cfg_zeta = { cfg with steps = { cfg.steps with zeta = true } } in
+            if force || Should_unfold_yes? (should_unfold true cfg_zeta (fun _ -> false) h qninfo) then
+              (* Just call do_unfold_fv, which keeps normalizing as needed.
+              We do need a proper stack, though. *)
+              let stack = List.fold_right (fun (arg : S.arg) acc ->
+                let memo = fresh_memo () in
+                Arg (Clos(env, fst arg, memo, false), snd arg, pos (fst arg))::acc)
+                a stack
+              in
+              let stack = if Cons? u then UnivArgs(u, t.pos)::stack else stack in
+              let t0 = S.fv_to_tm h in
+              log cfg (fun () -> Format.print2 "Continuing with t=%s, stack=%s\n" (show t0) (show stack));
+              do_unfold_fv cfg stack t0 qninfo h
+            else
+              do_rebuild cfg env stack t
       )
       | None ->
         do_rebuild cfg env stack t

--- a/src/typechecker/FStarC.TypeChecker.Normalize.fst
+++ b/src/typechecker/FStarC.TypeChecker.Normalize.fst
@@ -83,6 +83,16 @@ let cases f d = function
   | Some x -> f x
   | None -> d
 
+(* For strict_on_arguments *)
+let head_of_term_is_evaluated (t : term) : ML bool =
+  let h, _ = U.head_and_args_full t in
+  let h = h |> unlazy |> unmeta |> un_uinst in
+  match (SS.compress h).n with
+  | Tm_constant _ -> true
+  | Tm_fvar fv -> Env.is_datacon cfg.tcenv fv.fv_name
+  (* TODO: consider machine integer literals evaluated? *)
+  | _ -> false
+
 (* We memoize the normal form of variables in the environment, in
  * order to implement call-by-need and avoid an exponential explosion,
  * but we take care to only reuse memoized values when the cfg has not
@@ -570,9 +580,10 @@ let rec maybe_weakly_reduced tm :  ML bool =
            | Meta_desugared _
            | Meta_named _ -> false)
 
-let decide_unfolding cfg stack fv qninfo (* : option (option cfg * stack) *) =
+val decide_unfolding : cfg -> stack -> fv -> qninfo -> ML (option (option cfg & stack))
+let decide_unfolding cfg stack fv qninfo =
     let res =
-        should_unfold cfg (fun cfg -> should_reify cfg stack) fv qninfo
+        should_unfold false cfg (fun cfg -> should_reify cfg stack) fv qninfo
     in
     match res with
     | Should_unfold_no ->
@@ -1033,76 +1044,34 @@ let rec norm : cfg -> env -> stack -> term -> ML term =
             end
 
           | Tm_app {hd=head; args} ->
-            let strict_args =
-              match (head |> U.unascribe |> U.un_uinst).n with
-              | Tm_fvar fv -> Env.fv_has_strict_args cfg.tcenv fv
-              | _ -> None
+            let stack =
+              List.fold_right
+                (fun (a, aq) stack ->
+                  let a =
+                    if ((Cfg.cfg_env cfg).erase_erasable_args ||
+                        cfg.steps.for_extraction ||
+                        cfg.debug.erase_erasable_args) //just for experimentation
+                    && U.aqual_is_erasable aq //If we're extracting, then erase erasable arguments eagerly
+                    then U.exp_unit
+                    else a
+                  in
+                  // !! Optimization: if the argument we are pushing is an obvious
+                  // value/closed term, then drop the environment. This can save
+                  // a ton of memory, particularly when running tactics in tight loop.
+                  let env =
+                    match (Subst.compress a).n with
+                    | Tm_name _
+                    | Tm_constant _
+                    | Tm_lazy _
+                    | Tm_fvar _ -> empty_env
+                    | _ -> env
+                  in
+                  Arg (Clos(env, a, fresh_memo (), false),aq,t.pos)::stack)
+                args
+                stack
             in
-            begin
-            match strict_args with
-            | None ->
-              let stack =
-                List.fold_right
-                  (fun (a, aq) stack ->
-                    let a =
-                      if ((Cfg.cfg_env cfg).erase_erasable_args ||
-                          cfg.steps.for_extraction ||
-                          cfg.debug.erase_erasable_args) //just for experimentation
-                      && U.aqual_is_erasable aq //If we're extracting, then erase erasable arguments eagerly
-                      then U.exp_unit
-                      else a
-                    in
-                    // !! Optimization: if the argument we are pushing is an obvious
-                    // value/closed term, then drop the environment. This can save
-                    // a ton of memory, particularly when running tactics in tight loop.
-                    let env =
-                      match (Subst.compress a).n with
-                      | Tm_name _
-                      | Tm_constant _
-                      | Tm_lazy _
-                      | Tm_fvar _ -> empty_env
-                      | _ -> env
-                    in
-                    Arg (Clos(env, a, fresh_memo (), false),aq,t.pos)::stack)
-                  args
-                  stack
-              in
-              log cfg  (fun () -> Format.print1 "\tPushed %s arguments\n" (show <| List.length args));
-              norm cfg env stack head
-
-            | Some strict_args ->
-              // Format.print2 "%s has strict args %s\n" (show head) (show strict_args);
-              let norm_args = args |> List.map (fun (a, i) -> (norm cfg env [] a, i)) in
-              let norm_args_len = List.length norm_args in
-              if strict_args
-                |> List.for_all (fun i ->
-                  if i >= norm_args_len then false
-                  else
-                    let arg_i, _ = List.nth norm_args i in
-                    let head, _ = arg_i |> U.unmeta_safe |> U.head_and_args in
-                    match (un_uinst head).n with
-                    | Tm_constant _ -> true
-                    | Tm_fvar fv -> Env.is_datacon cfg.tcenv (S.lid_of_fv fv)
-                    | _ -> false)
-              then //all strict args have constant head symbols
-                   let stack =
-                     stack |>
-                     List.fold_right (fun (a, aq) stack ->
-                       Arg (Clos(env, a, mk_ref (Some (cfg, ([], a))), false),aq,t.pos)::stack)
-                     norm_args
-                   in
-                   log cfg  (fun () -> Format.print1 "\tPushed %s arguments\n" (show <| List.length args));
-                   norm cfg env stack head
-              else let head = closure_as_term cfg env head in
-                   let term = S.mk_Tm_app head norm_args t.pos in
-                   // let _ =
-                   //   Format.print3 "Rebuilding %s as %s\n%s\n"
-                   //     (show t)
-                   //     (show term)
-                   //     (BU.stack_dump())
-                   // in
-                   rebuild cfg env stack term
-            end
+            log cfg (fun () -> Format.print1 "\tPushed %s arguments\n" (show <| List.length args));
+            norm cfg env stack head
 
           | Tm_refine {b=x}
               when cfg.steps.for_extraction
@@ -2229,10 +2198,58 @@ and rebuild (cfg:cfg) (env:env) (stack:stack) (t:term) : ML term =
   if f_opt |> Some? && (match stack with | Arg _::_ -> true | _ -> false)  //AR: it is crucial to check that (on_domain a #b) is actually applied, else it would be unsound to reduce it to f
   then f_opt |> Option.must |> norm cfg env stack
   else
-      let t, renorm = maybe_simplify cfg env stack t in
-      if renorm
-      then norm cfg env stack t
-      else do_rebuild cfg env stack t
+    let t, renorm = maybe_simplify cfg env stack t in
+    if renorm
+    then norm cfg env stack t
+    else
+      (* Is this a saturated and valid strict_on_args application? If so,
+      try to unfold the head and keep normalizing. *)
+      let check_strict (t : term) : ML (option (fv & list universe & args & qninfo)) =
+        let open FStarC.Class.Monad in
+        let! (h, u, a) = U.hua t in
+        let! strict_indices = Env.fv_has_strict_args cfg.tcenv h in
+        log cfg (fun () -> Format.print3 "Checking strict application for %s, head=%s, strict_indices=%s\n"
+                                      (show t) (show h) (show strict_indices));
+        (* If there is no definition available for h at our delta level,
+           then just say no. We would go into an infinite loop otherwise. *)
+           // FIXME: this sucks, we're repeating a lot of the logic of do_unfold_fv
+        let qninfo = Env.lookup_qname cfg.tcenv (S.lid_of_fv h) in
+        let defn = Env.lookup_definition_qninfo cfg.delta_level h.fv_name qninfo in
+        match defn with
+        | None -> None
+        | Some _ ->
+        let len_a = List.length a in
+        let all_ok = strict_indices |> List.for_all (fun i ->
+                       if i >= len_a then false else head_of_term_is_evaluated (fst (List.nth a i))) in
+        if all_ok then
+          Some (h, u, a, qninfo)
+        else
+          None
+      in
+      match check_strict t with
+      | Some (h, u, a, qninfo) -> (
+        log cfg (fun () -> Format.print1 "Strict application detected, trying to unfold the head: %s\n" (show t));
+        let fv = S.lid_of_fv h in
+        let t0 = S.fvar fv None in // fake, but ok
+        (* strict_on_arguments makes recursive definitionis unfold even without zeta *)
+        let cfg_zeta = { cfg with steps = { cfg.steps with zeta = true } } in
+        match should_unfold true cfg_zeta (fun _ -> false) h qninfo with
+        | Should_unfold_yes ->
+          (* Just call do_unfold_fv, which keeps normalizing as needed.
+          We do need a proper stack, though. *)
+          let stack = List.fold_right (fun (arg : S.arg) acc ->
+            let memo = fresh_memo () in
+            Arg (Clos(env, fst arg, memo, false), snd arg, pos (fst arg))::acc)
+            a stack
+          in
+          let stack = if Cons? u then UnivArgs(u, t.pos)::stack else stack in
+          log cfg (fun () -> Format.print2 "Continuing with t=%s, stack=%s\n" (show t0) (show stack));
+          do_unfold_fv cfg stack t0 qninfo h
+        | _ ->
+          do_rebuild cfg env stack t
+      )
+      | None ->
+        do_rebuild cfg env stack t
 
 and do_rebuild (cfg:cfg) (env:env) (stack:stack) (t:term) : ML term =
       match stack with

--- a/tests/bug-reports/closed/Bug4274.fst
+++ b/tests/bug-reports/closed/Bug4274.fst
@@ -1,0 +1,75 @@
+module Bug4274
+
+#lang-pulse
+open Pulse
+
+noeq type foo = {
+  x: ref int;
+  y: ref int;
+  z: ref (ref int);
+}
+
+[@@erasable] noeq type foo_spec = {
+  x': int;
+  y': int;
+  z': ref int; z'': int;
+}
+
+let foo_pred ([@@@mkey]x: foo) (y: foo_spec) : slprop =
+  pts_to x.x y.x' ** pts_to x.y y.y'
+  ** pts_to x.z y.z' ** pts_to y.z' y.z''
+
+[@@pulse_intro]
+ghost fn foo_pred_unfold x y
+  requires foo_pred x y
+  ensures Pulse.Lib.Reference.pts_to x.x y.x'
+  ensures Pulse.Lib.Reference.pts_to x.y y.y'
+  ensures Pulse.Lib.Reference.pts_to x.z y.z'
+  ensures Pulse.Lib.Reference.pts_to y.z' y.z''
+{
+  unfold foo_pred;
+}
+
+[@@pulse_intro]
+ghost fn foo_pred_fold x vx vy vz vz'
+  requires Pulse.Lib.Reference.pts_to x.x vx
+  requires Pulse.Lib.Reference.pts_to x.y vy
+  requires Pulse.Lib.Reference.pts_to x.z vz
+  requires Pulse.Lib.Reference.pts_to vz vz'
+  ensures foo_pred x ({x'=vx;y'=vy;z'=vz;z''=vz'})
+{
+  fold foo_pred x ({x'=vx;y'=vy;z'=vz;z''=vz'});
+}
+
+fn read_x (x: foo)
+  preserves foo_pred x 'vx
+  returns _: int
+{
+  let tmp = !x.x;
+  x.x := 42 + tmp;
+  x.x := (!x.x) - 42;
+  tmp
+}
+
+let foo_value (x: foo) #y = observe (foo_pred x) #y
+
+#set-options "--ext pulse:admit_diag=1"
+
+fn write_x (x: foo)
+  preserves exists* vx. foo_pred x vx
+  ensures pure ((foo_value x).x' == 10)
+{
+  x.x := 10;
+  assert foo_pred x _;
+  x.y := !x.x;
+  assert foo_pred x _;
+  admit();
+(*
+- Current context:
+    foo_pred x
+      (Mkfoo_spec (Mkfoo_spec 10 vx.y' vx.z' vx.z'').x'
+          (Mkfoo_spec 10 vx.y' vx.z' vx.z'').x'
+          (Mkfoo_spec 10 vx.y' vx.z' vx.z'').z'
+          (Mkfoo_spec 10 vx.y' vx.z' vx.z'').z'')
+*)
+}

--- a/tests/bug-reports/closed/Bug4274.fst.output.expected
+++ b/tests/bug-reports/closed/Bug4274.fst.output.expected
@@ -1,0 +1,13 @@
+* Info at Bug4274.fst(66,2-66,9):
+  - Admitting continuation.
+  - Current context:
+      foo_pred x (Mkfoo_spec 10 10 vx.z' vx.z'')
+  - In typing environment:
+      __#512 : squash (rewrites_to_p __anf0 10)
+      __anf0#511 : int
+      vx#282 : erased foo_spec
+      x#278 : foo
+
+      goto _return#345 requires
+        (exists* (vx:foo_spec). foo_pred x vx ** pure (vx.x' == 10))
+

--- a/tests/micro-benchmarks/Strict.fst
+++ b/tests/micro-benchmarks/Strict.fst
@@ -1,0 +1,88 @@
+module Strict
+
+#set-options "--warn_error -328" // let rec unused in body
+
+[@@strict_on_arguments [0]]
+inline_for_extraction
+let sum0 (x y : int) : int = x + y
+
+let t00     = sum0 3 2
+let t01 x   = sum0 x 2
+let t02 y   = sum0 3 y
+let t03 x y = sum0 x y
+
+(* Marked recursive, but not really. Should reduce anyway in extraction. *)
+[@@strict_on_arguments [0]]
+inline_for_extraction
+let rec sum1 (x y : int) : int = x + y
+
+let t11     = sum1 3 2
+let t12 x   = sum1 x 2
+let t13 y   = sum1 3 y
+let t14 x y = sum1 x y
+
+(* Actually recursive *)
+[@@strict_on_arguments [0]]
+inline_for_extraction
+let rec sum2 (x y : nat) : int =
+  if x = 0 then y
+  else sum2 (x - 1) (y + 1)
+
+let t20     = sum2 3 2
+let t21 x   = sum2 x 2
+let t22 y   = sum2 3 y
+let t23 x y = sum2 x y
+
+
+open FStar.List.Tot
+open FStar.Ghost
+inline_for_extraction noextract
+let coerce_eq (#a:Type) (#b:Type) (_:squash (a == b)) (x:a) : b = x
+
+inline_for_extraction noextract
+let tupdesc = erased (list Type0)
+
+inline_for_extraction noextract
+let rec tup (d : tupdesc) : Type0 =
+  match d with
+  | [] -> unit
+  | h :: t -> h & tup t
+
+inline_for_extraction noextract
+let rec at (d : tupdesc) (i : nat{i < length d}) : Type0 =
+  match d with
+  | [] -> unit
+  | h :: t ->
+    if i = 0 then h
+    else at t (i - 1)
+
+inline_for_extraction noextract
+let rec remove (d : tupdesc) (i : nat{i < length d}) : (d' : tupdesc { length d' = length d - 1}) =
+  match d with
+  | [] -> []
+  | h :: t ->
+    if i = 0 then t
+    else h :: remove t (i - 1)
+
+(* This guy can extract as it is, but using unbounded integers
+and a LOT of casts. *)
+[@@strict_on_arguments [1]]
+inline_for_extraction
+let rec bring (#d : tupdesc) (i : nat{i < length d}) (x : tup d)
+  : at d i & tup (remove d i)
+  =
+  if i = 0 then x
+  else
+    let h : erased _ = hd d in
+    let t : erased _ = tail d in
+    let unfold xh, xt = x <: tup (reveal h :: t) in
+    let unfold (y, z) = bring (i - 1) xt in
+    (* Why do I need to coerce? *)
+    let unfold y : at d i = coerce_eq () y in
+    (y, (xh, z))
+
+(* Specialized versions look nicer: *)
+let bring0 (#d : tupdesc{length d > 0}) = bring #d 0
+let bring1 (#d : tupdesc{length d > 1}) = bring #d 1
+let bring2 (#d : tupdesc{length d > 2}) = bring #d 2
+let bring3 (#d : tupdesc{length d > 3}) = bring #d 3

--- a/tests/micro-benchmarks/Strict.ml.expected
+++ b/tests/micro-benchmarks/Strict.ml.expected
@@ -1,0 +1,61 @@
+open Prims
+let sum0 (x : Prims.int) (y : Prims.int) : Prims.int= x + y
+let t00 : Prims.int= Prims.of_int 5
+let t01 (x : Prims.int) : Prims.int= sum0 x (Prims.of_int 2)
+let t02 (y : Prims.int) : Prims.int= (Prims.of_int 3) + y
+let t03 (x : Prims.int) (y : Prims.int) : Prims.int= sum0 x y
+let rec sum1 (x : Prims.int) (y : Prims.int) : Prims.int= x + y
+let t11 : Prims.int= Prims.of_int 5
+let t12 (x : Prims.int) : Prims.int= sum1 x (Prims.of_int 2)
+let t13 (y : Prims.int) : Prims.int= (Prims.of_int 3) + y
+let t14 (x : Prims.int) (y : Prims.int) : Prims.int= sum1 x y
+let rec sum2 (x : Prims.nat) (y : Prims.nat) : Prims.int=
+  if x = Prims.int_zero
+  then y
+  else sum2 (x - Prims.int_one) (y + Prims.int_one)
+let t20 : Prims.int= Prims.of_int 5
+let t21 (x : Prims.nat) : Prims.int= sum2 x (Prims.of_int 2)
+let t22 (y : Prims.nat) : Prims.int=
+  ((y + Prims.int_one) + Prims.int_one) + Prims.int_one
+let t23 (x : Prims.nat) (y : Prims.nat) : Prims.int= sum2 x y
+let rec bring (uu___2 : unit) (uu___1 : Prims.nat) (uu___ : Obj.t) :
+  (Obj.t * Obj.t)=
+  (fun d i x ->
+     if i = Prims.int_zero
+     then Obj.magic (Obj.repr x)
+     else
+       Obj.magic
+         (Obj.repr
+            (match Obj.magic x with
+             | (xh, xt) ->
+                 (match bring () (i - Prims.int_one) xt with
+                  | (y, z) -> (y, (Obj.magic (xh, z))))))) uu___2 uu___1
+    uu___
+let bring0 (uu___1 : unit) (uu___ : Obj.t) : (Obj.t * Obj.t)=
+  (fun d x -> Obj.magic x) uu___1 uu___
+let bring1 (d : unit) (x : Obj.t) : (Obj.t * Obj.t)=
+  match Obj.magic x with
+  | (xh, xt) ->
+      (match Obj.magic xt with | (y, z) -> (y, (Obj.magic (xh, z))))
+let bring2 (d : unit) (x : Obj.t) : (Obj.t * Obj.t)=
+  match Obj.magic x with
+  | (xh, xt) ->
+      (match match Obj.magic xt with
+             | (xh1, xt1) ->
+                 (match Obj.magic xt1 with
+                  | (y, z) -> (y, (Obj.magic (xh1, z))))
+       with
+       | (y, z) -> (y, (Obj.magic (xh, z))))
+let bring3 (d : unit) (x : Obj.t) : (Obj.t * Obj.t)=
+  match Obj.magic x with
+  | (xh, xt) ->
+      (match match Obj.magic xt with
+             | (xh1, xt1) ->
+                 (match match Obj.magic xt1 with
+                        | (xh2, xt2) ->
+                            (match Obj.magic xt2 with
+                             | (y, z) -> (y, (Obj.magic (xh2, z))))
+                  with
+                  | (y, z) -> (y, (Obj.magic (xh1, z))))
+       with
+       | (y, z) -> (y, (Obj.magic (xh, z))))

--- a/ulib/FStar.NormSteps.fst
+++ b/ulib/FStar.NormSteps.fst
@@ -26,6 +26,7 @@ type norm_step =
   | UnfoldNamespace : list string -> norm_step
   | Unmeta : norm_step
   | Unascribe // Remove type ascriptions [t <: ty ~> t]
+  | ReduceProjections
 
 irreducible
 let simplify = Simpl
@@ -83,3 +84,6 @@ let unmeta = Unmeta
 
 irreducible
 let unascribe = Unascribe
+
+irreducible
+let reduce_projections = ReduceProjections

--- a/ulib/FStar.NormSteps.fsti
+++ b/ulib/FStar.NormSteps.fsti
@@ -161,3 +161,5 @@ val unmeta : norm_step
 
    *)
 val unascribe : norm_step
+
+val reduce_projections : norm_step


### PR DESCRIPTION
This overhauls strict_on_arguments (a patch I had queued up already) and also implements another normalizer flag to reduce projectors that are applied to a concrete constructor (see #4274). I would have liked to just add the strict_on_arguments attribute to the projectors, but that implies moving the attribute to Prims. Maybe that isn't so bad...

Marked draft since I think this makes the normalizer slower.