### PR TITLE
Allow typeclass instances with refined types

### DIFF
--- a/src/typechecker/FStarC.TypeChecker.Quals.fst
+++ b/src/typechecker/FStarC.TypeChecker.Quals.fst
@@ -391,11 +391,11 @@ let check_typeclass_instance_attribute env (rng:Range.t) se =
           text "This instance has effect" ^/^ pp (U.comp_effect_name res);
       ];
 
-    let t = U.comp_result res in
+    let t = U.comp_result res |> U.unrefine in
     let head, _ = U.head_and_args_full t in
     let err () =
       FStarC.Errors.log_issue rng FStarC.Errors.Error_UnexpectedTypeclassInstance [
-          text "Instances must define instances of `class` types.";
+          text "Instances must define instances of ‘class’ types.";
           text "Type" ^/^ pp t ^/^ text "is not a class.";
         ]
     in
@@ -421,7 +421,7 @@ let check_typeclass_instance_attribute env (rng:Range.t) se =
 
     | _ ->
       FStarC.Errors.log_issue rng FStarC.Errors.Error_UnexpectedTypeclassInstance [
-          text "The ‘instance’ attribute is only allowed on ‘let’ and ‘val’ declarations.";	
+          text "The ‘instance’ attribute is only allowed on ‘let’ and ‘val’ declarations.";
           text "It is not allowed for" ^/^ fquotes (arbitrary_string <| Print.sigelt_to_string_short se);
         ]
 

--- a/tests/typeclasses/Refinements.fst
+++ b/tests/typeclasses/Refinements.fst
@@ -63,8 +63,13 @@ let _ : box (dummy 4 string) = foo
 let _ : box (dummy 4 bool) = foo
 
 
-(* F* rejects this instance, claiming the resultl type is not a class. *)
-// instance inst_4_unit () : Tot (inst : cc (dummy 4 unit) { inst.meta == 45}) = { foo = C; meta = 45; }
+(* An instance whose result type is a refinement of a class type: F* used to
+   reject this, claiming the result type is not a class. *)
+instance inst_4_unit () : Tot (inst : cc (dummy 4 unit) { inst.meta == 45}) = { foo = C; meta = 45; }
+
+let _ : dummy 4 unit = foo
+
+let _ : squash ((solve <: cc (dummy 4 unit)).meta == 45) = ()
 
 
 

--- a/ulib/FStar.Tactics.Typeclasses.fst
+++ b/ulib/FStar.Tactics.Typeclasses.fst
@@ -113,6 +113,7 @@ let rec head_of (t:term) : Tac (option fv) =
   | Tv_FVar fv
   | Tv_UInst fv _ -> Some fv
   | Tv_App h _ -> head_of h
+  | Tv_Refine b _ -> head_of b.sort
   | v ->
     None
 
@@ -506,7 +507,7 @@ let binder_set_meta (b : binder) (t : term) : binder =
 let debug' (f : unit -> Tac string) : Tac unit =
   if debugging () then
     print (f ())
-    
+
 [@@plugin]
 let mk_class (nm:string) : Tac decls =
     let ns = explode_qn nm in


### PR DESCRIPTION
Cherry-picked from the `_kuiper` branch (4e4e4479b372b9e153402c95835ef04926417436, by @mtzguido).

> [!NOTE]
> Stacked on #4502 — please merge that one first. The last commit here is the only new one.

An instance whose result type is a *refinement* of a class type, e.g.

```fstar
instance inst_4_unit () : Tot (inst : cc (dummy 4 unit) { inst.meta == 45 }) = { foo = C; meta = 45; }
```

was rejected with "Instances must define instances of `class` types". This is in fact
exactly the case that `tests/typeclasses/Refinements.fst` had commented out with the note
*"F\* rejects this instance, claiming the result type is not a class."*

Two places need to look through the refinement:

* `check_typeclass_instance_attribute` (`FStarC.TypeChecker.Quals`), which validates the
  `instance` attribute;
* `head_of` in `FStar.Tactics.Typeclasses`, so that `class_of_typ` files the instance
  under the right class when building the instance map.

Actually *using* such an instance additionally needs #4502, since resolution applies the
instance and must relate its refined result type to the (unrefined) goal.

The dead `if false then begin ... end` debug block in the original commit is not included.

### Test

`tests/typeclasses/Refinements.fst`: the previously commented-out instance is now declared
for real, resolved (`let _ : dummy 4 unit = foo`), and its refinement is checked to survive
resolution (`(solve <: cc (dummy 4 unit)).meta == 45`).
