### PR TITLE
Fix res_summary.sh memory unit handling (KiB/MiB confusion)

### DIFF
--- a/.scripts/res_summary.sh
+++ b/.scripts/res_summary.sh
@@ -10,6 +10,23 @@ declare -A mem
 
 printAll=false
 
+memory_bytes() {
+	local amount=${1%%[A-Za-z]*}
+	local unit=${1#"$amount"}
+
+	case "$unit" in
+		B)   echo "$amount" ;;
+		KiB) echo $((amount * 1024)) ;;
+		MiB) echo $((amount * 1024 * 1024)) ;;
+		GiB) echo $((amount * 1024 * 1024 * 1024)) ;;
+		*)   echo 0 ;;
+	esac
+}
+
+memory_mib() {
+	awk -v bytes="$1" 'BEGIN { printf "%.1f", bytes / 1024 / 1024 }'
+}
+
 if [ $# -gt 0 ] && ( [ $1 == "--all" ] || [ $1 == "-a" ] ); then
 	printAll=true
 	shift
@@ -17,22 +34,22 @@ fi
 
 # Traverse all .ramon files and store the relevant information in the
 # associative arrays above.
-for f in $(find . -name '*.ramon'); do
+while IFS= read -r -d '' f; do
 	fp=${f/.ramon/}
 
-	s=$(grep 'group.mempeak' $f | grep -Eo '[0-9]+' | head -1)
-	mem[$fp]=$s
+	s=$(grep 'group.mempeak' "$f" | grep -Eo '[0-9]+(KiB|MiB|GiB|B)' | head -1)
+	mem[$fp]=$(memory_bytes "$s")
 
-	t=$(grep 'group.total' $f | grep -Eo '[0-9.]+s' | head -1)
+	t=$(grep 'group.total' "$f" | grep -Eo '[0-9.]+s' | head -1)
 	t=${t/s/}
 	cpu[$fp]=$t
-done
+done < <(find . -name '*.ramon' -print0)
 
 # If -a/--all was given, print a line for each file.
 if $printAll; then
 	echo "All space and time:"
 	for fp in "${!mem[@]}"; do
-		printf "RAMON: %-80s %12s %12s\n" "$fp" "${cpu[$fp]}s" "${mem[$fp]}MiB"
+		printf "RAMON: %-80s %12s %12s\n" "$fp" "${cpu[$fp]}s" "$(memory_mib "${mem[$fp]}")MiB"
 	done
 fi
 
@@ -41,8 +58,11 @@ echo
 # Print the top 20 in memory and CPU time.
 echo "Top 20 memory:"
 for fp in "${!mem[@]}"; do
-	printf " %-80s %12s\n" "$fp" "${mem[$fp]} MiB"
-done | sort -k2 -n -r  | head -n 20
+	printf "%s\t%s\n" "${mem[$fp]}" "$fp"
+done | sort -k1 -n -r | head -n 20 |
+	while IFS=$'\t' read -r bytes fp; do
+		printf " %-80s %12s\n" "$fp" "$(memory_mib "$bytes") MiB"
+	done
 echo
 
 echo "Top 20 CPU time:"
@@ -61,4 +81,4 @@ for fp in "${!mem[@]}"; do
 done
 
 echo "Total CPU: $TOTCPU seconds"
-echo "Total memory: $TOTMEM MiB"
+echo "Total memory: $(memory_mib "$TOTMEM") MiB"


### PR DESCRIPTION
Cherry-picked from the `_kuiper` branch (f31212ea7462fdb396ed152d61dfa8661fb12228, by @mtzguido).

`ramon` reports peak memory with an explicit unit suffix (`B`/`KiB`/`MiB`/`GiB`), but
`res_summary.sh` scraped only the digits and blindly labelled them `MiB`. So a run
peaking at `524288KiB` was reported as "524288 MiB", and the top-20 ranking mixed
values in different units.

This normalizes every `group.mempeak` value to bytes when parsing, sorts on the
normalized value, and converts back to MiB only when printing. Also switches the
`find` loop to `-print0` / `read -d ''` so paths containing spaces are handled.

Tested manually on synthetic `.ramon` files with `B`/`KiB`/`MiB`/`GiB` peaks and a path
containing a space; the totals and the ranking are now consistent.
