### PR TITLE
custard: emit a [@@custard_extern] target verbatim, keywords included

### DIFF
--- a/src/custard/FStarC.Custard.PrintC.fst
+++ b/src/custard/FStarC.Custard.PrintC.fst
@@ -2977,9 +2977,15 @@ let print_program (base:string) (cu:unit_info) (p:program) : ML (string & string
             a symbol that already exists on the other side, spelled the way
             its own language spells it.  Sanitizing [wmma::mma_sync] into
             [wmma__mma_sync] does not make it legal, it makes it absent.
-            [escape_kw] stays, because a C keyword really would be a
-            mistake. *)
-         | Some t -> escape_kw t);
+            A C keyword is not escaped either, and for the same reason.
+            The escape was here to catch a mistake, but it cannot: renaming
+            [float] to [float_] does not make a wrong name right, it turns a
+            link error against a name the program *did* write into one
+            against a name it did not.  And the name is sometimes exactly a
+            keyword on purpose -- Kuiper's [wmma::fragment<..., float>] needs
+            a token spelled [float], and the type path above already lets
+            [auto] through for the same reason.  The two paths now agree. *)
+         | Some t -> t);
       (* A unit parameter of an *external* goes too, and unconditionally: the
          function on the other side is C, C has no unit value, and whatever it
          was declared as it was not declared to take one.  There is no body to

--- a/tests/custard/ExternKw.fst
+++ b/tests/custard/ExternKw.fst
@@ -1,0 +1,34 @@
+module ExternKw
+
+open FStar.All
+
+module U64 = FStar.UInt64
+module U32 = FStar.UInt32
+
+(* Section 45.1.  A [@@custard_extern] target is a symbol that already exists
+   on the other side, spelled the way its own language spells it -- so it is
+   emitted verbatim, and that includes a C keyword.
+
+   The keyword case is not hypothetical: the operand of a C++ template
+   argument list or of a type-taking macro is often exactly a keyword.
+   Kuiper's Tensor Core accumulator is [wmma::fragment<..., float>], and
+   there is no other way to write [float].  Escaping it to [float_] could
+   not have caught a mistake -- it turns a link error against a name the
+   program wrote into one against a name it did not.
+
+   The external *type* path has always been verbatim, which is what lets
+   Kuiper spell a fragment's type as [auto]; this pins that the value path
+   agrees. *)
+
+assume new type tok : Type0
+
+[@@FStar.Attributes.custard_extern "float";
+   FStar.Attributes.custard_c_header "ExternKw_stubs.h"]
+assume val kw_float : tok
+
+[@@FStar.Attributes.custard_extern "KW_SIZEOF";
+   FStar.Attributes.custard_c_header "ExternKw_stubs.h"]
+assume val kw_sizeof : tok -> U64.t
+
+let main () : ML U32.t =
+  if kw_sizeof kw_float = 4uL then 0ul else 1ul

--- a/tests/custard/ExternKw_stubs.h
+++ b/tests/custard/ExternKw_stubs.h
@@ -1,0 +1,8 @@
+#ifndef EXTERN_KW_STUBS_H
+#define EXTERN_KW_STUBS_H 1
+
+/* A macro whose argument is a *type*, which is why the token passed to it has
+   to survive verbatim: [KW_SIZEOF(float_)] names nothing. */
+#define KW_SIZEOF(ty) ((uint64_t)sizeof(ty))
+
+#endif

--- a/tests/custard/Makefile
+++ b/tests/custard/Makefile
@@ -1397,6 +1397,16 @@ CGREP_Narrow += "typedef struct { uint16_t bits; } custard_f16;"
 # why it does not use them.
 CNOGREP_Narrow += "a + b"
 
+# Section 45.1.  A [@@custard_extern] target is emitted verbatim, and that
+# includes a C keyword: the operand of a type-taking macro or of a C++
+# template argument list often *is* one.  Kuiper's accumulator fragment is
+# wmma::fragment<..., float> and there is no other spelling of float.  The
+# external type path was already verbatim -- that is what lets Kuiper spell a
+# fragment type as auto -- and this pins that the value path agrees.
+C_TESTS += ExternKw
+CGREP_ExternKw += "KW_SIZEOF(float)"
+CNOGREP_ExternKw += "float_"
+
 # Section 66.  The support block is overridable, and the override reaches it
 # through [@@custard_c_header] -- so those includes have to be emitted above
 # the block.  NarrowOverride_stubs.h defines CUSTARD_FLOAT16_DEFINED and its


### PR DESCRIPTION
The external *type* path has always been verbatim — that is what lets Kuiper spell a Tensor Core fragment's type as `auto`. The value path agreed except for `escape_kw`, whose comment claimed parity with the type path while adding the escape.

A keyword is not a mistake to be caught here. The operand of a C++ template argument list or of a type-taking macro often *is* one: Kuiper's accumulator is `wmma::fragment<..., float>` and there is no other spelling of `float`. Rewriting it to `float_` cannot rescue a wrong name; it only turns a link error against a name the program wrote into one against a name it did not.

`tests/custard/ExternKw` passes `float` through `KW_SIZEOF`, a macro that takes a *type* — so the check is the compile, not just the grep. Verified to fail without the fix (`KW_SIZEOF(float_)`).

Found while getting Kuiper's Tensor Core kernels through the direct-to-C backend; `tok_float` was the declaration that hit it.