### PR TITLE
Fix quadratic normalization of nested stuck projections

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -182,6 +182,22 @@ Guidelines for the changelog:
     Once it can, library patterns will discharge these obligations
     automatically.)
 
+  * Fixes https://github.com/FStarLang/FStar/issues/4463. Normalizing a nested
+    chain of projections that are *stuck* (because the scrutinee never reduces
+    to a constructor) is no longer quadratic in the depth of the chain. The
+    normalizer reduces the scrutinee of a projector to weak head normal form
+    speculatively, and used to discard that work whenever the projection turned
+    out to be stuck, so the enclosing pass reduced the very same subterms all
+    over again; the reduced scrutinee is now kept. Two related fixes: the weak
+    head normal form is memoized in its own cell instead of evicting the memo of
+    the enclosing strong normalization (the pathology of #4394), and the config
+    it uses is cached so that memo lookups still succeed on physical equality.
+
+  * The `--ext no_prim_proj` option is removed. It was meant as an escape hatch
+    for the switch to declaration-only projectors, but since projectors no
+    longer have a definition to fall back to, all it did was make every
+    projection permanently stuck.
+
   * `nonempty` is now a lang item and lives in `Prims`; the module
     `FStar.Nonempty` has been removed. Replace `FStar.Nonempty.nonempty` (and
     `nonempty_intro`/`nonempty_elim`) with the corresponding `Prims` names, and
@@ -559,8 +575,10 @@ Guidelines for the changelog:
       function is expected still works, but code that relied on the projector
       being an ordinary `let` (for instance to unfold it explicitly) may need
       adjustment.
-    - `--ext no_prim_proj` restores the old behaviour for a single
-      `#push-options` scope, as an escape hatch for proofs that regress.
+    - `--ext no_prim_proj` was briefly available as an escape hatch, but it is
+      now removed: since projectors have no definition to fall back to,
+      disabling the primitive iota rule only made projections permanently
+      stuck rather than restoring the old behaviour.
 
   * As a consequence of the above, the machinery that existed to work around
     the cost of generating projectors is gone:

--- a/src/typechecker/FStarC.TypeChecker.NBE.fst
+++ b/src/typechecker/FStarC.TypeChecker.NBE.fst
@@ -734,7 +734,6 @@ and translate_comp cfg bs (c:S.comp) : ML comp =
 
 (* uncurried application *)
 and reduce_disc_proj (cfg : config) (h:fv) (args:args) : ML (option t) =
-  if Options.Ext.enabled "no_prim_proj" then None else
   let tcenv = Cfg.cfg_env cfg.core_cfg in
   if not cfg.core_cfg.steps.iota then None else
   match Env.disc_proj_info tcenv (S.lid_of_fv h) with

--- a/src/typechecker/FStarC.TypeChecker.Normalize.fst
+++ b/src/typechecker/FStarC.TypeChecker.Normalize.fst
@@ -159,7 +159,7 @@ let check_strict_projector (cfg : Cfg.cfg) (hua : fv & universes & args) : ML bo
    discriminator, the number of arguments preceding the scrutinee, and (for a
    projector) the position of the field among the constructor's arguments. *)
 let disc_proj_head (cfg : Cfg.cfg) (head : term) : ML (option (Ident.lident & bool & int & option int)) =
-  if not cfg.steps.iota || Options.Ext.enabled "no_prim_proj" then None else
+  if not cfg.steps.iota then None else
   match (U.un_uinst head).n with
   | Tm_fvar h -> (
     match Env.disc_proj_info cfg.tcenv h.fv_name with
@@ -368,10 +368,13 @@ let check_strict (cfg : Cfg.cfg) (hua : fv & universes & args) : ML (option bool
  * then strongly reduced), and the results of these two modes are not
  * interchangeable. To avoid each mode invalidating the memo of the
  * other one (causing repeated recomputation, see issue #4394), we keep
- * two independent memo cells: one for weak normalization and one for
- * strong normalization. *)
+ * independent memo cells, one per mode. There are three modes: strong
+ * normalization, weak normalization, and weak head normalization (the
+ * last one is used to reduce the scrutinee of a projector or
+ * discriminator; see whnf_cfg and issue #4463). *)
 type cfg_memo 'a = {
   weak_memo   : memo (Cfg.cfg & 'a);
+  whnf_memo   : memo (Cfg.cfg & 'a);
   strong_memo : memo (Cfg.cfg & 'a);
 }
 
@@ -379,16 +382,21 @@ let fresh_memo (#a:Type) () : ML (memo a) = mk_ref None
 
 let fresh_cfg_memo (#a:Type) () : ML (cfg_memo a) = {
   weak_memo   = mk_ref None;
+  whnf_memo   = mk_ref None;
   strong_memo = mk_ref None;
 }
 
 (* Select the memo cell corresponding to the normalization mode of cfg. *)
 let memo_cell (cfg:Cfg.cfg) (r:cfg_memo 'a) : memo (Cfg.cfg & 'a) =
-  if cfg.steps.weak then r.weak_memo else r.strong_memo
+  if not cfg.steps.weak then r.strong_memo
+  else if cfg.steps.hnf then r.whnf_memo
+  else r.weak_memo
 
-(* The cell for the *other* normalization mode. *)
-let other_memo_cell (cfg:Cfg.cfg) (r:cfg_memo 'a) : memo (Cfg.cfg & 'a) =
-  if cfg.steps.weak then r.strong_memo else r.weak_memo
+(* The cells for the *other* normalization modes. *)
+let other_memo_cells (cfg:Cfg.cfg) (r:cfg_memo 'a) : list (memo (Cfg.cfg & 'a)) =
+  if not cfg.steps.weak then [r.weak_memo; r.whnf_memo]
+  else if cfg.steps.hnf then [r.weak_memo; r.strong_memo]
+  else [r.whnf_memo; r.strong_memo]
 
 type closure =
   | Clos of env & term & cfg_memo (env & term) & bool //memo for lazy evaluation; bool marks whether or not this is a fixpoint
@@ -446,6 +454,26 @@ let weak_cfg (cfg:Cfg.cfg) : ML Cfg.cfg =
       weak_cfg_cache := Some (cfg, cfg');
       cfg'
 
+(* The cfg used to reduce the scrutinee of a projector or discriminator to
+   weak head normal form (see the Tm_app case of norm). Like weak_cfg it is
+   cached, so that the same object is reused across calls and memo lookups
+   succeed on physical equality (issue #4463).
+
+   It sets [weak], not just [hnf]: otherwise the result would land in the memo
+   cell of the enclosing strong normalization and the two modes would evict
+   each other's memos, which is exactly the pathology of issue #4394. *)
+let whnf_cfg_cache : ref (option (Cfg.cfg & Cfg.cfg)) = mk_ref None
+
+let whnf_cfg (cfg:Cfg.cfg) : ML Cfg.cfg =
+  if cfg.steps.weak && cfg.steps.hnf then cfg
+  else
+    match !whnf_cfg_cache with
+    | Some (cfg0, cfg0') when BU.physical_equality cfg cfg0 -> cfg0'
+    | _ ->
+      let cfg' = { cfg with steps = { cfg.steps with weak = true; hnf = true } } in
+      whnf_cfg_cache := Some (cfg, cfg');
+      cfg'
+
 let read_memo cfg (r:cfg_memo 'a) : ML (option 'a) =
   let read (c:memo (Cfg.cfg & 'a)) : ML (option 'a) =
     match !c with
@@ -459,9 +487,9 @@ let read_memo cfg (r:cfg_memo 'a) : ML (option 'a) =
   | Some a -> Some a
   | None ->
     (* In compatibility mode, any memoized value is accepted, including one
-    computed in the other normalization mode. *)
+    computed in another normalization mode. *)
     if cfg.compat_memo_ignore_cfg
-    then read (other_memo_cell cfg r)
+    then other_memo_cells cfg r |> List.tryPick read
     else None
 
 let set_memo cfg (r:cfg_memo 'a) (t:'a) : ML unit =
@@ -1430,9 +1458,12 @@ let rec norm : cfg -> env -> stack -> term -> ML term =
             (* Recover the whole application spine (head and all arguments); the
                node is now unary, holding a single argument. *)
             let head, args = U.head_and_args_full t in
-            let push_args env args stack =
+            (* Each argument is pushed together with the environment it lives
+               in: they are usually all under [env], but a scrutinee that we
+               have already reduced (see below) is closed. *)
+            let push_args_env args stack =
               List.fold_right
-                (fun (a, aq) stack ->
+                (fun ((a, aq), env) stack ->
                   let a =
                     if ((Cfg.cfg_env cfg).erase_erasable_args ||
                         cfg.steps.for_extraction ||
@@ -1456,8 +1487,11 @@ let rec norm : cfg -> env -> stack -> term -> ML term =
                 args
                 stack
             in
-            let fallback () =
-              let stack = push_args env args stack in
+            let push_args env args stack =
+              push_args_env (args |> List.map (fun a -> (a, env))) stack
+            in
+            let fallback args =
+              let stack = push_args_env args stack in
               log cfg (fun () -> Format.print1 "\tPushed %s arguments\n" (show <| List.length args));
               norm cfg env stack head
             in
@@ -1467,11 +1501,19 @@ let rec norm : cfg -> env -> stack -> term -> ML term =
                enough and the selected field is then normalized exactly once.
                Reducing in [rebuild] instead would normalize the whole scrutinee
                first and then normalize the selected field again, which is
-               exponential in the nesting depth of the projections. *)
-            let unfold_fallback () =
+               exponential in the nesting depth of the projections.
+
+               That weak head normalization is however *speculative*: when the
+               projection turns out to be stuck, the enclosing normalization
+               walks the very same subterm all over again.  For a chain of
+               stuck projections that is quadratic in the length of the chain
+               (issue #4463), so instead of throwing the reduced scrutinee away
+               we put it back into the application: the enclosing pass then
+               only has to normalize what is left. *)
+            let unfold_fallback args =
               (* Only when extracting; see unfold_disc_proj_for_extraction. *)
               match unfold_disc_proj_for_extraction cfg head with
-              | None -> fallback ()
+              | None -> fallback args
               | Some (us_names, def) ->
                 (* The universes of the head may be bound in [env] (that is how
                    do_unfold_fv passes them along), so normalize them before
@@ -1489,29 +1531,37 @@ let rec norm : cfg -> env -> stack -> term -> ML term =
                   else None
                 in
                 match us with
-                | None -> fallback ()
+                | None -> fallback args
                 | Some us ->
                   let def = snd (Env.inst_tscheme_with (us_names, def) us) in
-                  let stack = push_args env args stack in
+                  let stack = push_args_env args stack in
                   norm cfg empty_env stack def
             in
             (match disc_proj_head cfg head with
              | Some (d, is_disc, n_indexed, idx) when List.length args > n_indexed ->
-               let scrutinee = fst (List.nth args n_indexed) in
-               let scrutinee = norm ({cfg with steps={cfg.steps with hnf=true}}) env [] scrutinee in
+               let scrutinee0, aq = List.nth args n_indexed in
+               let cfg' = whnf_cfg cfg in
+               (* The reduced scrutinee is closed, hence the empty environments
+                  below. *)
+               let scrutinee = norm cfg' env [] scrutinee0 in
                (match reduce_disc_proj cfg d is_disc idx scrutinee with
-                | None -> unfold_fallback ()
+                | None ->
+                  (* Stuck: keep the weak head normal form we just computed
+                     rather than making the enclosing pass recompute it. *)
+                  let args =
+                    args |> List.mapi (fun i a ->
+                      if i = n_indexed then ((scrutinee, aq), empty_env) else (a, env))
+                  in
+                  unfold_fallback args
                 | Some field ->
                   log cfg (fun () -> Format.print2 "Reduced projector/discriminator %s to %s\n"
                                                    (show t) (show field));
                   (* A projector may be over-applied (e.g. [QProc?.wp qc k s0]);
-                     the extra arguments are re-applied to the selected field.
-                     [field] is closed: hnf normalization pushes the environment
-                     into the arguments it does not reduce. *)
+                     the extra arguments are re-applied to the selected field. *)
                   let _, rest = BU.first_N (n_indexed + 1) args in
                   let stack = push_args env rest stack in
                   norm cfg empty_env stack field)
-             | _ -> fallback ())
+             | _ -> fallback (args |> List.map (fun a -> (a, env))))
 
           | Tm_refine {b=x}
               when cfg.steps.for_extraction
@@ -2557,7 +2607,12 @@ and rebuild (cfg:cfg) (env:env) (stack:stack) (t:term) : ML term =
         | Some (field, rest) ->
           log cfg (fun () -> Format.print2 "Reduced projector/discriminator %s to %s\n"
                                            (show t) (show field));
-          if Nil? rest
+          (* A projector can be over-applied both within this term and on the
+             stack (e.g. [CM?.mult r x y], whose two extra arguments are still
+             pending). Either way the selected field ends up applied, so hand it
+             back to [norm] to reduce the redex that just appeared. *)
+          let stack_has_arg = match stack with Arg _ :: _ -> true | _ -> false in
+          if Nil? rest && not stack_has_arg
           then do_rebuild cfg env stack field
           else norm cfg env stack (U.mk_app field rest)
         | None ->

--- a/tests/micro-benchmarks/NestedProjectors.fst
+++ b/tests/micro-benchmarks/NestedProjectors.fst
@@ -1,0 +1,32 @@
+module NestedProjectors
+
+(* Issue #4463: normalizing a deeply nested chain of *stuck* projections used to
+   be quadratic in the nesting depth, because the scrutinee of every projector
+   application was speculatively reduced to weak head normal form and that work
+   was then thrown away as soon as the projection turned out to be stuck.  [g]
+   below took tens of seconds to check; it should now take about a second. *)
+
+noeq
+type b = | B : b -> b
+
+let rec idn (n:nat) (y:b) : Tot b (decreases n) =
+  if n = 0 then y else idn (n - 1) y
+
+let g (x:b) : b =
+  FStar.Pervasives.norm [delta; iota; zeta; primops] (B?._0 (idn 300 (B?._0 (idn 300 (B?._0 (idn 300 (B?._0 (idn 300 (B?._0 (idn 300 (B?._0 (idn 300 (B?._0 (idn 300 (B?._0 (idn 300 (B?._0 (idn 300 (B?._0 (idn 300 (B?._0 (idn 300 (B?._0 (idn 300 (B?._0 (idn 300 (B?._0 (idn 300 (B?._0 (idn 300 (B?._0 (idn 300 (B?._0 (idn 300 (B?._0 (idn 300 (B?._0 (idn 300 (B?._0 (idn 300 (B?._0 (idn 300 (B?._0 (idn 300 (B?._0 (idn 300 (B?._0 (idn 300 (B?._0 (idn 300 (B?._0 (idn 300 (B?._0 (idn 300 (B?._0 (idn 300 (B?._0 (idn 300 (B?._0 (idn 300 (B?._0 (idn 300 (B?._0 (idn 300 (x)))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))
+
+(* The dual property: reducing a projection must *not* normalize the whole
+   scrutinee, only the field that is selected. If it did, the [idnat 2000000]
+   below would be unfolded two million times. *)
+
+noeq
+type r = | R : a:nat -> bb:nat -> r
+
+let rec idnat (n:nat) (y:nat) : Tot nat (decreases n) =
+  if n = 0 then y else idnat (n - 1) y
+
+let mk (y:nat) : r = R y (idnat 2000000 y)
+
+let h (x:nat) : nat = FStar.Pervasives.norm [delta; iota; zeta; primops] (R?.a (mk x))
+
+let _ : squash (forall x. h x == x) = ()

--- a/tests/vale/X64.Vale.StrongPost_i.fst
+++ b/tests/vale/X64.Vale.StrongPost_i.fst
@@ -44,14 +44,11 @@ let assert_to_norm' (p:prop): Lemma
   (ensures (norm [delta_only wp_code_delta; zeta; iota; primops] p))
   = ()
 
-(* This proof relies on the exact shape of the term produced by
-   [assert_to_norm'], which lists the projectors it wants unfolded in
-   [wp_code_delta].  Projectors and discriminators are now reduced primitively
-   by an iota rule in the normalizer, so they reduce regardless of
-   [delta_only], and the resulting (smaller!) hypothesis no longer matches the
-   goal's encoding of the opaque [wp_code].  Vale is unmaintained, so we simply
-   restore the old behaviour for this one lemma. *)
-#push-options "--ext no_prim_proj"
+(* The hypothesis introduced by [assert_to_norm'] below is a quantifier whose
+   trigger needs a [Mkstate]-shaped ground term.  For the instructions that
+   update both a register and the flags, the state returned by [va_lemma_*] is
+   an opaque skolem, so the branches below hand back the explicit record-update
+   literal instead (proved equal to it) to make the trigger fire. *)
 let lemma_weak_pre_ins (i:ins) (inss:list ins) 
 			       (s0:state) (sN:state) (post: unit -> prop) :
   Ghost (option state)
@@ -97,13 +94,15 @@ let lemma_weak_pre_ins (i:ins) (inss:list ins)
   | Add64Wrap (OReg dst) src ->
       if dst <> Rsp && valid_operand_norm src s0 then
         let (bM, sM) = va_lemma_Add64Wrap b0 s0 sN (OReg dst) src in
-  	  Some sM
+	  assert (sM == ({update_reg dst (sM.regs dst) s0 with flags = sM.flags}));
+	  Some ({update_reg dst (sM.regs dst) s0 with flags = sM.flags})
       else
   	  None
   | Adc64Wrap (OReg dst) src ->
       if dst <> Rsp && valid_operand_norm src s0 then
         let (bM, sM) = va_lemma_Adc64Wrap b0 s0 sN (OReg dst) src in
-  	  Some sM
+	  assert (sM == ({update_reg dst (sM.regs dst) s0 with flags = sM.flags}));
+	  Some ({update_reg dst (sM.regs dst) s0 with flags = sM.flags})
       else
   	  None
   | Mul64Wrap src ->
@@ -116,32 +115,35 @@ let lemma_weak_pre_ins (i:ins) (inss:list ins)
       let a = s0.regs dst * eval_operand_norm src s0 in
       if dst <> Rsp && valid_operand_norm src s0 && a < nat64_max then
         let (bM, sM) = va_lemma_IMul64 b0 s0 sN (OReg dst) src in
-  	  Some sM
+	  assert (sM == ({update_reg dst (sM.regs dst) s0 with flags = sM.flags}));
+	  Some ({update_reg dst (sM.regs dst) s0 with flags = sM.flags})
       else
   	  None
   | And64 (OReg dst) src ->
     let a = logand64 (s0.regs dst) (eval_operand_norm src s0) in
     if dst <> Rsp && valid_operand_norm src s0 then
       let (bM, sM) = va_lemma_And64 b0 s0 sN (OReg dst) src in
-  	  Some sM
+	  assert (sM == ({update_reg dst (sM.regs dst) s0 with flags = sM.flags}));
+	  Some ({update_reg dst (sM.regs dst) s0 with flags = sM.flags})
       else
   	  None
   | Shr64 (OReg dst) src ->
     let a = shift_right64 (s0.regs dst) (eval_operand_norm src s0) in
     if dst <> Rsp && valid_operand_norm src s0 then
       let (bM, sM) = va_lemma_Shr64 b0 s0 sN (OReg dst) src in
-  	  Some sM
+	  assert (sM == ({update_reg dst (sM.regs dst) s0 with flags = sM.flags}));
+	  Some ({update_reg dst (sM.regs dst) s0 with flags = sM.flags})
       else
   	  None
   | Sub64 (OReg dst) src ->
     if dst <> Rsp && valid_operand_norm src s0 && 0 <= 
 		    (s0.regs dst) - (eval_operand_norm src s0) then
       let (bM, sM) = va_lemma_Sub64 b0 s0 sN (OReg dst) src in
-  	  Some sM
+	  assert (sM == ({update_reg dst (sM.regs dst) s0 with flags = sM.flags}));
+	  Some ({update_reg dst (sM.regs dst) s0 with flags = sM.flags})
       else
   	  None
   | _ -> None
-#pop-options
 
 
  let rec lemma_weak_pre (inss:list ins) (s0:state) (sN:state) (post: unit -> prop) : Lemma


### PR DESCRIPTION
Since projectors became declaration-only, the normalizer speculatively reduces the scrutinee of every projector application to weak head normal form.  When the projection turned out to be stuck that work was thrown away, so the enclosing pass reduced the very same subterms all over again, making normalization quadratic in the depth of a chain of stuck projections.  The reduced scrutinee is now kept.

Two related fixes: the weak head normal form is memoized in its own cell instead of evicting the memo of the enclosing strong normalization (the pathology of #4394), and the config it uses is cached so that memo lookups still succeed on physical equality.  Also fixes an over-application bug in rebuild's projector retry, which could leave an unreduced beta redex when the extra arguments were still on the stack.

Depth-K chains of stuck projections, wall clock:

|  K         |   8   |  16  |   32  |   64  |   128  |
|------------|-------|------|-------|-------|--------|
|  pre-#4389 | 2.93  | 3.06 |  3.38 |  5.21 |  17.17 |
|  before    | 2.32  | 4.05 | 10.49 | 36.68 | 147.06 |
|  after     | 1.87  | 1.96 |  2.47 |  4.62 |  17.45 |

The two wins that #4389 brought are preserved: projecting a single field out of a record whose other fields are expensive stays lazy (62.03s before #4389, 1.70s now) and Test.QuickCode stays at 1.8s (3.75s before #4389).

Also removes the --ext no_prim_proj option.  It was meant as an escape hatch for the switch to declaration-only projectors, but since projectors no longer have a definition to fall back to, all it did was make every projection permanently stuck.  Its only user was Vale's lemma_weak_pre_ins: the hypothesis introduced there by assert_to_norm' is a quantifier whose trigger needs a Mkstate-shaped ground term, and for the instructions updating both a register and the flags the state returned by va_lemma_* is an opaque skolem.  The redundant projector and discriminator applications that survived under no_prim_proj happened to supply the bridge; those branches now hand back the explicit record-update literal instead.

Fixes #4463