### PR TITLE
Make all arrow-equality paths agree on binder qualifiers

### DIFF
--- a/src/syntax/FStarC.Syntax.Util.fst
+++ b/src/syntax/FStarC.Syntax.Util.fst
@@ -1535,6 +1535,22 @@ let term_eq t1 t2 =
     debug_term_eq := false;
     r
 
+(* See the comment on the declaration in the interface. *)
+let bqual_compat (b1 b2 : bqual) : bool =
+    match b1, b2 with
+    | None, None -> true
+    (* [Implicit] and [Meta] binders are interchangeable, and we never
+       compare the metaprograms of two [Meta] binders nor the
+       inaccessibility flag of two [Implicit] binders. *)
+    | Some (Implicit _), Some (Implicit _)
+    | Some (Implicit _), Some (Meta _)
+    | Some (Meta _), Some (Implicit _)
+    | Some (Meta _), Some (Meta _) -> true
+    | Some Equality, Some Equality
+    | Some Equality, None
+    | None, Some Equality -> true
+    | _ -> false
+
 // An estimation of the size of a term, only for debugging
 let rec sizeof (t:term) : ML int =
     match t.n with

--- a/src/syntax/FStarC.Syntax.Util.fsti
+++ b/src/syntax/FStarC.Syntax.Util.fsti
@@ -520,6 +520,25 @@ val eq_aqual (a1 a2 : aqual) : ML bool
 val eq_bqual (b1 b2 : bqual) : ML bool
 val term_eq (t1 t2 : term) : ML bool
 
+(* Are these two binder qualifiers compatible, i.e., can two arrows that
+   differ only by these qualifiers denote the same type?
+
+   Binder qualifiers are elaboration metadata: an [Implicit] and a [Meta]
+   binder both elaborate to an argument with [aqual_implicit = true], and
+   the metaprogram in a [Meta] binder only affects how an argument is
+   *solved*, never what the arrow means. So type equality must not
+   distinguish them. Ditto for the [Equality] qualifier, which only
+   affects unification of applications.
+
+   This is the relation used by every path that decides equality of
+   arrow types: [Rel.solve_binders], [Core.check_bqual],
+   [TcTerm.check_binders_for_definition] and
+   [TermEqAndSimplify.eq_tm]. Keep them in sync.
+
+   Note this is deliberately *not* [eq_bqual], which is structural
+   equality of the qualifiers themselves. *)
+val bqual_compat (b1 b2 : bqual) : bool
+
 // An estimation of the size of a term, only for debugging
 val sizeof (t:term) : ML int
 

--- a/src/typechecker/FStarC.TypeChecker.Core.fst
+++ b/src/typechecker/FStarC.TypeChecker.Core.fst
@@ -608,22 +608,9 @@ let check_arg_qual (a:aqual) (b:bqual)
 
 let check_bqual (b0 b1:bqual)
   : ML (result unit)
-  = match b0, b1 with
-    | None, None -> return ()
-    | Some (Implicit b0), Some (Implicit b1) ->
-      //we don't care about the inaccessibility qualifier
-      //when comparing bquals
-      return ()
-    | Some Equality, None
-    | None, Some Equality // The equality qualifier is metadata, ignore it
-    | Some Equality, Some Equality ->
-      return ()
-    | Some (Meta t1), Some (Meta t2) ->
-      if equal_term t1 t2
-      then return ()
-      else fail_str (Format.fmt2 "Binder qualifier mismatch, %s vs %s" (show b0) (show b1))
-    | _ ->
-      fail_str (Format.fmt2 "Binder qualifier mismatch, %s vs %s" (show b0) (show b1))
+  = if U.bqual_compat b0 b1
+    then return ()
+    else fail_str (Format.fmt2 "Binder qualifier mismatch, %s vs %s" (show b0) (show b1))
 
 let check_aqual (a0 a1:aqual)
   : ML (result unit)

--- a/src/typechecker/FStarC.TypeChecker.Rel.fst
+++ b/src/typechecker/FStarC.TypeChecker.Rel.fst
@@ -3270,15 +3270,7 @@ let solve_binders (bs1:binders) (bs2:binders) (orig:prob) (wl:worklist)
                        (rel_to_string (p_rel orig))
                        (show bs2);
 
-   let eq_bqual a1 a2 =
-       match a1, a2 with
-       | Some (Implicit b1), Some (Implicit b2) ->
-         true //we don't care about comparing the dot qualifier in this context
-       | Some Equality, None | None, Some Equality ->
-         true // also don't care about the equality qualifier
-       | _ ->
-         U.eq_bqual a1 a2
-   in
+   let eq_bqual a1 a2 = U.bqual_compat a1 a2 in
 
    let compat_positivity_qualifiers (p1 p2:option positivity_qualifier) : bool =
       match p_rel orig with

--- a/src/typechecker/FStarC.TypeChecker.TcTerm.fst
+++ b/src/typechecker/FStarC.TypeChecker.TcTerm.fst
@@ -2500,14 +2500,7 @@ and tc_abs_check_binders env bs bs_expected use_eq
 
     | ({binder_bv=hd;binder_qual=imp;binder_positivity=pqual_actual; binder_attrs=attrs})::bs,
       ({binder_bv=hd_expected;binder_qual=imp';binder_positivity=pqual_expected;binder_attrs=attrs'})::bs_expected -> begin
-        (* These are the discrepancies in qualifiers that we allow *)
-        let special q1 q2 = match q1, q2 with
-        | Some (Meta _), Some (Meta _) -> true (* don't compare the metaprograms *)
-        | None, Some Equality -> true
-        | Some (Implicit _), Some (Meta _) -> true
-        | _ -> false in
-
-        if not (special imp imp') && not (U.eq_bqual imp imp') then
+        if not (U.bqual_compat imp imp') then
           let open FStarC.Errors.Msg in
           let open FStarC.Pprint in
           let open FStarC.Class.PP in

--- a/src/typechecker/FStarC.TypeChecker.TermEqAndSimplify.fst
+++ b/src/typechecker/FStarC.TypeChecker.TermEqAndSimplify.fst
@@ -225,6 +225,12 @@ let rec eq_tm (env:env_t) (t1:term) (t2:term) : ML eq_result =
              (fun () -> eq_tm env body1 body2)
 
     | Tm_arrow {b=b1; comp=c1}, Tm_arrow {b=b2; comp=c2} ->
+      // NB: binder qualifiers are compared (leniently, see [bqual_compat]);
+      // ignoring them entirely would make e.g. [#x:a -> b] and [x:a -> b]
+      // compare Equal.
+      if not (U.bqual_compat b1.binder_qual b2.binder_qual)
+      then Unknown
+      else
       eq_and (eq_tm env b1.binder_bv.sort b2.binder_bv.sort)
              (fun () -> eq_comp env c1 c2)
 

--- a/tests/micro-benchmarks/BinderQuals.fst
+++ b/tests/micro-benchmarks/BinderQuals.fst
@@ -1,0 +1,67 @@
+(*
+   Copyright 2008-2025 Microsoft Research
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*)
+module BinderQuals
+
+/// Binder qualifiers are elaboration metadata, so equality of arrow types
+/// must not distinguish an [Implicit] binder from a [Meta] one: both
+/// elaborate to an argument with [aqual_implicit = true], and the
+/// metaprogram of a [Meta] binder only says how the argument is *solved*.
+///
+/// All the paths that decide equality of arrows agree on this, via
+/// [FStarC.Syntax.Util.bqual_compat]: the unifier ([Rel.solve_binders]),
+/// the core typechecker ([Core.check_bqual]), the definition checker
+/// ([TcTerm]) and the syntactic fast path ([TermEqAndSimplify.eq_tm]).
+
+open FStar.Tactics.Typeclasses
+
+class def_c (a:Type) = { def : a }
+
+instance _ : def_c int = { def = 0 }
+
+(* [def] has type [#a:Type -> #[tcresolve ()] _:def_c a -> a]: typeclass method
+   types carry a Meta binder for the class argument, since [mk_class] builds
+   them with [binder_set_meta]. Here it is passed where an arrow with a plain
+   Implicit binder is expected. *)
+let apply_meta_as_implicit (g : (#a:Type -> #_:def_c a -> a)) : int =
+  g #int #solve
+
+let _ : int = apply_meta_as_implicit def
+
+(* The same, but with the arrows appearing as arguments of a matching head.
+   This goes through a different path in the unifier, which used to ignore
+   binder qualifiers entirely. *)
+let meta_as_implicit_under_ctor (l : list (#a:Type -> #[tcresolve ()] _:def_c a -> a))
+  : list (#a:Type -> #_:def_c a -> a) = l
+
+(* Two Meta binders are compatible even when their metaprograms differ: we
+   never compare the metaprograms. *)
+let distinct_metaprograms (f : (#[FStar.Tactics.exact (`0)] x:int -> int))
+  : (#[FStar.Tactics.exact (`1)] x:int -> int) = f
+
+(* But Implicit/Meta are still distinct from Explicit, including when the
+   arrows appear under a type constructor. This last case regressed for a
+   while: [eq_tm] compared the two [list] arguments while ignoring binder
+   qualifiers, and reported them equal. *)
+[@@expect_failure]
+let implicit_is_not_explicit (f : (#x:int -> int)) : (x:int -> int) = f
+
+[@@expect_failure]
+let implicit_is_not_explicit_under_ctor (l : list (#x:int -> int))
+  : list (x:int -> int) = l
+
+[@@expect_failure]
+let meta_is_not_explicit_under_ctor (l : list (#[FStar.Tactics.exact (`0)] x:int -> int))
+  : list (x:int -> int) = l


### PR DESCRIPTION
Ports `3989e8d8cd` ("tweak in core tc") from the `_kuiper` branch, generalised so that *all* the paths that decide equality of arrow types agree.

## The problem

Binder qualifiers are elaboration metadata. An `Implicit` and a `Meta` binder both elaborate to an argument with `aqual_implicit = true`, and the metaprogram in a `Meta` binder only says how the argument is *solved*, never what the arrow means. So `#[t] x:a -> b` and `#x:a -> b` denote the same type and equality must not distinguish them.

Four separate places decided this question, and all four disagreed:

| site | `Meta`~`Implicit` | `Meta t1`~`Meta t2` | `Implicit`~`Explicit` |
|---|---|---|---|
| `Rel.solve_binders` (`Rel.fst:3273`) | ✗ | only if `term_eq t1 t2` | ✗ |
| `Core.check_bqual` (`Core.fst:609`) | ✗ | only if `equal_term t1 t2` | ✗ |
| `TcTerm` (`TcTerm.fst:2503`) | ✗ (but `Implicit`~`Meta` ✓ — asymmetric!) | ✓ | ✗ |
| `TermEqAndSimplify.eq_tm` (`:227`) | ✓ | ✓ | **✓** |

The last row is a bug in its own right. `eq_tm` ignored binder qualifiers on `Tm_arrow` entirely, and it is used as a fast path by `Rel.rigid_heads_match` (`Rel.fst:3386`). So arrows that Rel correctly rejected bare were silently accepted one syntactic layer up:

```fstar
(* accepted on master! *)
let bad (l : list (#x:int -> int)) : list (x:int -> int) = l
```

Verified against master: with `[@@expect_failure]` on that definition, master reports `Error 303: This top-level definition was expected to fail, but it succeeded.` Confirmed with `--debug Rel` that no `Tm_arrow` sub-problem is ever created in that case — the `eq_args` short-circuit fires first.

## The fix

A single `Syntax.Util.bqual_compat` relation, used at all four sites:

- `Implicit` and `Meta` are fully interchangeable, and metaprograms of two `Meta` binders are never compared (matching what `TcTerm` already did).
- The `Implicit` inaccessibility flag and the `Equality` qualifier are still ignored, as before.
- `eq_tm` now consults it instead of ignoring qualifiers, which fixes the `list` case above. Being *more* conservative here is safe: `Unknown` just means the real unifier runs.

This is the change Kuiper needs — it unblocks passing a typeclass method where an arrow with a plain `Implicit` binder is expected. Typeclass method types carry a `Meta` binder for the class argument (`mk_class` builds it with `binder_set_meta`).

Note this is a superset of the original kuiper patch, which only touched `Core.check_bqual` and would have left Core strictly more permissive than `Rel`.

## Test

`tests/micro-benchmarks/BinderQuals.fst`, covering both directions. Minimal repro of the Kuiper failure:

```fstar
class def_c (a:Type) = { def : a }
instance _ : def_c int = { def = 0 }

let apply_meta_as_implicit (g : (#a:Type -> #_:def_c a -> a)) : int = g #int #solve
let _ : int = apply_meta_as_implicit def
```

On master:
```
* Error 189 at BinderQuals.fst(41,37-41,40):
  - Expected expression of type a
    got expression def
    of type {| projectee: def_c a |} -> a
```

The file also pins down the negative cases (`Implicit`/`Meta` still differ from `Explicit`, bare and under a type constructor), which fail on master with `Error 303`.

## Validation

Since `eq_tm` is hot and widely used, I checked this broadly:

- Full `make 3` — the compiler, all of `ulib` and the Pulse library re-verify.
- Green: `tests/micro-benchmarks`, `tests/typeclasses`, `tests/tactics`, `tests/error-messages`, `tests/bug-reports`, `tests/interfaces`, `pulse/test`.

No golden files needed updating.
