### PR TITLE
Eta-expand product-typed holes in Pulse

### DIFF
--- a/pulse/src/checker/Pulse.Checker.Prover.fst
+++ b/pulse/src/checker/Pulse.Checker.Prover.fst
@@ -366,16 +366,54 @@ let is_eq_unif (g: env) (p: term) : Dv (option (term & term)) =
     else
       None
   | None -> None
-let pure_eq_unif (g: env) (p: term) skip_eq_uvar : Dv bool =
-  match is_eq_unif g p with
-  | Some (lhs, rhs) ->
+
+// As above, but simplifying the goal first. Simplification reduces projections
+// applied to a constructed pair (`fst (a, b)` becomes `a`), which is what
+// exposes a bare uvar after an eta-expansion.
+let is_eq_unif_simpl (g: env) (p: term) : T.Tac (option (term & term)) =
+  match is_eq2 (Pulse.Simplify.simplify (RU.deep_compress_safe p)) with
+  | Some (_, lhs, rhs) ->
+    if is_uvar lhs || is_uvar rhs then
+      Some (lhs, rhs)
+    else
+      None
+  | None -> None
+
+let pure_eq_unif (g: env) (p: term) skip_eq_uvar : T.Tac bool =
+  // `skip_eq_uvar` asks for a uvar equation to be *deferred*, so that the goals
+  // that can pin the uvar down are attempted first. Returning true defers.
+  let solve (lhs:term) (rhs:term) : T.Tac bool =
     if skip_eq_uvar then
       true
     else (
       ignore (RU.teq_nosmt_force (elab_env g) lhs rhs);
       false
     )
-  | None -> false
+  in
+  match is_eq_unif g p with
+  | Some (lhs, rhs) -> solve lhs rhs
+  | None ->
+    (* Neither side is a bare uvar. The goal may still be an equation on a
+       projection of a product-typed hole, e.g. `fst ?u == 4`. Refining
+       `?u := (?a, ?b)` is not a guess -- every inhabitant of a product is a
+       pair, and a component left unsolved still raises an error -- and it lets
+       the simplifier reduce the projection, exposing a bare uvar.
+
+       Only equations can benefit, so non-equational goals bail out before the
+       simplifier is invoked; this is a hot path. *)
+    if None? (is_eq2 (RU.deep_compress_safe p)) then false
+    else begin
+      debug_prover g (fun _ -> Printf.sprintf "pure_eq_unif: trying eta on p=%s" (show p));
+      let leaves = Pulse.Eta.eta_expand_projected_uvars g p in
+      RU.try_solve_single_valued_implicits (elab_env g) leaves;
+      (* A component may already have been solved by an earlier goal, in which
+         case nothing is expanded here but the projection still needs reducing
+         before the remaining component is exposed. So this runs unconditionally,
+         not only when the expansion above fired. *)
+      match is_eq_unif_simpl g p with
+      | Some (lhs, rhs) -> solve lhs rhs
+      | None -> false
+    end
 
 // Restore a previously-captured error_range_bound around a thunk.
 let with_saved_bound (saved_bound: option RU.range) (f: unit -> T.Tac 'a)

--- a/pulse/src/checker/Pulse.Checker.ST.fst
+++ b/pulse/src/checker/Pulse.Checker.ST.fst
@@ -69,6 +69,18 @@ let check
     let allow_ambiguous = should_allow_ambiguous e in
     let (| g', ctxt', k |) = prove (RU.range_of_term e) g ctxt (comp_pre c0) allow_ambiguous in
 
+    (* Last resort before reporting unresolved holes: a hole at a product type
+       is solved by neither the prover (which needs a `pure` goal mentioning it)
+       nor F*'s uni-valued rule (which only handles `unit`). Refining it to a
+       pair of fresh holes is structural, not a guess, and it lets the
+       uni-valued rule reach components that *are* uniquely determined, e.g. a
+       hole at `unit & unit`. Firing only here means nothing that already
+       verifies can regress: the alternative at this point is an error. *)
+    if not (RU.no_uvars_in_term e) then begin
+      let leaves = Pulse.Eta.eta_expand_term_uvars g e in
+      RU.try_solve_single_valued_implicits (elab_env g) leaves
+    end;
+
     if not (RU.no_uvars_in_term e) then
       fail_doc g (Some range) [
         text "Unexpected unresolved uvars in the term:";

--- a/pulse/src/checker/Pulse.Eta.fst
+++ b/pulse/src/checker/Pulse.Eta.fst
@@ -1,0 +1,142 @@
+(*
+   Copyright 2026 Microsoft Research
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*)
+
+module Pulse.Eta
+
+open FStar.Reflection.V2
+open Pulse.Syntax.Base
+open Pulse.Reflection.Util
+open Pulse.Typing.Env
+module T = FStar.Tactics.V2
+module R = FStar.Reflection.V2
+module RU = Pulse.RuntimeUtils
+
+(* Depth of nesting we are willing to expand through. Expansion recurses into
+   component types, which are strictly smaller than the tuple type, so this is
+   only a guard against a pathological type. *)
+let max_depth = 16
+
+let uv_unk : universe = R.pack_universe R.Uv_Unk
+
+let dbg (g:env) (f: unit -> T.Tac string) : T.Tac unit =
+  if RU.debug_at_level (fstar_env g) "eta" then T.print (f ()) else ()
+
+(* Is [ty] (the whnf of) a [tuple2] application? If so, its two universes and
+   two component types. *)
+let is_tuple2_ty (g:env) (ty:typ) : T.Tac (option (universe & universe & typ & typ)) =
+  let ty = RU.whnf_lax (elab_env g) ty in
+  dbg g (fun _ -> "eta: is_tuple2_ty on " ^ T.term_to_string ty);
+  match T.hua ty with
+  | Some (h, us, args) ->
+    if implode_qn (T.inspect_fv h) = `%tuple2
+    then
+      match args with
+      | [(a1, Q_Explicit); (a2, Q_Explicit)] ->
+        let u1, u2 =
+          match us with
+          | [u1; u2] -> u1, u2
+          | _ -> uv_unk, uv_unk
+        in
+        Some (u1, u2, a1, a2)
+      | _ -> None
+    else None
+  | _ -> None
+
+(* If [t] is a tuple projection, the term being projected. *)
+let is_projected (t:term) : T.Tac (option term) =
+  match T.hua t with
+  | Some (h, _, args) ->
+    let n = implode_qn (T.inspect_fv h) in
+    if n = `%Mktuple2?._1 || n = `%fst
+    || n = `%Mktuple2?._2 || n = `%snd
+    then
+      match args with
+      | [(_, Q_Implicit); (_, Q_Implicit); (x, Q_Explicit)] -> Some x
+      | _ -> None
+    else None
+  | _ -> None
+
+(* Returns the fresh holes introduced, i.e. the leaves of the expansion; empty
+   if nothing was expanded. Callers hand these to F*'s uni-valued rule, which
+   can then solve any of them sitting at [unit]. *)
+let rec eta_expand_uvar' (g:env) (t:term) (fuel:nat) : T.Tac (list term) =
+  if fuel = 0 then []
+  else
+    match RU.uvar_typ t with
+    | None -> dbg g (fun _ -> "eta: not a uvar: " ^ T.term_to_string t); []
+    | Some ty ->
+      match is_tuple2_ty g ty with
+      | None -> []
+      | Some (u1, u2, a1, a2) ->
+        let r = RU.range_of_term t in
+        let reason = "eta-expansion of a product-typed hole" in
+        let v1 = RU.new_implicit_var reason r (elab_env g) a1 false in
+        let v2 = RU.new_implicit_var reason r (elab_env g) a2 false in
+        if RU.teq_nosmt_force (elab_env g) t (mk_mktuple2 u1 u2 a1 a2 v1 v2)
+        then
+          (* A component may itself be a product. *)
+          let leaves (v:term) : T.Tac (list term) =
+            match eta_expand_uvar' g v (fuel - 1) with
+            | [] -> [v]
+            | l -> l
+          in
+          leaves v1 @ leaves v2
+        else []
+
+let eta_expand_uvar (g:env) (t:term) : T.Tac (list term) =
+  eta_expand_uvar' g t max_depth
+
+let rec eta_projected' (g:env) (t:term) (fuel:nat) : T.Tac (list term) =
+  if fuel = 0 then []
+  else
+    let here =
+      match is_projected t with
+      | Some x ->
+        dbg g (fun _ -> "eta: projected " ^ T.term_to_string x);
+        eta_expand_uvar g x
+      | None -> []
+    in
+    let _, args = T.collect_app_ln t in
+    here @ eta_projected_args g args (fuel - 1)
+
+and eta_projected_args (g:env) (args:list argv) (fuel:nat) : T.Tac (list term) =
+  match args with
+  | [] -> []
+  | (a, _) :: args ->
+    let l1 = eta_projected' g a fuel in
+    l1 @ eta_projected_args g args fuel
+
+let eta_expand_projected_uvars (g:env) (t:term) : T.Tac (list term) =
+  eta_projected' g t max_depth
+
+let rec eta_term' (g:env) (t:term) (fuel:nat) : T.Tac (list term) =
+  if fuel = 0 then []
+  else
+    let l = eta_expand_uvar g t in
+    if Cons? l then l
+    else
+      let _, args = T.collect_app_ln t in
+      eta_term_args g args (fuel - 1)
+
+and eta_term_args (g:env) (args:list argv) (fuel:nat) : T.Tac (list term) =
+  match args with
+  | [] -> []
+  | (a, _) :: args ->
+    let l1 = eta_term' g a fuel in
+    l1 @ eta_term_args g args fuel
+
+let eta_expand_term_uvars (g:env) (t:term) : T.Tac (list term) =
+  eta_term' g t max_depth

--- a/pulse/src/checker/Pulse.Eta.fsti
+++ b/pulse/src/checker/Pulse.Eta.fsti
@@ -1,0 +1,60 @@
+(*
+   Copyright 2026 Microsoft Research
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*)
+
+module Pulse.Eta
+
+(* Eta-expansion of product-typed unification variables.
+
+   A hole standing for a pair is solved by neither of the two mechanisms Pulse
+   has available: F*'s uni-valued rule (try_solve_single_valued_implicits) only
+   handles [unit], and Pulse's [pure_eq_unif] only fires when one side of a
+   [pure (a == b)] goal is a *bare* uvar. So a goal like
+
+     pure (fst ?u == 4) ** pure (snd ?u == 7)     with ?u : int & int
+
+   is stuck: [fst ?u] is not a bare uvar, and [?u] is not uni-valued.
+
+   The missing step is purely structural. Every inhabitant of [t1 & t2] is a
+   pair, so refining [?u := (?a, ?b)] commits to no value; any component that
+   stays unsolved still raises an error. Once expanded, [Pulse.Simplify] reduces
+   [fst (?a, ?b)] to [?a], and the existing machinery takes over.
+
+   This must NOT be applied eagerly. A goal [pts_to r ?u] with [?u : int & int]
+   is today solved against a context [pts_to r v] by taking [?u := v]; had [?u]
+   already been expanded to [(?a, ?b)] the slprop matcher, which is syntactic,
+   would fail to match it against the variable [v]. So expansion fires only
+   where the checker is otherwise stuck -- see the two callers. *)
+
+open Pulse.Syntax.Base
+open Pulse.Typing.Env
+module T = FStar.Tactics.V2
+
+(* All three return the fresh holes introduced -- the leaves of the expansion --
+   which is empty exactly when nothing was expanded. Handing those leaves to
+   [RU.try_solve_single_valued_implicits] is what solves the ones at [unit]. *)
+
+(* If the head of [t] is an unsolved uvar whose type is a [tuple2], solve it
+   with a pair of fresh implicits, recursively. *)
+val eta_expand_uvar (g:env) (t:term) : T.Tac (list term)
+
+(* Eta-expand every uvar that appears under a tuple projector in [t]. Being
+   under a projector is exactly the evidence that the pair structure is needed,
+   and such a goal is unsolvable without it. *)
+val eta_expand_projected_uvars (g:env) (t:term) : T.Tac (list term)
+
+(* Eta-expand every product-typed uvar in [t], whether projected or not. Used
+   only as a last resort, when the alternative is an error. *)
+val eta_expand_term_uvars (g:env) (t:term) : T.Tac (list term)

--- a/pulse/src/checker/Pulse.RuntimeUtils.fsti
+++ b/pulse/src/checker/Pulse.RuntimeUtils.fsti
@@ -75,6 +75,8 @@ val map_seal (s:FStar.Sealed.sealed 't) (f: 't -> 'u) : FStar.Sealed.sealed 'u
 val float_one : FStar.Float64.float64
 val lax_check_term_with_unknown_universes (g:env) (t:T.term) : Dv (option T.term)
 val new_implicit_var : reason:string -> range -> env -> typ -> unrefine:bool -> Dv term
+(* If the head of the term is an unsolved uvar, the type it was created at. *)
+val uvar_typ (t:term) : Dv (option typ)
 val try_solve_single_valued_implicits : env -> list term -> Dv unit
 module T = FStar.Tactics.V2
 val tc_term_phase1 (g:env) (t:T.term) (instantiate_imps:bool) : Dv (option (T.term & T.term & T.tot_or_ghost) & T.issues)

--- a/pulse/src/ml/Pulse_RuntimeUtils.ml
+++ b/pulse/src/ml/Pulse_RuntimeUtils.ml
@@ -137,6 +137,15 @@ let new_implicit_var (reason: string) (r:FStarC_Range.range) (g:TcEnv.env) (e:S.
   let uvar, _, _ = FStarC_TypeChecker_Util.new_implicit_var reason r g e unrefine in
   uvar
 
+(* If [t] is (an application of) an unsolved uvar, return the type it was
+   created at.  Used to decide whether a stuck hole can be eta-expanded. *)
+let uvar_typ (t:S.term) : S.typ option =
+  let hd, _ = FStarC_Syntax_Util.head_and_args_full (FStarC_Syntax_Subst.compress t) in
+  match (FStarC_Syntax_Subst.compress hd).FStarC_Syntax_Syntax.n with
+  | FStarC_Syntax_Syntax.Tm_uvar (ctx_u, _) ->
+    Some (FStarC_Syntax_Util.ctx_uvar_typ ctx_u)
+  | _ -> None
+
 let try_solve_single_valued_implicits (g:TcEnv.env) (ts: S.term list) : unit =
   let g = {g with phase1=true; admit=true} in
   let imps = List.filter_map (fun t ->

--- a/pulse/test/EtaUnitInference.fst
+++ b/pulse/test/EtaUnitInference.fst
@@ -1,0 +1,235 @@
+(*
+   Which `_` holes can Pulse and F* solve?
+
+   Two mechanisms solve a hole outright:
+
+   - F* solves *uni-valued* implicits in `try_solve_single_valued_implicits`
+     (`FStarC.TypeChecker.Rel.fst`): a `?u : unit`, or a unit refinement, is set
+     to `()` with no constraint needed. The comment on that function records how
+     narrow it is:
+
+       For now we handle only unit and unit refinement typed implicits,
+       we can later extend it to single constructor inductives
+
+   - The Pulse prover solves a hole standing on one side of a `pure (a == b)`
+     goal (`Pulse.Checker.Prover.pure_eq_unif`). It requires a *bare* uvar there,
+     so `?u == 4` qualifies while `fst ?u == 4` does not.
+
+   Neither reaches a hole standing for a whole tuple, which used to mean such a
+   hole had to be split into `(_, _)` by hand -- even when the tuple was uniquely
+   determined, and even when every component would individually have been solved.
+
+   `Pulse.Eta` closes that gap by eta-expanding a product-typed hole, refining
+   `?u : t1 & t2` into `(?a, ?b)`. That is a structural step, not a guess: every
+   inhabitant of a product *is* a pair, so it commits to no value, and a
+   component left unsolved still raises Error 228. Once expanded, the two
+   mechanisms above reach the components, and `Pulse.Simplify` reduces the
+   projections that mention them.
+
+   The tests below are grouped by which mechanism does the work. Every one of
+   them is expected to verify; the second group is the one that eta-expansion
+   made possible, and each case there names the error it used to produce.
+*)
+module EtaUnitInference
+#lang-pulse
+open Pulse
+
+////////////////////////////////////////////////////////////////////////////////
+// Solved
+////////////////////////////////////////////////////////////////////////////////
+
+(* A lone hole at `unit`, with no equation mentioning it at all. *)
+
+fn takes_unit (u: unit)
+  requires emp
+  ensures  emp
+{ () }
+
+fn call_unit ()
+  requires emp
+  ensures  emp
+{
+  takes_unit _;
+}
+
+(* Unit refinements are covered by the same rule. *)
+
+fn takes_refined_unit (u: (x:unit{True}))
+  requires emp
+  ensures  emp
+{ () }
+
+fn call_refined_unit ()
+  requires emp
+  ensures  emp
+{
+  takes_refined_unit _;
+}
+
+(* Both components of a product, by the two different mechanisms: the `int` from
+   the precondition, the `unit` from the uni-valued rule. The two equations have
+   to be separate `pure`s joined by `**`; `pure (p /\ q)` is not split, so
+   `pure_eq_unif` would never see a bare equation. *)
+
+fn both (y: (int & int))
+  requires pure (fst y == 4) ** pure (snd y == 7)
+  ensures  emp
+{ () }
+
+fn call_both_split ()
+  requires emp
+  ensures  emp
+{
+  both (_, _);
+}
+
+fn unit_fst (y: (unit & int))
+  requires pure (snd y == 7)
+  ensures  emp
+{ () }
+
+fn call_unit_fst_split ()
+  requires emp
+  ensures  emp
+{
+  unit_fst (_, _);
+}
+
+fn pair_unit (y: (unit & unit))
+  requires emp
+  ensures  emp
+{ () }
+
+fn call_pair_unit_split ()
+  requires emp
+  ensures  emp
+{
+  pair_unit (_, _);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Solved only by eta-expanding the hole
+//
+// Each of these was an Error 228 before `Pulse.Eta` existed, and each is
+// written with a single `_` where the group above had to write `(_, _)`.
+////////////////////////////////////////////////////////////////////////////////
+
+(* `unit & unit` has exactly one inhabitant, so the hole is as uniquely
+   determined as a `unit` one -- but it is a single constructor inductive rather
+   than `unit`, so the uni-valued rule does not reach it.
+
+     Previously: Error 228, `pair_unit ?u` *)
+
+fn call_pair_unit_hole ()
+  requires emp
+  ensures  emp
+{
+  pair_unit _;
+}
+
+(* Mixing the two: one component uni-valued, the other fixed by an equation.
+   Both mechanisms would apply if the hole were split, and neither applies to the
+   undivided hole.
+
+     Previously: Error 228, `unit_fst ?u` *)
+
+fn call_unit_fst_hole ()
+  requires emp
+  ensures  emp
+{
+  unit_fst _;
+}
+
+(* Splitting only the outer product is not enough when a component is itself a
+   product. Here the `int` is solved from the precondition and the remaining hole
+   is the `unit & unit` one, which again needs eta:
+
+     Previously: Error 228, `mixed_left (?u, 7)` *)
+
+fn mixed_left (y: ((unit & unit) & int))
+  requires pure (snd y == 7)
+  ensures  emp
+{ () }
+
+fn call_mixed_left ()
+  requires emp
+  ensures  emp
+{
+  mixed_left (_, _);
+}
+
+(* The same nested on the right: the outer `unit` is solved by the uni-valued
+   rule, and the leftover hole at `unit & int` is not, even though both of *its*
+   components would be.
+
+     Previously: Error 228, `mixed_right ((), ?u)` *)
+
+fn mixed_right (y: (unit & (unit & int)))
+  requires pure (snd (snd y) == 7)
+  ensures  emp
+{ () }
+
+fn call_mixed_right ()
+  requires emp
+  ensures  emp
+{
+  mixed_right (_, _);
+}
+
+(* A product whose components are *both* determined -- `(4, 7)` is the only
+   possible argument -- yet the undivided hole is not solved. Nothing here is
+   uni-valued and nothing is nested: this is eta-expansion and nothing else,
+   which is why `call_both_split` above already succeeded on the very same
+   signature.
+
+   Note the two components are solved by two *different* goals, so by the time
+   `snd ?u == 7` is looked at, `?u` has already been expanded and partly solved;
+   the projection still has to be simplified to expose the second component. *)
+
+fn call_both_hole ()
+  requires emp
+  ensures  emp
+{
+  both _;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Still rejected -- eta-expansion refines a hole, it does not guess a value
+////////////////////////////////////////////////////////////////////////////////
+
+(* Nothing constrains either component, so both survive the expansion and the
+   error is still reported. This is the property that makes the expansion safe:
+   `?u` becomes `(?a, ?b)`, which commits to no value.
+
+     Error 228: `unconstrained (?a, ?b)` *)
+
+fn unconstrained (y: (int & int))
+  requires emp
+  ensures  emp
+{ () }
+
+[@@expect_failure [228]]
+fn call_unconstrained ()
+  requires emp
+  ensures  emp
+{
+  unconstrained _;
+}
+
+(* One component determined, the other not: the determined one is solved and the
+   error names only what is genuinely missing.
+
+     Error 228: `half_constrained (4, ?b)` *)
+
+fn half_constrained (y: (int & int))
+  requires pure (fst y == 4)
+  ensures  emp
+{ () }
+
+[@@expect_failure [228]]
+fn call_half_constrained ()
+  requires emp
+  ensures  emp
+{
+  half_constrained _;
+}


### PR DESCRIPTION

A `_` standing for a tuple was never solved, even when the tuple was uniquely
determined and every component would individually have been inferred. It had to
be split into `(_, _)` by hand:

```fstar
fn both (y: (int & int))
  requires pure (fst y == 4) ** pure (snd y == 7)
  ensures  emp
{ () }

both (_, _);   // fine
both _;        // Error 228: Unexpected unresolved uvars: `both ?u`
```

Nothing is ambiguous about the second line — `(4, 7)` is the only possible
argument — so the two spellings ought to behave the same.

## Why it failed

Two mechanisms solve a hole, and neither eta-expands:

- **F\*'s uni-valued rule**, `try_solve_single_valued_implicits`
  (`FStarC.TypeChecker.Rel.fst`), sets a `?u : unit` to `()`. Its own comment
  records the limit:

  > For now we handle only unit and unit refinement typed implicits, we can
  > later extend it to single constructor inductives

- **Pulse's `pure_eq_unif`** unifies when one side of a `pure (a == b)` goal is
  a *bare* uvar.

So `?u : int & int` under `pure (fst ?u == 4) ** pure (snd ?u == 7)` is stuck:
`fst ?u` is not bare, and `?u` is not uni-valued. A tuple is a single
constructor inductive — exactly the case the comment above leaves for later.

## The fix

A new module, `Pulse.Eta`, refines `?u : t1 & t2` into `(?a, ?b)`.

This is a **structural step, not a guess**. Every inhabitant of a product *is* a
pair, so the refinement commits to no value, and a component left unconstrained
still raises Error 228. The "infer only when uniquely determined" principle is
preserved.

It is the other half of #4492, which taught `Pulse.Simplify` to reduce nested
projector redexes. The two compose:

```
fst ?u  --eta-->  fst (?a, ?b)  --Simplify-->  ?a  --pure_eq_unif-->  ?a := 4
```

## Eta-expansion is deliberately not eager

This is the part worth reviewing. A goal `pts_to r ?u` with `?u : int & int` is
today solved against a context `pts_to r v` by taking `?u := v`. Had `?u`
already been expanded, the slprop matcher — which is syntactic — would try to
match `(?a, ?b)` against the variable `v` and fail, breaking code that verifies
today.

Expansion therefore fires only where the checker is otherwise stuck:

1. **Projection-driven**, in `pure_eq_unif`: only when a goal applies a
   projector to the hole. Being under a projector is exactly the evidence that
   the pair structure is needed, and such a goal is unsolvable as it stands.
2. **Last resort**, in `Pulse.Checker.ST.check`, immediately before the
   "Unexpected unresolved uvars" error, followed by a re-run of the uni-valued
   rule. Nothing can regress there, since the alternative at that point is an
   error. This is what solves a hole at `unit & unit`, which no goal mentions at
   all.

One subtlety worth flagging for reviewers: the expansion has to run in **both**
passes of `prove_pure`. `prove_step` tries `prove_pure g ctxt true` (the pass
that defers uvar equations) before the normal one, and a goal like
`snd ?u == 7` is not recognised as a uvar equation — so that first pass would
discharge it and the second would never see it. Under `skip_eq_uvar` the new
path defers the goal, exactly as a bare uvar equation does.

## Scope

`tuple2` only. N-ary tuples are nested `tuple2` in F\*, so `a & b & c` is covered
by the recursion. Arbitrary single-constructor inductives are left as future
work — indices, refinements and universe handling make them substantially
riskier, and nothing needs them yet. That remains the open half of the `Rel.fst`
TODO quoted above.

## Changes

| File | |
|---|---|
| `pulse/src/checker/Pulse.Eta.fst`/`.fsti` | new; the expansion and two term walkers |
| `pulse/src/checker/Pulse.Checker.Prover.fst` | projection-driven hook in `pure_eq_unif` |
| `pulse/src/checker/Pulse.Checker.ST.fst` | last-resort hook before the Error 228 check |
| `pulse/src/ml/Pulse_RuntimeUtils.ml`, `Pulse.RuntimeUtils.fsti` | new `uvar_typ` primitive, to read a uvar's type |
| `pulse/test/EtaUnitInference.fst` | new tests |

`Pulse.Eta` also registers a `--debug eta` trace.

## Tests

`pulse/test/EtaUnitInference.fst` documents which holes each mechanism solves.
Newly accepted:

| call | hole type | solved by |
|---|---|---|
| `both _` | `int & int` | eta + two `pure` equations |
| `pair_unit _` | `unit & unit` | eta + uni-valued rule |
| `unit_fst _` | `unit & int` | eta + one of each |
| `mixed_left (_, _)` | `(unit & unit) & int` | nested eta |
| `mixed_right (_, _)` | `unit & (unit & int)` | nested eta + #4492's Simplify |

It also includes **two negative controls**, an underdetermined product and a
half-determined one, both `[@@expect_failure [228]]`. These are the property
that makes the expansion safe: with nothing to pin the components down, the
error must still be reported.

`pulse/test/TupleDepth.fst` (the #4492 test) still passes.

Validated with a full `make test-3`. The only failures are pre-existing and
environmental: `tests/ide` needs `python`, and `pulse/test/pool` needs OCaml 5
(`Domain`, `domainslib`).
