### PR TITLE
Mention Unicode forms of syntax elements in book

### DIFF
--- a/doc/book/PoP-in-FStar/book/conf.py
+++ b/doc/book/PoP-in-FStar/book/conf.py
@@ -118,6 +118,7 @@ htmlhelp_basename = 'FStarDoc'
 
 # -- Options for LaTeX output ------------------------------------------------
 
+latex_engine = "xelatex"
 latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
     #

--- a/doc/book/PoP-in-FStar/book/part1/part1_getting_off_the_ground.rst
+++ b/doc/book/PoP-in-FStar/book/part1/part1_getting_off_the_ground.rst
@@ -88,9 +88,9 @@ definitions taken from the core F* module ``Prims``.
 False
 .....
 
-The type ``False`` has no elements. Since there are no terms that
-satisfy ``e : False``, the type ``False`` is the type of unprovable
-propositions.
+The type ``False`` (or ``⊥`` [#unicode]_) has no elements. Since there
+are no terms that satisfy ``e : False``, the type ``False`` is the
+type of unprovable propositions.
 
 Unit
 ....
@@ -141,9 +141,9 @@ precedence.
 * ``%``: Euclidean modulus (infix)
 * ``*``: Multiplication (infix)
 * ``<`` : Less than (infix)
-* ``<=``: Less than or equal (infix)
+* ``<=`` or ``≤``: Less than or equal (infix)
 * ``>`` : Greater than (infix)
-* ``>=``: Greater than or equal (infix)
+* ``>=`` or ``≥``: Greater than or equal (infix)
 
 .. note::
    
@@ -312,7 +312,7 @@ Lambda terms
 The term ``fun (x:int) -> x + 1`` defines a function,
 a lambda term, which adds 1 to its integer-typed parameter ``x``. You
 can also let F* infer the type of the parameter and write ``fun x ->
-x + 1`` instead.
+x + 1`` instead, or, even more compactly, ``λ x → x + 1``.
 
 .. _Part1_ch1_named_function:
 
@@ -717,3 +717,13 @@ What other types can you give to it?
        :language: fstar
        :start-after: SNIPPET_START: fibonacci_answers
        :end-before: SNIPPET_END: fibonacci_answers
+
+
+.. rubric:: Footnotes
+
+.. [#unicode] Many of F*'s primitives and syntactic elements can be
+   alternatively written as Unicode symbols corresponding to typical
+   mathematical notation. This is less commonly done than in some
+   other proof-oriented languages; for example, the standard library
+   hardly ever makes use of it. We'll nonetheless generally mention
+   these representations for the sake of completeness.

--- a/doc/book/PoP-in-FStar/book/part1/part1_prop_assertions.rst
+++ b/doc/book/PoP-in-FStar/book/part1/part1_prop_assertions.rst
@@ -65,11 +65,11 @@ F*, i.e., the parts that allow it to interface with an SMT solver.
 
    .. code-block:: fstar
 
-      p /\ q   //conjunction
-      p \/ q   //disjunction
-      ~p       //negation
-      p ==> q  //implication
-      p <==> q //bi-implication
+      p /\ q   //conjunction (∧)
+      p \/ q   //disjunction (∨)
+      ~p       //negation (¬)
+      p ==> q  //implication (⇒)
+      p <==> q //bi-implication (⇔)
 
    For example, one can say (as shown below) that for all natural
    numbers ``x`` and ``y``, if the modulus ``x % y`` is ``0``, then
@@ -143,8 +143,9 @@ quantifiers.
 Quantifiers
 ...........
 
-A universal quantifier is constructed using the ``forall`` keyword. Its
-syntax has the following shape.
+A universal quantifier is constructed using the ``forall`` keyword
+(or, equivalently, the Unicode character ``∀``). Its syntax has the
+following shape.
 
 .. code-block:: fstar
                 
@@ -155,8 +156,8 @@ which one the proposition ``p`` is quantified. That is, ``forall
 (x:t). p`` is valid when for all ``v : t`` the proposition ``p[v/x]``
 is valid.
 
-And existential quantifier has similar syntax, using the ``exists``
-keyword.
+An existential quantifier has similar syntax, using the ``exists``
+keyword (or its Unicode equivalent ``∃``).
 
 .. code-block:: fstar
                 
@@ -208,31 +209,31 @@ decreasing order of precedence.
 
 **Negation**
 
-The proposition ``~p`` is valid if the negation of ``p`` is
-valid. This is similar to the boolean operator ``not``, but applies to
-propositions rather than just booleans.
+The proposition ``~p`` (or ``¬p``) is valid if the negation of ``p``
+is valid. This is similar to the boolean operator ``not``, but applies
+to propositions rather than just booleans.
 
 **Conjunction**
 
-The proposition ``p /\ q`` is valid if both ``p`` and ``q`` are
-valid. This is similar to the boolean operator ``&&``, but applies to
-propositions rather than just booleans.
+The proposition ``p /\ q`` (or ``p ∧ q``) is valid if both ``p`` and
+``q`` are valid. This is similar to the boolean operator ``&&``, but
+applies to propositions rather than just booleans.
 
 **Disjunction**
 
-The proposition ``p \/ q`` is valid if at least one of ``p`` and ``q``
-are valid. This is similar to the boolean operator ``||``, but applies
-to propositions rather than just booleans.
+The proposition ``p \/ q`` (or ``p ∨ q``) is valid if at least one of
+``p`` and ``q`` are valid. This is similar to the boolean operator
+``||``, but applies to propositions rather than just booleans.
 
 **Implication**
 
-The proposition ``p ==> q`` is valid if whenever ``p`` is valid, ``q``
-is also valid.
+The proposition ``p ==> q`` (or ``p ⇒ q``) is valid if whenever ``p``
+is valid, ``q`` is also valid.
 
 **Double Implication**
 
-The proposition ``p <==> q`` is valid if ``p`` and ``q`` are
-equivalent.
+The proposition ``p <==> q`` (or ``p ⇔ q``) is valid if ``p`` and
+``q`` are equivalent.
 
 .. note::
 
@@ -252,12 +253,12 @@ propositions themselves?
 Falsehood
 .........
 
-The proposition ``False`` is always invalid.
+The proposition ``False`` (``⊥``) is always invalid.
 
 Truth
 .....
 
-The proposition ``True`` is always valid.
+The proposition ``True`` (``⊤``) is always valid.
 
 .. _Part1_ch2_propositional_equality:
 


### PR DESCRIPTION
Fixes #4411, see there for rationale.

Requires #4413 to be merged first (I don't really get how stacked PRs work in GitHub, so I've just included the commits from there here as well for now and will rebase if it gets merged).