### PR TITLE
overload: collect candidates through `include`

### DIFF
--- a/src/syntax/FStarC.Syntax.DsEnv.fst
+++ b/src/syntax/FStarC.Syntax.DsEnv.fst
@@ -380,6 +380,85 @@ let is_exported_id_field = function
   | _ -> false
 
 
+(* [find_in_module_with_includes_gen collect ...] walks the include graph of
+   [ns] as a worklist: [ns] itself, then the modules it includes in order,
+   then theirs.
+
+   The first answer found is returned as a [cont_t] -- that is the one plain
+   name resolution wants, the innermost definition. With [collect] the walk
+   keeps going past it and also returns the definitions it shadowed, in the
+   same order, for type-based overloading to choose among (see
+   FStarC.TypeChecker.Overload). With [collect=false] it stops at the first
+   hit exactly as it always has, so ordinary resolution pays nothing.
+
+   The [cont_t] is not folded into the list because it carries a distinction
+   the list cannot: [Cont_fail] means "not found, do not retry" and
+   [Cont_ignore] means "not found, retry", and [try_lookup_id''_gen] ends the
+   whole scope walk on the former. An empty list conflates the two.
+
+   [seen] keeps the walk finite, keyed by module *and* identifier since a
+   restriction may rename, so one module can legitimately be visited for two
+   names. Collecting would otherwise follow an include cycle forever, where
+   returning on the first hit merely made it unobservable. *)
+let find_in_module_with_includes_gen
+    (collect: bool)
+    (eikind: exported_id_kind)
+    (find_in_module: lident -> ML (cont_t 'a))
+    (find_in_module_default: cont_t 'a)
+    env
+    (ns: lident)
+    (id: ident)
+    : ML (cont_t 'a & list 'a) =
+  let rec aux (seen: list (string & string))
+              (found: option (cont_t 'a))
+              (acc: list 'a)
+              (x: list (lident & ident))
+    : ML (cont_t 'a & list 'a) =
+    let finish () = match found with
+      | None -> (find_in_module_default, [])
+      | Some k -> (k, List.rev acc)
+    in
+    match x with
+    | [] -> finish ()
+    | (modul, id) :: q ->
+      let mname = string_of_lid modul in
+      let key = (mname, string_of_id id) in
+      if List.mem key seen then aux seen found acc q
+      else
+        let seen = key :: seen in
+        let not_shadowed = match get_exported_id_set env mname with
+        | None -> true
+        | Some mex ->
+          let mexports = !(mex eikind) in
+          mem (string_of_id id) mexports
+        in
+        let mincludes = match SMap.try_find env.includes mname with
+        | None -> []
+        | Some minc ->
+          !minc |> filter_map (fun (ns, restriction) ->
+            let opt = is_ident_allowed_by_restriction id restriction in
+            Option.map (fun id -> (ns, id)) opt)
+        in
+        let look_into =
+         if not_shadowed
+         then find_in_module (qual modul id)
+         else Cont_ignore
+        in
+        begin match look_into with
+        | Cont_ignore -> aux seen found acc (mincludes @ q)
+        | Cont_fail ->
+          (* "do not retry" ends the walk; an answer already in hand stands. *)
+          finish ()
+        | Cont_ok v ->
+          match found with
+          | None ->
+            if not collect
+            then (Cont_ok v, [])
+            else aux seen (Some (Cont_ok v)) acc (mincludes @ q)
+          | Some _ -> aux seen found (v :: acc) (mincludes @ q)
+        end
+  in aux [] None [] [ (ns, id) ]
+
 let find_in_module_with_includes
     (eikind: exported_id_kind)
     (find_in_module: lident -> ML (cont_t 'a))
@@ -388,36 +467,7 @@ let find_in_module_with_includes
     (ns: lident)
     (id: ident)
     : ML (cont_t 'a) =
-  let rec aux (x: list (lident & ident)) : ML (cont_t 'a) = match x with
-  | [] ->
-    find_in_module_default
-  | (modul, id) :: q ->
-    let mname = string_of_lid modul in
-    let not_shadowed = match get_exported_id_set env mname with
-    | None -> true
-    | Some mex ->
-      let mexports = !(mex eikind) in
-      mem (string_of_id id) mexports
-    in
-    let mincludes = match SMap.try_find env.includes mname with
-    | None -> []
-    | Some minc ->
-      !minc |> filter_map (fun (ns, restriction) ->
-        let opt = is_ident_allowed_by_restriction id restriction in
-        Option.map (fun id -> (ns, id)) opt)
-    in
-    let look_into =
-     if not_shadowed
-     then find_in_module (qual modul id)
-     else Cont_ignore
-    in
-    begin match look_into with
-    | Cont_ignore ->
-      aux (mincludes @ q)
-    | _ ->
-      look_into
-    end
-  in aux [ (ns, id) ]
+  fst (find_in_module_with_includes_gen false eikind find_in_module find_in_module_default env ns id)
 
 (* [try_lookup_id''_gen collect ...] walks the scope, innermost first.
 
@@ -504,16 +554,30 @@ let try_lookup_id''_gen
       | Rec_binding _ -> true
       | _ -> false
     in
+    (* One [open] can reach several definitions of [id], when the module it
+       names [include]s others. [proc] answers with the first, which is the
+       right answer for plain resolution; when collecting we ask for the rest
+       as well. [k] is unchanged either way, so the head of the result is
+       still exactly what scope order alone would have picked. *)
+    let step (a:scope_mod) : ML (cont_t 'a & list 'a) =
+      match a with
+      | Open_module_or_namespace ((ns, Open_module, restriction),_) when collect ->
+        ( match is_ident_allowed_by_restriction id restriction with
+        | None -> (Cont_ignore, [])
+        | Some id -> find_in_module_with_includes_gen true eikind find_in_module Cont_ignore env ns id)
+      | _ -> (proc a, [])
+    in
     let rec aux (acc:list 'a) (l:list scope_mod) : ML (list 'a) = match l with
       | a :: q ->
-        begin match proc a with
+        let k, alts = step a in
+        begin match k with
         | Cont_ok v ->
           if not collect then [v]
           else if is_local_scope_mod a
           then (match acc with
                 | [] -> [v]
                 | _ -> List.rev acc)  // unreachable in practice: locals are innermost
-          else aux (v::acc) q
+          else aux (List.rev alts @ (v::acc)) q
         | Cont_fail -> List.rev acc
         | Cont_ignore -> aux acc q
         end

--- a/tests/overloading/OvlInclAll.fst
+++ b/tests/overloading/OvlInclAll.fst
@@ -1,0 +1,6 @@
+module OvlInclAll
+(* Re-exports both [f]s. [OvlBool] is included last, so plain scope order
+   inside this module resolves [f] to [OvlBool.f]. *)
+
+include OvlInt
+include OvlBool

--- a/tests/overloading/OvlInclude.fst
+++ b/tests/overloading/OvlInclude.fst
@@ -1,0 +1,22 @@
+module OvlInclude
+open OvlInclAll
+
+(* An [open] of a module that [include]s others has to contribute all the
+   names it re-exports, not just the first one the include walk reaches.
+   [find_in_module_with_includes] returned on that first hit, so this [open]
+   offered a single candidate and overloading never got to choose: [f] was
+   whatever the last [include] in OvlInclAll happened to name, regardless of
+   the argument. See #4460. *)
+
+(* 1. The report. Reached through the include, [OvlInt.f] is the candidate
+   an [int] argument selects, even though [OvlBool.f] is the one plain
+   scope order finds first. *)
+let use_int (x:int) : int = f x
+
+(* 2. The other direction, so this cannot be passed by always preferring the
+   deeper include: a [bool] argument still selects [OvlBool.f]. *)
+let use_bool (x:bool) : bool = f x
+
+(* 3. Nothing discriminates, so the scope-order answer stands, and through an
+   include that means the last one: [OvlBool.mk]. *)
+let primary_kept : OvlBool.t = mk true


### PR DESCRIPTION
An `open` of a module that `include`s others contributed a single name to overload resolution, so the alternatives it re-exported were never considered and the answer was decided by include order alone:

    module C
    include A     (* A.f : int -> int *)
    include B     (* B.f : bool -> bool *)

    module Test
    open C
    let test (x:int) : int = f x   (* picked B.f, ill-typed *)

Writing `open A open B` instead works, which is what makes this a bug rather than a missing feature: the same two candidates are in scope either way.

`find_in_module_with_includes` walks the include graph as a worklist and returns on the first hit, discarding the rest, and `try_lookup_id''_gen` accumulates one value per `scope_mod`. So `open C` offered one candidate, `try_lookup_lid_alternatives` bailed out at its "fewer than two candidates" case, and no `Unresolved_name` qualifier was ever attached.

Generalize the walk to `find_in_module_with_includes_gen collect`, which returns the first answer as a `cont_t` -- what plain resolution wants, and what `find_in_module_with_includes` now hands back unchanged -- together with the definitions it shadowed. The `cont_t` cannot be folded into the list: `Cont_fail` ("do not retry") and `Cont_ignore` ("retry") are distinguished by callers, `try_lookup_id''_gen` ending the whole scope walk on the former, and an empty list conflates them.

With `collect=false` the walk still stops at the first hit, so ordinary resolution and `--ext fstar:overload=off` pay nothing for this.

The walk now carries a `seen` set, keyed by module and identifier since a restriction may rename. Collecting would otherwise follow an include cycle forever, where returning on the first hit merely made one unobservable.

Fixes #4460