### PR TITLE
Upgrade F# extraction to support latest versions.

### DIFF
--- a/fsharp/base/FStar_All.fs
+++ b/fsharp/base/FStar_All.fs
@@ -1,4 +1,3 @@
-#light "off"
 module FStar_All
   let failwith x = failwith x
   let exit i = exit i

--- a/fsharp/base/FStar_Map.fs
+++ b/fsharp/base/FStar_Map.fs
@@ -1,4 +1,3 @@
-#nowarn 58
 module FStar_Map
 open Prims
 open FStar_Pervasives

--- a/fsharp/base/FStar_Map.fs
+++ b/fsharp/base/FStar_Map.fs
@@ -1,31 +1,30 @@
-#light "off"
+#nowarn 58
 module FStar_Map
 open Prims
 open FStar_Pervasives
 (* TODO: The extracted version of this file doesn't include the when 'key : comparison constraint which is required for F# *)
-type t<'key, 'value when 'key : comparison> =
-{mappings : ('key, 'value) FStar_FunctionalExtensionality.restricted_t; domain : 'key FStar_Set.set}
+type t<'key, 'value when 'key : comparison> = {mappings : FStar_FunctionalExtensionality.restricted_t<'key, 'value>; domain : 'key FStar_Set.set}
 
 
-let __proj__Mkt__item__mappings = (fun ( projectee  :  ('key, 'value) t ) -> (match (projectee) with
+let __proj__Mkt__item__mappings = (fun ( projectee  :  t<'key, 'value> ) -> (match (projectee) with
 | {mappings = mappings; domain = domain} -> begin
 mappings
 end))
 
 
-let __proj__Mkt__item__domain = (fun ( projectee  :  ('key, 'value) t ) -> (match (projectee) with
+let __proj__Mkt__item__domain = (fun ( projectee  :  t<'key, 'value> ) -> (match (projectee) with
 | {mappings = mappings; domain = domain} -> begin
 domain
 end))
 
 
-let sel = (fun ( m  :  ('key, 'value) t ) ( k  :  'key ) -> (m.mappings k))
+let sel = (fun ( m  :  t<'key, 'value> ) ( k  :  'key ) -> (m.mappings k))
 
 
-let upd = (fun ( m  :  ('key, 'value) t ) ( k  :  'key ) ( v  :  'value ) -> {mappings = (FStar_FunctionalExtensionality.on_domain (fun ( x  :  'key ) -> (match ((Prims.op_Equals x k)) with
+let upd = (fun ( m  :  t<'key, 'value> ) ( k  :  'key ) ( v  :  'value ) -> {mappings = (FStar_FunctionalExtensionality.on_domain (fun ( x  :  'key ) -> (match ((Prims.op_Equals x k)) with
 | true -> begin
-v
-end
+    v
+    end
 | uu____5020 -> begin
 (m.mappings x)
 end))); domain = (FStar_Set.union m.domain (FStar_Set.singleton k))})
@@ -34,16 +33,16 @@ end))); domain = (FStar_Set.union m.domain (FStar_Set.singleton k))})
 let const1 = (fun ( v  :  'value ) -> {mappings = (FStar_FunctionalExtensionality.on_domain (fun ( uu____5049  :  'key ) -> v)); domain = (FStar_Set.complement (FStar_Set.empty ()))})
 
 
-let domain = (fun ( m  :  ('key, 'value) t ) -> m.domain)
+let domain = (fun ( m  :  t<'key, 'value> ) -> m.domain)
 
 
-let contains = (fun ( m  :  ('key, 'value) t ) ( k  :  'key ) -> (FStar_Set.mem k m.domain))
+let contains = (fun ( m  :  t<'key, 'value> ) ( k  :  'key ) -> (FStar_Set.mem k m.domain))
 
 
-let concat = (fun ( m1  :  ('key, 'value) t ) ( m2  :  ('key, 'value) t ) -> {mappings = (FStar_FunctionalExtensionality.on_domain (fun ( x  :  'key ) -> (match ((FStar_Set.mem x m2.domain)) with
+let concat = (fun ( m1  :  t<'key, 'value> ) ( m2  :  t<'key, 'value> ) -> {mappings = (FStar_FunctionalExtensionality.on_domain (fun ( x  :  'key ) -> (match ((FStar_Set.mem x m2.domain)) with
 | true -> begin
-(m2.mappings x)
-end
+    (m2.mappings x)
+    end
 | uu____5174 -> begin
 (m1.mappings x)
 end))); domain = (FStar_Set.union m1.domain m2.domain)})
@@ -56,21 +55,19 @@ end))); domain = (FStar_Set.union m1.domain m2.domain)})
          A simple workaround would be to change the declaration of map_val in the FStar.Map.fsti so that 
          '#key:eqtype' parameter is moved before any non-implicit parameters (i.e. before 'f').
 *)
-let map_val = (fun ( f  :  'uuuuuu5195  ->  'uuuuuu5196 ) ( key  :  'key ) ( m  :  ('key, 'uuuuuu5195) t ) -> {mappings = (FStar_FunctionalExtensionality.on_domain (fun ( x  :  'key ) -> (f (m.mappings x)))); domain = m.domain})
+let map_val = (fun ( f  :  'value  ->  'value ) ( key  :  'key ) ( m  :  t<'key, 'value> ) -> {mappings = (FStar_FunctionalExtensionality.on_domain (fun ( x  :  'key ) -> (f (m.mappings x)))); domain = m.domain})
 
 
-let restrict = (fun ( s  :  'key FStar_Set.set ) ( m  :  ('key, 'value) t ) -> {mappings = m.mappings; domain = (FStar_Set.intersect s m.domain)})
+let restrict = (fun ( s  :  'key FStar_Set.set ) ( m  :  t<'key, 'value> ) -> {mappings = m.mappings; domain = (FStar_Set.intersect s m.domain)})
 
 
 let const_on = (fun ( dom  :  'key FStar_Set.set ) ( v  :  'value ) -> (restrict dom (const1 v)))
 
 
-type disjoint_dom =
-unit
+type disjoint_dom = unit
 
 
-type has_dom =
-unit
+type has_dom = unit
 
 
 
@@ -118,8 +115,7 @@ unit
 
 
 
-type equal =
-unit
+type equal = unit
 
 
 

--- a/fsharp/base/FStar_Pervasives_Native.fs
+++ b/fsharp/base/FStar_Pervasives_Native.fs
@@ -1,4 +1,3 @@
-#light "off"
 module FStar_Pervasives_Native
 open Prims
 type 'Aa option =

--- a/fsharp/base/Prims.fs
+++ b/fsharp/base/Prims.fs
@@ -1,4 +1,4 @@
-#light "off"
+#nowarn 58
 module Prims
 open System.Numerics
 
@@ -51,24 +51,24 @@ type 'a list   = 'a Microsoft.FSharp.Collections.list
 
 type nat       = int
 type pos       = int
-type 'd b2t    = B2t of unit
+type b2t<'d>    = B2t of unit
 
-type 'a squash = Squash of unit
+type squash<'a> = Squash of unit
 
-type (' p, ' q) sum =
-  | Left of ' p
-  | Right of ' q
+type sum<'p, 'q> =
+  | Left of 'p
+  | Right of 'q
 
-type (' p, ' q) l_or = ('p, 'q) sum squash
+type l_or<'p, 'q> = squash<sum<'p, 'q>>
 
-let uu___is_Left = function Left _ -> true | Right _ -> false
+let uu___is_Left x = match x with | Left _ -> true | Right _ -> false
 
-let uu___is_Right = function Left _ -> false | Right _ -> true
+let uu___is_Right x = match x with | Left _ -> false | Right _ -> true
 
-type (' p, ' q) pair =
-| Pair of ' p * ' q
+type pair<'p, 'q> =
+| Pair of 'p * 'q
 
-type (' p, ' q) l_and = ('p, 'q) pair squash
+type l_and<'p, 'q> = squash<pair<'p, 'q>>
 
 let uu___is_Pair _ = true
 
@@ -87,9 +87,9 @@ type l_False = empty squash
 
 type (' p, ' q) l_imp = ('p -> 'q) squash
 
-type (' p, ' q) l_iff = ((' p, ' q) l_imp, (' q, ' p) l_imp) l_and
+type l_iff<'p, 'q> = l_and<l_imp<'p, 'q>, l_imp<'q, 'p>>
 
-type ' p l_not = (' p, l_False) l_imp
+type ' p l_not = l_imp<'p, l_False>
 
 type (' a, ' p) l_Forall = L_forall of unit
 
@@ -128,12 +128,13 @@ let __proj__Mkdtuple2__item___1 x = match x with
 let __proj__Mkdtuple2__item___2 x = match x with
   | Mkdtuple2 (_, x) -> x
 
-let rec pow2 (n:int) = if n = bigint 0 then
-                      bigint 1
-                   else
-                      (bigint 2) * pow2 (n - (bigint 1))
+let rec pow2 (n:int) = 
+  if n = bigint 0 then
+    bigint 1
+  else
+    (bigint 2) * pow2 (n - (bigint 1))
 
-let __proj__Cons__item__tl = function
+let __proj__Cons__item__tl x = match x with
   | _::tl -> tl
   | _     -> failwith "Impossible"
 

--- a/fsharp/base/Prims.fs
+++ b/fsharp/base/Prims.fs
@@ -1,4 +1,3 @@
-#nowarn 58
 module Prims
 open System.Numerics
 

--- a/fsharp/ulibfs.fsproj
+++ b/fsharp/ulibfs.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <OtherFlags>--nowarn:0086 --strict-indentation- --nologo</OtherFlags>
+    <OtherFlags>--nowarn:0086 --nowarn:58 --strict-indentation- --nologo</OtherFlags>
     <OutputType>Library</OutputType>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <GenerateDocumentation>True</GenerateDocumentation>

--- a/fsharp/ulibfs.fsproj
+++ b/fsharp/ulibfs.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <OtherFlags>--nowarn:0086 --mlcompatibility --nologo --langversion:5.0</OtherFlags>
+    <OtherFlags>--nowarn:0086 --strict-indentation- --nologo</OtherFlags>
     <OutputType>Library</OutputType>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <GenerateDocumentation>True</GenerateDocumentation>

--- a/src/extraction/FStarC.Extraction.ML.Code.fst
+++ b/src/extraction/FStarC.Extraction.ML.Code.fst
@@ -505,14 +505,15 @@ let rec doc_of_expr (currentModule : mlsymbol) (outer : level) (e : mlexpr) : ML
 
     | MLE_If (cond, e1, Some e2) ->
         let cond = doc_of_expr currentModule  (min_op_prec, NonAssoc) cond in
+        let line_prefix = if Util.codegen_fsharp() then [text "    "] else [] in
         let doc  =
-            combine hardline [
+            combine hardline ((if Util.codegen_fsharp() then [break1] else []) @ [
                 reduce1 [text "if"; cond; text "then"; text "begin"];
-                doc_of_expr currentModule  (min_op_prec, NonAssoc) e1;
-                reduce1 [text "end"; text "else"; text "begin"];
-                doc_of_expr currentModule  (min_op_prec, NonAssoc) e2;
-                text "end"
-            ]
+                reduce1 (line_prefix @ [doc_of_expr currentModule  (min_op_prec, NonAssoc) e1 ]);
+                reduce1 (line_prefix @ [reduce1 [text "end"; text "else"; text "begin"] ]);
+                reduce1 (line_prefix @ [doc_of_expr currentModule  (min_op_prec, NonAssoc) e2 ]);
+                reduce1 (line_prefix @ [text "end" ])
+            ])
 
         in maybe_paren outer e_bin_prio_if doc
 
@@ -608,8 +609,8 @@ and doc_of_branch (currentModule : mlsymbol) (br : mlbranch) : ML doc =
 
     combine hardline [
         reduce1 [case; text "->"; text "begin"];
-        doc_of_expr currentModule  (min_op_prec, NonAssoc) e;
-        text "end";
+        reduce1 [if Util.codegen_fsharp() then text "    " else empty; doc_of_expr currentModule  (min_op_prec, NonAssoc) e];
+        reduce1 [if Util.codegen_fsharp() then text "    " else empty; text "end"]
     ]
 
 (* -------------------------------------------------------------------- *)

--- a/src/extraction/FStarC.Extraction.ML.Code.fst
+++ b/src/extraction/FStarC.Extraction.ML.Code.fst
@@ -723,9 +723,15 @@ let doc_of_mltydecl (currentModule : mlsymbol) (decls : mltydecl) =
 
         match body with
         | None      -> doc
-        | Some body ->
-            let body = forbody body in
-            combine (if Util.codegen_fsharp() then empty else hardline) [reduce1 [doc; text "="]; body]
+        | Some body_val ->
+            let body = forbody body_val in
+            let sep =
+                if Util.codegen_fsharp()
+                then match body_val with
+                    | MLTD_DType _ -> hardline
+                    | _ -> break1
+                else hardline in
+            combine sep [reduce1 [doc; text "="]; body]
 
     in
 

--- a/src/extraction/FStarC.Extraction.ML.Code.fst
+++ b/src/extraction/FStarC.Extraction.ML.Code.fst
@@ -76,6 +76,7 @@ let enclose (Doc l) (Doc r) (Doc x) =
 
 let cbrackets (Doc d) = enclose (text "{") (text "}") (Doc d)
 let parens   (Doc d ) = enclose (text "(") (text ")") (Doc d)
+let tparens   (Doc d ) = enclose (text "<") (text ">") (Doc d)
 
 let cat (Doc d1) (Doc d2) = Doc (d1 ^ d2)
 
@@ -336,16 +337,21 @@ let rec doc_of_mltype' (currentModule : mlsymbol) (outer : level) (ty : mlty) : 
         let args =
             match args with
             | []    -> empty
-            | [arg] -> doc_of_mltype currentModule (t_prio_name, Left) arg
+            | [arg] -> if Util.codegen_fsharp() 
+                then tparens (doc_of_mltype currentModule (t_prio_name, Left) arg)
+                else doc_of_mltype currentModule (t_prio_name, Left) arg
             | _     ->
                 let args = List.map (doc_of_mltype currentModule (min_op_prec, NonAssoc)) args in
-                parens (hbox (combine (text ", ") args))
+                if Util.codegen_fsharp() 
+                then tparens (hbox (combine (text ", ") args))
+                else parens (hbox (combine (text ", ") args))
 
         in
 
         let name = ptsym currentModule name in
-
-        hbox (reduce1 [args; text name])
+        if Util.codegen_fsharp()
+        then hbox (reduce [text name; args])
+        else hbox (reduce1 [args; text name])
     end
 
     | MLTY_Fun (t1, et, t2) ->
@@ -670,10 +676,14 @@ let doc_of_mltydecl (currentModule : mlsymbol) (decls : mltydecl) =
             let tparams = ty_param_names tparams in
             match tparams with
             | []  -> empty
-            | [x] -> text x
+            | [x] -> if Util.codegen_fsharp()
+                        then tparens (text x)
+                        else text x
             | _   ->
                 let doc = List.map (fun x -> (text x)) tparams in
-                parens (combine (text ", ") doc) in
+                if Util.codegen_fsharp()
+                then tparens (combine (text ", ") doc)
+                else parens (combine (text ", ") doc) in
 
         let forbody (body : mltybody) =
             match body with
@@ -706,13 +716,16 @@ let doc_of_mltydecl (currentModule : mlsymbol) (decls : mltydecl) =
 
         in
 
-        let doc = reduce1 [tparams; text (ptsym currentModule  ([], x))] in
+        let doc = 
+            if Util.codegen_fsharp()
+            then reduce [text (ptsym currentModule  ([], x)); tparams] 
+            else reduce1 [tparams; text (ptsym currentModule  ([], x))] in
 
         match body with
         | None      -> doc
         | Some body ->
             let body = forbody body in
-            combine hardline [reduce1 [doc; text "="]; body]
+            combine (if Util.codegen_fsharp() then empty else hardline) [reduce1 [doc; text "="]; body]
 
     in
 
@@ -798,7 +811,7 @@ let doc_of_mlmodule_r (fsharp : bool) (mod : mlmodule) : ML doc =
                    then reduce1 [text "end"]
                    else reduce1 [] in
         let doc  = Option.map (fun (_, m) -> doc_of_modbody target_mod_name m) sigmod in
-        let prefix = if fsharp then [cat (text "#light \"off\"") hardline] else [] in
+        let prefix = if fsharp then [cat (text "#nowarn 58") hardline] else [] in
         reduce <| (prefix @ [
             head;
             hardline;

--- a/src/extraction/FStarC.Extraction.ML.Code.fst
+++ b/src/extraction/FStarC.Extraction.ML.Code.fst
@@ -818,15 +818,14 @@ let doc_of_mlmodule_r (fsharp : bool) (mod : mlmodule) : ML doc =
                    then reduce1 [text "end"]
                    else reduce1 [] in
         let doc  = Option.map (fun (_, m) -> doc_of_modbody target_mod_name m) sigmod in
-        let prefix = if fsharp then [cat (text "#nowarn 58") hardline] else [] in
-        reduce <| (prefix @ [
+        reduce <| [
             head;
             hardline;
             (match doc with
              | None   -> empty
              | Some s -> cat s hardline);
             cat tail hardline;
-        ])
+        ]
     in
     p_mod true mod
 

--- a/tests/bug-reports/closed/RecordExtraction.fs.expected
+++ b/tests/bug-reports/closed/RecordExtraction.fs.expected
@@ -1,0 +1,18 @@
+module RecordExtraction
+type lens<'a, 'b> = {get : 'a  ->  'b; put : 'b  ->  'a  ->  'a}
+
+
+let __proj__Mklens__item__get = (fun ( projectee  :  lens<'a, 'b> ) -> (match (projectee) with
+| {get = get; put = put} -> begin
+     get
+     end))
+
+
+let __proj__Mklens__item__put = (fun ( projectee  :  lens<'a, 'b> ) -> (match (projectee) with
+| {get = get; put = put} -> begin
+     put
+     end))
+
+
+
+

--- a/tests/bug-reports/closed/RecordExtraction.fst
+++ b/tests/bug-reports/closed/RecordExtraction.fst
@@ -1,0 +1,7 @@
+module RecordExtraction
+
+noeq
+type lens (a:Type) (b:Type) = {
+  get: a -> b;
+  put: b -> a -> a
+}

--- a/tests/bug-reports/closed/RemoveUnusedTyparsIFace_A.fs.expected
+++ b/tests/bug-reports/closed/RemoveUnusedTyparsIFace_A.fs.expected
@@ -1,8 +1,7 @@
-#light "off"
+#nowarn 58
 module RemoveUnusedTyparsIFace_A
 
-type 'a t =
-'a Prims.list
+type t<'a> =Prims.list<'a>
 
 
 

--- a/tests/bug-reports/closed/RemoveUnusedTyparsIFace_A.fs.expected
+++ b/tests/bug-reports/closed/RemoveUnusedTyparsIFace_A.fs.expected
@@ -1,7 +1,6 @@
-#nowarn 58
 module RemoveUnusedTyparsIFace_A
 
-type t<'a> =Prims.list<'a>
+type t<'a> = Prims.list<'a>
 
 
 

--- a/tests/bug-reports/closed/RemoveUnusedTyparsIFace_B.fs.expected
+++ b/tests/bug-reports/closed/RemoveUnusedTyparsIFace_B.fs.expected
@@ -1,7 +1,7 @@
-#light "off"
+#nowarn 58
 module RemoveUnusedTyparsIFace_B
 
-let f = (fun ( x  :  'a RemoveUnusedTyparsIFace_A.t ) -> x)
+let f = (fun ( x  :  RemoveUnusedTyparsIFace_A.t<'a> ) -> x)
 
 
 

--- a/tests/bug-reports/closed/RemoveUnusedTyparsIFace_B.fs.expected
+++ b/tests/bug-reports/closed/RemoveUnusedTyparsIFace_B.fs.expected
@@ -1,4 +1,3 @@
-#nowarn 58
 module RemoveUnusedTyparsIFace_B
 
 let f = (fun ( x  :  RemoveUnusedTyparsIFace_A.t<'a> ) -> x)

--- a/tests/bug-reports/closed/RemoveUnusedTypars_A.fs.expected
+++ b/tests/bug-reports/closed/RemoveUnusedTypars_A.fs.expected
@@ -1,8 +1,7 @@
-#light "off"
+#nowarn 58
 module RemoveUnusedTypars_A
 
-type 'a t =
-'a Prims.list
+type t<'a> =Prims.list<'a>
 
 
 

--- a/tests/bug-reports/closed/RemoveUnusedTypars_A.fs.expected
+++ b/tests/bug-reports/closed/RemoveUnusedTypars_A.fs.expected
@@ -1,7 +1,6 @@
-#nowarn 58
 module RemoveUnusedTypars_A
 
-type t<'a> =Prims.list<'a>
+type t<'a> = Prims.list<'a>
 
 
 

--- a/tests/bug-reports/closed/RemoveUnusedTypars_B.fs.expected
+++ b/tests/bug-reports/closed/RemoveUnusedTypars_B.fs.expected
@@ -1,7 +1,7 @@
-#light "off"
+#nowarn 58
 module RemoveUnusedTypars_B
 
-let f = (fun ( x  :  'a RemoveUnusedTypars_A.t ) -> x)
+let f = (fun ( x  :  RemoveUnusedTypars_A.t<'a> ) -> x)
 
 
 

--- a/tests/bug-reports/closed/RemoveUnusedTypars_B.fs.expected
+++ b/tests/bug-reports/closed/RemoveUnusedTypars_B.fs.expected
@@ -1,4 +1,3 @@
-#nowarn 58
 module RemoveUnusedTypars_B
 
 let f = (fun ( x  :  RemoveUnusedTypars_A.t<'a> ) -> x)


### PR DESCRIPTION
The only requirement for now is to add
```
<OtherFlags>--strict-indentation-</OtherFlags>
```

to project properties, since F# love to have strict formatting by default, and having lot of these warnings will distract from actual 

Tested on .NET 11 Preview 6. Gladly accept redirection to fix any other version if somebody request for it. Currently build working on .NET 8, which is still supported until November 10, 2026. After that we can bump build to .NET 10, seems to be I make compiler happy which is super cool.

Closes #3368