### PR TITLE
overload: classify erased by its argument, not as compatible with everything

### DIFF
--- a/src/typechecker/FStarC.TypeChecker.Overload.fst
+++ b/src/typechecker/FStarC.TypeChecker.Overload.fst
@@ -35,11 +35,15 @@ module Print = FStarC.Syntax.Print
 
 let dbg = Debug.get_toggle "Overload"
 
+let rec show_base_typ (b : base_typ) : ML string =
+  match b with
+  | Base_rigid fv -> "Base_rigid " ^ show fv
+  | Base_type -> "Base_type"
+  | Base_erased (_, b) -> "Base_erased (" ^ show_base_typ b ^ ")"
+  | Base_unknown -> "Base_unknown"
+
 instance showable_base_typ : showable base_typ = {
-  show = (function
-          | Base_rigid fv -> "Base_rigid " ^ show fv
-          | Base_type -> "Base_type"
-          | Base_unknown -> "Base_unknown");
+  show = show_base_typ;
 }
 
 (* The normalization steps that define what "the base type" means: strip
@@ -48,27 +52,37 @@ instance showable_base_typ : showable base_typ = {
    has always used. *)
 let base_steps : list Env.step = [Unascribe; Unmeta; Unrefine]
 
-let base_of_typ env t =
+let rec base_of_typ env t =
   let t = N.unfold_whnf' base_steps env t in
-  let hd, _ = U.head_and_args_full t in
+  let hd, args = U.head_and_args_full t in
   let r =
-    match (SS.compress (U.un_uinst hd)).n with
-    | Tm_fvar fv -> Base_rigid fv
-    | Tm_type _ -> Base_type
+    match (SS.compress (U.un_uinst hd)).n, args with
+    (* [erased a] records the classification of [a] too: [hide] and [reveal]
+       relate the two, so the argument is what says which types this one can
+       reach. Every other head is compared by symbol alone. *)
+    | Tm_fvar fv, [(a, _)] when fv_eq_lid fv PC.erased_lid ->
+      Base_erased (fv, base_of_typ env a)
+    | Tm_fvar fv, _ -> Base_rigid fv
+    | Tm_type _, _ -> Base_type
     | _ -> Base_unknown
   in
   if !dbg then
     Format.print2 "(Overload) base_of_typ %s = %s\n" (show t) (show r);
   r
 
+(* The head symbol, [erased] included. This is what [find_coercion] compares
+   against, so it must stay a purely syntactic head: an [erased t] is headed by
+   [erased], whatever [t] is. *)
 let base_head_fv env t =
   match base_of_typ env t with
-  | Base_rigid fv -> Some fv
+  | Base_rigid fv
+  | Base_erased (fv, _) -> Some fv
   | _ -> None
 
 let is_base_lid l b =
   match b with
-  | Base_rigid fv -> fv_eq_lid fv l
+  | Base_rigid fv
+  | Base_erased (fv, _) -> fv_eq_lid fv l
   | _ -> false
 
 (* The source and target of a [@@coercion]-annotated function, classified.
@@ -122,16 +136,30 @@ let builtin_coercion b1 b2 =
   || (is_bool b1 && Base_type? b2)  (* squash of b2t *)
   || (is_prop b1 && is_bool b2)     (* t2b *)
 
+(* [maybe_coerce_lc] inserts [reveal] to go from an [erased t] to a [t] and
+   [hide] to go the other way, and those two coercions relate no other pair of
+   types. So an [erased t] reaches exactly what a [t] reaches, and the way to
+   account for the pair is to strip [erased] off both ends and compare what is
+   underneath -- iterating, since an [erased (erased t)] reveals twice.
+
+   Treating [erased] as a base compatible with everything, which is what this
+   module used to do, is not the conservative reading of that: it makes an
+   [erased nat] look like it could reach a [FStar.UInt64.t], so an overload on
+   machine integers survives a ghost argument and then wins on scope order. *)
+let rec strip_erased b =
+  match b with
+  | Base_erased (_, b) -> strip_erased b
+  | _ -> b
+
 (* A term whose type classifies as [src] can be passed where a [tgt] is
    expected when the two agree, or when a coercion bridges them. This is
    deliberately *not* equality, because the typechecker inserts coercions: it
    is equality up to every coercion that [Util.maybe_coerce_lc] can apply, in
    the direction it applies it. *)
 let coercible env src tgt : ML bool =
-  (* [maybe_coerce_lc] inserts [hide] and [reveal] around any type at all, so
-     [erased] is not one end of a pair but a base compatible with everything. *)
-  let is_erased = is_base_lid PC.erased_lid in
-  match src, tgt with
+  let src' = strip_erased src in
+  let tgt' = strip_erased tgt in
+  match src', tgt' with
   | Base_unknown, _
   | _, Base_unknown -> true
   | Base_type, Base_type -> true
@@ -140,10 +168,16 @@ let coercible env src tgt : ML bool =
     (* The heads differ, so the candidate is about to be eliminated unless some
        coercion relates them. Only here do we pay for consulting the
        environment, which keeps the cost off the common path. *)
-    is_erased src || is_erased tgt
-    || builtin_coercion src tgt
-    || (user_coercions env |> List.existsb (fun (s, t) ->
-          is_base_lid (lid_of_fv s) src && is_base_lid (lid_of_fv t) tgt))
+    builtin_coercion src' tgt'
+    || (let cs = user_coercions env in
+        let related src tgt =
+          cs |> List.existsb (fun (s, t) ->
+            is_base_lid (lid_of_fv s) src && is_base_lid (lid_of_fv t) tgt)
+        in
+        (* Both the stripped and the unstripped classifications: a user
+           coercion out of or into [erased t] itself names [erased] as its end,
+           and [find_coercion] will select it on that head. *)
+        related src' tgt' || related src tgt)
 
 (* [coercible] with the direction forgotten, for the positions where this
    module cannot tell which of the pair the elaborator would coerce; being
@@ -176,6 +210,7 @@ let arity_compatible env t n =
        cannot be applied any further; anything else might. *)
     match base_of_typ env (U.comp_result c) with
     | Base_rigid _
+    | Base_erased _
     | Base_type -> false
     | Base_unknown -> true
 

--- a/src/typechecker/FStarC.TypeChecker.Overload.fsti
+++ b/src/typechecker/FStarC.TypeChecker.Overload.fsti
@@ -58,6 +58,19 @@ type base_typ =
       comparing universes would make universe-polymorphic candidates look
       incompatible when they are not. *)
   | Base_type
+  (** The head is [FStar.Ghost.erased], applied to one argument: the [fv] is
+      that head and the [base_typ] is the classification of the argument.
+
+      [erased t] is the one head whose arguments matter, because it is the one
+      head the elaborator will strip: [maybe_coerce_lc] inserts [reveal] to
+      turn an [erased t] into a [t] and [hide] to turn a [t] into an [erased
+      t], and those are the only types those two coercions relate. Recording
+      the argument is what lets [coercible] say that [erased nat] can reach an
+      [int] but not a [FStar.UInt32.t]; classifying it as a rigid [erased]
+      alone leaves no way to tell those apart, and treating [erased] as
+      compatible with everything makes every machine-integer overload survive
+      a ghost argument. *)
+  | Base_erased of fv & base_typ
   (** A unification variable, a bound or type variable, an unresolved implicit,
       an arrow, or a type we simply could not compute. Never eliminates
       anything. Arrows land here on purpose, since a candidate's formal may be a
@@ -76,7 +89,11 @@ instance val showable_base_typ : Class.Show.showable base_typ
     Normalization must not unfold abstract types. [FStar.UInt32.t] is declared
     [new val t : eqtype] and so stays rigid; were it to collapse to [Prims.int],
     an overload of [+] on machine integers would be indistinguishable from the
-    one on [int]. *)
+    one on [int].
+
+    [FStar.Ghost.erased t] is the sole exception to "head symbol only": it
+    yields [Base_erased], which carries the classification of [t] as well. See
+    that constructor. *)
 val base_of_typ : env -> typ -> ML base_typ
 
 (** [base_of_typ] restricted to the rigid case. This is the signal the record
@@ -103,11 +120,17 @@ val coercion_source_and_target : env -> typ -> ML (option (fv & fv))
     over-approximation that keeps resolution conservative. Two rigid heads are
     coercible when they are the same lident, and also when a coercion relates
     them in that direction, since the elaborator will insert one: [bool] to
-    [prop] and [Type] by [b2t] and [squash], [prop] to [bool] by [t2b];
-    [erased t] to and from every type by [hide] and [reveal]; and every
-    [@@coercion]-annotated function in scope relates its argument's head to its
-    result's head. The last of these is read out of [env] on demand, and only
-    once the heads are already known to differ.
+    [prop] and [Type] by [b2t] and [squash], [prop] to [bool] by [t2b]; and
+    every [@@coercion]-annotated function in scope relates its argument's head
+    to its result's head. The last of these is read out of [env] on demand, and
+    only once the heads are already known to differ.
+
+    [hide] and [reveal] are handled by stripping [Base_erased] off both ends
+    before any of that, since those two coercions relate [erased t] to [t] and
+    to nothing else. An [erased t] therefore reaches exactly what a [t]
+    reaches. A [@@coercion] function that names [erased] at either end is still
+    honoured on the unstripped classification, so declaring one cannot lose a
+    candidate.
 
     The direction matters: a user coercion [t -> int] makes an argument of type
     [t] acceptable where an [int] is expected, but says nothing about the

--- a/src/typechecker/FStarC.TypeChecker.TcTerm.fst
+++ b/src/typechecker/FStarC.TypeChecker.TcTerm.fst
@@ -1744,7 +1744,7 @@ and tc_tactic (a:typ) (b:typ) (env:Env.env) (tau:term) : ML (term & lcomp & guar
 and speculate_base env (e:term) : ML Overload.base_typ =
   (* Typecheck [e] just far enough to learn the head symbol of its type,
      then undo everything: the unifier state is rolled back and any errors
-     are swallowed. [Base_rigid] only holds an fv, so the answer survives
+     are swallowed. A [base_typ] only ever holds fvs, so the answer survives
      the rollback.
 
      [admit] is set so that the speculative pass is uniformly lax. That is

--- a/tests/overloading/OvlErased.fst
+++ b/tests/overloading/OvlErased.fst
@@ -11,7 +11,7 @@ open OvlGhostCoercionB
    look at. [hide] and [reveal] relate an [erased t] to a [t] and to nothing
    else, so an [erased t] reaches exactly what a [t] reaches -- treating
    [erased] as a head compatible with everything instead keeps candidates the
-   elaborator can never reach. See #4471. *)
+   elaborator can never reach. *)
 
 (* 1. The report. [FStar.UInt64] is opened over [Prims], so [>=] is
    [FStar.UInt64.op_Greater_Equals] by scope order. Its formals are

--- a/tests/overloading/OvlErased.fst
+++ b/tests/overloading/OvlErased.fst
@@ -1,0 +1,41 @@
+module OvlErased
+open FStar.Ghost
+open OvlInt
+open OvlBool
+open OvlGhostA
+open OvlGhostB
+open OvlGhostCoercion
+open OvlGhostCoercionB
+
+(* [erased t] is the one head whose type argument overload resolution has to
+   look at. [hide] and [reveal] relate an [erased t] to a [t] and to nothing
+   else, so an [erased t] reaches exactly what a [t] reaches -- treating
+   [erased] as a head compatible with everything instead keeps candidates the
+   elaborator can never reach. See #4471. *)
+
+(* 1. The report. [FStar.UInt64] is opened over [Prims], so [>=] is
+   [FStar.UInt64.op_Greater_Equals] by scope order. Its formals are
+   [FStar.UInt64.t], which no coercion can produce from an [erased nat]:
+   [reveal] gives a [nat] and stops there. The answer is
+   [Prims.op_Greater_Equals]. *)
+open FStar.UInt64
+let ge_erased (x y : erased nat) = x >= y
+
+(* 2. [reveal] on an argument. [OvlBool.f] takes a [bool] and [OvlInt.f] an
+   [int], and only the latter is what an [erased int] reveals to. *)
+let arg_revealed (x : erased int) : GTot int = f x
+
+(* 3. [hide] on an argument, the same thing in the other direction:
+   [OvlGhostB.h] is the scope-order answer and takes a [bool], while an [int]
+   hides into the [erased int] that [OvlGhostA.h] takes. *)
+let arg_hidden (x : int) : int = h x
+
+(* 4. And on the result: [OvlBool.mk] returns an [OvlBool.t], [OvlInt.mk] an
+   [OvlInt.t], and the expected type is the latter under [erased]. *)
+let result_hidden (x : int) : erased OvlInt.t = mk x
+
+(* 5. Stripping [erased] must not hide a [@@coercion] that names [erased] as
+   one of its ends. [OvlGhostCoercionB.k] is the scope-order answer and takes
+   a [bool]; only [OvlGhostCoercion.k] can receive an [erased int], and only
+   because [erased_to_ghint] says so. *)
+let arg_user_coerced (x : erased int) : GTot int = k x

--- a/tests/overloading/OvlGhostA.fst
+++ b/tests/overloading/OvlGhostA.fst
@@ -1,0 +1,6 @@
+module OvlGhostA
+open FStar.Ghost
+
+(* A candidate whose formal is an [erased int]: an [int] argument reaches it
+   only because the elaborator inserts [hide]. *)
+let h (x : erased int) : int = 0

--- a/tests/overloading/OvlGhostB.fst
+++ b/tests/overloading/OvlGhostB.fst
@@ -1,0 +1,3 @@
+module OvlGhostB
+(* The other [h]. Opened after OvlGhostA, so it wins by scope order. *)
+let h (x : bool) : int = 1

--- a/tests/overloading/OvlGhostCoercion.fst
+++ b/tests/overloading/OvlGhostCoercion.fst
@@ -1,0 +1,13 @@
+module OvlGhostCoercion
+open FStar.Ghost
+
+(* A [@@coercion] whose source is [erased int] itself, rather than one of the
+   types [hide] and [reveal] relate. Overload resolution strips [erased]
+   before comparing heads, so it has to consult the coercions in scope on the
+   unstripped classification as well, or this coercion is invisible to it. *)
+type ghint = | GhInt of int
+
+[@@coercion]
+let erased_to_ghint (x : erased int) : GTot ghint = GhInt (reveal x)
+
+let k (x : ghint) : int = GhInt?._0 x

--- a/tests/overloading/OvlGhostCoercionB.fst
+++ b/tests/overloading/OvlGhostCoercionB.fst
@@ -1,0 +1,3 @@
+module OvlGhostCoercionB
+(* The other [k]. Opened last, so it is the scope-order answer. *)
+let k (x : bool) : int = 1


### PR DESCRIPTION
Fixing another issue with overloading

--

`Overload.coercible` treated `erased` as a head compatible with every other head, on the grounds that `maybe_coerce_lc` inserts `hide` and `reveal` at any type.  That reads the two coercions too generously: they relate an `erased t` to a `t` and to nothing else, so an `erased nat` reaches an `int` but can never reach a `FStar.UInt64.t`.

The effect was to keep candidates the elaborator could not possibly reach, and since resolution then falls back on scope order, the wrong one won:

    open FStar.Ghost
    open FStar.UInt64
    let test (x y : erased nat) = x >= y

resolved `>=` to `FStar.UInt64.op_Greater_Equals`, because `FStar.UInt64` is opened over `Prims` and the `erased nat` arguments eliminated neither candidate.  This was the last of the empirical over-approximations that e95e68d06b replaced elsewhere by deriving the relation from the coercions in scope.

Record the argument instead.  `base_of_typ` classifies `erased t` as `Base_erased`, carrying the classification of `t`, and `coercible` strips that off both ends before comparing -- so an `erased t` is coercible to exactly what a `t` is coercible to.  `base_head_fv` still reports `erased` as the head, so `find_coercion` and the record and projector paths, which want a purely syntactic head, are unaffected.

Stripping is not enough on its own: a `[@@coercion]` function may name `erased t` itself as its source or target, and `find_coercion` selects it on that head.  `coercible` therefore consults the coercions in scope on the unstripped classification as well, so declaring one cannot lose a candidate. OvlErased case 5 fails without that second lookup.