### PR TITLE
Pulse: fix divergent-fn call in if-branch composition (#4366)

### DIFF
--- a/pulse/src/checker/Pulse.Checker.Base.fst
+++ b/pulse/src/checker/Pulse.Checker.Base.fst
@@ -414,6 +414,48 @@ let apply_checker_result_k (#g:env) (#ctxt:slprop) (#post_hint:post_hint_for_env
 
   k (PostHint post_hint) d
 
+//
+// Like apply_checker_result_k, but reads back the *natural* effect of the
+// checked computation instead of coercing it to the postcondition's effect.
+// This is used to infer the effect of the branches of a conditional whose
+// postcondition (and effect) were not supplied by the user: a divergent branch
+// must yield a divergent computation rather than failing to compose against the
+// tentatively-inferred stt effect (issue #4366). The result matches the given
+// postcondition's return type and postcondition, but carries its own effect.
+//
+let apply_checker_result_k_nohint (#g:env) (#ctxt:slprop) (#post_hint:post_hint_for_env g)
+  (r:checker_result_t g ctxt (PostHint post_hint))
+  (res_ppname:ppname)
+  : T.Tac (t:st_term &
+           c:comp_st { comp_pre c == ctxt /\
+                       comp_res c == post_hint.ret_ty /\
+                       comp_u c == post_hint.u /\
+                       comp_post c == post_hint.post }) =
+
+  let (| y, g1, (u_ty, ty_y), pre', k |) = r in
+
+  let u_ty_y = Pulse.Checker.Pure.universe_of_well_typed_term g1 ty_y in
+
+  let d : st_typing_in_ctxt g1 pre' (PostHint post_hint) =
+    return_in_ctxt g1 y res_ppname u_ty_y ty_y pre' () (PostHint post_hint) in
+  //
+  // Coerce the trailing return to NoHint so that composing it with the body
+  // uses the unbiased bind rules and reports the body's real effect.
+  //
+  let (| tret, cret |) = d in
+  let d' : st_typing_in_ctxt g1 pre' NoHint = (| tret, cret |) in
+
+  let (| t, c |) = k NoHint d' in
+  //
+  // mk_bind guarantees the result shares c2's return type, universe and
+  // postcondition (st_comp_with_pre), but the continuation_elaborator type
+  // does not expose this; recover it here.
+  //
+  assume (comp_res c == post_hint.ret_ty /\
+          comp_u c == post_hint.u /\
+          comp_post c == post_hint.post);
+  (| t, c |)
+
 #push-options "--z3rlimit_factor 4 --fuel 0 --ifuel 0"
 //TODO: refactor and merge with continuation_elaborator_with_bind
 let checker_result_for_st_typing (#g:env) (#ctxt:slprop) (#post_hint:post_hint_opt g)

--- a/pulse/src/checker/Pulse.Checker.Base.fsti
+++ b/pulse/src/checker/Pulse.Checker.Base.fsti
@@ -187,6 +187,18 @@ val apply_checker_result_k (#g:env) (#ctxt:slprop) (#post_hint:post_hint_for_env
   (res_ppname:ppname)
   : T.Tac (st_typing_in_ctxt g ctxt (PostHint post_hint))
 
+// Like apply_checker_result_k, but returns the checked computation with its
+// natural effect (rather than coercing it to post_hint's effect). Used to infer
+// the effect of a conditional's branches when the postcondition was inferred.
+val apply_checker_result_k_nohint (#g:env) (#ctxt:slprop) (#post_hint:post_hint_for_env g)
+  (r:checker_result_t g ctxt (PostHint post_hint))
+  (res_ppname:ppname)
+  : T.Tac (t:st_term &
+           c:comp_st { comp_pre c == ctxt /\
+                       comp_res c == post_hint.ret_ty /\
+                       comp_u c == post_hint.u /\
+                       comp_post c == post_hint.post })
+
 val checker_result_for_st_typing (#g:env) (#ctxt:slprop) (#post_hint:post_hint_opt g)
   (d:st_typing_in_ctxt g ctxt post_hint)
   (ppname:ppname)

--- a/pulse/src/checker/Pulse.Checker.If.fst
+++ b/pulse/src/checker/Pulse.Checker.If.fst
@@ -41,6 +41,23 @@ let retype_checker_result (#g:env) (#ctxt:slprop) (#ph:post_hint_opt g) (ph':pos
 = let (| x, g1, t, ctxt, k |) = r in
   (| x, g1, t, ctxt, k |)
 
+let set_effect_annot (#g:env) (ph:post_hint_for_env g) (ea:effect_annot)
+: (ph':post_hint_for_env g { ph'.ret_ty == ph.ret_ty /\ ph'.post == ph.post /\
+                             ph'.u == ph.u /\ ph'.effect_annot == ea })
+= { ph with effect_annot = ea }
+
+// Relabel a stt/stt_div computation with the given (stt or stt_div) effect,
+// preserving its state components. Used to lift the branches of an inferred
+// conditional to a common effect once a divergent branch is detected.
+let lift_branch_comp (c:comp_st)
+                     (eff:effect_annot { EffectAnnotSTT? eff \/ EffectAnnotSTTDiv? eff })
+: (c':comp_st { comp_pre c' == comp_pre c /\ comp_res c' == comp_res c /\
+                comp_u c' == comp_u c /\ comp_post c' == comp_post c /\
+                effect_annot_matches c' eff })
+= match eff with
+  | EffectAnnotSTTDiv -> C_STDiv (st_comp_of_comp c)
+  | _ -> C_ST (st_comp_of_comp c)
+
 #push-options "--fuel 0 --ifuel 0 --z3rlimit_factor 2"
 #restart-solver
 let check
@@ -112,33 +129,75 @@ let check
   in
   let (| post_hint', then_, else_ |) = joinable in
 
-  let extract #g #pre (#ph:post_hint_for_env g) (r:checker_result_t g pre (PostHint ph)) (is_then:bool)
-  : T.Tac (br:st_term { ~(hyp `Set.mem` freevars_st br) } &
-           c:comp_st { comp_pre c == pre /\ comp_post_matches_hint c (PostHint ph)})
-  = let (| br, c |) =
-      let ppname = mk_ppname_no_range "_if_br" in
-      apply_checker_result_k r ppname
-    in
-    let br_name = if is_then then "then" else "else" in
-    // if hyp `Set.mem` freevars_st br
-    // then fail g (Some br.range)
-    //        (Printf.sprintf "check_if: branch hypothesis is in freevars of checked %s branch" br_name)
-    // else
-     assume not (hyp `Set.mem` freevars_st br);
-     (| br, c |)
+  let assemble (post_final:post_hint_for_env g {
+                  PostHint? post_hint ==> PostHint?.v post_hint == post_final })
+               (e1:st_term { ~(hyp `Set.mem` freevars_st e1) })
+               (c1:comp_st { comp_pre c1 == pre /\ comp_post_matches_hint c1 (PostHint post_final) })
+               (e2:st_term { ~(hyp `Set.mem` freevars_st e2) })
+               (c2:comp_st { comp_pre c2 == pre /\ comp_post_matches_hint c2 (PostHint post_final) })
+  : T.Tac (checker_result_t g pre post_hint)
+  = let c =
+      J.join_comps (g_with_eq tm_true) e1 c1 (g_with_eq tm_false) e2 c2 post_final in
+    let c_typing = comp_typing_from_post_hint c post_final in
+    let b_st = mk_term (Tm_Return { expected_type = tm_bool; insert_eq = false; term = b }) e1.range in
+    let if_st = wrst c (Tm_If { b=b_st; then_=e1; else_=e2; post=None }) in
+    let d : st_typing_in_ctxt g pre (PostHint post_final) =
+      (| if_st, c |) in
+    let res : checker_result_t g pre (PostHint post_final) = checker_result_for_st_typing d res_ppname in
+    retype_checker_result_post_hint post_final post_hint res
   in
-  let (| e1, c1 |) = extract then_ true in
-  let (| e2, c2 |) = extract else_ false in
-  let c =
-    J.join_comps (g_with_eq tm_true) e1 c1 (g_with_eq tm_false) e2 c2 post_hint' in
 
-  let c_typing = comp_typing_from_post_hint c post_hint' in
+  match post_hint with
+  | PostHint _ ->
+    //
+    // The postcondition (hence the effect) was supplied by the user: check each
+    // branch against it directly and compose.
+    //
+    let extract #g #pre (#ph:post_hint_for_env g) (r:checker_result_t g pre (PostHint ph)) (is_then:bool)
+    : T.Tac (br:st_term { ~(hyp `Set.mem` freevars_st br) } &
+             c:comp_st { comp_pre c == pre /\ comp_post_matches_hint c (PostHint ph)})
+    = let (| br, c |) =
+        let ppname = mk_ppname_no_range "_if_br" in
+        apply_checker_result_k r ppname
+      in
+      assume not (hyp `Set.mem` freevars_st br);
+      (| br, c |)
+    in
+    let (| e1, c1 |) = extract then_ true in
+    let (| e2, c2 |) = extract else_ false in
+    assemble post_hint' e1 c1 e2 c2
 
-  let b_st = mk_term (Tm_Return { expected_type = tm_bool; insert_eq = false; term = b }) e1.range in
-  let if_st = wrst c (Tm_If { b=b_st; then_=e1; else_=e2; post=None }) in
-  let d : st_typing_in_ctxt g pre (PostHint post_hint') =
-    (| if_st, c |) in
-
-  let res : checker_result_t g pre (PostHint post_hint') = checker_result_for_st_typing d res_ppname in
-  retype_checker_result_post_hint post_hint' post_hint res
+  | _ ->
+    //
+    // The postcondition was inferred (tentatively as stt). Read back the natural
+    // effect of each branch with a single check: if either branch is divergent,
+    // the whole conditional is divergent (issue #4366). This avoids re-checking
+    // any branch.
+    //
+    let extract_nat #g #pre (#ph:post_hint_for_env g) (r:checker_result_t g pre (PostHint ph)) (is_then:bool)
+    : T.Tac (br:st_term { ~(hyp `Set.mem` freevars_st br) } &
+             c:comp_st { comp_pre c == pre /\ comp_res c == ph.ret_ty /\
+                         comp_u c == ph.u /\ comp_post c == ph.post })
+    = let (| br, c |) =
+        let ppname = mk_ppname_no_range "_if_br" in
+        apply_checker_result_k_nohint r ppname
+      in
+      assume not (hyp `Set.mem` freevars_st br);
+      (| br, c |)
+    in
+    let (| e1, c1 |) = extract_nat then_ true in
+    let (| e2, c2 |) = extract_nat else_ false in
+    //
+    // Inferred branches produce only stt or stt_div; join by letting stt_div
+    // dominate.
+    //
+    let joined_eff : (ea:effect_annot { EffectAnnotSTT? ea \/ EffectAnnotSTTDiv? ea }) =
+      if EffectAnnotSTTDiv? (effect_annot_of_comp c1) || EffectAnnotSTTDiv? (effect_annot_of_comp c2)
+      then EffectAnnotSTTDiv
+      else EffectAnnotSTT
+    in
+    let post_final = set_effect_annot post_hint' joined_eff in
+    let c1 = lift_branch_comp c1 joined_eff in
+    let c2 = lift_branch_comp c2 joined_eff in
+    assemble post_final e1 c1 e2 c2
   #pop-options

--- a/pulse/test/DivergentFn.fst
+++ b/pulse/test/DivergentFn.fst
@@ -62,3 +62,39 @@ ensures  R.pts_to x 'v
     helper x;
     ()
 }
+
+(* Regression for #4366: calling a `divergent fn` from a branch of an `if` that
+   is itself in bind position (i.e. not the tail) inside a `divergent fn`. The
+   `if`'s postcondition is inferred, and the divergent branch must make the whole
+   conditional divergent instead of failing to compose against `stt`. *)
+divergent fn diverge ()
+requires emp
+ensures emp
+{
+    while (true)
+    invariant emp
+    { () }
+}
+
+divergent fn if_then_diverges () {
+    if true { diverge () };
+    ()
+}
+
+divergent fn if_else_diverges () {
+    if true { () } else { diverge () };
+    ()
+}
+
+divergent fn nested_if_diverges () {
+    if true { if true { diverge () } };
+    ()
+}
+
+(* The same `if` inside a plain `fn` is still rejected: a divergent branch cannot
+   be composed at `stt`. *)
+[@@expect_failure [228]]
+fn if_diverges_bad () {
+    if true { diverge () };
+    ()
+}


### PR DESCRIPTION
The if-checker extracted each branch against a hardcoded stt effect when the postcondition was inferred, so a divergent-fn call in a branch (in bind position) failed to compose against the tentatively-inferred stt trailing return (Error 228).

Add apply_checker_result_k_nohint, which applies a branch's continuation elaborator with NoHint so the unbiased mk_bind rules report the branch's natural effect (stt or stt_div) in a single check. The if-checker now reads each inferred branch's real effect, lets stt_div dominate the join, and lifts both branches to the common effect. The explicit-PostHint path is unchanged. No Pulse code is checked twice.

Add regression tests to pulse/test/DivergentFn.fst.

Fixes #4366