### PR TITLE
Collect nested quantifiers across Meta nodes when destructing formulas

### DIFF
--- a/src/syntax/FStarC.Syntax.Formula.fst
+++ b/src/syntax/FStarC.Syntax.Formula.fst
@@ -103,7 +103,7 @@ let patterns t : ML (list (list arg) & term) =
         | Tm_meta {tm=t; meta=Meta_pattern (_, pats)} -> pats, SS.compress t
         | _ -> [], t
 
-let destruct_q_conn t : ML (option connective) =
+let rec destruct_q_conn t : ML (option connective) =
     let is_q (fa:bool) (fv:fv) : ML bool =
         if fa
         then U.is_forall fv.fv_name
@@ -137,10 +137,37 @@ let destruct_q_conn t : ML (option connective) =
           let pats, body = patterns t in
           if b
           then Some (QAll(bs, pats, body))
-          else Some  (QEx(bs, pats, body))
+          else collect_nested <| Some (QEx(bs, pats, body))
 
         | _ -> None in
     aux None [] t
+
+(* The loop above stops collecting binders whenever the body of the quantifier
+   is not *syntactically* another application of the same quantifier. In
+   particular it stops at a Tm_meta node, even an empty Meta_pattern, which is
+   how the body of the specifications of FStar.Classical.Sugar's
+   indefinite_descriptionN appear. That would leave us with
+   nested existentials where a single one would do, and the nesting is very bad
+   for the SMT solver: it has no trigger for the outer quantifier that mentions
+   the inner binders, and falls back to a multi-pattern of the typing
+   hypotheses of the outer binders, hence enumerating every tuple of terms of
+   the right type. See issue #4405.
+
+   The [patterns] call above has stripped that Tm_meta node, so simply try to
+   destruct the body again and merge. We only do so when neither existential
+   carries SMT patterns, since merging two levels that do have patterns would
+   turn them into a single (conjunctive, and possibly ill-formed) multi-pattern.
+   We also only do it for existentials: universals are far more common in
+   hypotheses, and merging those perturbs the triggers Z3 infers for a lot of
+   already-fragile proofs, for no benefit here. *)
+and collect_nested f : ML (option connective) =
+    match f with
+    | Some (QEx (bs, [], phi)) ->
+        begin match destruct_q_conn phi with
+        | Some (QEx (bs', [], psi)) -> Some <| QEx(bs@bs', [], psi)
+        | _ -> f
+        end
+    | _ -> f
 
 let rec destruct_sq_forall t : ML (option connective) =
     let! t = U.un_squash t in

--- a/tests/bug-reports/closed/Bug4405.fst
+++ b/tests/bug-reports/closed/Bug4405.fst
@@ -1,0 +1,70 @@
+module Bug4405
+
+(* `eliminate exists` with more binders than
+   max_indefinite_description_arity used to be encoded as a nest of
+   existentials, one level per indefinite_descriptionN call. When the body is
+   a single application of a named predicate, the SMT solver has no good
+   trigger for the outer levels of the nest and falls back to a multi-pattern
+   of typing hypotheses, enumerating every tuple of terms of the right type.
+   All of these must verify at the default rlimit. *)
+
+assume val t : Type0
+assume val goal : prop
+assume val p1  : t -> prop
+assume val p2  : t -> prop
+assume val p3  : t -> prop
+assume val p4  : t -> prop
+assume val p5  : t -> prop
+assume val p6  : t -> prop
+assume val p7  : t -> prop
+assume val p8  : t -> prop
+assume val p9  : t -> prop
+assume val p10 : t -> prop
+assume val p11 : t -> prop
+
+assume val use10 : x1:t -> x2:t -> x3:t -> x4:t -> x5:t ->
+                   x6:t -> x7:t -> x8:t -> x9:t -> x10:t ->
+  Lemma (requires p1 x1 /\ p2 x2 /\ p3 x3 /\ p4 x4 /\ p5 x5 /\
+                  p6 x6 /\ p7 x7 /\ p8 x8 /\ p9 x9 /\ p10 x10)
+        (ensures goal)
+
+assume val use11 : x1:t -> x2:t -> x3:t -> x4:t -> x5:t ->
+                   x6:t -> x7:t -> x8:t -> x9:t -> x10:t -> x11:t ->
+  Lemma (requires p1 x1 /\ p2 x2 /\ p3 x3 /\ p4 x4 /\ p5 x5 /\ p6 x6 /\
+                  p7 x7 /\ p8 x8 /\ p9 x9 /\ p10 x10 /\ p11 x11)
+        (ensures goal)
+
+let body10 (x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 : t) : prop =
+  p1 x1 /\ p2 x2 /\ p3 x3 /\ p4 x4 /\ p5 x5 /\
+  p6 x6 /\ p7 x7 /\ p8 x8 /\ p9 x9 /\ p10 x10
+
+let body11 (x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 : t) : prop =
+  p1 x1 /\ p2 x2 /\ p3 x3 /\ p4 x4 /\ p5 x5 /\ p6 x6 /\
+  p7 x7 /\ p8 x8 /\ p9 x9 /\ p10 x10 /\ p11 x11
+
+(* Two levels of indefinite_description. *)
+let folded10 (_ : squash (exists (x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 : t).
+                            body10 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10))
+  : Lemma goal
+= eliminate exists (x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 : t).
+    body10 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10
+  with use10 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10
+
+(* Three levels: this one used not to return at all. *)
+let folded11 (_ : squash (exists (x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 : t).
+                            body11 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11))
+  : Lemma goal
+= eliminate exists (x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 : t).
+    body11 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11
+  with use11 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11
+
+(* The inlined form, which was always fine. *)
+let inlined10
+  (_ : squash (exists (x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 : t).
+                 p1 x1 /\ p2 x2 /\ p3 x3 /\ p4 x4 /\ p5 x5 /\
+                 p6 x6 /\ p7 x7 /\ p8 x8 /\ p9 x9 /\ p10 x10))
+  : Lemma goal
+= eliminate exists (x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 : t).
+    p1 x1 /\ p2 x2 /\ p3 x3 /\ p4 x4 /\ p5 x5 /\
+    p6 x6 /\ p7 x7 /\ p8 x8 /\ p9 x9 /\ p10 x10
+  with use10 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10


### PR DESCRIPTION
destruct_q_conn stops collecting binders as soon as the body of the quantifier is not syntactically another application of the same quantifier, which includes the (empty) Meta_pattern node that sits in the body of the specifications of FStar.Classical.Sugar's indefinite_descriptionN. So `eliminate exists x1 ... xn` with n greater than max_indefinite_description_arity was encoded as a nest of existentials, one level per indefinite_descriptionN call.

That nesting is catastrophic when the body is an opaque application, e.g. a folded predicate: Z3 has no candidate trigger for the outer levels that mentions the inner binders and falls back to a multi-pattern of the typing hypotheses of the outer binders, enumerating every k-tuple of terms of the right type (k^5 instantiations per level, so k^10 at three levels, which never returns). Collecting the binders into a single quantifier makes the goal match the hypothesis and the query is discharged with a single instantiation.

On the repro of #4405, goal 1 of folded10 goes from rlimit 8.213 to 0.004, and folded11 (which did not return at rlimit 100000) now verifies at the default rlimit.

Fixes #4405