### PR TITLE
tests/custard: put the header's directory on the mutant include path

### DIFF
--- a/tests/custard/cbor-corpus/mutants.py
+++ b/tests/custard/cbor-corpus/mutants.py
@@ -83,8 +83,12 @@ for c in cands:
 print('mutants:', len(C))
 
 os.makedirs(WORK, exist_ok=True)
+# The mutant is written into WORK/, but the generated .c includes its own
+# header by "" relative to where the extraction put it, so WORK/ is not
+# enough: the header's directory has to be on the include path.
 CC = ['cc', '-std=c11', '-w', '-fsanitize=address,undefined',
-      '-fno-sanitize-recover=all', '-x', 'c']
+      '-fno-sanitize-recover=all',
+      '-I' + (os.path.dirname(os.path.abspath(SRC)) or '.'), '-x', 'c']
 
 def run(k):
     old, new, name = C[k]


### PR DESCRIPTION
Since 89c7b67 the generated `.c` opens with `#include "<Module>.h"`, so it no longer compiles from a directory other than the one the extraction wrote it to.

`cbor-corpus/mutants.py` writes each mutant into `_output/mutants/`, where that include does not resolve. Every mutant is therefore reported `uncompilable`, and both adequacy figures collapse:

```
family=ops     killed 0 / 0  (uncompilable 46)
family=consts  killed 0 / 0  (uncompilable 46)
```

Note the failure mode: it does not error out. `killed 0 / 0` is a *pass* by any "did it fail?" reading, so the study keeps reporting success while measuring nothing. This is the same hazard section 23 warns about in the other direction — a green result that isn't evidence.

Adding the `.dc`'s own directory to the include path restores the table in `CborBoundary.md` exactly:

| module | ops | consts |
|---|---|---|
| `CborBoundary` | 46 / 46 | 46 / 46 |
| `CborBoundarySlice` | 48 / 49 | 46 / 59 |

Found while testing section 24 against EverParse's real CBOR parser; details in FStarLang/FStar#4395.
