### PR TITLE
Speed up dependency scanning

### DIFF
--- a/src/basic/FStarC.Find.fst
+++ b/src/basic/FStarC.Find.fst
@@ -33,11 +33,19 @@ let cached_fun #a (cache : SMap.t a) (f : string -> ML a) : string -> ML a =
 
 (* caches *)
 let _full_include : ref (option (list string)) = mk_ref None
+let _full_include_normalized : ref (option (list string)) = mk_ref None
 let find_file_cache : SMap.t (option string) = SMap.create 100
+
+(* Bumped every time the include path (or anything else affecting file
+resolution) changes. Clients that cache results derived from the include path
+can use this to invalidate their own caches. *)
+let _epoch : ref int = mk_ref 0
 
 let clear () : ML unit =
   SMap.clear find_file_cache;
   _full_include := None;
+  _full_include_normalized := None;
+  _epoch := !_epoch + 1;
   ()
 
 (* Internal state, settable with the functions exposed in the interface. *)
@@ -162,6 +170,8 @@ let command_line_include_paths () : ML (list string) =
     in
     expand_include_ds uncovered_roots @ expand_include_d "."
 
+let epoch () : ML int = !_epoch
+
 let full_include_path () : ML _ =
   // Stats.record "Find.full_include_path" fun () ->
   match !_full_include with
@@ -177,6 +187,18 @@ let full_include_path () : ML _ =
       cache_dir @ lib_paths () @ include_paths @ command_line_include_paths ()
     in
     _full_include := Some res;
+    res
+
+(* Normalizing every entry of the include path is not cheap (it involves
+querying the cwd for relative entries), and callers such as
+[FStarC.Parser.Dep.module_name_from_include_path] need it once per module in
+the dependency graph, so memoize it just like [full_include_path]. *)
+let full_include_path_normalized () : ML _ =
+  match !_full_include_normalized with
+  | Some paths -> paths
+  | None ->
+    let res = List.map Filepath.normalize_file_path (full_include_path ()) in
+    _full_include_normalized := Some res;
     res
 
 let do_find (paths : list string) (filename : string) : ML (option string) =

--- a/src/basic/FStarC.Find.fsti
+++ b/src/basic/FStarC.Find.fsti
@@ -51,8 +51,18 @@ val lib_root () : ML (option string)
 all transitive includes. *)
 val expand_include_d (dirname : string) : ML (list string)
 
+(* A counter that is bumped whenever the include path (or any other setting
+affecting file resolution) changes. Clients caching results derived from the
+include path can compare it to detect that their caches are stale. *)
+val epoch () : ML int
+
 (* The full include path. We search files in all of these directories. *)
 val full_include_path () : ML (list string)
+
+(* The full include path, with every entry normalized into an absolute path.
+This is memoized (and invalidated together with [full_include_path]), so it is
+cheap to call repeatedly. *)
+val full_include_path_normalized () : ML (list string)
 
 (* Try to find a file in the include path with a given basename. *)
 val find_file (basename : string) : ML (option string)

--- a/src/ml/FStarC_Filepath.ml
+++ b/src/ml/FStarC_Filepath.ml
@@ -30,6 +30,17 @@ let canonicalize path_str =
   let path = of_string path_str in
   to_string (normalize_in_tree path)
 
+(* The cwd never changes during a run of F* (we never call chdir), so we
+   cache it: normalize_file_path is called very often on relative paths. *)
+let cwd_cache : string option ref = ref None
+let cached_getcwd () =
+  match !cwd_cache with
+  | Some cwd -> cwd
+  | None ->
+    let cwd = BatSys.getcwd () in
+    cwd_cache := Some cwd;
+    cwd
+
 let normalize_file_path (path_str:string) =
   let open Batteries.Incubator in
   let open BatPathGen.OfString in
@@ -40,7 +51,7 @@ let normalize_file_path (path_str:string) =
     if is_path_absolute path_str
     then path
     else
-      let cwd = of_string (BatSys.getcwd ()) in
+      let cwd = of_string (cached_getcwd ()) in
       cwd //@ path
   in
   (* Normalize *)
@@ -60,6 +71,7 @@ let paths_to_same_file f g =
   (i,j) = (i',j')
 
 let file_exists = Sys.file_exists
-(* Sys.is_directory raises Sys_error if the path does not exist *)
-let is_directory f = Sys.file_exists f && Sys.is_directory f
+(* NB: Sys.is_directory raises Sys_error if the path does not exist. We catch
+   it instead of testing existence first, to only do a single stat. *)
+let is_directory f = try Sys.is_directory f with Sys_error _ -> false
 

--- a/src/parser/FStarC.Parser.Dep.fst
+++ b/src/parser/FStarC.Parser.Dep.fst
@@ -199,7 +199,7 @@ let list_of_pair (intf, impl) =
    not a valid F* source file. *)
 let module_name_from_include_path (f:string) : ML (option string) =
   let f = Filepath.normalize_file_path f in
-  let include_dirs = List.map Filepath.normalize_file_path (Find.full_include_path ()) in
+  let include_dirs = Find.full_include_path_normalized () in
   let best =
     List.fold_left (fun (acc:option string) d ->
       if Util.starts_with f (d ^ "/")
@@ -216,11 +216,31 @@ let module_name_from_include_path (f:string) : ML (option string) =
     | None -> None
     | Some stem -> Some (Util.replace_char (Util.replace_char stem '\\' '.') '/' '.')
 
+(* [maybe_module_name_of_file] is called once per dependency edge in the
+dependency graph, and is a pure function of the file name and the include
+path, so we memoize it, invalidating the cache whenever the include path
+changes. *)
+let module_name_cache : SMap.t (option string) = SMap.create 100
+let module_name_cache_epoch : ref int = mk_ref (-1)
+
 (* In public interface *)
 let maybe_module_name_of_file f =
-  match module_name_from_include_path f with
-  | Some longname -> Some longname
-  | None -> check_and_strip_suffix (Filepath.basename f)
+  let epoch = Find.epoch () in
+  if !module_name_cache_epoch <> epoch then (
+    SMap.clear module_name_cache;
+    module_name_cache_epoch := epoch
+  );
+  match SMap.try_find module_name_cache f with
+  | Some res -> res
+  | None ->
+    let res =
+      match module_name_from_include_path f with
+      | Some longname -> Some longname
+      | None -> check_and_strip_suffix (Filepath.basename f)
+    in
+    SMap.add module_name_cache f res;
+    res
+
 let module_name_of_file f =
     match maybe_module_name_of_file f with
     | Some longname ->
@@ -579,15 +599,28 @@ let module_candidate_of_file (ns_prefix:list string) (path:string) (filename:str
   | None -> []
   | Some modname -> [(String.concat "." (ns_prefix @ [modname]), path)]
 
+(* A directory can only contribute module names if its name can appear as a
+   namespace component, i.e. if it is a valid F* identifier: it must start with
+   a letter and contain only letters, digits, '_' and '\''. This prunes, e.g.,
+   hidden directories, '_build', 'fstar-lib' or 'a.b', which can never be part
+   of a module name, and (importantly) avoids descending into large build trees
+   that hold no reachable modules. Note that include roots themselves are always
+   traversed on their own (see [build_inclusion_candidates_list]), so no include
+   directory is lost by this. *)
+let can_be_namespace_component (s:string) : ML bool =
+  String.length s > 0
+  && Util.is_letter (String.get s 0)
+  && (List.for_all (fun c -> Util.is_letter_or_digit c || c = '_' || c = '\'')
+                   (String.list_of_string s))
+
 (* Enumerate the (long name, file path) candidates found under a single include
   directory [root], descending into subdirectories and turning each directory
   name into a namespace component: a file at [X/Y/Z.fst] (relative to [root]) is
-  mapped to the long name [X.Y.Z]. Directories whose name starts with a '.'
-  (e.g. [.git]) are skipped, since they can never be a valid namespace
-  component. We also never descend into a subdirectory that is itself an
-  include root, so that each include root owns its own traversal. [cwd] is the
-  normalized current directory: files under it are reported by their bare path
-  relative to [cwd]. *)
+  mapped to the long name [X.Y.Z]. Directories whose name cannot be a namespace
+  component (e.g. [.git]) are skipped. We also never descend into a
+  subdirectory that is itself an include root, so that each include root owns
+  its own traversal. [cwd] is the normalized current directory: files under it
+  are reported by their bare path relative to [cwd]. *)
 let hierarchical_modules_for_dir (cwd:string) (include_roots:list string) (root:string)
   : ML (list (string & string)) =
   let has_include_manifest = Filepath.file_exists (Filepath.join_paths root "fstar.include") in
@@ -601,14 +634,19 @@ let hierarchical_modules_for_dir (cwd:string) (include_roots:list string) (root:
       let entry = Filepath.basename entry in
       let rel' = if rel = "" then entry else Filepath.join_paths rel entry in
       let entry_path = Filepath.join_paths root rel' in
-      if Filepath.is_directory entry_path then
+      (* Check the name before touching the filesystem: an entry that can be
+         neither a namespace component nor an F* source file needs no [stat]. *)
+      if not (can_be_namespace_component entry)
+         && None? (check_and_strip_suffix entry)
+      then []
+      else if Filepath.is_directory entry_path then
         (* A manifest explicitly selects the child roots to scan; those roots
           are expanded separately by [Find.full_include_path]. *)
         if has_include_manifest
         then []
-        (* Never descend into hidden directories (they cannot be namespace
-           components). *)
-        else if String.length entry > 0 && String.get entry 0 = '.'
+        (* Never descend into directories that cannot be namespace components
+           (e.g. hidden directories, or build directories such as '_build'). *)
+        else if not (can_be_namespace_component entry)
         then []
         (* If this directory is itself an include root, let that root's own
            traversal cover it. *)
@@ -652,8 +690,7 @@ let check_unique_module_names_for_dir (dir:string)
     [X.Y.Z.fst] and a nested [X/Y/Z.fst]). *)
 (* In public interface *)
 let build_inclusion_candidates_list (): ML (list (string & string)) =
-  let include_directories = Find.full_include_path () in
-  let include_directories = List.map Filepath.normalize_file_path include_directories in
+  let include_directories = Find.full_include_path_normalized () in
   (* Note that [BatList.unique] keeps the last occurrence, that way one can
    * always override the precedence order. *)
   let include_directories = List.unique include_directories in


### PR DESCRIPTION
Since hierarchical includes became the default, module_name_from_include_path is called for every module file, and it re-normalized the whole include path on every call, issuing a getcwd syscall per relative include entry. This made dependency scanning several times slower.

- Memoize the normalized include path in FStarC.Find (invalidated with the rest of Find's caches), and expose an epoch counter for clients that cache include-path-derived data.
- Memoize maybe_module_name_of_file, which is called once per dependency edge.
- Cache the cwd in FStarC_Filepath.normalize_file_path (F* never chdirs).
- Do not descend into directories whose name cannot be a namespace component (e.g. '_build', 'fstar-lib'), and skip entries that can be neither a namespace component nor an F* source file without stat'ing them. This avoids walking (and stat'ing) entire build trees under the cwd include root.
- FStarC_Filepath.is_directory now uses a single stat instead of two.

Dependency output is unchanged; measured on this repo, 'fstar.exe --dep full' over all of src/ goes from 8.5s to 3.4s, and its stat/getcwd syscall count drops by ~7x.

Fixes #4435