### PR TITLE
Overloading: respect the direction of coercions

### DIFF
--- a/src/typechecker/FStarC.TypeChecker.Overload.fst
+++ b/src/typechecker/FStarC.TypeChecker.Overload.fst
@@ -122,21 +122,16 @@ let builtin_coercion b1 b2 =
   || (is_bool b1 && Base_type? b2)  (* squash of b2t *)
   || (is_prop b1 && is_bool b2)     (* t2b *)
 
-(* Two base types are compatible when a term of the first could be passed
-   where the second is expected. This is deliberately *not* equality, because
-   the typechecker inserts coercions: it is equality up to every coercion that
-   [Util.maybe_coerce_lc] can apply.
-
-   The relation is taken symmetrically. Callers compare a candidate's type
-   against an expected type, and formals of the two occur in contravariant
-   position, so which of the pair is the source of the coercion is not
-   something this module can tell; and being symmetric only ever keeps more
-   candidates, which is the safe direction (see [resolve]). *)
-let compatible env b1 b2 : ML bool =
+(* A term whose type classifies as [src] can be passed where a [tgt] is
+   expected when the two agree, or when a coercion bridges them. This is
+   deliberately *not* equality, because the typechecker inserts coercions: it
+   is equality up to every coercion that [Util.maybe_coerce_lc] can apply, in
+   the direction it applies it. *)
+let coercible env src tgt : ML bool =
   (* [maybe_coerce_lc] inserts [hide] and [reveal] around any type at all, so
      [erased] is not one end of a pair but a base compatible with everything. *)
   let is_erased = is_base_lid PC.erased_lid in
-  match b1, b2 with
+  match src, tgt with
   | Base_unknown, _
   | _, Base_unknown -> true
   | Base_type, Base_type -> true
@@ -145,11 +140,17 @@ let compatible env b1 b2 : ML bool =
     (* The heads differ, so the candidate is about to be eliminated unless some
        coercion relates them. Only here do we pay for consulting the
        environment, which keeps the cost off the common path. *)
-    is_erased b1 || is_erased b2
-    || builtin_coercion b1 b2 || builtin_coercion b2 b1
-    || (let related (src, tgt) = (is_base_lid (lid_of_fv src) b1 && is_base_lid (lid_of_fv tgt) b2)
-                             || (is_base_lid (lid_of_fv src) b2 && is_base_lid (lid_of_fv tgt) b1) in
-        user_coercions env |> List.existsb related)
+    is_erased src || is_erased tgt
+    || builtin_coercion src tgt
+    || (user_coercions env |> List.existsb (fun (s, t) ->
+          is_base_lid (lid_of_fv s) src && is_base_lid (lid_of_fv t) tgt))
+
+(* [coercible] with the direction forgotten, for the positions where this
+   module cannot tell which of the pair the elaborator would coerce; being
+   symmetric only ever keeps more candidates, which is the safe direction
+   (see [resolve]). *)
+let compatible env b1 b2 : ML bool =
+  coercible env b1 b2 || coercible env b2 b1
 
 let formals_of_typ env t =
   (* unfold_whnf sees through type abbreviations, so a candidate declared as
@@ -223,7 +224,9 @@ let explicit_shape env t n : ML (list typ & typ) =
 
 (* Could a candidate of type [t], applied to [n] explicit arguments, have the
    expected type [te]? Compares the remaining explicit formals pairwise and
-   then the results, always by rigid head only.
+   then the results, always by rigid head only. The results are compared with
+   the direction the elaborator would coerce in; the leftover formals occur in
+   contravariant position and are compared symmetrically.
 
    When the two shapes have a different number of explicit formals we conclude
    nothing: that can be currying, or a type abbreviation we did not unfold, and
@@ -236,7 +239,7 @@ let expected_compatible env t n te : ML bool =
     match ts, es with
     | t1 :: ts, e1 :: es ->
       compatible env (base_of_typ_safe env t1) (base_of_typ_safe env e1) && cmp ts es
-    | [], [] -> compatible env (base_of_typ_safe env rt) (base_of_typ_safe env re)
+    | [], [] -> coercible env (base_of_typ_safe env rt) (base_of_typ_safe env re)
     | _ -> true
   in
   cmp ts es
@@ -301,7 +304,7 @@ let resolve env speculate primary alts args expected =
         match b_arg with
         | Base_unknown -> cands
         | _ ->
-          narrow_at (Format.fmt1 "arg%s" (show i)) (keep_if (fun t -> compatible env b_arg (nth_explicit_formal_base env t i))) cands
+          narrow_at (Format.fmt1 "arg%s" (show i)) (keep_if (fun t -> coercible env b_arg (nth_explicit_formal_base env t i))) cands
       in
       by_args (i + 1) cands
   in
@@ -327,8 +330,9 @@ let resolve env speculate primary alts args expected =
       // warning and recover the scope-order answer.
       if not (already_reported (lid_of_fv primary) (List.map fst cands)) then
         Errors.log_issue (lid_of_fv primary) Errors.Error_AmbiguousName (
-             [Errors.Msg.text (Format.fmt1 "The name %s is ambiguous; candidates are:"
-                                 (show (lid_of_fv primary)))]
+             [group (Errors.Msg.text "The name"
+                     ^/^ Errors.Msg.fquotes (pp (Ident.ident_of_lid (lid_of_fv primary)))
+                     ^/^ Errors.Msg.text "is ambiguous; candidates are:")]
              @ candidates_doc env (List.map fst cands));
       fv
     )

--- a/src/typechecker/FStarC.TypeChecker.Overload.fsti
+++ b/src/typechecker/FStarC.TypeChecker.Overload.fsti
@@ -92,27 +92,34 @@ val base_head_fv : env -> typ -> ML (option fv)
     [None] when [f_typ] is not an arrow, or when either end has no rigid head;
     [Util.find_coercion] declines such a candidate for exactly that reason.
 
-    Exported so that [find_coercion] and [compatible] agree by construction on
+    Exported so that [find_coercion] and [coercible] agree by construction on
     which coercions exist. *)
 val coercion_source_and_target : env -> typ -> ML (option (fv & fv))
 
-(** Are these two classifications *possibly* compatible?
+(** Could a term whose type classifies as [src] *possibly* be passed where a
+    [tgt] is expected?
 
-    [Base_unknown] is compatible with everything; this is the
+    [Base_unknown] is coercible to and from everything; this is the
     over-approximation that keeps resolution conservative. Two rigid heads are
-    compatible when they are the same lident, and also when a coercion relates
-    them, since the elaborator will insert one: [bool], [prop] and [Type] are
-    related by [b2t], [squash] and [t2b]; [erased t] is related to every type by
-    [hide] and [reveal]; and every [@@coercion]-annotated function in scope
-    relates its argument's head to its result's head. The last of these is read
-    out of [env] on demand, and only once the heads are already known to
-    differ.
+    coercible when they are the same lident, and also when a coercion relates
+    them in that direction, since the elaborator will insert one: [bool] to
+    [prop] and [Type] by [b2t] and [squash], [prop] to [bool] by [t2b];
+    [erased t] to and from every type by [hide] and [reveal]; and every
+    [@@coercion]-annotated function in scope relates its argument's head to its
+    result's head. The last of these is read out of [env] on demand, and only
+    once the heads are already known to differ.
 
-    The relation is reflexive and symmetric -- symmetric because callers compare
-    formals of two function types, which stand in contravariant position, so the
-    direction of a coercion is not determined; symmetry only ever keeps more
-    candidates. It is deliberately *not* transitive, since [Base_unknown]
-    relates everything. *)
+    The direction matters: a user coercion [t -> int] makes an argument of type
+    [t] acceptable where an [int] is expected, but says nothing about the
+    reverse, and treating it as if it did would keep candidates that cannot
+    apply. The relation is therefore reflexive but neither symmetric nor -- with
+    [Base_unknown] relating everything -- transitive. *)
+val coercible : env -> base_typ -> base_typ -> ML bool
+
+(** [coercible] in either direction, for the positions where the caller cannot
+    tell which of the pair the elaborator would coerce: formals of two function
+    types stand in contravariant position, so the direction is not determined.
+    Symmetry only ever keeps more candidates, which is the safe direction. *)
 val compatible : env -> base_typ -> base_typ -> ML bool
 
 (** Split [t] into its formals and result, normalizing enough to see through
@@ -175,10 +182,11 @@ val reset_ambiguity_reports : unit -> ML unit
     separate ways:
 
       - a candidate is eliminated only when its formal and the argument have
-        two *different rigid heads*, so anything unknown eliminates nothing,
-        and "different rigid heads" is weaker than "different types" on
-        purpose: the elaborator inserts coercions, so [compatible] relates two
-        heads whenever a coercion in scope does;
+        two *different rigid heads* that no coercion bridges, so anything
+        unknown eliminates nothing, and "different rigid heads" is weaker than
+        "different types" on purpose: the elaborator inserts coercions, so
+        [coercible] relates two heads whenever a coercion in scope turns one
+        into the other;
       - if a filter would eliminate *every* remaining candidate it is skipped
         entirely, so we never turn a type error into a resolution error;
       - if several candidates survive, we return the first of *them*, in scope
@@ -196,7 +204,7 @@ val reset_ambiguity_reports : unit -> ML unit
     function of the candidates' types and of the application site, and not of
     whether some other candidate would have typechecked.
 
-    The whole weight of the design therefore rests on [compatible] being an
+    The whole weight of the design therefore rests on [coercible] being an
     over-approximation. It reasons about rigid head symbols and, although it
     knows which heads a coercion can bridge, it cannot see refinements,
     subtyping or typeclass constraints, so anything it cannot rule out it must

--- a/tests/bug-reports/closed/Bug4455.fst
+++ b/tests/bug-reports/closed/Bug4455.fst
@@ -1,0 +1,7 @@
+module Bug4455
+open FStar.SizeT
+
+[@@coercion]
+let sizet_to_nat (x: SizeT.t) : GTot int = SizeT.v x
+
+let test (x y : int) : int = x * y

--- a/tests/overloading/OvlCoercionDirection.fst
+++ b/tests/overloading/OvlCoercionDirection.fst
@@ -1,0 +1,43 @@
+module OvlCoercionDirection
+open OvlInt
+open OvlBool
+open OvlFeet
+
+(* A [@@coercion] relates two types in one direction only, and overload
+   resolution has to respect that direction. Taking the relation
+   symmetrically keeps candidates that the elaborator could never make
+   sense of, and since resolution is final, the occurrence then fails to
+   typecheck against a candidate that was never applicable. See #4455. *)
+
+(* 1. The bug. [OvlFeet] is opened last, so [( * )] is [OvlFeet.( * )] by
+   scope order. Its formals are [feet], and while a [feet] coerces to an
+   [int], an [int] does not coerce to a [feet]: the [int] arguments here
+   cannot reach it, so the answer is [Prims.op_Star]. *)
+let mul_int (x y : int) : int = x * y
+
+(* 2. Same site, [feet] arguments. Both candidates survive the arguments,
+   since [feet] does coerce to the [int] that [Prims.op_Star] expects; the
+   expected type is what settles it, and it settles it by direction too --
+   an [int] result cannot become the [feet] that is expected. *)
+let mul_feet (x y : feet) : feet = x * y
+
+(* 3. The coercion still applies where it points. [OvlBool.f] takes a
+   [bool] and [OvlInt.f] an [int], and only the latter can receive a
+   [feet]. *)
+let arg_coerced (x:feet) : int = f x
+
+(* 4. Likewise on results: [OvlInt.mk] returns [OvlInt.t] and
+   [OvlFeet.mk] a [feet], and only a [feet] can become the expected
+   [int]. *)
+let result_coerced (x:int) : int = mk x
+
+(* 5. The report, verbatim: [FStar.SizeT] is opened over [Prims] and the
+   coercion goes from [FStar.SizeT.t] to [int], so multiplying two [int]s
+   is [Prims.op_Star] and not [FStar.SizeT.op_Star]. *)
+module SizeT = FStar.SizeT
+open FStar.SizeT
+
+[@@coercion]
+let sizet_to_int (x: SizeT.t) : GTot int = SizeT.v x
+
+let mul_sizet_scope (x y : int) : int = x * y

--- a/tests/overloading/OvlFeet.fst
+++ b/tests/overloading/OvlFeet.fst
@@ -1,0 +1,13 @@
+module OvlFeet
+(* A type related to [int] by a coercion in *one* direction only: a
+   [feet] can be turned into an [int], but not the other way around.
+   Contrast with OvlMeters, which supplies both directions. *)
+
+type feet = | Feet of int
+
+[@@coercion]
+let feet_to_int (x:feet) : int = Feet?._0 x
+
+(* Overloads of names that Prims and OvlInt also provide. *)
+let ( * ) (x y : feet) : feet = Feet (feet_to_int x * feet_to_int y)
+let mk (x:int) : feet = Feet x

--- a/tests/overloading/strict/StrictAmbiguous.fst.output.expected
+++ b/tests/overloading/strict/StrictAmbiguous.fst.output.expected
@@ -1,6 +1,6 @@
 * Info at StrictAmbiguous.fst(10,10-10,11):
   - Expected failure:
-  - The name StrictBool.f is ambiguous; candidates are:
+  - The name ‘f’ is ambiguous; candidates are:
   - StrictBool.f : x: Prims.bool -> Prims.bool
   - StrictInt.f : x: Prims.int -> Prims.int
 

--- a/tests/overloading/strict/StrictCoercionDirection.fst
+++ b/tests/overloading/strict/StrictCoercionDirection.fst
@@ -1,0 +1,16 @@
+module StrictCoercionDirection
+module SizeT = FStar.SizeT
+open FStar.SizeT
+
+(* #4455 under 'strict': the coercion below goes from [FStar.SizeT.t] to
+   [int] and not back, so [FStar.SizeT.op_Star] is not a candidate for a
+   multiplication of two [int]s and there is no ambiguity to report. *)
+
+[@@coercion]
+let sizet_to_int (x: SizeT.t) : GTot int = SizeT.v x
+
+let mul_int (x y : int) : int = x * y
+
+(* And with [FStar.SizeT.t] arguments both candidates are applicable
+   until the expected type rules out [Prims.op_Star]. *)
+let mul_sizet (x y : SizeT.t) : Pure SizeT.t (requires SizeT.fits (SizeT.v x * SizeT.v y)) (ensures fun _ -> True) = x * y

--- a/tests/overloading/strict/StrictDuplicate.fst.output.expected
+++ b/tests/overloading/strict/StrictDuplicate.fst.output.expected
@@ -1,15 +1,15 @@
 * Warning 362 at StrictDuplicate.fst(20,54-20,58):
-  - The name StrictBool.same is ambiguous; candidates are:
+  - The name ‘same’ is ambiguous; candidates are:
   - StrictBool.same : Prims.int
   - StrictInt.same : Prims.int
 
 * Warning 362 at StrictDuplicate.fst(27,14-27,18):
-  - The name StrictBool.same is ambiguous; candidates are:
+  - The name ‘same’ is ambiguous; candidates are:
   - StrictBool.same : Prims.int
   - StrictInt.same : Prims.int
 
 * Warning 362 at StrictDuplicate.fst(34,48-34,52):
-  - The name StrictBool.same is ambiguous; candidates are:
+  - The name ‘same’ is ambiguous; candidates are:
   - StrictBool.same : Prims.int
   - StrictInt.same : Prims.int
 


### PR DESCRIPTION
Overload resolution eliminates a candidate when a rigid head symbol on the candidate's side and one on the use site's side cannot be reconciled, and it counts them as reconcilable when a coercion bridges them. That relation was taken symmetrically everywhere, so a single [@@coercion] from t to int made an int argument look acceptable to a candidate whose formal is a t, even though nothing can build a t out of an int:

    open FStar.SizeT
    [@@coercion] let sizet_to_nat (x:SizeT.t) : GTot int = SizeT.v x
    let test (x y : int) : int = x * y

FStar.SizeT.op_Star survived the argument filter, and being the scope-order candidate it was the answer: a type error under 'compat', an ambiguity report under 'strict'. Reported as #4455.

Split the relation into a directional [coercible src tgt] -- exactly the pairs Util.find_coercion will actually insert a coercion for -- and keep [compatible] as its symmetric closure. Arguments are compared against formals with the direction of the application, and a candidate's result against the expected type with the direction of the coercion; only the leftover formals of a curried comparison, which stand in contravariant position, still use the symmetric relation.

Also report the ambiguity under the name as written. Only unqualified names are ever overloaded, so printing the fully qualified name of the scope-order candidate claimed that a name that denotes exactly one thing was ambiguous.

Fixes #4455