### PR TITLE
Allow the `unfold` qualifier on classes and records

### DIFF
--- a/src/typechecker/FStarC.TypeChecker.Quals.fst
+++ b/src/typechecker/FStarC.TypeChecker.Quals.fst
@@ -115,10 +115,17 @@ let check_sigelt_quals_pre (env:FStarC.TypeChecker.Env.env) se : ML unit =
 
       | Unfold_for_unification_and_vcgen
       | Visible_default
-      | Irreducible
+      | Irreducible ->
+        q2=Logic || q2=Inline_for_extraction || q2=NoExtract || has_eq q2 || inferred q2 || visibility q2 || reification q2
+
       | Noeq
       | Unopteq ->
         q2=Logic || q2=Inline_for_extraction || q2=NoExtract || has_eq q2 || inferred q2 || visibility q2 || reification q2
+        (* `unfold` is allowed on a class or record, where it applies to the
+           generated typeclass methods. The equality qualifiers are often
+           inferred rather than written, so refusing the combination would make
+           `unfold class` fail for reasons the user did not choose. *)
+        || q2=Unfold_for_unification_and_vcgen
 
       | TotalEffect ->
         inferred q2 || visibility q2 || reification q2 || q2=Assumption
@@ -189,7 +196,8 @@ let check_sigelt_quals_pre (env:FStarC.TypeChecker.Env.env) se : ML unit =
               || x=NoExtract
               || inferred x
               || visibility x
-              || has_eq x))
+              || has_eq x
+              || x=Unfold_for_unification_and_vcgen))
         then err [];
         if quals |> List.existsb (function Unopteq -> true | _ -> false) &&
            U.has_attribute se.sigattrs FStarC.Parser.Const.erasable_attr

--- a/tests/typeclasses/UnfoldClass.fst
+++ b/tests/typeclasses/UnfoldClass.fst
@@ -1,0 +1,29 @@
+module UnfoldClass
+
+open FStar.Tactics.V2
+open FStar.Tactics.Typeclasses
+
+module L = FStar.List.Tot
+
+(* All fields here are propositional, so F* infers `noeq` for the class. The
+`unfold` written by the user must not clash with that inferred qualifier:
+refusing the combination would make `unfold class` fail for a reason the
+user did not choose. Reduced from Kuiper.Array.Vectorized. *)
+inline_for_extraction noextract
+unfold
+class sized (et : Type) = {
+  [@@@no_method] _chunk : nat;
+  [@@@no_method] _pf : squash (_chunk == 16);
+}
+
+unfold
+class uc (a:Type) = {
+  um : a -> nat;
+}
+
+class pc (a:Type) = {
+  pm : a -> nat;
+}
+
+instance ui : uc bool = { um = (fun b -> if b then 1 else 0); }
+instance pi : pc bool = { pm = (fun b -> if b then 1 else 0); }

--- a/tests/typeclasses/UnfoldClass.fst
+++ b/tests/typeclasses/UnfoldClass.fst
@@ -27,3 +27,35 @@ class pc (a:Type) = {
 
 instance ui : uc bool = { um = (fun b -> if b then 1 else 0); }
 instance pi : pc bool = { pm = (fun b -> if b then 1 else 0); }
+
+(* `unfold` on a class applies to the methods it generates. *)
+
+let method_quals (nm:string) : Tac (list qualifier) =
+  match lookup_typ (top_env ()) (explode_qn nm) with
+  | None -> fail ("no such name: " ^ nm)
+  | Some se -> sigelt_quals se
+
+let is_unfold (q:qualifier) : bool =
+  match q with
+  | Unfold_for_unification_and_vcgen -> true
+  | _ -> false
+
+let _ = assert True by begin
+  guard (L.existsb is_unfold (method_quals (`%um)));
+  guard (not (L.existsb is_unfold (method_quals (`%pm))))
+end
+
+let head_name (t:term) : Tac string =
+  match inspect (fst (collect_app t)) with
+  | Tv_FVar fv
+  | Tv_UInst fv _ -> implode_qn (inspect_fv fv)
+  | _ -> fail "head is not an fvar"
+
+(* And it is observable: `delta_qualifier ["unfold"]` turns the method of the
+`unfold` class into the projection it stands for, and leaves the other one
+alone. *)
+let _ = assert True by begin
+  let steps = [delta_qualifier ["unfold"]] in
+  guard (head_name (norm_term steps (`(um true))) = `%Mkuc?.um);
+  guard (head_name (norm_term steps (`(pm true))) = `%pm)
+end

--- a/ulib/FStar.Tactics.Typeclasses.fst
+++ b/ulib/FStar.Tactics.Typeclasses.fst
@@ -514,7 +514,11 @@ let mk_class (nm:string) : Tac decls =
     let r = lookup_typ (top_env ()) ns in
     guard (Some? r);
     let Some se = r in
-    let to_propagate = L.filter (function Inline_for_extraction | NoExtract -> true | _ -> false) (sigelt_quals se) in
+    (* Qualifiers carried over from the class to each generated method.
+       `unfold` on a class means its methods always reduce to the underlying
+       projector application; this is what makes the qualifier meaningful on
+       an inductive, which has no definition of its own to unfold. *)
+    let to_propagate = L.filter (function Inline_for_extraction | NoExtract | Unfold_for_unification_and_vcgen -> true | _ -> false) (sigelt_quals se) in
     let sv = inspect_sigelt se in
     guard (Sg_Inductive? sv);
     let Sg_Inductive {nm=name;univs=us;params;typ=ity;ctors} = sv in


### PR DESCRIPTION
Ports 38903e9149 `make noeq and unfold compatible (useful for typeclases, I think)`
from the `_kuiper` branch, with a narrower relaxation and a follow-up that
gives the qualifier a meaning.

## 1. Allow `unfold` on classes and records

`unfold class ... = { ... }` was rejected twice over: `unfold` was not listed
as compatible with `noeq`/`unopteq`, and the `Sig_bundle` case did not accept
it at all.

The first is the more annoying of the two, because the equality qualifier is
usually *inferred* rather than written &mdash; a class whose fields are all
propositional gets `noeq` automatically &mdash; so the user is told off for a
qualifier they never wrote:

```
- Invalid qualifiers for declaration ‘type Foo.cls’
- Qualifiers ‘noeq’ and ‘unfold’ are not compatible.
```

This is what [`Kuiper.Array.Vectorized.has_vec_cpy`][kuiper] hits.

[kuiper]: https://github.com/FStarLang/kuiper/blob/77fb31b6509bc1c510906079d8e22fcbbc1257f1/src/lib/data/Kuiper.Array.Vectorized.fsti#L11-L13

I narrowed the original patch here. It added `q2=Unfold_for_unification_and_vcgen`
to the arm that `Noeq` and `Unopteq` *share* with `Unfold_for_unification_and_vcgen`,
`Visible_default` and `Irreducible`, which also makes e.g. `irreducible unfold`
pass that check. (`pairwise_compat` tests both orders, so such pairs were still
caught by the other direction, but only by luck.) I split the arm instead, so
the only newly-permitted combination is `unfold` with `noeq`/`unopteq`.

## 2. Propagate `unfold` from a class to its methods

This is the part I would like a second opinion on.

When I first looked at this commit I skipped it, because an inductive has no
definition of its own to unfold: `lookup_definition_qninfo_aux` only ever
matches `Sig_let`, `delta_depth_of_qninfo_lid` returns `delta_constant` for
`Sig_bundle` regardless of qualifiers, and both places in the SMT encoder that
consult `Unfold_for_unification_and_vcgen` are `Sig_let`-only. So relaxing the
check on its own makes F\* accept a qualifier that does precisely nothing,
which seemed like a footgun rather than a feature.

The second commit fixes that by adding `Unfold_for_unification_and_vcgen` to
`mk_class`'s `to_propagate` list, next to `inline_for_extraction` and
`noextract`. `unfold class c = { m : ... }` then means "`m` always reduces to
the projection it stands for", which I think is the useful reading of the
qualifier and matches the "useful for typeclasses" in the original commit
message. It is purely additive, since `unfold` on a class was a hard error
before the first commit.

Note this is *not* needed for the Kuiper declaration above: both of its fields
are `no_method`, so that class generates no methods at all and the qualifier
stays inert there. If you would rather not take the semantic change, the second
commit can be dropped on its own and Kuiper is still unblocked.

## Tests

`tests/typeclasses/UnfoldClass.fst`, reduced from the Kuiper declaration:

- an `inline_for_extraction noextract unfold class` whose fields are all
  propositional, so `noeq` is inferred &mdash; this is the acceptance check,
  and it fails on `master` with the error quoted above;
- a check that the method of an `unfold` class carries the qualifier and the
  method of an ordinary class does not;
- a check that this is observable: under `delta_qualifier ["unfold"]` the
  former reduces to `Mkuc?.um` while the latter stays `pm`.

`tests/typeclasses`, `tests/tactics`, `tests/error-messages`,
`tests/micro-benchmarks` and `tests/extraction` all pass, and the ulib change
is exercised by the stage1 build. (`tests/bug-reports` and `tests/interfaces`
fail for me only because I ran them against a stage1 binary, which has no Pulse
plugin: "Unknown language extension pulse".)

Unrelated: `ulib/FStar.Rational.Gcd.fst` currently fails to check for me on a
clean `master` with a Z3 timeout at line 54, which is why I could not build a
stage3 to test with.
