### PR TITLE
custard: emit the [custard_c_header] includes above the narrow-float support block

### DIFF
--- a/src/custard/FStarC.Custard.PrintC.fst
+++ b/src/custard/FStarC.Custard.PrintC.fst
@@ -3131,8 +3131,18 @@ let print_program (base:string) (cu:unit_info) (p:program) : ML (string & string
 
   let hdr =
     header ^
-    (if !uses_narrow then narrow_support else "") ^ "\n" ^
   (match includes with [] -> "" | _ -> String.concat "\n" includes ^ "\n\n") ^
+    (* Section 66.  After the [custard_c_header] includes, not before them.
+       The support block is overridable by defining CUSTARD_FLOAT16_DEFINED
+       and supplying the type and the operations first -- which is how a CUDA
+       consumer reaches __half, the only 16-bit type wmma::fragment is a
+       template over.  Emitted above the includes, that override could not be
+       written in the program at all: the header carrying it is named by an
+       attribute on an F* declaration, so it arrives here and nowhere
+       earlier, and -include on the compiler command line was the only way
+       in.  [narrow_support] needs only <stdint.h> and <string.h>, both in
+       [header] above, so it has no reason to precede anything else. *)
+    (if !uses_narrow then narrow_support ^ "\n" else "") ^
   cpp_open ^
   String.concat "" fwds ^ (match fwds with [] -> "" | _ -> "\n") ^
   String.concat "" tys ^ (match tys with [] -> "" | _ -> "\n") ^

--- a/tests/custard/Makefile
+++ b/tests/custard/Makefile
@@ -1397,6 +1397,17 @@ CGREP_Narrow += "typedef struct { uint16_t bits; } custard_f16;"
 # why it does not use them.
 CNOGREP_Narrow += "a + b"
 
+# Section 66.  The support block is overridable, and the override reaches it
+# through [@@custard_c_header] -- so those includes have to be emitted above
+# the block.  NarrowOverride_stubs.h defines CUSTARD_FLOAT16_DEFINED and its
+# own custard_f16; below the block that is a redefinition and the compile
+# fails, so the ordering is checked by cc and not by a grep.  This is the
+# arrangement Kuiper needs, where custard_f16 has to become CUDA's __half for
+# wmma::fragment to accept it.
+C_TESTS += NarrowOverride
+CGREP_NarrowOverride += "NarrowOverride_stubs.h"
+CGREP_NarrowOverride += "CUSTARD_F16_LIT(15872U)"
+
 # Section 66.  A global at a narrow width takes the *initializer* spelling,
 # not the expression one: a compound literal has automatic storage duration
 # and cannot initialize an object with static storage duration.

--- a/tests/custard/NarrowOverride.fst
+++ b/tests/custard/NarrowOverride.fst
@@ -1,0 +1,44 @@
+module NarrowOverride
+
+open FStar.All
+
+module U16 = FStar.UInt16
+module U32 = FStar.UInt32
+
+(* Section 66.  The narrow-float support block is overridable, and the
+   override arrives through [@@custard_c_header] -- which only works if those
+   includes are emitted above the block.  Kuiper is the motivating consumer:
+   [wmma::fragment] is a template over CUDA's [__half], so a fragment holding
+   Custard's two-byte struct is not a type any [wmma] overload accepts, and
+   the way out is to make [custard_f16] be [__half] before the block is
+   reached.  There is no earlier place to say so: the header is named by an
+   attribute on an F* declaration.
+
+   [NarrowOverride_stubs.h] defines CUSTARD_FLOAT16_DEFINED and its own
+   [custard_f16].  If the block were emitted first, this file would be a
+   redefinition and the translation unit would not compile, so the ordering
+   is checked by the C compiler rather than by a grep. *)
+
+[@@FStar.Attributes.custard_float 16]
+assume val t : Type0
+
+assume val add : t -> t -> t
+assume val ieee_eq : t -> t -> bool
+assume val of_int : Int64.t -> t
+assume val of_literal : string -> t
+assume val zero : t
+assume val one : t
+
+(* The declaration that names the header.  It also reads the override's own
+   member, so the test fails if some other [custard_f16] were in scope. *)
+[@@FStar.Attributes.custard_extern "narrow_override_bits";
+   FStar.Attributes.custard_c_header "NarrowOverride_stubs.h"]
+assume val bits : t -> U16.t
+
+let main () : ML U32.t =
+  (* 1.5 at binary16 is 0x3E00 = 15872, and Custard emits that bit pattern
+     through the override's CUSTARD_F16_LIT. *)
+  let ok1 = bits (of_literal "1.5") = 15872us in
+  let ok2 = ieee_eq (add (of_int 1L) (of_int 2L)) (of_literal "3.0") in
+  let ok3 = ieee_eq (add zero one) one in
+  if ok1 && ok2 && ok3 then 0ul else 1ul

--- a/tests/custard/NarrowOverride_stubs.h
+++ b/tests/custard/NarrowOverride_stubs.h
@@ -1,0 +1,78 @@
+#ifndef NARROW_OVERRIDE_STUBS_H
+#define NARROW_OVERRIDE_STUBS_H 1
+
+/* Section 66.  A consumer's override of the narrow-float support block.
+
+   This is the arrangement the override exists for: the replacement type and
+   operations live in a header named by [@@custard_c_header] on an F*
+   declaration, so the only way they can reach the generated header is if the
+   [custard_c_header] includes are emitted *above* the block.  Emitted below
+   it, this file redefines custard_f16 and the translation unit does not
+   compile -- which is what makes this a test and not just an example.
+
+   The stand-in for CUDA's __half is a struct with a different member name,
+   so nothing here can accidentally agree with the block it replaces.  The
+   test is compiled as both C and C++, so the two literal spellings are
+   switched on __cplusplus exactly as the block does. */
+
+#include <stdint.h>
+#include <string.h>
+#ifndef __cplusplus
+#include <stdbool.h>
+#endif
+
+#define CUSTARD_FLOAT16_DEFINED
+
+typedef struct { uint16_t ovr; } custard_f16;
+typedef struct { uint16_t ovr; } custard_bf16;
+
+#ifdef __cplusplus
+#define CUSTARD_F16_LIT(b)  (custard_f16{ (uint16_t)(b) })
+#define CUSTARD_BF16_LIT(b) (custard_bf16{ (uint16_t)(b) })
+#else
+#define CUSTARD_F16_LIT(b)  ((custard_f16){ (uint16_t)(b) })
+#define CUSTARD_BF16_LIT(b) ((custard_bf16){ (uint16_t)(b) })
+#endif
+#define CUSTARD_F16_INIT(b)  { (uint16_t)(b) }
+#define CUSTARD_BF16_INIT(b) { (uint16_t)(b) }
+
+/* Only what this test uses.  A real override supplies the whole vocabulary;
+   the point here is which header wins, not the arithmetic. */
+static inline float custard_f16_to_f32(custard_f16 h) {
+  uint32_t s = (uint32_t)(h.ovr >> 15) & 1u;
+  uint32_t e = (uint32_t)(h.ovr >> 10) & 0x1Fu;
+  uint32_t m = (uint32_t)h.ovr & 0x3FFu;
+  uint32_t out; float f;
+  if (e == 0u) { out = s << 31; if (m != 0u) { out = 0u; } }
+  else { out = (s << 31) | ((e + 112u) << 23) | (m << 13); }
+  memcpy(&f, &out, sizeof f);
+  return f;
+}
+
+static inline custard_f16 custard_f16_of_f32(float f) {
+  uint32_t u; custard_f16 r;
+  memcpy(&u, &f, sizeof u);
+  r.ovr = (uint16_t)(((u >> 16) & 0x8000u) |
+                     ((((u >> 23) & 0xFFu) - 112u) << 10) |
+                     ((u >> 13) & 0x3FFu));
+  return r;
+}
+
+static inline custard_f16 custard_f16_of_i64(int64_t x) {
+  return custard_f16_of_f32((float)x);
+}
+
+static inline custard_f16 custard_f16_add(custard_f16 a, custard_f16 b) {
+  return custard_f16_of_f32(custard_f16_to_f32(a) + custard_f16_to_f32(b));
+}
+
+static inline bool custard_f16_eq(custard_f16 a, custard_f16 b) {
+  return custard_f16_to_f32(a) == custard_f16_to_f32(b);
+}
+
+/* The declaration that carries the [@@custard_c_header] naming this file.
+   It reads the override's own member, so the test would not link if some
+   other custard_f16 were the one in scope. */
+static inline uint16_t narrow_override_bits(custard_f16 v) { return v.ovr; }
+
+#endif


### PR DESCRIPTION
Follow-up to #4529, fixing a bug in it that only showed up when I tried to use the escape hatch I had built.

## The bug

Section 66 documents the narrow-float support block as overridable:

> Override by defining `CUSTARD_FLOAT16_DEFINED` and supplying the type and the operations first -- that is how a target with native instructions, or CUDA's `__half` and `__nv_bfloat16` (C++-only, hence not emitted here), gets used instead.

That was not reachable as emitted. `hdr` put the block **above** the `[@@custard_c_header]` includes:

```
  let hdr =
    header ^
    (if !uses_narrow then narrow_support else "") ^ "\n" ^
  (match includes with [] -> "" | _ -> String.concat "\n" includes ^ "\n\n") ^
```

and those includes are the only way a program can get a header of its own in front of it, because the header is named by an attribute on an F\* declaration -- so it arrives during printing and there is nowhere earlier to put it. The only way in was `-include` on the compiler command line, which is not something the program can say.

`narrow_support` needs only `<stdint.h>` and `<string.h>`, both already in the standard prologue above it, so it had no reason to precede anything.

## How it turned up

Kuiper's Tensor Core kernels. `wmma::fragment` is a template over `__half`, so a fragment holding Custard's two-byte struct is not a type any `wmma` overload accepts:

```
TC.cu(30): error: no instance of overloaded function "nvcuda::wmma::load_matrix_sync" matches the argument list
            argument types are: (nvcuda::wmma::fragment<nvcuda::wmma::accumulator, 16, 16, 16, __half, void>, custard_f16 *, size_t, nvcuda::wmma::layout_t)
```

Making `custard_f16` be `__half` is exactly what the override is for, and the representation is the format's own bit pattern either way, so it is layout-compatible by construction. With the includes moved, Kuiper's own `kuiper.h` does it and nothing else changes:

```
$ nvcc -std=c++17 -arch=sm_80 -I include -c TC.cu -o TC.o
$ cuobjdump -ptx TC.o | grep -E '\.entry|wmma\.'
.entry _Z13kuiper_kernelmmP6__halfS0_mS0_(
wmma.load.c.sync.aligned.row.m16n16k16.global.f16 ...
wmma.load.a.sync.aligned.row.m16n16k16.shared.f16 ...
wmma.load.b.sync.aligned.row.m16n16k16.shared.f16 ...
wmma.mma.sync.aligned.row.row.m16n16k16.f16.f16 ...
wmma.store.d.sync.aligned.row.m16n16k16.global.f16 ...
```

No `-include`, no post-processing pass.

## The test

`NarrowOverride` (C test). `NarrowOverride_stubs.h` defines `CUSTARD_FLOAT16_DEFINED` and its own `custard_f16` with a different member name, reached through `[@@custard_c_header]` on an extern the program calls.

The check is the compile, not a grep: the block's text is present either way, since what the guard suppresses is preprocessing and not printing. Below the includes it is a conflicting redefinition and the unit does not build. **I verified it fails under the old ordering** before restoring the fix:

```
NarrowOverride_stubs.h:76:71: error: 'struct custard_f16' has no member named 'ovr'
```

The stub switches its literal macros on `__cplusplus` exactly as the block does, since the test is compiled as both C and C++.

Full `tests/custard` suite green.

## One note for section 66

Writing a real override showed the guard is coarse: it covers the types, both literal macros, the conversions and all twenty arithmetic/comparison functions, so a consumer who only wants to change the *storage type* still reimplements arithmetic it does not care about. For Kuiper that is the right answer anyway -- on a GPU you want the native instructions too -- but a consumer that wanted `_Float16` storage with the portable arithmetic has no way to ask. Splitting the guard into a type half and an operations half would cost a second macro; I did not do it here because I have only the one consumer and would be guessing. Happy to if you want it.