### PR TITLE
Pulse: preserve divergent effects through locals

### DIFF
--- a/pulse/src/checker/Pulse.Checker.Base.fst
+++ b/pulse/src/checker/Pulse.Checker.Base.fst
@@ -418,14 +418,23 @@ let apply_checker_result_k (#g:env) (#ctxt:slprop) (#post_hint:post_hint_for_env
 
   k (PostHint post_hint) d
 
+let retype_checker_result_effect #g #pre
+    (p:post_hint_for_env g)
+    (p':post_hint_for_env g {
+      p'.u == p.u /\ p'.ret_ty == p.ret_ty /\ p'.post == p.post
+    })
+    (r:checker_result_t g pre (PostHint p))
+  : checker_result_t g pre (PostHint p')
+  = let (| x, g1, t, ctxt, k |) = r in
+    (| x, g1, t, ctxt, k |)
+
 //
 // Like apply_checker_result_k, but reads back the *natural* effect of the
 // checked computation instead of coercing it to the postcondition's effect.
-// This is used to infer the effect of the branches of a conditional whose
-// postcondition (and effect) were not supplied by the user: a divergent branch
-// must yield a divergent computation rather than failing to compose against the
-// tentatively-inferred stt effect (issue #4366). The result matches the given
-// postcondition's return type and postcondition, but carries its own effect.
+// A divergent computation must retain that effect rather than failing to
+// compose against a tentatively-inferred stt effect. The result matches the
+// given postcondition's universe, return type and postcondition, but carries
+// its own effect.
 //
 let apply_checker_result_k_nohint (#g:env) (#ctxt:slprop) (#post_hint:post_hint_for_env g)
   (r:checker_result_t g ctxt (PostHint post_hint))
@@ -438,10 +447,10 @@ let apply_checker_result_k_nohint (#g:env) (#ctxt:slprop) (#post_hint:post_hint_
 
   let (| y, g1, (u_ty, ty_y), pre', k |) = r in
 
-  let u_ty_y = Pulse.Checker.Pure.universe_of_well_typed_term g1 ty_y in
-
+  // The NoHint path rechecks the result universe in smaller environments while
+  // closing binds, so keep the canonical universe supplied by the post hint.
   let d : st_typing_in_ctxt g1 pre' (PostHint post_hint) =
-    return_in_ctxt g1 y res_ppname u_ty_y ty_y pre' () (PostHint post_hint) in
+    return_in_ctxt g1 y res_ppname post_hint.u ty_y pre' () (PostHint post_hint) in
   //
   // Coerce the trailing return to NoHint so that composing it with the body
   // uses the unbiased bind rules and reports the body's real effect.

--- a/pulse/src/checker/Pulse.Checker.Base.fsti
+++ b/pulse/src/checker/Pulse.Checker.Base.fsti
@@ -188,9 +188,16 @@ val apply_checker_result_k (#g:env) (#ctxt:slprop) (#post_hint:post_hint_for_env
   (res_ppname:ppname)
   : T.Tac (st_typing_in_ctxt g ctxt (PostHint post_hint))
 
+val retype_checker_result_effect #g #pre
+    (p:post_hint_for_env g)
+    (p':post_hint_for_env g {
+      p'.u == p.u /\ p'.ret_ty == p.ret_ty /\ p'.post == p.post
+    })
+    (r:checker_result_t g pre (PostHint p))
+  : checker_result_t g pre (PostHint p')
+
 // Like apply_checker_result_k, but returns the checked computation with its
-// natural effect (rather than coercing it to post_hint's effect). Used to infer
-// the effect of a conditional's branches when the postcondition was inferred.
+// natural effect rather than coercing it to post_hint's effect.
 val apply_checker_result_k_nohint (#g:env) (#ctxt:slprop) (#post_hint:post_hint_for_env g)
   (r:checker_result_t g ctxt (PostHint post_hint))
   (res_ppname:ppname)

--- a/pulse/src/checker/Pulse.Checker.WithLocal.fst
+++ b/pulse/src/checker/Pulse.Checker.WithLocal.fst
@@ -132,7 +132,7 @@ let check
           let body_post : post_hint_for_env g_extended = extend_post_hint_for_local g post init_t x binder.binder_ppname in
           let r = check g_extended body_pre (PostHint body_post) binder.binder_ppname (open_st_term_nv body px) in
           let r: checker_result_t g_extended body_pre (PostHint body_post) = r in
-          let (| opened_body, c_body |) = apply_checker_result_k #g_extended #body_pre #body_post r binder.binder_ppname in
+          let (| opened_body, c_body |) = apply_checker_result_k_nohint #g_extended #body_pre #body_post r binder.binder_ppname in
           let body = close_st_term opened_body x in
           assume (open_st_term (close_st_term opened_body x) x == opened_body);
           let c_st = {u=comp_u c_body;res=comp_res c_body;pre;post=post.post} in
@@ -144,5 +144,10 @@ let check
           assert (freshv g x);
           assert (~(Set.mem x (freevars_st body)));
           let st = wrst c (Tm_WithLocal { binder = mk_binder_ppname (mk_ref init_t) binder.binder_ppname; initializer=init; body }) in
-          checker_result_for_st_typing (| st, c |) res_ppname
+          let natural_post : post_hint_for_env g =
+            { post with effect_annot = effect_annot_of_comp c } in
+          let r = checker_result_for_st_typing
+            ((| st, c |) <: st_typing_in_ctxt g pre (PostHint natural_post))
+            res_ppname in
+          retype_checker_result_effect natural_post post r
 #pop-options

--- a/pulse/src/checker/Pulse.Checker.WithLocalArray.fst
+++ b/pulse/src/checker/Pulse.Checker.WithLocalArray.fst
@@ -146,11 +146,12 @@ let check
         //   so that later we can check the computed post to be equal to this one
         let post : post_hint_for_env g = post in
         assume ~(x `Set.mem` freevars post.post);
+          let open Pulse.Typing.Combinators in
           let body_post = extend_post_hint g post init_t init x binder.binder_ppname in
           let (| opened_body, c_body |) =
             let r =
               check g_extended body_pre (PostHint body_post) binder.binder_ppname (open_st_term_nv body px) in
-            apply_checker_result_k r binder.binder_ppname in
+            apply_checker_result_k_nohint r binder.binder_ppname in
           let body = close_st_term opened_body x in
           assume (open_st_term (close_st_term opened_body x) x == opened_body);
           let c_st = {u=comp_u c_body;res=comp_res c_body;pre;post=post.post} in
@@ -160,5 +161,10 @@ let check
               x
           in
           let st = wrst c (Tm_WithLocalArray { binder = mk_binder_ppname (mk_array init_t) binder.binder_ppname; initializer=init; length=len; body }) in
-          checker_result_for_st_typing (| st, c |) res_ppname
+          let natural_post : post_hint_for_env g =
+            { post with effect_annot = effect_annot_of_comp c } in
+          let r = checker_result_for_st_typing
+            ((| st, c |) <: st_typing_in_ctxt g pre (PostHint natural_post))
+            res_ppname in
+          retype_checker_result_effect natural_post post r
 #pop-options

--- a/pulse/test/DivergentFn.fst
+++ b/pulse/test/DivergentFn.fst
@@ -113,6 +113,58 @@ divergent fn if_ensures_else_diverges () {
     ()
 }
 
+(* Regression for #4418: effect inference must continue through a live mutable
+   local in an annotated branch. *)
+divergent fn if_ensures_local_diverges () {
+    if (true) ensures emp {
+        let mut local = true;
+        diverge ();
+    } else {};
+    ()
+}
+
+[@@expect_failure [228]]
+fn if_ensures_local_diverges_bad () {
+    if (true) ensures emp {
+        let mut local = true;
+        diverge ();
+    } else {};
+    ()
+}
+
+divergent fn if_ensures_local_array_diverges () {
+    if (true) ensures emp {
+        let mut local = [| true; 1sz |];
+        diverge ();
+    } else {};
+    ()
+}
+
+[@@expect_failure [228]]
+fn if_ensures_local_array_diverges_bad () {
+    if (true) ensures emp {
+        let mut local = [| true; 1sz |];
+        diverge ();
+    } else {};
+    ()
+}
+
+fn if_ensures_local_terminates () {
+    if (true) ensures emp {
+        let mut local = true;
+        local := false;
+    } else {};
+    ()
+}
+
+fn if_ensures_local_array_terminates () {
+    if (true) ensures emp {
+        let mut local = [| true; 1sz |];
+        ()
+    } else {};
+    ()
+}
+
 (* An annotated `if` with only terminating branches stays `stt` and is accepted
    in a plain `fn`. *)
 fn if_ensures_terminating () {


### PR DESCRIPTION
Keep the natural effect of local reference and array bodies during effect inference, and add regressions for divergent and terminating branches.

Fixes #4418.