### PR TITLE
Do not overwrite fsti.checked when checking fst

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -219,6 +219,14 @@ Guidelines for the changelog:
 
   * Friend modules (https://github.com/FStarLang/FStar/wiki/Friend-modules)
 
+  * F* no longer overwrites a `.checked` file that is already present and
+    valid. In particular, checking `M.fst` when `M` befriends some module used
+    by `M.fsti` used to rewrite an already valid `M.fsti.checked` with
+    different (though equally valid) contents, which silently invalidated every
+    module that had already been checked against it and broke parallel builds.
+    Pass `--force` to regenerate a checked file unconditionally.
+    Fixes https://github.com/FStarLang/FStar/issues/4399.
+
 ## Core typechecker
   * PR https://github.com/FStarLang/FStar/pull/2760 introduces core typechecking for
     implicits introduced for application of indexed effects combinators. This is a

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -231,6 +231,15 @@ Guidelines for the changelog:
     rechecking `M.fsti`, whenever that checked file (and those of its
     dependences) are valid.
 
+  * `--cache_checked_modules` now writes checked files only for the *files*
+    given on the command line, rather than for every file of a command-line
+    *module*. In particular `fstar.exe M.fst` no longer writes
+    `M.fsti.checked` as a side effect; only `fstar.exe M.fsti` does. This
+    guarantees that the contents of an interface's checked file never depend on
+    its implementation. Builds that need `M.fsti.checked` (any consumer of `M`
+    does) must ask for it explicitly, as the `--dep full` generated makefiles
+    already do.
+
 ## Core typechecker
   * PR https://github.com/FStarLang/FStar/pull/2760 introduces core typechecking for
     implicits introduced for application of indexed effects combinators. This is a

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -227,6 +227,10 @@ Guidelines for the changelog:
     Pass `--force` to regenerate a checked file unconditionally.
     Fixes https://github.com/FStarLang/FStar/issues/4399.
 
+  * Relatedly, when checking `M.fst` F* now loads `M.fsti.checked` instead of
+    rechecking `M.fsti`, whenever that checked file (and those of its
+    dependences) are valid.
+
 ## Core typechecker
   * PR https://github.com/FStarLang/FStar/pull/2760 introduces core typechecking for
     implicits introduced for application of indexed effects combinators. This is a

--- a/src/basic/FStarC.Options.fst
+++ b/src/basic/FStarC.Options.fst
@@ -1945,6 +1945,17 @@ let should_check_file fn =
 let should_verify_file fn =
     should_verify (module_name_of_file_name fn)
 
+(* Whether a checked file should be written for [fn].
+   Unlike [should_check_file], this is about the *file*, not the module: running
+   [fstar.exe A.fst] verifies A.fsti too, but it must not write A.fsti.checked.
+   Otherwise the contents of the interface's checked file would depend on which
+   of the two files happened to be checked --- checking A.fst reveals the
+   implementations of the modules A befriends. Only [fstar.exe A.fsti] writes
+   A.fsti.checked. See #4399. *)
+let should_write_checked_file fn =
+  let base f = String.lowercase (Filepath.basename f) in
+  file_list () |> List.existsb (fun f -> base f = base fn)
+
 let module_name_eq m1 m2 = String.lowercase m1 = String.lowercase m2
 
 let should_print_message m =

--- a/src/basic/FStarC.Options.fsti
+++ b/src/basic/FStarC.Options.fsti
@@ -170,6 +170,11 @@ val should_check_file           : string  -> ML bool (* Should check this file, 
 
 val should_verify_file          : string  -> ML bool (* Should check this file with verification enabled. *)
 
+(* Should a checked file be written for this file? True only for the files
+   given on the command line; note this is per *file*, not per module, so
+   `fstar.exe A.fst` does not write A.fsti.checked. *)
+val should_write_checked_file   : string  -> ML bool
+
 val should_print_message        : string  -> ML bool
 
 val custom_prims                : unit    -> ML (option string)

--- a/src/fstar/FStarC.CheckedFiles.fst
+++ b/src/fstar/FStarC.CheckedFiles.fst
@@ -573,6 +573,26 @@ let store_module_to_cache env fn parsing_data_and_direct_deps tc_result : ML uni
          we would clobber previously-written checked files. *)
       | None -> FStarC.Parser.Dep.cache_file_name fn
     in
+    (* Never overwrite a checked file that is already there and valid. A module
+       can have more than one valid encoding of its checked file: checking
+       [M.fst] reveals the implementations of the modules it befriends, so the
+       sigelts recorded for [M.fsti] then point at those implementations rather
+       than at their interfaces, even though the dependence hashes are the same.
+       Rewriting a valid [M.fsti.checked] as a side effect of the [M.fst] job
+       silently invalidates every module that was already checked against the
+       file we are about to clobber. See #4399. *)
+    let already_valid =
+      None? (Options.output_to ())
+      && not (Options.force ())
+      && (match try_find_in_cache cache_file with
+          | Some (Valid _, _) -> true
+          | _ -> false)
+    in
+    if already_valid then
+      debug (fun () ->
+        Format.print1 "Not rewriting checked file %s: it is already present and valid\n"
+          cache_file)
+    else
     let parsing_data, deps_of_fn = parsing_data_and_direct_deps in
     let digest = hash_dependences (TcEnv.dep_graph env) fn deps_of_fn in
     match digest with

--- a/src/fstar/FStarC.Main.fst
+++ b/src/fstar/FStarC.Main.fst
@@ -427,7 +427,7 @@ let go_normal () : ML unit =
               Options.add_verify_module m;
               let default_flydeps () =
                 //by default, just initialize an empty dep graph
-                //return the file, its interface if any, and go
+                //return the file and go
                 let deps = FStarC.Parser.Dep.empty_deps [fn] in
                 let filenames =
                   if FStarC.Parser.Dep.is_implementation fn
@@ -439,7 +439,23 @@ let go_normal () : ML unit =
                     FStarC.Parser.Dep.set_root_friends (friends_of_implementation fn);
                     match FStarC.Parser.Dep.interface_of deps m with
                     | None -> [fn]
-                    | Some iface -> [iface; fn]
+                    | Some iface ->
+                      (* If the interface already has a usable checked file, do
+                         not seed it into the batch: scanning the module header
+                         of [fn] makes the interface an on-the-fly dependence,
+                         so it is *loaded* from [M.fsti.checked] rather than
+                         rechecked and rewritten (see #4399). Otherwise we have
+                         to check it, and it must come first.
+
+                         With -o, [tc_one_file] deliberately ignores the cache
+                         for the module being written, so there is no point in
+                         relying on it here; nothing is clobbered in that mode
+                         either, since the checked file is written to the -o
+                         path. *)
+                      if None? (Options.output_to ())
+                      && Some? (CheckedFiles.scan_deps_and_check_cache_validity iface)
+                      then [fn]
+                      else [iface; fn]
                   )
                   else [fn]
                 in

--- a/src/fstar/FStarC.Universal.fst
+++ b/src/fstar/FStarC.Universal.fst
@@ -572,7 +572,7 @@ and tc_one_file_no_frame
         let parsing_data, tc_result, mllib, env = tc_source_file () in
 
         if FStarC.Errors.get_err_count() = 0
-        && Options.should_check (string_of_lid tc_result.checked_module.name)
+        && Options.should_write_checked_file fn
         then begin
           Ch.store_module_to_cache (tcenv_of_uenv env) fn parsing_data tc_result
         end;

--- a/tests/friends/5/A.fst
+++ b/tests/friends/5/A.fst
@@ -1,0 +1,2 @@
+module A
+let x = 0

--- a/tests/friends/5/A.fsti
+++ b/tests/friends/5/A.fsti
@@ -1,0 +1,2 @@
+module A
+val x : int

--- a/tests/friends/5/B.fst
+++ b/tests/friends/5/B.fst
@@ -1,0 +1,4 @@
+module B
+open A
+friend A
+let y = x + 1

--- a/tests/friends/5/B.fsti
+++ b/tests/friends/5/B.fsti
@@ -1,0 +1,3 @@
+module B
+open A
+val y : (z:int{z > x})

--- a/tests/friends/5/C.fst
+++ b/tests/friends/5/C.fst
@@ -1,0 +1,3 @@
+module C
+open B
+let w = y + 1

--- a/tests/friends/5/D.fst
+++ b/tests/friends/5/D.fst
@@ -1,0 +1,3 @@
+module D
+open C
+let v = w + 1

--- a/tests/friends/5/Makefile
+++ b/tests/friends/5/Makefile
@@ -1,0 +1,43 @@
+# Regression test for #4399.
+#
+# Checking B.fst, which befriends A, used to rewrite an already valid
+# B.fsti.checked with different (though equally valid) contents. That
+# silently invalidated every module, such as C, that had already been
+# checked against the previous B.fsti.checked.
+#
+# This test drives the individual files in the same order a parallel `make`
+# would, so it cannot use the generic mk/test.mk rules.
+
+FSTAR_ROOT ?= ../../..
+FSTAR_EXE ?= $(FSTAR_ROOT)/out/bin/fstar.exe
+FSTAR_EXE := $(abspath $(FSTAR_EXE))
+
+CACHE_DIR := _cache
+
+FSTAR = $(FSTAR_EXE) --cache_dir $(CACHE_DIR) --include . --include $(CACHE_DIR) \
+	--already_cached Prims,FStar --cache_checked_modules --warn_error @241 \
+	$(OTHERFLAGS)
+
+all: verify
+
+verify:
+	rm -rf $(CACHE_DIR)
+	mkdir -p $(CACHE_DIR)
+	$(FSTAR) A.fsti
+	$(FSTAR) A.fst
+	$(FSTAR) B.fsti
+	cp $(CACHE_DIR)/B.fsti.checked $(CACHE_DIR)/B.fsti.checked.bak
+#	C is legally checked against the B.fsti.checked just produced.
+	$(FSTAR) C.fst
+#	Building B.fst must leave B.fsti.checked alone.
+	$(FSTAR) B.fst
+	cmp $(CACHE_DIR)/B.fsti.checked.bak $(CACHE_DIR)/B.fsti.checked
+#	And so C.fst.checked must still be loadable.
+	$(FSTAR) D.fst
+
+accept depend:
+
+clean:
+	rm -rf $(CACHE_DIR)
+
+.PHONY: all verify accept depend clean

--- a/tests/friends/5/Makefile
+++ b/tests/friends/5/Makefile
@@ -29,8 +29,11 @@ verify:
 	cp $(CACHE_DIR)/B.fsti.checked $(CACHE_DIR)/B.fsti.checked.bak
 #	C is legally checked against the B.fsti.checked just produced.
 	$(FSTAR) C.fst
-#	Building B.fst must leave B.fsti.checked alone.
-	$(FSTAR) B.fst
+#	Building B.fst must load B.fsti.checked rather than recheck B.fsti,
+#	and must leave B.fsti.checked alone.
+	$(FSTAR) --debug CheckedFiles B.fst > $(CACHE_DIR)/B.log 2>&1
+	grep -q 'Successfully loaded module from checked file.*B\.fsti\.checked' $(CACHE_DIR)/B.log
+	! grep -q 'Storing checked file for B\.fsti' $(CACHE_DIR)/B.log
 	cmp $(CACHE_DIR)/B.fsti.checked.bak $(CACHE_DIR)/B.fsti.checked
 #	And so C.fst.checked must still be loadable.
 	$(FSTAR) D.fst

--- a/tests/friends/Makefile
+++ b/tests/friends/Makefile
@@ -3,5 +3,10 @@ SUBDIRS += 2
 SUBDIRS += 3
 SUBDIRS += 4
 
+# Has a special makefile: it drives fstar.exe file by file.
+SUBDIRS_ALL += 5
+SUBDIRS_VERIFY += 5
+SUBDIRS_CLEAN += 5
+
 FSTAR_ROOT ?= ../..
 include $(FSTAR_ROOT)/mk/test.mk


### PR DESCRIPTION
Fixes #4399.

There are two parts to this fix:
 1. We actually recompiled `.fsti` on the fly instead of loading the checked file.  We now load the checked file.
 2. We restore the property that we only write checked files for files specified on the command line.