### PR TITLE
Harden reading and writing checked files in the presence of concurrent F* processes

### DIFF
--- a/src/fstar/FStarC.CheckedFiles.fst
+++ b/src/fstar/FStarC.CheckedFiles.fst
@@ -301,16 +301,25 @@ let load_checked_file_with_tc_result
 =
   debug (fun _ -> Format.print1 "Trying to load checked file with tc result %s\n" checked_fn);
 
-  let load_tc_result' (fn:string) : ML (list (string & string) & tc_result) =
-    match load_tc_result fn with
-    | Some x -> x
-    | None -> failwith "Impossible! if first phase of loading was unknown, it should have succeeded"
+  (* The first phase of the load only reads the head of the checked file. A
+     concurrent fstar.exe sharing this --cache_dir may replace the file in
+     between the two phases, in which case reading the rest of it fails. That
+     is not an internal error: just record the entry as invalid, so that the
+     caller rechecks the module. *)
+  let vanished () : ML (either string tc_result) =
+    let msg = Format.fmt1 "checked file %s changed while it was being read" checked_fn in
+    let _ = add_and_return checked_fn (Invalid msg, Inl msg) in
+    Inl msg
   in
 
   let elt = load_checked_file fn checked_fn in  //first step, in case some client calls it directly
   match elt with
   | Invalid msg, _ -> Inl msg
-  | Valid _, _ -> checked_fn |> load_tc_result' |> snd |> Inr
+  | Valid _, _ -> (
+    match load_tc_result checked_fn with
+    | None -> vanished ()
+    | Some (_, tc_result) -> Inr tc_result
+  )
   | Unknown checked_digest, parsing_data ->
     match hash_dependences deps fn (Dep.deps_of deps fn) with
     | Inl msg ->
@@ -318,7 +327,9 @@ let load_checked_file_with_tc_result
       let _ = add_and_return checked_fn elt in
       Inl msg
     | Inr deps_dig' ->
-      let deps_dig, tc_result = checked_fn |> load_tc_result' in
+    match load_tc_result checked_fn with
+    | None -> vanished ()
+    | Some (deps_dig, tc_result) ->
       let module_name = fn |> Dep.module_name_of_file in
       if deps_dig = deps_dig'
       || Options.should_be_already_cached module_name

--- a/src/ml/FStarC_Util.ml
+++ b/src/ml/FStarC_Util.ml
@@ -776,15 +776,30 @@ let write_file (fn:string) s =
   append_to_file fh s;
   close_out_channel fh
 
+(* Write [fname] atomically: the payload is first written to a private
+   temporary file in the same directory, which is then renamed over [fname].
+   Since [Sys.rename] is atomic on POSIX, a concurrent reader of [fname]
+   observes either the previous contents or the new ones in full, but never a
+   partially written file. This matters because several fstar.exe processes
+   may share a single --cache_dir. *)
+let with_out_channel_atomic (fname:string) (f: out_channel -> 'a) : 'a =
+  maybe_create_parent fname;
+  let tmp =
+    Filename.temp_file ~temp_dir:(Filename.dirname fname)
+      (Filename.basename fname) ".tmp"
+  in
+  let channel = open_out_bin tmp in
+  let result =
+    try BatPervasives.finally (fun () -> close_out channel) f channel
+    with e -> (try Sys.remove tmp with _ -> ()); raise e
+  in
+  Sys.rename tmp fname;
+  result
+
 let save_value_to_file (fname:string) value =
   (* BatFile.with_file_out uses Unix.openfile (which isn't available in
      js_of_ocaml) instead of Pervasives.open_out, so we don't use it here. *)
-  maybe_create_parent fname;
-  let channel = open_out_bin fname in
-  BatPervasives.finally
-    (fun () -> close_out channel)
-    (fun channel -> output_value channel value)
-    channel
+  with_out_channel_atomic fname (fun channel -> output_value channel value)
 
 let load_value_from_file (fname:string) =
   (* BatFile.with_file_in uses Unix.openfile (which isn't available in
@@ -799,16 +814,13 @@ let load_value_from_file (fname:string) =
 
 let save_2values_to_file (fname:string) value1 value2 =
   try
-    maybe_create_parent fname;
-    let channel = open_out_bin fname in
-    BatPervasives.finally
-      (fun () -> close_out channel)
-      (fun channel ->
-        output_value channel value1;
-        output_value channel value2)
-      channel
+    with_out_channel_atomic fname (fun channel ->
+      output_value channel value1;
+      output_value channel value2)
   with
-  | e -> delete_file fname;
+  (* The atomic write leaves [fname] untouched on failure, but an older,
+     now-stale file may still be there: get rid of it. *)
+  | e -> (try delete_file fname with _ -> ());
          raise e
 
 let load_2values_from_file (fname:string) =
@@ -827,24 +839,21 @@ let load_2values_from_file (fname:string) =
 (* See FStarC.Util.fsti for the layout of this container format. *)
 let save_3values_to_file (fname:string) value1 value2 value3 =
   try
-    maybe_create_parent fname;
     let b12 = Marshal.to_string value1 [] ^ Marshal.to_string value2 [] in
     let b3 = Marshal.to_string value3 [] in
     (* A Merkle-style digest of the two halves, so that we never have to
        materialize the concatenation of the whole payload. *)
     let dig = BatDigest.to_hex (BatDigest.string (BatDigest.string b12 ^ BatDigest.string b3)) in
-    let channel = open_out_bin fname in
-    BatPervasives.finally
-      (fun () -> close_out channel)
-      (fun channel ->
-        output_value channel dig;
-        output_binary_int channel (String.length b12);
-        output_string channel b12;
-        output_string channel b3)
-      channel;
+    with_out_channel_atomic fname (fun channel ->
+      output_value channel dig;
+      output_binary_int channel (String.length b12);
+      output_string channel b12;
+      output_string channel b3);
     dig
   with
-  | e -> delete_file fname;
+  (* The atomic write leaves [fname] untouched on failure, but an older,
+     now-stale file may still be there: get rid of it. *)
+  | e -> (try delete_file fname with _ -> ());
          raise e
 
 let with_in_channel_opt (fname:string) (f: in_channel -> 'a) : 'a option =


### PR DESCRIPTION
This came up while porting hax to the latest F*, and its build seems to call F* multiple times on files with overlapping dependences