### PR TITLE
Pulse: purify if/match postcondition annotations

### DIFF
--- a/pulse/src/checker/Pulse.Checker.fst
+++ b/pulse/src/checker/Pulse.Checker.fst
@@ -46,6 +46,7 @@ module ForwardJumpLabel = Pulse.Checker.ForwardJumpLabel
 module Defer = Pulse.Checker.Defer
 module Goto = Pulse.Checker.Goto
 module PCP = Pulse.Checker.Pure
+module ImpureSpec = Pulse.Checker.ImpureSpec
 
 let terms_to_string (t:list term)
   : T.Tac string 
@@ -372,6 +373,7 @@ let rec check
           | Some p, TypeHint _ ->
             //We set the computation type to be STT in this case
             //We might allow the post_if annotation to also set the effect tag
+            let p = ImpureSpec.purify_spec g { ctxt_old = Some pre; ctxt_now = tm_emp } p in
             PostHint <| Checker.Base.intro_post_hint g EffectAnnotSTT None p
           | Some p, PostHint q ->
             Pulse.Typing.Env.fail g (Some t.range) 
@@ -423,6 +425,7 @@ let rec check
           | Some p, NoHint
           | Some p, TypeHint _ ->
             //See same remark in the If case
+            let p = ImpureSpec.purify_spec g { ctxt_old = Some pre; ctxt_now = tm_emp } p in
             Checker.Base.intro_post_hint g EffectAnnotSTT None p
           | Some p, PostHint q ->
             Pulse.Typing.Env.fail g (Some t.range)

--- a/pulse/test/ImpureSpec.fst
+++ b/pulse/test/ImpureSpec.fst
@@ -128,3 +128,56 @@ fn test14 ()
   assert live x ** pure (!x == 42);
   rewrite each !x as 42;
 }
+
+let max_spec (x y: int) = if x < y then y else x
+
+// A non-tail `if` annotated with a postcondition that uses impure spec
+// syntax (the `!result` selector). The annotation must be purified before
+// being used as the post hint.
+fn test15_if #p #q (x y: ref int)
+  preserves pts_to x #p 'vx
+  requires pts_to y #q 'vy
+  returns n: int
+  ensures pts_to y #q 'vy ** pure (n == max_spec 'vx 'vy)
+{
+  let mut result = 0;
+  let vx = !x;
+  let vy = !y;
+  if (vx > vy)
+  ensures
+    pts_to x #p 'vx **
+    pts_to y #q 'vy **
+    (exists* r. pts_to result r) **
+    pure (!result == max_spec 'vx 'vy)
+  {
+    result := vx;
+  }
+  else
+  {
+    result := vy;
+  };
+  !result;
+}
+
+// Same as test15_if, but for a non-tail `match`.
+fn test16_match #p #q (x y: ref int)
+  preserves pts_to x #p 'vx
+  requires pts_to y #q 'vy
+  returns n: int
+  ensures pts_to y #q 'vy ** pure (n == max_spec 'vx 'vy)
+{
+  let mut result = 0;
+  let vx = !x;
+  let vy = !y;
+  match (vx > vy)
+  ensures
+    pts_to x #p 'vx **
+    pts_to y #q 'vy **
+    (exists* r. pts_to result r) **
+    pure (!result == max_spec 'vx 'vy)
+  {
+    true -> { result := vx; }
+    false -> { result := vy; }
+  };
+  !result;
+}


### PR DESCRIPTION
The Tm_If and Tm_Match cases of the checker built a post hint directly from a user-written `ensures` annotation via intro_post_hint, which only runs check_slprop and does not elaborate impure-spec syntax (selectors like `!r`, `old(...)`). As a result, an annotated non-tail conditional whose postcondition used impure-spec syntax was rejected, even though the same annotation works on function specs, labels, etc.

Run ImpureSpec.purify_spec on the annotation before intro_post_hint, using { ctxt_old = Some pre; ctxt_now = tm_emp } as for function postconditions (Pulse.Checker.Abs): selectors resolve against the post's own re-stated resources and `old` resolves against the pre-state.

Add regression tests test15_if and test16_match.