### PR TITLE
Fix #4534: make Pulse.Lib.GlobalVar.mk_gvar nondeterministic

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,23 @@ Guidelines for the changelog:
     silently: no warning 272 (*top-level let-bindings must be total*) and no
     `Prims.nonempty` proof obligation. `Dv` at the top level is unchanged.
 
+    The effect is still *masked*, exactly as for `Dv`: the binding gets no
+    defining equation in the SMT encoding and is not delta-unfolded. So two
+    globals defined by the same nondeterministic expression are not provably
+    equal, which is what makes `Nd` usable for allocating global state.
+
+    ```fstar
+    assume val f : unit -> Nd int
+    let g1 = f ()
+    let g2 = f ()
+    let _ = assert (g1 == g2)  // fails, as it must
+    ```
+
+  * **`Pulse.Lib.GlobalVar.mk_gvar` is now `Nd`** (issue #4534). It used to be
+    a pure total function, so two global variables declared with the same
+    initializer were provably equal, while extraction gives each `let` its own
+    call to the initializer — enough to prove `False` about extracted code.
+
   * **`FStar.Sealed` is now an interface to nondivergent values.**
     `FStar.Sealed.unseal : sealed a -> Nd a` has been added: unsealing is
     total, but nondeterministic, which is exactly what keeps it compatible

--- a/pulse/lib/pulse/lib/Pulse.Lib.GlobalVar.fsti
+++ b/pulse/lib/pulse/lib/Pulse.Lib.GlobalVar.fsti
@@ -24,12 +24,18 @@ open Pulse.Lib.Trade
 
 val gvar (#a:Type0) (p:a -> slprop) : Type0
 
+(* Nondeterministic: each application of [mk_gvar] denotes a *distinct*
+   global, since extraction gives every top-level [let] its own call to
+   [init]. If this were a pure function, two syntactically equal
+   applications would be provably equal, while at runtime they are two
+   different objects (issue #4534). [Nd] terminates, so a [gvar] may still
+   be defined at the top level. *)
 val mk_gvar
       (#a:Type0)
       (#p:a -> slprop) 
       {| (x:a -> duplicable (p x)) |}
       (init:unit -> stt a emp (fun x -> p x))
-: gvar p
+: Nd (gvar p)
 
 val read_gvar_ghost (#a:Type0) (#p:a -> slprop) (x:gvar p) : GTot a
 

--- a/pulse/test/TestGlobalVar.fst
+++ b/pulse/test/TestGlobalVar.fst
@@ -1,0 +1,27 @@
+module TestGlobalVar
+#lang-pulse
+open Pulse.Lib.Pervasives
+open Pulse.Class.Duplicable
+module G = Pulse.Lib.GlobalVar
+
+assume val p : int -> slprop
+assume val dup_p : (x:int -> duplicable (p x))
+assume val init : unit -> stt int emp (fun x -> p x)
+
+(* [mk_gvar] is nondeterministic, so a global may still be defined at the
+   top level (no warning 272, no [nonempty] obligation). *)
+let g1 : G.gvar p = G.mk_gvar #_ #_ #dup_p init
+let g2 : G.gvar p = G.mk_gvar #_ #_ #dup_p init
+
+(* But two globals with the same initializer must not be identified: at
+   runtime each [let] gets its own call to [init]. See issue #4534. *)
+[@@expect_failure [19]]
+let bad () : squash (g1 == g2) = ()
+
+[@@expect_failure [19]]
+let bad_ghost () : squash (G.read_gvar_ghost g1 == G.read_gvar_ghost g2) = ()
+
+(* A global is of course equal to itself. *)
+let good () : squash (g1 == g1) = ()
+
+let good_ghost () : squash (G.read_gvar_ghost g1 == G.read_gvar_ghost g1) = ()

--- a/src/typechecker/FStarC.TypeChecker.TcTerm.fst
+++ b/src/typechecker/FStarC.TypeChecker.TcTerm.fst
@@ -4308,20 +4308,25 @@ and check_top_level_let env e : ML _ =
          (* Check that it doesn't have a top-level effect; warn if it does.
             Do not warn in phase1 to avoid double errors.*)
          let e2, c1 =
-           let ok, c1 = TcUtil.check_top_level (Env.push_univ_vars env univ_vars) g1 c1 in //check that it has no effect and a trivial pre-condition
-           if ok
-           then e2, c1
-           else (
-             if not env.phase1 then (
+           let action, c1 = TcUtil.check_top_level (Env.push_univ_vars env univ_vars) g1 c1 in //check that it has no effect and a trivial pre-condition
+           match action with
+           | TcUtil.Keep_effect -> e2, c1
+           | TcUtil.Mask_effect_silently
+           | TcUtil.Mask_effect_and_warn ->
+             if TcUtil.Mask_effect_and_warn? action && not env.phase1 then (
                Err.warn_top_level_effect (Env.get_range env); // maybe warn
                (* The effect of e1 is about to be masked, i.e., we are turning a
                   possibly-divergent computation of type t into a value of type t.
                   That is only sound if t is actually inhabited, so we demand a
-                  proof of it. See issue #4401. *)
+                  proof of it. See issue #4401. A terminating effect needs no
+                  such proof: the computation itself witnesses the type. *)
                check_nonempty_result (Env.push_univ_vars env univ_vars) (U.comp_result c1)
              );
-             mk (Tm_meta {tm=e2; meta=Meta_desugared Masked_effect}) e2.pos, c1 //and tag it as masking an effect
-           )
+             (* Tag it as masking an effect. This suppresses the defining
+                equation in the SMT encoding and blocks delta-unfolding, which
+                is what makes two syntactically equal definitions of a
+                nondeterministic (or divergent) computation distinguishable. *)
+             mk (Tm_meta {tm=e2; meta=Meta_desugared Masked_effect}) e2.pos, c1
          in
 
          (* Unfold all @tcnorm subterms in the binding *)

--- a/src/typechecker/FStarC.TypeChecker.Util.fst
+++ b/src/typechecker/FStarC.TypeChecker.Util.fst
@@ -2242,27 +2242,30 @@ let check_has_type_maybe_coerce env (e:term) (lc:lcomp) (t2:typ) use_eq : ML (te
   e, lc, (Env.conj_guard g g_c)
 
 /////////////////////////////////////////////////////////////////////////////////
-let check_top_level env g lc : ML (bool & comp) =
+let check_top_level env g lc : ML (top_level_effect_action & comp) =
  Errors.with_ctx "While checking for top-level effects" (fun () ->
   if Debug.medium () then
     Format.print1 "check_top_level, lc = %s\n" (TcComm.lcomp_to_string lc);
   let discharge g =
     force_trivial_guard env g;
-    if TcComm.is_pure_lcomp lc then true
+    if TcComm.is_pure_lcomp lc then Keep_effect
     (* An effect marked [@@top_level_effect] may appear at the top level. *)
-    else if Some? (Env.get_top_level_effect env lc.eff_name) then true
+    else if Some? (Env.get_top_level_effect env lc.eff_name) then Keep_effect
     (* An effect with a representation is a value of that representation;
        running it at the top level is meaningless. *)
     else if Env.is_reifiable_effect env lc.eff_name then
       raise_error env Errors.Fatal_UnexpectedEffect [
         text "Effect" ^/^ pp lc.eff_name ^/^ text "cannot be used as a top-level effect"
       ]
-    (* [NDET] computations always terminate, so masking the effect at the top
-       level is harmless: the definition really does denote a value of its
-       result type. E.g. `let global = f ()` for `f : unit -> Nd t`. *)
-    else if U.is_ndet_effect (Env.norm_eff_name env lc.eff_name) then true
+    (* [NDET] computations always terminate, so the definition really does
+       denote a value of its result type and there is nothing to warn about.
+       The effect is still masked: an [NDET] computation is not a function of
+       its definition, so the binding must not be given a defining equation.
+       E.g. `let g1 = f ()` and `let g2 = f ()` for `f : unit -> Nd t` must
+       not be provably equal. *)
+    else if U.is_ndet_effect (Env.norm_eff_name env lc.eff_name) then Mask_effect_silently
     (* Otherwise: warn, and mask the effect. *)
-    else false in
+    else Mask_effect_and_warn in
   let g = Rel.solve_deferred_constraints env g in
   let c, g_c = TcComm.lcomp_comp lc in
   if TcComm.is_total_lcomp lc

--- a/src/typechecker/FStarC.TypeChecker.Util.fsti
+++ b/src/typechecker/FStarC.TypeChecker.Util.fsti
@@ -148,7 +148,20 @@ val maybe_instantiate : env -> term -> typ -> ML (term & typ & guard_t)
 val check_has_type : env -> term -> t:typ -> t':typ -> use_eq:bool -> ML guard_t
 val check_has_type_maybe_coerce : env -> term -> lcomp -> typ -> bool -> ML (term & lcomp & guard_t)
 
-val check_top_level: env -> guard_t -> lcomp -> ML (bool & comp)
+(* What to do with the effect of a top-level let binding. *)
+type top_level_effect_action =
+  (* The computation is pure, or its effect is explicitly allowed at the top
+     level: keep it as-is. *)
+  | Keep_effect
+  (* The computation always terminates, so it really does denote a value of
+     its result type, but it is not a function of its definition: mask the
+     effect, but do not warn and do not demand that the type be inhabited. *)
+  | Mask_effect_silently
+  (* The computation may diverge: mask the effect, warn, and demand a proof
+     that the result type is inhabited. *)
+  | Mask_effect_and_warn
+
+val check_top_level: env -> guard_t -> lcomp -> ML (top_level_effect_action & comp)
 
 val short_circuit: term -> args -> ML guard_formula
 val short_circuit_head: term -> ML bool

--- a/tests/micro-benchmarks/TestNd.fst
+++ b/tests/micro-benchmarks/TestNd.fst
@@ -61,3 +61,20 @@ let ghost_into_nd () : Nd int = gh ()
    unlike Dv, whose arrows are all in Type0 since they are
    proof-irrelevant). *)
 let _ : Type u#1 = unit -> Nd (Type u#0)
+
+(* A top-level Nd binding is masked: it denotes *some* value of its type, but
+   not a function of its definition. Two identical definitions must therefore
+   not be provably equal, or a nondeterministic allocator used to define two
+   globals would identify them. See issue #4534. *)
+let nd_global1 = f ()
+let nd_global2 = f ()
+
+[@@expect_failure [19]]
+let _ = assert (nd_global1 == nd_global2)
+
+(* ...but a global is equal to itself, and its type is still known. *)
+let _ = assert (nd_global1 == nd_global1)
+let _ : int = nd_global1
+
+(* The definition is also not unfolded by the normalizer. *)
+let _ = assert_norm (nd_global1 == nd_global1)


### PR DESCRIPTION
Fixes #4534.

`Pulse.Lib.GlobalVar.mk_gvar` was a pure total function, so two global variables declared with the same initializer were provably equal by congruence:

```fstar
let g1 = Global.mk_gvar init
let g2 = Global.mk_gvar init
let _ : squash (g1 == g2) = ()   // used to succeed
```

Extraction gives every top-level `let` its own call to `init`, so at runtime they are distinct objects. With the `duplicable`/lock pattern from `dice/dpe/DPE.fst` that is enough to prove `False` about extracted code.

This gives `mk_gvar` the new `Nd` effect (#4532). `Nd` terminates, so a `gvar` may still be defined at the top level, but an `Nd` computation is not a function of its definition, so `g1 == g2` is no longer derivable.

### Top-level `Nd` bindings must actually be masked

#4532 made `check_top_level` report `Nd` as "fine as-is", which skipped the `HasMaskedEffect` tag — and that tag is exactly what suppresses the defining equation in the SMT encoding (`Encode.fst:1290`) and blocks delta-unfolding (`Normalize.Unfolding.fst:85`). So `Nd` globals were still being identified:

```fstar
assume val f : unit -> Nd int
let g1 = f ()
let g2 = f ()
let _ = assert (g1 == g2)   // succeeded before this PR
```

(`Dv` globals were already fine, because they are masked.)

`check_top_level` now returns a three-way `top_level_effect_action` instead of a `bool`:

| | mask | warn 272 | `nonempty` obligation |
|---|---|---|---|
| `Keep_effect` — pure, or `@@top_level_effect` | no | no | no |
| `Mask_effect_silently` — `Nd` | **yes** | no | no |
| `Mask_effect_and_warn` — `Dv`, … | yes | yes | yes |

`Nd` is masked like `Dv`, but silently: it terminates, so the computation witnesses its own result type and there is nothing to warn about (#4401's obligation does not apply).

### Testing

* `pulse/test/TestGlobalVar.fst` (new) — two globals with the same initializer are not provably equal, directly nor through `read_gvar_ghost`, but each is equal to itself.
* `tests/micro-benchmarks/TestNd.fst` — the same at the F* level, plus checks that the type of a masked global is still known and that its definition is not unfolded by the normalizer.
* Extraction is unchanged. `DPE.fst` still verifies, and extracting it to OCaml/krml produces the same `gst = mk_gvar () () initialize_global_state` (rewritten by `ExtractPulse.fst` to `initialize_global_state ()`).
* Full `make build` and `make test` are green, except the pre-existing `pulse/share/pulse/examples/dice` `Error 353` (`pulse.cmxs` double-load).

### Note

This makes the *proof* sound. It does not address the other suggestions in the issue (checking that a `gvar` token is used exactly once, or rejecting duplicate `mk_gvar` applications at extraction time); those are still worth doing if the goal is to also make the runtime representation explicit.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
