### PR TITLE
Pervasives: mark coerce_eq as inline_for_extraction noextract

### DIFF
--- a/ulib/FStar.Pervasives.fsti
+++ b/ulib/FStar.Pervasives.fsti
@@ -328,6 +328,7 @@ unfold let eqtype_as_type (a:eqtype) : Type = a
     to [b]. In most cases, F* will silently coerce from [a] to [b]
     along a provable equality (as in the body of this
     function). Occasionally, you may need to apply this explicitly *)
+inline_for_extraction noextract
 let coerce_eq (#a:Type) (#b:Type) (_:squash (a == b)) (x:a) : b = x
 
 (** This attribute decorates a let binding, e.g.,


### PR DESCRIPTION
So this does not appear in generated code. See
https://github.com/FStarLang/kuiper/pull/73#issuecomment-5348309274.

Fixes #4451 