### PR TITLE
bench: keep PR comment under GitHub's size limit

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -126,6 +126,7 @@ jobs:
           python3 fstar-head/.scripts/ramon-report.py \
             fstar-base fstar-head \
             -o report.md \
+            --max-bytes 60000 \
             --lhs-label "Base (${{ steps.pr.outputs.base_ref }} @ ${{ steps.pr.outputs.base_sha }})" \
             --rhs-label "PR #${{ github.event.issue.number }} (${{ steps.pr.outputs.head_ref }} @ ${{ steps.pr.outputs.head_sha }})"
           python3 fstar-head/.scripts/ramon-report.py \
@@ -157,6 +158,12 @@ jobs:
             const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
             let body = fs.readFileSync('report.md', 'utf8');
             body += `\n\n---\n📎 [Download HTML report and raw .ramon files](${runUrl}#artifacts)\n`;
+            // GitHub rejects comments over 65536 characters.
+            const LIMIT = 65000;
+            if (body.length > LIMIT) {
+              const note = '\n\n_(report truncated: exceeded GitHub comment size limit)_\n';
+              body = body.slice(0, LIMIT - note.length) + note;
+            }
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.scripts/ramon-report.py
+++ b/.scripts/ramon-report.py
@@ -204,7 +204,7 @@ def compute_stats(matches):
 
 # ── Markdown Report ──────────────────────────────────────────────────────────
 
-def generate_markdown(matches, stats, lhs_label, rhs_label):
+def generate_markdown(matches, stats, lhs_label, rhs_label, full_table=True):
     s = stats
     mp = s["mem_pct"]
     tp = s["time_pct"]
@@ -306,12 +306,16 @@ def generate_markdown(matches, stats, lhs_label, rhs_label):
     L.append("\n</details>\n")
 
     # ── Full comparison ──
-    L.append(f"<details><summary>📋 Full Comparison ({s['n_matches']} tests)</summary>\n")
-    L.append(md_table(sorted(matches, key=lambda m: m["fn"]), n=len(matches)))
-    L.append("\n</details>\n")
+    if full_table:
+        L.append(f"<details><summary>📋 Full Comparison ({s['n_matches']} tests)</summary>\n")
+        L.append(md_table(sorted(matches, key=lambda m: m["fn"]), n=len(matches)))
+        L.append("\n</details>\n")
 
     # ── Notes ──
     L.append("---\n")
+    if not full_table:
+        L.append(f"> ℹ️ The full comparison table ({s['n_matches']} tests) was omitted to keep this "
+                 "report within GitHub's comment size limit. See the attached HTML report for all tests.\n")
     L.append("> **Note:** Memory values report the peak OCaml heap of the F\\* process (excluding Z3 subprocesses). "
              "Time measurements are from single runs and may be noisy, especially for fast tests. "
              "Tests with baseline time < 0.1s are excluded from time statistics. "
@@ -624,6 +628,9 @@ def main():
                         help="Output format (default: auto-detect from filename)")
     parser.add_argument("--lhs-label", default=None, help="Label for baseline")
     parser.add_argument("--rhs-label", default=None, help="Label for patched")
+    parser.add_argument("--max-bytes", type=int, default=0,
+                        help="If > 0, keep the (markdown) report under this many bytes, "
+                             "dropping the full comparison table if needed")
     args = parser.parse_args()
 
     # Auto-detect format from filename
@@ -659,6 +666,14 @@ def main():
 
     if fmt == "md":
         output = generate_markdown(matches, st, lhs_label, rhs_label)
+        if args.max_bytes > 0 and len(output.encode("utf-8")) > args.max_bytes:
+            print(f"Report exceeds {args.max_bytes} bytes; dropping full comparison table")
+            output = generate_markdown(matches, st, lhs_label, rhs_label, full_table=False)
+        if args.max_bytes > 0 and len(output.encode("utf-8")) > args.max_bytes:
+            print(f"Report still exceeds {args.max_bytes} bytes; truncating")
+            suffix = "\n\n_(report truncated: exceeded size limit)_\n"
+            budget = args.max_bytes - len(suffix.encode("utf-8"))
+            output = output.encode("utf-8")[:budget].decode("utf-8", "ignore") + suffix
     else:
         output = generate_html(matches, st, lhs_label, rhs_label)
 


### PR DESCRIPTION
The benchmark action fails when the report comment exceeds GitHub's 65536-character limit (see [this run](https://github.com/FStarLang/FStar/actions/runs/33568462344)). The culprit is mostly the "Full Comparison" table, which is not essential since the HTML artifact has everything.

- `.scripts/ramon-report.py`: new `--max-bytes N` option. If the markdown report exceeds it, the full comparison table is dropped (with a note pointing at the HTML report); if it is still too large, the report is truncated.
- `.github/workflows/bench.yml`: pass `--max-bytes 60000` for `report.md`, and truncate the final comment body at 65000 chars as a safety net. The HTML report is unaffected.

Tested locally with 600 synthetic ramon results: 72 KB report → 11 KB, and the truncation fallback works.