### PR TITLE
Pulse: purify stateful-read sugar in call arguments (fixes #4423)

### DIFF
--- a/pulse/src/checker/Pulse.Checker.ImpureSpec.fst
+++ b/pulse/src/checker/Pulse.Checker.ImpureSpec.fst
@@ -563,6 +563,23 @@ let purify_term (g: env) (ctxt: ctxt) (t: term) : T.Tac term =
   let _, t = symb_eval_subterms g ctxt t in
   t
 
+(* Purify only the *arguments* of an application `t = head arg1 .. argn`,
+   leaving the outer application itself untouched. This is meant for a
+   genuinely effectful call used as a Pulse statement (see issue #4423):
+   `t` as a whole is not a spec expression and must not be routed through
+   `symb_eval_stateful_app` (which requires a `rewrites_to` postcondition
+   annotation, appropriate only for spec-level pure-reads-as-sugar like
+   `!r`, not for arbitrary stateful function calls). But any spec-sugar
+   (e.g. `!r`) nested inside `t`'s arguments -- including inside an
+   explicit type argument's refinement type -- still needs purifying
+   before elaboration. *)
+let purify_call_args (g: env) (ctxt: ctxt) (t: term) : T.Tac term =
+  let g', xs, ctxt = run_elim_ctxt g ctxt in
+  let ctxt = { ctxt; in_old = false } in
+  let head, args = T.collect_app_ln t in
+  let _, changed, args = symb_eval_subterms_args g' ctxt args in
+  if changed then RU.mk_app_flat head args (T.range_of_term t) else t
+
 let purify_spec (g: env) (ctxt: ctxt) (t0: slprop) : T.Tac slprop =
   let t = t0 in
   let g', xs, ctxt = run_elim_ctxt g ctxt in

--- a/pulse/src/checker/Pulse.Checker.ImpureSpec.fsti
+++ b/pulse/src/checker/Pulse.Checker.ImpureSpec.fsti
@@ -27,6 +27,8 @@ noeq type ctxt = {
 
 val purify_term (g: env) (ctxt: ctxt) (t: term) : T.Tac term
 
+val purify_call_args (g: env) (ctxt: ctxt) (t: term) : T.Tac term
+
 val purify_spec (g: env) (ctxt: ctxt) (t: slprop) :
   T.Tac slprop
 

--- a/pulse/src/checker/Pulse.Checker.ST.fst
+++ b/pulse/src/checker/Pulse.Checker.ST.fst
@@ -26,6 +26,7 @@ module T = FStar.Tactics.V2
 module RU = Pulse.RuntimeUtils
 module P = Pulse.Syntax.Printer
 open Pulse.Checker.Prover
+open Pulse.Checker.ImpureSpec
 open Pulse.Show
 
 let should_allow_ambiguous (t:term) : T.Tac bool =
@@ -50,6 +51,14 @@ let check
       text "Internal error: trailing combinator arguments not lifted in Tm_ST";
       fquotes (pp t)
     ];
+  // Purify any spec-level `!r`-style sugar (stateful reads) that may be
+  // nested in `e`'s *arguments*, including inside explicit type
+  // arguments' refinement types (see issue #4423) -- this term's
+  // arguments are not otherwise routed through `Pulse.Checker.ImpureSpec`,
+  // unlike asserts, rewrites, and while-loop invariants/measures. Only the
+  // arguments are purified, not the whole application `e`, since `e`
+  // itself is a genuinely effectful call (a statement), not a spec.
+  let e = purify_call_args g { ctxt_now = ctxt; ctxt_old = None } e in
   let e, ty, eff = tc_term_phase1 g e in
   match Pulse.Readback.readback_comp ty with
   | None -> fail g (Some range) (Printf.sprintf "readback of %s failed" (show ty))

--- a/pulse/test/CallArgPurify.fst
+++ b/pulse/test/CallArgPurify.fst
@@ -1,0 +1,27 @@
+(*
+   Regression test for issue #4423: `!r` sugar used inside a refinement
+   type that is passed as an *explicit type argument* to a function call
+   (as opposed to appearing in a `requires`/`ensures`/`assert` spec) used
+   to be left unpurified, causing the resulting proof obligation to
+   contain the raw (unrewritten) stateful `op_Bang` application, which the
+   prover could not relate to the concrete known value -- yielding a
+   "Cannot prove ..." error even though the equivalent `assert` typechecks
+   fine.
+*)
+module CallArgPurify
+open Pulse
+open Pulse.Lib.ForEvery
+#lang-pulse
+
+assume val p : nat -> slprop
+
+fn test ()
+  requires forall+ (i:nat{i < 0}). p i
+{
+  let mut z = 0;
+  assert (forall+ (i:nat{i < 0}). p i);
+  forevery_elim_empty
+    #(i:nat{i < !z})
+    (fun (i:nat{i < !z}) -> p i);
+  ()
+}


### PR DESCRIPTION
## Summary

Fixes #4423.

This is a follow-up to #4422 (issue #4421): while investigating whether that fix also covered #4423, I found it's a **distinct root cause**, not fixed by #4422.

### Problem

In `#lang-pulse`, a stateful reference read `!z` nested inside a refinement type used as an **explicit type argument** to a function call (e.g. `forevery_elim_empty #(i:nat{i < !z}) (fun (i:nat{i < !z}) -> p i)`) fails to verify with "Cannot prove ...", even though the same `!z` inside a plain `assert (...)` typechecks fine.

### Root cause

`Pulse.Checker.ST.fst`'s `check` function (which type-checks a *general function-call statement*, i.e. any `Tm_ST { t = e; args }`) elaborates the applied term `e` directly via `tc_term_phase1`. Unlike `assert`s (`Pulse.Checker.AssertWithBinders.fst`), `rewrite`s (`Pulse.Checker.Rewrite.fst`), while-loop invariants/measures (`Pulse.Checker.While.fst`), and `fn` pre/post specs (`Pulse.Checker.Abs.fst`) -- all of which already purify their terms through `Pulse.Checker.ImpureSpec` -- this general-call path never purifies `e` at all.

As a result, any spec-sugar (`!z`) nested anywhere in `e`'s arguments -- including inside an explicit type argument's refinement -- reaches the SMT encoding completely unrewritten. The failing goal literally prints the raw, unrewritten `!z` (e.g. `forall+ (x: i: nat{i < !z}). p x`), which the prover cannot relate to the concrete known value of `z`.

### Fix

Added a new `purify_call_args` entry point to `Pulse.Checker.ImpureSpec`, which purifies only the *arguments* of an application, not the whole application itself -- unlike a spec expression, the outer call `e` is a genuinely effectful statement and must not be routed through `symb_eval_stateful_app` (which requires a `rewrites_to` postcondition annotation that an arbitrary function like `forevery_elim_empty` doesn't have; I confirmed this by first trying the existing `purify_term`, which fails exactly this way).

`Pulse.Checker.ST.fst` now calls `purify_call_args` on `e` before `tc_term_phase1`.

### Testing

- Added `pulse/test/CallArgPurify.fst`, reproducing the issue's exact repro; verifies with the fix.
- Regression-checked `pulse/test/ImpureSpec.fst`, `pulse/test/BangBang.fst`, `pulse/test/LetAliasReference.fst`, `pulse/test/LetMutImps.fst`.
- Ran the full `pulse/test` suite (`make -k -j8`); no new failures (the only failures present are pre-existing, environment-specific `pool`/`domainslib` OCaml-multicore build issues unrelated to this change).
