### PR TITLE
Pulse: remove custom term printer, use normal one

### DIFF
--- a/pulse/src/checker/Pulse.Checker.Abs.fst
+++ b/pulse/src/checker/Pulse.Checker.Abs.fst
@@ -364,8 +364,8 @@ let check_effect_annotation g r (asc:comp_ascription) (c_computed:comp) : T.Tac 
       if None? tok then (
         let open Pulse.PP in
         fail_doc g (Some (RU.range_of_term i)) [
-          prefix 4 1 (text "Annotated effect expects only invariants in") (pp i) ^/^
-          prefix 4 1 (text "to be opened; but computed effect claims that invariants") (pp j) ^/^
+          prefix 4 1 (text "Annotated effect expects only invariants in") (fquotes (pp i)) ^/^
+          prefix 4 1 (text "to be opened; but computed effect claims that invariants") (fquotes (pp j)) ^/^
           text "are opened"
         ]
       );
@@ -378,9 +378,9 @@ let check_effect_annotation g r (asc:comp_ascription) (c_computed:comp) : T.Tac 
       let open Pulse.PP in
       fail_doc g (Some r) [
         prefix 4 1 (text "Expected effect")
-                      (arbitrary_string (P.tag_of_comp c)) ^/^
+                      (fquotes (arbitrary_string (P.tag_of_comp c))) ^/^
         prefix 4 1 (text "but this function body has effect")
-                      (arbitrary_string (P.tag_of_comp c_computed))
+                      (fquotes (arbitrary_string (P.tag_of_comp c_computed)))
       ]
 
 
@@ -401,8 +401,8 @@ let maybe_rewrite_body_typing
         | None, _ ->
           Env.fail_doc g (Some e.range) [
             text "Inferred type is incompatible with annotation.";
-            text "Inferred:" ^/^ pp t';
-            text "Annotated:" ^/^ pp t;
+            text "Inferred:" ^/^ fquotes (pp t');
+            text "Annotated:" ^/^ fquotes (pp t);
           ]
         | Some tok, _ ->
           debug_abs g

--- a/pulse/src/checker/Pulse.Checker.AssertWithBinders.fst
+++ b/pulse/src/checker/Pulse.Checker.AssertWithBinders.fst
@@ -270,8 +270,7 @@ let check_equiv_with_tac (g:env) (rng:Range.range) (lhs rhs ty:term) (tac_tm:ter
   match Pulse.Typing.Util.universe_of_now g_env ty with
   | None, issues ->
     fail_doc_with_subissues g (Some rng) issues [
-      text "rewrite: could not determine the universe of";
-      pp ty;
+      text "rewrite: could not determine the universe of" ^/^ fquotes (pp ty);
     ]
   | Some u, _ ->
     let goal = mk_squash (RT.eq2 u ty lhs rhs) in
@@ -303,8 +302,8 @@ let check_pair (g:env) rng (lhs rhs:term) (tac_opt:option term) : T.Tac unit =
   | Some issues -> 
     fail_doc_with_subissues g (Some rng) issues [
       text "rename: could not prove equality of";
-      pp lhs;
-      pp rhs;
+      fquotes (pp lhs);
+      fquotes (pp rhs);
     ]
   | _ ->
     ()

--- a/pulse/src/checker/Pulse.Checker.Base.fst
+++ b/pulse/src/checker/Pulse.Checker.Base.fst
@@ -372,8 +372,8 @@ let match_comp_res_with_post_hint (#g:env) (t:st_term) (c:comp_st)
          | None, issues ->
            let open Pulse.PP in
            fail_doc_with_subissues g (Some t.range) issues [
-            prefix 2 1 (text "Could not prove equality between computed type") (pp cres) ^/^
-            prefix 2 1 (text "and expected type") (pp ret_ty);
+            prefix 2 1 (text "Could not prove equality between computed type") (fquotes (pp cres)) ^/^
+            prefix 2 1 (text "and expected type") (fquotes (pp ret_ty));
            ]
          | Some tok, _ ->
            let d_equiv
@@ -823,7 +823,7 @@ let hoist_st_lambda
       fail_doc g (Some (RU.range_of_term e)) [
         text "Expected function";
         text "Actual type:" ^^ hardline ^^
-          pp e_ty
+          fquotes (pp e_ty)
       ]
     )
   | _ -> None

--- a/pulse/src/checker/Pulse.Checker.Bind.fst
+++ b/pulse/src/checker/Pulse.Checker.Bind.fst
@@ -68,13 +68,13 @@ let check_if_seq_lhs
     let open Pulse.PP in
     if T.Tv_Arrow? ty then
       fail_doc g (Some e1.range) [
-        prefix 2 1 (text "This function is partially applied. Remaining type:") (pp ty);
+        prefix 2 1 (text "This function is partially applied. Remaining type:") (fquotes (pp ty));
         text "Did you forget to apply some arguments?";
       ]
     else if None? (fst <| T.is_non_informative (elab_env g) ty) then (
       if None? (Pulse.Checker.Pure.try_get_non_informative_witness g u ty) then
         fail_doc g (Some e1.range) [
-          prefix 2 1 (text "This statement returns a value of type:") (pp ty);
+          prefix 2 1 (text "This statement returns a value of type:") (fquotes (pp ty));
           text "Did you forget to assign it or ignore it?";
         ]
     ) else
@@ -108,8 +108,8 @@ let check_binder_typ
       let open Pulse.PP in
       fail_doc g (Some e1.range) [
         text "Type mismatch (NB: this is a syntactic check)";
-        prefix 2 1 (text "Expected:") (pp ty);
-        prefix 2 1 (text "Got:") (pp t);
+        prefix 2 1 (text "Expected:") (fquotes (pp ty));
+        prefix 2 1 (text "Got:") (fquotes (pp t));
       ]
   end
 

--- a/pulse/src/checker/Pulse.Checker.ImpureSpec.fst
+++ b/pulse/src/checker/Pulse.Checker.ImpureSpec.fst
@@ -73,7 +73,7 @@ let symb_eval_stateful_app (g: env) (ctxt: slprop) (t: term) : T.Tac R.term =
   debug g (fun _ -> [ text "impure spec inferred type"; pp t; pp ty ]);
   match readback_comp ty with
   | None | Some (C_Tot ..) ->
-    T.fail_doc_at [text "Impossible: not a stateful application type"; pp ty] (Some (RU.range_of_term t))
+    T.fail_doc_at [text "Impossible: not a stateful application type"; fquotes (pp ty)] (Some (RU.range_of_term t))
   | Some c -> match c with
   | C_STAtomic _ _ { pre; post } | C_STGhost _ { pre; post } | C_ST { pre; post } ->
     let x = fresh g in
@@ -85,8 +85,8 @@ let symb_eval_stateful_app (g: env) (ctxt: slprop) (t: term) : T.Tac R.term =
     | None ->
       let head, _ = T.collect_app_ln t in
       T.fail_doc_at [
-        text "Cannot use" ^/^ pp head ^/^ text "in impure spec, cannot find rewrites_to in post:";
-        pp post;
+        text "Cannot use" ^/^ fquotes (pp head) ^/^ text "in impure spec, cannot find rewrites_to in post:";
+        fquotes (pp post);
       ] (Some (RU.range_of_term t))
     | Some rwr ->
       let allow_amb = true in

--- a/pulse/src/checker/Pulse.Checker.Prover.fst
+++ b/pulse/src/checker/Pulse.Checker.Prover.fst
@@ -456,7 +456,7 @@ let intro_exists (g: env) (frame: slprop) (u: universe) (b: binder) (body: slpro
  // implied by t2_typing
  // implied by t2_typing
   let _ = core_check_term' g e T.E_Ghost b.binder_ty (fun _ -> let open Pulse.PP in
-    [text "Cannot find witness for" ^/^ pp (tm_exists_sl u b body)]) in
+    [text "Cannot find witness for" ^/^ fquotes (pp (tm_exists_sl u b body))]) in
 
 
 
@@ -738,8 +738,8 @@ let check_slprop_equiv_ext r (g:env) (p q:slprop)
   | None -> 
     fail_doc_with_subissues g (Some r) issues [
       text "Could not prove equality of:";
-      pp p;
-      pp q;
+      fquotes (pp p);
+      fquotes (pp q);
     ]
   | Some token ->
     ()
@@ -1525,8 +1525,8 @@ let prove_post_hint (#g:env) (#ctxt:slprop) (r:checker_result_t g ctxt NoHint) (
           k_elab_trans k (k_elab_trans k3 k_unreach) |)
       ) else
         fail_doc g (Some rng) [
-          text "The return type" ^^ indent (pp ty) ^/^
-          text "does not match the expected" ^^ indent (pp post_hint.ret_ty)
+          text "The return type" ^^ indent (fquotes (pp ty)) ^/^
+          text "does not match the expected" ^^ indent (fquotes (pp post_hint.ret_ty))
         ]
     ) else
       let ppname = mk_ppname_no_range "_posth" in

--- a/pulse/src/checker/Pulse.Checker.Pure.fst
+++ b/pulse/src/checker/Pulse.Checker.Pure.fst
@@ -57,8 +57,8 @@ let check_ln (g:env) (label:string) (t:R.term) : Tac unit =
   if not (CheckLN.check_ln t) then
     fail_doc g (Some (RU.range_of_term t)) [
       text "Failure: not locally nameless!";
-      text "Aborting before calling" ^/^ pp label;
-      text "term" ^/^ equals ^/^ pp t;
+      text "Aborting before calling" ^/^ fquotes (pp label);
+      text "term" ^/^ equals ^/^ fquotes (pp t);
       text (RU.stack_dump ())
     ]
 
@@ -213,9 +213,9 @@ let instantiate_term_implicits
     match namedvs with
     | (v, vty) :: _ ->
       fail_doc g (Some rng) [
-        prefix 2 1 (doc_of_string "Could not resolve implicit") (pp v) ^/^
-        prefix 2 1 (doc_of_string "of type") (pp vty) ^/^
-        prefix 2 1 (doc_of_string "in term") (pp t0);
+        prefix 2 1 (doc_of_string "Could not resolve implicit") (fquotes (pp v)) ^/^
+        prefix 2 1 (doc_of_string "of type") (fquotes (pp vty)) ^/^
+        prefix 2 1 (doc_of_string "in term") (fquotes (pp t0));
       ]
     | [] ->
       t, ty
@@ -446,9 +446,9 @@ let tc_type_phase1 (g: env) (t: term) : T.Tac (term & universe) =
       let open Pulse.PP in
       T.fail_doc_at [
         text "Expected Type, got:";
-        pp sort;
+        fquotes (pp sort);
         text "This is the type of:";
-        pp t;
+        fquotes (pp t);
       ] (Some (RU.range_of_term t)) in
   t, u
 
@@ -607,7 +607,7 @@ let get_non_informative_witness g u t
       fail_doc g (Some (RU.range_of_term t)) [
         text "Expected a term with a non-informative (e.g., erased) type.";
         prefix 2 1 (text "Got:")
-          (pp t);
+          (fquotes (pp t));
       ]
     | Some e, issues ->
       e
@@ -628,14 +628,14 @@ let check_prop_validity (g:env) (p:term)
     | None -> 
       let open Pulse.PP in
       fail_doc_with_subissues g (Some <| RU.range_of_term p) issues [
-        prefix 2 1 (text "Failed to prove pure property:") (pp p);
+        prefix 2 1 (text "Failed to prove pure property:") (fquotes (pp p));
       ]
     | Some tok -> tok
 
 let fail_expected_tot_found_ghost (g:env) (t:term) =
   fail_doc g (Some (RU.range_of_term t)) [
     prefix 2 1 (text "Expected a total term, got found ghost term:")
-      (pp t);
+      (fquotes (pp t));
   ]
 
 let compute_tot_term_type g t =
@@ -674,7 +674,7 @@ let check_subtyping g t1 t2 =
   | None ->
     let open Pulse.PP in
     fail_doc_with_subissues g (Some (RU.range_of_term t1)) issues [
-      text "Could not prove subtyping of" ^/^ pp t1 ^/^ text "and" ^/^ pp t2
+      text "Could not prove subtyping of" ^/^ fquotes (pp t1) ^/^ text "and" ^/^ fquotes (pp t2)
     ]
   )
 

--- a/pulse/src/checker/Pulse.Checker.Rewrite.fst
+++ b/pulse/src/checker/Pulse.Checker.Rewrite.fst
@@ -34,8 +34,8 @@ let check_slprop_equiv_ext r (g:env) (p q:slprop)
   | None -> 
     fail_doc_with_subissues g (Some r) issues [
       text "rewrite: could not prove equality of";
-      pp p;
-      pp q;
+      fquotes (pp p);
+      fquotes (pp q);
     ]
   | Some token ->
     ()
@@ -66,9 +66,9 @@ let check_slprop_equiv_tac r (g:env) (p q:slprop) (tac_tm : term)
   | None -> 
     fail_doc_with_subissues g (Some r) issues [
       text "rewrite: could not prove equality of";
-      pp p;
-      pp q;
-      text "Using tactic:" ^/^ pp tac_tm
+      fquotes (pp p);
+      fquotes (pp q);
+      text "Using tactic:" ^/^ fquotes (pp tac_tm)
     ]
   | Some token ->
     ()

--- a/pulse/src/checker/Pulse.Checker.ST.fst
+++ b/pulse/src/checker/Pulse.Checker.ST.fst
@@ -48,7 +48,7 @@ let check
   if Cons? args then
     fail_doc g (Some t.range) [
       text "Internal error: trailing combinator arguments not lifted in Tm_ST";
-      pp t
+      fquotes (pp t)
     ];
   let e, ty, eff = tc_term_phase1 g e in
   match Pulse.Readback.readback_comp ty with
@@ -61,7 +61,7 @@ let check
       (Some range)
       [text "Expected an application of a function returning a computation type { stt, stt_ghost, stt_atomic }";
        text "But the application:";
-       pp e;
+       fquotes (pp e);
        text "is a total term";
        text "Maybe it is not fully applied?"]
 
@@ -72,12 +72,12 @@ let check
     if not (RU.no_uvars_in_term e) then
       fail_doc g (Some range) [
         text "Unexpected unresolved uvars in the term:";
-        pp e
+        fquotes (pp e)
       ];
     if not (RU.no_uvars_in_term ty) then
       fail_doc g (Some range) [
         text "Unexpected unresolved uvars in the type:";
-        pp ty
+        fquotes (pp ty)
       ];
 
     // remove spurious beta-redexes
@@ -94,9 +94,9 @@ let check
         let open Pulse.PP in
         fail_doc g (Some range)
           [text "Application of a stateful or atomic computation cannot have a ghost effect";
-          pp t;
+          fquotes (pp t);
           text "has computation type";
-          pp c]
+          fquotes (pp c)]
       | C_STGhost .. ->
         let token = is_non_informative g' c in
         (match token with

--- a/pulse/src/checker/Pulse.PP.fst
+++ b/pulse/src/checker/Pulse.PP.fst
@@ -32,6 +32,10 @@ open Pulse.Show
 let text (s:string) : FStar.Pprint.document =
   flow (break_ 1) (words s)
 
+(* Wrap in "fancy" quotes *)
+let fquotes (d : document) : document =
+  enclose (utf8string "‘") (utf8string "’") d
+
 (* Nests a document 2 levels deep, as a block. It inserts a hardline
 before the doc, so if you want to format something as
 

--- a/pulse/src/checker/Pulse.PP.fsti
+++ b/pulse/src/checker/Pulse.PP.fsti
@@ -26,6 +26,9 @@ open Pulse.Syntax.Base
 (* A helper to create wrapped text *)
 val text : string -> FStar.Pprint.document
 
+(* Wrap in "fancy" quotes *)
+val fquotes (d : document) : document
+
 (* Nests a document 2 levels deep, as a block. It inserts a hardline
 before the doc, so if you want to format something as
 

--- a/pulse/src/checker/Pulse.Recursion.fst
+++ b/pulse/src/checker/Pulse.Recursion.fst
@@ -110,7 +110,7 @@ let rec recover_bs (g: env) (qbs: list (option qualifier & binder & bv)) (ty: te
       (R.pack_ln (R.Tv_Var (R.pack_namedv { uniq = qbv.bv_index; sort = T.seal b.binder_ty; ppname = b.binder_ppname.name }))) 0) r in
     qb::bs, c
   | qb::qbs, _ ->
-    fail_doc g (Some r) [text "main: FnDefn: expected inferred type to be an arrow"; pp ty]
+    fail_doc g (Some r) [text "main: FnDefn: expected inferred type to be an arrow"; fquotes (pp ty)]
   | [], _ ->
     [], ty
 
@@ -210,7 +210,7 @@ let add_knot (g : env) (rng : R.range)
     | Some (C_ST _) ->
       r_bs
     | _ ->
-      fail_doc g (Some d.range) [text "main: FnDefn has unexpected type"; pp comp]
+      fail_doc g (Some d.range) [text "main: FnDefn has unexpected type"; fquotes (pp comp)]
   in
   let r_res = R.subst_term prime_subst comp in
   let r_ty = FStar.Tactics.V2.SyntaxHelpers.mk_tot_arr r_bs r_res in

--- a/pulse/src/checker/Pulse.Syntax.Printer.fst
+++ b/pulse/src/checker/Pulse.Syntax.Printer.fst
@@ -72,62 +72,7 @@ let rec collect_binders (until: term_view -> bool) (t:term) : list binder & term
     | _ -> [], t
   )
 
-let rec binder_to_string_paren (b:binder)
-  : T.Tac string
-  = sprintf "(%s%s:%s)"
-            (match b.binder_attrs with
-             | [] -> ""
-             | l -> sprintf "[@@@ %s] " (String.concat ";" (T.map (term_to_string' "") l)))
-            (T.unseal b.binder_ppname.name)
-            (term_to_string' "" b.binder_ty)
-
-and term_to_string' (level:string) (t:term) : T.Tac string
-  = match inspect_term t with
-    | Tm_Emp -> "emp"
-
-    | Tm_IsUnreachable -> "is_unreachable"
-
-    | Tm_Pure p ->
-      sprintf "pure (%s)" 
-        (term_to_string' (indent level) p)
-      
-    | Tm_Star p1 p2 ->
-      sprintf "%s ** \n%s%s" 
-        (term_to_string' level p1)
-        level
-        (term_to_string' level p2)
-
-    | Tm_WithPure p n v ->
-      sprintf "(with_pure %s fun _ ->\n%s%s)"
-              (term_to_string' (indent level) p)
-              level
-              (term_to_string' (indent level) v)
-                      
-    | Tm_ExistsSL _ _ _ ->
-      let bs, body = collect_binders Tm_ExistsSL? t in
-      sprintf "(exists* %s.\n%s%s)"
-              (T.map binder_to_string_paren bs |> String.concat " ")
-              level
-              (term_to_string' (indent level) body)
-
-    | Tm_ForallSL u b body ->
-      let bs, body = collect_binders Tm_ForallSL? t in
-      sprintf "(forall* %s.\n%s%s)"
-              (T.map binder_to_string_paren bs |> String.concat " ")
-              level
-              (term_to_string' (indent level) body)
-                          
-    | Tm_SLProp -> "slprop"
-    | Tm_Inames -> "inames"
-    | Tm_EmpInames -> "emp_inames"
-    | Tm_Unknown -> "_"
-    | Tm_Inv i p ->
-      sprintf "inv %s %s"
-        (term_to_string' level i)
-        (term_to_string' level p)
-    | Tm_FStar t -> T.term_to_string t
-
-let term_to_string t = term_to_string' "" t
+let term_to_string t = T.term_to_string t
 
 let star_doc = doc_of_string "**"
 
@@ -142,81 +87,19 @@ let should_paren_term (t:term) : T.Tac bool =
   | T.Tv_Match _ _ _ -> true
   | _ -> false
 
-let rec binder_to_doc b : T.Tac document =
+let binder_to_doc b : T.Tac document =
   parens (doc_of_string (T.unseal b.binder_ppname.name)
           ^^ doc_of_string ":"
-          ^^ term_to_doc b.binder_ty)
+          ^^ T.term_to_doc b.binder_ty)
 
-and term_to_doc t : T.Tac document
-  = match inspect_term t with
-    | Tm_Emp -> doc_of_string "emp"
-    | Tm_IsUnreachable -> doc_of_string "is_unreachable"
-
-    | Tm_Pure p -> doc_of_string "pure " ^^ parens (term_to_doc p)
-    | Tm_Star _ _ ->
-      (* We gather all the components of the star so we can
-         print in fully-flat or fully-unflattened style (otherwise
-          we could get most of the slprops in different lines, except for
-          one or two lines which have >1, which is misleading). See #96.
-          Some callers to this module also canonicalize the expression
-          to put the slprops in order, but we MUST NOT do that here,
-          since we are recursively called on arguments,
-          and we must not confound pledge p (q ** r) with pledge p (r ** q),
-          etc. *)
-      let components = slprop_as_list t in
-      let term_to_doc_paren (t:term) : T.Tac document =
-        if should_paren_term t
-        then parens (term_to_doc t)
-        else term_to_doc t
-      in
-      let docs = T.map term_to_doc_paren components in
-      (* This makes sure to either print everything on a single line
-      or break after every **. The doc_of_string is a non-breakable space,
-      the one introduced by ^/^ is breakable. *)
-      group <|
-        fold_right1 (fun p q -> (p ^^ doc_of_string " " ^^ star_doc) ^/^ q) docs
-    
-    | Tm_WithPure p n v ->
-      parens <|
-        prefix 2 1 (prefix 2 1 (doc_of_string "with_pure") (parens (term_to_doc p)
-            ^/^ doc_of_string "fun _ ->"))
-          (term_to_doc v)
-
-    | Tm_ExistsSL _ _ _ ->
-      let bs, body = collect_binders Tm_ExistsSL? t in
-      let bs_doc = align (group (separate (doc_of_string " ") (T.map binder_to_doc bs))) in
-      parens <|
-        prefix 2 1 (prefix 2 1 (doc_of_string "exists*") bs_doc ^^ dot)
-                   (term_to_doc body)
-      // parens (doc_of_string "exists*" ^/^ (separate (doc_of_string " ") (T.map binder_to_doc bs))
-      //         ^^ doc_of_string "."
-      //         ^/^ term_to_doc body)
-
-    | Tm_ForallSL _ _ _ ->
-      let bs, body = collect_binders Tm_ForallSL? t in
-      let bs_doc = align (group (separate (doc_of_string " ") (T.map binder_to_doc bs))) in
-      parens <|
-        prefix 2 1 (prefix 2 1 (doc_of_string "forall*") bs_doc ^^ dot)
-                   (term_to_doc body)
-
-    | Tm_SLProp -> doc_of_string "slprop"
-    | Tm_Inames -> doc_of_string "inames"
-    | Tm_EmpInames -> doc_of_string "emp_inames"
-    | Tm_Inv i p ->
-      doc_of_string "inv " ^^
-        term_to_doc i ^^
-        doc_of_string " " ^^
-        parens (term_to_doc p)
-
-    | Tm_Unknown -> doc_of_string "_"
-    | Tm_FStar t -> T.term_to_doc t
+let term_to_doc t : T.Tac document = T.term_to_doc t
 
 let binder_to_string (b:binder)
   : T.Tac string
   = sprintf "%s%s:%s"
             (match b.binder_attrs with
              | [] -> ""
-             | l -> sprintf "[@@@ %s] " (String.concat ";" (T.map (term_to_string' "") l)))
+             | l -> sprintf "[@@@ %s] " (String.concat ";" (T.map term_to_string l)))
             (T.unseal b.binder_ppname.name)
             (term_to_string b.binder_ty)
 
@@ -338,7 +221,7 @@ let rec st_term_to_string' (level:string) (t:st_term)
     | Tm_IntroPure { p } ->
       sprintf "introduce pure (\n%s%s)"
         (indent level)
-        (term_to_string' (indent level) p)
+        (term_to_string p)
 
     | Tm_ElimExists { p } ->
       sprintf "elim_exists %s"
@@ -347,7 +230,7 @@ let rec st_term_to_string' (level:string) (t:st_term)
     | Tm_IntroExists { p; witnesses } ->
       sprintf "introduce\n%s%s\n%swith %s"
         (indent level)
-        (term_to_string' (indent level) p)
+        (term_to_string p)
         level
         (term_list_to_string " " witnesses)
 
@@ -527,8 +410,15 @@ let tag_of_comp (c:comp) : T.Tac string =
     Printf.sprintf "%s %s" (observability_to_string obs) (term_to_string i)
   | C_STGhost _ _ ->
     "Ghost" 
-    
-let rec print_st_head (t:st_term)
+
+let print_head (t:term) =
+  match t with
+  // | Tm_FVar fv
+  // | Tm_UInst fv _ -> String.concat "." fv.fv_name
+  // | Tm_PureApp head _ _ -> print_head head
+  | _ -> "<pure term>"
+
+let print_st_head (t:st_term)
   : Tot string (decreases t) =
   match t.term with
   | Tm_Abs _  -> "Abs"
@@ -552,14 +442,6 @@ let rec print_st_head (t:st_term)
   | Tm_ForwardJumpLabel _ -> "ForwardJumpLabel"
   | Tm_Goto _ -> "Goto"
   | Tm_Defer _ -> "Defer"
-
-and print_head (t:term) =
-  match t with
-  // | Tm_FVar fv
-  // | Tm_UInst fv _ -> String.concat "." fv.fv_name
-  // | Tm_PureApp head _ _ -> print_head head
-  | _ -> "<pure term>"
-
 
 let rec print_skel (t:st_term) = 
   match t.term with

--- a/pulse/src/checker/Pulse.Typing.Combinators.fst
+++ b/pulse/src/checker/Pulse.Typing.Combinators.fst
@@ -110,7 +110,7 @@ let lift_ghost_atomic (g:env) (e:st_term) (c:comp_st { C_STGhost? c })
     fail_doc g (Some (RU.range_of_term t)) [
         text "Expected a term with a non-informative (e.g., erased) type.";
         prefix 2 1 (text "Got:")
-          (pp t);
+          (fquotes (pp t));
     ]
   | Some d ->
     d
@@ -210,8 +210,8 @@ let rec mk_bind (g:env)
   = let open Pulse.PP in
     fail_doc g (Some e1.range)
       [text "Cannot compose computations in this " ^/^ text tag ^/^ text " block:";
-       prefix 4 1 (text "This computation has effect: ") (pp (effect_annot_of_comp c1));
-       prefix 4 1 (text "The continuation has effect: ") (pp (effect_annot_of_comp c2))]
+       prefix 4 1 (text "This computation has effect: ") (fquotes (pp (effect_annot_of_comp c1)));
+       prefix 4 1 (text "The continuation has effect: ") (fquotes (pp (effect_annot_of_comp c2)))]
   in
   match c1, c2 with
   | C_ST _, C_ST _ ->

--- a/pulse/test/LoopInvariants.fst.output.expected
+++ b/pulse/test/LoopInvariants.fst.output.expected
@@ -1,8 +1,8 @@
 * Info at LoopInvariants.fst(65,4-65,8):
   - Expected failure:
   - Could not prove equality of:
-  - Pulse.Lib.Reference.pts_to s 3
-  - Pulse.Lib.Reference.pts_to s 2
+  - ‘Pulse.Lib.Reference.pts_to s 3’
+  - ‘Pulse.Lib.Reference.pts_to s 2’
   - Assertion failed
   - The SMT solver could not prove the query.
   - Env =
@@ -16,8 +16,8 @@
 * Info at LoopInvariants.fst(76,4-76,8):
   - Expected failure:
   - Could not prove equality of:
-  - Pulse.Lib.Reference.pts_to s 3
-  - Pulse.Lib.Reference.pts_to s 2
+  - ‘Pulse.Lib.Reference.pts_to s 3’
+  - ‘Pulse.Lib.Reference.pts_to s 2’
   - Assertion failed
   - The SMT solver could not prove the query.
   - Env =

--- a/pulse/test/bug-reports/Bug266.fst.output.expected
+++ b/pulse/test/bug-reports/Bug266.fst.output.expected
@@ -1,6 +1,6 @@
 * Info at Bug266.fst(10,2-10,14):
   - Expected failure:
-  - Failed to prove pure property: l_False
+  - Failed to prove pure property: ‘l_False’
   - Assertion failed
   - The SMT solver could not prove the query.
   - Env = (uu___0 : Prims.unit)

--- a/pulse/test/bug-reports/Bug267.fst.output.expected
+++ b/pulse/test/bug-reports/Bug267.fst.output.expected
@@ -5,7 +5,7 @@
 
 * Info at Bug267.fst(58,5-58,8):
   - Expected failure:
-  - Could not prove equality between computed type int and expected type nat
+  - Could not prove equality between computed type ‘int’ and expected type ‘nat’
   - Assertion failed
   - The SMT solver could not prove the query.
   - Env =

--- a/pulse/test/bug-reports/Bug278.fst.output.expected
+++ b/pulse/test/bug-reports/Bug278.fst.output.expected
@@ -2,5 +2,5 @@
   - Expected failure:
   - Tactic failed
   - Unexpected unresolved uvars in the term:
-  - spawn (pth n)
+  - ‘spawn (pth n)’
 

--- a/pulse/test/bug-reports/Bug45.fst.output.expected
+++ b/pulse/test/bug-reports/Bug45.fst.output.expected
@@ -2,5 +2,5 @@
   - Expected failure:
   - Tactic failed
   - Unexpected unresolved uvars in the term:
-  - spawn (pth n)
+  - ‘spawn (pth n)’
 

--- a/pulse/test/bug-reports/PartialApp.fst.output.expected
+++ b/pulse/test/bug-reports/PartialApp.fst.output.expected
@@ -1,16 +1,16 @@
 * Info at PartialApp.fst(24,2-24,3):
   - Expected failure:
   - Tactic failed
-  - This statement returns a value of type: int
+  - This statement returns a value of type: ‘int’
   - Did you forget to assign it or ignore it?
 
 * Info at PartialApp.fst(50,2-50,9):
   - Expected failure:
   - Tactic failed
   - This function is partially applied. Remaining type:
-      y: t
+      ‘y: t
         -> fn
              requires emp
-             ensures emp
+             ensures emp’
   - Did you forget to apply some arguments?
 

--- a/pulse/test/error_messages/AssertExtraContext.fst.output.expected
+++ b/pulse/test/error_messages/AssertExtraContext.fst.output.expected
@@ -1,6 +1,6 @@
 * Info at AssertExtraContext.fst(11,7-11,43):
   - Expected failure:
-  - Failed to prove pure property: 0 > 0
+  - Failed to prove pure property: ‘0 > 0’
   - Assertion failed
   - The SMT solver could not prove the query.
   - Env = (r : Pulse.Lib.Reference.ref Prims.int)

--- a/pulse/test/error_messages/AtomicMismatch.fst.output.expected
+++ b/pulse/test/error_messages/AtomicMismatch.fst.output.expected
@@ -2,6 +2,6 @@
   - Expected failure:
   - Tactic failed
   - Cannot compose computations in this atomic block:
-  - This computation has effect: stt
-  - The continuation has effect: stt_atomic emp_inames
+  - This computation has effect: ‘stt’
+  - The continuation has effect: ‘stt_atomic emp_inames’
 

--- a/pulse/test/error_messages/BindTypeMismatch.fst.output.expected
+++ b/pulse/test/error_messages/BindTypeMismatch.fst.output.expected
@@ -2,6 +2,6 @@
   - Expected failure:
   - Tactic failed
   - Type mismatch (NB: this is a syntactic check)
-  - Expected: bool
-  - Got: int
+  - Expected: ‘bool’
+  - Got: ‘int’
 

--- a/pulse/test/error_messages/ClosureError.fst.output.expected
+++ b/pulse/test/error_messages/ClosureError.fst.output.expected
@@ -1,8 +1,8 @@
 * Info at ClosureError.fst(17,2-17,8):
   - Expected failure:
   - Could not prove equality of:
-  - Pulse.Lib.Reference.pts_to r 0
-  - Pulse.Lib.Reference.pts_to r 1
+  - ‘Pulse.Lib.Reference.pts_to r 0’
+  - ‘Pulse.Lib.Reference.pts_to r 1’
   - Assertion failed
   - The SMT solver could not prove the query.
   - Env =

--- a/pulse/test/error_messages/ExistsIntro.fst.output.expected
+++ b/pulse/test/error_messages/ExistsIntro.fst.output.expected
@@ -1,6 +1,6 @@
 * Info at ExistsIntro.fst(12,2-12,4):
   - Expected failure:
-  - Failed to prove pure property: 5 > 10
+  - Failed to prove pure property: ‘5 > 10’
   - Assertion failed
   - The SMT solver could not prove the query.
   - Env = (r : Pulse.Lib.Reference.ref Prims.int)

--- a/pulse/test/error_messages/FoldError.fst.output.expected
+++ b/pulse/test/error_messages/FoldError.fst.output.expected
@@ -1,6 +1,6 @@
 * Info at FoldError.fst(13,2-13,22):
   - Expected failure:
-  - Failed to prove pure property: false
+  - Failed to prove pure property: ‘false’
   - Assertion failed
   - The SMT solver could not prove the query.
   - Env = (r : Pulse.Lib.Reference.ref Prims.int)

--- a/pulse/test/error_messages/GhostEffect.fst.output.expected
+++ b/pulse/test/error_messages/GhostEffect.fst.output.expected
@@ -2,6 +2,6 @@
   - Expected failure:
   - Tactic failed
   - Expected a term with a non-informative (e.g., erased) type.
-  - Got: int
+  - Got: ‘int’
   - See also GhostEffect.fst(20,1-22,3)
 

--- a/pulse/test/error_messages/IfBranchMismatch.fst.output.expected
+++ b/pulse/test/error_messages/IfBranchMismatch.fst.output.expected
@@ -1,8 +1,8 @@
 * Info at IfBranchMismatch.fst(14,4-14,8):
   - Expected failure:
   - Could not prove equality of:
-  - Pulse.Lib.Reference.pts_to r 2
-  - Pulse.Lib.Reference.pts_to r 1
+  - ‘Pulse.Lib.Reference.pts_to r 2’
+  - ‘Pulse.Lib.Reference.pts_to r 1’
   - Assertion failed
   - The SMT solver could not prove the query.
   - Env =
@@ -15,8 +15,8 @@
 * Info at IfBranchMismatch.fst(30,4-30,6):
   - Expected failure:
   - Could not prove equality of:
-  - Pulse.Lib.Reference.pts_to r 2
-  - Pulse.Lib.Reference.pts_to r 1
+  - ‘Pulse.Lib.Reference.pts_to r 2’
+  - ‘Pulse.Lib.Reference.pts_to r 1’
   - Assertion failed
   - The SMT solver could not prove the query.
   - Env =

--- a/pulse/test/error_messages/IllTypedInvariant.fst.output.expected
+++ b/pulse/test/error_messages/IllTypedInvariant.fst.output.expected
@@ -1,6 +1,6 @@
 * Info at IllTypedInvariant.fst(13,43-13,44):
   - Expected failure:
-  - Failed to prove pure property: true /\ true /\ false
+  - Failed to prove pure property: ‘true /\ true /\ false’
   - Assertion failed
   - The SMT solver could not prove the query.
   - Env = (uu___0 : Prims.unit) (i : Pulse.Lib.Reference.ref Prims.int)

--- a/pulse/test/error_messages/IntroExistsFail.fst.output.expected
+++ b/pulse/test/error_messages/IntroExistsFail.fst.output.expected
@@ -1,6 +1,6 @@
 * Info at IntroExistsFail.fst(11,2-11,4):
   - Expected failure:
-  - Failed to prove pure property: 0 > 0
+  - Failed to prove pure property: ‘0 > 0’
   - Assertion failed
   - The SMT solver could not prove the query.
   - Env = (r : Pulse.Lib.Reference.ref Prims.int)

--- a/pulse/test/error_messages/InvariantPayload.fst.output.expected
+++ b/pulse/test/error_messages/InvariantPayload.fst.output.expected
@@ -1,6 +1,6 @@
 * Info at InvariantPayload.fst(13,2-13,16):
   - Expected failure:
-  - Failed to prove pure property: 0 > 0
+  - Failed to prove pure property: ‘0 > 0’
   - Assertion failed
   - The SMT solver could not prove the query.
   - Env = (r : Pulse.Lib.Reference.ref Prims.int)

--- a/pulse/test/error_messages/MatchBranchMismatch.fst.output.expected
+++ b/pulse/test/error_messages/MatchBranchMismatch.fst.output.expected
@@ -1,8 +1,8 @@
 * Info at MatchBranchMismatch.fst(13,11-13,15):
   - Expected failure:
   - Could not prove equality of:
-  - Pulse.Lib.Reference.pts_to r 2
-  - Pulse.Lib.Reference.pts_to r 1
+  - ‘Pulse.Lib.Reference.pts_to r 2’
+  - ‘Pulse.Lib.Reference.pts_to r 1’
   - Assertion failed
   - The SMT solver could not prove the query.
   - Env =

--- a/pulse/test/error_messages/MultiError.fst.output.expected
+++ b/pulse/test/error_messages/MultiError.fst.output.expected
@@ -1,6 +1,6 @@
 * Info at MultiError.fst(12,18-12,19):
   - Expected failure:
-  - Failed to prove pure property: false
+  - Failed to prove pure property: ‘false’
   - Assertion failed
   - The SMT solver could not prove the query.
   - Env = (r : Pulse.Lib.Reference.ref Prims.int) (__ : Prims.unit)

--- a/pulse/test/error_messages/NestedBlock.fst.output.expected
+++ b/pulse/test/error_messages/NestedBlock.fst.output.expected
@@ -1,8 +1,8 @@
 * Info at NestedBlock.fst(14,2-14,4):
   - Expected failure:
   - Could not prove equality of:
-  - Pulse.Lib.Reference.pts_to r 1
-  - Pulse.Lib.Reference.pts_to r 0
+  - ‘Pulse.Lib.Reference.pts_to r 1’
+  - ‘Pulse.Lib.Reference.pts_to r 0’
   - Assertion failed
   - The SMT solver could not prove the query.
   - Env = (r : Pulse.Lib.Reference.ref Prims.int)

--- a/pulse/test/error_messages/NestedCall.fst.output.expected
+++ b/pulse/test/error_messages/NestedCall.fst.output.expected
@@ -1,8 +1,8 @@
 * Info at NestedCall.fst(18,2-18,9):
   - Expected failure:
   - Could not prove equality of:
-  - Pulse.Lib.Reference.pts_to r 5
-  - Pulse.Lib.Reference.pts_to r 0
+  - ‘Pulse.Lib.Reference.pts_to r 5’
+  - ‘Pulse.Lib.Reference.pts_to r 0’
   - Assertion failed
   - The SMT solver could not prove the query.
   - Env = (r : Pulse.Lib.Reference.ref Prims.int)

--- a/pulse/test/error_messages/PrePostMismatch.fst.output.expected
+++ b/pulse/test/error_messages/PrePostMismatch.fst.output.expected
@@ -1,8 +1,8 @@
 * Info at PrePostMismatch.fst(12,2-12,4):
   - Expected failure:
   - Could not prove equality of:
-  - Pulse.Lib.Reference.pts_to r 1
-  - Pulse.Lib.Reference.pts_to r 42
+  - ‘Pulse.Lib.Reference.pts_to r 1’
+  - ‘Pulse.Lib.Reference.pts_to r 42’
   - Assertion failed
   - The SMT solver could not prove the query.
   - Env = (r : Pulse.Lib.Reference.ref Prims.int) (__ : Prims.unit)

--- a/pulse/test/error_messages/RewriteFail.fst.output.expected
+++ b/pulse/test/error_messages/RewriteFail.fst.output.expected
@@ -1,8 +1,8 @@
 * Info at RewriteFail.fst(11,11-11,33):
   - Expected failure:
   - rewrite: could not prove equality of
-  - pts_to r 0
-  - pts_to r 1
+  - ‘pts_to r 0’
+  - ‘pts_to r 1’
   - Assertion failed
   - The SMT solver could not prove the query.
   - Env = (r : Pulse.Lib.Reference.ref Prims.int)

--- a/pulse/test/error_messages/SequenceError.fst.output.expected
+++ b/pulse/test/error_messages/SequenceError.fst.output.expected
@@ -1,8 +1,8 @@
 * Info at SequenceError.fst(13,2-13,4):
   - Expected failure:
   - Could not prove equality of:
-  - Pulse.Lib.Reference.pts_to r2 2
-  - Pulse.Lib.Reference.pts_to r2 1
+  - ‘Pulse.Lib.Reference.pts_to r2 2’
+  - ‘Pulse.Lib.Reference.pts_to r2 1’
   - Assertion failed
   - The SMT solver could not prove the query.
   - Env =

--- a/pulse/test/error_messages/TerminalActionPostConditionMismatch.fst.output.expected
+++ b/pulse/test/error_messages/TerminalActionPostConditionMismatch.fst.output.expected
@@ -1,8 +1,8 @@
 * Info at TerminalActionPostConditionMismatch.fst(12,2-12,6):
   - Expected failure:
   - Could not prove equality of:
-  - Pulse.Lib.Reference.pts_to r 2
-  - Pulse.Lib.Reference.pts_to r 1
+  - ‘Pulse.Lib.Reference.pts_to r 2’
+  - ‘Pulse.Lib.Reference.pts_to r 1’
   - Assertion failed
   - The SMT solver could not prove the query.
   - Env =
@@ -14,8 +14,8 @@
 * Info at TerminalActionPostConditionMismatch.fst(23,2-23,4):
   - Expected failure:
   - Could not prove equality of:
-  - Pulse.Lib.Reference.pts_to r 2
-  - Pulse.Lib.Reference.pts_to r 1
+  - ‘Pulse.Lib.Reference.pts_to r 2’
+  - ‘Pulse.Lib.Reference.pts_to r 1’
   - Assertion failed
   - The SMT solver could not prove the query.
   - Env =

--- a/pulse/test/error_messages/WhileInvPreservation.fst.output.expected
+++ b/pulse/test/error_messages/WhileInvPreservation.fst.output.expected
@@ -1,8 +1,8 @@
 * Info at WhileInvPreservation.fst(15,4-15,8):
   - Expected failure:
   - Could not prove equality of:
-  - Pulse.Lib.Reference.pts_to i 2
-  - Pulse.Lib.Reference.pts_to i 0
+  - ‘Pulse.Lib.Reference.pts_to i 2’
+  - ‘Pulse.Lib.Reference.pts_to i 0’
   - Assertion failed
   - The SMT solver could not prove the query.
   - Env =

--- a/pulse/test/nolib/ErrCantFindWitness.fst.output.expected
+++ b/pulse/test/nolib/ErrCantFindWitness.fst.output.expected
@@ -1,6 +1,6 @@
 * Info at ErrCantFindWitness.fst(8,1-8,1):
   - Expected failure:
-  - Cannot find witness for exists* (x: nat). emp
+  - Cannot find witness for ‘exists* (x: nat). emp’
   - Ill-typed term
   - Cannot check relation with uvars.
 

--- a/pulse/test/nolib/ErrCantFindWitness.fst.output.expected
+++ b/pulse/test/nolib/ErrCantFindWitness.fst.output.expected
@@ -1,6 +1,6 @@
 * Info at ErrCantFindWitness.fst(8,1-8,1):
   - Expected failure:
-  - Cannot find witness for (exists* (x:nat). emp)
+  - Cannot find witness for exists* (x: nat). emp
   - Ill-typed term
   - Cannot check relation with uvars.
 

--- a/pulse/test/nolib/Test.RewriteBy.fst.output.expected
+++ b/pulse/test/nolib/Test.RewriteBy.fst.output.expected
@@ -1,12 +1,12 @@
 * Info at Test.RewriteBy.fst(32,2-37,8):
   - Expected failure:
   - rewrite: could not prove equality of
-  - p
-  - q
+  - ‘p’
+  - ‘q’
   - Using tactic:
-    fun _ ->
+    ‘fun _ ->
       dump "a";
-      tac ()
+      tac ()’
   - Tactic failed
   - Tactic got stuck!
   - Reduction stopped at:

--- a/tests/bug-reports/closed/Bug4274.fst.output.expected
+++ b/tests/bug-reports/closed/Bug4274.fst.output.expected
@@ -9,5 +9,5 @@
       x#278 : foo
 
       goto _return#345 requires
-        (exists* (vx:foo_spec). foo_pred x vx ** pure (vx.x' == 10))
+        exists* (vx: foo_spec). foo_pred x vx ** pure (vx.x' == 10)
 


### PR DESCRIPTION
Pulse terms have been F* terms for a while. I believe this custom term printer is just asking for trouble since it is not exactly faithful (e.g. it drops ascriptions).

The expected output changes only minimally, looks even slightly better.