### PR TITLE
custard: refuse an unrepresentable float width at the value, not only at the type

### DIFF
--- a/src/custard/FStarC.Custard.PrintOCaml.fst
+++ b/src/custard/FStarC.Custard.PrintOCaml.fst
@@ -324,6 +324,31 @@ let int_inj (sw : signedness & width) : string =
   let sgn, _ = sw in
   int_module sw ^ (match sgn with Unsigned -> ".uint_to_t" | Signed -> ".int_to_t")
 
+(* Section 38.  OCaml has one floating-point type and it is [double], so
+   [Float64] is faithful and no other width is; the C backend is where a
+   single-precision program belongs, and the backend that cannot round right
+   says so rather than rounding wrong.
+
+   This is called from three places, not one.  {!ty} alone is not enough: it
+   is reached only when the width appears in a *signature*, and a program
+   whose float values all live inside one function has no signature that
+   mentions them.  Such a program used to extract silently and compute at
+   binary64 -- [1.0f +. 1e-8f] is [1.0f] at binary32 and is not at binary64,
+   so the C and OCaml backends returned different answers for the same source
+   with no diagnostic.  So the other two calls are at the two places a float
+   value is actually emitted: a literal, and an operator. *)
+let reject_fwidth (fw:fwidth) : ML unit =
+  if Float64? fw then () else
+  FStarC.Errors.raise_error0 FStarC.Errors.Codes.Error_CustardNoCRepresentation [
+    FStarC.Errors.Msg.text
+      "Custard: FStar.Float32 has no OCaml representation.";
+    FStarC.Errors.Msg.text
+      "OCaml's float is IEEE 754 binary64 and there is no binary32 type to \
+       round to, so a single-precision program would silently compute at \
+       double precision (section 38).";
+    FStarC.Errors.Msg.text
+      "Use FStar.Float64, or extract with --custard_backend C." ]
+
 let rec ty (t:cty) : ML string =
   match t with
   | TUnit -> "unit"
@@ -331,21 +356,10 @@ let rec ty (t:cty) : ML string =
   | TAny -> "Obj.t"
   | TVar x -> "'" ^ ocaml_var x
   | TInt sw -> int_module sw ^ ".t"
-  (* Section 38.  OCaml has one floating-point type and it is [double], so
-     [Float64] is faithful and [Float32] is not; the C backend is where a
-     single-precision program belongs, and the backend that cannot round
-     right says so rather than rounding wrong. *)
+  (* Section 38; the reason, and the other two call sites, are on
+     [reject_fwidth]. *)
   | TFloat Float64 -> "float"
-  | TFloat Float32 ->
-    FStarC.Errors.raise_error0 FStarC.Errors.Codes.Error_CustardNoCRepresentation [
-      FStarC.Errors.Msg.text
-        "Custard: FStar.Float32 has no OCaml representation.";
-      FStarC.Errors.Msg.text
-        "OCaml's float is IEEE 754 binary64 and there is no binary32 type to \
-         round to, so a single-precision program would silently compute at \
-         double precision (section 38).";
-      FStarC.Errors.Msg.text
-        "Use FStar.Float64, or extract with --custard_backend C." ]
+  | TFloat fw -> reject_fwidth fw; "float"
   | TArrow (t1, _, t2) -> "(" ^ ty t1 ^ " -> " ^ ty t2 ^ ")"
   | TTuple ts -> "(" ^ String.concat " * " (List.map ty ts) ^ ")"
   (* Section 8.4: a buffer is an OCaml array.  This is faithful for everything
@@ -411,7 +425,7 @@ let constant (c:constant) : ML string =
   | CBool b -> if b then "true" else "false"
   (* Section 39.  OCaml's lexer accepts the same grammar section 39.2 does,
      so no suffix and no reformatting. *)
-  | CFloat (v, _) -> "(" ^ float_lit_to_string v ^ ")"
+  | CFloat (v, fw) -> reject_fwidth fw; "(" ^ float_lit_to_string v ^ ")"
   (* Prims.int is arbitrary precision in the OCaml runtime, exactly as in the
      ML extraction. *)
   | CInt (v, b, None) -> "(Prims.parse_int \"" ^ int_lit_to_string v b ^ "\")"
@@ -437,7 +451,8 @@ let op_name (o:prim_op) : ML string =
   match o.po_ty with
   (* Section 38.  OCaml's own float operators, since [float] is a real OCaml
      type and going through a support module would only rename them. *)
-  | Some (PFloat _) ->
+  | Some (PFloat fw) ->
+    reject_fwidth fw;
     (match o.po_op with
      | Add | AddW -> "( +. )" | Sub | SubW -> "( -. )"
      | Mult | MultW -> "( *. )" | Div | DivW -> "( /. )"

--- a/tests/custard/FloatHole.fst
+++ b/tests/custard/FloatHole.fst
@@ -1,0 +1,23 @@
+module FloatHole
+
+(* Section 38.  A Float32 program with no Float32 in any signature.
+
+   [a], [b] and the sum are all local to [main], whose type is [unit -> ML
+   U32.t], so nothing the OCaml backend prints as a *type* is ever a float.
+   The refusal in [ty] therefore never fires, and before the check moved to
+   the literal and the operator this extracted silently and computed at
+   binary64.
+
+   That is not a missing feature, it is a different answer.  At binary32 the
+   sum is exactly [a], because 1e-8 is far below the ulp of 1.0 at 24 bits of
+   significand; at binary64 it is not.  So the C backend returned 0 here and
+   the OCaml backend returned 1, from this source, with no diagnostic. *)
+
+open FStar.All
+module U32 = FStar.UInt32
+module F = FStar.Float32
+
+let main () : ML U32.t =
+  let a = F.of_literal "1.0" in
+  let b = F.of_literal "0.00000001" in
+  if F.ieee_eq (F.add a b) a then 0ul else 1ul

--- a/tests/custard/Makefile
+++ b/tests/custard/Makefile
@@ -1360,6 +1360,19 @@ CGREP_FloatOptIn += "(1.0f < FLT_MAX)"
 # attribute existed every one of these was an undefined FloatLib_* symbol.
 CNOGREP_FloatOptIn += "FloatLib"
 
+# Section 38.1.  The OCaml backend refuses a width it cannot represent -- at
+# the value, not only at the type.  [ty] is reached only when the type is in
+# a signature, so a program whose floats are all local to one function slipped
+# past it and computed at binary64: the two backends returned different
+# answers for this source, quietly.  A wrong answer with no diagnostic is
+# worse than a refusal, so the check is at the literal and the operator too.
+REJECT_TESTS += FloatHole
+CODE_FloatHole = 368
+EGREP_FloatHole += "FStar.Float32 has no OCaml representation"
+EGREP_FloatHole += "silently compute at double precision"
+# It must name the way out, since Float64 really does work on this backend.
+EGREP_FloatHole += "custard_backend C"
+
 # Section 63.1.  A width Custard does not implement is refused at the
 # attribute, not at the first use of the type: 386 names the mistake, where
 # 368 would name the type and point at another module.


### PR DESCRIPTION
Split out of the float16 work at your suggestion in [round 59](https://github.com/FStarLang/FStar/pull/4395#issuecomment-5565265341). Independent of it, and predates it.

## The bug

`PrintOCaml` refuses `TFloat Float32`, but only in `ty`. `ty` is reached when a width appears in a **signature** — and a program whose float values all live inside one function has no signature that mentions them. That program extracted silently and computed at binary64.

`tests/custard/FloatHole.fst`:

```fstar
let main () : ML U32.t =
  let a = F.of_literal "1.0" in
  let b = F.of_literal "0.00000001" in
  if F.ieee_eq (F.add a b) a then 0ul else 1ul
```

`main : unit -> ML U32.t`. No float in any signature, so `ty` never sees one.

At binary32 the sum is exactly `a`: 1e-8 is far below the ulp of 1.0 at 24 bits of significand. At binary64 it is not. So:

| backend | emitted | exit |
|---|---|---|
| C | `1.0f + 1e-08f` | **0** |
| OCaml | `(( +. ) (1.0) (0.00000001))` | **1** |

Same source, no diagnostic. That is a different answer, not a missing feature — and it is precisely what the refusal in `ty` was written to prevent.

## The fix

The message moves to `reject_fwidth`, which `ty` now calls, and which is also called at the two places a float value is actually **emitted**: the `CFloat` constant and the `PFloat` operator. Checking where a value is printed rather than only where its type is printed is what makes it total.

`Float64` is unaffected — it is the one width OCaml's `float` represents faithfully.

## Test

`FloatHole` is a `REJECT_TESTS` entry asserting 368 on the default (OCaml) backend, pinning the width, the reason, and that the message names the way out (`--custard_backend C`), since `Float64` really does work there.

Full `tests/custard` suite green. Based on `e252e905bf`.
