### PR TITLE
Pulse: purify spec-level let-bindings before slprop splitting (fixes #4421)

### DIFF
--- a/pulse/src/checker/Pulse.Checker.ImpureSpec.fst
+++ b/pulse/src/checker/Pulse.Checker.ImpureSpec.fst
@@ -142,6 +142,30 @@ let rec symb_eval_subterms (g:env) (ctxt: ctxt') (t:R.term) : T.Tac (bool & R.te
     else
       false, t
 
+  | R.Tv_Let recf attrs b def body ->
+    (* A `let p = def in body` occurring in a spec (e.g. `let p = x in
+       exists* v. pts_to p #1.0R v ** observe (!p)`, issue #4421). Without
+       this case the `let` was left completely unprocessed by the fallback
+       branch below (it is not an application), so any stateful read (e.g.
+       `!p`) nested in its body was never rewritten to its pure result. *)
+    debug g (fun _ -> [text "symb eval subterms let 0"; pp t]);
+    let changed_def, def = symb_eval_subterms g ctxt def in
+    let b = R.inspect_binder b in
+    let x = fresh g in
+    let ppname = mk_ppname_no_range (T.unseal b.ppname) in
+    let changed1, b_ty = symb_eval_subterms g ctxt b.sort in
+    let b_ty, b_u = tc_type_phase1 g b_ty in
+    debug g (fun _ -> [text "symb eval subterms let 1"; pp changed1; pp b_ty]);
+    let b = { b with sort = b_ty } in
+    let g' = push_binding g x ppname b.sort in
+    let body = open_term_nv body (ppname, x) in
+    let changed2, body = symb_eval_subterms g' ctxt body in
+    debug g (fun _ -> [text "symb eval subterms let 2"; pp changed2; pp body]);
+    if changed_def || changed1 || changed2 then
+      true, R.pack_ln (R.Tv_Let recf attrs (R.pack_binder b) def (close_term body x))
+    else
+      false, t
+
   | R.Tv_Match sc ret brs ->
     let changed_sc, sc = symb_eval_subterms g ctxt sc in
     // TODO: branches
@@ -381,6 +405,22 @@ let rec purify_spec_core (g: env) (ctxt: ctxt') (ts: list slprop) : T.Tac (optio
   match ts with
   | [] -> None
   | t::ts ->
+    match R.inspect_ln t with
+    | R.Tv_Let false _ _ def body ->
+      (* Issue #4421: a spec-level `let p = def in body` (e.g. `let p = x in
+         exists* v. pts_to p #1.0R v ** observe (!p)`) is a pure alias, not
+         an effectful binding. Inline it by substituting `def` for the
+         let-bound variable in `body` (rather than opening `body` with a
+         fresh, unrelated variable), so that any slprop structure
+         (`exists*`, `**`, etc.) nested inside becomes visible to the same
+         splitting logic below, exactly as if `p` had been written as `def`
+         directly. Recursive lets fall through to the generic atom handling
+         below instead. *)
+      let _, def = symb_eval_subterms g ctxt def in
+      let body = open_term' body def 0 in
+      purify_spec_core g ctxt (body :: ts)
+
+    | _ ->
     match inspect_ast_term t with
     | Tm_Star t s ->
       purify_spec_core g ctxt (t::s::ts)

--- a/pulse/test/LetAliasReference.fst
+++ b/pulse/test/LetAliasReference.fst
@@ -1,0 +1,46 @@
+(*
+   Regression test for issue #4421: `!r` in a spec used to lose its
+   dereference elaboration when nested under a `let … in` in that spec,
+   causing an ill-typed term error (the stateful `op_Bang` application was
+   not rewritten into its pure value).
+*)
+module LetAliasReference
+open Pulse
+#lang-pulse
+
+let predicate observe (x: nat) =
+  pure (x == x)
+
+(* Works: dereference a direct function parameter. *)
+fn direct (p: ref nat)
+  requires exists* v. pts_to p #1.0R v ** observe (!p)
+  returns ret: unit
+  ensures exists* v. pts_to p #1.0R v ** observe (!p)
+{
+}
+
+(* Was Error 12 before the fix: same spec, wrapped in a let. *)
+fn alias_with_deref (x: ref nat)
+  requires
+    (let p = x in
+     exists* v. pts_to p #1.0R v ** observe (!p))
+  returns ret: unit
+  ensures
+    (let p = x in
+     exists* v. pts_to p #1.0R v ** observe (!p))
+{
+}
+
+(* Narrowing variant from the issue: dereference the original parameter
+   `x`, never the alias `p`; `p` is unused. This isolates that the trigger
+   is entering the `let` at all, not the aliasing itself. *)
+fn alias_unused_deref_original (x: ref nat)
+  requires
+    (let p = x in
+     exists* v. pts_to x #1.0R v ** observe (!x))
+  returns ret: unit
+  ensures
+    (let p = x in
+     exists* v. pts_to x #1.0R v ** observe (!x))
+{
+}


### PR DESCRIPTION
Fixes #4421.

## Problem

Spec-level `!r` sugar (a dereference of a reference in a `requires`/`ensures` clause) is supposed to be rewritten from the stateful `Pulse.Lib.Reference.op_Bang` application into its pure "current value" during spec purification (`Pulse.Checker.ImpureSpec.fst`). This stopped working as soon as the `!r` occurred underneath a `let p = ... in ...` in the spec, causing an Error 12 type mismatch (a stateful `fn ...` computation term ending up where a pure value like `nat` was expected).

As confirmed by @mtzguido in [this comment](https://github.com/FStarLang/FStar/issues/4421#issuecomment-5272362685), this isn't a name-resolution issue (`!` always desugars to `op_Bang`) -- the purification phase itself just doesn't handle `let` in spec position.

## Root cause

- `purify_spec_core`/`inspect_ast_term` in `pulse/src/checker/Pulse.Checker.ImpureSpec.fst` didn't recognize a `let`-term as slprop structure (only `**`, `exists*`, `with_pure` were recognized), so a spec-level `let` fell through to the generic "atom" case.
- `symb_eval_subterms`, the function that walks subterms rewriting stateful applications like `!r` into pure values, had explicit cases for `Tv_Abs`, `Tv_Refine`, `Tv_Match`, but no case for `Tv_Let`. Since a `let ... in ...` term is not an application, it was treated as an inert atom, leaving it (and everything nested inside, including any `!r`) completely unprocessed.

## Fix

- Added a `Tv_Let` case to `symb_eval_subterms`, so stateful reads nested in a spec-level `let`'s definition/body get rewritten wherever a `let` shows up as a generic subterm (e.g. inside a pure predicate argument).
- Added `Tv_Let` handling directly to `purify_spec_core`: a non-recursive spec-level `let p = def in body` is a pure alias, so it's inlined by substituting `def` for the let-bound variable directly in `body` (rather than opening `body` with a fresh, unrelated variable). This exposes any slprop structure (`exists*`, `**`, etc.) nested inside to the same splitting logic used for the rest of the spec. This turned out to be the change that actually fixes the reported issue: without it, the whole let-expression was purified as a single opaque atom, which hid resources like `pts_to` from the prover even after the stateful read itself was rewritten correctly.

## Testing

Added `pulse/test/LetAliasReference.fst`, covering:
- `direct`: the baseline case (no `let`), which already worked.
- `alias_with_deref`: the issue's originally-failing repro (`let p = x in ... !p ...`).
- `alias_unused_deref_original`: a narrowing variant from the issue where the alias `p` is unused and the original `x` is dereferenced instead, isolating that the trigger is entering the `let` at all, not the aliasing itself.

All three now verify. Also re-checked `pulse/test/ImpureSpec.fst` and `pulse/test/BangBang.fst` (existing purification tests) for regressions, and ran the full `pulse/test` suite -- everything passes.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>