### PR TITLE
resugar: fix quantifier uncurrying to respect flavor_matches across all alternatives

### DIFF
--- a/src/syntax/FStarC.Syntax.Resugar.fst
+++ b/src/syntax/FStarC.Syntax.Resugar.fst
@@ -711,10 +711,12 @@ let rec resugar_term_base' (env: DsEnv.env) (t : S.term) : ML A.term =
             || starts_with op "exists" ->
           (* desugared from QForall(binders * patterns * body) to Tm_app(forall, Tm_abs(binders, Tm_meta(body, meta_pattern(list args)*)
           let rec uncurry xs pats (t:A.term) flavor_matches =
+            if not (flavor_matches t) then xs, pats, t
+            else
             match t.tm with
             | A.QExists(xs', (_, pats'), body)
             | A.QForall(xs', (_, pats'), body)
-            | A.QuantOp(_, xs', (_, pats'), body) when flavor_matches t ->
+            | A.QuantOp(_, xs', (_, pats'), body) ->
                 uncurry (xs@xs') (pats@pats') body flavor_matches
             | _ ->
                 xs, pats, t


### PR DESCRIPTION
## Summary

Fixes #2363.

The `uncurry` function in `resugar_term'` (FStarC.Syntax.Resugar.fst ~line 713) used a `when flavor_matches t` guard on the last arm of an OR-pattern:

```fstar
| A.QExists(xs', (_, pats'), body)
| A.QForall(xs', (_, pats'), body)
| A.QuantOp(_, xs', (_, pats'), body) when flavor_matches t ->   (* guard only covers QuantOp *)
    uncurry (xs@xs') (pats@pats') body flavor_matches
```

In F\*, a `when` guard on an OR-pattern only applies to the **last** alternative. So `QExists` and `QForall` were always merged regardless of flavor, causing mixed-quantifier formulas like `forall x1. exists x2. phi` to be resugared as `forall x1 x2. phi`.

## Fix

Move the `flavor_matches` check to the top of `uncurry` as an early return, before any pattern match:

```fstar
let rec uncurry xs pats (t:A.term) flavor_matches =
  if not (flavor_matches t) then xs, pats, t
  else
  match t.tm with
  | A.QExists(xs', (_, pats'), body)
  | A.QForall(xs', (_, pats'), body)
  | A.QuantOp(_, xs', (_, pats'), body) ->
      uncurry (xs@xs') (pats@pats') body flavor_matches
  | _ ->
      xs, pats, t
```

This ensures all three quantifier forms are only merged when they share the same flavor.

## Test plan

- [ ] Verify `forall x1. forall x2. phi` still merges to `forall x1 x2. phi`
- [ ] Verify `forall x1. exists x2. phi` no longer incorrectly merges to `forall x1 x2. phi`
- [ ] Existing printer tests pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)