### PR TITLE
Fix record projection normalizer performance regression

### DIFF
--- a/src/typechecker/FStarC.TypeChecker.Normalize.fst
+++ b/src/typechecker/FStarC.TypeChecker.Normalize.fst
@@ -426,6 +426,9 @@ type stack_elt =
  | CBVApp   of env & term & aqual & Range.t
  | Meta     of env & S.metadata & Range.t
  | Let      of env & binders & letbinding & Range.t
+ (* A terminal continuation requesting a WHNF closure, rather than a closed
+    term. In particular, constructor fields must retain their shared env. *)
+ | Closure  of (env -> term -> ML term)
 type stack = list stack_elt
 
 let head_of t = let hd, _ = U.head_and_args_full t in hd
@@ -514,6 +517,7 @@ instance showable_stack_elt : showable stack_elt = {
   show = (function
           | Arg (c, _, _) -> Format.fmt1 "Arg %s" (show c)
           | MemoLazy _ -> "MemoLazy"
+          | Closure _ -> "Closure"
           | Abs (_, bs, _, _, _) -> Format.fmt1 "Abs %s" (show <| List.length bs)
           | UnivArgs us -> "UnivArgs " ^ show us
           | Match   _ -> "Match"
@@ -526,6 +530,22 @@ instance showable_stack_elt : showable stack_elt = {
 let is_empty = function
     | [] -> true
     | _ -> false
+
+(* Only memo frames may precede a closure continuation: arguments, matches,
+   etc. still have to be reduced before the constructor is a result. *)
+let rec wants_closure (stack:stack) : bool =
+  match stack with
+  | MemoLazy _ :: stack -> wants_closure stack
+  | [Closure _] -> true
+  | _ -> false
+
+let rec return_closure cfg env stack t : ML term =
+  match stack with
+  | MemoLazy r :: stack ->
+    set_memo cfg r (env, t);
+    return_closure cfg env stack t
+  | [Closure k] -> k env t
+  | _ -> failwith "return_closure: unexpected stack"
 
 let lookup_bvar (env : env) x =
     try (List.nth env x.index)._2
@@ -1351,7 +1371,10 @@ let rec norm : cfg -> env -> stack -> term -> ML term =
                    then match read_memo cfg r with
                         | Some (env, t') ->
                             log cfg  (fun () -> Format.print2 "Lazy hit: %s cached to %s\n" (show t) (show t'));
-                            if maybe_weakly_reduced t'
+                            (* A WHNF constructor, like an abstraction, may be
+                               memoized with its environment still attached. *)
+                            if Cons? env then norm cfg env stack t'
+                            else if maybe_weakly_reduced t'
                             then match stack with
                                  | [] when cfg.steps.weak || cfg.steps.compress_uvars ->
                                    rebuild cfg env stack t'
@@ -1453,6 +1476,7 @@ let rec norm : cfg -> env -> stack -> term -> ML term =
             | App _ :: _
             | CBVApp _ :: _
             | Abs _ :: _
+            | Closure _ :: _
             | [] ->
               fallback ()
             end
@@ -1463,7 +1487,7 @@ let rec norm : cfg -> env -> stack -> term -> ML term =
             let head, args = U.head_and_args_full t in
             (* Each argument is pushed together with the environment it lives
                in: they are usually all under [env], but a scrutinee that we
-               have already reduced (see below) is closed. *)
+               have already reduced (see below) may have its own environment. *)
             let push_args_env args stack =
               List.fold_right
                 (fun ((a, aq), env) stack ->
@@ -1493,6 +1517,35 @@ let rec norm : cfg -> env -> stack -> term -> ML term =
             let push_args env args stack =
               push_args_env (args |> List.map (fun a -> (a, env))) stack
             in
+            (* Do not close a constructor just to project one of its fields.
+               Give each argument a closure of its own before memoizing the
+               constructor, so repeated selections share the field's memo too
+               (not merely the environments of its subterms). See #4537. *)
+            if cfg.steps.hnf && wants_closure stack &&
+               (match (U.un_uinst head).n with
+                | Tm_fvar fv -> Env.is_datacon cfg.tcenv fv.fv_name
+                | _ -> false)
+            then
+              let cenv, cargs =
+                push_args env args [] |> List.mapi (fun i arg ->
+                  match arg with
+                  | Arg (c, aq, _) ->
+                    let bv = { ppname = Ident.mk_ident ("_", t.pos);
+                               index = i; sort = S.tun } in
+                    ((None, c, fresh_memo ()), (S.bv_to_tm bv, aq))
+                  | _ -> failwith "push_args: expected Arg")
+                |> List.unzip
+              in
+              (* The head's universe variables refer to [env], not [cenv]. *)
+              let head =
+                match head.n with
+                | Tm_uinst (h, us) ->
+                  if cfg.steps.erase_universes then h
+                  else S.mk_Tm_uinst h (List.map (norm_universe cfg env) us)
+                | _ -> head
+              in
+              return_closure cfg cenv stack (S.mk_Tm_app head cargs t.pos)
+            else
             let fallback args =
               let stack = push_args_env args stack in
               log cfg (fun () -> Format.print1 "\tPushed %s arguments\n" (show <| List.length args));
@@ -1544,16 +1597,14 @@ let rec norm : cfg -> env -> stack -> term -> ML term =
              | Some (d, is_disc, n_indexed, idx) when List.length args > n_indexed ->
                let scrutinee0, aq = List.nth args n_indexed in
                let cfg' = whnf_cfg cfg in
-               (* The reduced scrutinee is closed, hence the empty environments
-                  below. *)
-               let scrutinee = norm cfg' env [] scrutinee0 in
-               (match reduce_disc_proj cfg d is_disc idx scrutinee with
+               let project scrutinee_env scrutinee =
+                match reduce_disc_proj cfg d is_disc idx scrutinee with
                 | None ->
                   (* Stuck: keep the weak head normal form we just computed
                      rather than making the enclosing pass recompute it. *)
                   let args =
                     args |> List.mapi (fun i a ->
-                      if i = n_indexed then ((scrutinee, aq), empty_env) else (a, env))
+                      if i = n_indexed then ((scrutinee, aq), scrutinee_env) else (a, env))
                   in
                   unfold_fallback args
                 | Some field ->
@@ -1563,7 +1614,9 @@ let rec norm : cfg -> env -> stack -> term -> ML term =
                      the extra arguments are re-applied to the selected field. *)
                   let _, rest = BU.first_N (n_indexed + 1) args in
                   let stack = push_args env rest stack in
-                  norm cfg empty_env stack field)
+                  norm cfg scrutinee_env stack field
+               in
+               norm cfg' env [Closure project] scrutinee0
              | _ -> fallback (args |> List.map (fun a -> (a, env))))
 
           | Tm_refine {b=x}
@@ -1610,6 +1663,7 @@ let rec norm : cfg -> env -> stack -> term -> ML term =
               form of t1? *)
               match s with
               | Match _ :: _
+              | Closure _ :: _
               | Arg _ :: _
               | App (_, {n=Tm_constant (FC.Const_reify _)}, _, _) :: _
               | MemoLazy _ :: _ when cfg.steps.beta ->
@@ -2658,6 +2712,10 @@ and rebuild (cfg:cfg) (env:env) (stack:stack) (t:term) : ML term =
 and do_rebuild (cfg:cfg) (env:env) (stack:stack) (t:term) : ML term =
       match stack with
       | [] -> t
+      (* [rebuild] receives a closed term. Constructor applications can bypass
+         it via [return_closure], retaining their original environment. *)
+      | [Closure k] -> k empty_env t
+      | Closure _ :: _ -> failwith "Closure continuation must be terminal"
 
       | Meta(_, m, r)::stack ->
         let t =
@@ -2676,7 +2734,10 @@ and do_rebuild (cfg:cfg) (env:env) (stack:stack) (t:term) : ML term =
         rebuild cfg env stack t
 
       | MemoLazy r::stack ->
-        set_memo cfg r (env, t);
+        (* Unlike the closures memoized by [norm], [t] is already closed.
+           Dropping [env] also lets cache hits distinguish these results from
+           constructor/abstraction closures that must re-enter [norm]. *)
+        set_memo cfg r (empty_env, t);
         log cfg  (fun () -> Format.print1 "\tSet memo %s\n" (show t));
         rebuild cfg env stack t
 
@@ -2714,9 +2775,12 @@ and do_rebuild (cfg:cfg) (env:env) (stack:stack) (t:term) : ML term =
         ) else (
           (* If the argument was already normalized+memoized, reuse it. *)
           match read_memo cfg m with
-          | Some (_, a) ->
-            let t = S.extend_app t (a, aq) r in
-            rebuild cfg env_arg stack t
+          | Some (memo_env, a) ->
+            if Cons? memo_env then
+              norm cfg memo_env (App(env, t, aq, r)::stack) a
+            else
+              let t = S.extend_app t (a, aq) r in
+              rebuild cfg env_arg stack t
 
           | None when not cfg.steps.iota ->
             (* If we are not doing iota, do not memoize the partial solution.

--- a/tests/micro-benchmarks/ProjectorSharing.fst
+++ b/tests/micro-benchmarks/ProjectorSharing.fst
@@ -1,0 +1,28 @@
+module ProjectorSharing
+
+open FStar.Tactics.V2
+
+(* Issue #4537: closing a constructor before selecting its field loses the
+   shared closures for the previous state. This took about 11 seconds rather
+   than 0.5 seconds for 1000 iterations. *)
+type state = {
+  f00:int; f01:int; f02:int; f03:int; f04:int;
+  f05:int; f06:int; f07:int; f08:int; f09:int;
+}
+
+let initial = {
+  f00=0; f01=1; f02=2; f03=3; f04=4;
+  f05=5; f06=6; f07=7; f08=8; f09=9;
+}
+
+let step (s:state) : state = { s with f00 = s.f00 + s.f01 }
+
+let rec iterate (n:nat) (s:state) : Tot state (decreases n) =
+  if n=0 then s else iterate (n-1) (step s)
+
+let normalize () = norm [primops; iota; delta; zeta; weak]; trefl ()
+
+[@@postprocess_with normalize]
+let result = iterate 1000 initial
+
+let _ = assert_norm (result == { initial with f00 = 1000 })

--- a/tests/projectors/PrimProjectors.fst
+++ b/tests/projectors/PrimProjectors.fst
@@ -38,3 +38,44 @@ let _ = assert_norm (norm [iota] (Mkrcd?.fst ({ fst = (fun (x:int) -> x + 1); sn
 (* Unapplied, a projector or discriminator is still a first-class function. *)
 let _ = assert_norm (List.Tot.map Mkrcd?.snd [{fst=0; snd=1}] == [1])
 let _ = assert_norm (List.Tot.filter A? [A 1; B false] == [A 1])
+
+(* #4537: constructor WHNFs retain an environment of field closures. The
+   constructor's universes and parameters must not be interpreted in that new
+   environment, and a projected function's extra arguments still live in the
+   caller's environment, not the constructor's. *)
+let make_rcd #a (x:a) : rcd a = { fst = x; snd = 17 }
+
+let project_under_binder #a (x:a) : Lemma ((make_rcd x).fst == x) =
+  assert_norm ((make_rcd x).fst == x)
+
+let apply_field (captured caller:int) : int =
+  let r : rcd (int -> int) = make_rcd (fun (x:int) -> captured + x) in
+  r.fst caller
+
+let _ = assert_norm (apply_field 40 2 == 42)
+let _ = assert_norm ((fun x -> apply_field x 2) == (fun x -> x + 2))
+
+(* Reuse the record after projecting from it, in both weak-head and strong
+   normalization contexts. A cached open constructor must never be rebuilt
+   as though it were a closed term. *)
+let reuse (x:int) =
+  let r = make_rcd x in
+  (r.fst, r, r.snd)
+
+let _ = assert_norm (reuse 42 == (42, {fst=42; snd=17}, 17))
+
+let stuck #a (r:rcd a) : Lemma (Mkrcd?.fst r == r.fst) =
+  assert_norm (norm [iota; zeta] (let s = r in Mkrcd?.fst s) == r.fst)
+
+(* Indexed constructors have both parameters and indices before the
+   projectee, and their fields need not start at argument zero. *)
+noeq
+type indexed (a:Type) : nat -> Type =
+  | Item : n:nat -> value:a -> indexed a n
+  | Other : n:nat -> indexed a n
+
+let make_indexed #a (n:nat) (x:a) : indexed a n = Item n x
+
+let _ = assert_norm (Item?.value (make_indexed 3 42) == 42)
+let _ = assert_norm (Item? (make_indexed 3 42) == true)
+let _ = assert_norm (Item? (Other #int 3) == false)


### PR DESCRIPTION
## Summary

Fixes #4537.

Preserve constructor weak-head normal forms as closures when reducing primitive projectors, rather than closing them through substitution. Constructor fields retain shared closures and memo cells, so repeated projections across record updates do not repeatedly normalize the same state.

Preserve the environments for universes and extra arguments, and retain the existing stuck-projection fallback. Add the issue reproducer as a micro-benchmark and semantic regression coverage for binders, polymorphism, function-valued fields, record reuse, and indexed constructors.

## Performance

The original 1,000-iteration reproducer improved from 11.07–11.16 seconds to 0.57 seconds with the stage-3 compiler (about 19.6× faster). The regression including its result assertion takes 0.60 seconds.

## Validation

- Stage-3 rebuild and bootstrap fixed-point comparison (`make boot-diff`).
- Projector suite (2 checks), micro-benchmark suite (199 checks), and tactic suite (120 checks).
- `make stage2-unit-tests`.
- Pulse common/core/library verification (218 checks, with `--proof_recovery`) and Pulse `Bug4472.fst` regression.
- Escaping-variable diagnostics with `Norm,NormRebuild`.

The full repository-wide `test-3` suite was not run.