### PR TITLE
Pulse: infer effect for annotated if in divergent context (#4368)

### DIFF
--- a/pulse/src/checker/Pulse.Checker.If.fst
+++ b/pulse/src/checker/Pulse.Checker.If.fst
@@ -64,6 +64,7 @@ let check
   (g:env)
   (pre:term)
   (post_hint:post_hint_opt g)
+  (annot_post:option (post_hint_for_env g))
   (res_ppname:ppname)
   (b:st_term)
   (e1 e2:st_term)
@@ -80,9 +81,22 @@ let check
 
   let hyp = fresh g in
 
+  //
+  // The hint the branches are checked against. When the surrounding context
+  // fixes the postcondition (and effect), use it directly. Otherwise, if the
+  // conditional carries an `ensures` annotation, check the branches against that
+  // postcondition slprop but leave the effect to be inferred from the branches
+  // (issue #4368); with no annotation, infer the postcondition too (issue #4366).
+  //
+  let branch_hint : post_hint_opt g =
+    match post_hint with
+    | PostHint _ -> post_hint
+    | _ -> (match annot_post with | Some ap -> PostHint ap | None -> NoHint)
+  in
+
   let g_with_eq = g_with_eq g hyp b in  
   let check_branch (eq_v:term) (br:st_term) (is_then:bool)
-  : T.Tac (checker_result_t (g_with_eq eq_v) pre post_hint)
+  : T.Tac (checker_result_t (g_with_eq eq_v) pre branch_hint)
   =
     let branch_range = br.range in
     let br =
@@ -98,7 +112,7 @@ let check
 
     let ppname = mk_ppname_no_range "_if_br" in
     let r = RU.with_error_bound branch_range (fun () ->
-      check (g_with_eq eq_v) pre post_hint ppname br) in
+      check (g_with_eq eq_v) pre branch_hint ppname br) in
     r
   in
 
@@ -114,7 +128,7 @@ let check
     ph:post_hint_for_env g & 
     checker_result_t (g_with_eq tm_true) pre (PostHint ph) &
     checker_result_t (g_with_eq tm_false) pre (PostHint ph)
-  ) = match post_hint with
+  ) = match branch_hint with
       | PostHint ph -> 
         (| ph, then_, else_ |)
       | _ ->

--- a/pulse/src/checker/Pulse.Checker.If.fsti
+++ b/pulse/src/checker/Pulse.Checker.If.fsti
@@ -26,6 +26,7 @@ val check
   (g:env)
   (pre:term)
   (post_hint:post_hint_opt g)
+  (annot_post:option (post_hint_for_env g))
   (res_ppname:ppname)
   (b:st_term)
   (e1 e2:st_term)

--- a/pulse/src/checker/Pulse.Checker.fst
+++ b/pulse/src/checker/Pulse.Checker.fst
@@ -365,16 +365,8 @@ let rec check
         Bind.check_tot_bind g pre post_hint res_ppname t check
 
       | Tm_If { b; then_=e1; else_=e2; post=post_if } -> (
-        let post : post_hint_opt g =
+        let annot_post : option (post_hint_for_env g) =
           match post_if, post_hint with
-          | None, PostHint p ->
-            post_hint
-          | Some p, NoHint 
-          | Some p, TypeHint _ ->
-            //We set the computation type to be STT in this case
-            //We might allow the post_if annotation to also set the effect tag
-            let p = ImpureSpec.purify_spec g { ctxt_old = Some pre; ctxt_now = tm_emp } p in
-            PostHint <| Checker.Base.intro_post_hint g EffectAnnotSTT None p
           | Some p, PostHint q ->
             Pulse.Typing.Env.fail g (Some t.range) 
               (Printf.sprintf 
@@ -383,11 +375,18 @@ let rec check
                   but this conditional was annotated with postcondition %s"
                   (P.term_to_string (q <: post_hint_t).post)
                   (P.term_to_string p))
-          | _, _ ->
-            NoHint
+          | Some p, _ ->
+            //We set the computation type to be STT here, but the effect is
+            //re-inferred from the branches in Pulse.Checker.If, so that a
+            //divergent branch is accepted (issue #4368). This only fixes the
+            //postcondition slprop.
+            let p = ImpureSpec.purify_spec g { ctxt_old = Some pre; ctxt_now = tm_emp } p in
+            Some (Checker.Base.intro_post_hint g EffectAnnotSTT None p)
+          | None, _ ->
+            None
         in
-        let (| x, t, pre', g1, k |) : checker_result_t g pre post =
-          If.check g pre post res_ppname b e1 e2 check in
+        let (| x, t, pre', g1, k |) : checker_result_t g pre post_hint =
+          If.check g pre post_hint annot_post res_ppname b e1 e2 check in
         (| x, t, pre', g1, k |)
       )
 

--- a/pulse/test/DivergentFn.fst
+++ b/pulse/test/DivergentFn.fst
@@ -98,3 +98,31 @@ fn if_diverges_bad () {
     if true { diverge () };
     ()
 }
+
+(* Regression for #4368: an `if` with an explicit `ensures` annotation but no
+   effect annotation must still infer its effect from the branches. The `ensures`
+   only fixes the postcondition slprop; a divergent branch keeps the conditional
+   divergent instead of being forced to `stt`. *)
+divergent fn if_ensures_diverges () {
+    if (true) ensures emp { diverge () };
+    ()
+}
+
+divergent fn if_ensures_else_diverges () {
+    if (true) ensures emp { diverge () } else { () };
+    ()
+}
+
+(* An annotated `if` with only terminating branches stays `stt` and is accepted
+   in a plain `fn`. *)
+fn if_ensures_terminating () {
+    if (true) ensures emp { () };
+    ()
+}
+
+(* The annotated-`if` divergent branch is still rejected inside a plain `fn`. *)
+[@@expect_failure [228]]
+fn if_ensures_diverges_bad () {
+    if (true) ensures emp { diverge () };
+    ()
+}


### PR DESCRIPTION
An `if` with an explicit `ensures` but no effect annotation was given a PostHint with a hardcoded stt effect, so a divergent-fn call in a branch failed to compose (Error 228) even inside a divergent fn. The annotation should only fix the postcondition slprop, not the effect.

Thread the ensures annotation to If.check as a separate `annot_post` parameter, keeping the outer post_hint intact. If.check checks the branches against the annotated slprop but still infers the effect from the branches (via the single-pass NoHint path from #4366), letting stt_div dominate. The effect is respected strictly only when the outer context supplies a genuine PostHint. No Pulse code is checked twice.

Add regression tests to pulse/test/DivergentFn.fst.

Fixes #4368.