### PR TITLE
Extraction: do not normalize noextract definitions

### DIFF
--- a/src/extraction/FStarC.Extraction.ML.Modul.fst
+++ b/src/extraction/FStarC.Extraction.ML.Modul.fst
@@ -1074,9 +1074,10 @@ and extract_sig_let (g:uenv) (se:sigelt) : ML (uenv & list mlmodule1) =
     let attrs = se.sigattrs in
     let quals = se.sigquals in
     let se = TypeChecker.Tc.run_postprocess true (tcenv_of_uenv g) se in
+    let is_noextract = List.contains S.NoExtract se.sigquals in
     let Sig_let { lbs } = se.sigel in
-    let maybe_normalize_for_extraction lbs = 
-      let norm_steps =
+    let maybe_normalize_for_extraction lbs =
+      let norm_steps : option (list norm_step) =
         match U.extract_attr' PC.normalize_for_extraction_lid attrs with
         | None -> None
         | Some (_, (steps, None)::_) ->
@@ -1108,7 +1109,7 @@ and extract_sig_let (g:uenv) (se:sigelt) : ML (uenv & list mlmodule1) =
       let norm_one_lb steps lb =
         let env = tcenv_of_uenv g in
         let env = {env with erase_erasable_args=true} in
-        let lbd = 
+        let lbd =
           Profiling.profile
                 (fun () -> N.normalize steps env lb.lbdef)
                 (Some (Ident.string_of_lid (Env.current_module env)))
@@ -1132,9 +1133,10 @@ and extract_sig_let (g:uenv) (se:sigelt) : ML (uenv & list mlmodule1) =
     in
     let ml_let, _, _ =
       let lbs = maybe_normalize_for_extraction lbs in
-      Term.term_as_mlexpr
-              g
-              (mk (Tm_let {lbs; body=U.exp_false_bool}) se.sigrng)
+      let tm = mk (Tm_let {lbs; body=U.exp_false_bool}) se.sigrng in
+      if is_noextract
+      then Term.term_as_mlexpr_without_top_level_normalization g tm
+      else Term.term_as_mlexpr g tm
     in
     let mlattrs = extract_attrs g se.sigattrs in
     begin

--- a/src/extraction/FStarC.Extraction.ML.Term.fst
+++ b/src/extraction/FStarC.Extraction.ML.Term.fst
@@ -1408,8 +1408,11 @@ and term_as_mlexpr (g:uenv) (e:term) : ML (mlexpr & e_tag & mlty) =
     let e, f = maybe_promote_effect e f t in
     e, f, t
 
-
-and term_as_mlexpr' (g:uenv) (top:term) : ML (mlexpr & e_tag & mlty) =
+and term_as_mlexpr'
+    (normalize_top_level_lets:bool)
+    (g:uenv)
+    (top:term)
+  : ML (mlexpr & e_tag & mlty) =
     let top = SS.compress top in
     (debug g (fun u -> Format.print_string (Format.fmt3 "%s: term_as_mlexpr' (%s) :  %s \n"
         (Range.string_of_range top.pos)
@@ -1968,7 +1971,7 @@ and term_as_mlexpr' (g:uenv) (top:term) : ML (mlexpr & e_tag & mlty) =
           // extract_lb_sig can compute add_unit from the un-inlined body.
           let orig_lbs = lbs in
           let lbs =
-            if top_level
+            if top_level && normalize_top_level_lets
             then
             let tcenv = TcEnv.set_current_module (tcenv_of_uenv g)
                                 (Ident.lid_of_path ((fst (current_module_of_uenv g)) @ [snd (current_module_of_uenv g)]) Range.dummyRange) in
@@ -2129,6 +2132,17 @@ and term_as_mlexpr' (g:uenv) (top:term) : ML (mlexpr & e_tag & mlty) =
                    with_ty t_match <| MLE_Match(e, mlbranches), f_match, t_match
             end
 
+let term_as_mlexpr_without_top_level_normalization
+    (g:uenv)
+    (e:term)
+  : ML (mlexpr & e_tag & mlty) =
+    (* [Modul] uses this only for the synthetic top-level [Tm_let] that
+       packages a [NoExtract] declaration. Recursive translation of the
+       let bindings still goes through [term_as_mlexpr], including hooks. *)
+    let e, f, t = term_as_mlexpr' false g e in
+    let e, f = maybe_promote_effect e f t in
+    e, f, t
+
 let ind_discriminator_body env (discName:lident) (constrName:lident) : ML mlmodule1 =
     // First, lookup the original (F*) type to figure out how many implicit arguments there are.
     let _, fstar_disc_type = fst <| TypeChecker.Env.lookup_lid (tcenv_of_uenv env) discName in
@@ -2183,5 +2197,5 @@ let ind_discriminator_body env (discName:lident) (constrName:lident) : ML mlmodu
                mllb_def=discrBody;
                print_typ=false}] ) |> mk_mlmodule1
 
-let _ = register_pre_translate term_as_mlexpr'
+let _ = register_pre_translate (term_as_mlexpr' true)
 let _ = register_pre_translate_typ translate_term_to_mlty'

--- a/src/extraction/FStarC.Extraction.ML.Term.fsti
+++ b/src/extraction/FStarC.Extraction.ML.Term.fsti
@@ -33,4 +33,6 @@ val register_pre_translate (f : translate_t) : ML unit
 
 val extract_lb_iface : uenv -> letbindings -> ML (uenv & list (fv & exp_binding))
 val term_as_mlexpr: uenv -> term -> ML (mlexpr & e_tag & mlty)
+val term_as_mlexpr_without_top_level_normalization:
+  uenv -> term -> ML (mlexpr & e_tag & mlty)
 val ind_discriminator_body : env:uenv -> discName:lident -> constrName:lident -> ML mlmodule1

--- a/tests/extraction/Makefile
+++ b/tests/extraction/Makefile
@@ -29,6 +29,22 @@ include $(FSTAR_ROOT)/mk/test.mk
 
 all: $(OUTPUT_DIR)/FloatLiteralExtraction.krml
 all: $(OUTPUT_DIR)/FloatLiteralInjection.rejected
+all: $(OUTPUT_DIR)/NoExtractNorm.test
+all: $(OUTPUT_DIR)/NoExtractNormPerf.test
+
+$(OUTPUT_DIR)/NoExtractNorm.test: $(CACHE_DIR)/NoExtractNorm.fst.checked $(FSTAR_EXE)
+	@mkdir -p $(OUTPUT_DIR)
+	@$(FSTAR) $< --codegen krml --extract_module NoExtractNorm --debug ExtractionNorm >$(OUTPUT_DIR)/NoExtractNorm.out 2>&1
+	@grep -q "Starting to normalize top-level let Inr kept" $(OUTPUT_DIR)/NoExtractNorm.out
+	@if grep -q "Starting to normalize top-level let Inr dropped" $(OUTPUT_DIR)/NoExtractNorm.out; then \
+	  echo "ERROR: normalized a noextract definition"; false; \
+	fi
+	@touch $@
+
+$(OUTPUT_DIR)/NoExtractNormPerf.test: $(CACHE_DIR)/NoExtractNormPerf.fst.checked $(FSTAR_EXE)
+	@mkdir -p $(OUTPUT_DIR)
+	@$(FSTAR) $< --codegen krml --extract_module NoExtractNormPerf
+	@touch $@
 
 $(OUTPUT_DIR)/FloatLiteralInjection.rejected: $(CACHE_DIR)/FloatLiteralInjection.fst.checked $(FSTAR_EXE)
 	@mkdir -p $(OUTPUT_DIR)

--- a/tests/extraction/NoExtractNorm.fst
+++ b/tests/extraction/NoExtractNorm.fst
@@ -1,0 +1,9 @@
+module NoExtractNorm
+
+let kept (x:nat) = x + 1
+
+noextract
+let dropped (x:nat) = x + 1
+
+[@@ noextract_to "krml"]
+let dropped_to_krml (x:nat) = x + 1

--- a/tests/extraction/NoExtractNormPerf.fst
+++ b/tests/extraction/NoExtractNormPerf.fst
@@ -1,0 +1,63 @@
+module NoExtractNormPerf
+
+(* Each level doubles when extraction normalization unfolds
+   [inline_for_extraction] definitions. At level 18, the compact term below
+   expands to more than 250,000 applications. None of that work is useful:
+   every definition in this module is dropped by extraction. *)
+
+inline_for_extraction noextract
+let d0 (x:nat) : nat = x + 1
+
+inline_for_extraction noextract
+let d1 (x:nat) : nat = d0 (d0 x)
+
+inline_for_extraction noextract
+let d2 (x:nat) : nat = d1 (d1 x)
+
+inline_for_extraction noextract
+let d3 (x:nat) : nat = d2 (d2 x)
+
+inline_for_extraction noextract
+let d4 (x:nat) : nat = d3 (d3 x)
+
+inline_for_extraction noextract
+let d5 (x:nat) : nat = d4 (d4 x)
+
+inline_for_extraction noextract
+let d6 (x:nat) : nat = d5 (d5 x)
+
+inline_for_extraction noextract
+let d7 (x:nat) : nat = d6 (d6 x)
+
+inline_for_extraction noextract
+let d8 (x:nat) : nat = d7 (d7 x)
+
+inline_for_extraction noextract
+let d9 (x:nat) : nat = d8 (d8 x)
+
+inline_for_extraction noextract
+let d10 (x:nat) : nat = d9 (d9 x)
+
+inline_for_extraction noextract
+let d11 (x:nat) : nat = d10 (d10 x)
+
+inline_for_extraction noextract
+let d12 (x:nat) : nat = d11 (d11 x)
+
+inline_for_extraction noextract
+let d13 (x:nat) : nat = d12 (d12 x)
+
+inline_for_extraction noextract
+let d14 (x:nat) : nat = d13 (d13 x)
+
+inline_for_extraction noextract
+let d15 (x:nat) : nat = d14 (d14 x)
+
+inline_for_extraction noextract
+let d16 (x:nat) : nat = d15 (d15 x)
+
+inline_for_extraction noextract
+let d17 (x:nat) : nat = d16 (d16 x)
+
+inline_for_extraction noextract
+let d18 (x:nat) : nat = d17 (d17 x)


### PR DESCRIPTION
From the _kuiper branch and cleaned up.

--

Extraction generically normalized top-level definitions before dropping those marked noextract. Skip that normalization when the final, postprocessed sigelt has the NoExtract qualifier. This also handles noextract_to "krml", whose qualifier is added during extraction postprocessing. An explicit normalize_for_extraction attribute remains honored.

Add functional coverage and an exaggerated depth-18 performance test. Across five local extraction-only runs, the benchmark improved from 18.54s and 716 MiB peak RSS to 0.068s and 83 MiB.