### PR TITLE
Weaken Tot ascriptions when unfolding a definition

### DIFF
--- a/pulse/test/bug-reports/Bug4498.fst
+++ b/pulse/test/bug-reports/Bug4498.fst
@@ -1,0 +1,28 @@
+module Bug4498
+#lang-pulse
+
+(* Issue #4498: unfolding inside the scrutinee of a stuck projection (see
+   #4472) must not break rewrites on ghost values.  Unfolding [mk] here leaves
+   its [Tot] ascription around a body that is ghost, because [v] is erased, and
+   core checking of that term fails; the projection stays stuck anyway, so no
+   unfolding must happen and the equality is left to the SMT solver. *)
+
+open Pulse
+module G = FStar.Ghost
+
+noeq type t = | A : nat -> t | B : nat -> t
+
+let mk (x: t) : Tot (n: nat & nat) =
+  match x with
+  | A n -> (| n, n |)
+  | B n -> (| n + 1, n |)
+
+assume val p (n: nat) : slprop
+
+ghost
+fn test (v: G.erased t) (h: nat) (k: nat)
+requires p (dfst (mk v)) ** pure (mk v == (| h, k |))
+ensures p h
+{
+  rewrite each dfst (mk v) as h;
+}

--- a/src/typechecker/FStarC.TypeChecker.Normalize.fst
+++ b/src/typechecker/FStarC.TypeChecker.Normalize.fst
@@ -3550,6 +3550,21 @@ let get_n_binders env n t = get_n_binders' env [] n t
 let () =
   __get_n_binders := get_n_binders'
 
+(* [let f (x:t) : Tot ty = body] elaborates to [fun x -> (body <: Tot ty)].
+   That [Tot] is a claim about [body] for a *total* [x]: substituting a ghost
+   argument for [x] can make the body ghost, and the ascription then no longer
+   holds, so the beta-reduct of the unfolded definition does not typecheck
+   (issue #4498) even though the application we unfolded does.  Keep the type,
+   which is the useful part of the ascription, and let the effect be inferred:
+   the callers of [maybe_unfold_head] typecheck the term we return. *)
+let rec weaken_total_ascriptions (t:term) : ML term =
+  match (SS.compress t).n with
+  | Tm_abs {b; body; rc_opt} ->
+    S.mk (Tm_abs {b; body=weaken_total_ascriptions body; rc_opt}) t.pos
+  | Tm_ascribed {tm; asc=(Inr c, tacopt, use_eq); eff_opt} when U.is_total_comp c ->
+    S.mk (Tm_ascribed {tm; asc=(Inl (U.comp_result c), tacopt, use_eq); eff_opt}) t.pos
+  | _ -> t
+
 let maybe_unfold_head_fv (env:Env.env) (head:term)
   : ML (option term)
   = let fv_us_opt =
@@ -3565,7 +3580,7 @@ let maybe_unfold_head_fv (env:Env.env) (head:term)
       | None -> None
       | Some (us_formals, defn) ->
         let subst = mk_univ_subst us_formals us in
-        SS.subst subst defn |> Some
+        SS.subst subst defn |> weaken_total_ascriptions |> Some
 
 (* If [head] is a projector or discriminator applied to at least [n_args]
    arguments, the position of its scrutinee among them.  Projectors and

--- a/tests/micro-benchmarks/GhostProjectionUnfold.fst
+++ b/tests/micro-benchmarks/GhostProjectionUnfold.fst
@@ -1,0 +1,34 @@
+module GhostProjectionUnfold
+
+open FStar.Tactics.V2
+
+(* Issue #4498: making progress on a stuck projection by unfolding inside its
+   scrutinee must not produce a term that the core typechecker rejects.
+
+   Unfolding [mk] below beta-reduces to its body under the [Tot] ascription that
+   comes from the annotation of its definition; since the argument here is
+   ghost, that ascription no longer holds and core checking of the unfolded term
+   fails with "Expected a Total computation, but got Ghost".  The unfolding is
+   useless anyway: the scrutinee of the match is a variable, so the projection
+   stays stuck and the relation is decided by the SMT solver, exactly as it is
+   without unfolding at all. *)
+
+noeq type t = | A : nat -> t | B : nat -> t
+
+let mk (x: t) : Tot (n: nat & nat) =
+  match x with
+  | A n -> (| n, n |)
+  | B n -> (| n + 1, n |)
+
+let test (v: Ghost.erased t) (h k: nat) (_: squash (mk v == (| h, k |))) : unit =
+  assert True by (
+    let e = cur_env () in
+    let t0 = quote (dfst (mk (Ghost.reveal v))) in
+    let t1 = quote h in
+    let res, iss = t_check_equiv true true e t0 t1 in
+    if None? res then (
+      FStar.Stubs.Tactics.V2.Builtins.log_issues iss;
+      fail "not equivalent"
+    );
+    trivial ()
+  )


### PR DESCRIPTION
`let f (x:t) : Tot ty = body` elaborates to `fun x -> (body <: Tot ty)`. That `Tot` is a claim about `body` for a *total* `x`, so beta-reducing the unfolded definition against a *ghost* argument produces a term whose body is ghost while the ascription still claims `Tot`.  Such a term is rejected by FStarC.TypeChecker.Core ("Expected a Total computation, but got Ghost"), even though the application that was unfolded is perfectly well typed.

Since maybe_unfold_head's callers typecheck the term it returns, this made core reject legitimate goals.  The bug is not specific to projections, but 98a6d33def ("Unfold inside the scrutinee of a stuck projection") made check_relation reach it much more often, breaking everparse.

Fix: when unfolding a definition, rewrite `e <: Tot ty` into `e <: ty`. check_relation strips ascriptions anyway, so we lose nothing: we keep the type, which is the useful part, and let the effect be inferred.

Fixes #4498.