### PR TITLE
Introduce --ext no_krml_private

### DIFF
--- a/src/typechecker/FStarC.TypeChecker.Tc.fst
+++ b/src/typechecker/FStarC.TypeChecker.Tc.fst
@@ -1238,10 +1238,16 @@ let finish_iface_todo (env:Env.env)
 declare are private to the module. Extraction (in particular to C, via Karamel)
 needs to know this, so tag them with the internal `KrmlPrivate` attribute; see
 [FStarC.Extraction.ML.Modul.extract_meta]. This reproduces what the old
-syntactic interleaving used to do. *)
+syntactic interleaving used to do.
+
+Passing `--ext no_krml_private` disables this tagging entirely, so that no
+declaration is made C-private by virtue of being absent from the interface.
+This is useful when the generated C is meant to be consumed by other C code,
+or when debugging Karamel bundling/inlining issues. *)
 let mark_karamel_private (env:Env.env) (se:sigelt) : ML sigelt =
   let lids = U.lids_of_sigelt se in
-  if not (Env.has_iface env)
+  if Options.Ext.enabled "no_krml_private"
+  || not (Env.has_iface env)
   || Nil? lids
   || lids |> BU.for_some (Env.declared_in_iface env)
   then se

--- a/tests/extraction/Makefile
+++ b/tests/extraction/Makefile
@@ -8,6 +8,9 @@ SUBDIRS += cmi
 # message) if its toolchain is missing, so this is safe to run everywhere.
 SUBDIRS += backends
 
+# Test for --ext no_krml_private.
+SUBDIRS += krml-private
+
 RUN += Eta_expand.fst
 
 # The Div test is based on testing a non-terminating program and

--- a/tests/extraction/krml-private/KrmlPrivateTest.fst
+++ b/tests/extraction/krml-private/KrmlPrivateTest.fst
@@ -1,0 +1,11 @@
+module KrmlPrivateTest
+
+open FStar.UInt32
+
+(* [hidden] is not declared in the interface, so by default it is tagged
+   with the internal KrmlPrivate attribute and Karamel emits it as a
+   [static] C function. With --ext no_krml_private the tag is not added
+   and the function is externally visible. *)
+let hidden (x:UInt32.t) : UInt32.t = x `add_mod` 1ul
+
+let exposed x = hidden x

--- a/tests/extraction/krml-private/KrmlPrivateTest.fsti
+++ b/tests/extraction/krml-private/KrmlPrivateTest.fsti
@@ -1,0 +1,5 @@
+module KrmlPrivateTest
+
+open FStar.UInt32
+
+val exposed (x:UInt32.t) : UInt32.t

--- a/tests/extraction/krml-private/Makefile
+++ b/tests/extraction/krml-private/Makefile
@@ -1,0 +1,76 @@
+FSTAR_ROOT ?= ../../..
+
+include $(FSTAR_ROOT)/mk/test.mk
+
+# Test for `--ext no_krml_private`.
+#
+# When a module has an interface, the definitions the interface does not
+# declare are private to the module, and the typechecker tags them with the
+# internal `KrmlPrivate` attribute so that Karamel emits them as `static` C
+# functions (see [mark_karamel_private] in FStarC.TypeChecker.Tc).
+#
+# `--ext no_krml_private` disables that tagging. Here, KrmlPrivateTest.fsti
+# only declares `exposed`, so:
+#
+#   - by default, `hidden` is emitted as `static uint32_t hidden(...)` and
+#     does not appear in the header;
+#   - with `--ext no_krml_private`, it is emitted as a normal, externally
+#     visible `uint32_t KrmlPrivateTest_hidden(...)` and is declared in the
+#     header.
+#
+# NB: the flag is consumed at typechecking time, so each variant needs its
+# own cache directory.
+
+# mk/test.mk defaults KRML_EXE to $(FSTAR_ROOT)/out/bin/krml, which only
+# exists in a dev tree. `make install` also puts krml next to fstar.exe, so
+# try that too. If krml is nowhere to be found we skip (loudly), unless
+# REQUIRE_BACKENDS=1.
+KRML_CANDIDATES := $(KRML_EXE) $(dir $(FSTAR_EXE))krml $(FSTAR_ROOT)/karamel/out/bin/krml
+KRML_FOUND      := $(firstword $(wildcard $(KRML_CANDIDATES)) $(shell command -v krml 2>/dev/null))
+ifneq ($(KRML_FOUND),)
+  override KRML_EXE := $(KRML_FOUND)
+endif
+
+ifneq ($(KRML_FOUND),)
+all: $(OUTPUT_DIR)/private.checked $(OUTPUT_DIR)/nonprivate.checked
+else
+ifeq ($(REQUIRE_BACKENDS),1)
+  $(error krml not found (looked in $(KRML_CANDIDATES) and on PATH), and REQUIRE_BACKENDS=1)
+endif
+all:
+	@echo "SKIP: krml not found, not testing --ext no_krml_private"
+endif
+
+# $(1) = variant name, $(2) = extra F* flags
+define krml_variant
+$(OUTPUT_DIR)/$(1)/KrmlPrivateTest.c: KrmlPrivateTest.fsti KrmlPrivateTest.fst $(FSTAR_EXE)
+	$$(call msg, "EXTRACT", "KrmlPrivateTest ($(1))")
+	$$(Q)rm -rf $(OUTPUT_DIR)/$(1) && mkdir -p $(OUTPUT_DIR)/$(1)
+	$$(Q)$$(FSTAR_EXE) $$(SIL) $(2) --cache_checked_modules \
+	  --odir $(OUTPUT_DIR)/$(1) --cache_dir $(OUTPUT_DIR)/$(1) KrmlPrivateTest.fsti
+	$$(Q)$$(FSTAR_EXE) $$(SIL) $(2) --cache_checked_modules \
+	  --odir $(OUTPUT_DIR)/$(1) --cache_dir $(OUTPUT_DIR)/$(1) KrmlPrivateTest.fst
+	$$(Q)$$(FSTAR_EXE) $$(SIL) $(2) --codegen krml --extract_module KrmlPrivateTest \
+	  --odir $(OUTPUT_DIR)/$(1) --cache_dir $(OUTPUT_DIR)/$(1) \
+	  $(OUTPUT_DIR)/$(1)/KrmlPrivateTest.fst.checked
+	$$(call msg, "KRML", "KrmlPrivateTest ($(1))")
+	$$(Q)$$(KRML_EXE) -skip-makefiles -skip-compilation \
+	  -header=$$(FSTAR_ROOT)/mk/krmlheader \
+	  $(OUTPUT_DIR)/$(1)/KrmlPrivateTest.krml -tmpdir $(OUTPUT_DIR)/$(1) >/dev/null
+endef
+
+$(eval $(call krml_variant,private,))
+$(eval $(call krml_variant,nonprivate,--ext no_krml_private))
+
+$(OUTPUT_DIR)/private.checked: $(OUTPUT_DIR)/private/KrmlPrivateTest.c
+	$(call msg, "CHECK", "hidden is static")
+	$(Q)grep -q '^static uint32_t hidden(' $<
+	$(Q)! grep -q 'KrmlPrivateTest_hidden' $(OUTPUT_DIR)/private/KrmlPrivateTest.h
+	$(Q)touch $@
+
+$(OUTPUT_DIR)/nonprivate.checked: $(OUTPUT_DIR)/nonprivate/KrmlPrivateTest.c
+	$(call msg, "CHECK", "hidden is public")
+	$(Q)! grep -q '^static uint32_t hidden(' $<
+	$(Q)grep -q '^uint32_t KrmlPrivateTest_hidden(' $<
+	$(Q)grep -q 'KrmlPrivateTest_hidden' $(OUTPUT_DIR)/nonprivate/KrmlPrivateTest.h
+	$(Q)touch $@


### PR DESCRIPTION
Cherry-picked from the `_kuiper` branch (2c0ed13fde4e1f665ca6eb4113f05a68c776578a, by @mtzguido).

When a module has an interface, the definitions the interface does not declare are
private to the module, and `mark_karamel_private` tags them with the internal
`KrmlPrivate` attribute so that Karamel emits them as `static` C functions.

That is not always what you want: e.g. when the generated C is meant to be consumed
by hand-written C, or when debugging a Karamel bundling/inlining problem. This adds
an escape hatch, `--ext no_krml_private`, which disables the tagging.

Differences from the original commit:
* uses `Options.Ext.enabled` rather than `Options.Ext.get _ <> ""`, so
  `--ext no_krml_private=off` behaves as expected, like other extension options;
* documents the flag in the comment above `mark_karamel_private`;
* adds a test.

### Test

New `tests/extraction/krml-private`. `KrmlPrivateTest.fsti` declares only `exposed`,
while `KrmlPrivateTest.fst` also defines `hidden`. The test extracts the module to C
twice and checks that:

* by default, the C has `static uint32_t hidden(...)` and the header does not mention it;
* with `--ext no_krml_private`, the C has `uint32_t KrmlPrivateTest_hidden(...)` and the
  header declares it.

The directory skips itself (with a message) if `krml` is not available, like
`tests/extraction/backends` does, and errors out instead when `REQUIRE_BACKENDS=1`.
