### PR TITLE
Fix divergent while-loop guard rejection in Pulse

### DIFF
--- a/pulse/src/checker/Pulse.Checker.While.fst
+++ b/pulse/src/checker/Pulse.Checker.While.fst
@@ -217,6 +217,19 @@ let check_while
   let (| post_cond, r_cond |) : (ph:post_hint_for_env g1 & Pulse.Typing.Combinators.st_typing_in_ctxt g1 inv (PostHint ph)) =
     let res_cond = retype_checker_result NoHint res_cond in
     let ph = Pulse.JoinComp.infer_post res_cond in
+    // The postcondition/return-type here was only tentatively inferred above
+    // (via infer_post); its effect was left at the default (stt). A while
+    // loop with no `decreases` is divergent throughout -- the body and break
+    // label are already checked as such (see `div` above) -- so the
+    // condition must be allowed to be divergent too, e.g. when its guard
+    // calls a `divergent fn`. Conversely, when the loop *is* measured
+    // (div = false), the condition must still be non-divergent, exactly as
+    // before. Fix up the tentative post hint's effect to reflect `div`
+    // before composing (proving) against it, so the composition in
+    // `apply_checker_result_k` (mk_bind) sees a consistent, already
+    // divergence-aware target instead of failing with "Cannot compose
+    // computations in this divergent block".
+    let ph = { ph with effect_annot = (if div then EffectAnnotSTTDiv else EffectAnnotSTT) } in
     let r_cond = Pulse.Checker.Prover.prove_post_hint res_cond (PostHint ph) cond.range in
     (| ph, apply_checker_result_k r_cond ppname_default |)
   in
@@ -293,7 +306,7 @@ let check_while
   in
   let (| cond, comp_cond |) = r_cond in
   let (| body, comp_body |) = apply_checker_result_k r_body ppname_default in
-  assume (comp_cond == (comp_while_cond inv body_pre_open)); // regressed by term_spec re-index (pre-authorized)
+  assume (comp_cond == (comp_while_cond inv body_pre_open div)); // regressed by term_spec re-index (pre-authorized)
   assert (comp_post comp_body == comp_post (comp_while_body u_meas ty_meas is_tot dec_formula x_meas inv body_pre_open div));
   assert (comp_pre comp_body == comp_pre (comp_while_body u_meas ty_meas is_tot dec_formula x_meas inv body_pre_open div));
   assert (comp_u comp_body == comp_u (comp_while_body u_meas ty_meas is_tot dec_formula x_meas inv body_pre_open div));

--- a/pulse/src/checker/Pulse.Typing.fst
+++ b/pulse/src/checker/Pulse.Typing.fst
@@ -334,14 +334,15 @@ let comp_intro_exists_erased (u:universe) (b:binder) (p:term) (e:term)
         post=tm_exists_sl u b p
       }
 
-let comp_while_cond (inv:term) (post_cond:term)
+let comp_while_cond (inv:term) (post_cond:term) (div:bool)
   : comp
-  = C_ST {
+  = let sc = {
            u=u0;
            res=tm_bool;
            pre=inv;
            post=post_cond
-         }
+         } in
+    if div then C_STDiv sc else C_ST sc
 
 let mk_precedes u ty a b =
   R.mk_app (R.pack_ln <| R.Tv_UInst (R.pack_fv ["Prims"; "precedes"]) [u; u]) [

--- a/pulse/test/DivergentWhileGuard.fst
+++ b/pulse/test/DivergentWhileGuard.fst
@@ -3,27 +3,27 @@ open Pulse.Lib.Pervasives
 module R = Pulse.Lib.Reference
 #lang-pulse
 
-(* Regression test for https://github.com/FStarLang/FStar/issues/4423#issuecomment-5272362685
+(* Regression test for a bug found while investigating effectful/divergent
+   loop guards in Pulse.
 
    `cont` below is a trivially-terminating function, but it is marked
    `divergent` -- exactly as PAL (FStar's C-to-Pulse translator) marks every
    function it emits by default, since it never proves termination unless
    asked to. Calling `cont` therefore has effect `stt_div` rather than `stt`.
 
-   Using such a function as the guard of a `while` loop is currently
-   rejected, even though the loop itself has no `decreases` clause and is
-   otherwise treated as divergent throughout its body. This is because
+   Using such a function as the guard of a `while` loop used to be rejected,
+   even though the loop itself has no `decreases` clause and is otherwise
+   treated as divergent throughout its body. This was because
    `Pulse.Checker.While.fst`'s `check_while` computes a `div` flag (true
-   whenever the loop has no `decreases` measure) and threads it through the
+   whenever the loop has no `decreases` measure) and threaded it through the
    loop *body* and *break*-label checks, but not through the initial
-   *condition* check -- so the guard's real `stt_div` effect collides with
+   *condition* check -- so the guard's real `stt_div` effect collided with
    an implicitly-fixed non-divergent (`stt`) expectation when composing the
-   condition check, in `Pulse.Typing.Combinators.fst`'s `mk_bind`.
-
-   This is currently expected to fail with Error 228 ("Cannot compose
-   computations in this divergent block: stt_div vs stt"). Once the
-   `while`-condition checker is fixed to correctly propagate `div`, this
-   test should be updated to remove the `expect_failure` annotation. *)
+   condition check, in `Pulse.Typing.Combinators.fst`'s `mk_bind`, failing
+   with Error 228 ("Cannot compose computations in this divergent block:
+   stt_div vs stt"). Fixed by making the condition check's post hint
+   `div`-aware (and by making `comp_while_cond` take a `div` flag to match),
+   mirroring how `comp_while_body`/`comp_while` already do. *)
 
 divergent fn cont (i n : nat)
 requires emp
@@ -33,7 +33,6 @@ ensures pure (b == (i < n))
     (i < n)
 }
 
-[@@expect_failure [228]]
 divergent fn count_while_call_guard (n:nat)
 returns z:nat
 ensures pure (z <= n)

--- a/pulse/test/DivergentWhileGuard.fst
+++ b/pulse/test/DivergentWhileGuard.fst
@@ -1,0 +1,49 @@
+module DivergentWhileGuard
+open Pulse.Lib.Pervasives
+module R = Pulse.Lib.Reference
+#lang-pulse
+
+(* Regression test for https://github.com/FStarLang/FStar/issues/4423#issuecomment-5272362685
+
+   `cont` below is a trivially-terminating function, but it is marked
+   `divergent` -- exactly as PAL (FStar's C-to-Pulse translator) marks every
+   function it emits by default, since it never proves termination unless
+   asked to. Calling `cont` therefore has effect `stt_div` rather than `stt`.
+
+   Using such a function as the guard of a `while` loop is currently
+   rejected, even though the loop itself has no `decreases` clause and is
+   otherwise treated as divergent throughout its body. This is because
+   `Pulse.Checker.While.fst`'s `check_while` computes a `div` flag (true
+   whenever the loop has no `decreases` measure) and threads it through the
+   loop *body* and *break*-label checks, but not through the initial
+   *condition* check -- so the guard's real `stt_div` effect collides with
+   an implicitly-fixed non-divergent (`stt`) expectation when composing the
+   condition check, in `Pulse.Typing.Combinators.fst`'s `mk_bind`.
+
+   This is currently expected to fail with Error 228 ("Cannot compose
+   computations in this divergent block: stt_div vs stt"). Once the
+   `while`-condition checker is fixed to correctly propagate `div`, this
+   test should be updated to remove the `expect_failure` annotation. *)
+
+divergent fn cont (i n : nat)
+requires emp
+returns b:bool
+ensures pure (b == (i < n))
+{
+    (i < n)
+}
+
+[@@expect_failure [228]]
+divergent fn count_while_call_guard (n:nat)
+returns z:nat
+ensures pure (z <= n)
+{
+    let mut i : nat = 0;
+    while (cont (!i) n)
+    invariant exists* c. R.pts_to i c ** pure (c <= n)
+    {
+        let c = !i;
+        i := c + 1;
+    };
+    !i
+}


### PR DESCRIPTION
## Summary

While investigating effectful/divergent loop guards in Pulse, I found that a `while`-loop whose guard calls a `divergent fn` fails to verify, even though the loop itself has no `decreases` clause (i.e. is itself divergent) and its body/break label are already correctly treated as divergent.

Example (see `pulse/test/DivergentWhileGuard.fst`, added by this PR):

```pulse
divergent fn cont (i n : nat)
requires emp
returns b:bool
ensures pure (b == (i < n))
{
    (i < n)
}

divergent fn count_while_call_guard (n:nat)
returns z:nat
ensures pure (z <= n)
{
    let mut i : nat = 0;
    while (cont (!i) n)
    invariant exists* c. R.pts_to i c ** pure (c <= n)
    {
        let c = !i;
        i := c + 1;
    };
    !i
}
```

This previously failed with:
```
Error 228: Cannot compose computations in this divergent block:
This computation has effect: 'stt_div'
The continuation has effect: 'stt'
```

## Root cause

`check_while` (`Pulse.Checker.While.fst`) infers the loop condition's postcondition with a default, non-divergent (`stt`) effect annotation, regardless of whether the loop itself is divergent (the already-computed `div` flag, true whenever there is no `decreases` clause). When the guard genuinely has effect `stt_div`, composing it against that stale `stt`-tagged post hint hits `mk_bind`'s `C_STDiv _, C_ST _` bias-rejection -- even though the loop body and break label are already correctly checked as divergent.

## Fix

- In `check_while`, after tentatively inferring the condition's post hint, override its `effect_annot` based on `div` before proving against it. This makes the composition in `apply_checker_result_k` (`mk_bind`) see a consistent, divergence-aware target -- allowing a divergent guard exactly when the loop itself is divergent, and still rejecting it when the loop is measured (has a `decreases`).
- `Pulse.Typing.fst`: `comp_while_cond` now takes a `div` flag (mirroring `comp_while_body`/`comp_while`, which already did), keeping the internal `comp_cond == comp_while_cond ...` assumption in `check_while` sound.

## Testing

- Added `pulse/test/DivergentWhileGuard.fst`, which verifies successfully.
- Confirmed a negative control (a *measured* `while` loop, i.e. with a `decreases` clause, whose guard still calls a divergent function) is still correctly rejected with the same error -- the fix does not blanket-allow divergent guards, only in genuinely divergent loops.
- Ran the full `pulse/test` suite: no new failures.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
