### PR TITLE
includes fix: don't always recursively search '.'

### DIFF
--- a/src/basic/FStarC.Find.fst
+++ b/src/basic/FStarC.Find.fst
@@ -33,8 +33,7 @@ let cached_fun #a (cache : SMap.t a) (f : string -> ML a) : string -> ML a =
 
 (* caches *)
 let _full_include : ref (option (list string)) = mk_ref None
-let _full_include_normalized : ref (option (list string)) = mk_ref None
-let _recursive_include_normalized : ref (option (list string)) = mk_ref None
+let _module_include_paths_normalized : ref (option (list module_include_path)) = mk_ref None
 let find_file_cache : SMap.t (option string) = SMap.create 100
 
 (* Bumped every time the include path (or anything else affecting file
@@ -45,8 +44,7 @@ let _epoch : ref int = mk_ref 0
 let clear () : ML unit =
   SMap.clear find_file_cache;
   _full_include := None;
-  _full_include_normalized := None;
-  _recursive_include_normalized := None;
+  _module_include_paths_normalized := None;
   _epoch := !_epoch + 1;
   ()
 
@@ -216,30 +214,24 @@ let full_include_path () : ML _ =
     _full_include := Some res;
     res
 
-let recursive_include_path_normalized () : ML (list string) =
-  match !_recursive_include_normalized with
+let module_include_paths_normalized () : ML (list module_include_path) =
+  match !_module_include_paths_normalized with
   | Some paths -> paths
   | None ->
-    let paths =
+    let recursive_dirs =
       ((!_include |> List.collect recursive_include_d)
        @ ((lib_roots () @ command_line_include_roots () @ ["."])
           |> List.collect recursive_manifest_include_d))
       |> List.map Filepath.normalize_file_path
     in
-    _recursive_include_normalized := Some paths;
+    let paths =
+      full_include_path ()
+      |> List.map (fun dir ->
+        let dir = Filepath.normalize_file_path dir in
+        { dir; prefix=if List.contains dir recursive_dirs then Some [] else None })
+    in
+    _module_include_paths_normalized := Some paths;
     paths
-
-(* Normalizing every entry of the include path is not cheap (it involves
-querying the cwd for relative entries), and callers such as
-[FStarC.Parser.Dep.module_name_from_include_path] need it once per module in
-the dependency graph, so memoize it just like [full_include_path]. *)
-let full_include_path_normalized () : ML _ =
-  match !_full_include_normalized with
-  | Some paths -> paths
-  | None ->
-    let res = List.map Filepath.normalize_file_path (full_include_path ()) in
-    _full_include_normalized := Some res;
-    res
 
 let do_find (paths : list string) (filename : string) : ML (option string) =
   // Stats.record "Find.do_find" fun () ->

--- a/src/basic/FStarC.Find.fst
+++ b/src/basic/FStarC.Find.fst
@@ -168,43 +168,27 @@ let rec path_is_at_or_below (root:string) (path:string) : ML bool =
     let parent = Filepath.dirname path in
     parent <> path && path_is_at_or_below root parent
 
+let module_include_covers (inc: module_include_path) (path: string): ML bool =
+  let incnorm = Filepath.normalize_file_path inc.dir in
+  let pathnorm = Filepath.normalize_file_path path in
+  match inc.kind with
+  | Flat -> incnorm = pathnorm
+  | Recursive _ -> path_is_at_or_below incnorm pathnorm
+
 (* Add command-line file parents not already owned by an explicit root as flat
   roots. Roots declared by their [fstar.include] are flat too. For example, when running:
   > fstar.exe test/Test01.fst
   we add `test` as an include path under the assumption that the file defines the Test01 module. *)
 let command_line_include_roots () : ML (list string) =
-  match !_file_list with
-  | [] -> []
-  | files ->
-    let explicit_paths = !_include |> expand_module_include_paths (Recursive []) in
-    let explicit_roots =
-      explicit_paths |> include_dirs |> List.map Filepath.normalize_file_path
-    in
-    let recursive_explicit_roots =
-      explicit_paths
-      |> List.collect (fun path ->
-           match path.kind with
-           | Flat -> []
-           | Recursive _ -> [path.dir])
-      |> List.map Filepath.normalize_file_path
-    in
-    let cwd = Filepath.normalize_file_path (Filepath.getcwd ()) in
-    let file_roots =
-      List.fold_left (fun roots file ->
-        let root = Filepath.normalize_file_path (Filepath.dirname file) in
-        let is_file = Filepath.file_exists file && not (Filepath.is_directory file) in
-        (* Nonexistent entries may be unsaved files supplied through the IDE VFS,
-          but synthetic paths outside cwd must not introduce broad include roots. *)
-        if is_file || (not (Filepath.file_exists file) && path_is_at_or_below cwd root) then
-          if List.contains root roots then roots else roots @ [root]
-        else roots)
-        [] files
-    in
-    file_roots
-    |> List.filter (fun root ->
-        not (List.contains root explicit_roots
-          || List.existsb (fun explicit_root ->
-            path_is_at_or_below explicit_root root) recursive_explicit_roots))
+  let files = !_file_list in
+  let explicit_includes = !_include |> expand_module_include_paths (Recursive []) in
+  let file_roots = List.collect (fun file ->
+    let root = Filepath.normalize_file_path (Filepath.dirname file) in
+    let is_dir = Filepath.is_directory file in
+    if is_dir then [] else [root]
+  ) files in
+  file_roots |> List.filter (fun root ->
+      not (List.existsb (fun inc -> (module_include_covers inc root)) explicit_includes))
 
 let command_line_include_paths () : ML (list module_include_path) =
   command_line_include_roots () |> expand_module_include_paths Flat

--- a/src/basic/FStarC.Find.fst
+++ b/src/basic/FStarC.Find.fst
@@ -146,19 +146,22 @@ let rec path_is_at_or_below (root:string) (path:string) : ML bool =
     let parent = Filepath.dirname path in
     parent <> path && path_is_at_or_below root parent
 
-(* Add existing command-line file parents as specific roots while preserving the cwd root.
-  This is only necessary when no include path is specified. For example, when running:
+(* Add command-line file parents not already covered by an explicit include root. For example, when running:
   > fstar.exe test/Test01.fst
   we add `test` as an include path under the assumption that the file defines the Test01 module. *)
 let command_line_include_paths () : ML (list string) =
   match !_file_list with
-  | [] -> expand_include_d "."
+  | [] -> []
   | files ->
     let explicit_roots = List.map Filepath.normalize_file_path !_include in
+    let cwd = Filepath.normalize_file_path (Filepath.getcwd ()) in
     let file_roots =
       List.fold_left (fun roots file ->
-        if Filepath.file_exists file && not (Filepath.is_directory file) then
-          let root = Filepath.normalize_file_path (Filepath.dirname file) in
+        let root = Filepath.normalize_file_path (Filepath.dirname file) in
+        let is_file = Filepath.file_exists file && not (Filepath.is_directory file) in
+        (* Nonexistent entries may be unsaved files supplied through the IDE VFS,
+          but synthetic paths outside cwd must not introduce broad include roots. *)
+        if is_file || (not (Filepath.file_exists file) && path_is_at_or_below cwd root) then
           if List.contains root roots then roots else roots @ [root]
         else roots)
         [] files
@@ -168,7 +171,7 @@ let command_line_include_paths () : ML (list string) =
         not (List.existsb (fun explicit_root ->
           path_is_at_or_below explicit_root root) explicit_roots)) file_roots
     in
-    expand_include_ds uncovered_roots @ expand_include_d "."
+    expand_include_ds uncovered_roots
 
 let epoch () : ML int = !_epoch
 
@@ -184,10 +187,19 @@ let full_include_path () : ML _ =
         | Some c -> [c]
       in
       let include_paths = !_include |> expand_include_ds in
-      cache_dir @ lib_paths () @ include_paths @ command_line_include_paths ()
+      cache_dir @ lib_paths () @ include_paths @ command_line_include_paths () @ ["."]
     in
     _full_include := Some res;
     res
+
+let recursive_include_path_normalized () : ML (list string) =
+  let cache_dir =
+    match !_cache_dir with
+    | None -> []
+    | Some c -> [c]
+  in
+  cache_dir @ lib_paths () @ (!_include |> expand_include_ds) @ command_line_include_paths ()
+  |> List.map Filepath.normalize_file_path
 
 (* Normalizing every entry of the include path is not cheap (it involves
 querying the cwd for relative entries), and callers such as

--- a/src/basic/FStarC.Find.fst
+++ b/src/basic/FStarC.Find.fst
@@ -120,29 +120,21 @@ let read_fstar_include (fn : string) : ML (option (list string)) =
     failwith ("Could not read " ^ fn);
     None
 
-let has_fstar_include (dirname:string) : ML bool =
+let has_fstar_include (dirname : string) : ML bool =
   Filepath.file_exists (dirname ^ "/fstar.include")
 
-let rec expand_module_include_path
-  (root_kind:module_include_path_kind)
-  (dirname:string)
-  : ML (list module_include_path)
-=
+let rec expand_module_include_path (root_kind : module_include_path_kind)
+  (dirname : string) : ML (list module_include_path) =
   if has_fstar_include dirname then (
     let dot_inc_path = dirname ^ "/fstar.include" in
     let subdirs = Some?.v <| read_fstar_include dot_inc_path in
-    { dir=dirname; kind=Flat }
-    :: List.collect
-         (fun subd -> expand_module_include_path (Recursive []) (dirname ^ "/" ^ subd))
-         subdirs
+    let go subd = expand_module_include_path Recursive (dirname ^ "/" ^ subd) in
+    { dir=dirname; kind=Flat } :: List.collect go subdirs
   ) else
     [{ dir=dirname; kind=root_kind }]
 
-let expand_module_include_paths
-  (root_kind:module_include_path_kind)
-  (dirnames:list string)
-  : ML (list module_include_path)
-=
+let expand_module_include_paths (root_kind:module_include_path_kind)
+  (dirnames:list string) : ML (list module_include_path) =
   List.collect (expand_module_include_path root_kind) dirnames
 
 let include_dirs (paths:list module_include_path) : ML (list string) =
@@ -168,12 +160,12 @@ let rec path_is_at_or_below (root:string) (path:string) : ML bool =
     let parent = Filepath.dirname path in
     parent <> path && path_is_at_or_below root parent
 
-let module_include_covers (inc: module_include_path) (path: string): ML bool =
+let module_include_covers_path (inc: module_include_path) (path: string): ML bool =
   let incnorm = Filepath.normalize_file_path inc.dir in
   let pathnorm = Filepath.normalize_file_path path in
   match inc.kind with
   | Flat -> incnorm = pathnorm
-  | Recursive _ -> path_is_at_or_below incnorm pathnorm
+  | Recursive -> path_is_at_or_below incnorm pathnorm
 
 (* Add command-line file parents not already owned by an explicit root as flat
   roots. Roots declared by their [fstar.include] are flat too. For example, when running:
@@ -181,14 +173,14 @@ let module_include_covers (inc: module_include_path) (path: string): ML bool =
   we add `test` as an include path under the assumption that the file defines the Test01 module. *)
 let command_line_include_roots () : ML (list string) =
   let files = !_file_list in
-  let explicit_includes = !_include |> expand_module_include_paths (Recursive []) in
+  let explicit_includes = !_include |> expand_module_include_paths Recursive in
   let file_roots = List.collect (fun file ->
     let root = Filepath.normalize_file_path (Filepath.dirname file) in
     let is_dir = Filepath.is_directory file in
     if is_dir then [] else [root]
   ) files in
   file_roots |> List.filter (fun root ->
-      not (List.existsb (fun inc -> (module_include_covers inc root)) explicit_includes))
+      not (List.existsb (fun inc -> (module_include_covers_path inc root)) explicit_includes))
 
 let command_line_include_paths () : ML (list module_include_path) =
   command_line_include_roots () |> expand_module_include_paths Flat
@@ -201,7 +193,7 @@ let module_include_paths () : ML (list module_include_path) =
   in
   cache_dir
   @ lib_paths ()
-  @ expand_module_include_paths (Recursive []) !_include
+  @ expand_module_include_paths Recursive !_include
   @ command_line_include_paths ()
   @ expand_module_include_path Flat "."
 
@@ -220,10 +212,9 @@ let module_include_paths_normalized () : ML (list module_include_path) =
   match !_module_include_paths_normalized with
   | Some paths -> paths
   | None ->
-    let paths =
-      module_include_paths ()
+    let paths = module_include_paths ()
       |> List.map (fun path ->
-        { path with dir=Filepath.normalize_file_path path.dir })
+        { path with dir = Filepath.normalize_file_path path.dir })
     in
     _module_include_paths_normalized := Some paths;
     paths

--- a/src/basic/FStarC.Find.fst
+++ b/src/basic/FStarC.Find.fst
@@ -34,6 +34,7 @@ let cached_fun #a (cache : SMap.t a) (f : string -> ML a) : string -> ML a =
 (* caches *)
 let _full_include : ref (option (list string)) = mk_ref None
 let _full_include_normalized : ref (option (list string)) = mk_ref None
+let _recursive_include_normalized : ref (option (list string)) = mk_ref None
 let find_file_cache : SMap.t (option string) = SMap.create 100
 
 (* Bumped every time the include path (or anything else affecting file
@@ -45,6 +46,7 @@ let clear () : ML unit =
   SMap.clear find_file_cache;
   _full_include := None;
   _full_include_normalized := None;
+  _recursive_include_normalized := None;
   _epoch := !_epoch + 1;
   ()
 
@@ -120,9 +122,12 @@ let read_fstar_include (fn : string) : ML (option (list string)) =
     failwith ("Could not read " ^ fn);
     None
 
+let has_fstar_include (dirname:string) : ML bool =
+  Filepath.file_exists (dirname ^ "/fstar.include")
+
 let rec expand_include_d (dirname : string) : ML (list string) =
-  let dot_inc_path = dirname ^ "/fstar.include" in
-  if Filepath.file_exists dot_inc_path then (
+  if has_fstar_include dirname then (
+    let dot_inc_path = dirname ^ "/fstar.include" in
     let subdirs = Some?.v <| read_fstar_include dot_inc_path in
     dirname :: List.collect (fun subd -> expand_include_d (dirname ^ "/" ^ subd)) subdirs
   ) else
@@ -131,14 +136,24 @@ let rec expand_include_d (dirname : string) : ML (list string) =
 let expand_include_ds (dirnames : list string) : ML (list string) =
   List.collect expand_include_d dirnames
 
-let fstarc_paths () : ML _ =
+let recursive_include_d (dirname:string) : ML (list string) =
+  expand_include_d dirname |> List.filter (fun d -> not (has_fstar_include d))
+
+let recursive_manifest_include_d (dirname:string) : ML (list string) =
+  match expand_include_d dirname with
+  | _::paths -> paths |> List.filter (fun d -> not (has_fstar_include d))
+  | [] -> []
+
+let fstarc_roots () : ML (list string) =
   if !_with_fstarc
-  then expand_include_d (Filepath.canonicalize <| fstar_bin_directory ^ "/../lib/fstar/fstarc")
+  then [Filepath.canonicalize <| fstar_bin_directory ^ "/../lib/fstar/fstarc"]
   else []
 
-let lib_paths () : ML _ =
-  (Common.option_to_list (lib_root ()) |> expand_include_ds)
-  @ fstarc_paths ()
+let lib_roots () : ML (list string) =
+  Common.option_to_list (lib_root ()) @ fstarc_roots ()
+
+let lib_paths () : ML (list string) =
+  lib_roots () |> expand_include_ds
 
 let rec path_is_at_or_below (root:string) (path:string) : ML bool =
   if root = path then true
@@ -150,11 +165,16 @@ let rec path_is_at_or_below (root:string) (path:string) : ML bool =
   roots. Roots declared by their [fstar.include] are flat too. For example, when running:
   > fstar.exe test/Test01.fst
   we add `test` as an include path under the assumption that the file defines the Test01 module. *)
-let command_line_include_paths () : ML (list string) =
+let command_line_include_roots () : ML (list string) =
   match !_file_list with
   | [] -> []
   | files ->
-    let explicit_roots = List.map Filepath.normalize_file_path !_include in
+    let explicit_roots =
+      !_include |> expand_include_ds |> List.map Filepath.normalize_file_path
+    in
+    let recursive_explicit_roots =
+      !_include |> List.collect recursive_include_d |> List.map Filepath.normalize_file_path
+    in
     let cwd = Filepath.normalize_file_path (Filepath.getcwd ()) in
     let file_roots =
       List.fold_left (fun roots file ->
@@ -169,9 +189,12 @@ let command_line_include_paths () : ML (list string) =
     in
     file_roots
     |> List.filter (fun root ->
-       not (List.existsb (fun explicit_root ->
-         path_is_at_or_below explicit_root root) explicit_roots))
-    |> expand_include_ds
+        not (List.contains root explicit_roots
+          || List.existsb (fun explicit_root ->
+            path_is_at_or_below explicit_root root) recursive_explicit_roots))
+
+let command_line_include_paths () : ML (list string) =
+  command_line_include_roots () |> expand_include_ds
 
 let epoch () : ML int = !_epoch
 
@@ -194,8 +217,17 @@ let full_include_path () : ML _ =
     res
 
 let recursive_include_path_normalized () : ML (list string) =
-  (!_include |> expand_include_ds)
-  |> List.map Filepath.normalize_file_path
+  match !_recursive_include_normalized with
+  | Some paths -> paths
+  | None ->
+    let paths =
+      ((!_include |> List.collect recursive_include_d)
+       @ ((lib_roots () @ command_line_include_roots () @ ["."])
+          |> List.collect recursive_manifest_include_d))
+      |> List.map Filepath.normalize_file_path
+    in
+    _recursive_include_normalized := Some paths;
+    paths
 
 (* Normalizing every entry of the include path is not cheap (it involves
 querying the cwd for relative entries), and callers such as

--- a/src/basic/FStarC.Find.fst
+++ b/src/basic/FStarC.Find.fst
@@ -123,24 +123,33 @@ let read_fstar_include (fn : string) : ML (option (list string)) =
 let has_fstar_include (dirname:string) : ML bool =
   Filepath.file_exists (dirname ^ "/fstar.include")
 
-let rec expand_include_d (dirname : string) : ML (list string) =
+let rec expand_module_include_path
+  (root_kind:module_include_path_kind)
+  (dirname:string)
+  : ML (list module_include_path)
+=
   if has_fstar_include dirname then (
     let dot_inc_path = dirname ^ "/fstar.include" in
     let subdirs = Some?.v <| read_fstar_include dot_inc_path in
-    dirname :: List.collect (fun subd -> expand_include_d (dirname ^ "/" ^ subd)) subdirs
+    { dir=dirname; kind=Flat }
+    :: List.collect
+         (fun subd -> expand_module_include_path (Recursive []) (dirname ^ "/" ^ subd))
+         subdirs
   ) else
-    [dirname]
+    [{ dir=dirname; kind=root_kind }]
 
-let expand_include_ds (dirnames : list string) : ML (list string) =
-  List.collect expand_include_d dirnames
+let expand_module_include_paths
+  (root_kind:module_include_path_kind)
+  (dirnames:list string)
+  : ML (list module_include_path)
+=
+  List.collect (expand_module_include_path root_kind) dirnames
 
-let recursive_include_d (dirname:string) : ML (list string) =
-  expand_include_d dirname |> List.filter (fun d -> not (has_fstar_include d))
+let include_dirs (paths:list module_include_path) : ML (list string) =
+  paths |> List.map (fun path -> path.dir)
 
-let recursive_manifest_include_d (dirname:string) : ML (list string) =
-  match expand_include_d dirname with
-  | _::paths -> paths |> List.filter (fun d -> not (has_fstar_include d))
-  | [] -> []
+let expand_include_d (dirname:string) : ML (list string) =
+  expand_module_include_path Flat dirname |> include_dirs
 
 let fstarc_roots () : ML (list string) =
   if !_with_fstarc
@@ -150,8 +159,8 @@ let fstarc_roots () : ML (list string) =
 let lib_roots () : ML (list string) =
   Common.option_to_list (lib_root ()) @ fstarc_roots ()
 
-let lib_paths () : ML (list string) =
-  lib_roots () |> expand_include_ds
+let lib_paths () : ML (list module_include_path) =
+  lib_roots () |> expand_module_include_paths Flat
 
 let rec path_is_at_or_below (root:string) (path:string) : ML bool =
   if root = path then true
@@ -167,11 +176,17 @@ let command_line_include_roots () : ML (list string) =
   match !_file_list with
   | [] -> []
   | files ->
+    let explicit_paths = !_include |> expand_module_include_paths (Recursive []) in
     let explicit_roots =
-      !_include |> expand_include_ds |> List.map Filepath.normalize_file_path
+      explicit_paths |> include_dirs |> List.map Filepath.normalize_file_path
     in
     let recursive_explicit_roots =
-      !_include |> List.collect recursive_include_d |> List.map Filepath.normalize_file_path
+      explicit_paths
+      |> List.collect (fun path ->
+           match path.kind with
+           | Flat -> []
+           | Recursive _ -> [path.dir])
+      |> List.map Filepath.normalize_file_path
     in
     let cwd = Filepath.normalize_file_path (Filepath.getcwd ()) in
     let file_roots =
@@ -191,8 +206,20 @@ let command_line_include_roots () : ML (list string) =
           || List.existsb (fun explicit_root ->
             path_is_at_or_below explicit_root root) recursive_explicit_roots))
 
-let command_line_include_paths () : ML (list string) =
-  command_line_include_roots () |> expand_include_ds
+let command_line_include_paths () : ML (list module_include_path) =
+  command_line_include_roots () |> expand_module_include_paths Flat
+
+let module_include_paths () : ML (list module_include_path) =
+  let cache_dir =
+    match !_cache_dir with
+    | None -> []
+    | Some dir -> [{ dir; kind=Flat }]
+  in
+  cache_dir
+  @ lib_paths ()
+  @ expand_module_include_paths (Recursive []) !_include
+  @ command_line_include_paths ()
+  @ expand_module_include_path Flat "."
 
 let epoch () : ML int = !_epoch
 
@@ -201,16 +228,7 @@ let full_include_path () : ML _ =
   match !_full_include with
   | Some paths -> paths
   | None ->
-    let res =
-      let cache_dir =
-        match !_cache_dir with
-        | None -> []
-        | Some c -> [c]
-      in
-      let include_paths = !_include |> expand_include_ds in
-      cache_dir @ lib_paths () @ include_paths @ command_line_include_paths ()
-      @ expand_include_d "."
-    in
+    let res = module_include_paths () |> include_dirs in
     _full_include := Some res;
     res
 
@@ -218,17 +236,10 @@ let module_include_paths_normalized () : ML (list module_include_path) =
   match !_module_include_paths_normalized with
   | Some paths -> paths
   | None ->
-    let recursive_dirs =
-      ((!_include |> List.collect recursive_include_d)
-       @ ((lib_roots () @ command_line_include_roots () @ ["."])
-          |> List.collect recursive_manifest_include_d))
-      |> List.map Filepath.normalize_file_path
-    in
     let paths =
-      full_include_path ()
-      |> List.map (fun dir ->
-        let dir = Filepath.normalize_file_path dir in
-        { dir; prefix=if List.contains dir recursive_dirs then Some [] else None })
+      module_include_paths ()
+      |> List.map (fun path ->
+        { path with dir=Filepath.normalize_file_path path.dir })
     in
     _module_include_paths_normalized := Some paths;
     paths

--- a/src/basic/FStarC.Find.fst
+++ b/src/basic/FStarC.Find.fst
@@ -146,7 +146,8 @@ let rec path_is_at_or_below (root:string) (path:string) : ML bool =
     let parent = Filepath.dirname path in
     parent <> path && path_is_at_or_below root parent
 
-(* Add command-line file parents not already covered by an explicit include root. For example, when running:
+(* Add command-line file parents not already owned by an explicit root as flat
+  roots. Roots declared by their [fstar.include] are flat too. For example, when running:
   > fstar.exe test/Test01.fst
   we add `test` as an include path under the assumption that the file defines the Test01 module. *)
 let command_line_include_paths () : ML (list string) =
@@ -166,12 +167,11 @@ let command_line_include_paths () : ML (list string) =
         else roots)
         [] files
     in
-    let uncovered_roots =
-      List.filter (fun root ->
-        not (List.existsb (fun explicit_root ->
-          path_is_at_or_below explicit_root root) explicit_roots)) file_roots
-    in
-    expand_include_ds uncovered_roots
+    file_roots
+    |> List.filter (fun root ->
+       not (List.existsb (fun explicit_root ->
+         path_is_at_or_below explicit_root root) explicit_roots))
+    |> expand_include_ds
 
 let epoch () : ML int = !_epoch
 
@@ -187,18 +187,14 @@ let full_include_path () : ML _ =
         | Some c -> [c]
       in
       let include_paths = !_include |> expand_include_ds in
-      cache_dir @ lib_paths () @ include_paths @ command_line_include_paths () @ ["."]
+      cache_dir @ lib_paths () @ include_paths @ command_line_include_paths ()
+      @ expand_include_d "."
     in
     _full_include := Some res;
     res
 
 let recursive_include_path_normalized () : ML (list string) =
-  let cache_dir =
-    match !_cache_dir with
-    | None -> []
-    | Some c -> [c]
-  in
-  cache_dir @ lib_paths () @ (!_include |> expand_include_ds) @ command_line_include_paths ()
+  (!_include |> expand_include_ds)
   |> List.map Filepath.normalize_file_path
 
 (* Normalizing every entry of the include path is not cheap (it involves

--- a/src/basic/FStarC.Find.fsti
+++ b/src/basic/FStarC.Find.fsti
@@ -19,9 +19,15 @@ operations. *)
 
 open FStarC.Effect
 
+(* [Flat] provides only immediate files. [Recursive prefix] also provides files
+in subdirectories, extending [prefix] with their relative path. *)
+type module_include_path_kind =
+    | Flat
+    | Recursive of list string
+
 type module_include_path = {
     dir: string;
-    prefix: option (list string)
+    kind: module_include_path_kind
 }
 
 (* --include *)
@@ -64,9 +70,7 @@ val epoch () : ML int
 (* The full include path. We search files in all of these directories. *)
 val full_include_path () : ML (list string)
 
-(* Directories providing modules, normalized into absolute paths and paired
-with their hierarchy prefix. [None] means that only immediate files belong to
-the directory; [Some prefix] means that subdirectories extend [prefix]. *)
+(* Directories providing modules, normalized into absolute paths. *)
 val module_include_paths_normalized () : ML (list module_include_path)
 
 (* Try to find a file in the include path with a given basename. *)

--- a/src/basic/FStarC.Find.fsti
+++ b/src/basic/FStarC.Find.fsti
@@ -19,6 +19,11 @@ operations. *)
 
 open FStarC.Effect
 
+type module_include_path = {
+    dir: string;
+    prefix: option (list string)
+}
+
 (* --include *)
 val get_include_path () : ML (list string)
 val set_include_path (path : list string) : ML unit
@@ -59,15 +64,10 @@ val epoch () : ML int
 (* The full include path. We search files in all of these directories. *)
 val full_include_path () : ML (list string)
 
-(* Explicit include roots and roots declared by [fstar.include], normalized
-into absolute paths. Roots containing their own [fstar.include] are excluded:
-their declared roots take ownership instead. *)
-val recursive_include_path_normalized () : ML (list string)
-
-(* The full include path, with every entry normalized into an absolute path.
-This is memoized (and invalidated together with [full_include_path]), so it is
-cheap to call repeatedly. *)
-val full_include_path_normalized () : ML (list string)
+(* Directories providing modules, normalized into absolute paths and paired
+with their hierarchy prefix. [None] means that only immediate files belong to
+the directory; [Some prefix] means that subdirectories extend [prefix]. *)
+val module_include_paths_normalized () : ML (list module_include_path)
 
 (* Try to find a file in the include path with a given basename. *)
 val find_file (basename : string) : ML (option string)

--- a/src/basic/FStarC.Find.fsti
+++ b/src/basic/FStarC.Find.fsti
@@ -59,8 +59,9 @@ val epoch () : ML int
 (* The full include path. We search files in all of these directories. *)
 val full_include_path () : ML (list string)
 
-(* The include roots that should be scanned recursively for hierarchical
-modules. Unlike [full_include_path], this excludes the implicit cwd root. *)
+(* Explicit include roots, including roots from their [fstar.include],
+normalized into absolute paths. These roots are scanned recursively for
+hierarchical modules; all other roots in [full_include_path] remain flat. *)
 val recursive_include_path_normalized () : ML (list string)
 
 (* The full include path, with every entry normalized into an absolute path.

--- a/src/basic/FStarC.Find.fsti
+++ b/src/basic/FStarC.Find.fsti
@@ -19,11 +19,11 @@ operations. *)
 
 open FStarC.Effect
 
-(* [Flat] provides only immediate files. [Recursive prefix] also provides files
-in subdirectories, extending [prefix] with their relative path. *)
+(* [Flat] provides only immediate files. [Recursive] also provides files in
+subdirectories. *)
 type module_include_path_kind =
     | Flat
-    | Recursive of list string
+    | Recursive
 
 type module_include_path = {
     dir: string;

--- a/src/basic/FStarC.Find.fsti
+++ b/src/basic/FStarC.Find.fsti
@@ -59,9 +59,9 @@ val epoch () : ML int
 (* The full include path. We search files in all of these directories. *)
 val full_include_path () : ML (list string)
 
-(* Explicit include roots, including roots from their [fstar.include],
-normalized into absolute paths. These roots are scanned recursively for
-hierarchical modules; all other roots in [full_include_path] remain flat. *)
+(* Explicit include roots and roots declared by [fstar.include], normalized
+into absolute paths. Roots containing their own [fstar.include] are excluded:
+their declared roots take ownership instead. *)
 val recursive_include_path_normalized () : ML (list string)
 
 (* The full include path, with every entry normalized into an absolute path.

--- a/src/basic/FStarC.Find.fsti
+++ b/src/basic/FStarC.Find.fsti
@@ -59,6 +59,10 @@ val epoch () : ML int
 (* The full include path. We search files in all of these directories. *)
 val full_include_path () : ML (list string)
 
+(* The include roots that should be scanned recursively for hierarchical
+modules. Unlike [full_include_path], this excludes the implicit cwd root. *)
+val recursive_include_path_normalized () : ML (list string)
+
 (* The full include path, with every entry normalized into an absolute path.
 This is memoized (and invalidated together with [full_include_path]), so it is
 cheap to call repeatedly. *)

--- a/src/basic/FStarC.Options.fst
+++ b/src/basic/FStarC.Options.fst
@@ -1840,11 +1840,6 @@ let with_restored_cmd_line_options (f:unit -> ML 'a) : ML 'a =
   let _ = restore_cmd_line_options true in
   finally (fun _ -> history := h; restore_all snap) f
 
-let module_name_of_file_name f =
-    let f = Filepath.basename f in
-    let f = String.substring f 0 (String.length f - String.length (Filepath.get_file_extension f) - 1) in
-    String.lowercase f
-
 (* Basically returns true when the module is in the command line *)
 let should_check m =
   let l = get_verify_module () in
@@ -1853,14 +1848,9 @@ let should_check m =
 let should_verify m =
   not (get_admit_smt_queries ()) && not (get_lax ()) && should_check m
 
-let should_check_file fn =
-    should_check (module_name_of_file_name fn)
-
-let should_verify_file fn =
-    should_verify (module_name_of_file_name fn)
-
+(* TODO:RM *)
 (* Whether a checked file should be written for [fn].
-   Unlike [should_check_file], this is about the *file*, not the module: running
+  This is about the *file*, not the module: running
    [fstar.exe A.fst] verifies A.fsti too, but it must not write A.fsti.checked.
    Otherwise the contents of the interface's checked file would depend on which
    of the two files happened to be checked --- checking A.fst reveals the

--- a/src/basic/FStarC.Options.fst
+++ b/src/basic/FStarC.Options.fst
@@ -1848,7 +1848,6 @@ let should_check m =
 let should_verify m =
   not (get_admit_smt_queries ()) && not (get_lax ()) && should_check m
 
-(* TODO:RM *)
 (* Whether a checked file should be written for [fn].
   This is about the *file*, not the module: running
    [fstar.exe A.fst] verifies A.fsti too, but it must not write A.fsti.checked.

--- a/src/basic/FStarC.Options.fsti
+++ b/src/basic/FStarC.Options.fsti
@@ -180,7 +180,6 @@ val should_check                : string  -> ML bool (* Should check this module
 
 val should_verify               : string  -> ML bool (* Should check this module with verification enabled. *)
 
-(* TODO:RM *)
 (* Should a checked file be written for this file? True only for the files
    given on the command line; note this is per *file*, not per module, so
    `fstar.exe A.fst` does not write A.fsti.checked. *)

--- a/src/basic/FStarC.Options.fsti
+++ b/src/basic/FStarC.Options.fsti
@@ -180,10 +180,7 @@ val should_check                : string  -> ML bool (* Should check this module
 
 val should_verify               : string  -> ML bool (* Should check this module with verification enabled. *)
 
-val should_check_file           : string  -> ML bool (* Should check this file, lax or not. *)
-
-val should_verify_file          : string  -> ML bool (* Should check this file with verification enabled. *)
-
+(* TODO:RM *)
 (* Should a checked file be written for this file? True only for the files
    given on the command line; note this is per *file*, not per module, so
    `fstar.exe A.fst` does not write A.fsti.checked. *)

--- a/src/fstar/FStarC.CheckedFiles.fst
+++ b/src/fstar/FStarC.CheckedFiles.fst
@@ -443,7 +443,9 @@ let load_module_from_cache_internal =
       let fail msg cache_file =
         //Don't feel too bad if fn is the file on the command line
         //Also suppress the warning if already given to avoid a deluge
-        let suppress_warning = try_load || Options.should_check_file fn || !already_failed in
+        let suppress_warning =
+          try_load || Options.should_check (Dep.module_name_of_file fn) || !already_failed
+        in
         if not suppress_warning || !dbg then begin
           already_failed := true;
           FStarC.Errors.log_issue (Range.mk_range fn (Range.mk_pos 0 0) (Range.mk_pos 0 0))

--- a/src/fstar/FStarC.CheckedFiles.fst
+++ b/src/fstar/FStarC.CheckedFiles.fst
@@ -443,9 +443,7 @@ let load_module_from_cache_internal =
       let fail msg cache_file =
         //Don't feel too bad if fn is the file on the command line
         //Also suppress the warning if already given to avoid a deluge
-        let suppress_warning =
-          try_load || Options.should_check (Dep.module_name_of_file fn) || !already_failed
-        in
+        let suppress_warning = try_load || Options.should_check (Dep.module_name_of_file fn) || !already_failed in
         if not suppress_warning || !dbg then begin
           already_failed := true;
           FStarC.Errors.log_issue (Range.mk_range fn (Range.mk_pos 0 0) (Range.mk_pos 0 0))

--- a/src/fstar/FStarC.Universal.fst
+++ b/src/fstar/FStarC.Universal.fst
@@ -529,7 +529,7 @@ and tc_one_file_no_frame
   in
   if not (Options.cache_off()) then
       let r = 
-        if fly_deps && Options.should_check_file fn
+        if fly_deps && Options.should_check (Dep.module_name_of_file fn)
         then None //if we reach here with fly_deps, then checked files are invalid
         else Ch.load_module_from_cache (tcenv_of_uenv env) fn
       in
@@ -545,7 +545,7 @@ and tc_one_file_no_frame
          * If codegen was given, the the user wants an ml/krml file, and it is fine
          * to load the cache.
          *)
-        if Options.should_check_file fn && (
+        if Options.should_check (Dep.module_name_of_file fn) && (
              Options.force () ||
              (Some? (Options.output_to ()) && None? (Options.codegen ()))
            )
@@ -912,7 +912,8 @@ let batch_mode_tc fly_deps filenames dep_graph
     Format.print1 "Here's the list of filenames we will process: %s\n"
       (String.concat " " filenames);
     Format.print1 "Here's the list of modules we will verify: %s\n"
-      (String.concat " " (filenames |> List.filter Options.should_verify_file))
+      (String.concat " " (filenames |> List.filter (fun fn ->
+        Options.should_verify (Dep.module_name_of_file fn))))
   end;
   let env = FStarC.Extraction.ML.UEnv.new_uenv (init_env dep_graph) in
   let all_mods, mllibs, env = tc_fold_interleave fly_deps None ([], [], env) filenames in

--- a/src/parser/FStarC.Parser.Dep.fst
+++ b/src/parser/FStarC.Parser.Dep.fst
@@ -190,13 +190,9 @@ let list_of_option = function Some x -> [x] | None -> []
 let list_of_pair (intf, impl) =
   list_of_option intf @ list_of_option impl
 
-(* Given a source file path, if it lives (possibly transitively, through
-   subdirectories) under one of the include directories, recover its full
-   dotted module name. We match against the *longest* include directory that is
-   a path-boundary prefix of the file and turn the remaining relative path into
-   a dotted name: an include directory [d] and a file [d/X/Y/Z.fst] yield
-   "X.Y.Z". Returns None if the file is not under any include directory or is
-   not a valid F* source file. *)
+(* Recover a source file's module name relative to the longest applicable
+  include root. Recursive roots map [d/X/Y/Z.fst] to [X.Y.Z]; flat roots only
+  apply to immediate files. *)
 let module_name_from_include_path (f:string) : ML (option string) =
   let f = Filepath.normalize_file_path f in
   let include_dirs = Find.full_include_path_normalized () in
@@ -637,7 +633,6 @@ let can_be_namespace_component (s:string) : ML bool =
   are reported by their bare path relative to [cwd]. *)
 let hierarchical_modules_for_dir (cwd:string) (include_roots:list string) (root:string)
   : ML (list (string & string)) =
-  let has_include_manifest = Filepath.file_exists (Filepath.join_paths root "fstar.include") in
   (* [ns_prefix] is the list of namespace components corresponding to the
      subdirectories walked so far (in order); [rel] is the path, relative to
      [root], of the directory currently being scanned ("" for [root] itself). *)
@@ -654,13 +649,9 @@ let hierarchical_modules_for_dir (cwd:string) (include_roots:list string) (root:
          && None? (check_and_strip_suffix entry)
       then []
       else if Filepath.is_directory entry_path then
-        (* A manifest explicitly selects the child roots to scan; those roots
-          are expanded separately by [Find.full_include_path]. *)
-        if has_include_manifest
-        then []
         (* Never descend into directories that cannot be namespace components
            (e.g. hidden directories, or build directories such as '_build'). *)
-        else if not (can_be_namespace_component entry)
+        if not (can_be_namespace_component entry)
         then []
         (* If this directory is itself an include root, let that root's own
            traversal cover it. *)
@@ -692,12 +683,9 @@ let check_unique_module_names_for_dir (dir:string)
       ]
     | None -> SMap.add seen key path)
 
-(** Enumerate all F* files in all include directories, returning a list of pairs
-    of long names and full paths.
-
-    We descend into subdirectories, mapping a file at [X/Y/Z.fst] to the long
-    name [X.Y.Z] (matching is case-insensitive; long names are lowercased in
-    [build_map]).
+(** Enumerate F* files in all include directories, returning pairs of long names
+    and full paths. Explicit roots are scanned recursively, mapping [X/Y/Z.fst]
+    to [X.Y.Z]; implicit roots are scanned flat.
 
     We fail hard if any module long name is provided by more than one file of
     the same role within a single include directory (e.g. both a flat
@@ -714,7 +702,7 @@ let build_inclusion_candidates_list (): ML (list (string & string)) =
   include_directories |> List.concatMap (fun d ->
     let candidates =
       if List.contains d recursive_include_directories
-      then hierarchical_modules_for_dir cwd recursive_include_directories d
+      then hierarchical_modules_for_dir cwd include_directories d
       else
         safe_readdir_for_include d |> List.concatMap (fun entry ->
           let entry = Filepath.basename entry in

--- a/src/parser/FStarC.Parser.Dep.fst
+++ b/src/parser/FStarC.Parser.Dep.fst
@@ -195,24 +195,25 @@ let list_of_pair (intf, impl) =
   apply to immediate files. *)
 let module_name_from_include_path (f:string) : ML (option string) =
   let f = Filepath.normalize_file_path f in
-  let include_dirs = Find.full_include_path_normalized () in
-  let recursive_include_dirs = Find.recursive_include_path_normalized () in
+  let include_paths = Find.module_include_paths_normalized () in
   let best =
-    List.fold_left (fun (acc:option string) d ->
-      if Util.starts_with f (d ^ "/")
-      && (List.contains d recursive_include_dirs || Filepath.dirname f = d)
-      && (match acc with Some a -> String.length d > String.length a | None -> true)
-      then Some d
+    List.fold_left (fun (acc:option Find.module_include_path) (path:Find.module_include_path) ->
+      if Util.starts_with f (path.dir ^ "/")
+      && (Some? path.prefix || Filepath.dirname f = path.dir)
+      && (match acc with Some prev -> String.length path.dir > String.length prev.dir | None -> true)
+      then Some path
       else acc)
-      None include_dirs
+      None include_paths
   in
   match best with
   | None -> None
-  | Some d ->
-    let rel = Util.substring_from f (String.length d + 1) in
+  | Some path ->
+    let rel = Util.substring_from f (String.length path.dir + 1) in
     match check_and_strip_suffix rel with
     | None -> None
-    | Some stem -> Some (Util.replace_char (Util.replace_char stem '\\' '.') '/' '.')
+    | Some stem ->
+      let stem = Util.replace_char (Util.replace_char stem '\\' '.') '/' '.' in
+      Some (String.concat "." (Option.dflt [] path.prefix @ [stem]))
 
 (* [maybe_module_name_of_file] is called once per dependency edge in the
 dependency graph, and is a pure function of the file name and the include
@@ -631,7 +632,8 @@ let can_be_namespace_component (s:string) : ML bool =
   subdirectory that is itself an include root, so that each include root owns
   its own traversal. [cwd] is the normalized current directory: files under it
   are reported by their bare path relative to [cwd]. *)
-let hierarchical_modules_for_dir (cwd:string) (include_roots:list string) (root:string)
+let hierarchical_modules_for_dir (cwd:string) (include_roots:list string)
+                                 (root:string) (prefix:list string)
   : ML (list (string & string)) =
   (* [ns_prefix] is the list of namespace components corresponding to the
      subdirectories walked so far (in order); [rel] is the path, relative to
@@ -660,7 +662,7 @@ let hierarchical_modules_for_dir (cwd:string) (include_roots:list string) (root:
         else walk (ns_prefix @ [entry]) rel'
       else module_candidate_of_file ns_prefix (if root = cwd then rel' else entry_path) entry)
   in
-  walk [] ""
+  walk prefix ""
 
 (* Build a map from module long name (and interface/implementation role) to the
   file providing it within a single include directory, and check that this map
@@ -693,24 +695,24 @@ let check_unique_module_names_for_dir (dir:string)
     [X.Y.Z.fst] and a nested [X/Y/Z.fst]). *)
 (* In public interface *)
 let build_inclusion_candidates_list (): ML (list (string & string)) =
-  let include_directories = Find.full_include_path_normalized () in
-  let recursive_include_directories = Find.recursive_include_path_normalized () in
+  let include_paths = Find.module_include_paths_normalized () in
   (* Note that [BatList.unique] keeps the last occurrence, that way one can
    * always override the precedence order. *)
-  let include_directories = List.unique include_directories in
+  let include_paths = List.unique include_paths in
+  let include_directories = List.map (fun (path:Find.module_include_path) -> path.dir) include_paths in
   let cwd = Filepath.normalize_file_path (getcwd ()) in
-  include_directories |> List.concatMap (fun d ->
+  include_paths |> List.concatMap (fun (path:Find.module_include_path) ->
     let candidates =
-      if List.contains d recursive_include_directories
-      then hierarchical_modules_for_dir cwd include_directories d
-      else
-        safe_readdir_for_include d |> List.concatMap (fun entry ->
+      match path.prefix with
+      | Some prefix -> hierarchical_modules_for_dir cwd include_directories path.dir prefix
+      | None ->
+        safe_readdir_for_include path.dir |> List.concatMap (fun entry ->
           let entry = Filepath.basename entry in
-          let path = if d = cwd then entry else Filepath.join_paths d entry in
-          if Filepath.is_directory path then []
-          else module_candidate_of_file [] path entry)
+          let file_path = if path.dir = cwd then entry else Filepath.join_paths path.dir entry in
+          if Filepath.is_directory file_path then []
+          else module_candidate_of_file [] file_path entry)
     in
-    check_unique_module_names_for_dir d candidates;
+    check_unique_module_names_for_dir path.dir candidates;
     candidates)
 
 (** List the contents of all include directories, then build a map from long

--- a/src/parser/FStarC.Parser.Dep.fst
+++ b/src/parser/FStarC.Parser.Dep.fst
@@ -199,7 +199,9 @@ let module_name_from_include_path (f:string) : ML (option string) =
   let best =
     List.fold_left (fun (acc:option Find.module_include_path) (path:Find.module_include_path) ->
       if Util.starts_with f (path.dir ^ "/")
-      && (Some? path.prefix || Filepath.dirname f = path.dir)
+      && (match path.kind with
+          | Find.Flat -> Filepath.dirname f = path.dir
+          | Find.Recursive _ -> true)
       && (match acc with Some prev -> String.length path.dir > String.length prev.dir | None -> true)
       then Some path
       else acc)
@@ -213,7 +215,9 @@ let module_name_from_include_path (f:string) : ML (option string) =
     | None -> None
     | Some stem ->
       let stem = Util.replace_char (Util.replace_char stem '\\' '.') '/' '.' in
-      Some (String.concat "." (Option.dflt [] path.prefix @ [stem]))
+      match path.kind with
+      | Find.Flat -> Some stem
+      | Find.Recursive prefix -> Some (String.concat "." (prefix @ [stem]))
 
 (* [maybe_module_name_of_file] is called once per dependency edge in the
 dependency graph, and is a pure function of the file name and the include
@@ -703,9 +707,9 @@ let build_inclusion_candidates_list (): ML (list (string & string)) =
   let cwd = Filepath.normalize_file_path (getcwd ()) in
   include_paths |> List.concatMap (fun (path:Find.module_include_path) ->
     let candidates =
-      match path.prefix with
-      | Some prefix -> hierarchical_modules_for_dir cwd include_directories path.dir prefix
-      | None ->
+      match path.kind with
+      | Find.Recursive prefix -> hierarchical_modules_for_dir cwd include_directories path.dir prefix
+      | Find.Flat ->
         safe_readdir_for_include path.dir |> List.concatMap (fun entry ->
           let entry = Filepath.basename entry in
           let file_path = if path.dir = cwd then entry else Filepath.join_paths path.dir entry in

--- a/src/parser/FStarC.Parser.Dep.fst
+++ b/src/parser/FStarC.Parser.Dep.fst
@@ -200,9 +200,11 @@ let list_of_pair (intf, impl) =
 let module_name_from_include_path (f:string) : ML (option string) =
   let f = Filepath.normalize_file_path f in
   let include_dirs = Find.full_include_path_normalized () in
+  let recursive_include_dirs = Find.recursive_include_path_normalized () in
   let best =
     List.fold_left (fun (acc:option string) d ->
       if Util.starts_with f (d ^ "/")
+      && (List.contains d recursive_include_dirs || Filepath.dirname f = d)
       && (match acc with Some a -> String.length d > String.length a | None -> true)
       then Some d
       else acc)
@@ -703,12 +705,23 @@ let check_unique_module_names_for_dir (dir:string)
 (* In public interface *)
 let build_inclusion_candidates_list (): ML (list (string & string)) =
   let include_directories = Find.full_include_path_normalized () in
+  let recursive_include_directories = Find.recursive_include_path_normalized () in
   (* Note that [BatList.unique] keeps the last occurrence, that way one can
    * always override the precedence order. *)
   let include_directories = List.unique include_directories in
+  let recursive_include_directories = List.unique recursive_include_directories in
   let cwd = Filepath.normalize_file_path (getcwd ()) in
   include_directories |> List.concatMap (fun d ->
-    let candidates = hierarchical_modules_for_dir cwd include_directories d in
+    let candidates =
+      if List.contains d recursive_include_directories
+      then hierarchical_modules_for_dir cwd recursive_include_directories d
+      else
+        safe_readdir_for_include d |> List.concatMap (fun entry ->
+          let entry = Filepath.basename entry in
+          let path = if d = cwd then entry else Filepath.join_paths d entry in
+          if Filepath.is_directory path then []
+          else module_candidate_of_file [] path entry)
+    in
     check_unique_module_names_for_dir d candidates;
     candidates)
 

--- a/src/parser/FStarC.Parser.Dep.fst
+++ b/src/parser/FStarC.Parser.Dep.fst
@@ -196,28 +196,27 @@ let list_of_pair (intf, impl) =
 let module_name_from_include_path (f:string) : ML (option string) =
   let f = Filepath.normalize_file_path f in
   let include_paths = Find.module_include_paths_normalized () in
+  let chk acc (path: Find.module_include_path) =
+    if Util.starts_with f (path.dir ^ "/")
+    && (match path.kind with
+      | Find.Flat -> Filepath.dirname f = path.dir
+      | Find.Recursive -> true)
+    && (match acc with Some prev -> String.length path.dir > String.length prev | None -> true)
+    then Some path.dir
+    else acc
+  in
   let best =
-    List.fold_left (fun (acc:option Find.module_include_path) (path:Find.module_include_path) ->
-      if Util.starts_with f (path.dir ^ "/")
-      && (match path.kind with
-          | Find.Flat -> Filepath.dirname f = path.dir
-          | Find.Recursive _ -> true)
-      && (match acc with Some prev -> String.length path.dir > String.length prev.dir | None -> true)
-      then Some path
-      else acc)
-      None include_paths
+    List.fold_left chk None include_paths
   in
   match best with
   | None -> None
   | Some path ->
-    let rel = Util.substring_from f (String.length path.dir + 1) in
+    let rel = Util.substring_from f (String.length path + 1) in
     match check_and_strip_suffix rel with
     | None -> None
     | Some stem ->
       let stem = Util.replace_char (Util.replace_char stem '\\' '.') '/' '.' in
-      match path.kind with
-      | Find.Flat -> Some stem
-      | Find.Recursive prefix -> Some (String.concat "." (prefix @ [stem]))
+      Some stem
 
 (* [maybe_module_name_of_file] is called once per dependency edge in the
 dependency graph, and is a pure function of the file name and the include
@@ -637,7 +636,7 @@ let can_be_namespace_component (s:string) : ML bool =
   its own traversal. [cwd] is the normalized current directory: files under it
   are reported by their bare path relative to [cwd]. *)
 let hierarchical_modules_for_dir (cwd:string) (include_roots:list string)
-                                 (root:string) (prefix:list string)
+                                 (root:string)
   : ML (list (string & string)) =
   (* [ns_prefix] is the list of namespace components corresponding to the
      subdirectories walked so far (in order); [rel] is the path, relative to
@@ -666,7 +665,7 @@ let hierarchical_modules_for_dir (cwd:string) (include_roots:list string)
         else walk (ns_prefix @ [entry]) rel'
       else module_candidate_of_file ns_prefix (if root = cwd then rel' else entry_path) entry)
   in
-  walk prefix ""
+  walk [] ""
 
 (* Build a map from module long name (and interface/implementation role) to the
   file providing it within a single include directory, and check that this map
@@ -708,7 +707,7 @@ let build_inclusion_candidates_list (): ML (list (string & string)) =
   include_paths |> List.concatMap (fun (path:Find.module_include_path) ->
     let candidates =
       match path.kind with
-      | Find.Recursive prefix -> hierarchical_modules_for_dir cwd include_directories path.dir prefix
+      | Find.Recursive -> hierarchical_modules_for_dir cwd include_directories path.dir
       | Find.Flat ->
         safe_readdir_for_include path.dir |> List.concatMap (fun entry ->
           let entry = Filepath.basename entry in

--- a/src/parser/FStarC.Parser.Dep.fst
+++ b/src/parser/FStarC.Parser.Dep.fst
@@ -684,8 +684,9 @@ let check_unique_module_names_for_dir (dir:string)
     | None -> SMap.add seen key path)
 
 (** Enumerate F* files in all include directories, returning pairs of long names
-    and full paths. Explicit roots are scanned recursively, mapping [X/Y/Z.fst]
-    to [X.Y.Z]; implicit roots are scanned flat.
+  and full paths. Explicit and manifest-declared roots are scanned recursively,
+  mapping [X/Y/Z.fst] to [X.Y.Z]. Implicit roots and roots containing their
+  own [fstar.include] are scanned flat.
 
     We fail hard if any module long name is provided by more than one file of
     the same role within a single include directory (e.g. both a flat
@@ -697,7 +698,6 @@ let build_inclusion_candidates_list (): ML (list (string & string)) =
   (* Note that [BatList.unique] keeps the last occurrence, that way one can
    * always override the precedence order. *)
   let include_directories = List.unique include_directories in
-  let recursive_include_directories = List.unique recursive_include_directories in
   let cwd = Filepath.normalize_file_path (getcwd ()) in
   include_directories |> List.concatMap (fun d ->
     let candidates =


### PR DESCRIPTION
We're currently adding `-include .` automatically, to match the previous behaviour of eg `fstar.exe Blah.fst`. But unfortunately this means if we do `fstar.exe -include x/y/z x/y/z/Blah.fst` we also do a recursive search starting at `.`.

~~Would it make sense to tweak it to only add `-include .` if no other include directories are specified?~~

Update: the refined idea is, for explicit include paths mentioned on command-line and in fstar.include to treat them as recursive includes; and for implicit includes (`.` and the parent of a command-line file) to treat them as *flat* includes. This stops us from eagerly looking in ./karamel or other directories when they're not relevant