### PR TITLE
Shrink the SMT term representation

### DIFF
--- a/src/fstar/FStarC.CheckedFiles.fst
+++ b/src/fstar/FStarC.CheckedFiles.fst
@@ -36,7 +36,7 @@ let debug (f:unit -> ML unit) : ML unit = if !dbg then f () else ()
  * We write this version number to the cache files, and
  * detect when loading the cache that the version number is same
  *)
-let cache_version_number = 82
+let cache_version_number = 84
 
 (*
  * Abbreviation for what we store in the checked files (stages as described below)

--- a/src/smtencoding/FStarC.SMTEncoding.Encode.fst
+++ b/src/smtencoding/FStarC.SMTEncoding.Encode.fst
@@ -88,9 +88,9 @@ let prims =
     let xsym, x = fresh_fvar module_name "x" Term_sort in
     let ysym, y = fresh_fvar module_name "y" Term_sort in
     let quant_with_pre (rel:defn_rel_type) vars precondition body : Range.t -> string -> ML (term & int & list decl) = fun rng x ->
-        let xname_decl = Term.DeclFun(x, vars |> List.map fv_sort, Term_sort, None) in
+        let xname_decl = Term.DeclFun x (vars |> List.map fv_sort) Term_sort None in
         let xtok = x ^ "@tok" in
-        let xtok_decl = Term.DeclFun(xtok, [], Term_sort, None) in
+        let xtok_decl = Term.DeclFun xtok [] Term_sort None in
         let xapp = mkApp(x, List.map mkFreeV vars) in //arity ok, see decl (#1383)
         let xtok = mkApp(xtok, []) in //arity ok, see decl (#1383)
         let xtok_app = mk_Apply xtok vars in
@@ -169,7 +169,7 @@ let prims =
         (Const.real_op_Addition,    (quant Eq xy  (boxReal <| mkAdd(unboxReal x, unboxReal y))));
         (Const.real_op_Multiply,    (quant Eq xy  (boxReal <| mkMul(unboxReal x, unboxReal y))));
         (Const.real_op_Division,    (quant_with_pre Eq xy (Some (mkNot (mkEq (unboxReal y, mkReal "0")))) (boxReal <| mkRealDiv(unboxReal x, unboxReal y))));
-        (Const.real_of_int,         (quant Eq qx  (boxReal <| mkRealOfInt (unboxInt x) Range.dummyRange)))
+        (Const.real_of_int,         (quant Eq qx  (boxReal <| mkRealOfInt (unboxInt x))))
         ]
     in
     let mk : lident -> string -> ML (term & int & list decl) =
@@ -435,10 +435,10 @@ let forall_univs rng univ_fvs body =
     let csorts = List.map fv_sort cvars in
     let body = abstr cvars body in
     match body with
-    | {tm=Quant (Forall, pats, wopt, sorts, body); rng} ->
-      mkForall'' rng (pats, wopt, csorts @ sorts, body)
+    | Quant Forall pats wopt sorts body r ->
+      mkForall'' r (pats, wopt, csorts @ sorts, body)
     | _ ->
-      mkForall'' rng ([], None, csorts, body)
+      mkForall'' (range_of_term body) ([], None, csorts, body)
 
 let encode_smt_lemma env fv t =
     let lid = fv.fv_name in
@@ -490,8 +490,8 @@ let encode_free_var uninterpreted env fv us tt t_norm quals : ML (decls_t & env_
          let univ_arity = List.length us in
          let vname, vtok, env = new_term_constant_and_tok_from_lid env lid arity univ_arity in
          let univ_sorts = List.map (fun _ -> univ_sort) us in
-         let d = Term.DeclFun(vname, univ_sorts @ arg_sorts, Term_sort, Some "Uninterpreted function symbol for impure function") in
-         let dd = Term.DeclFun(vtok, univ_sorts, Term_sort, Some "Uninterpreted name for impure function") in
+         let d = Term.DeclFun vname (univ_sorts @ arg_sorts) Term_sort (Some "Uninterpreted function symbol for impure function") in
+         let dd = Term.DeclFun vtok univ_sorts Term_sort (Some "Uninterpreted name for impure function") in
          [d;dd] |> mk_decls_trivial, env
     else let encode_non_total_function_typ = nsstr lid <> "Prims" in
          (* Parameters *and* indices of the inductive [d] belongs to: exactly the
@@ -607,7 +607,7 @@ let encode_free_var uninterpreted env fv us tt t_norm quals : ML (decls_t & env_
            | None -> mk_and_l guards, decls1
            | Some p -> let g, ds = encode_formula p env' in mk_and_l (g::guards), decls1@ds in
          let dummy_var = mk_fv ("@dummy", dummy_sort) in
-         let dummy_tm = Term.mkFreeV dummy_var Range.dummyRange in
+         let dummy_tm = Term.mkFreeV dummy_var in
          let should_thunk () =
            //See note [Thunking Nullary Constants] in FStarC.SMTEncoding.Term.fs
            let is_type t =
@@ -655,7 +655,7 @@ let encode_free_var uninterpreted env fv us tt t_norm quals : ML (decls_t & env_
          let vtok_app = mk_Apply vtok_tm vars in
          let vapp = mkApp(vname, univs @ List.map mkFreeV vars) in //arity ok, see decl below, arity is |vars| (#1383)
          let decls2, env =
-           let vname_decl = Term.DeclFun(vname, univ_sorts @ (vars |> List.map fv_sort), Term_sort, None) in
+           let vname_decl = Term.DeclFun vname (univ_sorts @ (vars |> List.map fv_sort)) Term_sort None in
            let tok_typing, decls2 =
                let env = {env with encode_non_total_function_typ=encode_non_total_function_typ} in
                if not(head_normal env tt)
@@ -681,7 +681,7 @@ let encode_free_var uninterpreted env fv us tt t_norm quals : ML (decls_t & env_
                 (* Generate a token and a function symbol;
                    equate the two, and use the function symbol for full applications *)
                  let vtok = get_vtok() in
-                 let vtok_decl = Term.DeclFun(vtok, univ_sorts, Term_sort, None) in
+                 let vtok_decl = Term.DeclFun vtok univ_sorts Term_sort None in
                  let name_tok_corr_formula pat =
                      match univ_fvs with
                      | [] ->
@@ -1013,8 +1013,8 @@ let encode_top_level_let :
                     && vars = []
                     && univ_vars = []
                     then let dummy_var = mk_fv ("@dummy", dummy_sort) in
-                         let dummy_tm = Term.mkFreeV dummy_var Range.dummyRange in
-                         let app = Term.mkApp (fvb.smt_id, [dummy_tm]) (S.range_of_lbname lbn) in
+                         let dummy_tm = Term.mkFreeV dummy_var in
+                         let app = Term.mkApp (fvb.smt_id, [dummy_tm]) in
                          [dummy_var], app
                     else univ_vars@vars,
                          maybe_curry_fvb (S.range_of_lbname lbn)
@@ -1141,15 +1141,12 @@ let encode_top_level_let :
             let binder_decls = binder_decls @ guard_decls in
             let univ_sorts = List.map fv_sort univ_vars in
             let decl_g =
-              Term.DeclFun(g,
-                           (Fuel_sort::
+              Term.DeclFun g (Fuel_sort::
                             univ_sorts @
-                            List.map fv_sort (fst (BU.first_N fvb.smt_arity vars))),
-                           Term_sort,
-                           Some "Fuel-instrumented function name")
+                            List.map fv_sort (fst (BU.first_N fvb.smt_arity vars))) Term_sort (Some "Fuel-instrumented function name")
             in
             let env0 = push_zfuel_name env0 fvb.fvar_lid g gtok in
-            let decl_g_tok = Term.DeclFun(gtok, univ_sorts, Term_sort, Some "Token for fuel-instrumented partial applications") in
+            let decl_g_tok = Term.DeclFun gtok univ_sorts Term_sort (Some "Token for fuel-instrumented partial applications") in
             let univ_vars_tm = List.map mkFreeV univ_vars in
             let vars_tm = List.map mkFreeV vars in
             let rng = S.range_of_lbname lbn in
@@ -1231,7 +1228,7 @@ let encode_top_level_let :
           in
           (* Function declarations must come first to be defined in all recursive definitions *)
           let prefix_decls, elts, rest =
-            let isDeclFun = function | DeclFun _ -> true | _ -> false in
+            let isDeclFun = function | DeclFun _ _ _ _ -> true | _ -> false in
             decls |> List.flatten |> (fun decls ->
               //decls is a list of decls_elt ... each of which contains a list decl in it
               //we need to go through each of those, accumulate DeclFuns and remove them from there
@@ -1281,7 +1278,7 @@ let encode_sig_inductive (env:env_t) (se:sigelt)
   let is_logical = quals |> BU.for_some (function Logic | Assumption -> true | _ -> false) in
   let constructor_or_logic_type_decl (c:constructor_t) =
     if is_logical
-    then [Term.DeclFun(c.constr_name, c.constr_fields |> List.map (fun f -> f.field_sort), Term_sort, None)]
+    then [Term.DeclFun c.constr_name (c.constr_fields |> List.map (fun f -> f.field_sort)) Term_sort None]
     else constructor_to_decl (Ident.range_of_lid t) c in
   let inversion_axioms env tapp vars =
     if datas |> BU.for_some (fun l -> Env.try_lookup_lid env.tcenv l |> None?) //Q: Why would this happen?
@@ -1370,7 +1367,7 @@ let encode_sig_inductive (env:env_t) (se:sigelt)
       match vars with
       | [] -> [], push_free_var env t arity univ_arity tname (Some <| mkApp(tname, []))
       | _ ->
-        let ttok_decl = Term.DeclFun(ttok, List.map fv_sort univ_vars, Term_sort, Some "token") in
+        let ttok_decl = Term.DeclFun ttok (List.map fv_sort univ_vars) Term_sort (Some "token") in
         let ttok_fresh = Term.fresh_token (ttok_tm, univ_vars, Term_sort) (varops.next_id()) in
         let ttok_app = mk_Apply ttok_tm vars in
         let pats = [[ttok_app]; [tapp]] in
@@ -1700,8 +1697,8 @@ let encode_datacon (env:env_t) (se:sigelt)
     //Also see #2456
     //
     let ty_pred', vars, guard =
-      match t_res_tm.tm with
-      | App (op, args) ->
+      match t_res_tm with
+      | App op args _ ->
         //iargs are index arguments in the return type of the data constructor
         let targs, iargs = List.splitAt (n_univs + n_tps) args in
         //fresh vars for iargs
@@ -1715,7 +1712,7 @@ let encode_datacon (env:env_t) (se:sigelt)
         mk_HasTypeWithFuel
           (Some fuel_tm)
           dapp
-          ({t_res_tm with tm = App (op, targs@fresh_iargs)}),
+          (App op (targs@fresh_iargs) (range_of_term t_res_tm)),
 
         vars@(fresh_ivars |> List.map (fun s -> mk_fv (s, Term_sort))),
 
@@ -1731,7 +1728,7 @@ let encode_datacon (env:env_t) (se:sigelt)
   let g = binder_decls
           @decls2
           @decls3
-          @([Term.DeclFun(ddtok, univ_sorts, Term_sort, Some (Format.fmt1 "data constructor proxy: %s" (show d)))]
+          @([Term.DeclFun ddtok univ_sorts Term_sort (Some (Format.fmt1 "data constructor proxy: %s" (show d)))]
             @proxy_fresh |> mk_decls_trivial)
           @decls_pred
           @([Util.mkAssume(tok_typing, Some "typing for data constructor proxy", ("typing_tok_"^ddtok));
@@ -1830,8 +1827,8 @@ and encode_sigelt' (env:env_t) (se:sigelt) : ML (decls_t & env_t) =
               let tm, decls = encode_term action_defn env in
               let univ_sorts = ed_univs@action_univs |> List.map (fun _ -> univ_sort) in
               let a_decls =
-                [Term.DeclFun(aname, univ_sorts @ (formals |> List.map (fun _ -> Term_sort)), Term_sort, Some "Action");
-                  Term.DeclFun(atok, univ_sorts, Term_sort, Some "Action token")]
+                [Term.DeclFun aname (univ_sorts @ (formals |> List.map (fun _ -> Term_sort))) Term_sort (Some "Action");
+                  Term.DeclFun atok univ_sorts Term_sort (Some "Action token")]
               in
               let _, us_sorts, us = 
                 let aux u (env, acc_sorts, acc) =
@@ -1931,7 +1928,7 @@ and encode_sigelt' (env:env_t) (se:sigelt) : ML (decls_t & env_t) =
        let valid_b2t_x = mkApp("Valid", [b2t_x]) in //NS: Explicitly avoid the Vaild(b2t t) inlining
        let bool_ty = lookup_free_var env Const.bool_lid in
        let prop_ty = lookup_free_var env Const.prop_lid in
-       let decls = [Term.DeclFun(tname, [Term_sort], Term_sort, None);
+       let decls = [Term.DeclFun tname [Term_sort] Term_sort None;
                     Util.mkAssume(mkForall (S.range_of_fv b2t) ([[b2t_x]], [xx],
                                            mkEq(valid_b2t_x, mkApp(snd boxBoolFun, [x]))),
                                 Some "b2t def",
@@ -2033,14 +2030,14 @@ and encode_sigelt' (env:env_t) (se:sigelt) : ML (decls_t & env_t) =
         List.fold_left
           (fun (decls, elts, rest) elt ->
             if Some? elt.key //NS: Not sure what this case is for
-            && List.existsb (function | Term.DeclFun _ -> true | _ -> false) elt.decls
+            && List.existsb (function | Term.DeclFun _ _ _ _ -> true | _ -> false) elt.decls
             then decls, elts@[elt], rest 
             else ( //Pull the function symbol decls to the front
               let elt_decls, elt_rest =
                 elt.decls |>
                 List.partition
                   (function
-                    | Term.DeclFun _ -> true
+                    | Term.DeclFun _ _ _ _ -> true
                     | _ -> false)
               in
               decls @ elt_decls, elts, rest @ [ { elt with decls = elt_rest }]
@@ -2077,7 +2074,7 @@ let encode_env_bindings (env:env_t) (bindings:list S.binding) : ML (decls_t & en
     let encode_binding b (i, decls, env) = match b with
         | S.Binding_univ u ->
           let u_fv, u_tm = EncodeTerm.encode_univ_name u in
-          let decls' = [Term.DeclFun(fv_name u_fv, [], univ_sort, Some "universe local constant")] |> mk_decls_trivial in
+          let decls' = [Term.DeclFun (fv_name u_fv) [] univ_sort (Some "universe local constant")] |> mk_decls_trivial in
           i+1, decls@decls', env
 
         | S.Binding_var x ->
@@ -2097,7 +2094,7 @@ let encode_env_bindings (env:env_t) (bindings:list S.binding) : ML (decls_t & en
             let ax =
                 let a_name = ("binder_"^xxsym) in
                 Util.mkAssume(t, Some a_name, a_name) in
-            let g = ([Term.DeclFun(xxsym, [], Term_sort, caption)] |> mk_decls_trivial)
+            let g = ([Term.DeclFun xxsym [] Term_sort caption] |> mk_decls_trivial)
                     @decls'
                     @([ax] |> mk_decls_trivial) in
             i+1, decls@g, env'
@@ -2114,7 +2111,7 @@ let encode_env_bindings (env:env_t) (bindings:list S.binding) : ML (decls_t & en
     decls, env
 
 let encode_labels (labs:list error_label) =
-    let prefix = labs |> List.map (fun (l, _, _) -> Term.DeclFun(fv_name l, [], Bool_sort, None)) in
+    let prefix = labs |> List.map (fun (l, _, _) -> Term.DeclFun (fv_name l) [] Bool_sort None) in
     let suffix = labs |> List.collect (fun (l, _, _) -> [Echo <| fv_name l; Eval (mkFreeV l)]) in
     prefix, suffix
 
@@ -2229,8 +2226,8 @@ let give_decls_to_z3_and_set_env (env:env_t) (name:string) (decls:decls_t) : ML 
   let caption decls =
     if Options.log_queries()
     then let msg = "Externals for " ^ name in
-         [Module(name, Caption msg::decls@[Caption ("End " ^ msg)])]
-    else [Module(name, decls)] in
+         [Module name (Caption msg::decls@[Caption ("End " ^ msg)])]
+    else [Module name decls] in
   set_env ({env with warn=true});
   //recover caching and flatten before giving to Z3
   let z3_decls = caption (decls |> recover_caching_and_update_env env |> decls_list_of) in

--- a/src/smtencoding/FStarC.SMTEncoding.EncodeTerm.fst
+++ b/src/smtencoding/FStarC.SMTEncoding.EncodeTerm.fst
@@ -1798,11 +1798,7 @@ and encode_formula (phi:typ) (env:env_t) : ML (term & decls_t)  = (* expects phi
               let encode_valid () =
                 debug phi;
                 let tt, decls = encode_term phi env in
-                let tt =
-                    if Range.rng_included (Range.use_range (range_of_term tt)) (Range.use_range phi.pos)
-                    then tt
-                    else set_range tt phi.pos in
-                mk_Valid tt, decls
+                mk_valid_at phi.pos tt, decls
               in
               if head_redex env head
               then match maybe_whnf env head with
@@ -1813,11 +1809,7 @@ and encode_formula (phi:typ) (env:env_t) : ML (term & decls_t)  = (* expects phi
 
         | _ ->
             let tt, decls = encode_term phi env in
-            let tt =
-                  if Range.rng_included (Range.use_range (range_of_term tt)) (Range.use_range phi.pos)
-                  then tt
-                  else set_range tt phi.pos in
-            mk_Valid tt, decls in
+            mk_valid_at phi.pos tt, decls in
 
     let encode_q_body env (bs:Syntax.binders) (ps:list args) body =
         let vars, guards, env, decls, _ = encode_binders None bs env in

--- a/src/smtencoding/FStarC.SMTEncoding.EncodeTerm.fst
+++ b/src/smtencoding/FStarC.SMTEncoding.EncodeTerm.fst
@@ -62,14 +62,14 @@ let mkForall_fuel' mname r n (pats, vars, body) =
     then fallback ()
     else let fsym, fterm = fresh_fvar mname "f" Fuel_sort in
          let add_fuel tms =
-            tms |> List.map (fun p -> match p.tm with
-            | Term.App(Var "HasType", args) -> mkApp("HasTypeFuel", fterm::args)
+            tms |> List.map (fun p -> match p with
+            | Term.App (Var "HasType") args _ -> mkApp("HasTypeFuel", fterm::args)
             | _ -> p) in
          let pats = List.map add_fuel pats in
-         let body = match body.tm with
-            | Term.App(Imp, [guard; body']) ->
-              let guard = match guard.tm with
-                | App(And, guards) -> mk_and_l (add_fuel guards)
+         let body = match body with
+            | Term.App Imp [guard; body'] _ ->
+              let guard = match guard with
+                | App And guards _ -> mk_and_l (add_fuel guards)
                 | _ -> add_fuel [guard] |> List.hd in
               mkImp(guard,body')
             | _ -> body in
@@ -365,7 +365,7 @@ let is_BitVector_primitive head args =
 
 let encode_univ_name (u:univ_name) = 
     let u = mk_U_name (Ident.string_of_id u) in
-    match u.tm with
+    match u with
     | FreeV fv -> fv, u
     | _ -> failwith "Impossible"
     
@@ -634,8 +634,8 @@ and encode_deeply_embedded_quantifier (t:S.term) (env:env_t) : ML (term & decls_
     let valid_tm = mk_Valid tm in
     let key = mkForall t.pos ([], vars, valid_tm) in
     let tkey_hash = hash_of_term key in
-    match tm.tm with
-    | App(_, [{tm=FreeV _}; {tm=FreeV _}]) ->
+    match tm with
+    | App _ [(FreeV _); (FreeV _)] _ ->
       FStarC.Errors.log_issue t Errors.Warning_QuantifierWithoutPattern
         "Not encoding deeply embedded, unguarded quantifier to SMT";
       tm, decls
@@ -738,7 +738,7 @@ and encode_term (t:typ) (env:env_t) : ML (term         (* encoding of t, expects
           let fvb = lookup_free_var_name env v.fv_name in
           let tok = lookup_free_var env v.fv_name in
           let is_nullary, tok =
-            match tok.tm, us with
+            match tok, us with
             | FreeV _, _::_ -> 
               failwith "Impossible: Universe applications on nullary symbol"
             (* This is a pretty ugly pattern match to rewrite applications of universe-polymorphic 
@@ -759,16 +759,16 @@ and encode_term (t:typ) (env:env_t) : ML (term         (* encoding of t, expects
                and universe application to the right place.
 
                We should find a better way to do this! *)
-            | App(Var "ApplyTF", [{tm=FreeV (FV (tok, _, _))}; fuel]), us
-            | App(Var "ApplyTF", [{tm=App(Var tok, [])}; fuel]), us -> // when Some? fvb.needs_universe_instantiations -> 
+            | App (Var "ApplyTF") [(FreeV (FV tok _ _)); fuel] _, us
+            | App (Var "ApplyTF") [(App (Var tok) [] _); fuel] _, us -> // when Some? fvb.needs_universe_instantiations -> 
               true, mkApp("ApplyTF", [mkApp (tok, us); fuel])
-            | App(op, _::_), _::_ ->
+            | App op (_::_) _, _::_ ->
               failwith (Format.fmt1 "Impossible: Universe applications cannot be curried: head is %s" (show tok))
             | FreeV _, [] -> 
               true, tok
-            | App(op, []), us ->
-              true, {tok with tm=App(op, us)}
-            | App(op, ts), [] -> 
+            | App op [] _, us ->
+              true, App op us (range_of_term tok)
+            | App op ts _, [] -> 
               false, tok
           in
           let tkey_hash = Term.hash_of_term tok in
@@ -908,7 +908,7 @@ and encode_term (t:typ) (env:env_t) : ML (term         (* encoding of t, expects
                  then Some (BU.replace_char (N.term_to_string env.tcenv t0) '\n' ' ')
                  else None in
 
-             let tdecl = Term.DeclFun(tsym, cvar_sorts, Term_sort, caption) in
+             let tdecl = Term.DeclFun tsym cvar_sorts Term_sort caption in
 
              let t = mkApp(tsym, List.map mkFreeV cvars) in //arity ok
              let t_has_kind = 
@@ -971,7 +971,7 @@ and encode_term (t:typ) (env:env_t) : ML (term         (* encoding of t, expects
                let fvs = Free.names t0 |> elems in
 
                let getfreeV (t:term) : ML fv =
-                 match t.tm with
+                 match t with
                  | FreeV fv -> fv
                  | _ -> failwith "Impossible: getfreeV: gen_term_var should always returns a FreeV"
                in
@@ -995,7 +995,7 @@ and encode_term (t:typ) (env:env_t) : ML (term         (* encoding of t, expects
              let fv_guards = List.rev fv_guards in
 
              let arg_sorts = List.map (fun _ -> Term_sort) fv_tms in
-             let tdecl = Term.DeclFun(tsym, arg_sorts, Term_sort, None) in
+             let tdecl = Term.DeclFun tsym arg_sorts Term_sort None in
              let tapp = mkApp(tsym, fv_tms) in
              let t_kinding =
                 let a_name = "non_total_function_typing_" ^tsym in
@@ -1073,7 +1073,7 @@ and encode_term (t:typ) (env:env_t) : ML (term         (* encoding of t, expects
 
         let tsym = "Tm_refine_" ^ (BU.digest_of_string tkey_hash) in
         let cvar_sorts = List.map fv_sort cvars in
-        let tdecl = Term.DeclFun(tsym, cvar_sorts, Term_sort, None) in
+        let tdecl = Term.DeclFun tsym cvar_sorts Term_sort None in
         let t = mkApp(tsym, List.map mkFreeV cvars) in
 
         let x_has_base_t = mk_HasType xtm base_t in
@@ -1109,7 +1109,7 @@ and encode_term (t:typ) (env:env_t) : ML (term         (* encoding of t, expects
         t, decls@decls'@mk_decls tsym tkey_hash t_decls (decls@decls')
 
       | Tm_uvar (uv, _) ->
-        let ttm = mk_Term_uvar (Unionfind.uvar_id uv.ctx_uvar_head) Range.dummyRange in
+        let ttm = mk_Term_uvar (Unionfind.uvar_id uv.ctx_uvar_head) in
         let t_has_k, decls = encode_term_pred None (U.ctx_uvar_typ uv) env ttm in //TODO: skip encoding this if it has already been encoded before
         let d =
             Util.mkAssume(t_has_k,
@@ -1172,7 +1172,7 @@ and encode_term (t:typ) (env:env_t) : ML (term         (* encoding of t, expects
           let fallback () =
             let f = varops.fresh env.current_module_name "Tm_reify" in
             let decl =
-              Term.DeclFun (f, [], Term_sort, Some "Imprecise reify") in
+              Term.DeclFun f [] Term_sort (Some "Imprecise reify") in
             mkFreeV <| mk_fv (f, Term_sort), [decl] |> mk_decls_trivial in
 
           (match lopt with
@@ -1238,13 +1238,13 @@ and encode_term (t:typ) (env:env_t) : ML (term         (* encoding of t, expects
                         args
                       in
                       let t_head_hyp, decls' =
-                        match smt_head.tm with
+                        match smt_head with
                         | FreeV _ ->
                           encode_term_pred None head_type env smt_head
                         | _ ->
                           mkTrue, []
                       in
-                      let hyp = Term.mk_and_l (t_head_hyp::t_hyps) Range.dummyRange in
+                      let hyp = Term.mk_and_l (t_head_hyp::t_hyps) in
                       let has_type_conclusion, decls'' =
                           encode_term_pred None ty env app_tm
                       in
@@ -1381,7 +1381,7 @@ and encode_term (t:typ) (env:env_t) : ML (term         (* encoding of t, expects
               tms
             in
             let f = varops.fresh env.current_module_name "Tm_abs" in
-            let decl = Term.DeclFun(f, arg_sorts, Term_sort, Some "Imprecise function encoding") in
+            let decl = Term.DeclFun f arg_sorts Term_sort (Some "Imprecise function encoding") in
             let fv : term = mkFreeV <| mk_fv (f, Term_sort) in
             let fapp = mkApp (f, arg_terms) in
             fapp, [decl] |> mk_decls_trivial
@@ -1479,7 +1479,7 @@ and encode_term (t:typ) (env:env_t) : ML (term         (* encoding of t, expects
                        (print_smt_term body);
                 let cvar_sorts = List.map fv_sort cvars in
                 let fsym = "Tm_abs_" ^ (BU.digest_of_string tkey_hash) in
-                let fdecl = Term.DeclFun(fsym, cvar_sorts, Term_sort, None) in
+                let fdecl = Term.DeclFun fsym cvar_sorts Term_sort None in
                 let f = mkApp(fsym, List.map mkFreeV cvars) in //arity ok, since introduced at cvar_sorts (#1383)
                 let app = mk_Apply f vars in
                 let typing_f =
@@ -1523,7 +1523,7 @@ and encode_term (t:typ) (env:env_t) : ML (term         (* encoding of t, expects
       // fresh variable.
       | Tm_let {lbs=(true, lbs)} ->
         let f = varops.fresh env.current_module_name "inner_let_rec" in
-        let decl = Term.DeclFun (f, [], Term_sort, Some "Inner let rec") in
+        let decl = Term.DeclFun f [] Term_sort (Some "Inner let rec") in
         mkFreeV <| mk_fv (f, Term_sort), [decl] |> mk_decls_trivial
 
       | Tm_let _ ->
@@ -1569,7 +1569,7 @@ and encode_match (e:S.term) (pats:list S.branch) (default_case:term) (env:env_t)
       in
       List.fold_right encode_branch pats (default_case (* default; should be unreachable *), decls)
     in
-    mkLet' ([mk_fv (scrsym,Term_sort), scr], match_tm) Range.dummyRange, decls
+    mkLet' ([mk_fv (scrsym,Term_sort), scr], match_tm), decls
 
 and encode_pat (env:env_t) (pat:S.pat) : ML (env_t & pattern) =
     if Debug.medium () then Format.print1 "Encoding pattern %s\n" (show pat);
@@ -1674,9 +1674,9 @@ and encode_formula (phi:typ) (env:env_t) : ML (term & decls_t)  = (* expects phi
                      (show phi) in
     let enc (f:list term -> ML term) r l : ML (term & decls_t) =
         let decls, args = BU.fold_map (fun decls x -> let t, decls' = encode_term (fst x) env in decls@decls', t) [] l in
-        ({f args with rng=r}, decls) in
+        (set_range (f args) r, decls) in
 
-    let const_op (f: Range.range -> ML term) r _ : ML (term & decls_t) = (f r, []) in
+    let const_op (f: term) (r: Range.range) _ : ML (term & decls_t) = (set_range f r, []) in
     let un_op (f: term -> ML term) l : ML term = f <| List.hd l in
     let bin_op : ((term & term) -> ML term) -> list term -> ML term = fun f -> function
         | [t1;t2] -> f(t1,t2)
@@ -1688,7 +1688,7 @@ and encode_formula (phi:typ) (env:env_t) : ML (term & decls_t)  = (* expects phi
                 let phi, decls' = encode_formula t env in
                 decls@decls', phi)
             [] l in
-        ({f phis with rng=r}, decls) in
+        (set_range (f phis) r, decls) in
 
     // This gets called for
     // eq2 : #a:Type -> a -> a -> Type
@@ -1703,11 +1703,11 @@ and encode_formula (phi:typ) (env:env_t) : ML (term & decls_t)  = (* expects phi
     let mk_imp r = function
         | [(lhs, _); (rhs, _)] ->
           let l1, decls1 = encode_formula rhs env in
-          begin match l1.tm with
-            | App(TrueOp, _) -> (l1, decls1) (* Optimization: don't bother encoding the LHS of a trivial implication *)
+          begin match l1 with
+            | App TrueOp _ _ -> (l1, decls1) (* Optimization: don't bother encoding the LHS of a trivial implication *)
             | _ ->
              let l2, decls2 = encode_formula lhs env in
-             (Term.mkImp(l2, l1) r, decls1@decls2)
+             (set_range (Term.mkImp(l2, l1)) r, decls1@decls2)
           end
          | _ -> failwith "impossible" in
 
@@ -1717,7 +1717,7 @@ and encode_formula (phi:typ) (env:env_t) : ML (term & decls_t)  = (* expects phi
           let (t, decls2) = encode_formula _then env in
           let (e, decls3) = encode_formula _else env in
 
-          let res = Term.mkITE(g, t, e) r in
+          let res = set_range (Term.mkITE(g, t, e)) r in
           res, decls1@decls2@decls3
         | _ -> failwith "impossible" in
 
@@ -1739,7 +1739,7 @@ and encode_formula (phi:typ) (env:env_t) : ML (term & decls_t)  = (* expects phi
     let rec fallback phi : ML (term & decls_t) =  match phi.n with
         | Tm_meta {tm=phi'; meta=Meta_labeled(msg, r, b)} ->
           let phi, decls = encode_formula phi' env in
-          mk (Term.Labeled(phi, msg, r)) r, decls
+          Term.Labeled phi msg r, decls
 
         | Tm_meta _ ->
           encode_formula (U.unmeta phi) env
@@ -1799,9 +1799,9 @@ and encode_formula (phi:typ) (env:env_t) : ML (term & decls_t)  = (* expects phi
                 debug phi;
                 let tt, decls = encode_term phi env in
                 let tt =
-                    if Range.rng_included (Range.use_range tt.rng) (Range.use_range phi.pos)
+                    if Range.rng_included (Range.use_range (range_of_term tt)) (Range.use_range phi.pos)
                     then tt
-                    else {tt with rng=phi.pos} in
+                    else set_range tt phi.pos in
                 mk_Valid tt, decls
               in
               if head_redex env head
@@ -1814,9 +1814,9 @@ and encode_formula (phi:typ) (env:env_t) : ML (term & decls_t)  = (* expects phi
         | _ ->
             let tt, decls = encode_term phi env in
             let tt =
-                  if Range.rng_included (Range.use_range tt.rng) (Range.use_range phi.pos)
+                  if Range.rng_included (Range.use_range (range_of_term tt)) (Range.use_range phi.pos)
                   then tt
-                  else {tt with rng=phi.pos} in
+                  else set_range tt phi.pos in
             mk_Valid tt, decls in
 
     let encode_q_body env (bs:Syntax.binders) (ps:list args) body =
@@ -1824,7 +1824,7 @@ and encode_formula (phi:typ) (env:env_t) : ML (term & decls_t)  = (* expects phi
         let pats, decls' = encode_smt_patterns ps env in
         let body, decls'' = encode_formula body env in
         let guards = match pats with
-          | [[{tm=App(Var gf, [p])}]] when Ident.string_of_lid Const.guard_free = gf -> []
+          | [[(App (Var gf) [p] _)]] when Ident.string_of_lid Const.guard_free = gf -> []
           | _ -> guards in
         vars, pats, mk_and_l guards, body, decls@decls'@decls'' in
 

--- a/src/smtencoding/FStarC.SMTEncoding.Env.fst
+++ b/src/smtencoding/FStarC.SMTEncoding.Env.fst
@@ -130,8 +130,8 @@ let kick_partial_app (fvb:fvar_binding) =
   match fvb.smt_token, fvb.needs_fuel_and_universe_instantiations with
   | None, _ -> None
   | _, Some _ -> None
-  | Some ({tm=FreeV (FV(tok, _, _))}), _
-  | Some ({tm=App(Var tok, _)}), _ ->
+  | Some ((FreeV (FV tok _ _))), _
+  | Some ((App (Var tok) _ _)), _ ->
     if fvb.univ_arity = 0
     then (
       let t = mkApp(tok, []) in
@@ -182,7 +182,7 @@ let check_valid_fvb fvb =
     else if fvb.fvb_thunked && fvb.smt_arity <> 0
     then failwith (Format.fmt1 "Unexpected arity of thunked SMT symbol: %s" (Ident.string_of_lid fvb.fvar_lid));
     match fvb.smt_token with
-    | Some ({tm=FreeV _}) ->
+    | Some ((FreeV _)) ->
       failwith (Format.fmt1 "bad fvb\n%s" (fvb_to_string fvb))
     | _ -> ()
 
@@ -323,7 +323,7 @@ let push_zfuel_name env (x:lident) f ftok =
 let force_thunk fvb =
     if not (fvb.fvb_thunked) || fvb.smt_arity <> 0
     then failwith (Format.fmt1 "Forcing a non-thunk %s in the SMT encoding" (string_of_lid fvb.fvar_lid));
-    mkFreeV <| FV (fvb.smt_id, Term_sort, true)
+    mkFreeV <| FV fvb.smt_id Term_sort true
 let try_lookup_free_var env l =
     match lookup_fvar_binding env l with
     | None -> None
@@ -343,8 +343,8 @@ let try_lookup_free_var env l =
         match fvb.smt_token with
         | Some t ->
           begin
-          match t.tm with
-          | App(_, [fuel]) ->
+          match t with
+          | App _ [fuel] _ ->
             if (BU.starts_with (Term.fv_of_term fuel |> fv_name) "fuel")
             then Some <| mk_ApplyTF(mkFreeV <| mk_fv (fvb.smt_id, Term_sort)) fuel
             else Some t
@@ -361,7 +361,7 @@ let lookup_free_var_name env (a : lident) = lookup_lid env a
 let lookup_free_var_sym env (a : lident) =
     let fvb = lookup_lid env a in
     match fvb.smt_fuel_partial_app with
-    | Some({tm=App(g, zf)}, _)
+    | Some((App g zf _), _)
         when env.use_zfuel_name ->
       Inl g, zf, fvb.smt_arity + 1
     | _ ->
@@ -373,8 +373,8 @@ let lookup_free_var_sym env (a : lident) =
             Inl (Var fvb.smt_id), [], fvb.smt_arity
         | Some sym ->
             begin
-            match sym.tm with
-            | App(g, [fuel]) ->
+            match sym with
+            | App g [fuel] _ ->
                 Inl g, [fuel], fvb.smt_arity + 1
             | _ ->
                 Inl (Var fvb.smt_id), [], fvb.smt_arity
@@ -393,7 +393,7 @@ let tok_of_name env nm =
     PIMap.fold pi (fun _ y res ->
       match res, y with
       | Some _, _ -> res
-      | None, (_, {tm=App(Var sym, [])}) when sym=nm ->
+      | None, (_, (App (Var sym) [] _)) when sym=nm ->
         Some (snd y)
       | _ -> None) None)
 

--- a/src/smtencoding/FStarC.SMTEncoding.ErrorReporting.fst
+++ b/src/smtencoding/FStarC.SMTEncoding.ErrorReporting.fst
@@ -46,7 +46,7 @@ let fresh_label : Errors.error_message -> Range.t -> term -> ML (label & term) =
         let lvar = mk_fv (l, Bool_sort) in
         let label = (lvar, message, range) in
         let lterm = mkFreeV lvar in
-        let lt = Term.mkOr(lterm, t) range in
+        let lt = Term.mkOr(lterm, t) in
         label, lt
 
 (*
@@ -66,24 +66,24 @@ let label_goals use_env_msg  //when present, provides an alternate error message
                & term)       //the query, decorated with labels
                =
     let rec is_a_post_condition post_name_opt tm : ML bool =
-        match post_name_opt, tm.tm with
+        match post_name_opt, tm with
         | None, _ -> false
         | Some nm, FreeV fv ->
           nm=fv_name fv
-        | _, App (Var "Valid", [tm])
-        | _, App (Var "ApplyTT", tm::_) ->
+        | _, App (Var "Valid") [tm] _
+        | _, App (Var "ApplyTT") (tm::_) _ ->
           is_a_post_condition post_name_opt tm
         | _ ->
           false
     in
     let conjuncts t =
-        match t.tm with
-        | App(And, cs) -> cs
+        match t with
+        | App And cs _ -> cs
         | _ -> [t]
     in
     let is_guard_free tm =
-      match tm.tm with
-      | Quant(Forall, [[{tm=App(Var "Prims.guard_free", [p])}]], iopt, _, {tm=App(Imp, [l;r])}) ->
+      match tm with
+      | Quant Forall [[(App (Var "Prims.guard_free") [p] _)]] iopt _ (App Imp [l;r] _) _ ->
         true
       | _ -> false
     in
@@ -110,14 +110,14 @@ let label_goals use_env_msg  //when present, provides an alternate error message
                 (labels:list label) //the labels accumulated so far
                 (q:term) //the term being instrumented
      : ML (list label & term)
-     =  match q.tm with
+     =  match q with
         | BoundV _
         | Integer _
         | String _
         | Real _ ->
           labels, q
 
-        | Labeled(arg, [d], label_range) when Errors.Msg.renderdoc d = "Could not prove post-condition" ->
+        | Labeled arg [d] label_range when Errors.Msg.renderdoc d = "Could not prove post-condition" ->
           //printfn "GOT A LABELED WP IMPLICATION\n\t%s"
           //        (Term.print_smt_term q);
           let fallback debug_msg =
@@ -126,19 +126,19 @@ let label_goals use_env_msg  //when present, provides an alternate error message
             aux default_msg (Some label_range) post_name_opt labels arg
           in
           begin try
-              begin match arg.tm with
-                | Quant(Forall, pats, iopt, post::sorts, {tm=App(Imp, [lhs;rhs]); rng=rng}) ->
+              begin match arg with
+                | Quant Forall pats iopt (post::sorts) (App Imp [lhs;rhs] rng) _ ->
                   let post_name = "^^post_condition_"^ (show <| GenSym.next_id ()) in
                   let names = mk_fv (post_name, post)
                               ::List.map (fun s -> mk_fv ("^^" ^ (show <| GenSym.next_id()), s)) sorts in
                   let instantiation = List.map mkFreeV names in
                   let lhs, rhs = Term.inst instantiation lhs, Term.inst instantiation rhs in
 
-                  let labels, lhs = match lhs.tm with
-                    | App(And, clauses_lhs) ->
+                  let labels, lhs = match lhs with
+                    | App And clauses_lhs _ ->
                       let req, ens = BU.prefix clauses_lhs in
-                      begin match ens.tm with
-                        | Quant(Forall, pats_ens, iopt_ens, sorts_ens, {tm=App(Imp, [ensures_conjuncts; post]); rng=rng_ens}) ->
+                      begin match ens with
+                        | Quant Forall pats_ens iopt_ens sorts_ens (App Imp [ensures_conjuncts; post] rng_ens) ens_rng ->
                           if is_a_post_condition (Some post_name) post
                           then
                             let labels, ensures_conjuncts = aux (Errors.mkmsg "Could not prove post-condition") None (Some post_name) labels ensures_conjuncts in
@@ -147,9 +147,8 @@ let label_goals use_env_msg  //when present, provides an alternate error message
                               | []
                               | [[]] -> [[post]]  //make the post-condition formula the pattern, if there isn't one already (usually there isn't)
                               | _ -> pats_ens in
-                            let ens = Term.mk (Quant(Forall, pats_ens, iopt_ens, sorts_ens,
-                                                             Term.mk (App(Imp, [ensures_conjuncts; post])) rng_ens)) ens.rng in
-                            let lhs = Term.mk (App(And, req@[ens])) lhs.rng in
+                            let ens = Quant Forall pats_ens iopt_ens sorts_ens (App Imp [ensures_conjuncts; post] rng_ens) ens_rng in
+                            let lhs = App And (req@[ens]) (range_of_term lhs) in
                             labels, Term.abstr names lhs
                            else raise (Not_a_wp_implication ("Ensures clause doesn't match post name:  "
                                                             ^ post_name
@@ -167,8 +166,8 @@ let label_goals use_env_msg  //when present, provides an alternate error message
                     let labels, rhs = aux default_msg None (Some post_name) labels rhs in
                     labels, Term.abstr names rhs in
 
-                  let body = Term.mkImp(lhs, rhs) rng in
-                  labels, Term.mk (Quant(Forall, pats, iopt, post::sorts, body)) q.rng
+                  let body = set_range (Term.mkImp(lhs, rhs)) rng in
+                  labels, Quant Forall pats iopt (post::sorts) body (range_of_term q)
 
 
                 | _ -> //not in the form produced by an application of M_stronger
@@ -177,10 +176,10 @@ let label_goals use_env_msg  //when present, provides an alternate error message
           with Not_a_wp_implication msg -> fallback msg
           end
 
-        | Labeled(arg, reason, r) ->
+        | Labeled arg reason r ->
           aux reason (Some r) post_name_opt labels arg
 
-        | Quant(Forall, [], None, sorts, {tm=App(Imp, [lhs;rhs]); rng=rng})
+        | Quant Forall [] None sorts (App Imp [lhs;rhs] rng) _
             when is_a_named_continuation lhs ->
           let sorts', post = BU.prefix sorts in
           let new_post_name = "^^post_condition_"^ (show <| GenSym.next_id ()) in
@@ -192,8 +191,8 @@ let label_goals use_env_msg  //when present, provides an alternate error message
 
           let labels, lhs_conjs =
                 BU.fold_map (fun labels tm ->
-                    match tm.tm with
-                    | Quant(Forall, [[{tm=App(Var "Prims.guard_free", [p])}]], iopt, sorts, {tm=App(Imp, [l0;r])}) ->
+                    match tm with
+                    | Quant Forall [[(App (Var "Prims.guard_free") [p] _)]] iopt sorts (App Imp [l0;r] _) _ ->
                       if is_a_post_condition (Some new_post_name) r
                       then begin
                         //printfn "++++RHS is a post-condition for %s;\n\trhs=%s"
@@ -203,7 +202,7 @@ let label_goals use_env_msg  //when present, provides an alternate error message
                         //printfn "++++LHS %s\nlabeled as%s"
                         //        (Term.print_smt_term l0)
                         //        (Term.print_smt_term l);
-                        labels, mk (Quant(Forall, [[p]], Some 0, sorts, norng mk (App(Imp, [l;r])))) q.rng
+                        labels, Quant Forall [[p]] (Some 0) sorts (App Imp [l;r] Range.dummyRange) (range_of_term q)
                       end
                       else begin
                         //printfn "----RHS not a post-condition for %s;\n\trhs=%s"
@@ -215,92 +214,92 @@ let label_goals use_env_msg  //when present, provides an alternate error message
                 labels (conjuncts lhs) in
 
           let labels, rhs = aux default_msg None (Some new_post_name) labels rhs in
-          let body = Term.mkImp(Term.mk_and_l lhs_conjs lhs.rng, rhs) rng |> Term.abstr names in
-          let q = Term.mk (Quant(Forall, [], None, sorts, body)) q.rng in
+          let body = set_range (Term.mkImp(set_range (Term.mk_and_l lhs_conjs) (range_of_term lhs), rhs)) rng |> Term.abstr names in
+          let q = Quant Forall [] None sorts body (range_of_term q) in
           labels, q
 
-        | App(Imp, [lhs;rhs]) ->
+        | App Imp [lhs;rhs] _ ->
           let labels, rhs = aux default_msg ropt post_name_opt labels rhs in
           labels, mkImp(lhs, rhs)
 
-        | App(And, conjuncts) ->
+        | App And conjuncts _ ->
           let labels, conjuncts = BU.fold_map (aux default_msg ropt post_name_opt) labels conjuncts in
-          labels, Term.mk_and_l conjuncts q.rng
+          labels, set_range (Term.mk_and_l conjuncts) (range_of_term q)
 
-        | App(ITE, [hd; q1; q2]) ->
+        | App ITE [hd; q1; q2] _ ->
           let labels, q1 = aux default_msg ropt post_name_opt labels q1 in
           let labels, q2 = aux default_msg ropt post_name_opt labels q2 in
-          labels, Term.mkITE (hd, q1, q2) q.rng
+          labels, set_range (Term.mkITE (hd, q1, q2)) (range_of_term q)
 
-        | Quant(Exists, _, _, _, _)
-        | App(Iff, _)
-        | App(Or, _) -> //non-atomic, but can't case split
-          let lab, q = fresh_label default_msg ropt q.rng q in
+        | Quant Exists _ _ _ _ _
+        | App Iff _ _
+        | App Or _ _ -> //non-atomic, but can't case split
+          let lab, q = fresh_label default_msg ropt (range_of_term q) q in
           lab::labels, q
 
-        | App (Var "Unreachable", _) ->
+        | App (Var "Unreachable") _ _ ->
           //ITEs are encoded with an additional else case just to make them well-formed
           //These are not real goals and should not be labeled
           labels, q
           
-        | App (Var _, _) when is_a_post_condition post_name_opt q ->
+        | App (Var _) _ _ when is_a_post_condition post_name_opt q ->
           //applications of the post-condition variable are never labeled
           //only specific conjuncts of an ensures clause are labeled
           labels, q
 
         | FreeV _
-        | App(TrueOp, _)
-        | App(FalseOp, _)
-        | App(Not, _)
-        | App(Eq, _)
-        | App(LT, _)
-        | App(LTE, _)
-        | App(GT, _)
-        | App(GTE, _)
-        | App(BvUlt, _)
-        | App(Var _, _) -> //atomic goals
-          let lab, q = fresh_label default_msg ropt q.rng q in
+        | App TrueOp _ _
+        | App FalseOp _ _
+        | App Not _ _
+        | App Eq _ _
+        | App LT _ _
+        | App LTE _ _
+        | App GT _ _
+        | App GTE _ _
+        | App BvUlt _ _
+        | App (Var _) _ _ -> //atomic goals
+          let lab, q = fresh_label default_msg ropt (range_of_term q) q in
           lab::labels, q
 
-        | App(RealDiv, _)
-        | App(Add, _)
-        | App(Sub, _)
-        | App(Div, _)
-        | App(Mul, _)
-        | App(Minus, _)
-        | App(Mod, _)
-        | App(BvAnd, _)
-        | App(BvXor, _)
-        | App(BvOr, _)
-        | App(BvAdd, _)
-        | App(BvSub, _)
-        | App(BvShl, _)
-        | App(BvShr, _)
-        | App(BvRol _, _)
-        | App(BvRor _, _)
-        | App(BvExtRol, _)
-        | App(BvExtRor, _)
-        | App(BvUdiv, _)
-        | App(BvMod, _)
-        | App(BvMul, _)
-        | App(BvUext _, _)
-        | App(BvNot, _)
-        | App(BvToNat, _)
-        | App(NatToBv _, _) ->
+        | App RealDiv _ _
+        | App Add _ _
+        | App Sub _ _
+        | App Div _ _
+        | App Mul _ _
+        | App Minus _ _
+        | App Mod _ _
+        | App BvAnd _ _
+        | App BvXor _ _
+        | App BvOr _ _
+        | App BvAdd _ _
+        | App BvSub _ _
+        | App BvShl _ _
+        | App BvShr _ _
+        | App (BvRol _) _ _
+        | App (BvRor _) _ _
+        | App BvExtRol _ _
+        | App BvExtRor _ _
+        | App BvUdiv _ _
+        | App BvMod _ _
+        | App BvMul _ _
+        | App (BvUext _) _ _
+        | App BvNot _ _
+        | App BvToNat _ _
+        | App (NatToBv _) _ _ ->
           failwith "Impossible: non-propositional term"
 
-        | App(ITE, _)
-        | App(Imp, _) ->
+        | App ITE _ _
+        | App Imp _ _ ->
           failwith "Impossible: arity mismatch"
 
-        | Quant(Forall, pats, iopt, sorts, body) ->
+        | Quant Forall pats iopt sorts body _ ->
           let labels, body = aux default_msg ropt post_name_opt labels body in
-          labels, Term.mk (Quant(Forall, pats, iopt, sorts, body)) q.rng
+          labels, Quant Forall pats iopt sorts body (range_of_term q)
 
         (* TODO (KM) : I am not sure whether we should label the let-bounded expressions here *)
-        | Let(es, body) ->
+        | Let es body ->
           let labels, body = aux default_msg ropt post_name_opt labels body in
-          labels, Term.mkLet (es, body) q.rng
+          labels, Term.mkLet (es, body)
     in
     __ctr := 0;
     aux (Errors.mkmsg "Assertion failed") None None [] q

--- a/src/smtencoding/FStarC.SMTEncoding.Pruning.fst
+++ b/src/smtencoding/FStarC.SMTEncoding.Pruning.fst
@@ -169,11 +169,11 @@ let assumption_free_names a = diff a.assumption_free_names exclude_names
 let triggers_of_term (t:term)
 : ML triggers_set
 = let rec aux (t:term) : ML triggers_set =
-    match t.tm with
-    | Quant(Forall, triggers, _, _, _) ->
+    match t with
+    | Quant Forall triggers _ _ _ _ ->
       triggers |> List.map (fun disjunct ->
       disjunct |> List.fold_left (fun out t -> union out (free_top_level_names t)) (empty()))
-    | Labeled (t, _, _) -> aux t
+    | Labeled t _ _ -> aux t
     | _ -> []
   in aux t
 
@@ -184,7 +184,7 @@ let triggers_of_term (t:term)
    itself:
 
     - Applications of nullary functions are sometimes encoded as
-      App(Var "name", []) and sometiems as FreeV(FV("name", _, _))  
+      App (Var "name") [] and sometiems as FreeV(FV "name" _ _)  
 *)
 let maybe_add_ambient (a:assumption) (p:pruning_state)
 : ML pruning_state
@@ -204,23 +204,23 @@ let maybe_add_ambient (a:assumption) (p:pruning_state)
     | _ -> false
   in
   let is_ambient_refinement ty =
-    match ty.tm with
-    | App(Var "Prims.squash", _) -> true
-    | App(Var name, _) 
-    | FreeV(FV(name, _, _)) -> BU.starts_with name "Tm_refine_"
+    match ty with
+    | App (Var "Prims.squash") _ _ -> true
+    | App (Var name) _ _ 
+    | FreeV(FV name _ _) -> BU.starts_with name "Tm_refine_"
     | _ -> false
   in
   let ambient_refinement_payload ty =
-    match ty.tm with
-    | App(Var "Prims.squash", [_;t]) -> t
+    match ty with
+    | App (Var "Prims.squash") [_;t] _ -> t
     | _ -> ty
   in
   begin
-    match a.assumption_term.tm with
+    match a.assumption_term with
     // - l_quant_interp assumptions give interpretations to deeply embedded quantifiers
     //   and have a specific shape of an Iff, where the LHS has a pattern, if the
     //   user annotated one.
-    | App(Iff, [t0; t1]) when BU.starts_with a.assumption_name "l_quant_interp" -> (
+    | App Iff [t0; t1] _ when BU.starts_with a.assumption_name "l_quant_interp" -> (
       let triggers_lhs = free_top_level_names t0 in
       add_assumption_with_triggers [triggers_lhs]
     )
@@ -241,7 +241,7 @@ let maybe_add_ambient (a:assumption) (p:pruning_state)
     // - Top-level assumptions of the form `HasType term (squash ty)`
     //   or `HasType term (Tm_refine_... )` are deemed ambient and are
     //   always included in the pruned set and added as extra roots.
-    | App (Var "HasType", [term; ty])
+    | App (Var "HasType") [term; ty] _
       when is_ambient_refinement ty -> (
       //HasType term (squash ty) is an ambient that should trigger on either the term or the type
       let triggers = triggers_of_term (ambient_refinement_payload ty) in
@@ -257,14 +257,12 @@ let maybe_add_ambient (a:assumption) (p:pruning_state)
  
     // - Partial applications are triggered with a __uu__PartialApp token; this is
     //   triggered on either the symbol itself or its nullary token
-    | App (Var "Valid", 
-          [{tm=App (Var "ApplyTT", [{tm=FreeV (FV("__uu__PartialApp", _, _))}; term])}])
-    | App (Var "Valid", 
-          [{tm=App (Var "ApplyTT", [{tm=App(Var "__uu__PartialApp", _)}; term])}]) ->
+    | App (Var "Valid") [(App (Var "ApplyTT") [(FreeV (FV "__uu__PartialApp" _ _)); term] _)] _
+    | App (Var "Valid") [(App (Var "ApplyTT") [(App (Var "__uu__PartialApp") _ _); term] _)] _ ->
       let triggers =
-        match term.tm with
-        | FreeV(FV(token, _, _))
-        | App(Var token, []) ->
+        match term with
+        | FreeV(FV token _ _)
+        | App (Var token) [] _ ->
           if BU.ends_with token "@tok"
           then [singleton token; singleton (BU.substring token 0 (String.length token - 4))]
           else [singleton token]
@@ -275,32 +273,32 @@ let maybe_add_ambient (a:assumption) (p:pruning_state)
 
     // HasType, Valid, IsTotFun, and is-Tm_arrow are so common that we exclude them as triggers
     // and instead only consider the free names of the underlying terms
-    | App (Var "Valid", [term])
-    | App (Var "HasType", [term; _])
-    | App (Var "IsTotFun", [term])
-    | App (Var "is-Tm_arrow", [term]) ->
+    | App (Var "Valid") [term] _
+    | App (Var "HasType") [term; _] _
+    | App (Var "IsTotFun") [term] _
+    | App (Var "is-Tm_arrow") [term] _ ->
       add_assumption_with_triggers [free_top_level_names term]
 
     // Term_constr_id assumptions trigger on the free names of the underlying term
-    | App (Eq, [ _; {tm=App (Var "Term_constr_id", [term])}]) ->
+    | App Eq [ _; (App (Var "Term_constr_id") [term] _)] _ ->
       add_assumption_with_triggers [free_top_level_names term]
 
     // Descend into conjunctions and collect their triggers
     // Fire if any of the conjuncts have triggers that fire
-    | App (And, tms) ->
+    | App And tms _ ->
       let t1 = List.collect triggers_of_term tms in
       add_assumption_with_triggers t1
 
     // Assumptions named "equation_" are encodings of F* definitions and are
     // equations oriented from left to right
-    | App (Eq, [t0; t1]) when BU.starts_with a.assumption_name "equation_" ->
+    | App Eq [t0; t1] _ when BU.starts_with a.assumption_name "equation_" ->
       let t0 = free_top_level_names t0 in
       add_assumption_with_triggers [t0]
 
-    | App (Iff, [t0; t1]) -> (
-      match t0.tm, t1.tm with
-      | App(Var "Valid", [{tm=App(Var "Prims.hasEq", [_u; lhs])}]),
-        App(Var "Valid", [{tm=App(Var "Prims.hasEq", [_v; rhs])}]) ->
+    | App Iff [t0; t1] _ -> (
+      match t0, t1 with
+      | App (Var "Valid") [(App (Var "Prims.hasEq") [_u; lhs] _)] _,
+        App (Var "Valid") [(App (Var "Prims.hasEq") [_v; rhs] _)] _ ->
         //hasEq t0 <==> hasEq t1
         //We have many of these for every refinement type; triggers from left-to-right
         //perhaps these are better written hasEq t1 ==> hasEq t0, and trigger in a goal-directed way
@@ -315,13 +313,13 @@ let maybe_add_ambient (a:assumption) (p:pruning_state)
     )
 
     // Other equations are bidirectional
-    | App (Eq, [t0; t1]) ->
+    | App Eq [t0; t1] _ ->
       let t0 = free_top_level_names t0 in
       let t1 = free_top_level_names t1 in
       add_assumption_with_triggers [t0; t1]
 
     // we get many vacuous True facts; just drop them
-    | App (TrueOp, _) -> p
+    | App TrueOp _ _ -> p
 
     // Oterwise, add to ambients without scanning them further
     | _ ->
@@ -370,7 +368,7 @@ let rec assumptions_of_decl (d:decl)
 : ML (list assumption)
 = match d with
   | Assume a -> [a]
-  | Module (_, ds) -> List.collect assumptions_of_decl ds
+  | Module _ ds -> List.collect assumptions_of_decl ds
   | d -> []
 
 // Add a declaration to the pruning state, updating the trigger and assumption tables
@@ -382,13 +380,13 @@ let rec add_decl (d:decl) (p:pruning_state)
     let triggers = triggers_of_term a.assumption_term in
     let p = List.fold_left (List.fold_left (add_trigger_to_assumption a)) p (List.map elems triggers) in
     add_assumption_to_triggers a p triggers
-  | Module (_, ds) -> List.fold_left (fun p d -> add_decl d p) p ds
-  | DefineFun(macro, _, _, body, _) ->
+  | Module _ ds -> List.fold_left (fun p d -> add_decl d p) p ds
+  | DefineFun macro _ _ body _ ->
     let free_names = elems (free_top_level_names body) in
     { p with defs_and_decls=d::p.defs_and_decls; 
              defs_and_decls_map = PSMap.add p.defs_and_decls_map macro d;
              macro_freenames = PSMap.add p.macro_freenames macro free_names } 
-  | DeclFun(name, _, _, _) ->
+  | DeclFun name _ _ _ ->
     { p with defs_and_decls = d::p.defs_and_decls;
              defs_and_decls_map = PSMap.add p.defs_and_decls_map name d }
   | _ -> p
@@ -526,8 +524,8 @@ let print_reached_names_and_reasons (ctxt:ctxt) names : ML string =
 let name_of_decl (d:decl) : ML string =
   match d with
   | Assume a -> a.assumption_name
-  | DeclFun(a, _, _, _) -> a
-  | DefineFun(a, _, _, _, _) -> a
+  | DeclFun a _ _ _ -> a
+  | DefineFun a _ _ _ _ -> a
   | _ -> "<none>"
 
 let prune (p:pruning_state) (roots0:list decl)

--- a/src/smtencoding/FStarC.SMTEncoding.Solver.fst
+++ b/src/smtencoding/FStarC.SMTEncoding.Solver.fst
@@ -261,7 +261,7 @@ let with_fuel_and_diagnostics settings label_assumptions =
         settings.query_decl        //the query itself
     ]
     @label_assumptions         //the sub-goals that are currently disabled
-    @[  Term.SetOption ("rlimit", show rlimit); //the rlimit setting for the check-sat
+    @[  Term.SetOption "rlimit" (show rlimit); //the rlimit setting for the check-sat
 
         // Print stats just before the query, so we know the initial rlimit.
         Term.Echo "<initial_stats>";
@@ -269,7 +269,7 @@ let with_fuel_and_diagnostics settings label_assumptions =
         Term.Echo "</initial_stats>";
 
         Term.CheckSat; //go Z3!
-        Term.SetOption ("rlimit", "0"); //back to using infinite rlimit
+        Term.SetOption "rlimit" "0"; //back to using infinite rlimit
         Term.GetReasonUnknown; //explain why it failed
     ]@
     (if settings.query_record_hints
@@ -1389,7 +1389,7 @@ let encode_and_ask (can_split:bool) (is_retry:bool) use_env_msg tcenv q : ML (li
       let tcenv = incr_query_index tcenv in
       match qry with
       (* trivial cases *)
-      | Assume({assumption_term={tm=App(FalseOp, _)}}) -> ([], ans_ok)
+      | Assume({assumption_term=(App FalseOp _ _)}) -> ([], ans_ok)
       | _ when tcenv.admit -> ([], ans_ok)
 
       | Assume _ ->

--- a/src/smtencoding/FStarC.SMTEncoding.SolverState.fst
+++ b/src/smtencoding/FStarC.SMTEncoding.SolverState.fst
@@ -196,7 +196,7 @@ let already_given_decl (s:solver_state) (aname:string)
 
 let rec flatten (d:decl) : ML (list decl) = 
   match d with
-  | Module (_, ds) -> List.collect flatten ds
+  | Module _ ds -> List.collect flatten ds
   | _ -> [d]
 
 (* Record assumptions with their names *)
@@ -388,17 +388,17 @@ let reset (using_facts_from:option using_facts_from_setting) (s:solver_state)
 let name_of_decl (d:decl) : ML string =
   match d with
   | Assume a -> a.assumption_name
-  | DeclFun(a, _, _, _) -> a
-  | DefineFun(a, _, _, _, _) -> a
+  | DeclFun a _ _ _ -> a
+  | DefineFun a _ _ _ _ -> a
   | _ -> failwith "Expected an assumption"
 
 let compare_decls (d0 d1:decl) : ML int =
   match d0, d1 with
-  | DeclFun(a0, _, _, _), DeclFun(a1, _, _, _)
-  | DefineFun(a0, _, _, _, _), DefineFun(a1, _, _, _, _)
+  | DeclFun a0 _ _ _, DeclFun a1 _ _ _
+  | DefineFun a0 _ _ _ _, DefineFun a1 _ _ _ _
   | Assume {assumption_name=a0}, Assume{assumption_name=a1} -> BU.compare a0 a1
-  | DeclFun _, _ -> -1
-  | DefineFun _, _ -> -1
+  | DeclFun _ _ _ _, _ -> -1
+  | DefineFun _ _ _ _ _, _ -> -1
   | _ -> failwith "Unexpected decl in compare decls"
 
 (* Prune the context with respect to a set of roots *)

--- a/src/smtencoding/FStarC.SMTEncoding.Term.fst
+++ b/src/smtencoding/FStarC.SMTEncoding.Term.fst
@@ -133,7 +133,7 @@ printing.
 
 let mk_decls name key decls aux_decls : ML decls_t = [{
   sym_name    = Some name;
-  key         = Some key;
+  key         = Some (BU.digest_of_string key);
   decls       = decls;
   a_names     =  //AR: collect the names of aux_decls and decls to be retained in case of a cache hit
     let sm = SMap.create 20 in
@@ -157,9 +157,9 @@ let mk_decls_trivial decls : ML decls_t = [{
 
 let decls_list_of l : ML (list decl) = l |> List.collect (fun elt -> elt.decls)
 
-let mk_fv (x, y) : fv = FV (x, y, false)
+let mk_fv (x, y) : fv = FV x y false
 
-let fv_name (x:fv) = let FV (nm, _, _) = x in nm
+let fv_name (x:fv) = let FV nm _ _ = x in nm
 
 instance deq_fv : deq fv = {
   (=?) = (fun fv1 fv2 -> fv_name fv1 = fv_name fv2);
@@ -169,59 +169,53 @@ instance ord_fv : ord fv = {
   cmp = (fun fv1 fv2 -> Order.order_from_int (BU.compare (fv_name fv1) (fv_name fv2)));
 }
 
-let fv_sort (x:fv) = let FV (_, sort, _) = x in sort
-let fv_force (x:fv) = let FV (_, _, force) = x in force
+let fv_sort (x:fv) = let FV _ sort _ = x in sort
+let fv_force (x:fv) = let FV _ _ force = x in force
 let fv_eq (x:fv) (y:fv) = fv_name x = fv_name y
 let fvs_subset_of (x:fvs) (y:fvs) : ML bool =
   let open FStarC.Class.Setlike in
   subset (from_list x <: RBSet.t fv) (from_list y)
 
-let freevar_eq x y = match x.tm, y.tm with
+let freevar_eq x y = match x, y with
     | FreeV x, FreeV y -> fv_eq x y
     | _ -> false
 let freevar_sort  = function
-    | {tm=FreeV x} -> fv_sort x
+    | (FreeV x) -> fv_sort x
     | _ -> failwith "impossible"
 let fv_of_term : term -> ML fv = function
-    | {tm=FreeV fv} -> fv
+    | (FreeV fv) -> fv
     | _ -> failwith "impossible"
-let rec freevars t : ML (list fv) = match t.tm with
+let rec freevars t : ML (list fv) = match t with
   | Integer _
   | String _
   | Real _
   | BoundV _ -> []
   | FreeV fv when fv_force fv -> [] //this is actually a top-level constant
   | FreeV fv -> [fv]
-  | App(_, tms) -> List.collect freevars tms
-  | Quant(_, _, _, _, t)
-  | Labeled(t, _, _) -> freevars t
-  | Let (es, body) -> List.collect freevars (body::es)
+  | App _ tms _ -> List.collect freevars tms
+  | Quant _ _ _ _ t _
+  | Labeled t _ _ -> freevars t
+  | Let es body -> List.collect freevars (body::es)
 
-//memo-ized
-let free_variables t : ML fvs = match !t.freevars with
-  | Some b -> b
-  | None ->
-    let fvs = BU.remove_dups fv_eq (freevars t) in
-    t.freevars := Some fvs;
-    fvs
+let free_variables t : ML fvs = BU.remove_dups fv_eq (freevars t)
 
 open FStarC.Class.Setlike
 let free_top_level_names (t:term)
 : ML (RBSet.t string)
 = let rec free_top_level_names acc t : ML _ =
-    match t.tm with
-    | FreeV (FV (nm, _, _)) -> add nm acc
-    | App (Var s, args) -> 
+    match t with
+    | FreeV (FV nm _ _) -> add nm acc
+    | App (Var s) args _ -> 
       let acc = add s acc in
       List.fold_left free_top_level_names acc args
-    | App (_, args) -> List.fold_left free_top_level_names acc args
-    | Quant (_, pats, _, _, body) ->
+    | App _ args _ -> List.fold_left free_top_level_names acc args
+    | Quant _ pats _ _ body _ ->
       let acc = List.fold_left (fun acc pats -> List.fold_left free_top_level_names acc pats) acc pats in
       free_top_level_names acc body
-    | Let(tms, t) ->
+    | Let tms t ->
       let acc = List.fold_left free_top_level_names acc tms in
       free_top_level_names acc t
-    | Labeled(t, _, _) -> free_top_level_names acc t
+    | Labeled t _ _ -> free_top_level_names acc t
     | _ -> acc
   in
   free_top_level_names (empty()) t
@@ -295,10 +289,10 @@ let rec hash_of_term' t : ML string =
   | Real r -> r
   | BoundV i  -> "@"^show i
   | FreeV x   -> fv_name x ^ ":" ^ strSort (fv_sort x) //Question: Why is the sort part of the hash?
-  | App(op, tms) -> "("^(op_to_string op)^(List.map hash_of_term tms |> String.concat " ")^")"
-  | Labeled(t, _, _) ->
+  | App op tms _ -> "("^(op_to_string op)^(List.map hash_of_term tms |> String.concat " ")^")"
+  | Labeled t _ _ ->
     hash_of_term t // labels are semantically irrelevant, ignore them
-  | Quant(qop, pats, wopt, sorts, body) ->
+  | Quant qop pats wopt sorts body _ ->
       "("
     ^ (qop_to_string qop)
     ^ " ("
@@ -310,9 +304,9 @@ let rec hash_of_term' t : ML string =
     ^ " "
     ^ (pats |> List.map (fun pats -> (List.map hash_of_term pats |> String.concat " ")) |> String.concat "; ")
     ^ "))"
-  | Let (es, body) ->
+  | Let es body ->
     "(let (" ^ (List.map hash_of_term es |> String.concat " ") ^ ") " ^ hash_of_term body ^ ")"
-and hash_of_term tm : ML string = hash_of_term' tm.tm
+and hash_of_term tm : ML string = hash_of_term' tm
 
 let mkBoxFunctions s = (s, s ^ "_proj_0")
 let boxIntFun        = mkBoxFunctions "BoxInt"
@@ -328,91 +322,101 @@ let isInjective s =
         not (List.existsML (fun c -> c = '.') (FStar.String.list_of_string s))
     else false
 
-let mk t r : ML term = {tm=t; freevars=mk_ref None; rng=r}
-let mkTrue  r       = mk (App(TrueOp, [])) r
-let mkFalse r       = mk (App(FalseOp, [])) r
-let mkUnreachable   = mk (App(Var "Unreachable", [])) Range.dummyRange
-let mkInteger i  r  = mk (Integer (BU.ensure_decimal i)) r
-let mkInteger' i r  = mkInteger (show i) r
-let mkReal i r      = mk (Real i) r
-let mkBoundV i r    = mk (BoundV i) r
-let mkFreeV x r     = mk (FreeV x) r
-let mkApp' f r      = mk (App f) r
-let mkApp (s, args) r = mk (App (Var s, args)) r
-let mkNot t r       = match t.tm with
-  | App(TrueOp, _)  -> mkFalse r
-  | App(FalseOp, _) -> mkTrue r
-  | _ -> mkApp'(Not, [t]) r
-let mkAnd (t1, t2) r = match t1.tm, t2.tm with
-  | App(TrueOp, _), _ -> t2
-  | _, App(TrueOp, _) -> t1
-  | App(FalseOp, _), _
-  | _, App(FalseOp, _) -> mkFalse r
-  | App(And, ts1), App(And, ts2) -> mkApp'(And, ts1@ts2) r
-  | _, App(And, ts2) -> mkApp'(And, t1::ts2) r
-  | App(And, ts1), _ -> mkApp'(And, ts1@[t2]) r
-  | _ -> mkApp'(And, [t1;t2]) r
-let mkOr (t1, t2) r = match t1.tm, t2.tm with
-  | App(TrueOp, _), _
-  | _, App(TrueOp, _) -> mkTrue r
-  | App(FalseOp, _), _ -> t2
-  | _, App(FalseOp, _) -> t1
-  | App(Or, ts1), App(Or, ts2) -> mkApp'(Or, ts1@ts2) r
-  | _, App(Or, ts2) -> mkApp'(Or, t1::ts2) r
-  | App(Or, ts1), _ -> mkApp'(Or, ts1@[t2]) r
-  | _ -> mkApp'(Or, [t1;t2]) r
-let mkImp (t1, t2) r = match t1.tm, t2.tm with
-  | _, App(TrueOp, _)
-  | App(FalseOp, _), _ -> mkTrue r
-  | App(TrueOp, _), _ -> t2
-  | _, App(Imp, [t1'; t2']) -> mkApp'(Imp, [mkAnd(t1, t1') r; t2']) r
-  | _ -> mkApp'(Imp, [t1; t2]) r
+let mkTrue          = App TrueOp [] Range.dummyRange
+let mkFalse         = App FalseOp [] Range.dummyRange
+let mkUnreachable   = App (Var "Unreachable") [] Range.dummyRange
+let mkInteger i     = Integer (BU.ensure_decimal i)
+let mkInteger' i    = mkInteger (show i)
+let mkReal i        = Real i
+let mkBoundV i      = BoundV i
+let mkFreeV x       = FreeV x
+let mkApp' (op, args) = App op args Range.dummyRange
+let mkApp (s, args) = App (Var s) args Range.dummyRange
+let range_of_term t =
+  match t with
+  | App _ _ r
+  | Quant _ _ _ _ _ r
+  | Labeled _ _ r -> r
+  | _ -> Range.dummyRange
+let set_range t r =
+  match t with
+  | App op ts _ -> App op ts r
+  | Quant qop pats wopt sorts body _ -> Quant qop pats wopt sorts body r
+  | _ -> t
+let mkNot t         = match t with
+  | App TrueOp _ _  -> mkFalse
+  | App FalseOp _ _ -> mkTrue
+  | _ -> mkApp'(Not, [t])
+let mkAnd (t1, t2) = match t1, t2 with
+  | App TrueOp _ _, _ -> t2
+  | _, App TrueOp _ _ -> t1
+  | App FalseOp _ _, _
+  | _, App FalseOp _ _ -> mkFalse
+  | App And ts1 _, App And ts2 _ -> mkApp'(And, ts1@ts2)
+  | _, App And ts2 _ -> mkApp'(And, t1::ts2)
+  | App And ts1 _, _ -> mkApp'(And, ts1@[t2])
+  | _ -> mkApp'(And, [t1;t2])
+let mkOr (t1, t2) = match t1, t2 with
+  | App TrueOp _ _, _
+  | _, App TrueOp _ _ -> mkTrue
+  | App FalseOp _ _, _ -> t2
+  | _, App FalseOp _ _ -> t1
+  | App Or ts1 _, App Or ts2 _ -> mkApp'(Or, ts1@ts2)
+  | _, App Or ts2 _ -> mkApp'(Or, t1::ts2)
+  | App Or ts1 _, _ -> mkApp'(Or, ts1@[t2])
+  | _ -> mkApp'(Or, [t1;t2])
+let mkImp (t1, t2) = match t1, t2 with
+  | _, App TrueOp _ _
+  | App FalseOp _ _, _ -> mkTrue
+  | App TrueOp _ _, _ -> t2
+  | _, App Imp [t1'; t2'] _ -> mkApp'(Imp, [mkAnd(t1, t1'); t2'])
+  | _ -> mkApp'(Imp, [t1; t2])
 
-let mk_bin_op op (t1,t2) r = mkApp'(op, [t1;t2]) r
-let mkMinus t r = mkApp'(Minus, [t]) r
-let mkNatToBv sz t r = mkApp'(NatToBv sz, [t]) r
-let mkBvUext sz t r = mkApp'(BvUext sz, [t]) r
-let mkBvNot  t r = mkApp'(BvNot, [t]) r
-let mkBvToNat t r = mkApp'(BvToNat, [t]) r
+let mk_bin_op op (t1,t2) = mkApp'(op, [t1;t2])
+let mkMinus t = mkApp'(Minus, [t])
+let mkNatToBv sz t = mkApp'(NatToBv sz, [t])
+let mkBvUext sz t = mkApp'(BvUext sz, [t])
+let mkBvNot  t = mkApp'(BvNot, [t])
+let mkBvToNat t = mkApp'(BvToNat, [t])
 let mkBvAnd = mk_bin_op BvAnd
 let mkBvXor = mk_bin_op BvXor
 let mkBvOr = mk_bin_op BvOr
 let mkBvAdd = mk_bin_op BvAdd
 let mkBvSub = mk_bin_op BvSub
-let mkBvShl sz (t1, t2) r = mkApp'(BvShl, [t1;(mkNatToBv sz t2 r)]) r
-let mkBvShr sz (t1, t2) r = mkApp'(BvShr, [t1;(mkNatToBv sz t2 r)]) r
-let mkBvRol sz (t1, t2) r =
-  match t2.tm with
+let mkBvShl sz (t1, t2) = mkApp'(BvShl, [t1;(mkNatToBv sz t2)])
+let mkBvShr sz (t1, t2) = mkApp'(BvShr, [t1;(mkNatToBv sz t2)])
+let mkBvRol sz (t1, t2) =
+  match t2 with
   | Integer n ->
-    mkApp'(BvRol (FStarC.Util.int_of_string n), [t1]) r
-  | App(Var proj, [{tm=App(Var box, [{tm=Integer n}])}])
+    mkApp'(BvRol (FStarC.Util.int_of_string n), [t1])
+  | App (Var proj) [(App (Var box) [(Integer n)] _)] _
     when proj = "BoxInt_proj_0" && box = "BoxInt" ->
-    mkApp'(BvRol (FStarC.Util.int_of_string n), [t1]) r
-  | _ -> mkApp'(BvExtRol, [t1;(mkNatToBv sz t2 r)]) r
-let mkBvRor sz (t1, t2) r =
-  match t2.tm with
+    mkApp'(BvRol (FStarC.Util.int_of_string n), [t1])
+  | _ -> mkApp'(BvExtRol, [t1;(mkNatToBv sz t2)])
+let mkBvRor sz (t1, t2) =
+  match t2 with
   | Integer n ->
-    mkApp'(BvRor (FStarC.Util.int_of_string n), [t1]) r
-  | App(Var proj, [{tm=App(Var box, [{tm=Integer n}])}])
+    mkApp'(BvRor (FStarC.Util.int_of_string n), [t1])
+  | App (Var proj) [(App (Var box) [(Integer n)] _)] _
     when proj = "BoxInt_proj_0" && box = "BoxInt" ->
-    mkApp'(BvRor (FStarC.Util.int_of_string n), [t1]) r
-  | _ -> mkApp'(BvExtRor, [t1;(mkNatToBv sz t2 r)]) r
-let mkBvUdiv sz (t1, t2) r = mkApp'(BvUdiv, [t1;(mkNatToBv sz t2 r)]) r
-let mkBvMod sz (t1, t2) r = mkApp'(BvMod, [t1;(mkNatToBv sz t2 r)]) r
-let mkBvMul sz (t1, t2) r = mkApp' (BvMul, [t1;(mkNatToBv sz t2 r)]) r
-let mkBvShl' sz (t1, t2) r = mkApp'(BvShl, [t1;t2]) r
-let mkBvShr' sz (t1, t2) r = mkApp'(BvShr, [t1;t2]) r
-let mkBvRol' sz (t1, t2) r = mkApp'(BvExtRol, [t1;t2]) r
-let mkBvRor' sz (t1, t2) r = mkApp'(BvExtRor, [t1;t2]) r
-let mkBvMul' sz (t1, t2) r = mkApp' (BvMul, [t1;t2]) r
-let mkBvUdivUnsafe sz (t1, t2) r = mkApp'(BvUdiv, [t1;t2]) r
-let mkBvModUnsafe sz (t1, t2) r = mkApp'(BvMod, [t1;t2]) r
+    mkApp'(BvRor (FStarC.Util.int_of_string n), [t1])
+  | _ -> mkApp'(BvExtRor, [t1;(mkNatToBv sz t2)])
+let mkBvUdiv sz (t1, t2) = mkApp'(BvUdiv, [t1;(mkNatToBv sz t2)])
+let mkBvMod sz (t1, t2) = mkApp'(BvMod, [t1;(mkNatToBv sz t2)])
+let mkBvMul sz (t1, t2) = mkApp' (BvMul, [t1;(mkNatToBv sz t2)])
+let mkBvShl' sz (t1, t2) = mkApp'(BvShl, [t1;t2])
+let mkBvShr' sz (t1, t2) = mkApp'(BvShr, [t1;t2])
+let mkBvRol' sz (t1, t2) = mkApp'(BvExtRol, [t1;t2])
+let mkBvRor' sz (t1, t2) = mkApp'(BvExtRor, [t1;t2])
+let mkBvMul' sz (t1, t2) = mkApp' (BvMul, [t1;t2])
+let mkBvUdivUnsafe sz (t1, t2) = mkApp'(BvUdiv, [t1;t2])
+let mkBvModUnsafe sz (t1, t2) = mkApp'(BvMod, [t1;t2])
 let mkBvUlt = mk_bin_op BvUlt
 let mkIff = mk_bin_op Iff
-let mkEq (t1, t2) r = match t1.tm, t2.tm with
-    | App (Var f1, [s1]), App (Var f2, [s2]) when f1 = f2 && isInjective f1 ->
-        mk_bin_op Eq (s1, s2) r
-    | _ -> mk_bin_op Eq (t1, t2) r
+let mkEq (t1, t2) = match t1, t2 with
+    | App (Var f1) [s1] _, App (Var f2) [s2] _ when f1 = f2 && isInjective f1 ->
+        mk_bin_op Eq (s1, s2)
+    | _ -> mk_bin_op Eq (t1, t2)
 let mkLT  = mk_bin_op LT
 let mkLTE = mk_bin_op LTE
 let mkGT  = mk_bin_op GT
@@ -423,34 +427,34 @@ let mkDiv = mk_bin_op Div
 let mkRealDiv = mk_bin_op RealDiv
 let mkMul = mk_bin_op Mul
 let mkMod = mk_bin_op Mod
-let mkRealOfInt t r = mkApp ("to_real", [t]) r
-let mkITE (t1, t2, t3) r =
-  match t1.tm with
-  | App(TrueOp, _) -> t2
-  | App(FalseOp, _) -> t3
+let mkRealOfInt t = mkApp ("to_real", [t])
+let mkITE (t1, t2, t3) =
+  match t1 with
+  | App TrueOp _ _ -> t2
+  | App FalseOp _ _ -> t3
   | _ -> begin
-    match t2.tm, t3.tm with
-    | App(TrueOp,_), App(TrueOp, _) -> mkTrue r
-    | App(TrueOp,_), _ -> mkImp (mkNot t1 t1.rng, t3) r
-    | _, App(TrueOp, _) -> mkImp(t1, t2) r
-    | _, _ ->  mkApp'(ITE, [t1; t2; t3]) r
+    match t2, t3 with
+    | App TrueOp _ _, App TrueOp _ _ -> mkTrue
+    | App TrueOp _ _, _ -> mkImp (mkNot t1, t3)
+    | _, App TrueOp _ _ -> mkImp(t1, t2)
+    | _, _ ->  mkApp'(ITE, [t1; t2; t3])
   end
-let mkCases t r = match t with
+let mkCases t = match t with
   | [] -> failwith "Impos"
-  | hd::tl -> List.fold_left (fun out t -> mkAnd (out, t) r) hd tl
+  | hd::tl -> List.fold_left (fun out t -> mkAnd (out, t)) hd tl
 
 
 let check_pattern_ok (t:term) : option term =
     let rec aux t =
-        match t.tm with
+        match t with
         | Integer _
         | String _
         | Real _
         | BoundV _
         | FreeV _ -> None
-        | Let(tms, tm) ->
+        | Let tms tm ->
           aux_l (tm::tms)
-        | App(head, terms) ->
+        | App head terms _ ->
             let head_ok =
                 match head with
                 | Var _ -> true
@@ -496,9 +500,9 @@ let check_pattern_ok (t:term) : option term =
             in
             if not head_ok then Some t
             else aux_l terms
-        | Labeled(t, _, _) ->
+        | Labeled t _ _ ->
           aux t
-        | Quant _ -> Some t
+        | Quant _ _ _ _ _ _ -> Some t
     and aux_l ts =
         match ts with
         | [] -> None
@@ -510,23 +514,23 @@ let check_pattern_ok (t:term) : option term =
     aux t
 
  let rec print_smt_term (t:term) : ML string =
-  match t.tm with
+  match t with
   | Integer n               -> Format.fmt1 "(Integer %s)" n
   | String s                -> Format.fmt1 "(String %s)" s
   | Real r                  -> Format.fmt1 "(Real %s)" r
   | BoundV  n               -> Format.fmt1 "(BoundV %s)" (show n)
   | FreeV  fv               -> Format.fmt1 "(FreeV %s)" (fv_name fv)
-  | App (op, l)             -> Format.fmt2 "(%s %s)" (op_to_string op) (print_smt_term_list l)
-  | Labeled(t, r1, r2)      -> Format.fmt2 "(Labeled '%s' %s)" (Errors.Msg.rendermsg r1) (print_smt_term t)
-  | Quant (qop, l, _, _, t) -> Format.fmt3 "(%s %s %s)" (qop_to_string qop) (print_smt_term_list_list l) (print_smt_term t)
-  | Let (es, body) -> Format.fmt2 "(let %s %s)" (print_smt_term_list es) (print_smt_term body)
+  | App op l _             -> Format.fmt2 "(%s %s)" (op_to_string op) (print_smt_term_list l)
+  | Labeled t r1 r2      -> Format.fmt2 "(Labeled '%s' %s)" (Errors.Msg.rendermsg r1) (print_smt_term t)
+  | Quant qop l _ _ t _ -> Format.fmt3 "(%s %s %s)" (qop_to_string qop) (print_smt_term_list_list l) (print_smt_term t)
+  | Let es body -> Format.fmt2 "(let %s %s)" (print_smt_term_list es) (print_smt_term body)
 
 and print_smt_term_list (l:list term) : ML string = List.map print_smt_term l |> String.concat " "
 
 and print_smt_term_list_list (l:list (list term)) : ML string =
     List.fold_left (fun s l -> (s ^ "; [ " ^ (print_smt_term_list l) ^ " ] ")) "" l
 
-let mkQuant r check_pats (qop, pats, wopt, vars, body) =
+let mkQuant (r:Range.t) check_pats (qop, pats, wopt, vars, body) =
     let all_pats_ok pats =
         if not check_pats then pats else
         match BU.find_map pats (fun x -> BU.find_map x check_pattern_ok) with
@@ -539,13 +543,13 @@ let mkQuant r check_pats (qop, pats, wopt, vars, body) =
            end
     in
     if Nil? vars then body
-    else match body.tm with
-         | App(TrueOp, _) -> body
-         | _ -> mk (Quant(qop, all_pats_ok pats, wopt, vars, body)) r
+    else match body with
+         | App TrueOp _ _ -> body
+         | _ -> Quant qop (all_pats_ok pats) wopt vars body r
 
-let mkLet (es, body) r =
+let mkLet (es, body) =
   if Nil? es then body
-  else mk (Let (es,body)) r
+  else Let es body
 
 (*****************************************************)
 (* abstracting free names; instantiating bound vars  *)
@@ -557,10 +561,7 @@ let abstr fvs t = //fvs is a subset of the free vars of t; the result closes ove
     | Some i -> Some (nvars - (i + 1))
   in
   let rec aux ix t : ML term =
-    match !t.freevars with
-    | Some [] -> t
-    | _ ->
-      begin match t.tm with
+      begin match t with
         | Integer _
         | String _
         | Real _
@@ -568,16 +569,16 @@ let abstr fvs t = //fvs is a subset of the free vars of t; the result closes ove
         | FreeV x ->
           begin match index_of x with
             | None -> t
-            | Some i -> mkBoundV (i + ix) t.rng
+            | Some i -> mkBoundV (i + ix)
           end
-        | App(op, tms) -> mkApp'(op, List.map (aux ix) tms) t.rng
-        | Labeled(t, r1, r2) -> mk (Labeled(aux ix t, r1, r2)) t.rng
-        | Quant(qop, pats, wopt, vars, body) ->
+        | App op tms r -> set_range (mkApp'(op, List.map (aux ix) tms)) r
+        | Labeled t r1 r2 -> Labeled (aux ix t) r1 r2
+        | Quant qop pats wopt vars body r ->
           let n = List.length vars in
-          mkQuant t.rng false (qop, pats |> List.map (List.map (aux (ix + n))), wopt, vars, aux (ix + n) body)
-        | Let (es, body) ->
+          mkQuant r false (qop, pats |> List.map (List.map (aux (ix + n))), wopt, vars, aux (ix + n) body)
+        | Let es body ->
           let ix, es_rev = List.fold_left (fun (ix, l) e -> ix+1, aux ix e::l) (ix, []) es in
-          mkLet (List.rev es_rev, aux ix body) t.rng
+          mkLet (List.rev es_rev, aux ix body)
       end
   in
   aux 0 t
@@ -585,7 +586,7 @@ let abstr fvs t = //fvs is a subset of the free vars of t; the result closes ove
 let inst tms t =
   let tms = List.rev tms in //forall x y . t   ... y is an index 0 in t
   let n = List.length tms in //instantiate the first n BoundV's with tms, in order
-  let rec aux shift t : ML term = match t.tm with
+  let rec aux shift t : ML term = match t with
     | Integer _
     | String _
     | Real _
@@ -594,58 +595,58 @@ let inst tms t =
       if 0 <= i - shift && i - shift < n
       then List.nth tms (i - shift)
       else t
-    | App(op, tms) -> mkApp'(op, List.map (aux shift) tms) t.rng
-    | Labeled(t, r1, r2) -> mk (Labeled(aux shift t, r1, r2)) t.rng
-    | Quant(qop, pats, wopt, vars, body) ->
+    | App op tms r -> set_range (mkApp'(op, List.map (aux shift) tms)) r
+    | Labeled t r1 r2 -> Labeled (aux shift t) r1 r2
+    | Quant qop pats wopt vars body r ->
       let m = List.length vars in
       let shift = shift + m in
-      mkQuant t.rng false (qop, pats |> List.map (List.map (aux shift)), wopt, vars, aux shift body)
-    | Let (es, body) ->
+      mkQuant r false (qop, pats |> List.map (List.map (aux shift)), wopt, vars, aux shift body)
+    | Let es body ->
       let shift, es_rev = List.fold_left (fun (ix, es) e -> shift+1, aux shift e::es) (shift, []) es in
-      mkLet (List.rev es_rev, aux shift body) t.rng
+      mkLet (List.rev es_rev, aux shift body)
   in
   aux 0 t
 
 let subst (t:term) (fv:fv) (s:term) = inst [s] (abstr [fv] t)
-let mkQuant' r (qop, pats, wopt, vars, body) =
+let mkQuant' (r:Range.t) (qop, pats, wopt, vars, body) =
     mkQuant r true (qop, pats |> List.map (List.map (abstr vars)), wopt, List.map fv_sort vars, abstr vars body)
 
 //these are the external facing functions for building quantifiers
-let mkForall r (pats, vars, body) =
+let mkForall (r:Range.t) (pats, vars, body) =
     mkQuant' r (Forall, pats, None, vars, body)
-let mkForall'' r (pats, wopt, sorts, body) =
+let mkForall'' (r:Range.t) (pats, wopt, sorts, body) =
     mkQuant r true (Forall, pats, wopt, sorts, body)
-let mkForall' r (pats, wopt, vars, body) =
+let mkForall' (r:Range.t) (pats, wopt, vars, body) =
     mkQuant' r (Forall, pats, wopt, vars, body)
-let mkExists r (pats, vars, body) =
+let mkExists (r:Range.t) (pats, vars, body) =
     mkQuant' r (Exists, pats, None, vars, body)
 let mkForallFlat (vars, body) =
-    match body.tm with
-    | Quant(Forall, pats, wopt, sorts, body') ->
-      let closing = vars @ List.map (fun s -> FV ("ignore", s, true)) sorts in
-      mkQuant body.rng true (Forall,
+    match body with
+    | Quant Forall pats wopt sorts body' r ->
+      let closing = vars @ List.map (fun s -> FV "ignore" s true) sorts in
+      mkQuant r true (Forall,
                              pats |> List.map (List.map (abstr closing)),
                              wopt,
                              List.map fv_sort vars@sorts,
                              abstr closing body')
-    | _ -> mkForall body.rng ([], vars, body)
-let mkLet' (bindings, body) r =
+    | _ -> mkForall (range_of_term body) ([], vars, body)
+let mkLet' (bindings, body) =
   let vars, es = List.split bindings in
-  mkLet (es, abstr vars body) r
+  mkLet (es, abstr vars body)
 
 let norng = Range.dummyRange
-let mkDefineFun (nm, vars, s, tm, c) = DefineFun(nm, List.map fv_sort vars, s, abstr vars tm, c)
+let mkDefineFun (nm, vars, s, tm, c) = DefineFun nm (List.map fv_sort vars) s (abstr vars tm) c
 let constr_id_of_sort sort = Format.fmt1 "%s_constr_id" (strSort sort)
 let fresh_token (tok, univ_fvs, sort) id =
     let tok_name =
-      match tok.tm with
-      | App(Var name, _) -> name
+      match tok with
+      | App (Var name) _ _ -> name
       | _ -> failwith "Unexpected fresh token"
     in
     let a_name = "fresh_token_" ^tok_name in
-    let tm = mkEq(mkInteger' id norng,
+    let tm = mkEq(mkInteger' id,
                                   mkApp(constr_id_of_sort sort,
-                                        [mkApp (tok_name, List.map (fun f -> mkFreeV f norng) univ_fvs) norng]) norng) norng in
+                                        [mkApp (tok_name, List.map (fun f -> mkFreeV f) univ_fvs)])) in
     let tm = mkForall norng ([[tok]], univ_fvs, tm) in
     let a = {assumption_name=escape a_name;
              assumption_caption=Some "fresh token";
@@ -656,12 +657,12 @@ let fresh_token (tok, univ_fvs, sort) id =
 
 let fresh_constructor rng (name, arg_sorts, sort, id) =
   let id = show id in
-  let bvars = arg_sorts |> List.mapi (fun i s -> mkFreeV(mk_fv ("x_" ^ show i, s)) norng) in
+  let bvars = arg_sorts |> List.mapi (fun i s -> mkFreeV(mk_fv ("x_" ^ show i, s))) in
   let bvar_names = List.map fv_of_term bvars in
-  let capp = mkApp(name, bvars) norng in
-  let cid_app = mkApp(constr_id_of_sort sort, [capp]) norng in
+  let capp = mkApp(name, bvars) in
+  let cid_app = mkApp(constr_id_of_sort sort, [capp]) in
   let a_name = "constructor_distinct_" ^name in
-  let tm = mkForall rng ([[capp]], bvar_names, mkEq(mkInteger id norng, cid_app) norng) in
+  let tm = mkForall rng ([[capp]], bvar_names, mkEq(mkInteger id, cid_app)) in
   let a = {
     assumption_name=escape a_name;
     assumption_caption=Some "Constructor distinct";
@@ -679,16 +680,16 @@ let injective_constructor
     let bvar_name i = "x_" ^ show i in
     let bvar_index i = n_bvars - (i + 1) in
     let bvar i s = mkFreeV <| mk_fv (bvar_name i, s) in
-    let bvars = fields |> List.mapi (fun i f -> bvar i f.field_sort norng) in
+    let bvars = fields |> List.mapi (fun i f -> bvar i f.field_sort) in
     let bvar_names = List.map fv_of_term bvars in
-    let capp = mkApp(name, bvars) norng in
+    let capp = mkApp(name, bvars) in
     fields
     |> List.mapi (fun i {field_projectible=projectible; field_name=name; field_sort=s} ->
             if projectible
             then
-              let cproj_app = mkApp(name, [capp]) norng in
-              let proj_name = DeclFun(name, [sort], s, Some "Projector") in
-              let tm = mkForall rng ([[capp]], bvar_names, mkEq(cproj_app, bvar i s norng) norng) in
+              let cproj_app = mkApp(name, [capp]) in
+              let proj_name = DeclFun name [sort] s (Some "Projector") in
+              let tm = mkForall rng ([[capp]], bvar_names, mkEq(cproj_app, bvar i s)) in
               let a = {
                     assumption_name = escape ("projection_inverse_"^name);
                     assumption_caption = Some "Projection inverse";
@@ -705,7 +706,7 @@ let discriminator_name constr = "is-"^constr.constr_name
 let constructor_to_decl rng constr =
     let sort = constr.constr_sort in
     let field_sorts = constr.constr_fields |> List.map (fun f -> f.field_sort) in
-    let cdecl = DeclFun(constr.constr_name, field_sorts, constr.constr_sort, Some "Constructor") in
+    let cdecl = DeclFun constr.constr_name field_sorts constr.constr_sort (Some "Constructor") in
     let cid = 
       match constr.constr_id with
       | None -> []
@@ -714,17 +715,17 @@ let constructor_to_decl rng constr =
     let disc =
         let disc_name = discriminator_name constr in
         let xfv = mk_fv ("x", sort) in
-        let xx = mkFreeV xfv norng in
+        let xx = mkFreeV xfv in
         let proj_terms, ex_vars =
             constr.constr_fields
          |> List.mapi (fun i {field_projectible=projectible; field_sort=s; field_name=proj} ->
                 if projectible
-                then mkApp(proj, [xx]) norng, []
+                then mkApp(proj, [xx]), []
                 else let fi = mk_fv ("f_" ^ show i, s) in
-                     mkFreeV fi norng, [fi])
+                     mkFreeV fi, [fi])
          |> List.split in
         let ex_vars = List.flatten ex_vars in
-        let disc_inv_body = mkEq(xx, mkApp(constr.constr_name, proj_terms) norng) norng in
+        let disc_inv_body = mkEq(xx, mkApp(constr.constr_name, proj_terms)) in
         let disc_inv_body = match ex_vars with
             | [] -> disc_inv_body
             | _ -> mkExists norng ([], ex_vars, disc_inv_body) in
@@ -732,8 +733,8 @@ let constructor_to_decl rng constr =
           match constr.constr_id with
           | None -> disc_inv_body
           | Some id ->
-            let disc_eq = mkEq(mkApp(constr_id_of_sort constr.constr_sort, [xx]) norng, mkInteger (show id) norng) norng in
-            mkAnd(disc_eq, disc_inv_body) norng in
+            let disc_eq = mkEq(mkApp(constr_id_of_sort constr.constr_sort, [xx]), mkInteger (show id)) in
+            mkAnd(disc_eq, disc_inv_body) in
         let def = mkDefineFun(disc_name, [xfv], Bool_sort,
                     disc_ax,
                     Some "Discriminator definition") in
@@ -749,14 +750,14 @@ let constructor_to_decl rng constr =
           |> List.map (fun f -> f.field_sort)
         in
         let base_name = constr.constr_name ^ "@base" in
-        let decl = DeclFun(base_name, arg_sorts, Term_sort, Some "Constructor base") in
+        let decl = DeclFun base_name arg_sorts Term_sort (Some "Constructor base") in
         let formals = List.mapi (fun i f -> mk_fv ("x" ^ show i, f.field_sort)) constr.constr_fields in
-        let constructed_term = mkApp(constr.constr_name, List.map (fun fv -> mkFreeV fv norng) formals) norng in
+        let constructed_term = mkApp(constr.constr_name, List.map (fun fv -> mkFreeV fv) formals) in
         let inj_formals = List.flatten <| List.map2 (fun f fld -> if fld.field_projectible then [f] else []) formals constr.constr_fields in
-        let base_term = mkApp(base_name, List.map (fun fv -> mkFreeV fv norng) inj_formals) norng in
-        let eq = mkEq(constructed_term, base_term) norng in
-        let guard = mkApp(discriminator_name constr, [constructed_term]) norng in
-        let q = mkForall rng ([[constructed_term]], formals, mkImp (guard, eq) norng) in
+        let base_term = mkApp(base_name, List.map (fun fv -> mkFreeV fv) inj_formals) in
+        let eq = mkEq(constructed_term, base_term) in
+        let guard = mkApp(discriminator_name constr, [constructed_term]) in
+        let q = mkForall rng ([[constructed_term]], formals, mkImp (guard, eq)) in
         //forall (x0...xn:Term). {:pattern (C x0 ...xn)} is-C (C x0..xn) ==> C x0..xn == C-base x2 x3..xn
         let a = {
           assumption_name=escape ("constructor_base_" ^ constr.constr_name);
@@ -816,14 +817,14 @@ let termToSmt
       let remove_guard_free pats =
         pats |> List.map (fun ps ->
           ps |> List.map (fun tm ->
-            match tm.tm with
-            | App(Var "Prims.guard_free", [{tm=BoundV _}]) -> tm
-            | App(Var "Prims.guard_free", [p]) -> p
+            match tm with
+            | App (Var "Prims.guard_free") [(BoundV _)] _ -> tm
+            | App (Var "Prims.guard_free") [p] _ -> p
             | _ -> tm))
       in
       let rec aux' depth n (names:list fv) t : ML document =
         let aux = aux (depth + 1) in
-        match t.tm with
+        match t with
         | Integer i -> doc_of_string i
         | Real r -> doc_of_string r
         | String s ->
@@ -839,10 +840,10 @@ let termToSmt
           List.nth names i |> fv_name |> doc_of_string
         | FreeV x when fv_force x -> form (fv_name x) [doc_of_string "Dummy_value"] //force a thunked name
         | FreeV x -> doc_of_string (fv_name x)
-        | App(op, []) -> doc_of_string (op_to_string op)
-        | App(op, tms) -> form (op_to_string op) (List.map (aux n names) tms)
-        | Labeled(t, _, _) -> aux n names t
-        | Quant(qop, pats, wopt, sorts, body) ->
+        | App op [] _ -> doc_of_string (op_to_string op)
+        | App op tms _ -> form (op_to_string op) (List.map (aux n names) tms)
+        | Labeled t _ _ -> aux n names t
+        | Quant qop pats wopt sorts body _ ->
           let qid = next_qid () in
           let names, binders, n = name_binders_inner None names n sorts in
           let pats = remove_guard_free pats in
@@ -855,7 +856,7 @@ let termToSmt
           binder (qop_to_string qop) (form_core binders)
             [mk_tag (aux n names body) (weightToSmt wopt @ pats_str @ [mk_qid qid])]
 
-        | Let (es, body) ->
+        | Let es body ->
           (* binders are reversed but according to the smt2 standard *)
           (* substitution should occur in parallel and order should not matter *)
           let names, binders, n =
@@ -870,13 +871,7 @@ let termToSmt
           binder "let" (form_core binders) [aux n names body]
 
       and aux depth n names t : ML document =
-        let s = aux' depth n names t in
-        if print_ranges && t.rng <> norng
-        then
-          doc_of_string ";; def=" ^^ doc_of_string (Range.string_of_range t.rng) ^^
-          doc_of_string "; use=" ^^ doc_of_string (Range.string_of_use_range t.rng) ^^ hardline ^^
-          s
-        else s
+        aux' depth n names t
       in
       aux 0 0 [] t
 
@@ -890,7 +885,7 @@ let rec declToSmt' (print_captions:bool) (z3options:string) (decl:decl) : ML doc
   match decl with
   | DefPrelude ->
     doc_of_string (mkPrelude z3options)
-  | Module (s, decls) ->
+  | Module s decls ->
     let res = separate_map hardline (declToSmt' print_captions z3options) decls in
     if Options.keep_query_captions()
     then
@@ -903,16 +898,16 @@ let rec declToSmt' (print_captions:bool) (z3options:string) (decl:decl) : ML doc
     if print_captions
     then (BU.splitlines c |> separate_map hardline (fun s -> doc_of_string ("; " ^ s)))
     else FStarC.Pprint.empty
-  | DeclFun(f,argsorts,retsort,c) ->
+  | DeclFun f argsorts retsort c ->
     with_caption c <|
       form "declare-fun" [
         doc_of_string f;
         form_core (List.map docSort argsorts);
         docSort retsort;
       ]
-  | DefineFun(f,arg_sorts,retsort,body,c) ->
+  | DefineFun f arg_sorts retsort body c ->
     let names, binders = name_macro_binders arg_sorts in
-    let body = inst (List.map (fun x -> mkFreeV x norng) names) body in
+    let body = inst (List.map (fun x -> mkFreeV x) names) body in
     with_caption c <|
       form_core [
         group (nest 1 (separate (break_ 1) [
@@ -952,7 +947,7 @@ let rec declToSmt' (print_captions:bool) (z3options:string) (decl:decl) : ML doc
   | EmptyLine -> FStarC.Pprint.empty
   | Push n -> doc_of_string "(push) ;; push{" ^^ doc_of_string (show n)
   | Pop n -> doc_of_string "(pop) ;; " ^^ doc_of_string (show n) ^^ doc_of_string "}pop"
-  | SetOption (s, v) ->
+  | SetOption s v ->
     form "set-option" [
       doc_of_string (":" ^ s);
       doc_of_string v;
@@ -1127,23 +1122,23 @@ let __range_c = mk_ref 0
 let mk_Range_const () =
     let i = !__range_c in
     __range_c := !__range_c + 1;
-    mkApp("Range_const", [mkInteger' i norng]) norng
+    mkApp("Range_const", [mkInteger' i])
 
 let univ_sort           = Sort "Universe"
-let mk_U_zero           = mkApp("U_zero", []) norng
-let mk_U_succ u         = mkApp("U_succ", [u]) norng
-let mk_U_max t0 t1      = mkApp("U_max", [t0;t1]) norng
-let mk_U_name s         = mkFreeV (mk_fv (s, univ_sort)) norng
-let mk_U_unif i         = mkApp("U_unif", [i]) norng
-let mk_U_unknown        = mkApp("U_unknown", []) norng
-let mk_Term_type u      = mkApp("Tm_type", [u]) norng
-let mk_Term_app t1 t2 r = mkApp("Tm_app", [t1;t2]) r
-let mk_Term_uvar i    r = mkApp("Tm_uvar", [mkInteger' i norng]) r
-let mk_Term_unit        = mkApp("Tm_unit", []) norng
+let mk_U_zero           = mkApp("U_zero", [])
+let mk_U_succ u         = mkApp("U_succ", [u])
+let mk_U_max t0 t1      = mkApp("U_max", [t0;t1])
+let mk_U_name s         = mkFreeV (mk_fv (s, univ_sort))
+let mk_U_unif i         = mkApp("U_unif", [i])
+let mk_U_unknown        = mkApp("U_unknown", [])
+let mk_Term_type u      = mkApp("Tm_type", [u])
+let mk_Term_app t1 t2 = mkApp("Tm_app", [t1;t2])
+let mk_Term_uvar i = mkApp("Tm_uvar", [mkInteger' i])
+let mk_Term_unit        = mkApp("Tm_unit", [])
 let elim_box cond u v t =
-    match t.tm with
-    | App(Var v', [t]) when v=v' && cond -> t
-    | _ -> mkApp(u, [t]) t.rng
+    match t with
+    | App (Var v') [t] _ when v=v' && cond -> t
+    | _ -> mkApp(u, [t])
 let maybe_elim_box u v t =
     elim_box (Options.smtencoding_elim_box()) u v t
 let boxInt t      = maybe_elim_box (fst boxIntFun) (snd boxIntFun) t
@@ -1174,65 +1169,66 @@ let unboxTerm sort t = match sort with
   | _ -> raise BU.Impos
 
 let getBoxedInteger (t:term) =
-  match t.tm with
-  | App(Var s, [t2]) when s = fst boxIntFun ->
+  match t with
+  | App (Var s) [t2] _ when s = fst boxIntFun ->
     begin
-    match t2.tm with
+    match t2 with
     | Integer n -> Some (BU.int_of_string n)
     | _ -> None
     end
   | _ -> None
 
-let mk_PreType t      = mkApp("PreType", [t]) t.rng
-let mk_Valid t        = match t.tm with
-    | App(Var "Prims.b2t", [{tm=App(Var "Prims.op_Equality", [_; t1; t2])}]) -> mkEq (t1, t2) t.rng
-    | App(Var "Prims.b2t", [{tm=App(Var "Prims.op_disEquality", [_; t1; t2])}]) -> mkNot (mkEq (t1, t2) norng) t.rng
-    | App(Var "Prims.b2t", [{tm=App(Var "Prims.op_LessThanOrEqual", [t1; t2])}]) -> mkLTE (unboxInt t1, unboxInt t2) t.rng
-    | App(Var "Prims.b2t", [{tm=App(Var "Prims.op_LessThan", [t1; t2])}]) -> mkLT (unboxInt t1, unboxInt t2) t.rng
-    | App(Var "Prims.b2t", [{tm=App(Var "Prims.op_GreaterThanOrEqual", [t1; t2])}]) -> mkGTE (unboxInt t1, unboxInt t2) t.rng
-    | App(Var "Prims.b2t", [{tm=App(Var "Prims.op_GreaterThan", [t1; t2])}]) -> mkGT (unboxInt t1, unboxInt t2) t.rng
-    | App(Var "Prims.b2t", [{tm=App(Var "Prims.op_AmpAmp", [t1; t2])}]) -> mkAnd (unboxBool t1, unboxBool t2) t.rng
-    | App(Var "Prims.b2t", [{tm=App(Var "Prims.op_BarBar", [t1; t2])}]) -> mkOr (unboxBool t1, unboxBool t2) t.rng
-    | App(Var "Prims.b2t", [{tm=App(Var "Prims.op_Negation", [t])}]) -> mkNot (unboxBool t) t.rng
-    | App(Var "Prims.b2t", [{tm=App(Var "FStar.BV.bvult", [t0; t1;t2])}])
-    | App(Var "Prims.equals", [_; {tm=App(Var "FStar.BV.bvult", [t0; t1;t2])}; _])
+let rng_of t t' = set_range t' (range_of_term t)
+let mk_PreType t      = rng_of t (mkApp("PreType", [t]))
+let mk_Valid t        = match t with
+    | App (Var "Prims.b2t") [(App (Var "Prims.op_Equality") [_; t1; t2] _)] _ -> rng_of t (mkEq (t1, t2))
+    | App (Var "Prims.b2t") [(App (Var "Prims.op_disEquality") [_; t1; t2] _)] _ -> rng_of t (mkNot (mkEq (t1, t2)))
+    | App (Var "Prims.b2t") [(App (Var "Prims.op_LessThanOrEqual") [t1; t2] _)] _ -> rng_of t (mkLTE (unboxInt t1, unboxInt t2))
+    | App (Var "Prims.b2t") [(App (Var "Prims.op_LessThan") [t1; t2] _)] _ -> rng_of t (mkLT (unboxInt t1, unboxInt t2))
+    | App (Var "Prims.b2t") [(App (Var "Prims.op_GreaterThanOrEqual") [t1; t2] _)] _ -> rng_of t (mkGTE (unboxInt t1, unboxInt t2))
+    | App (Var "Prims.b2t") [(App (Var "Prims.op_GreaterThan") [t1; t2] _)] _ -> rng_of t (mkGT (unboxInt t1, unboxInt t2))
+    | App (Var "Prims.b2t") [(App (Var "Prims.op_AmpAmp") [t1; t2] _)] _ -> rng_of t (mkAnd (unboxBool t1, unboxBool t2))
+    | App (Var "Prims.b2t") [(App (Var "Prims.op_BarBar") [t1; t2] _)] _ -> rng_of t (mkOr (unboxBool t1, unboxBool t2))
+    | App (Var "Prims.b2t") [(App (Var "Prims.op_Negation") [t] _)] _ -> rng_of t (mkNot (unboxBool t))
+    | App (Var "Prims.b2t") [(App (Var "FStar.BV.bvult") [t0; t1;t2] _)] _
+    | App (Var "Prims.equals") [_; (App (Var "FStar.BV.bvult") [t0; t1;t2] _); _] _
             when (Some? (getBoxedInteger t0))->
         // sometimes b2t gets needlessly normalized...
         let sz = match getBoxedInteger t0 with | Some sz -> sz | _ -> failwith "impossible" in
-        mkBvUlt (unboxBitVec sz t1, unboxBitVec sz t2) t.rng
-    | App(Var "Prims.b2t", [t1]) -> {unboxBool t1 with rng=t.rng}
+        rng_of t (mkBvUlt (unboxBitVec sz t1, unboxBitVec sz t2))
+    | App (Var "Prims.b2t") [t1] _ -> rng_of t (unboxBool t1)
     | _ ->
-        mkApp("Valid",  [t]) t.rng
-let mk_unit_type = mkApp("Prims.unit", []) norng
-let mk_HasType v t    = mkApp("HasType", [v;t]) t.rng
-let mk_HasTypeZ v t   = mkApp("HasTypeZ", [v;t]) t.rng
-let mk_IsTotFun t     = mkApp("IsTotFun", [t]) t.rng
+        rng_of t (mkApp("Valid",  [t]))
+let mk_unit_type = mkApp("Prims.unit", [])
+let mk_HasType v t    = rng_of t (mkApp("HasType", [v;t]))
+let mk_HasTypeZ v t   = rng_of t (mkApp("HasTypeZ", [v;t]))
+let mk_IsTotFun t     = rng_of t (mkApp("IsTotFun", [t]))
 let mk_HasTypeFuel f v t =
    if Options.unthrottle_inductives()
    then mk_HasType v t
-   else mkApp("HasTypeFuel", [f;v;t]) t.rng
+   else rng_of t (mkApp("HasTypeFuel", [f;v;t]))
 let mk_HasTypeWithFuel f v t = match f with
     | None -> mk_HasType v t
     | Some f -> mk_HasTypeFuel f v t
-let mk_NoHoist dummy b = mkApp("NoHoist", [dummy;b]) b.rng
-let mk_tester n t     = mkApp("is-"^n,   [t]) t.rng
-let mk_ApplyTF t t'   = mkApp("ApplyTF", [t;t']) t.rng
-let mk_ApplyTT t t'  r  = mkApp("ApplyTT", [t;t']) r
-let mk_String_const s r = mkApp ("FString_const", [mk (String s) r]) r
-let mk_Precedes_term u0 u1 x1 x2 x3 x4 r = mkApp("Prims.precedes", [u0;u1;x1;x2;x3;x4]) r
-let mk_Precedes u0 u1 x1 x2 x3 x4 r = mk_Valid (mk_Precedes_term u0 u1 x1 x2 x3 x4 r)
-let mk_lex_t r = mkApp("Prims.lex_t", []) r
-let mk_LexCons x1 x2 x3 r  = mkApp("LexCons", [x1;x2;x3]) r
-let mk_LexTop r  = mkApp("LexTop", []) r
+let mk_NoHoist dummy b = rng_of b (mkApp("NoHoist", [dummy;b]))
+let mk_tester n t     = rng_of t (mkApp("is-"^n,   [t]))
+let mk_ApplyTF t t'   = rng_of t (mkApp("ApplyTF", [t;t']))
+let mk_ApplyTT t t'  = rng_of t (mkApp("ApplyTT", [t;t']))
+let mk_String_const s = mkApp ("FString_const", [String s])
+let mk_Precedes_term u0 u1 x1 x2 x3 x4 = mkApp("Prims.precedes", [u0;u1;x1;x2;x3;x4])
+let mk_Precedes u0 u1 x1 x2 x3 x4 = mk_Valid (mk_Precedes_term u0 u1 x1 x2 x3 x4)
+let mk_lex_t = mkApp("Prims.lex_t", [])
+let mk_LexCons x1 x2 x3 = mkApp("LexCons", [x1;x2;x3])
+let mk_LexTop = mkApp("LexTop", [])
 let rec n_fuel n =
-    if n = 0 then mkApp("ZFuel", []) norng
-    else mkApp("SFuel", [n_fuel (n - 1)]) norng
+    if n = 0 then mkApp("ZFuel", [])
+    else mkApp("SFuel", [n_fuel (n - 1)])
 
-let mk_and_l l r = List.fold_right (fun p1 p2 -> mkAnd(p1, p2) r) l (mkTrue r)
+let mk_and_l l = List.fold_right (fun p1 p2 -> mkAnd(p1, p2)) l mkTrue
 
-let mk_or_l l r = List.fold_right (fun p1 p2 -> mkOr(p1,p2) r) l (mkFalse r)
+let mk_or_l l = List.fold_right (fun p1 p2 -> mkOr(p1,p2)) l mkFalse
 
-let mk_haseq u t = mk_Valid (mkApp ("Prims.hasEq", [u; t]) t.rng)
+let mk_haseq u t = mk_Valid (rng_of t (mkApp ("Prims.hasEq", [u; t])))
 let dummy_sort = Sort "Dummy_sort"
 
 instance showable_sort : showable sort = {
@@ -1240,7 +1236,7 @@ instance showable_sort : showable sort = {
 }
 
 instance showable_fv : showable fv = {
-  show = fun (FV (n, _, _)) -> n
+  show = fun (FV n _ _) -> n
 }
 
 instance showable_smt_term = {
@@ -1258,17 +1254,17 @@ instance showable_decls_elt = {
 let rec names_of_decl d =
   match d with
   | Assume a -> [a.assumption_name]
-  | Module (_, ds) -> List.collect names_of_decl ds
+  | Module _ ds -> List.collect names_of_decl ds
   | _ -> []
 
 let decl_to_string_short d =
   match d with
   | DefPrelude -> "prelude"
-  | DeclFun (s, _, _, _) -> "DeclFun " ^ s
-  | DefineFun (s, _, _, _, _) -> "DefineFun " ^ s
+  | DeclFun s _ _ _ -> "DeclFun " ^ s
+  | DefineFun s _ _ _ _ -> "DefineFun " ^ s
   | Assume a -> "Assumption " ^ a.assumption_name
   | Caption s -> "Caption " ^s
-  | Module (s, _) -> "Module " ^ s
+  | Module s _ -> "Module " ^ s
   | Eval _ -> "Eval"
   | Echo s -> "Echo " ^ s
   | RetainAssumptions _ -> "RetainAssumptions"
@@ -1277,6 +1273,6 @@ let decl_to_string_short d =
   | CheckSat -> "check-sat"
   | GetUnsatCore -> "get-unsat-core"
   | EmptyLine -> "; empty line"
-  | SetOption (s, v) -> "SetOption " ^ s ^ " " ^ v
+  | SetOption s v -> "SetOption " ^ s ^ " " ^ v
   | GetStatistics -> "get-statistics"
   | GetReasonUnknown -> "get-reason-unknown"

--- a/src/smtencoding/FStarC.SMTEncoding.Term.fst
+++ b/src/smtencoding/FStarC.SMTEncoding.Term.fst
@@ -1199,6 +1199,19 @@ let mk_Valid t        = match t with
     | App (Var "Prims.b2t") [t1] _ -> rng_of t (unboxBool t1)
     | _ ->
         rng_of t (mkApp("Valid",  [t]))
+
+(* [mk_Valid t] with the range [r] attached to the *result*.  Only [App] and
+   [Quant] nodes carry a range, so setting the range on [t] itself is a no-op
+   when [t] is e.g. a [FreeV]; the range would then be lost and, with it, the
+   "See also <definition site>" secondary location of an SMT error. *)
+let mk_valid_at (r:Range.t) (t:term) : ML term =
+    let r =
+      if Range.rng_included (Range.use_range (range_of_term t)) (Range.use_range r)
+      then range_of_term t
+      else r
+    in
+    set_range (mk_Valid (set_range t r)) r
+
 let mk_unit_type = mkApp("Prims.unit", [])
 let mk_HasType v t    = rng_of t (mkApp("HasType", [v;t]))
 let mk_HasTypeZ v t   = rng_of t (mkApp("HasTypeZ", [v;t]))

--- a/src/smtencoding/FStarC.SMTEncoding.Term.fsti
+++ b/src/smtencoding/FStarC.SMTEncoding.Term.fsti
@@ -80,19 +80,28 @@ type qop =
   | Forall
   | Exists
 
-type term' =
-  | Integer    of string
-  | String     of string
-  | Real       of string
-  | BoundV     of int
-  | FreeV      of fv
-  | App        of op  & list term
-  | Quant      of qop & list (list pat) & option int & list sort & term
-  | Let        of list term & term
-  | Labeled    of term & Errors.error_message & Range.t
+(* NOTE: the constructors below are deliberately declared in curried form
+   (`C : a -> b -> t`) rather than with a single tuple argument
+   (`C of a & b`). F* extracts the latter to an OCaml constructor holding a
+   *boxed tuple*, costing an extra header and indirection per node. SMT terms
+   are by far the largest thing stored in .checked files, so this matters. *)
+type term =
+  | Integer    : string -> term
+  | String     : string -> term
+  | Real       : string -> term
+  | BoundV     : int -> term
+  | FreeV      : fv -> term
+  (* App and Quant carry a range: it is the only source of position
+     information for SMT goals, used by ErrorReporting to attach source
+     locations to labels. It is Range.dummyRange for all but the
+     formula-level nodes built by EncodeTerm.encode_formula. *)
+  | App        : op -> list term -> Range.t -> term
+  | Quant      : qop -> list (list pat) -> option int -> list sort -> term -> Range.t -> term
+  | Let        : list term -> term -> term
+  | Labeled    : term -> Errors.error_message -> Range.t -> term
 and pat  = term
-and term = {tm:term'; freevars:S.memo fvs; rng:Range.t}
-and fv = | FV of string & sort & bool (* bool iff variable must be forced/unthunked *)
+(* bool iff variable must be forced/unthunked *)
+and fv = | FV : string -> sort -> bool -> fv
 and fvs = list fv
 
 type caption = option string
@@ -125,19 +134,19 @@ type assumption = {
 }
 type decl =
   | DefPrelude
-  | DeclFun    of string & list sort & sort & caption
-  | DefineFun  of string & list sort & sort & term & caption
-  | Assume     of assumption
-  | Caption    of string
-  | Module     of string & list decl
-  | Eval       of term
-  | Echo       of string
-  | RetainAssumptions of list string
-  | Push       of int
-  | Pop        of int
+  | DeclFun    : string -> list sort -> sort -> caption -> decl
+  | DefineFun  : string -> list sort -> sort -> term -> caption -> decl
+  | Assume     : assumption -> decl
+  | Caption    : string -> decl
+  | Module     : string -> list decl -> decl
+  | Eval       : term -> decl
+  | Echo       : string -> decl
+  | RetainAssumptions : list string -> decl
+  | Push       : int -> decl
+  | Pop        : int -> decl
   | CheckSat
   | GetUnsatCore
-  | SetOption  of string & string
+  | SetOption  : string -> string -> decl
   | GetStatistics
   | GetReasonUnknown
   | EmptyLine
@@ -153,7 +162,8 @@ type decl =
  *       duplicate such blocks
  *
  *     Deduplication happens when giving the decls to Z3
- *       at which point, if the key below -- which is the MD5 string --
+ *       at which point, if the key below -- the MD5 digest of the
+ *       s-expression rendering of the term (see hash_of_term) --
  *       matches, the whole block is dropped (see Encode.fs.recover_caching_and_update_env)
  *
  *     Alternative way would have been to do some smt name matching
@@ -211,66 +221,71 @@ val boxIntFun : string & string
 val boxBoolFun : string & string
 val boxStringFun : string & string
 val boxRealFun: string & string
-val mk: term' -> Range.t -> ML term
-val mkTrue :  (Range.t -> ML term)
-val mkFalse : (Range.t -> ML term)
+val mkTrue :  term
+val mkFalse : term
 val mkUnreachable : term
-val mkInteger : string -> Range.t -> ML term
-val mkInteger': int -> Range.t -> ML term
-val mkReal: string -> Range.t -> ML term
-val mkBoundV : int -> Range.t -> ML term
-val mkFreeV  : fv -> Range.t -> ML term
-val mkApp' : (op & list term) -> Range.t -> ML term
-val mkApp  : (string & list term) -> Range.t -> ML term
-val mkNot  : term -> Range.t -> ML term
-val mkAnd  : ((term & term) -> Range.t -> ML term)
-val mkOr  :  ((term & term) -> Range.t -> ML term)
-val mkImp :  ((term & term) -> Range.t -> ML term)
-val mkMinus: term -> Range.t -> ML term
-val mkNatToBv : (int -> term -> Range.t -> ML term)
-val mkBvUext  : (int -> term -> Range.t -> ML term)
-val mkBvNot   : (term -> Range.t -> ML term)
-val mkBvToNat : (term -> Range.t -> ML term)
-val mkBvAnd   : ((term & term) -> Range.t -> ML term)
-val mkBvXor   : ((term & term) -> Range.t -> ML term)
-val mkBvOr    : ((term & term) -> Range.t -> ML term)
-val mkBvAdd   : ((term & term) -> Range.t -> ML term)
-val mkBvSub   : ((term & term) -> Range.t -> ML term)
-val mkBvShl   : (int -> (term & term) -> Range.t -> ML term)
-val mkBvShr   : (int -> (term & term) -> Range.t -> ML term)
-val mkBvRol   : (int -> (term & term) -> Range.t -> ML term)
-val mkBvRor   : (int -> (term & term) -> Range.t -> ML term)
-val mkBvUdiv  : (int -> (term & term) -> Range.t -> ML term)
-val mkBvMod   : (int -> (term & term) -> Range.t -> ML term)
-val mkBvMul   : (int -> (term & term) -> Range.t -> ML term)
-val mkBvShl'  : (int -> (term & term) -> Range.t -> ML term)
-val mkBvShr'  : (int -> (term & term) -> Range.t -> ML term)
-val mkBvRol'  : (int -> (term & term) -> Range.t -> ML term)
-val mkBvRor'  : (int -> (term & term) -> Range.t -> ML term)
-val mkBvMul'  : (int -> (term & term) -> Range.t -> ML term)
-val mkBvUdivUnsafe : (int -> (term & term) -> Range.t -> ML term)
-val mkBvModUnsafe  : (int -> (term & term) -> Range.t -> ML term)
-val mkBvUlt   : ((term & term) -> Range.t -> ML term)
-val mkIff :  ((term & term) -> Range.t -> ML term)
-val mkEq :   ((term & term) -> Range.t -> ML term)
-val mkLT :   ((term & term) -> Range.t -> ML term)
-val mkLTE :  ((term & term) -> Range.t -> ML term)
-val mkGT:    ((term & term) -> Range.t -> ML term)
-val mkGTE:   ((term & term) -> Range.t -> ML term)
-val mkAdd:   ((term & term) -> Range.t -> ML term)
-val mkSub:   ((term & term) -> Range.t -> ML term)
-val mkDiv:   ((term & term) -> Range.t -> ML term)
-val mkRealDiv:   ((term & term) -> Range.t -> ML term)
-val mkMul:   ((term & term) -> Range.t -> ML term)
-val mkMod:   ((term & term) -> Range.t -> ML term)
-val mkRealOfInt: term -> Range.t -> ML term
-val mkITE: (term & term & term) -> Range.t -> ML term
-val mkCases : list term -> Range.t -> ML term
+val mkInteger : string -> ML term
+val mkInteger': int -> ML term
+val mkReal: string -> ML term
+val mkBoundV : int -> ML term
+val mkFreeV  : fv -> ML term
+val mkApp' : (op & list term) -> ML term
+val mkApp  : (string & list term) -> ML term
+
+(* The range of a term, if it carries one (App/Quant/Labeled), else
+   Range.dummyRange. Only formula-level nodes carry meaningful ranges. *)
+val range_of_term : term -> Range.t
+(* Set the range of an App or Quant node; a no-op on other nodes. *)
+val set_range : term -> Range.t -> term
+val mkNot  : term -> ML term
+val mkAnd  : ((term & term) -> ML term)
+val mkOr  :  ((term & term) -> ML term)
+val mkImp :  ((term & term) -> ML term)
+val mkMinus: term -> ML term
+val mkNatToBv : (int -> term -> ML term)
+val mkBvUext  : (int -> term -> ML term)
+val mkBvNot   : (term -> ML term)
+val mkBvToNat : (term -> ML term)
+val mkBvAnd   : ((term & term) -> ML term)
+val mkBvXor   : ((term & term) -> ML term)
+val mkBvOr    : ((term & term) -> ML term)
+val mkBvAdd   : ((term & term) -> ML term)
+val mkBvSub   : ((term & term) -> ML term)
+val mkBvShl   : (int -> (term & term) -> ML term)
+val mkBvShr   : (int -> (term & term) -> ML term)
+val mkBvRol   : (int -> (term & term) -> ML term)
+val mkBvRor   : (int -> (term & term) -> ML term)
+val mkBvUdiv  : (int -> (term & term) -> ML term)
+val mkBvMod   : (int -> (term & term) -> ML term)
+val mkBvMul   : (int -> (term & term) -> ML term)
+val mkBvShl'  : (int -> (term & term) -> ML term)
+val mkBvShr'  : (int -> (term & term) -> ML term)
+val mkBvRol'  : (int -> (term & term) -> ML term)
+val mkBvRor'  : (int -> (term & term) -> ML term)
+val mkBvMul'  : (int -> (term & term) -> ML term)
+val mkBvUdivUnsafe : (int -> (term & term) -> ML term)
+val mkBvModUnsafe  : (int -> (term & term) -> ML term)
+val mkBvUlt   : ((term & term) -> ML term)
+val mkIff :  ((term & term) -> ML term)
+val mkEq :   ((term & term) -> ML term)
+val mkLT :   ((term & term) -> ML term)
+val mkLTE :  ((term & term) -> ML term)
+val mkGT:    ((term & term) -> ML term)
+val mkGTE:   ((term & term) -> ML term)
+val mkAdd:   ((term & term) -> ML term)
+val mkSub:   ((term & term) -> ML term)
+val mkDiv:   ((term & term) -> ML term)
+val mkRealDiv:   ((term & term) -> ML term)
+val mkMul:   ((term & term) -> ML term)
+val mkMod:   ((term & term) -> ML term)
+val mkRealOfInt: term -> ML term
+val mkITE: (term & term & term) -> ML term
+val mkCases : list term -> ML term
 val check_pattern_ok: term -> option term
 val print_smt_term: term -> ML string
 val print_smt_term_list: list term -> ML string
 val print_smt_term_list_list: list (list term) -> ML string
-val mkLet: (list term & term) -> Range.t -> ML term
+val mkLet: (list term & term) -> ML term
 val abstr: list fv -> term -> ML term
 val inst: list term -> term -> ML term
 val subst: term -> fv -> term -> ML term
@@ -279,7 +294,7 @@ val mkForall'': Range.t -> (list (list pat) & option int & list sort & term) -> 
 val mkForall': Range.t -> (list (list pat) & option int & fvs & term)  -> ML term
 val mkExists: Range.t -> (list (list pat) & fvs & term) -> ML term
 val mkForallFlat:  (fvs & term) -> ML term
-val mkLet': (list (fv & term) & term) -> Range.t -> ML term
+val mkLet': (list (fv & term) & term) -> ML term
 val fresh_token: (term & fvs & sort) -> int -> ML decl
 val fresh_constructor : Range.t -> (string & list sort & sort & int) -> ML decl
 //val constructor_to_decl_aux: bool -> constructor_t -> decls_t
@@ -298,8 +313,8 @@ val mk_U_name:       string -> ML term
 val mk_U_unif:       term -> ML term
 val mk_U_unknown:    term
 val mk_Term_type:    term -> ML term
-val mk_Term_app : term -> term -> Range.t -> ML term
-val mk_Term_uvar: int -> Range.t -> ML term
+val mk_Term_app : term -> term -> ML term
+val mk_Term_uvar: int -> ML term
 val mk_Term_unit:    term
 
 val boxInt:      term -> ML term
@@ -323,16 +338,16 @@ val mk_HasTypeWithFuel: option term -> term -> term -> ML term
 val mk_NoHoist:      term -> term -> ML term
 val mk_tester:       string -> term -> ML term
 val mk_ApplyTF:      term -> term -> ML term
-val mk_ApplyTT:      term -> term -> Range.t -> ML term
-val mk_String_const: string -> Range.t -> ML term
-val mk_Precedes_term:term -> term -> term -> term -> term -> term -> Range.t -> ML term
-val mk_Precedes:     term -> term -> term -> term -> term -> term -> Range.t -> ML term
-val mk_lex_t:        Range.t -> ML term
-val mk_LexCons:      term -> term -> term -> Range.t -> ML term
-val mk_LexTop:       Range.t -> ML term
+val mk_ApplyTT:      term -> term -> ML term
+val mk_String_const: string -> ML term
+val mk_Precedes_term:term -> term -> term -> term -> term -> term -> ML term
+val mk_Precedes:     term -> term -> term -> term -> term -> term -> ML term
+val mk_lex_t:        term
+val mk_LexCons:      term -> term -> term -> ML term
+val mk_LexTop:       term
 val n_fuel: int -> ML term
-val mk_and_l: list term -> Range.t -> ML term
-val mk_or_l: list term -> Range.t -> ML term
+val mk_and_l: list term -> ML term
+val mk_or_l: list term -> ML term
 val mk_haseq: univ:term -> term -> ML term
 val dummy_sort : sort
 

--- a/src/smtencoding/FStarC.SMTEncoding.Term.fsti
+++ b/src/smtencoding/FStarC.SMTEncoding.Term.fsti
@@ -330,6 +330,7 @@ val unboxBitVec: int -> term -> ML term
 
 val mk_PreType:      term -> ML term
 val mk_Valid:        term -> ML term
+val mk_valid_at:     Range.t -> term -> ML term
 val mk_HasType:      term -> term -> ML term
 val mk_HasTypeZ:     term -> term -> ML term
 val mk_IsTotFun:     term -> ML term

--- a/src/smtencoding/FStarC.SMTEncoding.UnsatCore.fst
+++ b/src/smtencoding/FStarC.SMTEncoding.UnsatCore.fst
@@ -34,9 +34,9 @@ let filter (core:unsat_core) (decls:list decl)
               else if BU.starts_with a.assumption_name "@"
               then d::keep, n_retained, n_pruned
               else keep, n_retained, n_pruned+1
-          | Module (name, decls) ->
+          | Module name decls ->
               let keep', n, m = aux decls in
-              Module(name, keep')::keep, n_retained + n, n_pruned + m
+              Module name keep'::keep, n_retained + n, n_pruned + m
           | _ -> d::keep, n_retained, n_pruned)
         ([Caption ("UNSAT CORE USED: " ^ (core |> String.concat ", "))],//start with the unsat core caption at the end
         0,

--- a/src/smtencoding/FStarC.SMTEncoding.Util.fst
+++ b/src/smtencoding/FStarC.SMTEncoding.Util.fst
@@ -22,6 +22,7 @@ open FStarC.Syntax.Syntax
 open FStarC.SMTEncoding.Term
 open FStarC.Ident
 
+module Term = FStarC.SMTEncoding.Term
 module S = FStarC.Syntax.Syntax
 module U = FStarC.Syntax.Util
 module SS = FStarC.Syntax.Subst
@@ -36,74 +37,67 @@ let mkAssume x : ML decl =
         assumption_fact_ids=[];
         assumption_free_names=free_top_level_names tm;
     })
-let norng f = fun x -> f x Range.dummyRange
-let norng2 f = fun x y -> f x y Range.dummyRange
-let norng3 f = fun x y z -> f x y z Range.dummyRange
-let norng4 f = fun x y z w -> f x y z w Range.dummyRange
-let _fv_empty : S.memo fvs = alloc None
-let mkTrue : term  = {tm=App(TrueOp, []); freevars=_fv_empty; rng=Range.dummyRange}
-let mkFalse : term = {tm=App(FalseOp, []); freevars=alloc None; rng=Range.dummyRange}
-let mkInteger  = norng mkInteger
-let mkInteger' = norng mkInteger'
-let mkReal     = norng mkReal
-let mkBoundV   = norng mkBoundV
-let mkFreeV    = norng mkFreeV
-let mkApp'     = norng mkApp'
-let mkApp      = norng mkApp
-let mkNot = norng mkNot
-let mkMinus = norng mkMinus
-let mkAnd = norng mkAnd
-let mkOr = norng mkOr
-let mkImp = norng mkImp
-let mkIff = norng mkIff
-let mkEq = norng mkEq
-let mkLT = norng mkLT
-let mkLTE = norng mkLTE
-let mkGT = norng mkGT
-let mkGTE = norng mkGTE
-let mkAdd = norng mkAdd
-let mkSub = norng mkSub
-let mkDiv = norng mkDiv
-let mkRealDiv = norng mkRealDiv
-let mkMul = norng mkMul
-let mkMod = norng mkMod
-
-let mkNatToBv sz = norng (mkNatToBv sz)
-let mkBvAnd = norng mkBvAnd
-let mkBvXor = norng mkBvXor
-let mkBvOr = norng mkBvOr
-let mkBvAdd = norng mkBvAdd
-let mkBvSub = norng mkBvSub
-let mkBvShl sz = norng (mkBvShl sz)
-let mkBvShr sz = norng (mkBvShr sz)
-let mkBvRol sz = norng (mkBvRol sz)
-let mkBvRor sz = norng (mkBvRor sz)
-let mkBvUdiv sz = norng (mkBvUdiv sz)
-let mkBvMod sz = norng (mkBvMod sz)
-let mkBvMul sz = norng (mkBvMul sz)
-let mkBvShl' sz = norng (mkBvShl' sz)
-let mkBvShr' sz = norng (mkBvShr' sz)
-let mkBvRol' sz = norng (mkBvRol' sz)
-let mkBvRor' sz = norng (mkBvRor' sz)
-let mkBvUdivUnsafe sz = norng (mkBvUdivUnsafe sz)
-let mkBvModUnsafe  sz = norng (mkBvModUnsafe sz)
-let mkBvMul' sz = norng (mkBvMul' sz)
-let mkBvUlt = norng mkBvUlt
-let mkBvUext sz = norng (mkBvUext sz)
-let mkBvNot = norng mkBvNot
-let mkBvToNat = norng mkBvToNat
-let mkITE = norng mkITE
-let mkCases = norng mkCases
-
-let mk_Term_app  = norng2 mk_Term_app
-let mk_and_l = norng mk_and_l
-let mk_or_l = norng mk_or_l
-let mk_ApplyTT = norng2 mk_ApplyTT
-let mk_String_const = norng mk_String_const
-let mk_Precedes u0 u1 = norng4 (mk_Precedes u0 u1)
-let mk_LexCons = norng3 mk_LexCons
-let mk_lex_t : term = {tm=App(Var "Prims.lex_t", []); freevars=alloc None; rng=Range.dummyRange}
-let mk_LexTop : term = {tm=App(Var "LexTop", []); freevars=alloc None; rng=Range.dummyRange}
+let mkTrue = Term.mkTrue
+let mkFalse = Term.mkFalse
+let mkInteger = Term.mkInteger
+let mkInteger' = Term.mkInteger'
+let mkReal = Term.mkReal
+let mkBoundV = Term.mkBoundV
+let mkFreeV = Term.mkFreeV
+let mkApp' = Term.mkApp'
+let mkApp = Term.mkApp
+let mkNot = Term.mkNot
+let mkMinus = Term.mkMinus
+let mkAnd = Term.mkAnd
+let mkOr = Term.mkOr
+let mkImp = Term.mkImp
+let mkIff = Term.mkIff
+let mkEq = Term.mkEq
+let mkLT = Term.mkLT
+let mkLTE = Term.mkLTE
+let mkGT = Term.mkGT
+let mkGTE = Term.mkGTE
+let mkAdd = Term.mkAdd
+let mkSub = Term.mkSub
+let mkDiv = Term.mkDiv
+let mkRealDiv = Term.mkRealDiv
+let mkMul = Term.mkMul
+let mkMod = Term.mkMod
+let mkNatToBv = Term.mkNatToBv
+let mkBvAnd = Term.mkBvAnd
+let mkBvXor = Term.mkBvXor
+let mkBvOr = Term.mkBvOr
+let mkBvAdd = Term.mkBvAdd
+let mkBvSub = Term.mkBvSub
+let mkBvShl = Term.mkBvShl
+let mkBvShr = Term.mkBvShr
+let mkBvRol = Term.mkBvRol
+let mkBvRor = Term.mkBvRor
+let mkBvUdiv = Term.mkBvUdiv
+let mkBvMod = Term.mkBvMod
+let mkBvMul = Term.mkBvMul
+let mkBvShl' = Term.mkBvShl'
+let mkBvShr' = Term.mkBvShr'
+let mkBvRol' = Term.mkBvRol'
+let mkBvRor' = Term.mkBvRor'
+let mkBvUdivUnsafe = Term.mkBvUdivUnsafe
+let mkBvModUnsafe = Term.mkBvModUnsafe
+let mkBvMul' = Term.mkBvMul'
+let mkBvUlt = Term.mkBvUlt
+let mkBvUext = Term.mkBvUext
+let mkBvNot = Term.mkBvNot
+let mkBvToNat = Term.mkBvToNat
+let mkITE = Term.mkITE
+let mkCases = Term.mkCases
+let mk_Term_app = Term.mk_Term_app
+let mk_and_l = Term.mk_and_l
+let mk_or_l = Term.mk_or_l
+let mk_ApplyTT = Term.mk_ApplyTT
+let mk_String_const = Term.mk_String_const
+let mk_Precedes = Term.mk_Precedes
+let mk_LexCons = Term.mk_LexCons
+let mk_lex_t = Term.mk_lex_t
+let mk_LexTop = Term.mk_LexTop
 
 
 (*

--- a/src/smtencoding/FStarC.SMTEncoding.Util.fsti
+++ b/src/smtencoding/FStarC.SMTEncoding.Util.fsti
@@ -27,10 +27,6 @@ module TcEnv = FStarC.TypeChecker.Env
 
 val mkAssume : term & caption & string -> ML decl
 
-val norng  (f : 'a -> Range.t -> ML term) : 'a -> ML term
-val norng2 (f : 'a -> 'b -> Range.t -> ML term) : 'a -> 'b -> ML term
-val norng3 (f : 'a -> 'b -> 'c -> Range.t -> ML term) : 'a -> 'b -> 'c -> ML term
-val norng4 (f : 'a -> 'b -> 'c -> 'd -> Range.t -> ML term) : 'a -> 'b -> 'c -> 'd -> ML term
 
 val mkTrue : term
 val mkFalse : term

--- a/src/smtencoding/FStarC.SMTEncoding.Z3.fst
+++ b/src/smtencoding/FStarC.SMTEncoding.Z3.fst
@@ -554,7 +554,7 @@ let context_profile (theory:list decl) : ML unit =
     let modules, total_decls =
         List.fold_left (fun (out, _total) d ->
             match d with
-            | Module(name, decls) ->
+            | Module name decls ->
               let decls =
                 List.filter
                     (function Assume _ -> true


### PR DESCRIPTION
SMT declarations dominate the size of .checked files (138 MB of a 221 MB live heap when loading Pulse). This reworks the representation in src/smtencoding/:

* Flatten the `term'`/`term` record indirection into a single `type term`, dropping the per-node `freevars` memo field and the per-node range.
* Declare all `term` and `decl` constructors in curried form, so extraction emits multi-argument OCaml constructors instead of a boxed tuple per node.
* Keep a `Range.t` on `App` and `Quant` only. These are the only nodes that ever carried a meaningful range (set by `EncodeTerm.encode_formula`), and it is what `ErrorReporting` uses for the "See also <definition site>" secondary range of an SMT error. Keeping it costs ~5%.
* Make `decls_elt.key` the MD5 digest of the rendering, as its comment already claimed, instead of the (potentially multi-kilobyte) rendering.
* Delete the `Util.norng*` wrappers; `Util.mkX` are now plain aliases.

`assumption_free_names` is kept: it is used for dependency pruning.

Result on ulib + pulse: smt_decls shrinks from 140.4 MB to 84.3 MB (-40%), and checking an empty module that opens Pulse goes from 1.104s to 0.99s.

Bumps cache_version_number.