### PR TITLE
Krml: let extraction plugins inject declarations

### DIFF
--- a/src/extraction/FStarC.Extraction.Krml.fst
+++ b/src/extraction/FStarC.Extraction.Krml.fst
@@ -204,6 +204,8 @@ and typ =
   | TConstBuf of typ
   | TArray of typ & constant
 
+let translate_decl_accum : ref (list decl) = mk_ref []
+
 instance pretty_width = { pp = function
   | UInt8 -> doc_of_string "UInt8"
   | UInt16 -> doc_of_string "UInt16"
@@ -1626,28 +1628,32 @@ let translate_let env flavor lb: ML (option decl) =
   !ref_translate_let env flavor lb
 
 let translate_decl env d: ML (list decl) =
-  match d.mlmodule1_m with
-  | MLM_Let (flavor, lbs) ->
-      // We don't care about mutual recursion, since every C file will include
-      // its own header with the forward declarations.
-      List.choose (translate_let env flavor) lbs
+  translate_decl_accum := [];
+  let base =
+    match d.mlmodule1_m with
+    | MLM_Let (flavor, lbs) ->
+        // We don't care about mutual recursion, since every C file will include
+        // its own header with the forward declarations.
+        List.choose (translate_let env flavor) lbs
 
-  | MLM_Loc _ ->
-      // JP: TODO: use this to reconstruct location information
-      []
+    | MLM_Loc _ ->
+        // JP: TODO: use this to reconstruct location information
+        []
 
-  | MLM_Ty tys ->
-      // We don't care about mutual recursion, since KaRaMeL will insert forward
-      // declarations exactly as needed, as part of its monomorphization phase
-      List.choose (translate_type_decl env) tys
+    | MLM_Ty tys ->
+        // We don't care about mutual recursion, since KaRaMeL will insert forward
+        // declarations exactly as needed, as part of its monomorphization phase
+        List.choose (translate_type_decl env) tys
 
-  | MLM_Top _ ->
-      failwith "todo: translate_decl [MLM_Top]"
+    | MLM_Top _ ->
+        failwith "todo: translate_decl [MLM_Top]"
 
-  | MLM_Exn (m, _) ->
-      if not (Options.silent ()) then
-        Format.print1_warning "Not extracting exception %s to KaRaMeL (exceptions unsupported)\n" m;
-      []
+    | MLM_Exn (m, _) ->
+        if not (Options.silent ()) then
+          Format.print1_warning "Not extracting exception %s to KaRaMeL (exceptions unsupported)\n" m;
+        []
+  in
+  !translate_decl_accum @ base
 
 let translate_module uenv (m : mlpath & option (mlsig & mlmodulebody)) : ML file =
   let (module_name, modul) = m in

--- a/src/extraction/FStarC.Extraction.Krml.fst
+++ b/src/extraction/FStarC.Extraction.Krml.fst
@@ -204,7 +204,16 @@ and typ =
   | TConstBuf of typ
   | TArray of typ & constant
 
+(* Extraction plugins (registered via the register_{pre,post}_translate_*
+   functions below) can push extra declarations here while translating a
+   top-level declaration; they are emitted just before it. The accumulator is
+   reset at the beginning of every [translate_decl]. *)
 let translate_decl_accum : ref (list decl) = mk_ref []
+
+(* The name of the top-level let being translated, if any, for the benefit of
+   those same plugins (e.g. to name the declarations they inject). Set by
+   [translate_decl]. *)
+let krml_current_decl : ref (option mlident) = mk_ref None
 
 instance pretty_width = { pp = function
   | UInt8 -> doc_of_string "UInt8"
@@ -1628,6 +1637,11 @@ let translate_let env flavor lb: ML (option decl) =
   !ref_translate_let env flavor lb
 
 let translate_decl env d: ML (list decl) =
+  krml_current_decl := (
+    match d.mlmodule1_m with
+    | MLM_Let (_, lb::_) -> Some lb.mllb_name
+    | _ -> None
+  );
   translate_decl_accum := [];
   let base =
     match d.mlmodule1_m with


### PR DESCRIPTION
Cherry-picked from the `_kuiper` branch:
* 21af1182886f2bb2bdbbf8ce84d4a08676b50b91 — "Krml: adding a way for extraction plugins to inject decls"
* 8af490220d042112553461cf552ff42642935fa6 — "adding a krml_current_decl ref"

Both are plumbing for extraction plugins that `friend FStarC.Extraction.Krml` and
register hooks with `register_{pre,post}_translate_*` — in-tree, that is Pulse
(`pulse/src/extraction/ExtractPulseC.fst`, `ExtractPulse.fst`).

* `translate_decl_accum` lets such a hook *inject* extra top-level declarations while
  translating one: `translate_decl` clears the accumulator before translating and emits
  its contents just before the declaration proper. Today a hook can only replace the
  decl(s) it is handed.
* `krml_current_decl` records the name of the top-level `let` being translated, so an
  injecting hook can derive names from it.

They are kept as two commits since the second builds on the first. Submitted together
because they touch the same function and would otherwise conflict.

Beyond the cherry-picks, `krml_current_decl` is reset to `None` when the declaration is
not a `let` (the original kept the previous, stale name), and both refs are documented.

### Testing

No test: these are hooks with no in-tree consumer yet, so there is nothing observable to
assert on without writing a throwaway extraction plugin. The change is behaviour
preserving — `translate_decl_accum` is always empty unless a plugin pushes to it.
Checked that the compiler builds and that `make -C tests/extraction` (including the
Karamel/C and Rust backend matrix) passes.
