### PR TITLE
Fix qualified record type lookup

### DIFF
--- a/src/syntax/FStarC.Syntax.DsEnv.fst
+++ b/src/syntax/FStarC.Syntax.DsEnv.fst
@@ -1277,9 +1277,8 @@ let try_lookup_record_by_field_name_many env (fieldnames:list lident) : ML _ =
 
 let try_lookup_record_type env (typename:lident) : ML (option record_or_dc) =
   let find_in_cache (name:lident) : ML (option record_or_dc) =
-    let ns, id = ns_of_lid name, ident_of_lid name in
     BU.find_map (peek_record_cache()) (fun record ->
-      if ident_equals (ident_of_lid record.typename) id
+      if lid_equals record.typename name
       then Some record
       else None
     )

--- a/tests/bug-reports/closed/RecordTypeLookupModA.fst
+++ b/tests/bug-reports/closed/RecordTypeLookupModA.fst
@@ -1,0 +1,5 @@
+module RecordTypeLookupModA
+
+type shared_t = { target: int; pad1: int; pad2: int }
+
+let val_a : shared_t = { target = 111; pad1 = 1; pad2 = 2 }

--- a/tests/bug-reports/closed/RecordTypeLookupModB.fst
+++ b/tests/bug-reports/closed/RecordTypeLookupModB.fst
@@ -1,0 +1,5 @@
+module RecordTypeLookupModB
+
+type shared_t = { pad1: int; pad2: int; target: int }
+
+let val_b : shared_t = { pad1 = 8; pad2 = 9; target = 222 }

--- a/tests/bug-reports/closed/RecordTypeLookupTest.fst
+++ b/tests/bug-reports/closed/RecordTypeLookupTest.fst
@@ -1,0 +1,10 @@
+module RecordTypeLookupTest
+
+open RecordTypeLookupModA
+open RecordTypeLookupModB
+
+let a () : int =
+  let open val_a <: RecordTypeLookupModA.shared_t in
+  target
+
+let _ = assert_norm (a () == 111)


### PR DESCRIPTION
`FStarC.Syntax.DsEnv.try_lookup_record_type` uses resolve_in_open_namespaces to resolve the fully-qualified name, then searches in the peek_record_cache to find the actual record.
However, it was comparing against the unqualified name in peek_record_cache, so if you're importing modules that both define records with the same unqualified name, it might take the wrong one.

The fix seems simple: check the resolved qualified name against the cached name.

(Opening this as a draft PR for now to check in CI. If this draft PR workflow is annoying let me know and I can run more tests locally first)