### PR TITLE
Encode prop like bool, with boxing to SMT Bool

### DIFF
--- a/examples/algorithms/StringMatching.fst
+++ b/examples/algorithms/StringMatching.fst
@@ -147,7 +147,11 @@ let aux (x: str nat) (base: nat) (prime:nat { prime > 0 }) (i: nat) (j: nat { i+
                 base
                 (hash x base prime (i + 1) (j - 1))
                 (pow base (j - i - 2) * Seq.index x i);
-            pow_lemma base (j - i - 2) }
+            pow_lemma base (j - i - 2);
+            FStar.Math.Lemmas.paren_mul_right
+                base
+                (pow base (j - i - 2))
+                (Seq.index x i) }
       (h_lsd + msd) % prime;            
   }
 

--- a/examples/dsls/bool_refinement/BoolRefinement.fst
+++ b/examples/dsls/bool_refinement/BoolRefinement.fst
@@ -621,7 +621,7 @@ let rec shift_subst_spec_n_succ_list (n:nat) (ss:subst_spec)
     | [] -> ()
     | _::xs -> shift_subst_spec_n_succ_list n xs
 
-#push-options "--fuel 8 --ifuel 2"
+#push-options "--fuel 8 --ifuel 2 --z3rlimit_factor 4"
 #restart-solver
 let rec src_refinements_are_closed_core
                        (n:nat)

--- a/src/fstar/FStarC.CheckedFiles.fst
+++ b/src/fstar/FStarC.CheckedFiles.fst
@@ -38,7 +38,7 @@ let debug (f:unit -> ML unit) : ML unit = if !dbg then f () else ()
  * We write this version number to the cache files, and
  * detect when loading the cache that the version number is same
  *)
-let cache_version_number = 95
+let cache_version_number = 96
 
 (*
  * Abbreviation for what we store in the checked files (stages as described below)

--- a/src/fstar/FStarC.CheckedFiles.fst
+++ b/src/fstar/FStarC.CheckedFiles.fst
@@ -38,7 +38,7 @@ let debug (f:unit -> ML unit) : ML unit = if !dbg then f () else ()
  * We write this version number to the cache files, and
  * detect when loading the cache that the version number is same
  *)
-let cache_version_number = 94
+let cache_version_number = 95
 
 (*
  * Abbreviation for what we store in the checked files (stages as described below)

--- a/src/fstar/FStarC.CheckedFiles.fst
+++ b/src/fstar/FStarC.CheckedFiles.fst
@@ -38,7 +38,7 @@ let debug (f:unit -> ML unit) : ML unit = if !dbg then f () else ()
  * We write this version number to the cache files, and
  * detect when loading the cache that the version number is same
  *)
-let cache_version_number = 93
+let cache_version_number = 94
 
 (*
  * Abbreviation for what we store in the checked files (stages as described below)

--- a/src/fstar/FStarC.CheckedFiles.fst
+++ b/src/fstar/FStarC.CheckedFiles.fst
@@ -38,7 +38,7 @@ let debug (f:unit -> ML unit) : ML unit = if !dbg then f () else ()
  * We write this version number to the cache files, and
  * detect when loading the cache that the version number is same
  *)
-let cache_version_number = 96
+let cache_version_number = 97
 
 (*
  * Abbreviation for what we store in the checked files (stages as described below)

--- a/src/smtencoding/FStarC.SMTEncoding.Encode.fst
+++ b/src/smtencoding/FStarC.SMTEncoding.Encode.fst
@@ -765,7 +765,12 @@ let encode_free_var uninterpreted env fv us tt t_norm quals : ML (decls_t & env_
                                        Some "free var typing",
                                        ("typing_"^vname)) in
          let freshness =
+           // A `new` type whose result type is prop cannot be given a distinct
+           // constructor id: the encoding of prop is extensional (see mk_prop),
+           // so every prop is equal to True or False, and hence a prop-valued
+           // type constructor cannot be distinct from every other term.
            if quals |> List.contains New
+           && not (U.is_fvar Const.prop_lid (SS.compress res_t))
            then [Term.fresh_constructor (S.range_of_fv fv) (vname, univ_sorts @ (vars |> List.map fv_sort), Term_sort, varops.next_id());
                  pretype_axiom false (S.range_of_fv fv) env vapp (univ_fvs@vars)]
            else [] in

--- a/src/smtencoding/FStarC.SMTEncoding.Encode.fst
+++ b/src/smtencoding/FStarC.SMTEncoding.Encode.fst
@@ -1029,7 +1029,7 @@ let encode_top_level_let :
                                 (show binders)
                                 (show body);
                 (* Encode binders *)
-                let vars, binder_guards, env', binder_decls, _ = encode_binders None binders env' in
+                let vars, _binder_guards, env', binder_decls, _ = encode_binders None binders env' in
                 let vars, app =
                     if fvb.fvb_thunked
                     && vars = []
@@ -1043,54 +1043,35 @@ let encode_top_level_let :
                                          ({fvb with smt_arity = List.length univ_terms + fvb.smt_arity})
                                          (univ_terms @ List.map mkFreeV vars)
                 in
-                let is_logical =
-                  // A prop-valued definition is encoded as a formula equation
-                  // `Valid (f x) <==> body`, rather than a term equation
-                  // `f x == body`. The latter follows from the former, since
-                  // the SMT encoding of prop is extensional (see mk_prop).
+                let is_prop_valued =
                   match (SS.compress t_body).n with
-                  | Tm_fvar fv when S.fv_eq_lid fv FStarC.Parser.Const.prop_lid -> true
+                  | Tm_fvar fv -> S.fv_eq_lid fv FStarC.Parser.Const.prop_lid
                   | _ -> false
                 in
-                let is_smt_theory_symbol =
-                    let fv = Inr?.v lbn in
-                    Env.fv_has_attr env.tcenv fv FStarC.Parser.Const.smt_theory_symbol_attr_lid
-                in
-                let should_encode_logical =
-                    not is_smt_theory_symbol
-                    && (quals |> List.contains Logic || is_logical)
-                in
-                let make_eqn name pat app body =
+                let make_eqn pat app body =
                     //NS 05.25: This used to be mkImp(mk_and_l guards, mkEq(app, body))),
                     //But the guard is unnecessary given the pattern
                     Util.mkAssume(mkForall (S.range_of_lbname lbn)
                                            ([[pat]], vars, mkEq(app,body)),
                                   Some (Format.fmt1 "Equation for %s" (string_of_lid flid)),
-                                  (name ^ "_" ^ fvb.smt_id))
+                                  ("equation_" ^ fvb.smt_id))
                 in
-                let eqns,decls2 =
-                  let mk_basic_eqn name =
-                    let body, decls = encode_term body env' in
-                    make_eqn name app app body, decls
-                  in
-                  if should_encode_logical
+                let eqn, decls2 =
+                  if is_prop_valued
                   then
-                    let logical_eqn, decls2 =
-                      let bodyf, decls2 = encode_formula body env' in
-                      make_eqn "equation" app (mk_Valid app) bodyf, decls2
-                    in
-                    if is_logical
-                    then //A prop-valued definition only gets the formula equation:
-                         //the term equation follows from it, since prop is
-                         //encoded extensionally (see mk_prop above).
-                         [logical_eqn], decls2
-                    else let basic_eqn, decls = mk_basic_eqn "defn_equation" in
-                         [logical_eqn; basic_eqn], decls@decls2
-                  else let basic_eqn, decls = mk_basic_eqn "equation" in
-                       [basic_eqn], decls
+                    // A prop-valued definition gets a formula equation
+                    // `Valid (f x) <==> body`. The term equation `f x == body`
+                    // follows from it, since the SMT encoding of prop is
+                    // extensional (see mk_prop above).
+                    let bodyf, decls2 = encode_formula body env' in
+                    make_eqn app (mk_Valid app) bodyf, decls2
+                  else
+                    let body, decls2 = encode_term body env' in
+                    make_eqn app app body, decls2
                 in
-                decls@binder_decls@decls2@((eqns@primitive_type_axioms env.tcenv flid fvb.smt_id app)
-                                                 |> mk_decls_trivial),
+                decls@binder_decls@decls2@
+                  ((eqn :: primitive_type_axioms env.tcenv flid fvb.smt_id app)
+                   |> mk_decls_trivial),
                 env
             | _ -> failwith "Impossible"
         in

--- a/src/smtencoding/FStarC.SMTEncoding.Encode.fst
+++ b/src/smtencoding/FStarC.SMTEncoding.Encode.fst
@@ -1039,9 +1039,10 @@ let encode_top_level_let :
                                          (univ_terms @ List.map mkFreeV vars)
                 in
                 let is_logical =
-                  // A prop-valued definition additionally gets a formula
-                  // equation `Valid (f x) <==> body`, where the body is
-                  // encoded as a formula rather than as a term.
+                  // A prop-valued definition is encoded as a formula equation
+                  // `Valid (f x) <==> body`, rather than a term equation
+                  // `f x == body`. The latter follows from the former, since
+                  // the SMT encoding of prop is extensional (see mk_prop).
                   match (SS.compress t_body).n with
                   | Tm_fvar fv when S.fv_eq_lid fv FStarC.Parser.Const.prop_lid -> true
                   | _ -> false
@@ -1063,22 +1064,25 @@ let encode_top_level_let :
                                   (name ^ "_" ^ fvb.smt_id))
                 in
                 let eqns,decls2 =
-                  let basic_eqn_name =
-                    if should_encode_logical
-                    then "defn_equation"
-                    else "equation"
-                  in
-                  let basic_eqn, decls =
+                  let mk_basic_eqn name =
                     let body, decls = encode_term body env' in
-                    make_eqn basic_eqn_name app app body, decls
+                    make_eqn name app app body, decls
                   in
                   if should_encode_logical
-                  then let pat, app, (body, decls2) =
-                           app, mk_Valid app, encode_formula body env'
-                       in
-                       let logical_eqn = make_eqn "equation" pat app body in
-                       [logical_eqn; basic_eqn], decls@decls2
-                  else [basic_eqn], decls
+                  then
+                    let logical_eqn, decls2 =
+                      let bodyf, decls2 = encode_formula body env' in
+                      make_eqn "equation" app (mk_Valid app) bodyf, decls2
+                    in
+                    if is_logical
+                    then //A prop-valued definition only gets the formula equation:
+                         //the term equation follows from it, since prop is
+                         //encoded extensionally (see mk_prop above).
+                         [logical_eqn], decls2
+                    else let basic_eqn, decls = mk_basic_eqn "defn_equation" in
+                         [logical_eqn; basic_eqn], decls@decls2
+                  else let basic_eqn, decls = mk_basic_eqn "equation" in
+                       [basic_eqn], decls
                 in
                 decls@binder_decls@decls2@((eqns@primitive_type_axioms env.tcenv flid fvb.smt_id app)
                                                  |> mk_decls_trivial),

--- a/src/smtencoding/FStarC.SMTEncoding.Encode.fst
+++ b/src/smtencoding/FStarC.SMTEncoding.Encode.fst
@@ -220,6 +220,22 @@ let primitive_type_axioms : env -> lident -> string -> term -> ML (list decl) =
                                 ([[Term.boxBool b]], [bb], mk_HasType (Term.boxBool b) tt), Some "bool typing", "bool_typing");
          Util.mkAssume(mkForall_fuel env (Env.get_range env)
                                      ([[typing_pred]], [xx], mkImp(typing_pred, mk_tester (fst boxBoolFun) x)), Some "bool inversion", "bool_inversion")] in
+    let mk_prop : env -> string -> term -> ML (list decl) = fun env nm tt ->
+        // prop is encoded like bool: every prop is a boxed SMT boolean,
+        // where the boxed boolean records the validity of the prop.
+        let typing_pred = mk_HasType x tt in
+        let bb = mk_fv ("b", Bool_sort) in
+        let b = mkFreeV bb in
+        [Util.mkAssume(mkForall (Env.get_range env)
+                                ([[Term.boxProp b]], [bb], mk_HasType (Term.boxProp b) tt),
+                       Some "prop typing", "prop_typing");
+         Util.mkAssume(mkForall (Env.get_range env)
+                                ([[mkApp("Valid", [Term.boxProp b])]], [bb],
+                                 mkIff(mkApp("Valid", [Term.boxProp b]), b)),
+                       Some "prop validity", "prop_validity");
+         Util.mkAssume(mkForall_fuel env (Env.get_range env)
+                                     ([[typing_pred]], [xx], mkImp(typing_pred, mk_tester (fst boxPropFun) x)),
+                       Some "prop inversion", "prop_inversion")] in
     let mk_int : env -> string -> term -> ML (list decl) = fun env nm tt ->
         let lex_t = mkFreeV <| mk_fv (string_of_lid Const.lex_t_lid, Term_sort) in
         let typing_pred = mk_HasType x tt in
@@ -405,6 +421,7 @@ let primitive_type_axioms : env -> lident -> string -> term -> ML (list decl) =
    in
    let prims : list (lident & (env -> string -> term -> ML (list decl))) =  [(Const.unit_lid,   mk_unit);
                  (Const.bool_lid,   mk_bool);
+                 (Const.prop_lid,   mk_prop);
                  (Const.int_lid,    mk_int);
                  (Const.real_lid,   mk_real);
                  (Const.string_lid, mk_str);

--- a/src/smtencoding/FStarC.SMTEncoding.Encode.fst
+++ b/src/smtencoding/FStarC.SMTEncoding.Encode.fst
@@ -1039,13 +1039,12 @@ let encode_top_level_let :
                                          (univ_terms @ List.map mkFreeV vars)
                 in
                 let is_logical =
-                  // match (SS.compress t_body).n with
-                  // | Tm_fvar fv when S.fv_eq_lid fv FStarC.Parser.Const.prop_lid -> true
-                  // | _ -> false
-
-                  // GE: this is a cute idea, but the formula axiom shouldn't
-                  // replace the default equation axiom, so disabling this for now
-                  false
+                  // A prop-valued definition additionally gets a formula
+                  // equation `Valid (f x) <==> body`, where the body is
+                  // encoded as a formula rather than as a term.
+                  match (SS.compress t_body).n with
+                  | Tm_fvar fv when S.fv_eq_lid fv FStarC.Parser.Const.prop_lid -> true
+                  | _ -> false
                 in
                 let is_smt_theory_symbol =
                     let fv = Inr?.v lbn in

--- a/src/smtencoding/FStarC.SMTEncoding.Pruning.fst
+++ b/src/smtencoding/FStarC.SMTEncoding.Pruning.fst
@@ -139,6 +139,7 @@ let init_macro_freenames =
     ("is-BoxInt", ["BoxInt"]);
     ("is-BoxString", ["BoxString"]);
     ("is-BoxReal", ["BoxReal"]);
+    ("is-BoxProp", ["BoxProp"]);
   ]
 
 (* Initial state: everything is empty *)

--- a/src/smtencoding/FStarC.SMTEncoding.Term.fst
+++ b/src/smtencoding/FStarC.SMTEncoding.Term.fst
@@ -318,6 +318,7 @@ let boxBoolFun       = mkBoxFunctions "BoxBool"
 let boxStringFun     = mkBoxFunctions "BoxString"
 let boxBitVecFun (sz:int) = mkBoxFunctions ("BoxBitVec" ^ show sz)
 let boxRealFun       = mkBoxFunctions "BoxReal"
+let boxPropFun       = mkBoxFunctions "BoxProp"
 
 // Assume the Box/Unbox functions to be injective
 let isInjective s =
@@ -1057,6 +1058,7 @@ and mkPrelude z3options : ML string =
         (fst boxStringFun,  [snd boxStringFun, String_sort, true], Term_sort, 9, true);
         (fst boxRealFun,    [snd boxRealFun, Sort "Real", true], Term_sort, 10, true);
         ("LexCons",    [("LexCons_0", Term_sort, true); ("LexCons_1", Term_sort, true); ("LexCons_2", Term_sort, true)], Term_sort, 11, true);
+        (fst boxPropFun,    [snd boxPropFun, Bool_sort, true],  Term_sort, 12, true);
       ] in
    let bcons = constrs |> List.collect (constructor_to_decl norng)
                        |> List.map (declToSmt z3options) |> String.concat "\n" in
@@ -1148,6 +1150,11 @@ let boxString t   = maybe_elim_box (fst boxStringFun) (snd boxStringFun) t
 let unboxString t = maybe_elim_box (snd boxStringFun) (fst boxStringFun) t
 let boxReal t     = maybe_elim_box (fst boxRealFun) (snd boxRealFun) t
 let unboxReal t   = maybe_elim_box (snd boxRealFun) (fst boxRealFun) t
+(* Note: props are always boxed, regardless of --smtencoding.elim_box, since
+   there is no native SMT sort for them. We only cancel a directly nested
+   box/unbox pair. *)
+let boxProp t     = elim_box true (fst boxPropFun) (snd boxPropFun) t
+let unboxProp t   = elim_box true (snd boxPropFun) (fst boxPropFun) t
 let boxBitVec (sz:int) t =
     elim_box true (fst (boxBitVecFun sz)) (snd (boxBitVecFun sz)) t
 let unboxBitVec (sz:int) t =

--- a/src/smtencoding/FStarC.SMTEncoding.Term.fsti
+++ b/src/smtencoding/FStarC.SMTEncoding.Term.fsti
@@ -216,6 +216,7 @@ val boxIntFun : string & string
 val boxBoolFun : string & string
 val boxStringFun : string & string
 val boxRealFun: string & string
+val boxPropFun: string & string
 val mkTrue :  term
 val mkFalse : term
 val mkUnreachable : term
@@ -320,6 +321,8 @@ val boxString:   term -> ML term
 val unboxString: term -> ML term
 val boxReal:      term -> ML term
 val unboxReal:    term -> ML term
+val boxProp:      term -> ML term
+val unboxProp:    term -> ML term
 val boxBitVec:   int -> term -> ML term
 val unboxBitVec: int -> term -> ML term
 

--- a/tests/bug-reports/closed/Bug185.fst
+++ b/tests/bug-reports/closed/Bug185.fst
@@ -44,7 +44,12 @@ assume Certified:
             certified (format [k]) <==> verified k == certified )
 
 val validate: vkey certified -> list data -> unit
-let rec validate vk0 chain =
+(* The `decreases` used to be inferred, but only because the context of the
+   recursive call was inconsistent: `verified vk == certified` is refutable when
+   prop-valued type constructors are given distinct SMT constructor ids. They no
+   longer are, since the encoding of prop is extensional. The point of this test
+   is the subtyping check on the recursive call, which still goes through. *)
+let rec validate vk0 chain : Tot unit (decreases chain) =
     (match chain with
     | cert:: chain_tl ->
         (match parse cert with

--- a/tests/error-messages/Monoid.fst.json_output.expected
+++ b/tests/error-messages/Monoid.fst.json_output.expected
@@ -299,8 +299,8 @@ let left_action_morphism f mf la lb = forall (g: ma) (x: a). lb.act (mf g) (f x)
 Module after type checking:
 module Monoid
 Declarations: [
-let right_unitality_lemma m u902 mult = forall (x: m). mult x u902 == x
-let left_unitality_lemma m u902 mult = forall (x: m). mult u902 x == x
+let right_unitality_lemma m u857 mult = forall (x: m). mult x u857 == x
+let left_unitality_lemma m u857 mult = forall (x: m). mult u857 x == x
 let associativity_lemma m mult = forall (x: m) (y: m) (z: m). mult (mult x y) z == mult x (mult y z)
 unopteq
 type monoid (m: Type) =
@@ -330,25 +330,25 @@ val monoid__uu___haseq: Prims.l_True /\
 
 
 
-let intro_monoid m u902 mult = Monoid.Monoid u902 mult () () () <: Prims.Pure (Monoid.monoid m)
+let intro_monoid m u857 mult = Monoid.Monoid u857 mult () () () <: Prims.Pure (Monoid.monoid m)
 let nat_plus_monoid =
   let add x y = x + y <: Prims.nat in
   Monoid.intro_monoid Prims.nat 0 add
 let int_plus_monoid = Monoid.intro_monoid Prims.int 0 Prims.op_Plus
 let conjunction_monoid =
-  let u900 = FStar.Pervasives.singleton Prims.l_True in
+  let u855 = FStar.Pervasives.singleton Prims.l_True in
   let mult p q = p /\ q <: Prims.prop in
   let left_unitality_helper p =
-    (assert (mult u900 p <==> p);
-      FStar.PropositionalExtensionality.apply (mult u900 p) p)
+    (assert (mult u855 p <==> p);
+      FStar.PropositionalExtensionality.apply (mult u855 p) p)
     <:
-    FStar.Pervasives.Lemma (ensures mult u900 p == p)
+    FStar.Pervasives.Lemma (ensures mult u855 p == p)
   in
   let right_unitality_helper p =
-    (assert (mult p u900 <==> p);
-      FStar.PropositionalExtensionality.apply (mult p u900) p)
+    (assert (mult p u855 <==> p);
+      FStar.PropositionalExtensionality.apply (mult p u855) p)
     <:
-    FStar.Pervasives.Lemma (ensures mult p u900 == p)
+    FStar.Pervasives.Lemma (ensures mult p u855 == p)
   in
   let associativity_helper p1 p2 p3 =
     (assert (mult (mult p1 p2) p3 <==> mult p1 (mult p2 p3));
@@ -357,26 +357,26 @@ let conjunction_monoid =
     FStar.Pervasives.Lemma (ensures mult (mult p1 p2) p3 == mult p1 (mult p2 p3))
   in
   FStar.Classical.forall_intro right_unitality_helper;
-  assert (Monoid.right_unitality_lemma Prims.prop u900 mult);
+  assert (Monoid.right_unitality_lemma Prims.prop u855 mult);
   FStar.Classical.forall_intro left_unitality_helper;
-  assert (Monoid.left_unitality_lemma Prims.prop u900 mult);
+  assert (Monoid.left_unitality_lemma Prims.prop u855 mult);
   FStar.Classical.forall_intro_3 associativity_helper;
   assert (Monoid.associativity_lemma Prims.prop mult);
-  Monoid.intro_monoid Prims.prop u900 mult
+  Monoid.intro_monoid Prims.prop u855 mult
 let disjunction_monoid =
-  let u900 = FStar.Pervasives.singleton Prims.l_False in
+  let u855 = FStar.Pervasives.singleton Prims.l_False in
   let mult p q = p \/ q <: Prims.prop in
   let left_unitality_helper p =
-    (assert (mult u900 p <==> p);
-      FStar.PropositionalExtensionality.apply (mult u900 p) p)
+    (assert (mult u855 p <==> p);
+      FStar.PropositionalExtensionality.apply (mult u855 p) p)
     <:
-    FStar.Pervasives.Lemma (ensures mult u900 p == p)
+    FStar.Pervasives.Lemma (ensures mult u855 p == p)
   in
   let right_unitality_helper p =
-    (assert (mult p u900 <==> p);
-      FStar.PropositionalExtensionality.apply (mult p u900) p)
+    (assert (mult p u855 <==> p);
+      FStar.PropositionalExtensionality.apply (mult p u855) p)
     <:
-    FStar.Pervasives.Lemma (ensures mult p u900 == p)
+    FStar.Pervasives.Lemma (ensures mult p u855 == p)
   in
   let associativity_helper p1 p2 p3 =
     (assert (mult (mult p1 p2) p3 <==> mult p1 (mult p2 p3));
@@ -385,12 +385,12 @@ let disjunction_monoid =
     FStar.Pervasives.Lemma (ensures mult (mult p1 p2) p3 == mult p1 (mult p2 p3))
   in
   FStar.Classical.forall_intro right_unitality_helper;
-  assert (Monoid.right_unitality_lemma Prims.prop u900 mult);
+  assert (Monoid.right_unitality_lemma Prims.prop u855 mult);
   FStar.Classical.forall_intro left_unitality_helper;
-  assert (Monoid.left_unitality_lemma Prims.prop u900 mult);
+  assert (Monoid.left_unitality_lemma Prims.prop u855 mult);
   FStar.Classical.forall_intro_3 associativity_helper;
   assert (Monoid.associativity_lemma Prims.prop mult);
-  Monoid.intro_monoid Prims.prop u900 mult
+  Monoid.intro_monoid Prims.prop u855 mult
 let bool_and_monoid =
   let and_ b1 b2 = b1 && b2 in
   Monoid.intro_monoid Prims.bool true and_
@@ -465,7 +465,7 @@ let _ =
   Monoid.intro_monoid_morphism Monoid.neg Monoid.disjunction_monoid Monoid.conjunction_monoid
 let mult_act_lemma m a mult act =
   forall (x: m) (x': m) (y: a). act (mult x x') y == act x (act x' y)
-let unit_act_lemma m a u904 act = forall (y: a). act u904 y == y
+let unit_act_lemma m a u859 act = forall (y: a). act u859 y == y
 unopteq
 type left_action (mm: Monoid.monoid m) (a: Type) =
   | LAct :

--- a/tests/error-messages/Monoid.fst.output.expected
+++ b/tests/error-messages/Monoid.fst.output.expected
@@ -299,8 +299,8 @@ let left_action_morphism f mf la lb = forall (g: ma) (x: a). lb.act (mf g) (f x)
 Module after type checking:
 module Monoid
 Declarations: [
-let right_unitality_lemma m u902 mult = forall (x: m). mult x u902 == x
-let left_unitality_lemma m u902 mult = forall (x: m). mult u902 x == x
+let right_unitality_lemma m u857 mult = forall (x: m). mult x u857 == x
+let left_unitality_lemma m u857 mult = forall (x: m). mult u857 x == x
 let associativity_lemma m mult = forall (x: m) (y: m) (z: m). mult (mult x y) z == mult x (mult y z)
 unopteq
 type monoid (m: Type) =
@@ -330,25 +330,25 @@ val monoid__uu___haseq: Prims.l_True /\
 
 
 
-let intro_monoid m u902 mult = Monoid.Monoid u902 mult () () () <: Prims.Pure (Monoid.monoid m)
+let intro_monoid m u857 mult = Monoid.Monoid u857 mult () () () <: Prims.Pure (Monoid.monoid m)
 let nat_plus_monoid =
   let add x y = x + y <: Prims.nat in
   Monoid.intro_monoid Prims.nat 0 add
 let int_plus_monoid = Monoid.intro_monoid Prims.int 0 Prims.op_Plus
 let conjunction_monoid =
-  let u900 = FStar.Pervasives.singleton Prims.l_True in
+  let u855 = FStar.Pervasives.singleton Prims.l_True in
   let mult p q = p /\ q <: Prims.prop in
   let left_unitality_helper p =
-    (assert (mult u900 p <==> p);
-      FStar.PropositionalExtensionality.apply (mult u900 p) p)
+    (assert (mult u855 p <==> p);
+      FStar.PropositionalExtensionality.apply (mult u855 p) p)
     <:
-    FStar.Pervasives.Lemma (ensures mult u900 p == p)
+    FStar.Pervasives.Lemma (ensures mult u855 p == p)
   in
   let right_unitality_helper p =
-    (assert (mult p u900 <==> p);
-      FStar.PropositionalExtensionality.apply (mult p u900) p)
+    (assert (mult p u855 <==> p);
+      FStar.PropositionalExtensionality.apply (mult p u855) p)
     <:
-    FStar.Pervasives.Lemma (ensures mult p u900 == p)
+    FStar.Pervasives.Lemma (ensures mult p u855 == p)
   in
   let associativity_helper p1 p2 p3 =
     (assert (mult (mult p1 p2) p3 <==> mult p1 (mult p2 p3));
@@ -357,26 +357,26 @@ let conjunction_monoid =
     FStar.Pervasives.Lemma (ensures mult (mult p1 p2) p3 == mult p1 (mult p2 p3))
   in
   FStar.Classical.forall_intro right_unitality_helper;
-  assert (Monoid.right_unitality_lemma Prims.prop u900 mult);
+  assert (Monoid.right_unitality_lemma Prims.prop u855 mult);
   FStar.Classical.forall_intro left_unitality_helper;
-  assert (Monoid.left_unitality_lemma Prims.prop u900 mult);
+  assert (Monoid.left_unitality_lemma Prims.prop u855 mult);
   FStar.Classical.forall_intro_3 associativity_helper;
   assert (Monoid.associativity_lemma Prims.prop mult);
-  Monoid.intro_monoid Prims.prop u900 mult
+  Monoid.intro_monoid Prims.prop u855 mult
 let disjunction_monoid =
-  let u900 = FStar.Pervasives.singleton Prims.l_False in
+  let u855 = FStar.Pervasives.singleton Prims.l_False in
   let mult p q = p \/ q <: Prims.prop in
   let left_unitality_helper p =
-    (assert (mult u900 p <==> p);
-      FStar.PropositionalExtensionality.apply (mult u900 p) p)
+    (assert (mult u855 p <==> p);
+      FStar.PropositionalExtensionality.apply (mult u855 p) p)
     <:
-    FStar.Pervasives.Lemma (ensures mult u900 p == p)
+    FStar.Pervasives.Lemma (ensures mult u855 p == p)
   in
   let right_unitality_helper p =
-    (assert (mult p u900 <==> p);
-      FStar.PropositionalExtensionality.apply (mult p u900) p)
+    (assert (mult p u855 <==> p);
+      FStar.PropositionalExtensionality.apply (mult p u855) p)
     <:
-    FStar.Pervasives.Lemma (ensures mult p u900 == p)
+    FStar.Pervasives.Lemma (ensures mult p u855 == p)
   in
   let associativity_helper p1 p2 p3 =
     (assert (mult (mult p1 p2) p3 <==> mult p1 (mult p2 p3));
@@ -385,12 +385,12 @@ let disjunction_monoid =
     FStar.Pervasives.Lemma (ensures mult (mult p1 p2) p3 == mult p1 (mult p2 p3))
   in
   FStar.Classical.forall_intro right_unitality_helper;
-  assert (Monoid.right_unitality_lemma Prims.prop u900 mult);
+  assert (Monoid.right_unitality_lemma Prims.prop u855 mult);
   FStar.Classical.forall_intro left_unitality_helper;
-  assert (Monoid.left_unitality_lemma Prims.prop u900 mult);
+  assert (Monoid.left_unitality_lemma Prims.prop u855 mult);
   FStar.Classical.forall_intro_3 associativity_helper;
   assert (Monoid.associativity_lemma Prims.prop mult);
-  Monoid.intro_monoid Prims.prop u900 mult
+  Monoid.intro_monoid Prims.prop u855 mult
 let bool_and_monoid =
   let and_ b1 b2 = b1 && b2 in
   Monoid.intro_monoid Prims.bool true and_
@@ -465,7 +465,7 @@ let _ =
   Monoid.intro_monoid_morphism Monoid.neg Monoid.disjunction_monoid Monoid.conjunction_monoid
 let mult_act_lemma m a mult act =
   forall (x: m) (x': m) (y: a). act (mult x x') y == act x (act x' y)
-let unit_act_lemma m a u904 act = forall (y: a). act u904 y == y
+let unit_act_lemma m a u859 act = forall (y: a). act u859 y == y
 unopteq
 type left_action (mm: Monoid.monoid m) (a: Type) =
   | LAct :

--- a/tests/micro-benchmarks/PropEncoding.fst
+++ b/tests/micro-benchmarks/PropEncoding.fst
@@ -1,0 +1,30 @@
+module PropEncoding
+
+(* The SMT encoding of prop is extensional: a prop is encoded as a boxed SMT
+   boolean recording its validity. So propositional extensionality, excluded
+   middle, and the fact that every prop is either True or False hold out of the
+   box. *)
+
+let every_prop_is_true_or_false = assert (forall (p: prop). p == True \/ p == False)
+
+let excluded_middle (p: prop) = assert (p \/ ~p)
+
+let prop_ext (p q: prop) = assert ((p <==> q) ==> p == q)
+
+let true_is_not_false = assert (~(True == False))
+
+(* Extensionality must not make abstract props provable. In particular,
+   prop-valued type constructors, which are `new` and would otherwise be given a
+   distinct SMT constructor id, must stay uninterpreted. *)
+
+assume val prop_val : int -> prop
+[@@expect_failure] let leak_val (x:int) : squash (prop_val x) = ()
+
+assume new type prop_typ : int -> prop
+[@@expect_failure] let leak_typ (x:int) : squash (prop_typ x) = ()
+
+assume new type prop_typ0 : prop
+[@@expect_failure] let leak_typ0 () : squash prop_typ0 = ()
+
+assume new type prop_typ2 : int -> int -> prop
+[@@expect_failure] let leak_typ2 (x y:int) : squash (prop_typ2 x y) = ()

--- a/ulib/FStar.Algebra.Monoid.fst
+++ b/ulib/FStar.Algebra.Monoid.fst
@@ -27,13 +27,13 @@ module PropExt = FStar.PropositionalExtensionality
 (** Definition of a monoid *)
 
 let right_unitality_lemma (m:Type) (u:m) (mult:m -> m -> m) =
-  forall (x:m). x `mult` u == x
+  forall (x:m). {:pattern (x `mult` u)} x `mult` u == x
 
 let left_unitality_lemma (m:Type) (u:m) (mult:m -> m -> m) =
-  forall (x:m). u `mult` x == x
+  forall (x:m). {:pattern (u `mult` x)} u `mult` x == x
 
 let associativity_lemma (m:Type) (mult:m -> m -> m) =
-  forall (x y z:m). x `mult` y `mult` z == x `mult` (y `mult` z)
+  forall (x y z:m). {:pattern (x `mult` y `mult` z)} x `mult` y `mult` z == x `mult` (y `mult` z)
 
 unopteq
 type monoid (m:Type) =

--- a/ulib/FStar.Matrix.fst
+++ b/ulib/FStar.Matrix.fst
@@ -1126,7 +1126,7 @@ let matrix_mul_is_left_distributive #c #eq #m #n #p (add: CE.cm c eq)
   in matrix_equiv_from_proof eq lhs rhs aux 
 #pop-options
 
-#push-options "--z3rlimit_factor 8"
+#push-options "--z3rlimit_factor 4"
 #restart-solver
 let matrix_mul_is_right_distributive #c #eq #m #n #p (add: CE.cm c eq)
                                     (mul: CE.cm c eq{is_fully_distributive mul add /\ is_absorber add.unit mul}) 

--- a/ulib/FStar.Matrix.fst
+++ b/ulib/FStar.Matrix.fst
@@ -1126,7 +1126,7 @@ let matrix_mul_is_left_distributive #c #eq #m #n #p (add: CE.cm c eq)
   in matrix_equiv_from_proof eq lhs rhs aux 
 #pop-options
 
-#push-options "--z3rlimit_factor 4"
+#push-options "--z3rlimit_factor 8"
 #restart-solver
 let matrix_mul_is_right_distributive #c #eq #m #n #p (add: CE.cm c eq)
                                     (mul: CE.cm c eq{is_fully_distributive mul add /\ is_absorber add.unit mul}) 

--- a/ulib/FStar.PCM.fst
+++ b/ulib/FStar.PCM.fst
@@ -179,6 +179,8 @@ let frame_preserving_val_to_fp_upd (#a:Type u#a) (p:pcm a)
   (x:Ghost.erased a) (v:a{frame_preserving p x v /\ p.refine v})
   : frame_preserving_upd p x v
   = Classical.forall_intro (p.comm v);
+    compatible_refl p v;
+    assert (forall (y z:a). composable p y z <==> composable p z y);
     fun _ -> v
 
 (** The PCM [p] is exclusive to element [x] if the only element composable with [x] is [p.one] *)

--- a/ulib/FStar.Reflection.TermEq.fst
+++ b/ulib/FStar.Reflection.TermEq.fst
@@ -671,7 +671,7 @@ val pat_arg_cmp      : comparator_for' pareq
 val br_cmp           : comparator_for' breq
 val match_returns_ascription_cmp : comparator_for' maeq
 
-#push-options "--fuel 2 --ifuel 2"
+#push-options "--fuel 2 --ifuel 2 --z3rlimit_factor 4"
 
 let rec term_cmp t1 t2 =
   let tv1 = inspect_ln t1 in

--- a/ulib/FStar.UInt.fst
+++ b/ulib/FStar.UInt.fst
@@ -290,7 +290,7 @@ let rec to_vec_lt_pow2 #n a m i =
       end
 
 (** Used in the next two lemmas *)
-#push-options "--initial_fuel 0 --max_fuel 1"
+#push-options "--initial_fuel 0 --max_fuel 1 --z3rlimit_factor 4"
 let rec index_to_vec_ones #n m i =
    let a = pow2 m - 1 in
    pow2_le_compat n m;


### PR DESCRIPTION
Experiment: change the SMT encoding of `prop` so that it is boxed to an SMT `Bool`, just like `bool`, and use the formula encoding for prop-valued definitions.

### 1. `prop` is boxed to an SMT `Bool`

A new `BoxProp` constructor, plus primitive type axioms for `Prims.prop` mirroring those for `Prims.bool`:

```smt2
(assert (! (forall ((@u0 Bool)) (! (HasType (BoxProp @u0) Prims.prop) :pattern ((BoxProp @u0)))) :named prop_typing))
(assert (! (forall ((@u0 Bool)) (! (iff (Valid (BoxProp @u0)) @u0) :pattern ((Valid (BoxProp @u0))))) :named prop_validity))
(assert (! (forall ((@u0 Fuel) (@x1 Term)) (! (implies (HasTypeFuel @u0 @x1 Prims.prop) (is-BoxProp @x1)) :pattern ((HasTypeFuel @u0 @x1 Prims.prop)))) :named prop_inversion))
```

This bakes propositional extensionality into the encoding. The following now all go through out of the box:

```fstar
let test1 = assert (forall (p: prop). p == True \/ p == False)
let test2 (p:prop) = assert (p \/ ~p)
let test3 (p q:prop) = assert ((p <==> q) ==> p == q)
```

`True <> False` is of course still provable.

### 2. Formula equations for prop-valued definitions

This re-enables the `is_logical` check in `encode_top_level_let`, which was disabled precisely because it needed propositional extensionality. For `let f (n: nat) : prop = n > 0 /\ n < 10` we now generate

```smt2
(assert (! (forall ((@x0 Term))
  (! (= (Valid (E.f @x0))
        (and (> (BoxInt_proj_0 @x0) 0) (< (BoxInt_proj_0 @x0) 10)))
   :pattern ((E.f @x0)) :qid equation_E.f)) :named equation_E.f))
```

instead of a term equation `f n == body`. The term equation is no longer emitted at all: it follows from the formula equation now that `prop` is extensional.

### Fallout

- `FStar.Reflection.TermEq`, `FStar.UInt`: rlimit bumps (borderline queries).
- `FStar.PCM.frame_preserving_val_to_fp_upd`: needs `compatible_refl` and a symmetry hint for `composable`.
- `FStar.Algebra.Monoid`: the monoid laws are prop-valued definitions, so their bodies are now encoded as native SMT quantifiers. Without patterns they made `FStar.Tactics.CanonMonoid` blow up (no rlimit was sufficient — up to 16x), so they get their natural patterns. The "quantified formulas without any patterns. Dangerous stuff!" comment in `FStar.Tactics.CanonMonoid` was already flagging this.
- `tests/error-messages/Monoid`: expected output re-accepted; gensym numbering only.
- Checked files cache the SMT declarations of a module, so `cache_version_number` is bumped.

### Validation

Full `ulib`, `tests/micro-benchmarks`, `tests/error-messages`, and the stage2 bootstrap all pass.