### PR TITLE
Preserve divergent effects through forward labels

### DIFF
--- a/pulse/src/checker/Pulse.Checker.ForwardJumpLabel.fst
+++ b/pulse/src/checker/Pulse.Checker.ForwardJumpLabel.fst
@@ -29,6 +29,35 @@ let starts_with (a b: string) : bool =
   if String.length b > String.length a then false
   else String.sub a 0 (String.length b) = b
 
+(* The effect annotation (STT vs STT_Div) of a labeled block is inherited from
+   its enclosing computation; a label only fixes the postcondition. We recover
+   it from, in order:
+     - the comp recorded on the label node itself: `while` loops containing a
+       `break` are elaborated into a Tm_ForwardJumpLabel whose post is the
+       loop's comp (see Pulse.Checker.While), so it is already tagged;
+     - the post hint, when the label is in tail position;
+     - the innermost enclosing goto label in the environment. Every fn body is
+       wrapped in a `_return` label (see PulseSyntaxExtension.Desugar), so this
+       records the ambient effect even when the label is the head of a bind and
+       is therefore checked with no hint.
+   Note we must *not* recover it by handing the label a synthesized PostHint
+   from `bind`: proving the label's own post against such a hint sends the
+   prover into a loop on loop-heavy code. *)
+let ambient_effect_annot (g:env) (c:comp_st) (post_hint0:post_hint_opt g)
+  : effect_annot
+  = if C_STDiv? c then EffectAnnotSTTDiv
+    else match post_hint0 with
+    | PostHint ph -> ph.effect_annot
+    | _ ->
+      let rec aux (bs:list binding) : effect_annot =
+        match bs with
+        | BindingGotoLabel { post } :: _ ->
+          if C_STDiv? post then EffectAnnotSTTDiv else EffectAnnotSTT
+        | _ :: bs -> aux bs
+        | [] -> EffectAnnotSTT
+      in
+      aux (bindings g)
+
 #push-options "--z3rlimit 10 --split_queries always"
 let check
     (g:env)
@@ -44,7 +73,8 @@ let check
   let post : post_hint_t =
     if has_explicit_post then
       let post_slprop = purify_spec g { ctxt_now = pre; ctxt_old = None } (comp_post c) in
-      intro_post_hint g EffectAnnotSTT None post_slprop
+      let effect_annot = ambient_effect_annot g c post_hint0 in
+      intro_post_hint g effect_annot None post_slprop
     else
       match post_hint0 with
       | NoHint | TypeHint .. ->

--- a/pulse/test/DivergentFn.fst
+++ b/pulse/test/DivergentFn.fst
@@ -126,3 +126,24 @@ fn if_ensures_diverges_bad () {
     if (true) ensures emp { diverge () };
     ()
 }
+
+(* An explicit forward-label postcondition fixes only the postcondition, not
+   the effect of the labeled body. *)
+divergent fn label_ensures_diverges () {
+    {
+        diverge ();
+    }
+    ensures pure True
+    label done:;
+    ()
+}
+
+[@expect_failure [228]]
+fn label_ensures_diverges_bad () {
+    {
+        diverge ();
+    }
+    ensures pure True
+    label done:;
+    ()
+}


### PR DESCRIPTION
Preserve divergent effects through forward labels
A forward jump label only fixes the postcondition of the block it labels;
its effect annotation (STT vs STT_Div) should be inherited from the
enclosing computation. Previously Pulse.Checker.ForwardJumpLabel.check
hard-coded EffectAnnotSTT whenever the label carried an explicit post, so
a divergent body under a label with an `ensures` was rejected with
Error 228.

Recover the annotation with `ambient_effect_annot`, which consults, in
order:

  - the comp recorded on the label node itself: a `while` loop containing
    a `break` is elaborated into a Tm_ForwardJumpLabel whose post is the
    loop's comp (Pulse.Checker.While), so it is already tagged;
  - the post hint, when the label is in tail position;
  - the innermost enclosing goto label in the environment. Every fn body
    is wrapped in a `_return` label (PulseSyntaxExtension.Desugar), so
    this records the ambient effect even when the label is the head of a
    bind and is therefore checked with no hint.

Note the annotation must *not* be recovered by having `bind` synthesize a
PostHint for a labeled head: since every `while` with a `break` is such a
label, proving its own post against that hint sends the prover into a
loop on ordinary loop-heavy code (Pulse.Lib.HashTable, Break.fst,
Example.BreakReturnContinue.fst, LoopRequires.fst all hang).

Adds tests for a divergent body under a label with an explicit post, and
for the same under a plain `fn`, which must still be rejected.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>