### PR TITLE
Validate float literal extraction

### DIFF
--- a/src/extraction/FStarC.Extraction.Krml.fst
+++ b/src/extraction/FStarC.Extraction.Krml.fst
@@ -437,6 +437,43 @@ let is_float_width = function
   | Some Float32 | Some Float64 -> true
   | _ -> false
 
+(* Float literals are emitted by KaRaMeL as raw C tokens. Accept only a
+   conservative decimal grammar here instead of forwarding arbitrary strings
+   into generated C. *)
+let valid_float_literal (s:string) : bool =
+  let is_digit (c:FStar.Char.char) =
+    let i = BU.int_of_char c in
+    i >= 48 && i <= 57 in
+  let rec consume_digits cs =
+    match cs with
+    | c :: cs' when is_digit c -> consume_digits cs'
+    | _ -> cs in
+  let has_digits cs = consume_digits cs <> cs in
+  let cs =
+    match FStar.String.list_of_string s with
+    | '+' :: cs | '-' :: cs -> cs
+    | cs -> cs in
+  let before_dot = consume_digits cs in
+  let after_mantissa, has_mantissa_digit =
+    match before_dot with
+    | '.' :: cs' ->
+        let after_dot = consume_digits cs' in
+        after_dot, before_dot <> cs || after_dot <> cs'
+    | _ ->
+        before_dot, before_dot <> cs in
+  if not has_mantissa_digit
+  then false
+  else
+    match after_mantissa with
+    | [] -> true
+    | 'e' :: exp | 'E' :: exp ->
+        let exp =
+          match exp with
+          | '+' :: exp | '-' :: exp -> exp
+          | exp -> exp in
+        has_digits exp && consume_digits exp = []
+    | _ -> false
+
 let mk_bool_op = function
   | "op_Negation" ->
       Some Not
@@ -1084,6 +1121,12 @@ and translate_expr' env e: ML expr =
 
   // Float modules: of_literal "3.14" is a floating-point constant.
   | MLE_App ({ expr = MLE_Name ([ "FStar"; m ], "of_literal") }, [ { expr = MLE_Const (MLC_String s) } ]) when is_float_width (mk_width m) ->
+      if not (valid_float_literal s)
+      then
+        failwith
+          (Format.fmt2
+             "Refusing to extract invalid %s.of_literal argument as a C floating-point constant: %s"
+             m s);
       EConstant (Option.must (mk_width m), s)
 
   // Operators from fixed-width integer modules, e.g. [FStar.Int32.addw].

--- a/tests/extraction/FloatLiteralExtraction.fst
+++ b/tests/extraction/FloatLiteralExtraction.fst
@@ -1,0 +1,7 @@
+module FloatLiteralExtraction
+
+let f64 : FStar.Float64.t =
+  FStar.Float64.of_literal "-1.25e+3"
+
+let f32 : FStar.Float32.t =
+  FStar.Float32.of_literal ".5"

--- a/tests/extraction/FloatLiteralInjection.fst
+++ b/tests/extraction/FloatLiteralInjection.fst
@@ -1,0 +1,4 @@
+module FloatLiteralInjection
+
+let bad : FStar.Float64.t =
+  FStar.Float64.of_literal "0.0); KRML_HOST_EXIT(0); /*"

--- a/tests/extraction/Makefile
+++ b/tests/extraction/Makefile
@@ -17,6 +17,16 @@ RUN += ParseTest.fst
 
 include $(FSTAR_ROOT)/mk/test.mk
 
+all: $(OUTPUT_DIR)/FloatLiteralExtraction.krml
+all: $(OUTPUT_DIR)/FloatLiteralInjection.rejected
+
+$(OUTPUT_DIR)/FloatLiteralInjection.rejected: $(CACHE_DIR)/FloatLiteralInjection.fst.checked $(FSTAR_EXE)
+	@mkdir -p $(OUTPUT_DIR)
+	@$(FSTAR) $< --codegen krml --extract_module FloatLiteralInjection >$(OUTPUT_DIR)/FloatLiteralInjection.out 2>&1 || true
+	@grep -q "Warning 242" $(OUTPUT_DIR)/FloatLiteralInjection.out
+	@grep -q "Refusing to extract invalid Float64.of_literal argument" $(OUTPUT_DIR)/FloatLiteralInjection.out
+	@touch $@
+
 # Overriding the default rule for this one. We need to wrap this in a timeout.
 $(OUTPUT_DIR)/Div.out: $(OUTPUT_DIR)/Div.exe
 	$(call msg,TIMEOUT,$<)


### PR DESCRIPTION
This PR rejects `Float32.of_literal` and `Float64.of_literal` strings that are not plain decimal floating-point literals before KaRaMeL emits them as raw C constants.

The extraction path now validates the literal text before producing an `EConstant`. It accepts only a conservative decimal float grammar and rejects suffixes, hex literals, comments, punctuation, whitespace, and other non-literal text, so injected C cannot be carried through `of_literal`.

Regression tests cover successful `Float32`/`Float64` extraction and a malicious literal that must be rejected during extraction.