### PR TITLE
Pulse: only drop leaked branch refinements, fixing #4488 rlimit regression

### DIFF
--- a/pulse/src/checker/Pulse.Checker.Return.fst
+++ b/pulse/src/checker/Pulse.Checker.Return.fst
@@ -107,31 +107,78 @@ let rec free_named_vars (t:term) : T.Tac (list var) =
 let refinement_constrains_result (bx:var) (ref:term) : T.Tac bool =
   List.Tot.mem bx (free_named_vars ref)
 
+// Does `t` mention a variable introduced by ANF-hoisting a stateful
+// sub-expression (`Pulse.Checker.Base.fresh_anf_name`, which names them
+// `__anf<N>`)? Such variables are bound by a `Tm_Bind` local to the branch, so
+// anything mentioning them cannot be stated outside it. We read the pretty-name
+// off the `namedv` itself rather than looking the variable up in the
+// environment, since `push_binding` keeps the ppname but drops the binder
+// attribute that `bind_st_term` attaches.
+let rec mentions_anf_temp (t:term) : T.Tac bool =
+  let any (l:list term) : T.Tac bool = TU.fold_left (fun acc e -> acc || mentions_anf_temp e) false l in
+  match R.inspect_ln t with
+  | R.Tv_Var nv ->
+    let nm = T.unseal (R.inspect_namedv nv).ppname in
+    FStar.String.length nm >= 5 && FStar.String.sub nm 0 5 = "__anf"
+  | R.Tv_App hd (a, _) -> any [hd; a]
+  | R.Tv_Abs _ body -> mentions_anf_temp body
+  | R.Tv_Refine b ref -> any [(R.inspect_binder b).sort; ref]
+  | R.Tv_Arrow b c ->
+    any ((R.inspect_binder b).sort ::
+         (match R.inspect_comp c with
+          | R.C_Total ret | R.C_GTotal ret -> [ret]
+          | R.C_Lemma pre post pats -> [pre; post; pats]
+          | R.C_Eff _ _ ret _ _ _ -> [ret]))
+  | R.Tv_Let _ _ _ def body -> any [def; body]
+  | R.Tv_Match sc _ brs -> any (sc :: T.map snd brs)
+  | R.Tv_AscribedT e ty _ _ -> any [e; ty]
+  | R.Tv_AscribedC e _ _ _ -> mentions_anf_temp e
+  | _ -> false
+
 // When inferring a return type (no post-condition hint), the Core typechecker
 // turns a `Pure`-effect `ensures` into a refinement on the returned value's
-// type, e.g. `SZ.lt : Pure bool (ensures z == (v x < v y))` gives a return type
-// `z:bool{z == (SZ.v x < SZ.v y)}`. When the operand is a branch-local hoisted
-// ANF temporary `__anf0` (introduced by hoisting a stateful read such as `!j`),
-// that temporary leaks into the refinement, e.g. `z:bool{z == (SZ.v __anf0 < ...)}`.
-// Closing the branch closes the *term* over `__anf0` but not the *type*, so when
-// the type is later used in the outer scope where `__anf0` no longer exists it
-// fails with Error 76 ("universe_of failed ... Variable not found"); the refined
-// result type also blocks joining two `if`/`match` branches whose boolean results
-// are refined differently.
+// type, e.g. `SZ.lt : Pure bool (ensures fun z -> z == (v x < v y))` applied to
+// `x` gives the return type `z:bool{z == (SZ.v x < SZ.v y)}`.
 //
-// We weaken the inferred type by dropping refinements that constrain the result
-// value itself, i.e. whose formula mentions the refinement binder -- of *any*
-// shape (`z == e`, `z > 0`, ...), not just equalities. Such refinements are
-// redundant: in the inference path `comp_return` re-establishes the value via the
-// equality `result == term` (`use_eq` below, which holds for any non-`unit`
-// result), and any `Pure` postcondition of the operand is in scope at its call.
-// Refinements that do *not* mention the result are payload facts with no other
-// carrier -- e.g. a lemma application's conclusion (`some_lemma x : Lemma (p x)`
-// flows through this same path as `_:unit{ p x }`) -- and are kept.
+// If the operand is an ANF temporary `__anf0` -- introduced by hoisting a
+// stateful read such as `!j` out of an `if`/`match` condition or a `while`
+// guard -- then that temporary leaks into the refinement, e.g.
+// `z:bool{z == (SZ.v __anf0 < SZ.v l2)}`. Joining/closing the branch closes the
+// *term* over `__anf0` but not the *type*, so the type is later used in the
+// outer scope where `__anf0` no longer exists and fails with Error 76
+// ("universe_of failed ... Variable not found"). Such a refinement also blocks
+// joining two `if`/`match` branches whose results are refined differently.
+//
+// We therefore drop a refinement when it *both*
+//
+//   (a) constrains the result value (its formula mentions the refinement
+//       binder), and
+//   (b) mentions an ANF temporary.
+//
+// Both conditions are needed:
+//
+//  * (a) alone is too coarse. It also discards refinements phrased purely in
+//    terms of variables that stay in scope, e.g. the `z == (SZ.v ii < SZ.v n)`
+//    of a `while` guard `(let ii = !i; SZ.lt ii n)` where `ii` is user-written.
+//    Those are recoverable in principle -- `comp_return` adds `result == term`
+//    -- but only at a large cost to the solver: dropping them unconditionally
+//    caused a ~9x rlimit regression on the loop invariants of issue #4488.
+//
+//  * (b) alone is too coarse in the other direction. A refinement that mentions
+//    an ANF temporary but *not* the result is a payload fact with no other
+//    carrier -- typically a lemma's conclusion, since `some_lemma x : Lemma (p x)`
+//    flows through this same path as `_:unit{ p x }`. Dropping those loses the
+//    lemma (e.g. `Seq.mem_index v (value_of x)` in
+//    `pulse/test/Example.BreakReturnContinue.fst`).
+//
+// Dropping a refinement satisfying both is sound: the value relation is
+// re-established by the `result == term` equality that `comp_return` adds
+// (`use_eq` below, which holds for any non-`unit` result), and any `Pure`
+// postcondition of the operand is already in scope at its call.
 let rec unrefine_result (t:term) : T.Tac term =
   match T.inspect t with
   | T.Tv_Refine b ref ->
-    if refinement_constrains_result b.uniq ref
+    if refinement_constrains_result b.uniq ref && mentions_anf_temp ref
     then unrefine_result b.sort
     else t
   | T.Tv_AscribedT e _ _ _ -> unrefine_result e

--- a/pulse/test/BranchGuardHoist.fst
+++ b/pulse/test/BranchGuardHoist.fst
@@ -114,3 +114,26 @@ fn let_nonEq_refinement (i:ref SZ.t) (j:ref SZ.t) (l1:SZ.t)
   let r = (if (!i `SZ.lt` l1) then 0sz else (bump (!j)));
   r
 }
+
+(* Regression test for issue #4488, the converse direction: a refinement that
+   constrains the result but mentions *no* hoisted temporary must be kept.
+
+   Here the `while` guard binds the stateful read to a user-written `ii`, so
+   `SZ.lt`'s `ensures` yields `z:bool{ z == (SZ.v ii < SZ.v n) }` with `ii` in
+   scope; nothing escapes. Dropping such refinements (as the original fix for
+   the leak above did, for every result-constraining refinement) is not
+   observable as a failure here, but it forces the solver to rederive the guard
+   through `result == term` and made the loop invariants of #4488 about 9x more
+   expensive. The `invariant` below is deliberately arithmetic so that the
+   connection between the guard and `SZ.v ii` is actually used. *)
+divergent fn while_user_bound_guard (i:ref SZ.t) (n:SZ.t)
+  requires i |-> 'vi ** pure (SZ.v 'vi <= SZ.v n)
+  ensures  exists* vi. i |-> vi ** pure (SZ.v vi <= SZ.v n)
+{
+  while (let ii = !i; SZ.lt ii n)
+  invariant exists* (vi:SZ.t). i |-> vi ** pure (SZ.v vi <= SZ.v n)
+  {
+    let ii = !i;
+    i := SZ.add ii 1sz;
+  }
+}


### PR DESCRIPTION
Fixes #4488.

### Background

`0506dbd225` ("Pulse: fix branch return-type refinement leak in if/match/while guards", #4324) fixed a real bug. When an `if`/`match` is used as a value — a `while` guard, or a plain `let`-binding — and is checked with no post-condition hint, its return type is inferred. If a branch's value comes from an operator with a refined return type applied to an ANF-hoisted temporary (#4138), that temporary leaks into the refinement:

```
_:bool{ _ == (SZ.v __anf0 < SZ.v l2) }
```

Closing the branch closes the *term* over `__anf0` but not the *type*, so it is later checked in the outer scope and fails with Error 76 (`universe_of failed ... Variable not found: __anf0`).

### The problem

That fix weakened the inferred type by dropping **every** refinement that constrains the result value, on the grounds that `comp_return` re-establishes it through the `result == term` equality.

That is too coarse. It also discards refinements phrased purely in terms of variables that stay in scope, where nothing was escaping — and recovering those through `result == term` is far from free for the solver.

#4488 reports a Pulse `while` loop whose invariant VC went from **0.652** to **5.857** rlimit (~9x) between 2026.06.14 and 2026.08.16 on identical sources, options and Z3. I bisected it (11 full stage3 builds) to exactly `0506dbd225` — its parent `ef14e8c8d7` measures 0.652, the merge `d1cdba2697` measures 7.611. Full table in https://github.com/FStarLang/FStar/issues/4488#issuecomment-5442401131.

The guard there is

```fstar
while (let ii = !i; SZ.lt ii n)
```

so `ii` is **user-written**, not a hoisted temporary: `z:bool{ z == (SZ.v ii < SZ.v n) }` is perfectly statable and was being dropped for nothing. Essentially all the extra cost lands in a single arithmetic obligation, whose quantifier-instantiation profile (~117K instantiations, dominated by facts that do not appear in the ~90-fact unsat core) explodes once the guard refinement is gone.

### The fix

Drop a refinement only when it **both**

1. constrains the result value (its formula mentions the refinement binder), **and**
2. mentions an ANF temporary.

Both conditions are load-bearing, and I verified each direction:

* **(1) alone** is the current behaviour, i.e. the #4488 regression.
* **(2) alone** drops payload facts that have no other carrier. A lemma's conclusion flows through this same path as `_:unit{ p x }`, so this loses e.g. `Seq.mem_index v (value_of x)` — I hit exactly that as a `test-pulse` failure in `Example.BreakReturnContinue.fst` while developing this.

ANF temporaries are recognised by the `__anf<N>` pretty-name that `Pulse.Checker.Base.fresh_anf_name` gives them. (`bind_st_term` also attaches a distinguishing binder attribute, but that does not survive `push_binding`, whereas the ppname does.)

<details>
<summary>An alternative I tried and rejected</summary>

The more principled-looking place for the weakening is `Pulse.JoinComp.infer_post'`, which is where the branch's inferred result type actually crosses from `g'` into `g` — and which already contains an unused `fvs_t` / `fail_fv_typ` pair clearly written in anticipation of this. Weakening there by dropping refinements that mention variables outside `var_dom g` does eliminate the Error 76, but it is too late: by that point the `rewrites_to_p __anf1 _vj9` machinery has already renamed the temporary to a variable that *is* in scope, so the refinement is retained and then cannot be proved (Error 19 on `BranchGuardHoist.while_szlt_else`). Doing it in `Pulse.Checker.Return`, before the rename, is what works.

</details>

### Validation

* `Repro.Bad.fst` from #4488: max `used rlimit` **5.857 → 0.288**.
* `pulse/test/BranchGuardHoist.fst`, the regression test added by `0506dbd225`, still verifies — including the `while`-guard, plain `let`-binding, and non-equality-refinement (`ensures fun z -> v z > v x`) forms.
* `make test-pulse` passes.
* Adds a test to `BranchGuardHoist.fst` for the converse direction: a `while` guard binding its stateful read to a user-written variable, whose refinement must be retained. Its `invariant` is arithmetic so that the guard/`SZ.v ii` connection is genuinely used.

cc @KimayaBedarkar
