### PR TITLE
Change book's LaTeX engine to XeLaTex

### DIFF
--- a/doc/book/PoP-in-FStar/book/conf.py
+++ b/doc/book/PoP-in-FStar/book/conf.py
@@ -118,6 +118,7 @@ htmlhelp_basename = 'FStarDoc'
 
 # -- Options for LaTeX output ------------------------------------------------
 
+latex_engine = "xelatex"
 latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
     #


### PR DESCRIPTION
This is required for #4412, but as it's a significant enough change that it deserves its own discussion, I'm submitting it as a separate PR.

Works fine for me when I build the book's PDF locally, but I already had XeLaTeX installed anyway - I don't know if there are any CI pipelines etc. I'm missing that don't have it?