### PR TITLE
Pulse: reduce nested projector redexes in `Pulse.Simplify`

### DIFF
--- a/pulse/src/checker/Pulse.Simplify.fst
+++ b/pulse/src/checker/Pulse.Simplify.fst
@@ -46,21 +46,21 @@ let is_List_Tot_tl (t:thua_t) : T.Tac (option term) =
     None
   | _ -> None
 
-let simpl_list (t:thua_t) : T.Tac thua_t =
+let _simpl_list (t:thua_t) : T.Tac (option term) =
   match is_List_Tot_hd t with
   | Some x ->
     begin match is_Cons (thua x) with
-    | Some (h, t) -> thua h
-    | None -> t
+    | Some (h, _) -> Some h
+    | None -> None
     end
   | None ->
     match is_List_Tot_tl t with
     | Some x ->
       begin match is_Cons (thua x) with
-      | Some (_, t) -> thua t
-      | None -> t
+      | Some (_, tl) -> Some tl
+      | None -> None
       end
-    | None -> t
+    | None -> None
 
 let is_Some (t:thua_t) : T.Tac (option term) =
   match hua t with
@@ -86,13 +86,13 @@ let is_Some_v (t:thua_t) : T.Tac (option term) =
     None
   | _ -> None
 
-let simpl_option (t:thua_t) : T.Tac thua_t =
+let _simpl_option (t:thua_t) : T.Tac (option term) =
   match is_Some_v t with
   | Some o ->
     (match is_Some (thua o) with
-    | Some x -> thua x
-    | None -> t)
-  | None -> t
+    | Some x -> Some x
+    | None -> None)
+  | None -> None
 
 let is_tuple2__1 (t:thua_t) : T.Tac (option term) =
   match hua t with
@@ -150,11 +150,6 @@ let _simpl_proj (t:thua_t) : T.Tac (option term) =
     | Some t -> omap snd (is_tuple2 (thua t))
     | None -> None
 
-let simpl_proj (t:thua_t) : T.Tac thua_t =
-  match _simpl_proj t with
-  | Some t -> thua t
-  | None -> t
-
 let is_reveal (t:thua_t) : T.Tac (option (typ & term)) =
   match hua t with
   | Some (h, us, args) ->
@@ -179,40 +174,74 @@ let is_hide (t:thua_t) : T.Tac (option (typ & term)) =
     None
   | _ -> None
 
-let simpl_reveal_hide (t:thua_t) : T.Tac thua_t =
+let _simpl_reveal_hide (t:thua_t) : T.Tac (option term) =
   match is_reveal t with
   | Some (_, x) ->
     begin match is_hide (thua x) with
-    | Some (_, x) -> thua x
-    | None -> t
+    | Some (_, x) -> Some x
+    | None -> None
     end
-  | None -> t
+  | None -> None
 
-let simpl_hide_reveal (t:thua_t) : T.Tac thua_t =
+let _simpl_hide_reveal (t:thua_t) : T.Tac (option term) =
   match is_hide t with
   | Some (t1, x) ->
     begin match is_reveal (thua x) with
     | Some (t2, x) ->
       (* hide #nat (reveal #int x) is == to x *)
       if FStar.Reflection.TermEq.term_eq t1 t2
-      then thua x
-      else t
-    | None -> t
+      then Some x
+      else None
+    | None -> None
     end
+  | None -> None
+
+(* Try each rule in turn, returning the rewritten term if one of them fires.
+Note that we cannot detect "did anything change?" by comparing terms:
+`FStar.Reflection.TermEq.term_eq` is conservative and returns false for equal
+terms that are not faithful, e.g. any term containing a uvar. *)
+let try_rules (t:thua_t) : T.Tac (option thua_t) =
+  match _simpl_proj t with
+  | Some t -> Some (thua t)
+  | None ->
+  match _simpl_option t with
+  | Some t -> Some (thua t)
+  | None ->
+  match _simpl_list t with
+  | Some t -> Some (thua t)
+  | None ->
+  match _simpl_hide_reveal t with
+  | Some t -> Some (thua t)
+  | None ->
+  match _simpl_reveal_hide t with
+  | Some t -> Some (thua t)
+  | None -> None
+
+(* Apply the rules at the root until none of them fires. Every rule replaces the
+term by one of its own subterms, so this terminates. *)
+let rec apply_rules_fix (t:thua_t) : T.Tac thua_t =
+  match try_rules t with
+  | Some t' -> apply_rules_fix t'
   | None -> t
 
+(* The rules are applied at a node both before and after its arguments are
+simplified.
+
+Applying them before is what keeps this cheap: a rule discards whole branches
+(`fst (a, b)` becomes `a`), and those branches are then never traversed.
+
+Applying them again afterwards is what makes the pass complete: simplifying an
+argument can expose a redex at a node that has already been visited, e.g. the
+outer projection of `fst (fst ((c, ()), ()))` only becomes reducible once its
+argument has been rewritten to `(c, ())`. A rule firing at that point returns a
+subterm of an already-simplified argument, so no further traversal is needed. *)
 let rec simplify (t0:term) : T.Tac term =
-  let t = thua t0  in
-  let t = simpl_proj t in
-  let t = simpl_option t in
-  let t = simpl_list t in
-  let t = simpl_hide_reveal t in
-  let t = simpl_reveal_hide t in
+  let t = apply_rules_fix (thua t0) in
   let t =
     match hua t with
     | Some (h, us, args) ->
       let args = T.map (fun (t, q) -> simplify t, q) args in
-      T.mk_app (T.Tv_UInst h us) args
+      fst (apply_rules_fix (thua (T.mk_app (T.Tv_UInst h us) args)))
     | _ -> fst t
   in
   // T.print <| "simplified " ^ show t0 ^ " to " ^ show t;

--- a/pulse/test/TupleDepth.fst
+++ b/pulse/test/TupleDepth.fst
@@ -1,24 +1,23 @@
 (*
-   Reproducer (currently FAILING, deliberately not fixed) for
-   https://github.com/FStarLang/FStar/issues/4491
+   Regression test for https://github.com/FStarLang/FStar/issues/4491
 
    When a Pulse function's specification mentions a value reached from an
-   argument by *one* tuple projection, an `_` at the call site is solved. When
-   the same value is reached by *two* projections, the `_` is left unsolved and
-   the call fails with Error 228, even though the precondition pins the value
-   under the hole to `7` and there is nothing else the hole could be.
+   argument by tuple projections, an `_` at the call site should be solved: the
+   precondition pins the value under the hole to `7`, and there is nothing else
+   the hole could be.
 
-   The specification is provable; only inference fails: writing the value out by
-   hand (`d2 ((7, ()), ())`) verifies. It is depth, not arity or position: three
-   projections fail too, and a single hole for the whole inner tuple
-   (`d2 (_, ())`) fails the same way.
+   This used to work at one projection but fail at two with Error 228
+   ("Unexpected unresolved uvars"). `Pulse.Checker.Prover.pure_eq_unif` only
+   unifies when one side of the equation is a *bare* uvar, and the projections
+   were reduced by `Pulse.Simplify.simplify`, which was a single top-down pass:
+   at `fst (fst ((c, ()), ()))` no rule fired at the outer node, and by the time
+   the argument had been rewritten to `(c, ())` the outer node was never revisited,
+   leaving the stuck goal `pure (fst (c, ()) == 7)`.
 
-   Expected output today:
-
-     * Error 228 at TupleDepth.fst(...):
-       - Tactic failed
-       - Unexpected unresolved uvars in the term:
-       - 'd2 (((*?u45*)_, ()), ())'
+   `simplify` now simplifies arguments first and iterates to a fixpoint, so both
+   calls below are solved. Note that this is inference only where the answer is
+   unique: `d2 (_, ())`, with a single hole for the whole inner tuple, is still
+   rejected, since `fst ?u == 7` does not determine `?u`.
 *)
 module TupleDepth
 #lang-pulse
@@ -35,7 +34,7 @@ fn call_d1 ()
   requires emp
   ensures  emp
 {
-  d1 (_, ());          // verifies
+  d1 (_, ());
 }
 
 (* two projections: `fst (fst y)` *)
@@ -49,5 +48,19 @@ fn call_d2 ()
   requires emp
   ensures  emp
 {
-  d2 ((_, ()), ());    // Error 228
+  d2 ((_, ()), ());
+}
+
+(* three projections *)
+
+fn d3 (y: (((int & unit) & unit) & unit))
+  requires pure (fst (fst (fst y)) == 7)
+  ensures  emp
+{ () }
+
+fn call_d3 ()
+  requires emp
+  ensures  emp
+{
+  d3 (((_, ()), ()), ());
 }

--- a/pulse/test/TupleDepth.fst
+++ b/pulse/test/TupleDepth.fst
@@ -1,0 +1,53 @@
+(*
+   Reproducer (currently FAILING, deliberately not fixed) for
+   https://github.com/FStarLang/FStar/issues/4491
+
+   When a Pulse function's specification mentions a value reached from an
+   argument by *one* tuple projection, an `_` at the call site is solved. When
+   the same value is reached by *two* projections, the `_` is left unsolved and
+   the call fails with Error 228, even though the precondition pins the value
+   under the hole to `7` and there is nothing else the hole could be.
+
+   The specification is provable; only inference fails: writing the value out by
+   hand (`d2 ((7, ()), ())`) verifies. It is depth, not arity or position: three
+   projections fail too, and a single hole for the whole inner tuple
+   (`d2 (_, ())`) fails the same way.
+
+   Expected output today:
+
+     * Error 228 at TupleDepth.fst(...):
+       - Tactic failed
+       - Unexpected unresolved uvars in the term:
+       - 'd2 (((*?u45*)_, ()), ())'
+*)
+module TupleDepth
+#lang-pulse
+open Pulse
+
+(* one projection: `fst y` *)
+
+fn d1 (y: (int & unit))
+  requires pure (fst y == 7)
+  ensures  emp
+{ () }
+
+fn call_d1 ()
+  requires emp
+  ensures  emp
+{
+  d1 (_, ());          // verifies
+}
+
+(* two projections: `fst (fst y)` *)
+
+fn d2 (y: ((int & unit) & unit))
+  requires pure (fst (fst y) == 7)
+  ensures  emp
+{ () }
+
+fn call_d2 ()
+  requires emp
+  ensures  emp
+{
+  d2 ((_, ()), ());    // Error 228
+}


### PR DESCRIPTION
Fixes FStarLang/FStar#4491.

## Problem

Pulse argument inference works when the inferred value sits one tuple projection
deep, but fails as soon as it is two or more:

```fstar
fn d1 (x : int & unit)          requires pure (fst x == 7) ...
fn d2 (x : (int & unit) & unit) requires pure (fst (fst x) == 7) ...

d1 (_, ())        // verifies
d2 ((_, ()), ())  // Error 228: Unexpected unresolved uvars in the term
```

## Root cause

`Pulse.Checker.Prover.pure_eq_unif` only unifies when one side of a `pure`
equation is a **bare** uvar. Getting there requires reducing the projector
redexes, which the F* normalizer does not do here (`fst` is not `unfold`, and
`__normalize_slprop` deliberately avoids delta-unfolding `fst`/`snd`) — it is
done by `Pulse.Simplify.simplify`.

`simplify` was a single **top-down** pass: it applied the rewrite rules at a node
once, then mapped itself over the arguments and never revisited the node. For
`fst (fst ((c, ()), ()))`:

1. at the top no rule fires — the argument's head is `fst`, not `Mktuple2`;
2. recursion rewrites the argument to `(c, ())`;
3. the now-reducible top-level `fst (c, ())` is never looked at again.

So depth 1 reaches `pure (?u == 7)` and is solved; depth 2 gets stuck at
`pure (fst (?u, ()) == 7)`.

## Fix

Each rewrite rule now returns `option term`, so "a rule fired" is explicit, and
`simplify` applies the rules at a node **both** before descending and after its
arguments have been simplified:

- applying them first preserves the branch pruning (`fst (A, B)` → `A` means `B`
  is never traversed);
- re-applying afterwards restores completeness for nested redexes. The result is
  a subterm of already-normalized arguments, so no extra traversal is needed.

Note for anyone touching this again: detecting "did anything change?" with
`FStar.Reflection.TermEq.term_eq` **loops forever**. `term_eq` has type
`b:bool{b ==> denote_term t1 == denote_term t2}` — one-way only — and returns
`false` for equal terms that are not `faithful`, which excludes uvars. Hence the
explicit `option` returns.

## Not addressed

The other variant in the issue, `d2 (_, ())` (a hole at the whole inner tuple,
giving `fst ?u == 7`), still fails and is left failing on purpose: that
constraint does not determine `?u` in general, and inference should only fire
when the solution is unique. Solving it would require η-expanding metavariables
at single-constructor types — cf. the existing TODO in
`FStarC.TypeChecker.Rel.fst` ("we can later extend it to single constructor
inductives").

## Test

`pulse/test/TupleDepth.fst`, covering projection depths 1, 2 and 3.

## Validation

- `make test-3`: no F* verification errors. The remaining make-level failures on
  this machine are environmental/pre-existing and reproduce with the pre-change
  binary (missing `python`, OCaml 5 `Domain`/`domainslib` for `pulse/test/pool`,
  a stale `Simple.cmxs` in `examples/native_tactics`).
- No performance regression from the extra rule applications:
  `EqualOrDisjoint.fst` 3.6 s vs 3.5 s unpatched.