### PR TITLE
Introduce --ext freshen, restart Z3 between top-level decls

### DIFF
--- a/src/typechecker/FStarC.TypeChecker.Tc.fst
+++ b/src/typechecker/FStarC.TypeChecker.Tc.fst
@@ -1269,6 +1269,15 @@ let tc_decls env ses : ML (list sigelt & Env.env) =
     if Options.ide_id_info_off() then Env.toggle_id_info env false;
     if !dbg_IdInfoOn then Env.toggle_id_info env true;
 
+    (* `--ext freshen` restarts the solver before every top-level declaration,
+       as if there was a `#restart-solver` pragma in front of each of them.
+       This makes each declaration's proof independent of the solver state
+       left behind by the previous ones, which is useful to diagnose
+       proof instability and cross-declaration interference. It is of course
+       much slower. *)
+    if Options.Ext.enabled "freshen" then
+      env.solver.refresh (Some env.proof_ns);
+
     (* Tick off the entries of the interface's to-do list that this declaration
        discharges. Copied interface sigelts and the declarations being
        implemented are added to the environment and emitted before [se]. *)

--- a/tests/micro-benchmarks/ExtFreshen.fst
+++ b/tests/micro-benchmarks/ExtFreshen.fst
@@ -1,0 +1,35 @@
+module ExtFreshen
+
+(* A test for `--ext freshen`, which restarts the solver before every
+   top-level declaration. The option is passed by the Makefile, so that the
+   same file can also be checked with the option off.
+
+   The point of this test is not just that the option is accepted, but that
+   the SMT context is correctly replayed after each restart: every
+   declaration below depends on facts (definitions, lemmas, axioms) that were
+   introduced by the ones before it, so a restart that loses the context
+   would make them fail. *)
+
+let rec fact (n:nat) : nat =  if n = 0 then 1 else n * fact (n - 1)
+
+let rec fact_pos (n:nat) : Lemma (ensures fact n > 0) =
+  if n = 0 then () else fact_pos (n - 1)
+
+let fact_5 () : Lemma (fact 5 == 120) = ()
+
+assume val p : int -> prop
+assume val p_zero : squash (p 0)
+assume val p_succ (n:int) : Lemma (requires p n) (ensures p (n + 1))
+
+let p_two () : Lemma (p 2) =
+  p_succ 0;
+  p_succ 1
+
+type color = | Red | Green | Blue
+
+let is_red (c:color) : bool = Red? c
+
+let red_is_red () : Lemma (is_red Red /\ ~(is_red Green)) = ()
+
+let fact_pos_still_available (n:nat) : Lemma (fact n <> 0) =
+  fact_pos n

--- a/tests/micro-benchmarks/Makefile
+++ b/tests/micro-benchmarks/Makefile
@@ -7,3 +7,34 @@ SUBDIRS += ns_resolution
 # none of them may raise 318. The cases that do are in tests/interfaces.
 $(CACHE_DIR)/MustEraseForExtraction.fst.checked: FSTAR_ARGS += --warn_error @318
 FSTAR_ARGS += --warn_error +240
+
+# `--ext freshen` restarts the solver before every top-level declaration.
+# ExtFreshen.fst is written so that each declaration depends on facts
+# introduced by the previous ones, so checking it with the option on tests
+# that the SMT context is properly replayed across the restarts.
+$(CACHE_DIR)/ExtFreshen.fst.checked: FSTAR_ARGS += --ext freshen
+
+# And check that the restarts really do happen: --query_stats reports every
+# Z3 process it spawns, and there must be several of them when the option is
+# on but only one when it is off.
+all: $(OUTPUT_DIR)/ExtFreshen.restarts
+
+$(OUTPUT_DIR)/ExtFreshen.restarts: ExtFreshen.fst $(FSTAR_EXE)
+	$(call msg, "FRESHEN", $<)
+	$(Q)rm -rf $(OUTPUT_DIR)/freshen-on $(OUTPUT_DIR)/freshen-off
+	$(Q)mkdir -p $(OUTPUT_DIR)/freshen-on $(OUTPUT_DIR)/freshen-off
+	$(Q)$(FSTAR_EXE) $(SIL) --query_stats --ext freshen \
+	  --odir $(OUTPUT_DIR)/freshen-on --cache_dir $(OUTPUT_DIR)/freshen-on $< \
+	  > $(OUTPUT_DIR)/freshen-on.out 2>&1
+	$(Q)$(FSTAR_EXE) $(SIL) --query_stats \
+	  --odir $(OUTPUT_DIR)/freshen-off --cache_dir $(OUTPUT_DIR)/freshen-off $< \
+	  > $(OUTPUT_DIR)/freshen-off.out 2>&1
+	$(Q)on=$$(grep -c 'Creating new z3proc' $(OUTPUT_DIR)/freshen-on.out); \
+	  off=$$(grep -c 'Creating new z3proc' $(OUTPUT_DIR)/freshen-off.out); \
+	  if [ "$$off" -ne 1 ]; then \
+	    echo "ERROR: expected 1 Z3 process without --ext freshen, got $$off"; false; \
+	  fi; \
+	  if [ "$$on" -le "$$off" ]; then \
+	    echo "ERROR: --ext freshen did not restart Z3 ($$on processes, vs $$off without)"; false; \
+	  fi
+	$(Q)touch $@


### PR DESCRIPTION
Cherry-picked from the `_kuiper` branch (a39533b026501addae9658274cd7ef4285a71a82, by @mtzguido).

With `--ext freshen`, `tc_decls` refreshes the solver before every top-level
declaration, as if there were a `#restart-solver` pragma in front of each of them.
Each declaration's proof then no longer depends on the solver state left behind by
the previous ones, which is a useful (if slow) tool when chasing proof instability
or cross-declaration interference.

Added on top of the original commit: a comment explaining the option, and tests.

### Tests

* `tests/micro-benchmarks/ExtFreshen.fst`, checked with `--ext freshen` (set from the
  Makefile). Its declarations are chained so that each one depends on definitions,
  lemmas or axioms introduced by the earlier ones — so this checks that the SMT
  context is correctly replayed after each restart, not merely that the option parses.
* A Makefile rule that checks the restarts really happen: `--query_stats` logs every
  Z3 process spawned, and the same file must spawn exactly one without the option and
  strictly more with it. (Measured here: 1 vs 6.)
