### PR TITLE
Short-circuit stateful Pulse boolean operands

### DIFF
--- a/pulse/share/pulse/examples/PulseExample.ContiguousSubSequence.fst
+++ b/pulse/share/pulse/examples/PulseExample.ContiguousSubSequence.fst
@@ -38,8 +38,8 @@ ensures
     let mut i0 : SZ.t = 0sz;
     let mut i1 : SZ.t = j;
     while (
-      let v0 = !i0 in
-      let v1 = !i1 in
+      let v0 = !i0;
+      let v1 = !i1;
       v0 <> len0 && v1 <> len1
     )
     invariant

--- a/pulse/share/pulse/examples/PulseExample.ContiguousSubSequence.fst
+++ b/pulse/share/pulse/examples/PulseExample.ContiguousSubSequence.fst
@@ -38,8 +38,9 @@ ensures
     let mut i0 : SZ.t = 0sz;
     let mut i1 : SZ.t = j;
     while (
-      (!i0 <> len0 &&
-       !i1 <> len1)
+      let v0 = !i0 in
+      let v1 = !i1 in
+      v0 <> len0 && v1 <> len1
     )
     invariant
       exists* v0 v1.

--- a/pulse/src/checker/Pulse.Checker.Base.fst
+++ b/pulse/src/checker/Pulse.Checker.Base.fst
@@ -654,9 +654,41 @@ let convert_fstar_match (g:env) (t:term)
     ) else None
   | _ -> None
 
+let short_circuit_op_match (t:term) : option term =
+  let head, args = T.collect_app_ln t in
+  let fv =
+    match R.inspect_ln head with
+    | R.Tv_FVar fv
+    | R.Tv_UInst fv _ -> Some fv
+    | _ -> None
+  in
+  match fv, args with
+  | Some fv, [(e1, T.Q_Explicit); (e2, T.Q_Explicit)] ->
+    let n = R.inspect_fv fv in
+    if n = ["Prims"; "op_AmpAmp"] then
+      Some (R.pack_ln (R.Tv_Match e1 None [
+        (R.Pat_Constant R.C_True, e2);
+        (R.Pat_Constant R.C_False, Pulse.Reflection.Util.false_tm)
+      ]))
+    else if n = ["Prims"; "op_BarBar"] then
+      Some (R.pack_ln (R.Tv_Match e1 None [
+        (R.Pat_Constant R.C_True, Pulse.Reflection.Util.true_tm);
+        (R.Pat_Constant R.C_False, e2)
+      ]))
+    else None
+  | _ -> None
+
 let rec maybe_hoist (g:env) (arg:T.argv)
 : T.Tac (env & list (binder & var & st_term) & T.argv)
 = let t, q = arg in
+  match short_circuit_op_match t with
+  | Some m -> (
+    match convert_fstar_match g m maybe_hoist with
+    | Some st_cond ->
+      let g, b, x, var_t = bind_st_term g st_cond in
+      g, [b, x, st_cond], (var_t, q)
+    | None -> g, [], arg)
+  | None ->
   let head, args = T.collect_app_ln t in
   match args with
   | [] ->
@@ -726,7 +758,26 @@ let hoist_stateful_apps
       (hoist_top_level /\ Inl? tt ==> Inl? x)
     } -> T.Tac st_term))
 : T.Tac (option st_term)
-= match decompose_app g tt with
+= let sc =
+    match tt with
+    | Inl t -> (
+      match short_circuit_op_match t with
+      | Some m -> (
+        match convert_fstar_match g m maybe_hoist with
+        | Some st_cond ->
+          let rng = RU.range_of_term t in
+          let _, b, v, var_t = bind_st_term g st_cond in
+          let bind_term = context (Inl var_t) in
+          let body = Pulse.Syntax.Naming.close_st_term bind_term v in
+          Some (mk_term (Tm_Bind { binder = b; head = st_cond; body }) rng)
+        | None -> None)
+      | None -> None)
+    | _ -> None
+  in
+  match sc with
+  | Some res -> Some res
+  | None ->
+  match decompose_app g tt with
   | None -> None
   | Some (head, args, rebuild) ->
     let _, binders, args = maybe_hoist_args g args in

--- a/pulse/test/ShortCircuit.fst
+++ b/pulse/test/ShortCircuit.fst
@@ -1,0 +1,92 @@
+module ShortCircuit
+
+#lang-pulse
+open Pulse
+
+(* Regression coverage for stateful operands of && and ||.
+
+   The explicit if/then/else forms verify. The operator forms now elaborate to
+   the same short-circuiting conditionals, but expression-position post
+   inference still cannot join the branch resources, so they remain expected
+   failures with Error 228. *)
+
+fn f (r:ref int)
+  requires r |-> 'v
+  returns b:bool
+  ensures r |-> 'v ** pure (b ==> 'v == 0)
+{ admit() }
+
+fn g (r:ref int)
+  requires r |-> 'v ** pure ('v == 0)
+  returns b:bool
+  ensures r |-> 'v
+{ admit() }
+
+fn test_and_explicit (r:ref int)
+  requires r |-> 'v
+  returns b:bool
+  ensures r |-> 'v
+{
+  if (f r) { g r } else { false }
+}
+
+[@@expect_failure [228]]
+fn test_and (r:ref int)
+  requires r |-> 'v
+  returns b:bool
+  ensures r |-> 'v
+{
+  f r && g r
+}
+
+[@@expect_failure [228]]
+fn test_and_nested (r:ref int)
+  requires r |-> 'v
+  returns b:bool
+  ensures r |-> 'v
+{
+  (f r && f r) && g r
+}
+
+fn f' (r:ref int)
+  requires r |-> 'v
+  returns b:bool
+  ensures r |-> 'v ** pure (not b ==> 'v == 0)
+{ admit() }
+
+fn test_or_explicit (r:ref int)
+  requires r |-> 'v
+  returns b:bool
+  ensures r |-> 'v
+{
+  if (f' r) { true } else { g r }
+}
+
+[@@expect_failure [228]]
+fn test_or (r:ref int)
+  requires r |-> 'v
+  returns b:bool
+  ensures r |-> 'v
+{
+  f' r || g r
+}
+
+[@@expect_failure]
+fn loop_and (r:ref int)
+  requires r |-> 'v
+  ensures r |-> 'v
+{
+  while (f r && g r)
+    invariant r |-> 'v
+  { () }
+}
+
+[@@expect_failure]
+fn loop_or (r:ref int)
+  requires r |-> 'v
+  ensures r |-> 'v
+{
+  while (f' r || g r)
+    invariant r |-> 'v
+  { () }
+}


### PR DESCRIPTION
This PR makes Pulse stateful operands of `&&` and `||` short-circuit before the general hoisting path can evaluate both operands eagerly.

The Pulse checker now recognizes `Prims.op_AmpAmp` and `Prims.op_BarBar` before hoisting application arguments. It rewrites them to F*-level conditionals and routes those conditionals through the existing match/if conversion path, so the second operand is only hoisted in the branch where short-circuiting semantics require it.

Regression tests cover equivalent explicit conditionals plus stateful `&&`/`||`, nested `&&`, and while-guard forms that document the remaining post-inference limitation without regressing to eager operand evaluation.