### PR TITLE
Tactics: unrefine functions being applied

### DIFF
--- a/src/tactics/FStarC.Tactics.V2.Basic.fst
+++ b/src/tactics/FStarC.Tactics.V2.Basic.fst
@@ -979,13 +979,24 @@ let try_unify_by_application (should_check:option should_check_uvar)
           | false ->
             (* Not a match, try instantiating the first type by application *)
             match U.arrow_one ty1 with
-            | None ->
-              fail_doc [
-                prefix 2 1 (text "Could not instantiate")
-                  (ttd e ty1) ^/^
-                prefix 2 1 (text "to")
-                  (ttd e ty2)
-              ]
+            | None -> (
+              (* Not an arrow either. If ty1 is a refinement x:t{p}, any term of
+                 type ty1 also has type t, so drop the refinement and retry:
+                 this allows applying a function returning a refined type to
+                 solve an unrefined goal. *)
+              match (SS.compress ty1).n with
+              | Tm_refine _
+              | Tm_ascribed _ ->
+                aux acc typedness_deps (U.unrefine ty1)
+
+              | _ ->
+                fail_doc [
+                  prefix 2 1 (text "Could not instantiate")
+                    (ttd e ty1) ^/^
+                  prefix 2 1 (text "to")
+                    (ttd e ty2)
+                ]
+            )
 
             | Some (b, c) ->
               if not (U.is_total_comp c) then fail "Codomain is effectful" else

--- a/tests/tactics/ApplyUnrefine.fst
+++ b/tests/tactics/ApplyUnrefine.fst
@@ -1,0 +1,32 @@
+module ApplyUnrefine
+
+open FStar.Tactics.V2
+
+(* `apply` instantiates the type of the term being applied by peeling off
+   arrows until it matches the goal. If what is left is a refinement (or an
+   ascription) rather than an arrow, the refinement is dropped and the match
+   is retried: a term of type `x:t{p}` is also a term of type `t`. *)
+
+let posv : x:int{x > 0} = 1
+
+(* Goal is `int`, the term has type `x:int{x > 0}`. *)
+let test0 : int = _ by (apply (`posv))
+
+let pos (u:unit) : x:int{x > 0} = 1
+
+(* Same, with an arrow to peel off first. *)
+let test1 : int = _ by (apply (`pos); exact (`()))
+
+let pos2 (a:Type) (x:a) (u:unit) : y:int{y > 0} = 1
+
+(* Several arrows before reaching the refinement. *)
+let test2 : int = _ by (apply (`pos2); exact (`true); exact (`()))
+
+(* Also works through an ascription. *)
+let asc (u:unit) : int = (1 <: x:int{x > 0})
+
+let test3 : int = _ by (apply (`asc); exact (`()))
+
+(* Neither an arrow nor a refinement: still an error. *)
+[@@expect_failure [228]]
+let test4 : int = _ by (apply (`true))


### PR DESCRIPTION
Cherry-picked from the `_kuiper` branch (cf02b02b515e00ce161b65dfcc8e250bbbc05a82, by @mtzguido).

`try_unify_by_application` (used by `apply`) instantiates the type of the term being
applied by peeling arrows off it until it unifies with the goal. When what is left is
not an arrow, it gave up with "Could not instantiate ... to ...". But if what is left
is a refinement `x:t{p}` (or an ascription), the term also has type `t`, so we can
drop the refinement and retry.

Concretely, this makes `apply (`f)` work on a goal of type `int` when
`f : unit -> x:int{x > 0}`.

This is also a prerequisite for making typeclass instances with refined result types
usable; see the follow-up PR.

### Test

`tests/tactics/ApplyUnrefine.fst`: applying a refined value, a function with one or
several arrows returning a refined type, and one hidden behind an ascription; plus an
`expect_failure` checking that applying something that is neither an arrow nor a
refinement still errors out. Verified that the file fails on `master`
("Could not instantiate `x: Prims.int{x > 0}` to `Prims.int`") and passes with this change.
