### PR TITLE
Rel: more reveal/hide inference

### DIFF
--- a/src/typechecker/FStarC.TypeChecker.Rel.fst
+++ b/src/typechecker/FStarC.TypeChecker.Rel.fst
@@ -3898,25 +3898,29 @@ let solve_t'_aux (problem:tprob) (wl:worklist) : ML solution =
                   ~> t1        =?= hide t2
                   ~> reveal t1 =?= t2
                 *)
+                | Some (Reveal (u, ty, lhs)), Some (Hide _)
                 | Some (Reveal (u, ty, lhs)), None when is_flex lhs ->
                   // reveal (?u _) / _
                   //add hide to rhs and simplify lhs
                   let rhs = mk_fv_app PC.hide u [(ty, S.as_aqual_implicit true); (t2, None)] t2.pos in
                   Some (lhs, rhs)
 
-                | None, Some (Reveal (u, ty, rhs)) when is_flex rhs ->
+                | Some (Hide _), Some (Reveal (u, ty, rhs))
+                | None,          Some (Reveal (u, ty, rhs)) when is_flex rhs ->
                   // _ / reveal (?u _)
                   //add hide to lhs and simplify rhs
                   let lhs = mk_fv_app PC.hide u [(ty, S.as_aqual_implicit true); (t1, None)] t1.pos in
                   Some (lhs, rhs)
 
+                | Some (Hide (u, ty, lhs)), Some (Reveal _)
                 | Some (Hide (u, ty, lhs)), None ->
                   // hide _ / _
                   //add reveal to rhs and simplify lhs
                   let rhs = mk_fv_app PC.reveal u [(ty,S.as_aqual_implicit true); (t2, None)] t2.pos in
                   Some (lhs, rhs)
 
-                | None, Some (Hide (u, ty, rhs)) ->
+                | Some (Reveal _), Some (Hide (u, ty, rhs))
+                | None,            Some (Hide (u, ty, rhs)) ->
                   // _ / hide _
                   //add reveal to lhs and simplify rhs
                   let lhs = mk_fv_app PC.reveal u [(ty,S.as_aqual_implicit true); (t1, None)] t1.pos in

--- a/tests/bug-reports/closed/Bug4287.fst
+++ b/tests/bug-reports/closed/Bug4287.fst
@@ -1,0 +1,17 @@
+module Bug4287
+
+#lang-pulse
+open Pulse
+
+fn foo ()
+{
+  let mut rr : erased real = 0.0R;
+  assert pure (!rr == 0.0R);
+}
+
+fn bar()
+{
+  let mut rr : erased int = 0;
+  let v : erased int = Pulse.Lib.Reference.read rr #_ #_;
+  ()
+}


### PR DESCRIPTION
The unifier solves problems like `reveal ?u = bar` specially, by assigning `?u` to `hide bar`. The catch is that we have to check that bar is not of the form `reveal _`, or we will go into a loop. The existing check checking that bar is also not of the form `hide _`, mistakenly. This changes the check to fix this.

Fixes #4287, which was failing to unify an expected `reveal ?v` for the argument to read with the `hide 0` in the context.