### PR TITLE
Unfold inside the scrutinee of a stuck projection

### DIFF
--- a/pulse/test/bug-reports/Bug4472.fst
+++ b/pulse/test/bug-reports/Bug4472.fst
@@ -1,0 +1,58 @@
+module Bug4472
+#lang-pulse
+
+(* Issue #4472: a fold-direction [rewrite], i.e. one whose right-hand side is a
+   [pulse_unfold] typeclass-instance projection, must discharge just like the
+   unfold-direction one.  The projection is stuck until its scrutinee (the
+   instance) is unfolded, which is what makes the two sides of the equality
+   asymmetric. *)
+
+open Pulse
+include Pulse.Lib.Reference
+open FStar.Tactics.Typeclasses { noinst }
+
+let maybe_pts_to (#a: Type u#a) ([@@@mkey] r:ref a) (#f:perm) (x:option a) : slprop =
+  if is_null r then pure (x == None)
+  else exists* v. (r |-> Frac f v) ** pure (x == Some v)
+
+(* The attributes below mirror Pulse's own has_pts_to / ( |-> ) / pts_to_frac. *)
+[@@FStar.Tactics.Typeclasses.fundeps [1]; pulse_unfold]
+class has_my (p r : Type) = {
+  [@@@pulse_unfold]
+  my : p -> (#[full_default()] f : perm) -> r -> slprop;
+}
+
+[@@pulse_unfold]
+let ( |--> ) #p #r {| has_my p r |} = my #p #r
+
+[@@pulse_unfold; noinst]
+instance my_frac (p a : Type) (d : has_my p a) : has_my p (frac a) = {
+  my = (fun p #f' (Frac f v) -> d.my p #(f' *. f) v);
+}
+
+[@@pulse_unfold]
+instance my_base (a:Type) : has_my (ref a) (option a) = {
+  my = (fun r #f v -> maybe_pts_to r #f v);
+}
+
+(* Unfolding the instance. *)
+ghost
+fn elim_null u#a (#a: Type u#a) (r:ref a) #p (#x:option a)
+requires r |--> Frac p x
+requires pure (is_null r)
+ensures pure (x == None)
+{
+  rewrite (r |--> Frac p x) as maybe_pts_to r #p x;
+  unfold maybe_pts_to;
+  rewrite each (is_null r) as true;
+}
+
+(* Folding into the instance. *)
+ghost
+fn intro_null u#a (#a: Type u#a) (r:ref a) #p
+requires pure (is_null r)
+ensures r |--> Frac p None
+{
+  rewrite (pure (None #a == None #a)) as (maybe_pts_to r #p None);
+  rewrite (maybe_pts_to r #p None) as (r |--> Frac p None);
+}

--- a/src/typechecker/FStarC.TypeChecker.Normalize.fst
+++ b/src/typechecker/FStarC.TypeChecker.Normalize.fst
@@ -3567,6 +3567,22 @@ let maybe_unfold_head_fv (env:Env.env) (head:term)
         let subst = mk_univ_subst us_formals us in
         SS.subst subst defn |> Some
 
+(* If [head] is a projector or discriminator applied to at least [n_args]
+   arguments, the position of its scrutinee among them.  Projectors and
+   discriminators are declaration-only (see
+   TcInductive.mk_discriminator_and_indexed_projectors), so there is no
+   definition of the head to unfold: the only way to make progress on a stuck
+   projection is to unfold inside its scrutinee, just like the Tm_match case
+   below --- which is precisely what the projector's definition used to expand
+   to. *)
+let disc_proj_scrutinee_index (env:Env.env) (head:term) (n_args:int) : ML (option int) =
+  match (U.un_uinst head).n with
+  | Tm_fvar fv -> (
+    match Env.disc_proj_info env fv.fv_name with
+    | Some (_, n_indexed, _) when n_args > n_indexed -> Some n_indexed
+    | _ -> None)
+  | _ -> None
+
 let rec maybe_unfold_aux (env:Env.env) (t:term) : ML (option term) =
   match (SS.compress t).n with
   | Tm_match {scrutinee=t0; ret_opt; brs; rc_opt} ->
@@ -3581,8 +3597,17 @@ let rec maybe_unfold_aux (env:Env.env) (t:term) : ML (option term) =
     then maybe_unfold_head_fv env head
     else
       match maybe_unfold_aux env head with
-      | None -> None
       | Some head -> S.mk_Tm_app head args t.pos |> Some
+      | None ->
+        match disc_proj_scrutinee_index env head (List.length args) with
+        | None -> None
+        | Some i ->
+          let scrutinee, aq = List.nth args i in
+          match maybe_unfold_aux env scrutinee with
+          | None -> None
+          | Some scrutinee ->
+            let args = args |> List.mapi (fun j a -> if j = i then (scrutinee, aq) else a) in
+            S.mk_Tm_app head args t.pos |> Some
 
 let maybe_unfold_head (env:Env.env) (t:term) : ML (option term) =
   Option.map

--- a/tests/micro-benchmarks/StuckProjectorUnfold.fst
+++ b/tests/micro-benchmarks/StuckProjectorUnfold.fst
@@ -1,0 +1,30 @@
+module StuckProjectorUnfold
+
+open FStar.Tactics.V2
+
+(* Issue #4472: projectors are declaration-only, so there is no definition of
+   the projector itself for the core typechecker to unfold when it compares a
+   projection against something else.  Progress on such a stuck projection can
+   only be made by unfolding inside its scrutinee, which is what the projector's
+   definition used to expand to.  Without that, the two terms below are only
+   related in the direction in which [opaque_prop] can be unfolded. *)
+
+noeq type wrap (a:Type) = | Wrap : a -> wrap a
+
+assume val opaque_prop (r:int) (f:int) : Type0
+
+class has_my (r : Type) = { my : r -> int -> Type0 }
+
+instance my_base : has_my (wrap int) = { my = (fun (Wrap r) f -> opaque_prop r f) }
+
+let test (r:int) (f:int) : unit =
+  assert True by (
+    let t0 = quote (opaque_prop r f) in
+    let t1 = quote (my_base.my (Wrap r) f) in
+    let e = cur_env () in
+    let res, _ = t_check_equiv false true e t0 t1 in
+    if None? res then fail "not equivalent";
+    let res, _ = t_check_equiv false true e t1 t0 in
+    if None? res then fail "not equivalent (reversed)";
+    trivial ()
+  )


### PR DESCRIPTION
The core typechecker makes progress on two terms that do not match by unfolding the head of one of them (maybe_unfold_head).  Since projectors and discriminators became declaration-only there is no definition of the head to unfold, so a projection applied to an instance that is itself a definition, such as a Pulse [pulse_unfold] typeclass instance, could never be reduced: check_relation handed the stuck projection to the SMT solver, which cannot beta-reduce the encoded field.

The projection was only stuck on one side of the relation, since the other side usually still has an unfoldable head; that is why the fold-direction Pulse [rewrite] of issue #4472 failed while the unfold-direction one succeeded.

maybe_unfold_aux now descends into the scrutinee of a projector or discriminator application whose head has no definition, and the [Beta;Iota;Weak;HNF] pass of maybe_unfold_head then fires the iota rule. This mirrors the Tm_match case right above it, which is exactly what the projector's definition used to expand to.

Fixes #4472.