### PR TITLE
Pulse: --ext pulse:extra_simplify

### DIFF
--- a/pulse/src/checker/Pulse.Checker.Prover.Normalize.fst
+++ b/pulse/src/checker/Pulse.Checker.Prover.Normalize.fst
@@ -47,6 +47,16 @@ let __normalize_slprop
   (* Reduce applied projections like {x=1; ..}.x *)
   let steps = steps @ [reduce_projections] in
 
+  (* Simplify logical connectives (e.g. `True /\ p` into `p`), which show up
+  in pure slprops after the unfoldings above. Gated: it makes error messages
+  about failing pure slprops less precise, since the simplified term carries
+  no range. *)
+  let steps =
+    if Pulse.Simplify.extra_simplify_enabled ()
+    then steps @ [simplify]
+    else steps
+  in
+
   let v' = PCP.norm_well_typed_term (elab_env g) steps v in
   let v' = Pulse.Simplify.simplify v' in (* NOTE: the simplify stage is unverified *)
   v'

--- a/pulse/src/checker/Pulse.Simplify.fst
+++ b/pulse/src/checker/Pulse.Simplify.fst
@@ -4,6 +4,12 @@ open Pulse.Show
 open FStar.Reflection.V2
 module T = FStar.Tactics.V2
 
+(* Additional simplifications, gated behind `--ext pulse:extra_simplify`
+since they change which slprops the prover can match syntactically, and
+hence which programs verify. *)
+let extra_simplify_enabled () : T.Tac bool =
+  T.ext_enabled "pulse:extra_simplify"
+
 let thua_t = term & option (fv & universes & list argv)
 let thua x = x, T.hua x
 let hua (x:thua_t) = snd x
@@ -196,11 +202,89 @@ let _simpl_hide_reveal (t:thua_t) : T.Tac (option term) =
     end
   | None -> None
 
+let is_size_t_v (t:thua_t) : T.Tac (option term) =
+  match hua t with
+  | Some (h, us, args) ->
+    if implode_qn (T.inspect_fv h) = `%FStar.SizeT.v
+    then
+      match args with
+      | [(t, Q_Explicit)] -> Some t
+      | _ -> None
+    else
+    None
+  | _ -> None
+
+let _simpl_sizet_literal (t:thua_t) : T.Tac (option term) =
+  match is_size_t_v t with
+  | Some e -> (
+    match hua (thua e) with
+    | Some (h, us, args) ->
+      if implode_qn (T.inspect_fv h) = `%FStar.SizeT.uint_to_t
+      then
+        match args with
+        | [(t, Q_Explicit)] -> Some t
+        | _ -> None
+      else
+      None
+    | None -> None
+    )
+  | None -> None
+
+type op =
+  | Add
+  | Sub
+  | Mul
+  | Div
+  | Rem
+
+let is_size_t_op (fv : fv) : option op =
+  match implode_qn (T.inspect_fv fv) with
+  | `%FStar.SizeT.add -> Some Add
+  | `%FStar.SizeT.sub -> Some Sub
+  | `%FStar.SizeT.mul -> Some Mul
+  | `%FStar.SizeT.div -> Some Div
+  | `%FStar.SizeT.rem -> Some Rem
+  | _ -> None
+
+let math_opfv (o : op) : string =
+  match o with
+  | Add -> `%(+)
+  | Sub -> `%(-)
+  | Mul -> `%( * )
+  | Div -> `%(/)
+  | Rem -> `%(%)
+
+let is_size_t_applied_op (t:thua_t) : T.Tac (option (op & term & term)) =
+  match hua t with
+  | Some (h, us, args) -> (
+    match is_size_t_op h, args with
+    | Some op, [(l, Q_Explicit); (r, Q_Explicit)] ->
+      Some (op, l, r)
+    | _ -> None
+  )
+  | _ -> None
+
+// Rewrites SZ.v (SZ.mul x y) to SZ.v x * SZ.v y, and similar
+let _simpl_sizet_op (t:thua_t) : T.Tac (option term) =
+  match is_size_t_v t with
+  | Some e -> (
+    match is_size_t_applied_op (thua e) with
+    | Some (h, l, r) ->
+      let f : fv = pack_fv <| explode_qn (math_opfv h) in
+      let l' = `(FStar.SizeT.v (`#l)) in
+      let r' = `(FStar.SizeT.v (`#r)) in
+      Some (T.mk_app (T.Tv_UInst f []) [(l', Q_Explicit); (r', Q_Explicit)])
+    | None -> None
+    )
+  | None -> None
+
 (* Try each rule in turn, returning the rewritten term if one of them fires.
+The rules guarded by `extra` are only tried when `--ext pulse:extra_simplify`
+is set.
 Note that we cannot detect "did anything change?" by comparing terms:
 `FStar.Reflection.TermEq.term_eq` is conservative and returns false for equal
 terms that are not faithful, e.g. any term containing a uvar. *)
-let try_rules (t:thua_t) : T.Tac (option thua_t) =
+let try_rules (extra:bool) (t:thua_t) : T.Tac (option thua_t) =
   match _simpl_proj t with
   | Some t -> Some (thua t)
   | None ->
@@ -215,13 +299,21 @@ let try_rules (t:thua_t) : T.Tac (option thua_t) =
   | None ->
   match _simpl_reveal_hide t with
   | Some t -> Some (thua t)
-  | None -> None
+  | None ->
+  if not extra then None else
+  match _simpl_sizet_op t with
+  | Some t -> Some (thua t)
+  | None ->
+  match _simpl_sizet_literal t with
+  | Some t -> Some (thua t)
+  | None ->
+  None
 
 (* Apply the rules at the root until none of them fires. Every rule replaces the
 term by one of its own subterms, so this terminates. *)
-let rec apply_rules_fix (t:thua_t) : T.Tac thua_t =
-  match try_rules t with
-  | Some t' -> apply_rules_fix t'
+let rec apply_rules_fix (extra:bool) (t:thua_t) : T.Tac thua_t =
+  match try_rules extra t with
+  | Some t' -> apply_rules_fix extra t'
   | None -> t
 
 (* The rules are applied at a node both before and after its arguments are
@@ -235,14 +327,17 @@ argument can expose a redex at a node that has already been visited, e.g. the
 outer projection of `fst (fst ((c, ()), ()))` only becomes reducible once its
 argument has been rewritten to `(c, ())`. A rule firing at that point returns a
 subterm of an already-simplified argument, so no further traversal is needed. *)
-let rec simplify (t0:term) : T.Tac term =
-  let t = apply_rules_fix (thua t0) in
+let rec simplify' (extra:bool) (t0:term) : T.Tac term =
+  let t = apply_rules_fix extra (thua t0) in
   let t =
     match hua t with
     | Some (h, us, args) ->
-      let args = T.map (fun (t, q) -> simplify t, q) args in
-      fst (apply_rules_fix (thua (T.mk_app (T.Tv_UInst h us) args)))
+      let args = T.map (fun (t, q) -> simplify' extra t, q) args in
+      fst (apply_rules_fix extra (thua (T.mk_app (T.Tv_UInst h us) args)))
     | _ -> fst t
   in
   // T.print <| "simplified " ^ show t0 ^ " to " ^ show t;
   t
+
+let simplify (t0:term) : T.Tac term =
+  simplify' (extra_simplify_enabled ()) t0

--- a/pulse/src/checker/Pulse.Simplify.fsti
+++ b/pulse/src/checker/Pulse.Simplify.fsti
@@ -5,4 +5,7 @@ module Pulse.Simplify
 open FStar.Reflection.V2
 module T       = FStar.Tactics.V2
 
+(* Whether the `--ext pulse:extra_simplify` flag is set. *)
+val extra_simplify_enabled : unit -> T.Tac bool
+
 val simplify (t:term) : T.Tac term

--- a/pulse/test/SimplifySizeT.fst
+++ b/pulse/test/SimplifySizeT.fst
@@ -1,0 +1,68 @@
+module SimplifySizeT
+#lang-pulse
+open Pulse.Lib.Pervasives
+module SZ = FStar.SizeT
+
+
+(* An opaque slprop indexed by a nat. The prover can only discharge these
+goals by matching the index syntactically, so they exercise the SizeT
+rewrites in Pulse.Simplify: without them, `SZ.v (SZ.add x y)` and
+`SZ.v x + SZ.v y` are distinct terms and the goals below fail. *)
+assume val myp (n:nat) : slprop
+
+(* Off by default. *)
+[@@expect_failure [228]]
+fn add_without_flag (x:SZ.t) (y:SZ.t { SZ.fits (SZ.v x + SZ.v y) })
+  requires myp (SZ.v x + SZ.v y)
+  ensures myp (SZ.v (SZ.add x y))
+{
+  ()
+}
+
+#push-options "--ext pulse:extra_simplify"
+
+fn add (x:SZ.t) (y:SZ.t { SZ.fits (SZ.v x + SZ.v y) })
+  requires myp (SZ.v x + SZ.v y)
+  ensures myp (SZ.v (SZ.add x y))
+{
+  ()
+}
+
+fn sub (x:SZ.t) (y:SZ.t { SZ.v x >= SZ.v y })
+  requires myp (SZ.v x - SZ.v y)
+  ensures myp (SZ.v (SZ.sub x y))
+{
+  ()
+}
+
+fn mul (x:SZ.t) (y:SZ.t { SZ.fits (SZ.v x * SZ.v y) })
+  requires myp (SZ.v x * SZ.v y)
+  ensures myp (SZ.v (SZ.mul x y))
+{
+  ()
+}
+
+fn div (x:SZ.t) (y:SZ.t { SZ.v y <> 0 })
+  requires myp (SZ.v x / SZ.v y)
+  ensures myp (SZ.v (SZ.div x y))
+{
+  ()
+}
+
+fn rem (x:SZ.t) (y:SZ.t { SZ.v y <> 0 })
+  requires myp (SZ.v x % SZ.v y)
+  ensures myp (SZ.v (SZ.rem x y))
+{
+  ()
+}
+
+(* Nested rewrite: the operator rule exposes `SZ.v 1sz`, which the SMT
+solver then relates to 1. *)
+fn add_literal (x:SZ.t { SZ.fits (SZ.v x + 1) })
+  requires myp (SZ.v x + 1)
+  ensures myp (SZ.v (SZ.add x 1sz))
+{
+  ()
+}
+
+#pop-options


### PR DESCRIPTION
Ports the simplification-related commits from the `_kuiper` branch, **gated
behind a new `--ext pulse:extra_simplify` flag** so the default behaviour is
byte-for-byte unchanged:

- d97af5606e `Simplify: Add some SizeT rewrites`
- aab4746741 `Pulse.Simplify: SZ.v (SZ.uint_to_x) ~> x`
- da12f3df00 `Fix the Simplify patch`
- b0d19b9dd9 `also norm-simplify vprops`

These are used heavily downstream in Kuiper.

## What the flag turns on

**1. SizeT rewrite rules in `Pulse.Simplify`**

- `SZ.v (SZ.uint_to_t n)` &rarr; `n`
- `SZ.v (x `SZ.add` y)` &rarr; `SZ.v x + SZ.v y`, likewise `sub`/`mul`/`div`/`rem`

Without these, slprops indexed by machine-integer arithmetic (array and slice
offsets and lengths) are syntactically distinct from their `nat` counterparts
and the prover's matching fails on goals that are otherwise identical.

**2. The `simplify` norm step when normalizing slprops**

Pure slprops routinely end up with `True /\ p` and friends after the
`pulse_unfold` / `unfold` expansions that `__normalize_slprop` already
performs.

## Why it is gated

Both halves change which slprops the prover can match, and hence which
programs verify. The second one additionally costs some error localization:
`simplify` collapses an (already primops-reduced) pure conjunction into
`l_False`, which carries no range, so the reported location widens to the
enclosing statement:

```diff
-* Info at IllTypedInvariant.fst(13,43-13,44):
-  - Failed to prove pure property: ‘true /\ true /\ false’
+* Info at IllTypedInvariant.fst(12,2-16,3):
+  - Failed to prove pure property: ‘l_False’
```

i.e. the whole `while` loop rather than the offending conjunct of its
`invariant`. The root cause is upstream of this patch (the elaborated `l_and`
node has a dummy range, so `Normalize`'s `w t = {t with pos=tm.pos}` has
nothing to propagate and `check_prop_validity`'s `RU.range_of_term p` falls
back to the statement range), and fixing it properly means giving the
elaborated connectives real ranges. With the flag off, none of this is
observable and no goldens change.

## Fix on top of the ported commits

`math_opfv` mapped `Mul` to `` `%( Prims.op_Multiply ) ``, but
`Prims.op_Multiply` does not exist &mdash; the multiplication operator
declared in `Prims` is `( * )`, i.e. `Prims.op_Star`. As written the module
did not typecheck.

## Tests

New `pulse/test/SimplifySizeT.fst` discharges goals over an opaque
`nat`-indexed slprop, so the prover has to match the index syntactically. It
covers all five arithmetic operators plus a nested literal case under the
flag, and asserts with `expect_failure [228]` that the same goal is *not*
provable with the flag off.

I separately confirmed, by building a stage3 from `master` and splitting the
cases into one module each, that every one of them fails without the patch.
The whole of `pulse/test` is green, and 208 modules in
`pulse/share/pulse/examples` check successfully. (`examples/dice/cbor` fails
in my tree for unrelated environmental reasons: missing installed
`out/lib/pulse/lib/*.checked` files and a `pulse.cmxs` double-load; no
verification errors.)
