### PR TITLE
Remove duplicate version number definition.

### DIFF
--- a/pulse/lib/pulse/lib/Pulse.Lib.Swap.Spec.fst
+++ b/pulse/lib/pulse/lib/Pulse.Lib.Swap.Spec.fst
@@ -671,6 +671,7 @@ let array_swap_inner_invariant
         Seq.index s idx == Seq.index s0 (if i' < i || (i' = i && j' < j) then jump (n) (l) idx else idx)
   )
 
+#push-options "--z3rlimit 20"
 let array_swap_inner_invariant_end
   (#t: Type)
   (n: nat)
@@ -692,6 +693,7 @@ let array_swap_inner_invariant_end
   ))
 //  [SMTPat (array_swap_inner_invariant s0 n l bz s i j idx)]
 = ()
+#pop-options
 
 module SZ = FStar.SizeT
 

--- a/src/fstar/FStarC.CheckedFiles.fst
+++ b/src/fstar/FStarC.CheckedFiles.fst
@@ -34,7 +34,7 @@ let debug (f:unit -> ML unit) : ML unit = if !dbg then f () else ()
  * We write this version number to the cache files, and
  * detect when loading the cache that the version number is same
  *)
-let cache_version_number = Prims.__cache_version_number__
+let cache_version_number = 78
 
 (*
  * Abbreviation for what we store in the checked files (stages as described below)

--- a/src/fstar/FStarC.CheckedFiles.fst
+++ b/src/fstar/FStarC.CheckedFiles.fst
@@ -33,9 +33,8 @@ let debug (f:unit -> ML unit) : ML unit = if !dbg then f () else ()
 (*
  * We write this version number to the cache files, and
  * detect when loading the cache that the version number is same
- * It needs to be kept in sync with Prims.fst
  *)
-let cache_version_number = 78
+let cache_version_number = Prims.__cache_version_number__
 
 (*
  * Abbreviation for what we store in the checked files (stages as described below)

--- a/src/smtencoding/FStarC.SMTEncoding.Pruning.fst
+++ b/src/smtencoding/FStarC.SMTEncoding.Pruning.fst
@@ -217,12 +217,6 @@ let maybe_add_ambient (a:assumption) (p:pruning_state)
   in
   begin
     match a.assumption_term.tm with
-    // - The top-level assumption `function_token_typing_Prims.__cache_version_number__`
-    //   is always included in the pruned set, since it provides an inhabitation proof
-    //   for int which some proofs rely on
-    | _ when a.assumption_name = "function_token_typing_Prims.__cache_version_number__" ->
-      { p with ambients = a.assumption_name::p.ambients }
-
     // - l_quant_interp assumptions give interpretations to deeply embedded quantifiers
     //   and have a specific shape of an Iff, where the LHS has a pattern, if the
     //   user annotated one.

--- a/ulib/Prims.fst
+++ b/ulib/Prims.fst
@@ -687,7 +687,3 @@ val string_of_bool: bool -> Tot string
 (** A primitive printer for [int] *)
 assume
 val string_of_int: int -> Tot string
-
-(** Incrementing this forces all .checked files to be invalidated *)
-irreducible
-let __cache_version_number__ = 78

--- a/ulib/Prims.fst
+++ b/ulib/Prims.fst
@@ -688,7 +688,6 @@ val string_of_bool: bool -> Tot string
 assume
 val string_of_int: int -> Tot string
 
-(** THIS IS MEANT TO BE KEPT IN SYNC WITH FStar.CheckedFiles.fs
-    Incrementing this forces all .checked files to be invalidated *)
+(** Incrementing this forces all .checked files to be invalidated *)
 irreducible
 let __cache_version_number__ = 78


### PR DESCRIPTION
We forget to keep this in sync all the time, see #4272 for the latest fix.  Since we now build the compiler with its own ulib, we can just take the version number from Prims and use that as a single source of truth.

(FWIW, I'm not sure why the number is in Prims at all.  I don't think anything refers to it at all.)