### PR TITLE
Pulse: add term context when implicit instantiation fails

### DIFF
--- a/pulse/src/checker/Pulse.Checker.Pure.fst
+++ b/pulse/src/checker/Pulse.Checker.Pure.fst
@@ -207,8 +207,11 @@ let instantiate_term_implicits
   : Tac _
 = let rng, f = elab_env_with_term_range g t0 in
   let topt, issues = catch_all (fun _ -> rtb_instantiate_implicits g f t0 expected inst_extra) in
-  let fail issues : Tac _ = 
-    fail_doc_with_subissues g (Some rng) issues []
+  let fail issues : Tac _ =
+    fail_doc_with_subissues g (Some rng) issues [
+      text "Could not instantiate implicits in term:"
+        ^/^ pp t0;
+    ]
   in
   match topt with
   | None -> fail issues

--- a/pulse/test/error_messages/IfCondType.fst.output.expected
+++ b/pulse/test/error_messages/IfCondType.fst.output.expected
@@ -1,4 +1,5 @@
 * Info at IfCondType.fst(11,5-11,6):
   - Expected failure:
+  - Could not instantiate implicits in term: x
   - Expected expression of type Prims.bool got expression x of type Prims.int
 

--- a/pulse/test/error_messages/LetBindingType.fst.output.expected
+++ b/pulse/test/error_messages/LetBindingType.fst.output.expected
@@ -1,4 +1,5 @@
 * Info at LetBindingType.fst(11,17-11,19):
   - Expected failure:
+  - Could not instantiate implicits in term: 42
   - Expected expression of type Prims.bool got expression 42 of type Prims.int
 

--- a/pulse/test/error_messages/ReturnTypeMismatch.fst.output.expected
+++ b/pulse/test/error_messages/ReturnTypeMismatch.fst.output.expected
@@ -1,4 +1,5 @@
 * Info at ReturnTypeMismatch.fst(12,2-12,3):
   - Expected failure:
+  - Could not instantiate implicits in term: x
   - Expected expression of type Prims.bool got expression x of type Prims.int
 


### PR DESCRIPTION
Ports commit f7cd35e2657e9c5ed4f30a8bae7e85df35cf27d2 from the `_kuiper` branch.

`instantiate_term_implicits` in `Pulse.Checker.Pure` was the only
`fail_doc_with_subissues` call site in that file passing an empty list of
extra context documents. Since `fail_doc_with_subissues` falls back to a
generic *"F\* did not provide any extra information on why this failed."*
message when the sub-issue list is empty, a failure there could produce an
error with no indication at all of which term was being checked.

This prepends the term being checked, which is what every sibling call site
already does via `ill_typed_term`.

### Tests

No new test file: three existing tests in `pulse/test/error_messages` already
exercise this path, and their `.output.expected` files are updated to show the
new context line (`IfCondType`, `LetBindingType`, `ReturnTypeMismatch`).
`make -C pulse/test/error_messages` passes.
